### PR TITLE
feat: Add workflow to test building ParadeDB

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,19 +25,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-            ~/.cargo/
-            ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.11.0
-          restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.11.0
-            ${{ runner.os }}-cargo-pgrx
-            ${{ runner.os }}-cargo
-
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -51,7 +38,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-15 postgresql-server-dev-15
 
       - name: Install pgrx
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -33,18 +33,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-            ~/.cargo/
-            ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.11.0
-          restore-keys: |
-            ${{ runner.os }}-cargo-pgrx
-            ${{ runner.os }}-cargo
-
       - name: Retrieve GitHub Tag Version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -71,7 +59,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -33,18 +33,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-            ~/.cargo/
-            ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.11.0
-          restore-keys: |
-            ${{ runner.os }}-cargo-pgrx
-            ${{ runner.os }}-cargo
-
       - name: Retrieve GitHub Tag Version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -71,7 +59,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Test Building ParadeDB Docker Image
         working-directory: docker/
-        run: docker build -t paradedb .
+        run: docker compose -f docker-compose.dev.yml build

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -1,0 +1,37 @@
+# workflows/test-paradedb.yml
+#
+# Testing: ParadeDB
+# Lint Dockerfiles using Hadolint.
+
+name: Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+      - dev
+    paths:
+      - "docker/Dockerfile"
+      - ".github/workflows/test-paradedb.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: test-paradedb-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-pg_search:
+    name: Test ParadeDB for PostgreSQL ${{ matrix.pg_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg_version: [15]
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Test Building ParadeDB Docker Image
+        working-directory: docker/
+        run: docker build -t paradedb .

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-pg_search:
-    name: Test ParadeDB for PostgreSQL ${{ matrix.pg_version }}
+    name: Test ParadeDB on PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      # By using the docker-compose.dev.yml file, we also test that the build arguments are correct
       - name: Test Building ParadeDB Docker Image
         working-directory: docker/
-        run: docker compose -f docker-compose.dev.yml build
+        run: docker buildx create --use && docker compose -f docker-compose.dev.yml build

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -1,6 +1,6 @@
 # workflows/test-pg_bm25.yml
 #
-# pg_bm25: Tests
+# Testing: pg_bm25
 # Run unit and packaging tests for the pg_bm25 extension.
 
 name: Testing
@@ -33,19 +33,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-            ~/.cargo/
-            ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
-          restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
-            ${{ runner.os }}-cargo-pgrx
-            ${{ runner.os }}-cargo
-
       - name: Remove old postgres, llvm, clang, and install appropriate version
         run: |
           sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
@@ -61,7 +48,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx, grcov & llvm-tools-preview
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
           cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
           rustup component add llvm-tools-preview

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -1,6 +1,6 @@
 # workflows/test-pg_search.yml
 #
-# pg_search: Tests
+# Testing: pg_search
 # Run unit and packaging tests for the pg_search extension.
 
 name: Testing
@@ -33,19 +33,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Cache Cargo Dependencies
-        uses: actions/cache@v3
-        id: cache-cargo
-        with:
-          path: |
-            ~/.cargo/
-            ~/.rustup/
-          key: ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
-          restore-keys: |
-            ${{ runner.os }}-cargo-pgrx-0.11.0-grcov
-            ${{ runner.os }}-cargo-pgrx
-            ${{ runner.os }}-cargo
-
       - name: Remove old postgres, llvm, clang, and install appropriate version
         run: |
           sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
@@ -61,7 +48,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx, grcov & llvm-tools-preview
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
           cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
           rustup component add llvm-tools-preview


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
In the recent promotion to `prod`, we faced some issues which stemmed from a small issue in the Dockerfile. Yeah, should've been caught by manual testing. But also, it shouldn't make it's way up to being caught in `prod`. This PR adds a workflow to test the Dockerfile building, to avoid this happening again!

I also removed the caching in CI, it really does not work at all...

## Why

## How

## Tests
