### PR TITLE
chore: Upgrade `pgml`, small typos, fix CI deprecation warnings

### DIFF
--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Python Environment
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Install Beautysh
         run: pip install beautysh

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Dependencies
         run: pip install black pylint flake8

--- a/.github/workflows/publish-paradedb-to-dockerhub.yml
+++ b/.github/workflows/publish-paradedb-to-dockerhub.yml
@@ -53,7 +53,7 @@ jobs:
             PG_BM25_VERSION=${{ steps.version.outputs.version }}
             PG_SEARCH_VERSION=${{ steps.version.outputs.version }}
             PGVECTOR_VERSION=0.5.1
-            PGML_VERSION=2.7.10
+            PGML_VERSION=2.7.12
             PGAUDIT_VERSION=1.7.0
             PG_NET_VERSION=0.7.2
             PG_GRAPHQL_VERSION=1.3.0

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -115,11 +115,10 @@ jobs:
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_bm25 .deb to GitHub Release
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         with:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_bm25-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
           asset_name: pg_bm25-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
-          asset_content_type: application/vnd.DEBIAN.binary-package

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -99,11 +99,11 @@ jobs:
           touch ${package_dir}/DEBIAN/control
           deb_version=${{ steps.version.outputs.version }}
           CONTROL_FILE="${package_dir}/DEBIAN/control"
-          echo 'Package: pg-bm25' >> $CONTROL_FILE
+          echo 'Package: pg-search' >> $CONTROL_FILE
           echo 'Version:' ${deb_version} >> $CONTROL_FILE
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Full text search for PostgreSQL using BM25' >> $CONTROL_FILE
+          echo 'Description: Hybrid search for PostgreSQL' >> $CONTROL_FILE
 
           # Create .deb package
           sudo chown -R root:root ${package_dir}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -115,11 +115,10 @@ jobs:
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_search .deb to GitHub Release
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         with:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
           asset_name: pg_search-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
-          asset_content_type: application/vnd.DEBIAN.binary-package

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -189,7 +189,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pgml*"` archive
-          package_dir=pgml-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu
+          package_dir=pgml-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -228,5 +228,5 @@ jobs:
           tag_name: pgml-v${{ steps.version.outputs.version }}-${{ matrix.arch }}
           name: pgml ${{ steps.version.outputs.version }} ${{ matrix.arch }}
           body: Internal ParadeDB Release for pgml version ${{ steps.version.outputs.version }} for arch ${{ matrix.arch }}. This release is not intended for public use.
-          files: ./pgml-extension/pgml-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
+          files: ./pgml-extension/pgml-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -155,7 +155,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install cargo-pgrx --version 0.10.0
+        run: cargo install cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pgml-extension/

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -228,19 +228,5 @@ jobs:
           tag_name: pgml-v${{ steps.version.outputs.version }}-${{ matrix.arch }}
           name: pgml ${{ steps.version.outputs.version }} ${{ matrix.arch }}
           body: Internal ParadeDB Release for pgml version ${{ steps.version.outputs.version }} for arch ${{ matrix.arch }}. This release is not intended for public use.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-
-      - name: Retrieve GitHub Release Upload URL
-        id: upload_url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/paradedb/third-party-pg_extensions/releases/latest | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
-
-      - name: Upload pgml .deb to GitHub Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-        with:
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pgml-extension/pgml-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
-          asset_name: pgml-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
-          asset_content_type: application/vnd.DEBIAN.binary-package
+          files: ./pgml-extension/pgml-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-linux-gnu.deb
+          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -119,11 +119,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: postgresml/postgresml
-          ref: v2.7.10
+          ref: v2.7.12
 
       - name: Retrieve GitHub Tag Version
         id: version
-        run: echo "version=2.7.10" >> $GITHUB_OUTPUT
+        run: echo "version=2.7.12" >> $GITHUB_OUTPUT
 
       - name: Retrieve Arch
         id: arch

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -13,7 +13,7 @@ on:
       - staging
       - dev
     paths:
-      - "docker/Dockerfile"
+      - "docker/**"
       - ".github/workflows/test-paradedb.yml"
   workflow_dispatch:
 

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -1,7 +1,8 @@
 # workflows/test-paradedb.yml
 #
 # Testing: ParadeDB
-# Lint Dockerfiles using Hadolint.
+# Test building the ParadeDB Docker Image using Docker Compose. We use a ubuntu-latest-m
+# runner for faster builds and to avoid running out of storage on the runner.
 
 name: Testing
 
@@ -23,7 +24,7 @@ concurrency:
 jobs:
   test-pg_search:
     name: Test ParadeDB on PostgreSQL ${{ matrix.pg_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
     strategy:
       matrix:
         pg_version: [15]

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,2 @@
 ignored:
   - DL3008 # Pin versions in apt-get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-  - DL3013 # Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Alternatively, you can clone this repo and run our `docker-compose.yml` file. By
 psql -h <hostname> -U <user> -d <dbname> -p 5432 -W
 ```
 
-ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt-out of telemetry by adding `-e TELEMETRY=false` (or unsetting the variable) to your `docker run` command, or by setting `TELEMETRY=false` in the `docker-compose.yml` file.
+ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt-out of telemetry by adding `-e TELEMETRY=false` (or unsetting the variable) to your `docker run` command, or by setting `TELEMETRY: false` in the `docker-compose.yml` file.
 
 #### ParadeDB Extension(s)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     libc++abi1 \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
-    pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \    
+    pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \
     # Symlink libproj.so.22 to libproj.so.25, since Postgis requires an older version, and
     # copy relevant library for Crunchy operator
     # Only need to copy on x84_64, since the lib is already in the right place on arm64

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
         PG_BM25_VERSION: 0.0.0
         PG_SEARCH_VERSION: 0.0.0
         PGVECTOR_VERSION: 0.5.1
-        PGML_VERSION: 2.7.10
+        PGML_VERSION: 2.7.12
         PG_CRON_VERSION: 1.6.0
         PG_NET_VERSION: 0.7.2
         PG_IVM_VERSION: 1.5.1


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR:
- Upgrades `pgml` to be Postgres 16 compatible
- Fix a small typo in the `pg_search` packaging
- Swaps the release action for our CI to be a maintained one, instead of the deprecated one we were using

## Why

## How

## Tests
