### PR TITLE
New pgml version, compatible with pg16

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
         PG_BM25_VERSION: 0.0.0
         PG_SEARCH_VERSION: 0.0.0
         PGVECTOR_VERSION: 0.5.1
-        PGML_VERSION: 2.7.10
+        PGML_VERSION: 2.7.12
         PG_CRON_VERSION: 1.6.0
         PG_NET_VERSION: 0.7.2
         PG_IVM_VERSION: 1.5.1


### PR DESCRIPTION
# Ticket(s) Closed

## What

Bump pgml version

## Why

The new version uses pgxs 0.11, and can work on Postgres 16

## How

## Tests
