### PR TITLE
fix: add pgnodemx version to release workflow

### DIFF
--- a/.github/workflows/publish-paradedb-to-dockerhub.yml
+++ b/.github/workflows/publish-paradedb-to-dockerhub.yml
@@ -54,6 +54,7 @@ jobs:
             PG_NET_VERSION=0.7.2
             PG_GRAPHQL_VERSION=1.3.0
             PG_JSONSCHEMA_VERSION=0.1.4
+            PGNODEMX_VERSION=1.6
             PG_CRON_VERSION=1.6.0
             PG_IVM_VERSION=1.5.1
             PG_HASHIDS_VERSION=1.2.1


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Adds the missing pgnodemx version to the github release workflow.

## Why
Because the latest deploy failed since the extension has an empty version.

## How
Add to `publish-paradedb-to-dockerhub` workflow.

## Tests
Will have to merge to test.