### PR TITLE
fix: Make all benchmarks download dataset

### DIFF
--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -6,6 +6,9 @@ set -Eeuo pipefail
 # Ensure the "out" directory exists
 mkdir -p out
 
+# shellcheck disable=SC1091
+source "helpers/get_data.sh"
+
 PORT=9200
 ES_VERSION=8.9.2
 WIKI_ARTICLES_FILE=wiki-articles.json
@@ -48,6 +51,12 @@ docker run \
 echo ""
 echo "Waiting for server to spin up..."
 sleep 40
+echo "Done!"
+
+# Retrieve the benchmarking dataset
+echo ""
+echo "Retrieving dataset..."
+download_data
 echo "Done!"
 
 # Produce and save password

--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -90,6 +90,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   curl --cacert http_ca.crt -u elastic:"$ELASTIC_PASSWORD" -X POST "https://localhost:$PORT/wikipedia_articles/_refresh"
 
   # Time search
+  echo "-- Timing search..."
   start_time=$( (time curl --cacert http_ca.crt -u elastic:"$ELASTIC_PASSWORD" -X GET "https://localhost:$PORT/wikipedia_articles/_search?pretty" -H 'Content-Type: application/json' -d'
       {
         "query": {

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -6,6 +6,9 @@ set -Eeuo pipefail
 # Ensure the "out" directory exists
 mkdir -p out
 
+# shellcheck disable=SC1091
+source "helpers/get_data.sh"
+
 PORT=8108
 TS_VERSION=0.25.1
 WIKI_ARTICLES_FILE=wiki-articles.json
@@ -49,6 +52,12 @@ docker run \
 echo ""
 echo "Waiting for server to spin up..."
 sleep 30
+echo "Done!"
+
+# Retrieve the benchmarking dataset
+echo ""
+echo "Retrieving dataset..."
+download_data
 echo "Done!"
 
 # Output file for recording times

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -64,49 +64,37 @@ echo "Done!"
 echo "Table Size,Index Time,Search Time" > $OUTPUT_CSV
 
 # Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
-# TODO: Make it work on more tham 600k rows -- currently times out due to curl runs out of memory
-# TABLE_SIZES=(600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
-TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000)
+TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 2000000 3000000 4000000 5000000)
 
 for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""
   echo "Running benchmarking suite on index with $SIZE documents..."
 
   # Create Typesense collection (only if it doesn't exist)
-  COLLECTION_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/collections/wikipedia_articles")
-  if [ "$COLLECTION_EXISTS" -ne "200" ]; then
+  COLLECTION_EXISTS=$(python3 helpers/typesense_requests.py collection_exists)
+  if [ "$COLLECTION_EXISTS" -eq "0" ]; then
     echo "-- Creating Typesense collection..."
-    curl "http://localhost:$PORT/collections" \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '{
-        "name": "wikipedia_articles",
-        "fields": [
-          {"name": "title", "type": "string"},
-          {"name": "body", "type": "string"},
-          {"name": "url", "type": "string"}
-        ]
-    }'
+    python3 helpers/typesense_requests.py create_collection
   fi
 
   # Prepare data to be indexed by Typesense
-  echo ""
   echo "-- Preparing data to be consumed by Typesense..."
   data_filename="${SIZE}_ts.json"
   head -n "$SIZE" "$WIKI_ARTICLES_FILE" > "$data_filename"
 
-  # Time indexing using bulk import
+  # Time indexing
   echo "-- Loading data of size $SIZE into wikipedia_articles index..."
   echo "-- Timing indexing..."
-  start_time=$( (time curl "http://localhost:$PORT/collections/wikipedia_articles/documents/import?batch_size=500" -X POST -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" --data-binary @"$data_filename") )
+  start_time=$( (time python3 helpers/typesense_requests.py bulk_import "$data_filename" > /dev/null) 2>&1 )
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Time search
-  start_time=$( (time curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:$PORT/collections/wikipedia_articles/documents/search?q=Canada&query_by=title,body" > /dev/null) 2>&1 )
+  echo "-- Timing search..."
+  start_time=$( (time python3 helpers/typesense_requests.py search > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Confirm document count
-  doc_count=$(curl --silent -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET "http://localhost:$PORT/collections/wikipedia_articles" | jq '.num_documents')
+  doc_count=$(python3 helpers/typesense_requests.py num_documents)
   echo "-- Number of documents in wikipedia_articles index for size $SIZE: $doc_count"
 
   # Record times to CSV

--- a/benchmarks/helpers/get_data.sh
+++ b/benchmarks/helpers/get_data.sh
@@ -16,8 +16,8 @@ db_query () {
   PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PORT" -d "$DATABASE" -U "$USER" -c "$QUERY"
 }
 
-# This function downloads the benchmarking dataset and loads it into the benchmarking database
-load_data () {
+# Helper function to download the benchmarking dataset
+download_data () {
   if [ ! -f "$WIKI_ARTICLES_FILE" ]; then
     if wget https://www.dropbox.com/s/wwnfnu441w1ec9p/$WIKI_ARTICLES_FILE.bz2 -O $WIKI_ARTICLES_FILE.bz2; then
       echo "-- Unzipping $WIKI_ARTICLES_FILE..."
@@ -30,7 +30,13 @@ load_data () {
   else
     echo "-- Dataset $WIKI_ARTICLES_FILE found, skipping download."
   fi
+}
 
+# This function loads the benchmarking dataset into the benchmarking database, for SQL-based benchmarks
+load_data () {
+  # First, download the dataset
+  download_data
+  
   # In order to pull entries from your local files, you have to use the combo of cat and COPY FROM STDIN with the -c option
   echo "-- Creating table for JSON entries and loading entries from file into table (this may take a few minutes)..."
   db_query "DROP TABLE IF EXISTS temp_json;"

--- a/benchmarks/helpers/typesense_requests.py
+++ b/benchmarks/helpers/typesense_requests.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import requests
+import json
+import sys
+
+BASE_URL = "http://localhost:8108"
+API_KEY = "xyz"
+HEADERS = {
+    "Content-Type": "application/json",
+    "X-TYPESENSE-API-KEY": API_KEY
+}
+
+def collection_exists():
+    response = requests.get(f"{BASE_URL}/collections/wikipedia_articles", headers=HEADERS)
+    return 1 if response.status_code == 200 else 0
+
+def create_collection():
+    data = {
+        "name": "wikipedia_articles",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "body", "type": "string"},
+            {"name": "url", "type": "string"}
+        ]
+    }
+    requests.post(f"{BASE_URL}/collections", headers=HEADERS, json=data)
+
+def bulk_import(data_filename):
+    try:
+        with open(data_filename, 'r', encoding='utf-8') as f:
+            data = f.read().encode('utf-8')
+        response = requests.post(f"{BASE_URL}/collections/wikipedia_articles/documents/import?batch_size=500", headers=HEADERS, data=data)
+        response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an error
+    except requests.RequestException as e:
+        print(f"Error in bulk_import: {e}")
+        sys.exit(1)
+
+def search():
+    params = {
+        "q": "Canada",
+        "query_by": "title,body"
+    }
+    requests.get(f"{BASE_URL}/collections/wikipedia_articles/documents/search", headers=HEADERS, params=params)
+
+def num_documents():
+    response = requests.get(f"{BASE_URL}/collections/wikipedia_articles", headers=HEADERS)
+    return json.loads(response.text)['num_documents']
+
+if __name__ == "__main__":
+    action = sys.argv[1]
+    if action == "collection_exists":
+        print(collection_exists())
+    elif action == "create_collection":
+        create_collection()
+    elif action == "bulk_import":
+        bulk_import(sys.argv[2])
+    elif action == "search":
+        search()
+    elif action == "num_documents":
+        print(num_documents())


### PR DESCRIPTION
…its not there yet

# Ticket(s) Closed

- Closes #

## What
The Elastic and Typesense benchmarks didn't download the dataset if it's not there, leading to them not working in CI.

## Why

## How

## Tests
