### PR TITLE
fix: Fix mobile usability issue in blog

### DIFF
--- a/docs/blog/introducing_bm25.mdx
+++ b/docs/blog/introducing_bm25.mdx
@@ -3,7 +3,7 @@ title: "pg_bm25: Elastic-Quality Full Text Search Inside Postgres"
 "og:image": "https://raw.githubusercontent.com/paradedb/paradedb/main/docs/blog/images/bm25.png"
 ---
 
-<img src="/blog/images/bm25.png" noZoom />
+<img height="300" src="/blog/images/bm25.png" noZoom />
 
 We're unveiling `pg_bm25`: a Rust-based Postgres extension that significantly improves Postgres' full text
 search capabilities. `pg_bm25` is named after BM25, the algorithm used by modern search engines to calculate the


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
A user reported issues w/ ParadeDB's doc/blogs on mobile, and so does Google. It's very minor, but it appears our image is too big in the bm25 blog post, leading to some issues on the page. I make it the same size as the image for the initial blog post, which does not cause issues.

<img width="1049" alt="Capture d’écran, le 2023-10-24 à 16 35 09" src="https://github.com/paradedb/paradedb/assets/21990816/38c76bb0-c851-4f2f-b797-c9c89f68c540">

## Why

## How

## Tests
