### PR TITLE
perf: Create initial implementation of RESTRICT for @@@ operator

### DIFF
--- a/pg_bm25/src/index_access/cost.rs
+++ b/pg_bm25/src/index_access/cost.rs
@@ -65,7 +65,12 @@ pub unsafe extern "C" fn amcostestimate(
         }
     }
 
-    let reltuples = heap_relation.reltuples().unwrap_or(1f32) as f64;
+    let mut reltuples = heap_relation.reltuples().unwrap_or(1f32) as f64;
+    if reltuples < 0.0 {
+        // https://github.com/paradedb/paradedb/issues/323
+        warning!("amcostestimate: reltuples is negative! value: {reltuples}");
+        reltuples *= -1.0;
+    }
     *index_total_cost += *index_selectivity * reltuples * pg_sys::cpu_index_tuple_cost;
     *index_total_cost -= pg_sys::random_page_cost;
 }

--- a/pg_bm25/src/operator/mod.rs
+++ b/pg_bm25/src/operator/mod.rs
@@ -203,12 +203,6 @@ fn restrict(planner_info: Internal, _oid: pg_sys::Oid, args: Internal, var_rel_i
     }
 
     if let Some(heap_relation) = heap_relation {
-        info!(
-            "heap relation namespace {}, name {}",
-            heap_relation.namespace(),
-            heap_relation.name()
-        );
-
         // -2 chosen as debugging sentinel since apparently `heap_relation.reltuples()` is returning -1 in some (all?) cases
         // https://github.com/paradedb/paradedb/issues/323
         let reltuples = heap_relation.reltuples().unwrap_or(-2f32) as f64;


### PR DESCRIPTION
# Ticket(s) Closed

- Partially closes #268 
- Discovers and opens #323 

## What/Why

This gives Postgres some more information for query optimization purposes.

## How

The current implementation is pretty simple and takes a limit-based approach to enable some optimizations. 

## Tests

By definition, this doesn't affect correctness of the queries themselves and only provides opportunity for optimization. 
