### PR TITLE
feat: Introduce fuzzy search/typo tolerance

### DIFF
--- a/docs/search/bm25.mdx
+++ b/docs/search/bm25.mdx
@@ -97,6 +97,28 @@ FROM mock_items
 WHERE mock_items @@@ 'description:keyboard^2 OR category:electronics'
 ```
 
+## Fuzzy Search (Typo Tolerance)
+
+A trailing `:::` at the end of a query string marks the beginning of a config string, which uses standard
+URL param syntax. Here, fields can be marked as fuzzy for typo tolerance.
+
+```sql
+SELECT *
+FROM mock_items
+WHERE mock_items @@@ 'description:keybroadd OR category:elecrontisc:::fuzzy_fields=description,category'
+```
+
+## Limit and Offset
+
+Similarly, limit and offset can be passed into the config string. This provides a more efficient way of iterating
+through search results than through SQL's `LIMIT` and `OFFSET` clauses.
+
+```sql
+SELECT *
+FROM mock_items
+WHERE mock_items @@@ 'keyboard:::limit=2&offset=1'
+```
+
 ## Boolean Operators
 
 `AND`, `OR`, and `NOT` can be used to combine and filter multiple terms:

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -24,7 +24,7 @@ Lucene, using `pgrx`.
 - [x] JSON field search
 - [ ] Faceting/aggregations
 - [ ] Autocomplete
-- [ ] Fuzzy search
+- [x] Fuzzy search
 - [ ] Custom tokenizers
 
 ## Usage

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -51,7 +51,6 @@ pub extern "C" fn amrescan(
 
     // Parse a SearchQuery from the raw query string.
     // This will parse paradedb-specific config from the string.
-
     let query_config: SearchQuery = raw_query.parse().unwrap_or_else(|err| {
         panic!("Failed to parse query: {}", err);
     });

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -1,7 +1,7 @@
 use pgrx::*;
 use serde::Deserialize;
 use serde_json::json;
-use serde_qs;
+
 use std::str::FromStr;
 
 use crate::json::builder::JsonBuilder;

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -25,6 +25,7 @@ pub struct SearchQuery {
 pub struct SearchQueryConfig {
     pub offset: Option<usize>,
     pub limit: Option<usize>,
+    pub fuzzy_fields: Option<String>,
 }
 
 impl FromStr for SearchQuery {

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -1,7 +1,7 @@
 use pgrx::*;
 use serde::Deserialize;
 use serde_json::json;
-
+use serde_qs;
 use std::str::FromStr;
 
 use crate::json::builder::JsonBuilder;

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -44,3 +44,20 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
  12 | Innovative wireless earbuds |      5 | Electronics
 (2 rows)
 
+-- With fuzzy field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics:::fuzzy_fields=category';
+ id |         description         | rating |  category   
+----+-----------------------------+--------+-------------
+  1 | Ergonomic metal keyboard    |      4 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+ 22 | Fast charging power bank    |      4 | Electronics
+ 32 | Bluetooth-enabled speaker   |      3 | Electronics
+(5 rows)
+
+-- Without fuzzy field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';
+ id |         description         | rating |  category      
+----+-----------------------------+--------+-------------
+(0 rows)
+

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -57,7 +57,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 
 -- Without fuzzy field
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';
- id |         description         | rating |  category      
-----+-----------------------------+--------+-------------
+ id | description | rating | category 
+----+-------------+--------+----------
 (0 rows)
 

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -8,5 +8,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&';
 -- With limit and offset
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&offset=1';
-
-
+-- With fuzzy field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics:::fuzzy_fields=category';
+-- Without fuzzy field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #263 

## What
- Implements fuzzy search/typo tolerance
- User can specify which fields are typo tolerant:

```sql
SELECT * 
FROM mock_items 
WHERE mock_items @@@ 'description:keyboardd OR category:electornics:::fuzzy_fields=description,category';
```
- Updated documentation

## Why
- Typo tolerance is important

## How
Used the new `:::` syntax to enable users to pass in a comma-separated list of fields that they would like to be typo-tolerant/fuzzy. Inside `amrescan` we set the specified fields to fuzzy using `QueryParser::set_field_fuzzy`. We default the max Levenshtein distance to `2` (maximum allowed by Tantivy).

## Tests
Wrote additional regression tests for fuzzy search