### PR TITLE
feat: Use json5 crate to parse index/query options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
  "bitflags 2.4.0",
  "cexpr",
@@ -137,6 +137,21 @@ dependencies = [
  "shlex",
  "syn 2.0.37",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -200,9 +215,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.3"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
+checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
  "toml",
@@ -262,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
+checksum = "25122ca6ebad5f53578c26638afd9f0160426969970dc37ec6c363ff6b082ebd"
 dependencies = [
  "clap",
  "doc-comment",
@@ -832,6 +847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +890,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1030,6 +1062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,13 +1229,47 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -1211,6 +1287,7 @@ name = "pg_bm25"
 version = "0.0.0"
 dependencies = [
  "csv",
+ "json5",
  "memoffset",
  "paradedb-tantivy",
  "pgrx",
@@ -1233,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e80e25d7f85997d5d24c824297529bcb73231bbdc74d77906004d41cd3ffee3"
+checksum = "dde2cf81d16772f2e75c91edd2e868de1bd67a79d6c45c3d25c62b2ed3851d70"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1258,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999ef782b36bb511806277f2a74a7f9e075edcad8c9439a3b90f4c90384f2a29"
+checksum = "1b9c035c16a41b126f8c2b37307f2c717b5ee72ff8e7495ff502ad35471a0b38"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1270,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b27ccd3d892e3b27bcb7a6e2bf86588d82fad3da622db168261bc6b534a737"
+checksum = "16f9d9b6310ea9f13570d773d173bbcfe47ac844075bf6a3e207e7209786c631"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1288,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0767fdf6930ba6fa2d1b1934313aae3694b70732e0b6169ece26b03de27f8dc"
+checksum = "f821614646963302a8499b8ac8332cc0e2ae3f8715a0220986984443d8880f74"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1310,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d632abaa9c3da42e5e2a17a6268afb0449a7f655764c65e06695ee55763ff0e"
+checksum = "4743b5b23fd418cded0c2dbe4b1529628f7fa59b8d68426eafdde0cb51541c96"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1325,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.8"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44327bd084bcdc6fe4e72dfce8065e23b5b4522f36d63d14ee21c5000e7c73c"
+checksum = "177bb8f6811bd65180c5a24a33666baed0ed5c08cc584c4bdb78f7fe19304363"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1338,6 +1415,7 @@ dependencies = [
  "pgrx-macros",
  "pgrx-pg-config",
  "postgres",
+ "proptest",
  "rand",
  "regex",
  "serde",
@@ -1465,6 +1543,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.7.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1662,6 +1775,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2149,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2170,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
@@ -2254,6 +2379,12 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unescape"
@@ -2350,6 +2481,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/docs/aggregations/bucket.mdx
+++ b/docs/aggregations/bucket.mdx
@@ -20,7 +20,7 @@ FROM paradedb.aggregation('<index_name>', '<aggregation_query>');
 SELECT *
 FROM paradedb.aggregation(
     'idx_mock_items',
-    '{"aggs": {"histogram": {"field": "rating", "interval": 2}}}'
+    '{aggs: {histogram: {field: rating, interval: 2}}}'
 )
 ```
 
@@ -34,6 +34,8 @@ FROM paradedb.aggregation(
 
 ## Bucket Aggregation JSON Format
 
+Aggregation queries are a [JSON5](https://json5.org)-formatted string. Keys don't need to be quoted, and trailing commas and comments are allowed. JSON5 is backwards-compatible, so standard JSON works too.
+
 ### Histogram
 
 The `Histogram` aggregation returns a list of buckets, each representing a specific range of values in the
@@ -41,9 +43,9 @@ aggregated field.
 
 ```sql
 '{
-    "histogram": {
-        "field": "rating",
-        "interval": 2
+    histogram: {
+        field: "rating",
+        interval: 2
     }
 }'
 ```
@@ -82,11 +84,11 @@ enabling a clear, segmented view of data distribution across defined boundaries.
 
 ```sql
 '{
-    "range": {
-        "field": "rating",
-        "ranges": [
-            { "to": 3.0 },
-            { "from": 3.0, "to": 7.0 }
+    range: {
+        field: "rating",
+        ranges: [
+            { to: 3.0 },
+            { from: 3.0, to: 7.0 }
         ]
     }
 }'
@@ -114,8 +116,8 @@ The `Terms` aggregation creates a bucket for every unique term and counts the nu
 
 ```sql
 '{
-    "terms": {
-        "field": "description"
+    terms: {
+        field: "description"
     }
 }'
 ```

--- a/docs/aggregations/metrics.mdx
+++ b/docs/aggregations/metrics.mdx
@@ -20,7 +20,7 @@ FROM paradedb.aggregation('<index_name>', '<aggregation_query>');
 SELECT *
 FROM paradedb.aggregation(
     'idx_mock_items',
-    '{"aggs": {"avg": {"field": "rating"}}}'
+    '{aggs: {avg: {field: "rating"}}}'
 )
 ```
 
@@ -34,12 +34,14 @@ FROM paradedb.aggregation(
 
 ## Metrics Aggregation JSON Format
 
+Aggregation queries are a [JSON5](https://json5.org)-formatted string. Keys don’t need to be quoted, and trailing commas and comments are allowed. JSON5 is backwards-compatible, so standard JSON works too.
+
 ### Average
 
 ```sql
 '{
-    "avg": {
-        "field": "rating"
+    avg: {
+        field: "rating"
     }
 }'
 ```
@@ -59,8 +61,8 @@ FROM paradedb.aggregation(
 
 ```sql
 '{
-    "value_count": {
-        "field": "rating"
+    value_count: {
+        field: "rating"
     }
 }'
 ```
@@ -80,8 +82,8 @@ FROM paradedb.aggregation(
 
 ```sql
 '{
-    "max": {
-        "field": "rating"
+    max: {
+        field: "rating"
     }
 }'
 ```
@@ -101,8 +103,8 @@ FROM paradedb.aggregation(
 
 ```sql
 '{
-    "min": {
-        "field": "rating"
+    min: {
+        field: "rating"
     }
 }'
 ```
@@ -122,8 +124,8 @@ FROM paradedb.aggregation(
 
 ```sql
 '{
-    "stats": {
-        "field": "rating"
+    stats: {
+        field: "rating"
     }
 }'
 ```
@@ -143,8 +145,8 @@ FROM paradedb.aggregation(
 
 ```sql
 '{
-    "percentiles": {
-        "field": "rating"
+    percentiles: {
+        field: "rating"
     }
 }'
 ```

--- a/docs/indexing/bm25.mdx
+++ b/docs/indexing/bm25.mdx
@@ -35,12 +35,14 @@ ON mock_items
 USING bm25 ((mock_items.*))
 WITH (
   text_fields='{
-    "description": {"tokenizer": {"type": "en_stem"}}, "category": {"fast": true}
+    description: {tokenizer: {type: "en_stem"}}, category: {fast: true}
   }'
 );
 ```
 
 </Accordion>
+
+Each input to `WITH ()` accepts a [JSON5](https://json5.org)-formatted string. Keys don't need to be quoted, and trailing commas and comments are allowed. JSON5 is backwards-compatible, so standard JSON works too.
 
 <ParamField body="index_name" required>
   The name of the index. The index name can be anything, as long as doesn't

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -19,6 +19,7 @@ pg_test = []
 
 [dependencies]
 csv = "1.2.2"
+json5 = "0.4.1"
 memoffset = "0.9.0"
 pgrx = "=0.9.8"
 rustc-hash = "1.1.0"

--- a/pg_bm25/src/api/aggregation.rs
+++ b/pg_bm25/src/api/aggregation.rs
@@ -1,5 +1,6 @@
+use json5::from_str;
 use pgrx::*;
-use serde_json::{from_str, Value as JsonValue};
+use serde_json::Value as JsonValue;
 use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::AggregationCollector;

--- a/pg_bm25/src/index_access/options.rs
+++ b/pg_bm25/src/index_access/options.rs
@@ -1,7 +1,7 @@
+use json5::from_str;
 use memoffset::*;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::*;
-use serde_json::from_str;
 use std::collections::HashMap;
 use std::ffi::CStr;
 

--- a/pg_bm25/test/expected/aggregations.out
+++ b/pg_bm25/test/expected/aggregations.out
@@ -1,12 +1,12 @@
 -- Bucket aggregation 
-SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {"histogram": {"field": "rating", "interval": 2}}}');
+SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {histogram: {field: "rating", interval: 2}}}');
                                                      aggregation                                                     
 ---------------------------------------------------------------------------------------------------------------------
  {"aggs": {"buckets": [{"key": 0.0, "doc_count": 1}, {"key": 2.0, "doc_count": 12}, {"key": 4.0, "doc_count": 28}]}}
 (1 row)
 
 -- Metrics aggregation
-SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {"avg": {"field": "rating"}}}');
+SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {avg: {field: "rating"}}}');
                aggregation               
 -----------------------------------------
  {"aggs": {"value": 3.8536585365853657}}

--- a/pg_bm25/test/expected/index_config.out
+++ b/pg_bm25/test/expected/index_config.out
@@ -24,7 +24,7 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 
 DROP INDEX idxindexconfig;
 -- Multiple text fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}, "category": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
 -------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
@@ -85,7 +85,7 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 
 DROP INDEX idxindexconfig;
 -- Json field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{"metadata": {"fast": true, "expand_dots": false, "tokenizer": { "type": "raw" }, "normalizer": "raw"}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
    name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
 ----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
@@ -95,7 +95,7 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 
 DROP INDEX idxindexconfig;
 -- Multiple fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
 -------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------

--- a/pg_bm25/test/sql/aggregations.sql
+++ b/pg_bm25/test/sql/aggregations.sql
@@ -1,5 +1,5 @@
 -- Bucket aggregation 
-SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {"histogram": {"field": "rating", "interval": 2}}}');
+SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {histogram: {field: "rating", interval: 2}}}');
 
 -- Metrics aggregation
-SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {"avg": {"field": "rating"}}}');
+SELECT * FROM paradedb.aggregation('idxaggregations', '{"aggs": {avg: {field: "rating"}}}');

--- a/pg_bm25/test/sql/index_config.sql
+++ b/pg_bm25/test/sql/index_config.sql
@@ -48,6 +48,6 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Multiple fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;

--- a/pg_bm25/test/sql/index_config.sql
+++ b/pg_bm25/test/sql/index_config.sql
@@ -13,7 +13,7 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Multiple text fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}, "category": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
@@ -43,11 +43,11 @@ SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Json field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{"metadata": {"fast": true, "expand_dots": false, "tokenizer": { "type": "raw" }, "normalizer": "raw"}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Multiple fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;


### PR DESCRIPTION
## What
Use [JSON5](https://json5.org/) for query/options parsing. It's backwards compatible with JSON, so we won't break anybody's existing queries.

## Why
We're starting to rely heavily on nested configuration objects, which are cumbersome to write. JSON5 removes a lot of the noise, and lets us write:
```sql
CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) 
WITH (text_fields='{description: {tokenizer: {type: "ngram", min_gram: 3, max_gram: 5}}}');
```
Notice we don't need quotes on the `text_fields` keys, just like object literals in JavaScript. Trailing commas are also not a problem. If someone wants to put comments in their JSON, for some reason, that's supported too.

## How
Change a couple imports. Serde is awesome. Rust is awesome.

## Tests
Edited some existing tests to use a mix of JSON5 and JSON syntax.