### PR TITLE
fix:  add extensions for monitoring and backups, fix numeric user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ FROM postgres:${PG_VERSION_MAJOR}-bullseye as base
 ARG PG_VERSION_MAJOR
 ARG PG_BM25_VERSION
 ARG PG_SEARCH_VERSION
+ARG PGNODEMX_VERSION
 ARG PG_CRON_VERSION
 ARG PG_NET_VERSION
 ARG PG_IVM_VERSION
@@ -33,6 +34,7 @@ ARG RUM_VERSION
 ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     PG_BM25_VERSION=${PG_BM25_VERSION} \
     PG_SEARCH_VERSION=${PG_SEARCH_VERSION} \
+    PGNODEMX_VERSION=${PGNODEMX_VERSION} \
     PG_CRON_VERSION=${PG_CRON_VERSION} \
     PG_NET_VERSION=${PG_NET_VERSION} \
     PG_IVM_VERSION=${PG_IVM_VERSION} \
@@ -207,6 +209,7 @@ COPY scripts/install_pg_extensions.sh /usr/local/bin/
 RUN /usr/local/bin/install_pg_extensions.sh \
     "pgvector,${PGVECTOR_VERSION},https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz" \
     "pgaudit,${PGAUDIT_VERSION},https://github.com/pgaudit/pgaudit/archive/refs/tags/${PGAUDIT_VERSION}.tar.gz" \
+    "pgnodemx,${PGNODEMX_VERSION},https://github.com/crunchydata/pgnodemx/archive/refs/tags/${PGNODEMX_VERSION}.tar.gz" \
     "pg_cron,${PG_CRON_VERSION},https://github.com/citusdata/pg_cron/archive/refs/tags/v${PG_CRON_VERSION}.tar.gz" \
     "pg_ivm,${PG_IVM_VERSION},https://github.com/sraoss/pg_ivm/archive/refs/tags/v${PG_IVM_VERSION}.tar.gz" \
     "pg_hashids,${PG_HASHIDS_VERSION},https://github.com/iCyberon/pg_hashids/archive/refs/tags/v${PG_HASHIDS_VERSION}.tar.gz" \
@@ -245,6 +248,7 @@ RUN apt-get update && apt-fast install -y --no-install-recommends \
     libprotobuf-c1 \
     # Crunchy operator
     libnss-wrapper \
+    pgbackrest \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
     pip3 install --no-cache-dir -r requirements.txt && rm -rf requirements.txt && \
@@ -275,3 +279,5 @@ COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_M
 # Copy entrypoint script, which will be handled by the official image
 # initialization scipt
 COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
+
+USER 999

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -15,6 +15,7 @@ services:
         PG_VERSION_MAJOR: 15
         PG_BM25_VERSION: 0.0.0
         PG_SEARCH_VERSION: 0.0.0
+        PGNODEMX_VERSION: 1.6
         PG_CRON_VERSION: 1.6.0
         PG_NET_VERSION: 0.7.2
         PG_IVM_VERSION: 1.5.1

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,6 +9,7 @@ declare -A extensions=(
   [pgml]=${PGML_VERSION:-}
   [vector]=${PGVECTOR_VERSION:-}
   [pg_search]=${PG_SEARCH_VERSION:-}
+  [pgnodemx]=${PGNODEMX_VERSION:-}
   [pg_cron]=${PG_CRON_VERSION:-}
   [pg_net]=${PG_NET_VERSION:-}
   [pg_ivm]=${PG_IVM_VERSION:-}
@@ -30,6 +31,7 @@ declare -A extensions=(
 # List of extensions that must be added to shared_preload_libraries
 declare -A preload_names=(
   [pgml]=pgml
+  [pgnodemx]=pgnodemx
   [pg_cron]=pg_cron
   [pg_net]=pg_net
   [pgaudit]=pgaudit


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What
- Run the postgres image with a numeric user  (defined in the official postgres image)
- Add the `pgnodemx` extension
- Install `pgbackrest`

## Why
Because PR #325 changed the image to use the official postgres image, and while it creates the postgres user and assigns it a numeric uid, our image didn't change to that user. This is explicitly needed for running the image with the Crunchy Operator.

In addition, the monitoring and backup extensions make it possible to set those options in the helm chart.

## How
Add the new extensions to the main Dockerfile, add to shared preload list.

## Tests
Manually tested.