### PR TITLE
perf: Cache reader along with ParadeIndex

### DIFF
--- a/pg_bm25/src/api/aggregation.rs
+++ b/pg_bm25/src/api/aggregation.rs
@@ -12,13 +12,9 @@ use crate::index_access::utils::get_parade_index;
 pub fn aggregation(index_name: &str, query: &str) -> JsonB {
     // Get Parade index
     let parade_index = get_parade_index(index_name.to_string());
-    let underlying_index = parade_index.underlying_index;
 
     // Initialize aggregation searcher + collector
-    let reader = underlying_index
-        .reader()
-        .expect("failed to create index reader");
-    let searcher = reader.searcher();
+    let searcher = parade_index.searcher();
     let agg_req: Aggregations = from_str(query).expect("error parsing query");
     let collector = AggregationCollector::from_aggs(agg_req, Default::default());
 

--- a/pg_bm25/src/api/index.rs
+++ b/pg_bm25/src/api/index.rs
@@ -21,8 +21,7 @@ pub fn schema_bm25(
     name!(normalizer, Option<String>),
 )> {
     let parade_index = get_parade_index(index_name.to_string());
-    let underlying_index = parade_index.underlying_index;
-    let schema = underlying_index.schema();
+    let schema = parade_index.schema();
 
     let mut field_rows = Vec::new();
 

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -165,11 +165,10 @@ impl ParadeIndex {
         let field_configs =
             Self::read_index_field_configs(&name).expect("failed to open index field configs");
 
+        // We need to setup tokenizers again after retrieving an index from disk.
         Self::setup_tokenizers(&mut underlying_index, &field_configs);
 
         let reader = Self::reader(&underlying_index);
-
-        // We need to setup tokenizers again after retrieving an index from disk.
 
         Self {
             fields,


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #410 

## What
Persist the Tantivy `IndexReader` instance across queries.

## Why
Right now, we're re-builder the Tantivy `IndexReader` object on every query. This is inefficient: there is overhead to re-opening the index segments, and we don't get any benefits from the docstore block cache.

## How
In #375, I introduced a system to persist our `ParadeIndex` instance in-memory over the lifetime of a connection. This memory space is per-connection, so each connection to Postgres should have its own singleton instance of `ParadeIndex`.

In several places across the codebase, we've been accessing the `reader()` method of our `ParadeIndex.underlying_index` to get a Tantivy `searcher` object, which actually performs the lookup in our index. This PR makes `underlying_index` private, and instead exposes a `searcher` method to accomplish this.

This lets us encapsulate any caching behavior within `ParadeIndex`, and I chose to store the Tantivy `reader` within the `ParadeIndex` struct itself. This way, it's persisted in memory, and we're just calling `searcher()` on an already-existing `IndexReader` on every query. This is what Tantivy recommends, as creating a `searcher` is very cheap.

We've been wary of the side-effects of having multiple Tantivy `IndexReader` instances floating around our Postgres server, so I dug deep on this problem and discussed it with the Tantivy maintainer. My conclusion is that we should be perfectly fine maintaining one `IndexReader` per connection, as opposed to using a single instance globally across Postgres Shared Memory.

The main damage done by creating new `IndexReader` instances is more reopening of new segments within the index, and the inability to utilize caching associated with an `IndexReader` instance. While it's true that a new connection to Postgres would need to reopen segments and deal with its own empty cache... that just shouldn't end up causing significant overhead. A Postgres connection is long-lived, and expected to receive thousands or millions of queries over its lifetime. The average query just won't have to deal with any overhead introduced by the connection maintaining its own `IndexReader`.

There is a memory cost to having multiple `IndexReader` instances, because they each build up their own cache, but its not expected to be significant. The main index lives in a memory-mapped directory (`tantivy::directory::MmapDirectory`), and that can be shared between `IndexReader` instances.

## Tests
No new tests are necessary, but I should mention that the tokenizer tests helped me catch a problem. We need to make sure the reader is created after we `setup_tokenizers()`, so I refactored that method in a way that would allow this ordering.
