### PR TITLE
chore: fix tsquery benchmarking and add Typesense benchmark

### DIFF
--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -1,0 +1,35 @@
+# workflows/benchmark-paradedb.yml
+#
+# ParadeDB: Benchmark
+# Benchmark ParadeDB on a nightly basis.
+
+name: Benchmarking
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - dev
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-paradedb-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark-paradedb:
+    name: Benchmark ParadeDB (Nightly)
+    runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Run 
+        working-directory: benchmarks/
+        run: ./benchmark-paradedb.sh
+
+      - name: Print Results
+        working-directory: benchmarks/
+        run: cat benchmark_paradedb.csv

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -12,24 +12,34 @@ on:
     branches:
       - suriya/benchmark-plus # TODO: Remove once testing is done
   workflow_dispatch:
+    inputs:
+      name:
+        description: "Select the system to benchmark"
+        default: "paradedb"
+        type: choice
+        options: 
+          - paradedb
+          - tsquery
+          - elasticsearch
+          - typesense
 
 concurrency:
-  group: benchmark-paradedb-${{ github.head_ref || github.run_id }}
+  group: benchmark-${{ github.event.inputs.name }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   benchmark-paradedb:
-    name: Benchmark ParadeDB
+    name: Benchmark ${{ github.event.inputs.name }}
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Run
+      - name: Run Benchmarking Script
         working-directory: benchmarks/
-        run: ./benchmark-paradedb.sh
+        run: ./benchmark-${{ github.event.inputs.name }}.sh
 
       - name: Print Results
-        working-directory: benchmarks/
-        run: cat benchmark_paradedb.csv
+        working-directory: benchmarks/out/
+        run: cat benchmark_${{ github.event.inputs.name }}.csv

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -6,11 +6,11 @@
 name: Benchmarking
 
 on:
+#   schedule:
+#     - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
   push:
     branches:
-      - main
-      - staging
-      - dev
+      - suriya/benchmark-plus # TODO: Remove once testing is done
   workflow_dispatch:
 
 concurrency:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Run 
+      - name: Run
         working-directory: benchmarks/
         run: ./benchmark-paradedb.sh
 

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -1,7 +1,8 @@
 # workflows/benchmark-paradedb.yml
 #
 # ParadeDB: Benchmark
-# Benchmark ParadeDB on a nightly basis.
+# Benchmark ParadeDB's performance on a nightly basis. This workflow can also be triggered
+# manually to benchmark other systems on one-off basis, to compare against ParadeDB.
 
 name: Benchmarking
 
@@ -17,7 +18,7 @@ on:
         description: "Select the system to benchmark"
         default: "paradedb"
         type: choice
-        options: 
+        options:
           - paradedb
           - tsquery
           - elasticsearch
@@ -29,7 +30,7 @@ concurrency:
 
 jobs:
   benchmark-paradedb:
-    name: Benchmark ${{ github.event.inputs.name }}
+    name: Benchmark ParadeDB
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
 
     steps:

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -6,8 +6,8 @@
 name: Benchmarking
 
 on:
-#   schedule:
-#     - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
+  #   schedule:
+  #     - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
   push:
     branches:
       - suriya/benchmark-plus # TODO: Remove once testing is done
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   benchmark-paradedb:
-    name: Benchmark ParadeDB (Nightly)
+    name: Benchmark ParadeDB
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
 
     steps:

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -34,6 +34,11 @@ jobs:
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
 
     steps:
+      - name: Tmp
+        run: |
+          cat /proc/cpuinfo
+          echo $RUNNER_OS
+
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -7,11 +7,8 @@
 name: Benchmarking
 
 on:
-  #   schedule:
-  #     - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
-  push:
-    branches:
-      - suriya/benchmark-plus # TODO: Remove once testing is done
+  schedule:
+    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
   workflow_dispatch:
     inputs:
       name:
@@ -25,7 +22,7 @@ on:
           - typesense
 
 concurrency:
-  group: benchmark-${{ github.event.inputs.name }}-${{ github.head_ref || github.run_id }}
+  group: benchmark-paradedb-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -34,11 +31,6 @@ jobs:
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
 
     steps:
-      - name: Tmp
-        run: |
-          cat /proc/cpuinfo
-          echo $RUNNER_OS
-
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -37,10 +37,14 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      - name: Configure System to Benchmark
+        id: system
+        run: echo "system_to_benchmark=${{ github.event.inputs.name || 'paradedb' }}" >> $GITHUB_OUTPUT
+
       - name: Run Benchmarking Script
         working-directory: benchmarks/
-        run: ./benchmark-${{ github.event.inputs.name }}.sh
+        run: ./benchmark-${{ steps.system.outputs.system_to_benchmark }}.sh
 
       - name: Print Results
         working-directory: benchmarks/out/
-        run: cat benchmark_${{ github.event.inputs.name }}.csv
+        run: cat benchmark_${{ steps.system.outputs.system_to_benchmark }}.csv

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /benchmarks/out/
+/benchmarks/*_ts.json
 /benchmarks/wiki-articles.json
 /docker/.docker_cache_dev/
 /docker/.docker_cache_local/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ---
 
 [![Publishing](https://github.com/paradedb/paradedb/actions/workflows/publish-paradedb-to-dockerhub.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/publish-paradedb-to-dockerhub.yml)
+[![Benchmarking](https://github.com/paradedb/paradedb/actions/workflows/benchmark-paradedb.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/benchmark-paradedb.yml)
 
 [ParadeDB](https://paradedb.com) is an ElasticSearch alternative built on PostgreSQL,
 engineered for lightning-fast full text, similarity, and hybrid search.

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -7,3 +7,4 @@
 
 # Outputs
 out/
+typesense-data/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,8 @@ This folder contains the results and scripts for benchmarking ParadeDB against o
 
 - [x] ParadeDB
 - [x] ElasticSearch
-- [x] PostgreSQL tsquery
+- [x] Typesense
+- [x] PostgreSQL tsvector/tsquery
 
 If you'd like to see benchmarks against another system, please open an issue or a pull request.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,9 +13,60 @@ If you'd like to see benchmarks against another system, please open an issue or 
 
 ### Experimental Setup
 
-The benchmarks below were run on a 2021 MacBook Pro with 16GB of RAM and an Apple M1 processor. A more thorough benchmarking setup is coming soon.
+The benchmarks below were run on the following hardware and software:
+
+```bash
+# VM
+# See here for full details: https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series
+VM Type: GitHub Actions Large Runner ubuntu-latest-m (Azure Standard_D4ads_v5)
+
+# Image
+# See here for full details: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+OS Version: 22.04.3 LTS
+Kernel Version: 6.2.0-1012-azure
+
+# CPU
+vCPUs: 4
+CPU: AMD 3rd Generation EPYC 7763v 64-Core Processor
+CPU MHz: 2693.965
+Cache size: 512 KB
+Bogomips: 4890.86
+TLB size: 2560 4K pages
+Clflush size: 64
+Cache_alignment: 64
+Address sizes: 48 bits physical, 48 bits virtual
+
+# Memory
+RAM: 16 GiB
+Storage: 150 GiB SSD
+Max Data Disks: 8
+Max temp storage throughput: 19000 / 250 IOPS/MBps
+Max uncached disk throughput: 6400 / 144 IOPS/MBps
+Max burst uncached disk throughput: 20000 / 600 IOPS/MBps
+
+# Network
+Max NICs: 2
+Max network bandwidth: 12500 Mbps
+```
+
+The system is warmed up by booting, with no other warmup steps taken. The system is started cold as a new GitHub Actions Large Runner instance each time.
+
+The dataset used is a [snapshot of the Wikipedia English corpus](https://www.dropbox.com/s/wwnfnu441w1ec9p/wiki-articles.json.bz2), with 5,032,105 entries composed of the URL, title, and body, formatted as a JSON file. The dataset is 8.89 GB in size.
+
+The query used for benchmarking is a simple search of the word "Canada" across any field. More benchmark queries will be added in the future, with varying degrees of complexity.
+
+The versions of the systems used for benchmarking are:
+
+- ParadeDB: 0.2.18
+- PostgreSQL: 15.4
+- ElasticSearch: 8.9.2
+- Typesense: 0.25.1
+
+For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ).
 
 ### pg_bm25
+
+NOTE: The below benchmarks are from _before_ the experimental setup introduced above. We are currently updating the benchmarks and will update the results below very soon.
 
 On a table with 1 million rows, `pg_bm25` indexes 50 seconds faster than `tsvector` and searches + ranks
 results 20x faster. Indexing and search times are nearly identical to those of a dedicated ElasticSearch
@@ -33,14 +84,14 @@ To generate new benchmarks, simply run the relevant Bash script:
 # Benchmark ParadeDB
 ./benchmark-paradedb.sh
 
+# Benchmark PostgreSQL tsquery/tsvector
+./benchmark-tsquery
+
 # Benchmark ElasticSearch
 ./benchmark-elasticsearch.sh
 
 # Benchmark Typesense
 ./benchmark-typesense.sh
-
-# Benchmark PostgreSQL tsquery/tsvector
-./benchmark-tsquery
 ```
 
 The results of the benchmarks will be written to a `.csv` file in the `out/` folder.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,9 +3,9 @@
 This folder contains the results and scripts for benchmarking ParadeDB against other search engines and databases. Currently, the following systems are benchmarked:
 
 - [x] ParadeDB
+- [x] PostgreSQL tsquery/tsvector
 - [x] ElasticSearch
 - [x] Typesense
-- [x] PostgreSQL tsquery
 
 If you'd like to see benchmarks against another system, please open an issue or a pull request.
 
@@ -39,7 +39,7 @@ To generate new benchmarks, simply run the relevant Bash script:
 # Benchmark Typesense
 ./benchmark-typesense.sh
 
-# Benchmark PostgreSQL tsquery
+# Benchmark PostgreSQL tsquery/tsvector
 ./benchmark-tsquery
 ```
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,7 +5,7 @@ This folder contains the results and scripts for benchmarking ParadeDB against o
 - [x] ParadeDB
 - [x] ElasticSearch
 - [x] Typesense
-- [x] PostgreSQL tsvector/tsquery
+- [x] PostgreSQL tsquery
 
 If you'd like to see benchmarks against another system, please open an issue or a pull request.
 
@@ -36,7 +36,10 @@ To generate new benchmarks, simply run the relevant Bash script:
 # Benchmark ElasticSearch
 ./benchmark-elasticsearch.sh
 
-# Benchmark tsquery
+# Benchmark Typesense
+./benchmark-typesense.sh
+
+# Benchmark PostgreSQL tsquery
 ./benchmark-tsquery
 ```
 

--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -47,7 +47,7 @@ docker run \
 # Wait for Docker container to spin up
 echo ""
 echo "Waiting for server to spin up..."
-sleep 30
+sleep 40
 echo "Done!"
 
 # Produce and save password

--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -34,7 +34,7 @@ echo "*******************************************************"
 echo ""
 
 # Download and run docker container for ElasticSearch
-echo "Creating ElasticSearch node..."
+echo "Creating ElasticSearch $ES_VERSION node..."
 docker network create elastic
 docker run \
   -d \

--- a/benchmarks/benchmark-tsquery.sh
+++ b/benchmarks/benchmark-tsquery.sh
@@ -73,15 +73,9 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   db_query "CREATE TABLE $TABLE_NAME AS SELECT * FROM wikipedia_articles LIMIT $SIZE;"
   db_query "ALTER TABLE $TABLE_NAME ADD COLUMN search_vector tsvector;"
 
-  # Time vector creation
-  echo "-- Timing vector creation..."
-  start_time=$( (time db_query "UPDATE $TABLE_NAME SET search_vector = to_tsvector('english', title) || to_tsvector('english', body);" > /dev/null) 2>&1 )
-  vector_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
-  echo "Vector creation took $vector_time seconds"
-
-  # Time indexing
+  # Time indexing -- we include vector creation with the indexing metric because it is a required setup for search via tsvector
   echo "-- Timing indexing..."
-  start_time=$( (time db_query "CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING gin(search_vector);" > /dev/null) 2>&1 )
+  start_time=$( (time db_query "UPDATE $TABLE_NAME SET search_vector = to_tsvector('english', title) || to_tsvector('english', body); CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING gin(search_vector);" > /dev/null) 2>&1 )
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Time search

--- a/benchmarks/benchmark-tsquery.sh
+++ b/benchmarks/benchmark-tsquery.sh
@@ -80,7 +80,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
 
   # Time search
   echo "-- Timing search..."
-  start_time=$( (time db_query "SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
+  start_time=$( (time db_query "SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Record times to CSV

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Exit on subcommand errors
+set -Eeuo pipefail
+
+# Ensure the "out" directory exists
+mkdir -p out
+
+PORT=8108
+TS_VERSION=0.25.1
+WIKI_ARTICLES_FILE=wiki-articles.json
+TYPESENSE_API_KEY=xyz
+TYPESENSE_DATA=$(pwd)/typesense-data
+OUTPUT_CSV=out/benchmark_typesense.csv
+
+# Cleanup function to stop and remove the Docker container
+cleanup() {
+  echo ""
+  echo "Cleaning up benchmark environment..."
+  if docker ps -q --filter "name=typesense" | grep -q .; then
+    docker kill typesense
+  fi
+  docker rm typesense
+  rm -rf $TYPESENSE_DATA
+  echo "Done!"
+}
+
+# Register the cleanup function to run when the script exits
+trap cleanup EXIT
+
+echo ""
+echo "*******************************************************"
+echo "* Benchmarking Typesense version: $TS_VERSION"
+echo "*******************************************************"
+echo ""
+
+# Download and run docker container for Typesense
+echo "Creating Typesense node..."
+docker run \
+  -d \
+  --name typesense \
+  -p $PORT:8108 \
+  -v$TYPESENSE_DATA:/data typesense/typesense:$TS_VERSION \
+  --data-dir /data \
+  --api-key=$TYPESENSE_API_KEY \
+  --enable-cors
+
+# Wait for Docker container to spin up
+echo ""
+echo "Waiting for server to spin up..."
+sleep 30
+echo "Done!"
+
+# Output file for recording times
+echo "Table Size,Index Time,Search Time" > $OUTPUT_CSV
+
+# Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
+TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
+
+for SIZE in "${TABLE_SIZES[@]}"; do
+  echo ""
+  echo "Running benchmarking suite on index with $SIZE documents..."
+
+  # Create Typesense collection
+  echo "-- Creating Typesense collection..."
+  curl "http://localhost:$PORT/collections" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '{
+      "name": "wikipedia_articles",
+      "fields": [
+        {"name": "title", "type": "string"},
+        {"name": "body", "type": "string"},
+        {"name": "url", "type": "string"}
+      ]
+    }'
+
+  # Prepare data to be indexed by Typesense
+  echo "-- Preparing data to be consumed by Typesense..."
+  data_filename="${SIZE}_ts.json"
+  head -n $SIZE $WIKI_ARTICLES_FILE > $data_filename
+
+  # Time indexing
+  echo "-- Loading data of size $SIZE into wikipedia_articles index..."
+  echo "-- Timing indexing..."
+  start_time=$( (time curl "http://localhost:$PORT/collections/wikipedia_articles/documents/import" -X POST -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" --data-binary @"$data_filename") 2>&1 )
+  index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
+
+  # Time search
+  start_time=$( (time curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:$PORT/collections/wikipedia_articles/documents/search?q=Canada&query_by=title,body" > test_output.txt) 2>&1 )
+  search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
+
+  # Confirm document count
+  doc_count=$(curl --silent -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET "http://localhost:$PORT/collections/wikipedia_articles" | jq '.num_documents')
+  echo ""
+  echo "-- Number of documents in wikipedia_articles index for size $SIZE: $doc_count"
+
+  # Record times to CSV
+  echo "$SIZE,$index_time,$search_time" >> $OUTPUT_CSV
+
+  # Cleanup: delete the index and temporary data file
+  echo "-- Cleaning up..."
+  rm $data_filename
+  curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE "http://localhost:8108/collections/wikipedia_articles"
+  echo ""
+  echo "Done!"
+done

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -55,8 +55,9 @@ echo "Done!"
 echo "Table Size,Index Time,Search Time" > $OUTPUT_CSV
 
 # Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
-# TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
-TABLE_SIZES=(600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
+# TODO: Make it work on more tham 600k rows -- currently times out due to curl runs out of memory
+# TABLE_SIZES=(600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
+TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000)
 
 for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -35,7 +35,9 @@ echo "*******************************************************"
 echo ""
 
 # Download and run docker container for Typesense
-echo "Creating Typesense node..."
+
+
+echo "Creating Typesense $TS_VERSION node..."
 docker run \
   -d \
   --name typesense \

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -21,7 +21,7 @@ cleanup() {
     docker kill typesense
   fi
   docker rm typesense
-  rm -rf $TYPESENSE_DATA
+  rm -rf "$TYPESENSE_DATA"
   echo "Done!"
 }
 
@@ -40,7 +40,7 @@ docker run \
   -d \
   --name typesense \
   -p $PORT:8108 \
-  -v$TYPESENSE_DATA:/data typesense/typesense:$TS_VERSION \
+  -v$TYPESENSE_DATA:/data "typesense/typesense:$TS_VERSION" \
   --data-dir /data \
   --api-key=$TYPESENSE_API_KEY \
   --enable-cors
@@ -78,7 +78,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   # Prepare data to be indexed by Typesense
   echo "-- Preparing data to be consumed by Typesense..."
   data_filename="${SIZE}_ts.json"
-  head -n $SIZE $WIKI_ARTICLES_FILE > $data_filename
+  head -n "$SIZE" "$WIKI_ARTICLES_FILE" > $data_filename
 
   # Time indexing
   echo "-- Loading data of size $SIZE into wikipedia_articles index..."
@@ -100,7 +100,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
 
   # Cleanup: delete the index and temporary data file
   echo "-- Cleaning up..."
-  rm $data_filename
+  rm "$data_filename"
   curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE "http://localhost:8108/collections/wikipedia_articles"
   echo ""
   echo "Done!"

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -40,7 +40,7 @@ docker run \
   -d \
   --name typesense \
   -p $PORT:8108 \
-  -v$TYPESENSE_DATA:/data "typesense/typesense:$TS_VERSION" \
+  -v"$TYPESENSE_DATA:/data" "typesense/typesense:$TS_VERSION" \
   --data-dir /data \
   --api-key=$TYPESENSE_API_KEY \
   --enable-cors
@@ -78,7 +78,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   # Prepare data to be indexed by Typesense
   echo "-- Preparing data to be consumed by Typesense..."
   data_filename="${SIZE}_ts.json"
-  head -n "$SIZE" "$WIKI_ARTICLES_FILE" > $data_filename
+  head -n "$SIZE" "$WIKI_ARTICLES_FILE" > "$data_filename"
 
   # Time indexing
   echo "-- Loading data of size $SIZE into wikipedia_articles index..."

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -73,7 +73,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
         {"name": "body", "type": "string"},
         {"name": "url", "type": "string"}
       ]
-    }'
+  }'
 
   # Prepare data to be indexed by Typesense
   echo "-- Preparing data to be consumed by Typesense..."

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -87,7 +87,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Time search
-  start_time=$( (time curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:$PORT/collections/wikipedia_articles/documents/search?q=Canada&query_by=title,body" > test_output.txt) 2>&1 )
+  start_time=$( (time curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:$PORT/collections/wikipedia_articles/documents/search?q=Canada&query_by=title,body" > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Confirm document count

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -35,8 +35,6 @@ echo "*******************************************************"
 echo ""
 
 # Download and run docker container for Typesense
-
-
 echo "Creating Typesense $TS_VERSION node..."
 docker run \
   -d \
@@ -57,7 +55,8 @@ echo "Done!"
 echo "Table Size,Index Time,Search Time" > $OUTPUT_CSV
 
 # Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
-TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
+# TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
+TABLE_SIZES=(600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
 
 for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""
@@ -78,6 +77,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   }'
 
   # Prepare data to be indexed by Typesense
+  echo ""
   echo "-- Preparing data to be consumed by Typesense..."
   data_filename="${SIZE}_ts.json"
   head -n "$SIZE" "$WIKI_ARTICLES_FILE" > "$data_filename"
@@ -94,7 +94,6 @@ for SIZE in "${TABLE_SIZES[@]}"; do
 
   # Confirm document count
   doc_count=$(curl --silent -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET "http://localhost:$PORT/collections/wikipedia_articles" | jq '.num_documents')
-  echo ""
   echo "-- Number of documents in wikipedia_articles index for size $SIZE: $doc_count"
 
   # Record times to CSV


### PR DESCRIPTION
## What
* Fix `tsquery` benchmarking
* Add another benchmarking script for Typesense

TODOs (added by Phil): 
- Update all benchmarks in README once we've run them all in CI
- Fix the issue with Typesense failing at 600k+ rows
I am opening up a new issue for these

## Why
* `tsquery` benchmarking was originally not actually indexing - we add the gin index here.
* More benches

## How
🤔 

## Tests
Run the benchmarking scripts!
