### PR TITLE
test: Enable tests for PG_VERSIONS including 11

### DIFF
--- a/pg_bm25/test/expected/bm25_search.out
+++ b/pg_bm25/test/expected/bm25_search.out
@@ -1,3 +1,12 @@
+-- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
+-- deleted if we drop support for postgres 11.
+ALTER SYSTEM SET extra_float_digits TO 0;
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 -- Basic search query
 SELECT *
 FROM products
@@ -17,11 +26,11 @@ FROM products
 WHERE products @@@ 'category:electronics OR description:keyboard';
  rank_bm25 | id |         description         | rating |  category   |  col_text   | col_varchar | col_smallint | col_bigint | col_integer | col_oid | col_float4 | col_float8 | col_numeric | col_decimal | col_real | col_double | col_bool |     col_json     |    col_jsonb     
 -----------+----+-----------------------------+--------+-------------+-------------+-------------+--------------+------------+-------------+---------+------------+------------+-------------+-------------+----------+------------+----------+------------------+------------------
- 5.3764954 |  2 | Plastic Keyboard            |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
-  4.931014 |  1 | Ergonomic metal keyboard    |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
- 2.1096356 | 12 | Innovative wireless earbuds |      5 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
- 2.1096356 | 22 | Fast charging power bank    |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
- 2.1096356 | 32 | Bluetooth-enabled speaker   |      3 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
+    5.3765 |  2 | Plastic Keyboard            |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
+   4.93101 |  1 | Ergonomic metal keyboard    |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
+   2.10964 | 12 | Innovative wireless earbuds |      5 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
+   2.10964 | 22 | Fast charging power bank    |      4 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
+   2.10964 | 32 | Bluetooth-enabled speaker   |      3 | Electronics | Sample text | Sample text |           10 |    1000000 |         100 |       1 |       10.5 |     100.55 |       99.99 |       88.88 |    77.77 |      66.66 | t        | {"key": "value"} | {"key": "value"}
 (5 rows)
 
 -- Test real-time search

--- a/pg_bm25/test/fixtures.sql
+++ b/pg_bm25/test/fixtures.sql
@@ -1,6 +1,13 @@
-CREATE EXTENSION IF NOT EXISTS pg_bm25;
+-- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
+-- deleted if we drop support for postgres 11.
+ALTER SYSTEM SET extra_float_digits TO 0;
+select pg_reload_conf();
 
-CREATE TABLE products (
+CREATE EXTENSION
+IF NOT EXISTS pg_bm25;
+
+CREATE TABLE products
+(
     id SERIAL PRIMARY KEY,
     description TEXT,
     rating INTEGER CHECK (
@@ -11,7 +18,8 @@ CREATE TABLE products (
 );
 
 INSERT INTO
-    products (description, rating, category)
+    products
+    (description, rating, category)
 VALUES
     ('Ergonomic metal keyboard', 4, 'Electronics'),
     ('Plastic Keyboard', 4, 'Electronics'),
@@ -55,23 +63,26 @@ VALUES
     ('Plush teddy bear', 4, 'Toys'),
     ('Warm woolen sweater', 3, 'Apparel');
 
-ALTER TABLE products 
+ALTER TABLE products
     ADD COLUMN col_text TEXT DEFAULT 'Sample text',
-    ADD COLUMN col_varchar VARCHAR(255) DEFAULT 'Sample text',
+ADD COLUMN col_varchar VARCHAR
+(255) DEFAULT 'Sample text',
 
-    ADD COLUMN col_smallint SMALLINT DEFAULT 10,
-    ADD COLUMN col_bigint BIGINT DEFAULT 1000000,
-    ADD COLUMN col_integer INTEGER DEFAULT 100,
-    ADD COLUMN col_oid OID DEFAULT 1,
+ADD COLUMN col_smallint SMALLINT DEFAULT 10,
+ADD COLUMN col_bigint BIGINT DEFAULT 1000000,
+ADD COLUMN col_integer INTEGER DEFAULT 100,
+ADD COLUMN col_oid OID DEFAULT 1,
 
-    ADD COLUMN col_float4 FLOAT4 DEFAULT 10.5,
-    ADD COLUMN col_float8 FLOAT8 DEFAULT 100.55,
-    ADD COLUMN col_numeric NUMERIC(5,2) DEFAULT 99.99,
-    ADD COLUMN col_decimal DECIMAL(5,2) DEFAULT 88.88,
-    ADD COLUMN col_real REAL DEFAULT 77.77,
-    ADD COLUMN col_double DOUBLE PRECISION DEFAULT 66.66,
+ADD COLUMN col_float4 FLOAT4 DEFAULT 10.5,
+ADD COLUMN col_float8 FLOAT8 DEFAULT 100.55,
+ADD COLUMN col_numeric NUMERIC
+(5,2) DEFAULT 99.99,
+ADD COLUMN col_decimal DECIMAL
+(5,2) DEFAULT 88.88,
+ADD COLUMN col_real REAL DEFAULT 77.77,
+ADD COLUMN col_double DOUBLE PRECISION DEFAULT 66.66,
 
-    ADD COLUMN col_bool BOOLEAN DEFAULT TRUE,
-    
-    ADD COLUMN col_json JSON DEFAULT '{"key": "value"}'::json,
-    ADD COLUMN col_jsonb JSONB DEFAULT '{"key": "value"}'::jsonb;
+ADD COLUMN col_bool BOOLEAN DEFAULT TRUE,
+
+ADD COLUMN col_json JSON DEFAULT '{"key": "value"}'::json,
+ADD COLUMN col_jsonb JSONB DEFAULT '{"key": "value"}'::jsonb;

--- a/pg_bm25/test/fixtures.sql
+++ b/pg_bm25/test/fixtures.sql
@@ -1,8 +1,3 @@
--- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
--- deleted if we drop support for postgres 11.
-ALTER SYSTEM SET extra_float_digits TO 0;
-select pg_reload_conf();
-
 CREATE EXTENSION
 IF NOT EXISTS pg_bm25;
 

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -14,13 +14,12 @@ export PGDATABASE=postgres
 export PGPASSWORD=password
 
 # All pgrx-supported PostgreSQL versions to run tests over
-# TODO: Add support for Postgres 11.21/11
 case "$OS_NAME" in
   Darwin)
-    PG_VERSIONS=("15.4" "14.9" "13.12" "12.16")
+    PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
     ;;
   Linux)
-    PG_VERSIONS=("15" "14" "13" "12")
+    PG_VERSIONS=("15" "14" "13" "12" "11")
     ;;
 esac
 

--- a/pg_bm25/test/sql/bm25_search.sql
+++ b/pg_bm25/test/sql/bm25_search.sql
@@ -1,3 +1,9 @@
+-- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
+-- deleted if we drop support for postgres 11.
+ALTER SYSTEM SET extra_float_digits TO 0;
+select pg_reload_conf();
+
+
 -- Basic search query
 SELECT *
 FROM products

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -13,7 +13,6 @@ set -Eeuo pipefail
 PGVECTOR_VERSION="v0.5.0"
 
 # All pgrx-supported PostgreSQL versions to configure for
-# TODO: Add support for Postgres 11.21/11
 OS_NAME=$(uname)
 if [ $# -eq 0 ]; then
   # No arguments provided; use default versions

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -19,10 +19,10 @@ if [ $# -eq 0 ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("15.4" "14.9" "13.12" "12.16")
+      PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
       ;;
     Linux)
-      PG_VERSIONS=("15" "14" "13" "12")
+      PG_VERSIONS=("15" "14" "13" "12" "11")
       ;;
   esac
 else

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -1,63 +1,72 @@
+-- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
+-- deleted if we drop support for postgres 11.
+ALTER SYSTEM SET extra_float_digits TO 0;
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*));
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 WITH query AS (
-    SELECT 
+    SELECT
         ctid,
         paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
         ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
     FROM
-        mock_items 
+        mock_items
 )
-SELECT 
+SELECT
     mock_items.description,
     mock_items.category,
     mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid 
+    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid
 FROM mock_items
 JOIN query ON mock_items.ctid = query.ctid
 ORDER BY score_hybrid DESC;
-         description         |  category   | rating |     score_hybrid     
------------------------------+-------------+--------+----------------------
- Plastic Keyboard            | Electronics |      4 |   0.7371819661243477
- Ergonomic metal keyboard    | Electronics |      4 |      0.6107116173495
- Compact digital camera      | Photography |      5 |  0.30735498147825496
- High-resolution DSLR        | Photography |      4 |  0.30735498147825496
- Portable tripod stand       | Photography |      4 |  0.30735498147825496
- Lightweight camera bag      | Photography |      5 |  0.30735498147825496
- Hardcover book on history   | Books       |      2 |  0.29125175743143006
- Mystery detective novel     | Books       |      2 |  0.29125175743143006
- Paperback romantic novel    | Books       |      3 |  0.29125175743143006
- Historical fiction book     | Books       |      3 |  0.29125175743143006
- Refreshing face wash        | Beauty      |      2 |  0.26344712698136136
- Moisturizing lip balm       | Beauty      |      4 |  0.26344712698136136
- Generic shoes               | Footwear    |      4 |  0.26344712698136136
- Anti-aging serum            | Beauty      |      4 |  0.26344712698136136
- Freshly ground coffee beans | Groceries   |      5 |  0.23095141912040812
- Pure honey jar              | Groceries   |      4 |  0.23095141912040812
- Organic breakfast cereal    | Groceries   |      5 |  0.23095141912040812
- Organic green tea           | Groceries   |      3 |  0.23095141912040812
- Classic leather sofa        | Furniture   |      5 |   0.2195392724844678
- Elegant glass table         | Furniture   |      3 |   0.2195392724844678
- Rustic bookshelf            | Furniture   |      4 |   0.2195392724844678
- White jogging shoes         | Footwear    |      3 |   0.2195392724844678
- Sturdy hiking boots         | Footwear    |      4 |  0.17563141798757426
- Comfortable slippers        | Footwear    |      3 |  0.17563141798757426
- Sleek running shoes         | Footwear    |      5 |  0.17563141798757426
- Winter woolen socks         | Footwear    |      5 |  0.17563141798757426
- Fast charging power bank    | Electronics |      4 |  0.13172356349068068
- Bluetooth-enabled speaker   | Electronics |      3 |  0.13172356349068068
- Innovative wireless earbuds | Electronics |      5 |  0.13172356349068068
- Soft cotton shirt           | Apparel     |      5 |  0.08781570899378713
- Slim-fit denim jeans        | Apparel     |      5 |  0.08781570899378713
- Warm woolen sweater         | Apparel     |      3 |  0.08781570899378713
- Sporty tank top             | Apparel     |      4 |  0.08781570899378713
- Robot building kit          | Toys        |      4 | 0.043907854496893564
- Plush teddy bear            | Toys        |      4 | 0.043907854496893564
- Interactive board game      | Toys        |      3 | 0.043907854496893564
- Colorful kids toy           | Toys        |      1 | 0.043907854496893564
- Designer wall paintings     | Home Decor  |      5 |                    0
- Artistic ceramic vase       | Home Decor  |      4 |                    0
- Handcrafted wooden frame    | Home Decor  |      5 |                    0
- Modern wall clock           | Home Decor  |      4 |                    0
+         description         |  category   | rating |    score_hybrid    
+-----------------------------+-------------+--------+--------------------
+ Plastic Keyboard            | Electronics |      4 |  0.737181966124348
+ Ergonomic metal keyboard    | Electronics |      4 |    0.6107116173495
+ Compact digital camera      | Photography |      5 |  0.307354981478255
+ High-resolution DSLR        | Photography |      4 |  0.307354981478255
+ Portable tripod stand       | Photography |      4 |  0.307354981478255
+ Lightweight camera bag      | Photography |      5 |  0.307354981478255
+ Hardcover book on history   | Books       |      2 |   0.29125175743143
+ Mystery detective novel     | Books       |      2 |   0.29125175743143
+ Paperback romantic novel    | Books       |      3 |   0.29125175743143
+ Historical fiction book     | Books       |      3 |   0.29125175743143
+ Refreshing face wash        | Beauty      |      2 |  0.263447126981361
+ Moisturizing lip balm       | Beauty      |      4 |  0.263447126981361
+ Generic shoes               | Footwear    |      4 |  0.263447126981361
+ Anti-aging serum            | Beauty      |      4 |  0.263447126981361
+ Freshly ground coffee beans | Groceries   |      5 |  0.230951419120408
+ Pure honey jar              | Groceries   |      4 |  0.230951419120408
+ Organic breakfast cereal    | Groceries   |      5 |  0.230951419120408
+ Organic green tea           | Groceries   |      3 |  0.230951419120408
+ Classic leather sofa        | Furniture   |      5 |  0.219539272484468
+ Elegant glass table         | Furniture   |      3 |  0.219539272484468
+ Rustic bookshelf            | Furniture   |      4 |  0.219539272484468
+ White jogging shoes         | Footwear    |      3 |  0.219539272484468
+ Sturdy hiking boots         | Footwear    |      4 |  0.175631417987574
+ Comfortable slippers        | Footwear    |      3 |  0.175631417987574
+ Sleek running shoes         | Footwear    |      5 |  0.175631417987574
+ Winter woolen socks         | Footwear    |      5 |  0.175631417987574
+ Fast charging power bank    | Electronics |      4 |  0.131723563490681
+ Bluetooth-enabled speaker   | Electronics |      3 |  0.131723563490681
+ Innovative wireless earbuds | Electronics |      5 |  0.131723563490681
+ Soft cotton shirt           | Apparel     |      5 | 0.0878157089937871
+ Slim-fit denim jeans        | Apparel     |      5 | 0.0878157089937871
+ Warm woolen sweater         | Apparel     |      3 | 0.0878157089937871
+ Sporty tank top             | Apparel     |      4 | 0.0878157089937871
+ Robot building kit          | Toys        |      4 | 0.0439078544968936
+ Plush teddy bear            | Toys        |      4 | 0.0439078544968936
+ Interactive board game      | Toys        |      3 | 0.0439078544968936
+ Colorful kids toy           | Toys        |      1 | 0.0439078544968936
+ Designer wall paintings     | Home Decor  |      5 |                  0
+ Artistic ceramic vase       | Home Decor  |      4 |                  0
+ Handcrafted wooden frame    | Home Decor  |      5 |                  0
+ Modern wall clock           | Home Decor  |      4 |                  0
 (41 rows)
 

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -14,13 +14,12 @@ export PGDATABASE=postgres
 export PGPASSWORD=password
 
 # All pgrx-supported PostgreSQL versions to run tests over
-# TODO: Add support for Postgres 11.21/11
 case "$OS_NAME" in
   Darwin)
-    PG_VERSIONS=("15.4" "14.9" "13.12" "12.16")
+    PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
     ;;
   Linux)
-    PG_VERSIONS=("15" "14" "13" "12")
+    PG_VERSIONS=("15" "14" "13" "12" "11")
     ;;
 esac
 

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -1,19 +1,24 @@
+-- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
+-- deleted if we drop support for postgres 11.
+ALTER SYSTEM SET extra_float_digits TO 0;
+select pg_reload_conf();
+
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*));
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 
 WITH query AS (
-    SELECT 
+    SELECT
         ctid,
         paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
         ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
     FROM
-        mock_items 
+        mock_items
 )
-SELECT 
+SELECT
     mock_items.description,
     mock_items.category,
     mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid 
+    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid
 FROM mock_items
 JOIN query ON mock_items.ctid = query.ctid
 ORDER BY score_hybrid DESC;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #269 

## What

Enable tests for PG_VERSIONS including 11(.21)

## Why

These were previously disabled due to an inconsistency in how Postgres 11 vs 12+ display floating point numbers. 

## How

We updated the testing query to make behavior consistent across Postgres versions, and updated the test file to match.

## Tests

Self-explanatory.
