### PR TITLE
refactor: Add additional parsing for lists in SearchConfig

### DIFF
--- a/pg_bm25/Cargo.lock
+++ b/pg_bm25/Cargo.lock
@@ -397,6 +397,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1209,7 @@ dependencies = [
 name = "pg_bm25"
 version = "0.0.0"
 dependencies = [
+ "csv",
  "paradedb-tantivy",
  "pgrx",
  "pgrx-tests",

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -18,6 +18,7 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg_test = []
 
 [dependencies]
+csv = "1.2.2"
 pgrx = "=0.9.8"
 rustc-hash = "1.1.0"
 serde = "1.0.188"

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -67,14 +67,7 @@ pub extern "C" fn amrescan(
     let offset = query_config.config.offset.unwrap_or(0);
 
     // Set fuzzy fields
-    let fuzzy_fields: Vec<&str> = query_config
-        .config
-        .fuzzy_fields
-        .as_deref()
-        .unwrap_or("")
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .collect();
+    let fuzzy_fields: Vec<String> = query_config.config.fuzzy_fields;
 
     let require_prefix = false;
     let transpose_cost_one = true;

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -2,10 +2,8 @@ use pgrx::*;
 use serde::Deserialize;
 use serde_json::json;
 
-use csv;
-use serde;
 use serde::de::DeserializeOwned;
-use serde_qs;
+
 use std::default::Default;
 
 use std::str::FromStr;

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -2,6 +2,12 @@ use pgrx::*;
 use serde::Deserialize;
 use serde_json::json;
 
+use csv;
+use serde;
+use serde::de::DeserializeOwned;
+use serde_qs;
+use std::default::Default;
+
 use std::str::FromStr;
 
 use crate::json::builder::JsonBuilder;
@@ -25,7 +31,8 @@ pub struct SearchQuery {
 pub struct SearchQueryConfig {
     pub offset: Option<usize>,
     pub limit: Option<usize>,
-    pub fuzzy_fields: Option<String>,
+    #[serde(default, deserialize_with = "from_csv")]
+    pub fuzzy_fields: Vec<String>,
 }
 
 impl FromStr for SearchQuery {
@@ -208,4 +215,71 @@ pub unsafe fn decon_row<'a>(
             Some((&attributes[idx - drop_cnt], datums[idx]))
         }
     })
+}
+
+// Helpers to deserialize a comma-separated string, following all the rules
+// of csv documents. This let's us easily use syntax like 1,2,3 or one,two,three
+// in the SearchQuery input strings.
+
+fn from_csv<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: DeserializeOwned + std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    deserializer.deserialize_str(CSVVecVisitor::<T>::default())
+}
+
+/// Visits a string value of the form "v1,v2,v3" into a vector of bytes Vec<u8>
+struct CSVVecVisitor<T: DeserializeOwned + std::str::FromStr>(std::marker::PhantomData<T>);
+
+impl<T: DeserializeOwned + std::str::FromStr> Default for CSVVecVisitor<T> {
+    fn default() -> Self {
+        CSVVecVisitor(std::marker::PhantomData)
+    }
+}
+
+impl<'de, T: DeserializeOwned + std::str::FromStr> serde::de::Visitor<'de> for CSVVecVisitor<T>
+where
+    <T as std::str::FromStr>::Err: std::fmt::Debug, // handle the parse error in a generic way
+{
+    type Value = Vec<T>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "a str")
+    }
+
+    fn visit_str<E>(self, s: &str) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // Treat the comma-separated string as a single record in a CSV.
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(s.as_bytes());
+
+        // Try to get the record and collect its values into a vector.
+        let mut output = Vec::new();
+        for result in rdr.records() {
+            match result {
+                Ok(record) => {
+                    for field in record.iter() {
+                        output.push(
+                            field
+                                .parse::<T>()
+                                .map_err(|_| E::custom("Failed to parse field"))?,
+                        );
+                    }
+                }
+                Err(e) => {
+                    return Err(E::custom(format!(
+                        "could not deserialize sequence value: {:?}",
+                        e
+                    )));
+                }
+            }
+        }
+
+        Ok(output)
+    }
 }


### PR DESCRIPTION
# Ticket(s) Closed

I wanted to make a quick improvement to the `SearchConfig` from earlier today, inspired by @rebasedming's syntax for fuzzy search:

```
:::fuzzy_fields=category,description,notes
```

This PR uses Rust's CSV parsing tools to give our `SearchConfig` more of a "first-class" way to parse lists. We have to use an additional attribute for lists fields, but now we can parse them using `serde`, just like the rest of the config:
```rust
#[derive(Debug, Deserialize, Default)]
pub struct SearchQueryConfig {
    pub offset: Option<usize>,
    pub limit: Option<usize>,
    #[serde(default, deserialize_with = "from_csv")]
    pub fuzzy_fields: Vec<String>,
}

```

The macro just points `serde` to the custom parser that I've defined at the bottom of the `utils.rs` file. In this function, I delegate all parsing of the comma separated string to the `csv` crate. This gets us a much better parser than we could write ourselves, along with the easy ability to parse strings, different number types, numbers as strings, etc. We also get proper handling of quotes and commas, as you'd expect from a good CSV lib.

Notice that, unlike other fields, we're not using `Option` on the `Vec<String>`. By passing `default` in the attribute, `serde` will just hand us an empty `Vec` if the user doesn't pass the `fuzzy_fields` option. This means instead of the caller doing this:

```rust
    let fuzzy_fields: Vec<&str> = query_config
        .config
        .fuzzy_fields
        .as_deref()
        .unwrap_or("")
        .split(',')
        .filter(|s| !s.is_empty())
        .collect();
```

They can just do this:

```rust
    let fuzzy_fields: Vec<String> = query_config.config.fuzzy_fields;
```

I figure we'll have plenty of ideas for things to put in the query config string, so we might as well make it as easy to use as possible!