### PR TITLE
feat: Enable configuration of fuzzy query options

### DIFF
--- a/docs/search/autocomplete.mdx
+++ b/docs/search/autocomplete.mdx
@@ -19,7 +19,7 @@ WHERE <table_name> @@@ '<query>:::<regex_field_options>'
 ```sql
 SELECT *
 FROM mock_items
-WHERE mock_items @@@ 'key:::prefix_fields=description,category'
+WHERE mock_items @@@ 'key:::regex_fields=description,category'
 ```
 </Accordion>
 
@@ -32,7 +32,7 @@ WHERE mock_items @@@ 'key:::prefix_fields=description,category'
 <ParamField body="regex_field_options" required>
   Regex field config options.
     <Expandable title="Config Options">
-    <ParamField body="prefix_fields">
+    <ParamField body="regex_fields" required>
       A comma-separated string list of column names to perform regex search over.
     </ParamField>
     </Expandable>

--- a/docs/search/fuzzy.mdx
+++ b/docs/search/fuzzy.mdx
@@ -33,8 +33,20 @@ WHERE mock_items @@@ 'keybroadd:::fuzzy_fields=description,category'
 <ParamField body="fuzzy_field_options" required>
   Fuzzy field config options.
     <Expandable title="Config Options">
-    <ParamField body="fuzzy_fields">
-      A comma-separated string list of column names to perform fuzzy search over.
-    </ParamField>
+      <ParamField body="fuzzy_fields" required>
+        A comma-separated string list of column names to perform fuzzy search over.
+      </ParamField>
+      <ParamField body="distance" default={2}>
+        The maximum Levenshtein distance (i.e. single character edits) allowed to consider a term in the index as a match for the query term. 
+        Maximum value is `2`.
+      </ParamField>
+      <ParamField body="transpose_cost_one" default={true}>
+        When set to `true`, transpositions (swapping two adjacent characters) as a single edit in the Levenshtein distance calculation,
+        while `false` considers it two separate edits (a deletion and an insertion).
+      </ParamField>
+      <ParamField body="prefix" default={true}>
+        When set to `true`, the initial substring (prefix) of the query term is exempted from the fuzzy edit distance calculation, 
+        while false includes the entire string in the calculation.
+      </ParamField>
     </Expandable>
 </ParamField>

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -144,7 +144,7 @@ pub extern "C" fn amrescan(
             &tantivy_query,
             &TopDocs::with_limit(limit).and_offset(offset),
         )
-        .unwrap();
+        .expect("failed to search");
 
     // Cache min/max score
     let scores: Vec<f32> = top_docs.iter().map(|(score, _)| *score).collect();

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -71,12 +71,12 @@ pub extern "C" fn amrescan(
     });
 
     let fuzzy_fields = query_config.config.fuzzy_fields;
-    let prefix_fields = query_config.config.prefix_fields;
+    let regex_fields = query_config.config.regex_fields;
 
-    // Determine if we're using prefix fields based on the presence or absence of prefix and fuzzy fields.
+    // Determine if we're using regex fields based on the presence or absence of prefix and fuzzy fields.
     // It panics if both are provided as that's considered an invalid input.
-    let using_prefix_fields = match (!prefix_fields.is_empty(), !fuzzy_fields.is_empty()) {
-        (true, true) => panic!("cannot search with both prefix_fields and fuzzy_fields"),
+    let using_regex_fields = match (!regex_fields.is_empty(), !fuzzy_fields.is_empty()) {
+        (true, true) => panic!("cannot search with both regex_fields and fuzzy_fields"),
         (true, false) => true,
         _ => false,
     };
@@ -94,12 +94,12 @@ pub extern "C" fn amrescan(
     let offset = query_config.config.offset.unwrap_or(0);
 
     // Construct the actual Tantivy search query based on the mode determined above.
-    let tantivy_query: Box<dyn Query> = if using_prefix_fields {
+    let tantivy_query: Box<dyn Query> = if using_regex_fields {
         let regex_pattern = format!("{}.*", &query_config.query);
         let mut queries: Vec<Box<dyn Query>> = Vec::new();
 
-        // Build a regex query for each specified prefix field.
-        for field_name in &prefix_fields {
+        // Build a regex query for each specified regex field.
+        for field_name in &regex_fields {
             if let Ok(field) = schema.get_field(field_name) {
                 let regex_query =
                     Box::new(RegexQuery::from_pattern(&regex_pattern, field).unwrap());
@@ -119,9 +119,9 @@ pub extern "C" fn amrescan(
         // Set fuzzy search configuration for each specified fuzzy field.
         let fuzzy_fields: Vec<String> = fuzzy_fields;
 
-        let require_prefix = false;
-        let transpose_cost_one = true;
-        let max_distance = 2;
+        let require_prefix = query_config.config.prefix.unwrap_or(true);
+        let transpose_cost_one = query_config.config.transpose_cost_one.unwrap_or(true);
+        let max_distance = query_config.config.distance.unwrap_or(2);
 
         for field_name in &fuzzy_fields {
             if let Ok(field) = schema.get_field(field_name) {

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -32,8 +32,11 @@ pub struct SearchQueryConfig {
     pub limit: Option<usize>,
     #[serde(default, deserialize_with = "from_csv")]
     pub fuzzy_fields: Vec<String>,
+    pub distance: Option<u8>,
+    pub transpose_cost_one: Option<bool>,
+    pub prefix: Option<bool>,
     #[serde(default, deserialize_with = "from_csv")]
-    pub prefix_fields: Vec<String>,
+    pub regex_fields: Vec<String>,
 }
 
 impl FromStr for SearchQuery {

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -61,11 +61,25 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 ----+-------------+--------+----------
 (0 rows)
 
--- With fuzzy and prefix field
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description&fuzzy_fields=description';
-ERROR:  cannot search with both prefix_fields and fuzzy_fields
--- With prefix field 
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description';
+-- With fuzzy field and transpose_cost_one=false and distance=1
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
+ id | description | rating | category 
+----+-------------+--------+----------
+(0 rows)
+
+-- With fuzzy field and transpose_cost_one=true and distance=1
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
+ id |       description        | rating |  category   
+----+--------------------------+--------+-------------
+  1 | Ergonomic metal keyboard |      4 | Electronics
+  2 | Plastic Keyboard         |      4 | Electronics
+(2 rows)
+
+-- With fuzzy and regex field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description&fuzzy_fields=description';
+ERROR:  cannot search with both regex_fields and fuzzy_fields
+-- With regex field 
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';
  id |      description       | rating |  category   
 ----+------------------------+--------+-------------
   6 | Compact digital camera |      5 | Photography

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -12,7 +12,11 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics:::fuzzy_fields=category';
 -- Without fuzzy field
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';
--- With fuzzy and prefix field
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description&fuzzy_fields=description';
--- With prefix field 
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::prefix_fields=description';
+-- With fuzzy field and transpose_cost_one=false and distance=1
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
+-- With fuzzy field and transpose_cost_one=true and distance=1
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
+-- With fuzzy and regex field
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description&fuzzy_fields=description';
+-- With regex field 
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #329 

## What
- Enables the user to configure the max Levenshtein distance, transpose cost, and prefix for fuzzy queries 
- Also renamed `prefix_fields` to `regex_fields` to avoid confusion
- Example usage:

```sql
SELECT id, description, rating, category 
FROM search_config 
WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';

```

## Why
- We no longer have to hard-code these options

## How
- Via the config string

## Tests
Wrote an additional regression test