### PR TITLE
fix: Set write permission for new userID

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 /dashboard/                                                    @rebasedming
 /docker/                                                       @philippemnoel
 /docs/                                                         @rebasedming
-/pg_bm25/                                                      @rebasedming @mauaraujo
-/pg_search/                                                    @rebasedming @mauaraujo
-/scripts/                                                      @philippemnoel
+/pg_bm25/                                                      @rebasedming @neilyio
+/pg_search/                                                    @rebasedming @neilyio
+/scripts/                                                      @philippemnoel @mauaraujo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -223,5 +223,7 @@ COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
 # Change the uid of postgres to 26
 RUN usermod -u 26 postgres \
     && chown -R 26:26 /var/lib/postgresql \
-    && chown -R 26:26 /var/run/postgresql
+    && chown -R 26:26 /var/run/postgresql \
+    && chmod 700 /var/lib/postgresql
+
 USER 26


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
There was an issue vectorizing with `pgml` because we swapped the userID for `postgres` to match with the new CloudNativePG operator, and had forgotten to set write permissions on the PGDATA folder for the new user. This fixes it.

Bug:
<img width="1143" alt="Capture d’écran, le 2023-10-26 à 16 24 18" src="https://github.com/paradedb/paradedb/assets/21990816/a81f34dc-c1ee-46ae-8d54-f5f156524f5c">

## Why

## How

## Tests
Tested locally, can now run the `ALTER TABLE` command on the Parade Quickstart tutorial properly