### PR TITLE
feat: implement fuzzy scoring by pinning latest version of paradedb-tantivy

### DIFF
--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -25,7 +25,7 @@ rustc-hash = "1.1.0"
 serde = "1.0.188"
 serde_json = "1.0.105"
 serde_qs = "0.12.0"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "paradedb-tantivy" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "paradedb-tantivy", rev = "227ddda1" }
 utoipa = "3.5.0"
 
 [dev-dependencies]


### PR DESCRIPTION
# Ticket(s) Closed
Closes #309

Our paradedb-tantivy fork now contains an initial implementation of fuzzy scoring. This PR pins the version in our `pg_bm25` Cargo.toml file to point to the newest version of the fork.

The work in the current version of paradedb-tantivy takes somewhat of a naive approach, which is just to add together inverted levenshtein distances. It means that we'll "give extra points" to documents that contain multiple relevant terms.
For example, consider these (score, document) pairs, returned for the search term "Rob".
```
1, Str("WHEN GOLD LIKE ROB")
0.8333334, Str("WENN ROT WIE ROBIN")
0.6666667, Str("WHEN RED LIKE ROBIN")
0.5, Str("IF BRONZE LIKE ROBE")
```

Notice that the second item's score is higher than the third, because we match on both "ROBIN" and "ROT".
Next, "RED" is still distance 2 away from ROB, so it contributes to the score along with "ROBIN".
Since the final result only has 1 similar term, "ROBE", it scores lower.

It's easy to put exact matches at the top, which this algorithm does. But it's a little ambiguous what to do with the non-exact matches. The algorithm will blend the score using all the terms in the document that are Levenshtein 2 to the query... and that may not be your preference as a fuzzy search user. You may only care about the score for the single term in the document that is the closest to your query.

But in my testing, I find the approach we have here to be intuitive, with the results being returned in the order I would personally expect.  The most important thing is that exact matches are at the top, and that the ordering follows a reasonable logic.

Down the road, we can refine this by adding options for users to fine-tune fuzzy scoring.