### PR TITLE
docs: Add "Edit in GitHub" Button to our docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -53,5 +53,8 @@
   "backgroundImage": "/background.png",
   "integrations": {
     "intercom": "d3sdz6rs"
+  },
+  "feedback": {
+    "suggestEdit": true
   }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes (partial) #283

## What
This makes it so visitors of our documentation can see an "edit" button on our docs, which will lead them to our docs page to suggest contributions and help keep documentation up-to-date. This is a very standard thing in the documentation world.

## Why
^

## How
The founder of Mintlify kindly told us the setting to add :)

## Tests
