### PR TITLE
fix: Hybrid search + use minmax normalization

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -156,24 +156,23 @@ Finally, let's implement hybrid search, which combines BM25-based full text scor
 similarity scores. Hybrid search is especially useful in scenarios where you want to match by both 
 exact keywords and semantic meaning.
 
-Let's execute a simple hybrid search:
+Let's execute a hybrid search:
 
 ```sql 
-WITH query AS (
-    SELECT 
-        ctid,
-        paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
-        ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
-    FROM
-        mock_items 
-)
-SELECT 
-    mock_items.description,
-    mock_items.category,
-    mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid 
+SELECT
+    description,
+    category,
+    rating,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0.8,0.2]
+    ) as score_hybrid
 FROM mock_items
-JOIN query ON mock_items.ctid = query.ctid
 ORDER BY score_hybrid DESC
 LIMIT 3;
 ```
@@ -188,9 +187,9 @@ LIMIT 3;
 ```
 </Accordion>
 
-In this query, we first use `paradedb.l2_normalized_bm25` to calculate each row's normalized BM25 score with respect to 
-the query "keyboard." Next, we use a window function called `paradedb.l2_norm` to calculate each row's normalized 
-vector similarity score. Finally, we combine the two scores as a weighted average, assigning a weight of `0.8` to the first BM25 score and 
+In this query, we first use `paradedb.minmax_bm25` to calculate each row's normalized BM25 score with respect to 
+the query "keyboard." Next, we use a function called `paradedb.minmax_norm` to normalize the HNSW scores, and invert 
+the scores such that the lowest HNSW score is ranked the highest. Finally, we combine the two scores as a weighted average, assigning a weight of `0.8` to the first BM25 score and 
 a weight of `0.2` to the latter score.
 
 ## Congratulations!

--- a/docs/search/hybrid.mdx
+++ b/docs/search/hybrid.mdx
@@ -18,21 +18,20 @@ exact keywords and semantic meaning.
 To calculate a row's hybrid score, ParadeDB introduces a `paradedb.weighted_mean` function.
 
 ```sql
-WITH query AS (
-    SELECT
-        ctid,
-        paradedb.l2_normalized_bm25(ctid, '[index_name]', '[query]') as bm25,
-        ([vector] <-> [vector_column]) / paradedb.l2_norm([vector] <-> [vector_column]) OVER () as hnsw
-    FROM
-        mock_items
-)
 SELECT
-    mock_items.description,
-    mock_items.category,
-    mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, [weights]) as score_hybrid
-FROM mock_items
-JOIN query ON mock_items.ctid = query.ctid
+    description,
+    category,
+    rating,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, '[index_name]', '[query]'),
+        1 - paradedb.minmax_norm(
+          [l2_distance],
+          MIN([l2_distance]) OVER (),
+          MAX([l2_distance]) OVER ()
+        ),
+        [weights]
+    ) as score_hybrid
+FROM [table_name]
 ORDER BY score_hybrid DESC;
 ```
 
@@ -44,16 +43,16 @@ ORDER BY score_hybrid DESC;
 <ParamField body="query" required>
   The full text search query. For instance, `'description:keyboard'`.
 </ParamField>
-<ParamField body="vector" required>
-  The vectorized representation of your query. For instance, `'[1,2,3]'`
-</ParamField>
-<ParamField body="vector_column" required>
-  The name of the column containing the embeddings you wish to compare with the
-  vector.
+<ParamField body="l2_distance" required>
+  The L2 distance between two vectors. Supports distance operators like 
+  `'[1,2,3] <-> embedding'`.
 </ParamField>
 <ParamField body="weights" required>
   An array of length 2. The first element of the array is the weight assigned to
   the first argument of `paradedb.weighted_mean`. The two weights must be
   between `0` and `1` and add up to `1`. For instance, `ARRAY[0.5,0.5]` applies
   an equal weight to both scores.
+</ParamField>
+<ParamField body="table_name" required>
+  The name of the table.
 </ParamField>

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -90,12 +90,10 @@ pub extern "C" fn amrescan(
 
     // Cache L2 norm of the scores
     let scores: Vec<f32> = top_docs.iter().map(|(score, _)| *score).collect();
-    let l2_norm = scores
-        .iter()
-        .map(|&score| score * score)
-        .sum::<f32>()
-        .sqrt();
-    get_executor_manager().set_l2_norm(l2_norm);
+    let max_score = scores.iter().fold(0.0f32, |a, b| a.max(*b));
+    let min_score = scores.iter().fold(0.0f32, |a, b| a.min(*b));
+    get_executor_manager().set_max_score(max_score);
+    get_executor_manager().set_min_score(min_score);
 
     // Add query to scan state
     state.query = tantivy_query;

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -16,7 +16,8 @@ type BlockInfo = (BlockNumber, OffsetNumber);
 
 #[derive(Debug, PartialEq)]
 pub struct Manager {
-    l2_norm: f32,
+    max_score: f32,
+    min_score: f32,
     scores: Option<HashMap<BlockInfo, f32>>,
     highlights: Option<HashMap<(BlockInfo, String), String>>,
 }
@@ -26,7 +27,8 @@ impl Manager {
         Self {
             scores: None,
             highlights: None,
-            l2_norm: 1.0,
+            max_score: 0.0,
+            min_score: 0.0
         }
     }
 
@@ -43,12 +45,20 @@ impl Manager {
         self.scores.as_mut().unwrap().get(&(block, offset)).copied()
     }
 
-    pub fn set_l2_norm(&mut self, l2_norm: f32) {
-        self.l2_norm = l2_norm;
+    pub fn set_max_score(&mut self, max_score: f32) {
+        self.max_score = max_score;
     }
 
-    pub fn get_l2_norm(&self) -> f32 {
-        self.l2_norm
+    pub fn get_max_score(&self) -> f32 {
+        self.max_score
+    }
+
+    pub fn set_min_score(&mut self, min_score: f32) {
+        self.min_score = min_score;
+    }
+
+    pub fn get_min_score(&self) -> f32 {
+        self.min_score
     }
 
     pub fn add_highlight(&mut self, ctid: ItemPointerData, field_name: String, snippet: Snippet) {

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -28,7 +28,7 @@ impl Manager {
             scores: None,
             highlights: None,
             max_score: 0.0,
-            min_score: 0.0
+            min_score: 0.0,
         }
     }
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -80,21 +80,20 @@ CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 The following query executes a hybrid search on `mock_items`:
 
 ```sql
-WITH query AS (
-    SELECT
-        ctid,
-        paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
-        ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
-    FROM
-        mock_items
-)
 SELECT
-    mock_items.description,
-    mock_items.category,
-    mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid
+    description,
+    category,
+    rating,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding,
+          MIN('[1,2,3]' <-> embedding) OVER (),
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0.8,0.2]
+    ) as score_hybrid
 FROM mock_items
-JOIN query ON mock_items.ctid = query.ctid
 ORDER BY score_hybrid DESC;
 ```
 

--- a/pg_search/src/api.rs
+++ b/pg_search/src/api.rs
@@ -1,76 +1,20 @@
 use pgrx::*;
-use serde::{Deserialize, Serialize};
 use std::f64;
-use std::ffi::CStr;
-use std::str::FromStr;
 
-#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
-#[pgvarlena_inoutfuncs]
-pub struct L2NormState {
-    sum_of_squares: f64,
-    count: i32,
-}
-
-impl PgVarlenaInOutFuncs for L2NormState {
-    fn input(input: &CStr) -> PgVarlena<Self> {
-        let mut result = PgVarlena::<Self>::new();
-        let input_str = input.to_str().expect("failed to convert CStr to str");
-
-        let mut split = input_str.split(',');
-        let sum_of_squares = split
-            .next()
-            .and_then(|value| f64::from_str(value).ok())
-            .expect("expected sum_of_squares to be a valid f64");
-
-        let count = split
-            .next()
-            .and_then(|value| i32::from_str(value).ok())
-            .expect("expected count to be a valid i32");
-
-        result.sum_of_squares = sum_of_squares;
-        result.count = count;
-
-        result
+#[pg_extern]
+pub fn minmax_norm(value: f64, min: f64, max: f64) -> f64 {
+    if max == min {
+        return 0.0;
     }
-
-    fn output(&self, buffer: &mut StringInfo) {
-        buffer.push_str(&format!("{},{}", self.sum_of_squares, self.count));
-    }
-}
-
-#[pg_aggregate]
-impl Aggregate for L2NormState {
-    type State = PgVarlena<Self>;
-    type Args = f64;
-    type Finalize = f64;
-    const NAME: &'static str = "l2_norm";
-    const INITIAL_CONDITION: Option<&'static str> = Some("0.0,0");
-
-    fn state(
-        mut current: Self::State,
-        arg: Self::Args,
-        _fcinfo: pg_sys::FunctionCallInfo,
-    ) -> Self::State {
-        current.sum_of_squares += arg.powi(2);
-        current.count += 1;
-        current
-    }
-
-    fn finalize(
-        current: Self::State,
-        _args: (),
-        _fcinfo: pg_sys::FunctionCallInfo,
-    ) -> Self::Finalize {
-        (current.sum_of_squares / (current.count as f64)).sqrt()
-    }
+    (value - min) / (max - min)
 }
 
 #[pg_extern]
-pub fn weighted_mean(a: Option<f64>, b: Option<f64>, weights: Vec<Option<f64>>) -> f64 {
+pub fn weighted_mean(a: f64, b: f64, weights: Vec<f64>) -> f64 {
     assert!(weights.len() == 2, "There must be exactly 2 weights");
 
-    let weight_a = weights[0].unwrap_or(0.0);
-    let weight_b = weights[1].unwrap_or(0.0);
+    let weight_a = weights[0];
+    let weight_b = weights[1];
 
     assert!(
         (0.0..=1.0).contains(&weight_a) && (0.0..=1.0).contains(&weight_b),
@@ -82,8 +26,5 @@ pub fn weighted_mean(a: Option<f64>, b: Option<f64>, weights: Vec<Option<f64>>) 
         "Weights must add up to 1"
     );
 
-    let a_val = a.unwrap_or(0.0);
-    let b_val = b.unwrap_or(0.0);
-
-    a_val * weight_a + b_val * weight_b
+    a * weight_a + b * weight_b
 }

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -9,64 +9,84 @@ select pg_reload_conf();
 
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*));
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
-WITH query AS (
-    SELECT
-        ctid,
-        paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
-        ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
-    FROM
-        mock_items
-)
+-- Hybrid search with equal weights
 SELECT
-    mock_items.description,
-    mock_items.category,
-    mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0.5,0.5]
+    ) as score_hybrid
 FROM mock_items
-JOIN query ON mock_items.ctid = query.ctid
-ORDER BY score_hybrid DESC;
-         description         |  category   | rating |    score_hybrid    
------------------------------+-------------+--------+--------------------
- Plastic Keyboard            | Electronics |      4 |  0.737181966124348
- Ergonomic metal keyboard    | Electronics |      4 |    0.6107116173495
- Compact digital camera      | Photography |      5 |  0.307354981478255
- High-resolution DSLR        | Photography |      4 |  0.307354981478255
- Portable tripod stand       | Photography |      4 |  0.307354981478255
- Lightweight camera bag      | Photography |      5 |  0.307354981478255
- Hardcover book on history   | Books       |      2 |   0.29125175743143
- Mystery detective novel     | Books       |      2 |   0.29125175743143
- Paperback romantic novel    | Books       |      3 |   0.29125175743143
- Historical fiction book     | Books       |      3 |   0.29125175743143
- Refreshing face wash        | Beauty      |      2 |  0.263447126981361
- Moisturizing lip balm       | Beauty      |      4 |  0.263447126981361
- Generic shoes               | Footwear    |      4 |  0.263447126981361
- Anti-aging serum            | Beauty      |      4 |  0.263447126981361
- Freshly ground coffee beans | Groceries   |      5 |  0.230951419120408
- Pure honey jar              | Groceries   |      4 |  0.230951419120408
- Organic breakfast cereal    | Groceries   |      5 |  0.230951419120408
- Organic green tea           | Groceries   |      3 |  0.230951419120408
- Classic leather sofa        | Furniture   |      5 |  0.219539272484468
- Elegant glass table         | Furniture   |      3 |  0.219539272484468
- Rustic bookshelf            | Furniture   |      4 |  0.219539272484468
- White jogging shoes         | Footwear    |      3 |  0.219539272484468
- Sturdy hiking boots         | Footwear    |      4 |  0.175631417987574
- Comfortable slippers        | Footwear    |      3 |  0.175631417987574
- Sleek running shoes         | Footwear    |      5 |  0.175631417987574
- Winter woolen socks         | Footwear    |      5 |  0.175631417987574
- Fast charging power bank    | Electronics |      4 |  0.131723563490681
- Bluetooth-enabled speaker   | Electronics |      3 |  0.131723563490681
- Innovative wireless earbuds | Electronics |      5 |  0.131723563490681
- Soft cotton shirt           | Apparel     |      5 | 0.0878157089937871
- Slim-fit denim jeans        | Apparel     |      5 | 0.0878157089937871
- Warm woolen sweater         | Apparel     |      3 | 0.0878157089937871
- Sporty tank top             | Apparel     |      4 | 0.0878157089937871
- Robot building kit          | Toys        |      4 | 0.0439078544968936
- Plush teddy bear            | Toys        |      4 | 0.0439078544968936
- Interactive board game      | Toys        |      3 | 0.0439078544968936
- Colorful kids toy           | Toys        |      1 | 0.0439078544968936
- Designer wall paintings     | Home Decor  |      5 |                  0
- Artistic ceramic vase       | Home Decor  |      4 |                  0
- Handcrafted wooden frame    | Home Decor  |      5 |                  0
- Modern wall clock           | Home Decor  |      4 |                  0
-(41 rows)
+ORDER BY score_hybrid DESC
+LIMIT 5;
+       description        |  category   | rating | embedding |   score_hybrid    
+--------------------------+-------------+--------+-----------+-------------------
+ Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.788961044379643
+ Plastic Keyboard         | Electronics |      4 | [4,5,6]   | 0.785714285714286
+ Artistic ceramic vase    | Home Decor  |      4 | [1,2,3]   |               0.5
+ Modern wall clock        | Home Decor  |      4 | [1,2,3]   |               0.5
+ Designer wall paintings  | Home Decor  |      5 | [1,2,3]   |               0.5
+(5 rows)
+
+-- All weighted on BM25
+SELECT
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[1,0]
+    ) as score_hybrid
+FROM mock_items
+ORDER BY score_hybrid DESC
+LIMIT 5;
+       description        |  category   | rating | embedding |   score_hybrid    
+--------------------------+-------------+--------+-----------+-------------------
+ Plastic Keyboard         | Electronics |      4 | [4,5,6]   |                 1
+ Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.863636374473572
+ White jogging shoes      | Footwear    |      3 | [6,7,8]   |                 0
+ Generic shoes            | Footwear    |      4 | [7,8,9]   |                 0
+ Sleek running shoes      | Footwear    |      5 | [5,6,7]   |                 0
+(5 rows)
+
+-- All weighted on HNSW
+SELECT
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0,1]
+    ) as score_hybrid
+FROM mock_items
+ORDER BY score_hybrid DESC
+LIMIT 5;
+       description        |  category  | rating | embedding |   score_hybrid    
+--------------------------+------------+--------+-----------+-------------------
+ Designer wall paintings  | Home Decor |      5 | [1,2,3]   |                 1
+ Handcrafted wooden frame | Home Decor |      5 | [1,2,3]   |                 1
+ Artistic ceramic vase    | Home Decor |      4 | [1,2,3]   |                 1
+ Modern wall clock        | Home Decor |      4 | [1,2,3]   |                 1
+ Interactive board game   | Toys       |      3 | [2,3,4]   | 0.857142857142857
+(5 rows)
 

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -6,19 +6,59 @@ select pg_reload_conf();
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*));
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 
-WITH query AS (
-    SELECT
-        ctid,
-        paradedb.l2_normalized_bm25(ctid, 'idx_mock_items', 'keyboard') as bm25,
-        ('[1,2,3]' <-> embedding) / paradedb.l2_norm('[1,2,3]' <-> embedding) OVER () as hnsw
-    FROM
-        mock_items
-)
+-- Hybrid search with equal weights
 SELECT
-    mock_items.description,
-    mock_items.category,
-    mock_items.rating,
-    paradedb.weighted_mean(query.bm25, query.hnsw, ARRAY[0.8, 0.2]) as score_hybrid
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0.5,0.5]
+    ) as score_hybrid
 FROM mock_items
-JOIN query ON mock_items.ctid = query.ctid
-ORDER BY score_hybrid DESC;
+ORDER BY score_hybrid DESC
+LIMIT 5;
+
+-- All weighted on BM25
+SELECT
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[1,0]
+    ) as score_hybrid
+FROM mock_items
+ORDER BY score_hybrid DESC
+LIMIT 5;
+
+-- All weighted on HNSW
+SELECT
+    description,
+    category,
+    rating,
+    embedding,
+    paradedb.weighted_mean(
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        1 - paradedb.minmax_norm(
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
+        ),
+        ARRAY[0,1]
+    ) as score_hybrid
+FROM mock_items
+ORDER BY score_hybrid DESC
+LIMIT 5;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #291 

## What
The existing hybrid search query was broken because BM25 considers higher scores to be better, whereas L2 distance between vectors considers lower scores to be better.

To fix this, I switched our normalization method to minmax normalization, which collapses scores to a range between 0 and 1. This allowed me to invert the L2 distance scores by subtracting them from 1.

In the process I also managed to simplify the hybrid search query and remove the CTE. Here is what it now looks like:

```sql
SELECT
    description,
    category,
    rating,
    paradedb.weighted_mean(
        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'keyboard'),
        1 - paradedb.minmax_norm(
          '[1,2,3]' <-> embedding,
          MIN('[1,2,3]' <-> embedding) OVER (),
          MAX('[1,2,3]' <-> embedding) OVER ()
        ),
        ARRAY[0.8,0.2]
    ) as score_hybrid
FROM mock_items
ORDER BY score_hybrid DESC;
```

## Why
Make hybrid search work

## How

## Tests
Wrote additional tests for various hybrid search weights.