### PR TITLE
fix: Download dataset for elastic and typesense too

### DIFF
--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -6,6 +6,9 @@ set -Eeuo pipefail
 # Ensure the "out" directory exists
 mkdir -p out
 
+# shellcheck disable=SC1091
+source "helpers/get_data.sh"
+
 PORT=9200
 ES_VERSION=8.9.2
 WIKI_ARTICLES_FILE=wiki-articles.json
@@ -50,6 +53,12 @@ echo "Waiting for server to spin up..."
 sleep 40
 echo "Done!"
 
+# Retrieve the benchmarking dataset
+echo ""
+echo "Retrieving dataset..."
+download_data
+echo "Done!"
+
 # Produce and save password
 echo ""
 echo "Producing and saving new ElasticSearch password..."
@@ -81,6 +90,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   curl --cacert http_ca.crt -u elastic:"$ELASTIC_PASSWORD" -X POST "https://localhost:$PORT/wikipedia_articles/_refresh"
 
   # Time search
+  echo "-- Timing search..."
   start_time=$( (time curl --cacert http_ca.crt -u elastic:"$ELASTIC_PASSWORD" -X GET "https://localhost:$PORT/wikipedia_articles/_search?pretty" -H 'Content-Type: application/json' -d'
       {
         "query": {

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -107,6 +107,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Time search
+  echo "-- Timing search..."
   start_time=$( (time curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:$PORT/collections/wikipedia_articles/documents/search?q=Canada&query_by=title,body" > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -25,7 +25,6 @@ cleanup() {
     docker kill typesense
   fi
   docker rm typesense
-  sudo rm -rf "$TYPESENSE_DATA"
   echo "Done!"
 }
 

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -25,7 +25,7 @@ cleanup() {
     docker kill typesense
   fi
   docker rm typesense
-  rm -rf "$TYPESENSE_DATA"
+  sudo rm -rf "$TYPESENSE_DATA"
   echo "Done!"
 }
 

--- a/benchmarks/benchmark-typesense.sh
+++ b/benchmarks/benchmark-typesense.sh
@@ -6,6 +6,9 @@ set -Eeuo pipefail
 # Ensure the "out" directory exists
 mkdir -p out
 
+# shellcheck disable=SC1091
+source "helpers/get_data.sh"
+
 PORT=8108
 TS_VERSION=0.25.1
 WIKI_ARTICLES_FILE=wiki-articles.json
@@ -50,6 +53,12 @@ docker run \
 echo ""
 echo "Waiting for server to spin up..."
 sleep 30
+echo "Done!"
+
+# Retrieve the benchmarking dataset
+echo ""
+echo "Retrieving dataset..."
+download_data
 echo "Done!"
 
 # Output file for recording times

--- a/benchmarks/helpers/get_data.sh
+++ b/benchmarks/helpers/get_data.sh
@@ -16,8 +16,8 @@ db_query () {
   PGPASSWORD="$PASSWORD" psql -h "$HOST" -p "$PORT" -d "$DATABASE" -U "$USER" -c "$QUERY"
 }
 
-# This function downloads the benchmarking dataset and loads it into the benchmarking database
-load_data () {
+# Helper function to download the benchmarking dataset
+download_data () {
   if [ ! -f "$WIKI_ARTICLES_FILE" ]; then
     if wget https://www.dropbox.com/s/wwnfnu441w1ec9p/$WIKI_ARTICLES_FILE.bz2 -O $WIKI_ARTICLES_FILE.bz2; then
       echo "-- Unzipping $WIKI_ARTICLES_FILE..."
@@ -30,6 +30,12 @@ load_data () {
   else
     echo "-- Dataset $WIKI_ARTICLES_FILE found, skipping download."
   fi
+}
+
+# This function loads the benchmarking dataset into the benchmarking database, for SQL-based benchmarks
+load_data () {
+  # First, download the dataset
+  download_data
 
   # In order to pull entries from your local files, you have to use the combo of cat and COPY FROM STDIN with the -c option
   echo "-- Creating table for JSON entries and loading entries from file into table (this may take a few minutes)..."


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Right now, in CI the benchmarks don't work for Elastic and Typesense because we don't download the dataset. This fixes it.

## Why

## How

## Tests
