### PR TITLE
feat: CloudNativePG compatible image

### DIFF
--- a/.github/workflows/publish-paradedb-to-dockerhub.yml
+++ b/.github/workflows/publish-paradedb-to-dockerhub.yml
@@ -85,5 +85,6 @@ jobs:
           token: ${{ secrets.DEPOT_TOKEN }}
           tags: |
             paradedb/paradedb:latest
+            paradedb/paradedb:${{ matrix.pg_version }}-{{ steps.version.outputs.tag }}
             paradedb/paradedb:${{ steps.version.outputs.tag }}
             paradedb/paradedb:${{ steps.version.outputs.version }}

--- a/conf/third_party_pg_extensions.json
+++ b/conf/third_party_pg_extensions.json
@@ -8,10 +8,6 @@
       "version": "1.7.0",
       "url": "https://github.com/pgaudit/pgaudit/archive/refs/tags/1.7.0.tar.gz"
     },
-    "pgnodemx": {
-      "version": "1.6",
-      "url": "https://github.com/crunchydata/pgnodemx/archive/refs/tags/1.6.tar.gz"
-    },
     "pg_cron": {
       "version": "1.6.0",
       "url": "https://github.com/citusdata/pg_cron/archive/refs/tags/v1.6.0.tar.gz"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -166,7 +166,8 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     libgeos-c1v5 \
     libproj-dev \
     libprotobuf-c1 \
-    libc++1 libc++abi1 \
+    libc++1 \
+    libc++abi1 \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
     pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \    

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ ARG PG_VERSION_MAJOR
 ARG PG_BM25_VERSION
 ARG PG_SEARCH_VERSION
 ARG PGML_VERSION
-ARG PGNODEMX_VERSION
 ARG PG_CRON_VERSION
 ARG PG_NET_VERSION
 ARG PG_IVM_VERSION
@@ -42,7 +41,6 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     PG_BM25_VERSION=${PG_BM25_VERSION} \
     PG_SEARCH_VERSION=${PG_SEARCH_VERSION} \
     PGML_VERSION=${PGML_VERSION} \
-    PGNODEMX_VERSION=${PGNODEMX_VERSION} \
     PG_CRON_VERSION=${PG_CRON_VERSION} \
     PG_NET_VERSION=${PG_NET_VERSION} \
     PG_IVM_VERSION=${PG_IVM_VERSION} \
@@ -162,20 +160,15 @@ FROM base as paradedb
 
 ARG TARGETARCH
 
-# Install pgml, postgis, patroni & Crunchy operator runtime dependencies
+# Install pgml and postgis runtime dependencies
 RUN apt-fast update && apt-fast install -y --no-install-recommends \
     # postgis
     libgeos-c1v5 \
     libproj-dev \
     libprotobuf-c1 \
-    # Crunchy operator
-    libnss-wrapper \
-    pgbackrest \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
-    pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \
-    # patroni
-    pip3 install --no-cache-dir --break-system-packages patroni[etcd3] psycopg[binary]>=3.0.0 && \
+    pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \    
     # Symlink libproj.so.22 to libproj.so.25, since Postgis requires an older version, and
     # copy relevant library for Crunchy operator
     # Only need to copy on x84_64, since the lib is already in the right place on arm64
@@ -190,7 +183,6 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 # Download & install the non-ParadeDB extensions from their builder stage
 RUN curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pgvector-v${PGVECTOR_VERSION}-$TARGETARCH/pgvector-v${PGVECTOR_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pgvector.deb && \
     curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pgaudit-v${PGAUDIT_VERSION}-$TARGETARCH/pgaudit-v${PGAUDIT_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pgaudit.deb && \
-    curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pgnodemx-v${PGNODEMX_VERSION}-$TARGETARCH/pgnodemx-v${PGNODEMX_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pgnodemx.deb && \
     curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pg_cron-v${PG_CRON_VERSION}-$TARGETARCH/pg_cron-v${PG_CRON_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_cron.deb && \
     curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pg_ivm-v${PG_IVM_VERSION}-$TARGETARCH/pg_ivm-v${PG_IVM_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_ivm.deb && \
     curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/download/pg_hashids-v${PG_HASHIDS_VERSION}-$TARGETARCH/pg_hashids-v${PG_HASHIDS_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_hashids.deb && \
@@ -224,5 +216,6 @@ COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_M
 # initialization scipt
 COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
 
-# Postgres user for Crunchy operator
-USER 999
+# Change the uid of postgres to 26
+RUN usermod -u 26 postgres && chown -R 26:26 /var/lib/postgresql/data && chown -R 26:26 /var/run/postgresql
+USER 26

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -220,6 +220,5 @@ COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
 # Change the uid of postgres to 26
 RUN usermod -u 26 postgres \
     && chown -R 26:26 /var/lib/postgresql \
-    && chown -R 26:26 /var/run/postgresql \
-    && chown -R 26:26 /usr/lib/postgresql
+    && chown -R 26:26 /var/run/postgresql
 USER 26

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -166,6 +166,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     libgeos-c1v5 \
     libproj-dev \
     libprotobuf-c1 \
+    libc++1 libc++abi1 \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
     pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \    
@@ -217,5 +218,8 @@ COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_M
 COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
 
 # Change the uid of postgres to 26
-RUN usermod -u 26 postgres && chown -R 26:26 /var/lib/postgresql/data && chown -R 26:26 /var/run/postgresql
+RUN usermod -u 26 postgres \
+    && chown -R 26:26 /var/lib/postgresql \
+    && chown -R 26:26 /var/run/postgresql \
+    && chown -R 26:26 /usr/lib/postgresql
 USER 26

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -17,7 +17,6 @@ services:
         PG_SEARCH_VERSION: 0.0.0
         PGVECTOR_VERSION: 0.5.1
         PGML_VERSION: 2.7.10
-        PGNODEMX_VERSION: 1.6
         PG_CRON_VERSION: 1.6.0
         PG_NET_VERSION: 0.7.2
         PG_IVM_VERSION: 1.5.1

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,7 +9,6 @@ declare -A extensions=(
   [vector]=${PGVECTOR_VERSION:-}
   [pg_search]=${PG_SEARCH_VERSION:-}
   [pgml]=${PGML_VERSION:-}
-  [pgnodemx]=${PGNODEMX_VERSION:-}
   [pg_cron]=${PG_CRON_VERSION:-}
   [pg_net]=${PG_NET_VERSION:-}
   [pg_ivm]=${PG_IVM_VERSION:-}
@@ -34,7 +33,6 @@ declare -A extensions=(
 # List of extensions that must be added to shared_preload_libraries
 declare -A preload_names=(
   [pgml]=pgml
-  [pgnodemx]=pgnodemx
   [pg_cron]=pg_cron
   [pg_net]=pg_net
   [pgaudit]=pgaudit


### PR DESCRIPTION
# Ticket(s) Closed
N/A

## What
Make the modifications necessary for the image to be fully compatible with the CloudNativePG operator. This PR removes all the Crunchy Operator comments and dependencies.

## Why
Because as of https://github.com/paradedb/helm-charts/pull/36, the operator used in the helm chart will be switched, and the modifications made in this PR make our image work with the new operator.

## How
Change postgres uid to `26` (its the uid used by kubernetes), fix permissions on necessary directories, add some dependencies and create a new tag in the form of: `paradedb:{pg-major}-{version}`. This is necessary because the operator uses the tag to determine the postgres version.

## Tests
Tested with the new helm chart.