### PR TITLE
chore: Add restore keys to CI cache action

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -33,6 +33,10 @@ jobs:
             ~/.cargo/
             ~/.rustup/
           key: ${{ runner.os }}-cargo-pgrx-0.9.8
+          restore-keys: |
+            ${{ runner.os }}-cargo-pgrx-0.9.8
+            ${{ runner.os }}-cargo-pgrx
+            ${{ runner.os }}-cargo
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -41,6 +41,10 @@ jobs:
             ~/.cargo/
             ~/.rustup/
           key: ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+          restore-keys: |
+            ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+            ${{ runner.os }}-cargo-pgrx
+            ${{ runner.os }}-cargo
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -41,6 +41,10 @@ jobs:
             ~/.cargo/
             ~/.rustup/
           key: ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+          restore-keys: |
+            ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+            ${{ runner.os }}-cargo-pgrx
+            ${{ runner.os }}-cargo
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,4 +44,3 @@ repos:
         args: ["--manifest-path", "Cargo.toml"]
       - id: cargo-check
         args: ["--manifest-path", "Cargo.toml"]
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,17 +38,10 @@ repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:
-      # pg_bm25
       - id: fmt
-        args: ["--manifest-path", "pg_bm25/Cargo.toml", "--"]
+        args: ["--manifest-path", "Cargo.toml", "--"]
       - id: clippy
-        args: ["--manifest-path", "pg_bm25/Cargo.toml"]
+        args: ["--manifest-path", "Cargo.toml"]
       - id: cargo-check
-        args: ["--manifest-path", "pg_bm25/Cargo.toml"]
-      # pg_search
-      - id: fmt
-        args: ["--manifest-path", "pg_search/Cargo.toml", "--"]
-      - id: clippy
-        args: ["--manifest-path", "pg_search/Cargo.toml"]
-      - id: cargo-check
-        args: ["--manifest-path", "pg_search/Cargo.toml"]
+        args: ["--manifest-path", "Cargo.toml"]
+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ vector database on top.
 ParadeDB is still under active development and is not yet ready to use
 in production. We're aiming to be ready by the end of September 2023.
 
-We are currently in Private Alpha. Star & watch this repo to get notified of
+We are currently in Private Beta. Star & watch this repo to get notified of
 major updates.
 
 ### Roadmap


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This is a very small nit, which will make sure we maximize the cache hits we get from our cache action.

## Why
Faster CI

## How
Followed: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows

## Tests
See CI