### PR TITLE
feat: Add prefix search options for new autocomplete feature

### DIFF
--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -3,8 +3,8 @@ use tantivy::{
     collector::TopDocs,
     query::{BooleanQuery, Query, RegexQuery},
     query_grammar::Occur,
-    schema::FieldType,
     schema::Document,
+    schema::FieldType,
     SnippetGenerator,
 };
 

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -31,6 +31,8 @@ pub struct SearchQueryConfig {
     pub limit: Option<usize>,
     #[serde(default, deserialize_with = "from_csv")]
     pub fuzzy_fields: Vec<String>,
+    #[serde(default, deserialize_with = "from_csv")]
+    pub prefix_fields: Vec<String>,
 }
 
 impl FromStr for SearchQuery {

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -61,3 +61,14 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 ----+-------------+--------+----------
 (0 rows)
 
+-- With fuzzy and prefix field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description&fuzzy_fields=description';
+ERROR:  cannot search with both prefix_fields and fuzzy_fields
+-- With prefix field 
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description';
+ id |      description       | rating |  category   
+----+------------------------+--------+-------------
+  6 | Compact digital camera |      5 | Photography
+ 23 | Comfortable slippers   |      3 | Footwear
+(2 rows)
+

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -12,3 +12,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics:::fuzzy_fields=category';
 -- Without fuzzy field
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';
+-- With fuzzy and prefix field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description&fuzzy_fields=description';
+-- With prefix field 
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description';


### PR DESCRIPTION
Implements autocomplete by using Tanvity's `RegexQuery`. This is a different kind of query, so it's an exclusive codepath. It's compatible with some config options, like `limit` and `offset`, but we'll have to make sure that we make it panic when given contradictory options, like `fuzzy_fields`.

Here's an example of a result:
```sql
select * from products where products @@@ 'com:::prefix_fields=description'
+----+------------------------+--------+-------------+
| id | description            | rating | category    |
|----+------------------------+--------+-------------|
| 6  | Compact digital camera | 5      | Photography |
| 23 | Comfortable slippers   | 3      | Footwear    |
+----+------------------------+--------+-------------+
```

The RegexQuery matches on any word in the document, not just the first word, so you get matches like this:
```sql
select * from products where products @@@ 'se:::prefix_fields=description'
+----+------------------+--------+----------+
| id | description      | rating | category |
|----+------------------+--------+----------|
| 25 | Anti-aging serum | 4      | Beauty   |
+----+------------------+--------+----------+
```

@rebasedming and I have discussed moving to a non-string config syntax once we figure out the remaining mysteries with the `@@@` operator entrypoint:
```sql
select * from products
where products
@@@ 'sh*'::regex_query
  || 100::limit
  || 25::offset
  || ("description", "categories")::fuzzy_fields
  ```


Closes #266.