### PR TITLE
docs: fix broken anchor links in indexing/bm25

### DIFF
--- a/docs/indexing/bm25.mdx
+++ b/docs/indexing/bm25.mdx
@@ -73,15 +73,15 @@ WITH (
       the BM25 score.
     </ParamField>
     <ParamField body="tokenizer" default="default">
-      The name of the tokenizer. See [tokenizers]([indexing/bm25#tokenizers]) for a list of available tokenizers.
+      The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
     </ParamField>
     <ParamField body="record" default="basic">
-      Describes the amount of information indexed. See [records](indexing/bm25#records) for a list of available
+      Describes the amount of information indexed. See [records](#records) for a list of available
       record types.
     </ParamField>
     <ParamField body="normalizer" default="raw">
       The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](indexing/bm25#normalizers) for a list of available normalizers.
+      [normalizers](#normalizers) for a list of available normalizers.
     </ParamField>
   </Expandable>
 </ParamField>
@@ -140,15 +140,15 @@ WITH (
       `{"metadata.color": "red"}` will be indexed as if it was `{"metadata": {"color": "red"}}`.
     </ParamField>
     <ParamField body="tokenizer" default="default">
-      The name of the tokenizer. See [tokenizers]([indexing/bm25#tokenizers]) for a list of available tokenizers.
+      The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
     </ParamField>
     <ParamField body="record" default="basic">
-      Describes the amount of information indexed. See [records](indexing/bm25#records) for a list of available
+      Describes the amount of information indexed. See [records](#records) for a list of available
       record types.
     </ParamField>
     <ParamField body="normalizer" default="raw">
       The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](indexing/bm25#normalizers) for a list of available normalizers.
+      [normalizers](#normalizers) for a list of available normalizers.
     </ParamField>
   </Expandable>
 </ParamField>

--- a/docs/indexing/bm25.mdx
+++ b/docs/indexing/bm25.mdx
@@ -73,15 +73,15 @@ WITH (
       the BM25 score.
     </ParamField>
     <ParamField body="tokenizer" default="default">
-      The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
+      The name of the tokenizer. See [tokenizers](bm25#tokenizers) for a list of available tokenizers.
     </ParamField>
     <ParamField body="record" default="basic">
-      Describes the amount of information indexed. See [records](#records) for a list of available
+      Describes the amount of information indexed. See [records](bm25#records) for a list of available
       record types.
     </ParamField>
     <ParamField body="normalizer" default="raw">
       The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](#normalizers) for a list of available normalizers.
+      [normalizers](bm25#normalizers) for a list of available normalizers.
     </ParamField>
   </Expandable>
 </ParamField>
@@ -140,15 +140,15 @@ WITH (
       `{"metadata.color": "red"}` will be indexed as if it was `{"metadata": {"color": "red"}}`.
     </ParamField>
     <ParamField body="tokenizer" default="default">
-      The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
+      The name of the tokenizer. See [tokenizers](bm25#tokenizers) for a list of available tokenizers.
     </ParamField>
     <ParamField body="record" default="basic">
-      Describes the amount of information indexed. See [records](#records) for a list of available
+      Describes the amount of information indexed. See [records](bm25#records) for a list of available
       record types.
     </ParamField>
     <ParamField body="normalizer" default="raw">
       The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](#normalizers) for a list of available normalizers.
+      [normalizers](bm25#normalizers) for a list of available normalizers.
     </ParamField>
   </Expandable>
 </ParamField>


### PR DESCRIPTION
# Ticket(s) Closed

None ticket.

## What

Fix broken anchor links on the `indexing/bm25` page: 
https://docs.paradedb.com/indexing/bm25

## Why

## How

Change links on the `/docs` path.

## Tests
