### PR TITLE
fix: Upload packaged extensions to the proper GitHub release

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -110,9 +110,10 @@ jobs:
           sudo chmod -R 00755 ${package_dir}
           sudo dpkg-deb --build --root-owner-group ${package_dir}
 
+      # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_bm25 .deb to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -110,9 +110,10 @@ jobs:
           sudo chmod -R 00755 ${package_dir}
           sudo dpkg-deb --build --root-owner-group ${package_dir}
 
+      # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/latest | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_search .deb to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
There was a small issue in the `pg_bm25` and `pg_search` release flows, where they uploaded their packaged version to the latest GitHub release. Usually, this was correct, but if we run multiple releases close to one another, due to the time it takes to package, it wasn't always the case. This small fix ensures the releases always upload to the right GitHub release.

## Why

## How

## Tests
