### PR TITLE
fix: Blog images

### DIFF
--- a/docs/blog/introducing_bm25.mdx
+++ b/docs/blog/introducing_bm25.mdx
@@ -1,11 +1,10 @@
 ---
-title: "pg_bm25: A Rust-based, full text search engine for Postgres"
+title: "pg_bm25: Elastic-Quality Search Inside Postgres"
 ---
 
-<img src="blog/images/bm25.png" noZoom />
+<img src="/blog/images/bm25.png" noZoom />
 
-We're unveiling `pg_bm25`: a Postgres extension that enables Elastic-quality, full text search 
-natively within Postgres.
+We're unveiling `pg_bm25`: a Rust-based Postgres extension that enables full text search with BM25 within Postgres.
 
 Today, Postgres’ full text queries are sluggish over large tables, have limited query and tokenization support, 
 and have no support for BM25 relevance scoring. `pg_bm25` is our first step in bridging the gap between the 

--- a/docs/blog/introducing_paradedb.mdx
+++ b/docs/blog/introducing_paradedb.mdx
@@ -2,7 +2,7 @@
 title: Introducing ParadeDB
 ---
 
-<img height="300" src="blog/images/paradedb.png" noZoom />
+<img height="300" src="/blog/images/paradedb.png" noZoom />
 
 We’re excited to announce ParadeDB: a PostgreSQL database optimized for search.
 ParadeDB is the first Postgres database built to be an ElasticSearch alternative, engineered for lightning-fast full


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The path of the blog images were wrong, causing them to not render.

## Why

## How

## Tests
