### PR TITLE
chore: use precompiled extensions in S3

### DIFF
--- a/.github/workflows/publish-paradedb-to-dockerhub.yml
+++ b/.github/workflows/publish-paradedb-to-dockerhub.yml
@@ -70,6 +70,8 @@ jobs:
             HYPOPG_VERSION=1.4.0
             RUM_VERSION=1.3.13
             AGE_VERSION=1.4.0-rc0
+            PGX_GET_AWS_ACCESS_KEY=${{ secrets.PGX_GET_AWS_ACCESS_KEY }}
+            PGX_GET_AWS_SECRET_KEY=${{ secrets.PGX_GET_AWS_SECRET_KEY }}
           platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           push: true

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -142,10 +142,13 @@ RUN sed -i "s/version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"${PG_SEARCH_VERSI
 
 FROM builder as builder-others
 
-COPY scripts/install_pg_extensions.sh /usr/local/bin/
+ARG S3_SECRET_KEY
+ARG S3_ACCESS_KEY
 
 ENV S3_ACCESS_KEY=${S3_ACCESS_KEY} \
     S3_SECRET_KEY=${S3_SECRET_KEY}
+
+COPY scripts/install_pg_extensions.sh /usr/local/bin/
 
 # Compile and install extensions from source
 RUN /usr/local/bin/install_pg_extensions.sh \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -144,6 +144,9 @@ FROM builder as builder-others
 
 COPY scripts/install_pg_extensions.sh /usr/local/bin/
 
+ENV S3_ACCESS_KEY=${S3_ACCESS_KEY} \
+    S3_SECRET_KEY=${S3_SECRET_KEY}
+
 # Compile and install extensions from source
 RUN /usr/local/bin/install_pg_extensions.sh \
     "pgvector,${PGVECTOR_VERSION},https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -142,12 +142,6 @@ RUN sed -i "s/version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"${PG_SEARCH_VERSI
 
 FROM builder as builder-others
 
-ARG S3_SECRET_KEY
-ARG S3_ACCESS_KEY
-
-ENV S3_ACCESS_KEY=${S3_ACCESS_KEY} \
-    S3_SECRET_KEY=${S3_SECRET_KEY}
-
 COPY scripts/install_pg_extensions.sh /usr/local/bin/
 
 # Compile and install extensions from source

--- a/scripts/install_pg_extensions.sh
+++ b/scripts/install_pg_extensions.sh
@@ -15,10 +15,41 @@ sanitize_version() {
 }
 
 
-# Function to compile & package a single PostgreSQL extension as a .deb
-# Example:
-# install_pg_extension "pg_cron" "1.0.0" "https://github.com/citusdata/pg_cron/archive/refs/tags/v1.0.0.tar.gz"
-install_pg_extension() {
+
+
+check_pgx_package_exists() {
+  local s3_bucket_url="https://pgx-get.s3.amazonaws.com"
+  local deb_file="$1"
+
+  # Check if the .deb file exists by sending a HEAD request
+  response_code=$(curl -s -o /dev/null -w "%{http_code}" -I "$s3_bucket_url/$deb_file")
+
+  if [ "$response_code" == "200" ]; then
+    return 0  # File exists
+  else
+    return 1  # File doesn't exist
+  fi
+}
+
+download_pgx_package() {
+  local s3_bucket_url="https://pgx-get.s3.amazonaws.com"
+  local deb_file="$1"
+
+  # Download the .deb file from S3
+  curl -O "$s3_bucket_url/$deb_file"
+  echo ".deb file downloaded from S3."
+}
+
+upload_pgx_package() {
+  local s3_bucket_url="https://pgx-get.s3.amazonaws.com"
+  local deb_file="$1"
+
+  # Upload the .deb file to S3 using a PUT request
+  curl -X PUT --upload-file "$deb_file" "$s3_bucket_url/$deb_file"
+  echo ".deb file created and uploaded to S3."
+}
+
+compile_pgx_package() {
   local PG_EXTENSION_NAME=$1
   local PG_EXTENSION_VERSION=$2
   local PG_EXTENSION_URL=$3
@@ -50,6 +81,33 @@ install_pg_extension() {
   fi
   make OPTFLAGS="$OPTFLAGS" "-j$(nproc)"
   checkinstall -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp
+}
+
+
+
+
+
+
+
+
+# Function to compile & package a single PostgreSQL extension as a .deb
+# Example:
+# install_pg_extension "pg_cron" "1.0.0" "https://github.com/citusdata/pg_cron/archive/refs/tags/v1.0.0.tar.gz"
+install_pg_extension() {
+  local PG_EXTENSION_NAME=$1
+  local PG_EXTENSION_VERSION=$2
+  local PG_EXTENSION_URL=$3
+
+  # If the extension package already exists in S3, we simply retrieve it. Otherwise we compile and upload it
+  Check if the extension is already compiled and stored in S3
+  if check_pgx_package_exists "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"; then
+    echo "Extension package $PG_EXTENSION_NAME-$PG_EXTENSION_VERSION already exists in S3, downloading pre-compiled package..."
+    download_pgx_package "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"
+  else
+    echo "Extension package $PG_EXTENSION_NAME-$PG_EXTENSION_VERSION does not exist in S3, compiling and uploading..."
+    compile_pgx_package "$PG_EXTENSION_NAME" "$PG_EXTENSION_VERSION" "$PG_EXTENSION_URL"
+    upload_pgx_package "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"
+  fi
 }
 
 

--- a/scripts/install_pg_extensions.sh
+++ b/scripts/install_pg_extensions.sh
@@ -41,6 +41,15 @@ upload_pgx_package() {
   local s3_bucket="pgx-get"
   local deb_filename="$1"
 
+  # s3 keys -- environment variables
+  if [[ -z ${S3_ACCESS_KEY}  ||  -z ${S3_SECRET_KEY} ]]; then 
+    echo "S3 keys not set... not uploading to S3"
+    return
+  fi
+
+  local s3_access_key="$S3_ACCESS_KEY"
+  local s3_secret_key="$S3_SECRET_KEY"
+
   # about the file
   local bucket_filepath="/${s3_bucket}/${deb_filename}"
   local all_users_group="uri=http://acs.amazonaws.com/groups/global/AllUsers"
@@ -49,10 +58,6 @@ upload_pgx_package() {
   local contentType="application/x-compressed-tar"
   local dateValue=`date -R`
   local signature_string="PUT\n\n${contentType}\n${dateValue}\nx-amz-grant-read:${all_users_group}\n${bucket_filepath}"
-
-  # s3 keys -- environment variables
-  local s3_access_key="$S3_ACCESS_KEY"
-  local s3_secret_key="$S3_SECRET_KEY"
 
   # prepare signature hash to be sent in Authorization header
   local signature_hash=`echo -en ${signature_string} | openssl sha1 -hmac ${s3_secret_key} -binary | base64`

--- a/scripts/install_pg_extensions.sh
+++ b/scripts/install_pg_extensions.sh
@@ -14,9 +14,6 @@ sanitize_version() {
   echo "$VERSION" | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/;s/[^0-9]*[0-9]+_([0-9]+)_([0-9]+)_([0-9]+).*/\1.\2.\3/'
 }
 
-
-
-
 check_pgx_package_exists() {
   local s3_bucket_url="https://pgx-get.s3.amazonaws.com"
   local deb_file="$1"
@@ -44,8 +41,32 @@ upload_pgx_package() {
   local s3_bucket_url="https://pgx-get.s3.amazonaws.com"
   local deb_file="$1"
 
+  # about the file
+  file_to_upload=$deb_file
+  bucket=pgx-get
+  filepath="/${bucket}/${file_to_upload}"
+
+  # metadata
+  contentType="application/x-compressed-tar"
+  dateValue=`date -R`
+  signature_string="PUT\n\n${contentType}\n${dateValue}\n${filepath}"
+
+  #s3 keys
+  s3_access_key=$S3_ACCESS_KEY
+  s3_secret_key=$S3_SECRET_KEY
+
+  #prepare signature hash to be sent in Authorization header
+  signature_hash=`echo -en ${signature_string} | openssl sha1 -hmac ${s3_secret_key} -binary | base64`
+
+  echo lol
+
   # Upload the .deb file to S3 using a PUT request
-  curl -X PUT --upload-file "$deb_file" "$s3_bucket_url/$deb_file"
+  curl -X PUT -T "/tmp/${file_to_upload}" \
+    -H "Host: ${bucket}.s3.amazonaws.com" \
+    -H "Date: ${dateValue}" \
+    -H "Content-Type: ${contentType}" \
+    -H "Authorization: AWS ${s3_access_key}:${signature_hash}" \
+    https://${bucket}.s3.amazonaws.com/${file_to_upload}
   echo ".deb file created and uploaded to S3."
 }
 
@@ -59,10 +80,16 @@ compile_pgx_package() {
   SANITIZED_VERSION=$(sanitize_version "$PG_EXTENSION_VERSION")
 
   # Download & extract source code
+  echo "mkdir -p /tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
   mkdir -p "/tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
+  echo "curl -L $PG_EXTENSION_URL" -o "/tmp/$PG_EXTENSION_NAME.tar.gz"
   curl -L "$PG_EXTENSION_URL" -o "/tmp/$PG_EXTENSION_NAME.tar.gz"
+  echo "tar -xvf /tmp/$PG_EXTENSION_NAME.tar.gz --strip-components=1 -C /tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
   tar -xvf "/tmp/$PG_EXTENSION_NAME.tar.gz" --strip-components=1 -C "/tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
+  echo "cd /tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
   cd "/tmp/$PG_EXTENSION_NAME-$SANITIZED_VERSION"
+
+  echo "Done with this stuff"
 
   # Set OPTFLAGS to an empty string if it's not already set
   OPTFLAGS=${OPTFLAGS:-""}
@@ -79,7 +106,9 @@ compile_pgx_package() {
     mkdir build && cd build
     cmake ..
   fi
+  echo make OPTFLAGS="$OPTFLAGS" "-j$(nproc)"
   make OPTFLAGS="$OPTFLAGS" "-j$(nproc)"
+  echo checkinstall -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp 
   checkinstall -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp
 }
 
@@ -99,14 +128,13 @@ install_pg_extension() {
   local PG_EXTENSION_URL=$3
 
   # If the extension package already exists in S3, we simply retrieve it. Otherwise we compile and upload it
-  Check if the extension is already compiled and stored in S3
-  if check_pgx_package_exists "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"; then
-    echo "Extension package $PG_EXTENSION_NAME-$PG_EXTENSION_VERSION already exists in S3, downloading pre-compiled package..."
-    download_pgx_package "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"
+  if check_pgx_package_exists "${PG_EXTENSION_NAME}_${PG_EXTENSION_VERSION}-1_arm64.deb"; then
+    echo "Extension package ${PG_EXTENSION_NAME}_${PG_EXTENSION_VERSION} already exists in S3, downloading pre-compiled package..."
+    download_pgx_package "${PG_EXTENSION_NAME}_${PG_EXTENSION_VERSION}-1_arm64.deb"
   else
-    echo "Extension package $PG_EXTENSION_NAME-$PG_EXTENSION_VERSION does not exist in S3, compiling and uploading..."
+    echo "Extension package ${PG_EXTENSION_NAME}_${PG_EXTENSION_VERSION} does not exist in S3, compiling and uploading..."
     compile_pgx_package "$PG_EXTENSION_NAME" "$PG_EXTENSION_VERSION" "$PG_EXTENSION_URL"
-    upload_pgx_package "$PG_EXTENSION_NAME-$PG_EXTENSION_VERSION.deb"
+    upload_pgx_package "${PG_EXTENSION_NAME}_${PG_EXTENSION_VERSION}-1_arm64.deb"
   fi
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #357

## What
Downloads extensions from S3 and compiles + uploads them if they don’t exist.

## Why
Speed up builds!

## How
S3 curls
**NOTE**: need to add `S3_SECRET_KEY` and `S3_ACCESS_KEY` to the Docker compose files to allow upload to the S3 bucket on compile.

^ We don't want to expose the S3 upload credentials to the public (so that they can't overwrite/corrupt the extensions with malware). As a result, we just bake them into the `prod` image for CI to compile/upload. For `dev` deployment, it will still pull but just won't upload

## Tests
