### PR TITLE
build: Successful build and test on pg16

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -32,9 +32,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.9.8
+          key: ${{ runner.os }}-cargo-pgrx-0.10.1
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.9.8
+            ${{ runner.os }}-cargo-pgrx-0.10.1
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install pgrx
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: cargo install cargo-pgrx --version 0.9.8
+        run: cargo install cargo-pgrx --version 0.10.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg15=/usr/lib/postgresql/15/bin/pg_config

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -32,9 +32,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.10.1
+          key: ${{ runner.os }}-cargo-pgrx-0.11.0
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.10.1
+            ${{ runner.os }}-cargo-pgrx-0.11.0
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install pgrx
         if: steps.cache-cargo.outputs.cache-hit != 'true'
-        run: cargo install cargo-pgrx --version 0.10.1
+        run: cargo install cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg15=/usr/lib/postgresql/15/bin/pg_config

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -46,6 +46,12 @@ jobs:
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
+      - name: Remove old postgres, llvm, clang, and install appropriate version
+        run: |
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D14(\D.*)?$' | xargs sudo apt remove -y
+          sudo apt-get install -y llvm-14-dev libclang-14-dev clang-14 gcc
+
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -40,9 +40,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+          key: ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+            ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -57,7 +57,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install cargo-pgrx --version 0.9.8 && cargo install grcov
+          cargo install cargo-pgrx --version 0.10.1 && cargo install grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -40,9 +40,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
+          key: ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
+            ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -63,7 +63,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install cargo-pgrx --version 0.10.1 && cargo install grcov
+          cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [11, 12, 13, 14, 15]
+        pg_version: [11, 12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -46,6 +46,12 @@ jobs:
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
+      - name: Remove old postgres, llvm, clang, and install appropriate version
+        run: |
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D14(\D.*)?$' | xargs sudo apt remove -y
+          sudo apt-get install -y llvm-14-dev libclang-14-dev clang-14 gcc
+
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -40,9 +40,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+          key: ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.9.8-grcov
+            ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -57,7 +57,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install cargo-pgrx --version 0.9.8 && cargo install grcov
+          cargo install cargo-pgrx --version 0.10.1 && cargo install grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -40,9 +40,9 @@ jobs:
           path: |
             ~/.cargo/
             ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
+          key: ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
           restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.10.1-grcov
+            ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
             ${{ runner.os }}-cargo-pgrx
             ${{ runner.os }}-cargo
 
@@ -63,7 +63,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install cargo-pgrx --version 0.10.1 && cargo install grcov
+          cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [11, 12, 13, 14, 15]
+        pg_version: [11, 12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml",
 ]
 
 [[package]]
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c4fe036f9493e674a7db27f7a06d54acb89735a0c1d4421128c341d3cf240f"
+checksum = "bd3c4b36fbe84329b86c83bfd33b9514a50606f00074f47085f99062a7dd8c9c"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1335,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f9e2f46585b8f4540c72e26b079303b3520f8de0da090f96acaabe3f99e28"
+checksum = "9c6a41e021321a814fac1aa27bd4266208b4507709ecbc28fc99693adfbd0c41"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48800161320294c5a5ab72d38235e2e97f3bf1849661ee977502c8e64362285"
+checksum = "17da1e26800e747d501b8d8bb8aeee4530a07d93a39c3fb2c4229a8feff213b2"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1359,15 +1359,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "toml 0.8.2",
+ "toml",
  "url",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27dd6c4f2f098f62b5a8f07cf6447f640ce81637d20f269662a043a55195ed9d"
+checksum = "f9032b517525ec71579cc68e92905b5f5f63e892c094834202313c42f2f1a669"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7514a083c8c062f8bb9f53ced124f120515af3b49b92a57305e749ec736f98c"
+checksum = "2e4a88203974b887bca8bfdea17ab9936411fb7e84957763dc0124df78d07907"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a71327ab5e5ddbc2d43ffad391ce515a358096c3713b360b57c5eec107d1cb7"
+checksum = "c80deb4310538e6ef14f4cbb30b56eb24b6d7aae66bfd4e516f153987159e65e"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2287,19 +2287,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2309,19 +2297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -877,9 +877,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde2cf81d16772f2e75c91edd2e868de1bd67a79d6c45c3d25c62b2ed3851d70"
+checksum = "d2c4fe036f9493e674a7db27f7a06d54acb89735a0c1d4421128c341d3cf240f"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1335,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9c035c16a41b126f8c2b37307f2c717b5ee72ff8e7495ff502ad35471a0b38"
+checksum = "943f9e2f46585b8f4540c72e26b079303b3520f8de0da090f96acaabe3f99e28"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f9d9b6310ea9f13570d773d173bbcfe47ac844075bf6a3e207e7209786c631"
+checksum = "a48800161320294c5a5ab72d38235e2e97f3bf1849661ee977502c8e64362285"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1359,15 +1359,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "toml",
+ "toml 0.8.2",
  "url",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f821614646963302a8499b8ac8332cc0e2ae3f8715a0220986984443d8880f74"
+checksum = "27dd6c4f2f098f62b5a8f07cf6447f640ce81637d20f269662a043a55195ed9d"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4743b5b23fd418cded0c2dbe4b1529628f7fa59b8d68426eafdde0cb51541c96"
+checksum = "e7514a083c8c062f8bb9f53ced124f120515af3b49b92a57305e749ec736f98c"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177bb8f6811bd65180c5a24a33666baed0ed5c08cc584c4bdb78f7fe19304363"
+checksum = "9a71327ab5e5ddbc2d43ffad391ce515a358096c3713b360b57c5eec107d1cb7"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1535,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1675,14 +1675,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1696,13 +1696,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1716,6 +1716,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rust-stemmers"
@@ -2281,7 +2287,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -2291,6 +2309,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,7 +114,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
-RUN cargo install cargo-pgrx --version 0.10.1 && \
+RUN cargo install cargo-pgrx --version 0.11.0 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,7 +114,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
-RUN cargo install cargo-pgrx --version 0.9.8 && \
+RUN cargo install cargo-pgrx --version 0.10.1 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -15,13 +15,14 @@ pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = []
 
 [dependencies]
 csv = "1.2.2"
 json5 = "0.4.1"
 memoffset = "0.9.0"
-pgrx = "=0.9.8"
+pgrx = "=0.10.1"
 rustc-hash = "1.1.0"
 serde = "1.0.188"
 serde_json = "1.0.105"
@@ -30,4 +31,4 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "paradedb
 utoipa = "3.5.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.8"
+pgrx-tests = "=0.10.1"

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -22,7 +22,7 @@ pg_test = []
 csv = "1.2.2"
 json5 = "0.4.1"
 memoffset = "0.9.0"
-pgrx = "=0.10.1"
+pgrx = "=0.11.0"
 rustc-hash = "1.1.0"
 serde = "1.0.188"
 serde_json = "1.0.105"
@@ -31,4 +31,4 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "paradedb
 utoipa = "3.5.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.1"
+pgrx-tests = "=0.11.0"

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -183,7 +183,7 @@ Before developing the extension, ensure that you have Rust installed
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.9.8
+cargo install cargo-pgrx --version 0.10.1
 cargo pgrx init
 ```
 

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -183,7 +183,7 @@ Before developing the extension, ensure that you have Rust installed
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.10.1
+cargo install cargo-pgrx --version 0.11.0
 cargo pgrx init
 ```
 

--- a/pg_bm25/src/index_access/build.rs
+++ b/pg_bm25/src/index_access/build.rs
@@ -118,7 +118,7 @@ unsafe extern "C" fn build_callback(
     build_callback_internal(htup.t_self, values, state, index);
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
 #[pg_guard]
 unsafe extern "C" fn build_callback(
     index: pg_sys::Relation,

--- a/pg_bm25/src/index_access/cost.rs
+++ b/pg_bm25/src/index_access/cost.rs
@@ -33,14 +33,26 @@ pub unsafe extern "C" fn amcostestimate(
     #[cfg(any(feature = "pg10", feature = "pg11"))]
     let index_clauses = PgList::<pg_sys::RestrictInfo>::from_pg(path.indexclauses);
 
-    #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
+    #[cfg(any(
+        feature = "pg12",
+        feature = "pg13",
+        feature = "pg14",
+        feature = "pg15",
+        feature = "pg16"
+    ))]
     let index_clauses = PgList::<pg_sys::IndexClause>::from_pg(path.indexclauses);
 
     for clause in index_clauses.iter_ptr() {
         #[cfg(any(feature = "pg10", feature = "pg11"))]
         let ri = clause.as_ref().expect("restrict info is NULL");
 
-        #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
+        #[cfg(any(
+            feature = "pg12",
+            feature = "pg13",
+            feature = "pg14",
+            feature = "pg15",
+            feature = "pg16"
+        ))]
         let ri = clause
             .as_ref()
             .unwrap()

--- a/pg_bm25/src/index_access/insert.rs
+++ b/pg_bm25/src/index_access/insert.rs
@@ -8,7 +8,7 @@ use crate::index_access::utils::{
 const INDEX_WRITER_MEM_BUDGET: usize = 50_000_000;
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(any(feature = "pg14", feature = "pg15"))]
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,

--- a/pg_bm25/src/index_access/mod.rs
+++ b/pg_bm25/src/index_access/mod.rs
@@ -18,7 +18,7 @@ COMMENT ON ACCESS METHOD bm25 IS 'bm25 index access method';
 ")]
 fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
     let mut amroutine =
-        unsafe { PgBox::<pg_sys::IndexAmRoutine>::alloc_node(pg_sys::NodeTag_T_IndexAmRoutine) };
+        unsafe { PgBox::<pg_sys::IndexAmRoutine>::alloc_node(pg_sys::NodeTag::T_IndexAmRoutine) };
 
     amroutine.amstrategies = 4;
     amroutine.amsupport = 0;

--- a/pg_bm25/src/index_access/options.rs
+++ b/pg_bm25/src/index_access/options.rs
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn amoptions(
     build_relopts(reloptions, validate, options)
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
 unsafe fn build_relopts(
     reloptions: pg_sys::Datum,
     validate: bool,
@@ -247,7 +247,7 @@ pub unsafe fn init() {
         "JSON string specifying how text fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_text_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -258,7 +258,7 @@ pub unsafe fn init() {
         "JSON string specifying how numeric fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_numeric_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -269,7 +269,7 @@ pub unsafe fn init() {
         "JSON string specifying how boolean fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_boolean_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -280,7 +280,7 @@ pub unsafe fn init() {
         "JSON string specifying how JSON fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_json_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -186,7 +186,13 @@ pub extern "C" fn amgettuple(
         Some((score, doc_address)) => {
             #[cfg(any(feature = "pg10", feature = "pg11"))]
             let tid = &mut scan.xs_ctup.t_self;
-            #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
+            #[cfg(any(
+                feature = "pg12",
+                feature = "pg13",
+                feature = "pg14",
+                feature = "pg15",
+                feature = "pg16"
+            ))]
             let tid = &mut scan.xs_heaptid;
 
             let searcher = &state.searcher;

--- a/pg_bm25/src/operator/mod.rs
+++ b/pg_bm25/src/operator/mod.rs
@@ -74,7 +74,13 @@ pub fn scan_index(query: &str, index_oid: pg_sys::Oid) -> FxHashSet<u64> {
                 item_pointer_to_u64(htup.as_ref().unwrap().t_self)
             };
 
-            #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
+            #[cfg(any(
+                feature = "pg12",
+                feature = "pg13",
+                feature = "pg14",
+                feature = "pg15",
+                feature = "pg16"
+            ))]
             let tid = {
                 let slot = pg_sys::MakeSingleTupleTableSlot(
                     heap.as_ref().unwrap().rd_att,

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -15,11 +15,12 @@ pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.8"
+pgrx = "=0.10.1"
 serde = "1.0.188"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.8"
+pgrx-tests = "=0.10.1"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,8 +19,8 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.1"
+pgrx = "=0.11.0"
 serde = "1.0.188"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.1"
+pgrx-tests = "=0.11.0"

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -117,7 +117,7 @@ Before developing the extension, ensure that you have Rust installed
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.9.8
+cargo install cargo-pgrx --version 0.10.1
 cargo pgrx init
 ```
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -117,7 +117,7 @@ Before developing the extension, ensure that you have Rust installed
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.10.1
+cargo install cargo-pgrx --version 0.11.0
 cargo pgrx init
 ```
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # 252

## What and why

Changes the version of pgrx to 0.10.1, which aligns with pgml and allows to use Postgres 16

## How

Version upgrades, add pg16 as required.

## Tests

Ran the pg_bm25 tests successfully.
