### PR TITLE
fix: Don't tail logs in `entrypoint.sh`

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -73,10 +73,5 @@ for extension in "${!extensions[@]}"; do
   fi
 done
 
-echo "PostgreSQL extensions installed - tailing server..."
-
-# Trap SIGINT and SIGTERM signals, stop PostgreSQL, and gracefully shut down
-trap "service postgresql stop; echo 'PostgreSQL server has stopped - exiting...'; exit 0" SIGINT SIGTERM
-
-# Keep the container running
-tail -f /dev/null
+echo "PostgreSQL extensions installed - initialization completed!"
+echo "ParadeDB is ready for connections!"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
There's a bug when running the `docker run` ParadeDB image where you can't snap out of it. I believe this is the remaining cause of Wilhelm's issue, where the containers don't exit properly which leads to permission errors with old containers. Either way, this is something that should be fixed. I had added tailing logs to facilitate development, but I realize now this is not necessary and is causing issues. I'm removing it here. This should fix the `docker run` issue.

## Why
^

## How
Just remove the logs tailing

## Tests
Needs testing