### PR TITLE
feat: Enable cloud caches

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -19,8 +19,10 @@ services:
         PGVECTOR_VERSION: 0.5.0
       cache_from:
         - type=local,src=./.docker_cache_dev
+        - type=registry,src=paradedb/paradedb-dev:cache
       cache_to:
         - type=local,dest=./.docker_cache_dev
+        - type=registry,src=paradedb/paradedb-dev:cache
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -35,8 +35,10 @@ services:
         RUM_VERSION: 1.3.13
       cache_from:
         - type=local,src=./.docker_cache_local
+        - type=registry,src=paradedb/paradedb-local:cache
       cache_to:
         - type=local,dest=./.docker_cache_local
+        - type=registry,src=paradedb/paradedb-local:cache
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This enables caching our builds in Docker Hub, in the cloud. This means there will not be slow builds, even on start! You'll be caching both locally and in the cloud, so we can share builds if there's anything missing in your local cache.

## Why
Faster builds for everyone!

## How
Use Docker's `to_cache` feature

## Tests
Tested that it works for my builds, both with local and cloud caches