### PR TITLE
perf: Move highlighting code out of main query loop

### DIFF
--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -8,7 +8,7 @@ use tantivy::{
 
 use crate::{
     index_access::utils::{get_parade_index, SearchQuery},
-    manager::get_current_executor_manager,
+    manager::{get_current_executor_manager, get_fresh_executor_manager},
     parade_index::index::TantivyScanState,
 };
 
@@ -79,8 +79,9 @@ pub extern "C" fn amrescan(
         _ => false,
     };
 
+    // We get a fresh executor manager here to clear out memory from previous queries.
+    let manager = get_fresh_executor_manager();
     // Fetching references to state components for building the query.
-    let manager = get_current_executor_manager();
     let query_parser = &mut state.query_parser;
     let searcher = &state.searcher;
     let schema = &state.schema;
@@ -225,7 +226,8 @@ pub extern "C" fn amgettuple(
 
 #[pg_guard]
 pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TIDBitmap) -> i64 {
-    let manager = get_current_executor_manager();
+    // We get a fresh executor manager here to clear out memory from previous queries.
+    let manager = get_fresh_executor_manager();
     let scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
     let state =
         unsafe { (scan.opaque as *mut TantivyScanState).as_mut() }.expect("no scandesc state");

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -155,8 +155,8 @@ pub extern "C" fn amrescan(
 
     // Extract highlight_max_num_chars from the query config and add snippet generators.
     manager.add_snippet_generators(
-        &searcher,
-        &schema,
+        searcher,
+        schema,
         &tantivy_query,
         query_config.config.max_num_chars,
     );
@@ -236,7 +236,7 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
     let query = &state.query;
 
     // Add snippet generators
-    manager.add_snippet_generators(&searcher, &schema, &query, None);
+    manager.add_snippet_generators(searcher, schema, query, None);
 
     let mut cnt = 0i64;
     let iterator = unsafe { state.iterator.as_mut() }.expect("no iterator in state");

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -3,14 +3,12 @@ use tantivy::{
     collector::TopDocs,
     query::{BooleanQuery, Query, RegexQuery},
     query_grammar::Occur,
-    schema::Document,
-    schema::FieldType,
-    SnippetGenerator,
+    DocAddress,
 };
 
 use crate::{
     index_access::utils::{get_parade_index, SearchQuery},
-    manager::get_executor_manager,
+    manager::get_current_executor_manager,
     parade_index::index::TantivyScanState,
 };
 
@@ -82,6 +80,7 @@ pub extern "C" fn amrescan(
     };
 
     // Fetching references to state components for building the query.
+    let manager = get_current_executor_manager();
     let query_parser = &mut state.query_parser;
     let searcher = &state.searcher;
     let schema = &state.schema;
@@ -92,11 +91,6 @@ pub extern "C" fn amrescan(
         .limit
         .unwrap_or(searcher.num_docs() as usize);
     let offset = query_config.config.offset.unwrap_or(0);
-
-    // Extract highlight_max_num_chars from the query config
-    if let Some(max_num_chars) = query_config.config.max_num_chars {
-        get_executor_manager().set_highlight_max_num_chars(max_num_chars);
-    }
 
     // Construct the actual Tantivy search query based on the mode determined above.
     let tantivy_query: Box<dyn Query> = if using_regex_fields {
@@ -155,8 +149,16 @@ pub extern "C" fn amrescan(
     let scores: Vec<f32> = top_docs.iter().map(|(score, _)| *score).collect();
     let max_score = scores.iter().fold(0.0f32, |a, b| a.max(*b));
     let min_score = scores.iter().fold(0.0f32, |a, b| a.min(*b));
-    get_executor_manager().set_max_score(max_score);
-    get_executor_manager().set_min_score(min_score);
+    manager.set_max_score(max_score);
+    manager.set_min_score(min_score);
+
+    // Extract highlight_max_num_chars from the query config and add snippet generators.
+    manager.add_snippet_generators(
+        &searcher,
+        &schema,
+        &tantivy_query,
+        query_config.config.max_num_chars,
+    );
 
     // Cache the constructed query in the scan state for potential subsequent use.
     state.query = tantivy_query;
@@ -214,8 +216,7 @@ pub extern "C" fn amgettuple(
                 panic!("invalid item pointer: {:?}", item_pointer_get_both(*tid));
             }
 
-            write_to_manager(*tid, score, state, &retrieved_doc);
-
+            write_to_manager(*tid, score, doc_address);
             true
         }
         None => false,
@@ -224,11 +225,16 @@ pub extern "C" fn amgettuple(
 
 #[pg_guard]
 pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TIDBitmap) -> i64 {
+    let manager = get_current_executor_manager();
     let scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
     let state =
         unsafe { (scan.opaque as *mut TantivyScanState).as_mut() }.expect("no scandesc state");
     let searcher = &state.searcher;
     let schema = &state.schema;
+    let query = &state.query;
+
+    // Add snippet generators
+    manager.add_snippet_generators(&searcher, &schema, &query, None);
 
     let mut cnt = 0i64;
     let iterator = unsafe { state.iterator.as_mut() }.expect("no iterator in state");
@@ -249,7 +255,7 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
                 pg_sys::tbm_add_tuples(tbm, &mut tid, 1, false);
             }
 
-            write_to_manager(tid, score, state, &retrieved_doc);
+            write_to_manager(tid, score, doc_address);
             cnt += 1;
         }
     }
@@ -258,33 +264,11 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
 }
 
 #[inline]
-fn write_to_manager(
-    ctid: pg_sys::ItemPointerData,
-    score: f32,
-    state: &TantivyScanState,
-    retrieved_doc: &Document,
-) {
+fn write_to_manager(ctid: pg_sys::ItemPointerData, score: f32, doc_address: DocAddress) {
+    let manager = get_current_executor_manager();
     // Add score
-    get_executor_manager().add_score(item_pointer_get_both(ctid), score);
+    manager.add_score(item_pointer_get_both(ctid), score);
 
-    // Add highlighting
-    for field in state.schema.fields() {
-        let field_name = field.1.name().to_string();
-
-        if let FieldType::Str(_) = field.1.field_type() {
-            let snippet_generator =
-                SnippetGenerator::create(&state.searcher, &state.query, field.0);
-
-            let mut snippet = snippet_generator
-                .unwrap_or_else(|_| panic!("failed to highlight field: {}", field_name));
-
-            if let Some(max_num_chars) = get_executor_manager().get_highlight_max_num_chars() {
-                snippet.set_max_num_chars(max_num_chars);
-            }
-
-            let snippet = snippet.snippet_from_doc(retrieved_doc);
-
-            get_executor_manager().add_highlight(ctid, field_name, snippet)
-        }
-    }
+    // Add doc address
+    manager.add_doc_address(item_pointer_get_both(ctid), doc_address);
 }

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -100,7 +100,7 @@ impl Manager {
         &mut self,
         searcher: &Searcher,
         schema: &Schema,
-        query: &Box<dyn Query>,
+        query: &dyn Query,
         highlights_max_num_chars: Option<usize>,
     ) {
         // Because we're adding the whole schema at once, we can replace to make sure

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -15,14 +15,14 @@ pub fn get_current_executor_manager() -> &'static mut Manager {
     unsafe { &mut MANAGER }
 }
 
-// pub fn get_fresh_executor_manager() -> &'static mut Manager {
-//     // We should call this at the top of a scan to clear out the manager memory.
-//     // Otherwise, the static manager could grow unbound and leak memory.
-//     unsafe {
-//         MANAGER = Manager::new();
-//         &mut MANAGER
-//     }
-// }
+pub fn get_fresh_executor_manager() -> &'static mut Manager {
+    // We should call this at the top of a scan to clear out the manager memory.
+    // Otherwise, the static manager could grow unbound and leak memory.
+    unsafe {
+        MANAGER = Manager::new();
+        &mut MANAGER
+    }
+}
 
 type BlockInfo = (BlockNumber, OffsetNumber);
 

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -1,36 +1,49 @@
-use std::collections::HashMap;
-
 use pgrx::{
     item_pointer_get_both,
     pg_sys::{BlockNumber, ItemPointerData, OffsetNumber},
 };
-use tantivy::Snippet;
+use std::collections::HashMap;
+use tantivy::{
+    query::Query,
+    schema::{FieldType, Schema},
+    DocAddress, Document, Searcher, Snippet, SnippetGenerator,
+};
 
 static mut MANAGER: Manager = Manager::new();
 
-pub fn get_executor_manager() -> &'static mut Manager {
+pub fn get_current_executor_manager() -> &'static mut Manager {
     unsafe { &mut MANAGER }
 }
 
+// pub fn get_fresh_executor_manager() -> &'static mut Manager {
+//     // We should call this at the top of a scan to clear out the manager memory.
+//     // Otherwise, the static manager could grow unbound and leak memory.
+//     unsafe {
+//         MANAGER = Manager::new();
+//         &mut MANAGER
+//     }
+// }
+
 type BlockInfo = (BlockNumber, OffsetNumber);
 
-#[derive(Debug, PartialEq)]
 pub struct Manager {
     max_score: f32,
     min_score: f32,
     scores: Option<HashMap<BlockInfo, f32>>,
-    highlights: Option<HashMap<(BlockInfo, String), String>>,
-    highlights_max_num_chars: Option<usize>,
+    doc_addresses: Option<HashMap<BlockInfo, DocAddress>>,
+    snippet_generators: Option<HashMap<String, SnippetGenerator>>,
+    // highlights_max_num_chars: Option<usize>,
 }
 
 impl Manager {
     pub const fn new() -> Self {
         Self {
             scores: None,
-            highlights: None,
             max_score: 0.0,
             min_score: 0.0,
-            highlights_max_num_chars: None,
+            doc_addresses: None,
+            snippet_generators: None,
+            // highlights_max_num_chars: None,
         }
     }
 
@@ -63,36 +76,77 @@ impl Manager {
         self.min_score
     }
 
-    pub fn set_highlight_max_num_chars(&mut self, max_num_chars: usize) {
-        self.highlights_max_num_chars = max_num_chars.into();
-    }
+    // pub fn set_highlight_max_num_chars(&mut self, max_num_chars: usize) {
+    //     self.highlights_max_num_chars = max_num_chars.into();
+    // }
 
-    pub fn get_highlight_max_num_chars(&self) -> Option<usize> {
-        self.highlights_max_num_chars
-    }
+    // pub fn get_highlight_max_num_chars(&self) -> Option<usize> {
+    //     self.highlights_max_num_chars
+    // }
 
-    pub fn add_highlight(&mut self, ctid: ItemPointerData, field_name: String, snippet: Snippet) {
-        if self.highlights.is_none() {
-            self.highlights.replace(HashMap::new());
+    pub fn add_doc_address(&mut self, ctid: (BlockNumber, OffsetNumber), doc_address: DocAddress) {
+        if self.doc_addresses.is_none() {
+            self.doc_addresses.replace(HashMap::new());
         }
 
-        let highlighted_str = self.parse_snippet(snippet);
-        self.highlights.as_mut().unwrap().insert(
-            (item_pointer_get_both(ctid), field_name.to_string()),
-            highlighted_str,
-        );
+        self.doc_addresses
+            .as_mut()
+            .unwrap()
+            .insert(ctid, doc_address);
     }
 
-    pub fn get_highlight(&mut self, ctid: ItemPointerData, field_name: String) -> Option<String> {
+    pub fn get_doc_address(&mut self, ctid: ItemPointerData) -> Option<DocAddress> {
         let (block, offset) = item_pointer_get_both(ctid);
-        Some(
-            self.highlights
-                .as_mut()
-                .unwrap()
-                .get(&((block, offset), field_name))
-                .expect("failed to get highlight")
-                .clone(),
-        )
+        self.doc_addresses
+            .as_mut()
+            .unwrap()
+            .get(&(block, offset))
+            .copied()
+    }
+
+    pub fn add_snippet_generators(
+        &mut self,
+        searcher: &Searcher,
+        schema: &Schema,
+        query: &Box<dyn Query>,
+        highlights_max_num_chars: Option<usize>,
+    ) {
+        // Because we're adding the whole schema at once, we can replace to make sure
+        // that we're adding to a clean hash map.
+
+        self.snippet_generators.replace(HashMap::new());
+        for field in schema.fields() {
+            let field_name = field.1.name().to_string();
+
+            if let FieldType::Str(_) = field.1.field_type() {
+                let mut snippet_generator = SnippetGenerator::create(searcher, query, field.0)
+                    .expect("failed to create snippet generator for field: {field_name}");
+
+                if let Some(max_num_chars) = highlights_max_num_chars {
+                    snippet_generator.set_max_num_chars(max_num_chars);
+                }
+
+                self.snippet_generators
+                    .as_mut()
+                    .unwrap()
+                    .insert(field_name, snippet_generator);
+            }
+        }
+    }
+
+    pub fn get_highlight(&mut self, field_name: &str, doc: &Document) -> Option<String> {
+        let snippet_generator_map = self
+            .snippet_generators
+            .as_ref()
+            .expect("snippet generators not correctly initialized");
+
+        let snippet_generator = snippet_generator_map
+            .get(field_name)
+            .expect("failed to retrieve snippet generator for field: {field_name}");
+
+        let snippet = snippet_generator.snippet_from_doc(doc);
+
+        Some(self.parse_snippet(snippet))
     }
 
     fn parse_snippet(&self, snippet: Snippet) -> String {

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -76,14 +76,6 @@ impl Manager {
         self.min_score
     }
 
-    // pub fn set_highlight_max_num_chars(&mut self, max_num_chars: usize) {
-    //     self.highlights_max_num_chars = max_num_chars.into();
-    // }
-
-    // pub fn get_highlight_max_num_chars(&self) -> Option<usize> {
-    //     self.highlights_max_num_chars
-    // }
-
     pub fn add_doc_address(&mut self, ctid: (BlockNumber, OffsetNumber), doc_address: DocAddress) {
         if self.doc_addresses.is_none() {
             self.doc_addresses.replace(HashMap::new());

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -87,7 +87,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (2 rows)
 
 -- Default highlighting without max_num_chars
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
          description         | rating |  category   |         highlight_bm25          
 -----------------------------+--------+-------------+---------------------------------
  Plastic Keyboard            |      4 | Electronics | Plastic <b>Keyboard</b>
@@ -98,7 +98,7 @@ SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'description
 (5 rows)
 
 -- max_num_chars is set to 14 
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
          description         | rating |  category   |    highlight_bm25     
 -----------------------------+--------+-------------+-----------------------
  Plastic Keyboard            |      4 | Electronics | <b>Keyboard</b>

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -21,6 +21,6 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 -- With regex field 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';
 -- Default highlighting without max_num_chars
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
 -- max_num_chars is set to 14 
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #409

## What
Compute highlights on the fly when they're actually requested, as opposed to on every iteration of an index scan.

## Why
Efficiency! This could potentially be a big speedup for queries that return lots of results.

## How
Generate the highlight snippets inside the `highlight_bm25` `#[pg_extern]` function. This way, we ensure that we're only doing the highlight processing when it's actually part of the query.

To do this, I needed to change the API of `highlight_bm25`. It will require manually specifying the index name, just like `minmax_bm25`.

I also split `get_executor_manager()` into `get_current_executor_manager()` and `get_fresh_exectuor_manager()`. We now call the `fresh()` variant at the top of `amrescan` and `ambitmapscan`, which instantiates a new copy of the manager. Without doing this, the manager would grow unbounded, because we keep adding keys/values to its member hash maps without cleaning them up.

I don't expect any concurrency issues from re-instantiating the manager, because it's stored per-connection, and each connection is single-threaded.

## Tests
No new tests, just changing implementation.
