### PR TITLE
fix: Add instructions for self-hosting ParadeDB extensions on macOS with Postgres.app

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-15 postgresql-server-dev-15
 
       - name: Install pgrx
-        run: cargo install cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg15=/usr/lib/postgresql/15/bin/pg_config

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -59,7 +59,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_bm25/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -59,7 +59,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -155,7 +155,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.0
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pgml-extension/

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install pgrx, grcov & llvm-tools-preview
         run: |
-          cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
+          cargo install --locked cargo-pgrx --version 0.11.0 && cargo install --locked grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install pgrx, grcov & llvm-tools-preview
         run: |
-          cargo install cargo-pgrx --version 0.11.0 && cargo install grcov
+          cargo install --locked cargo-pgrx --version 0.11.0 && cargo install --locked grcov
           rustup component add llvm-tools-preview
 
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,7 +121,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
-RUN cargo install cargo-pgrx --version 0.11.0 && \
+RUN cargo install --locked cargo-pgrx --version 0.11.0 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -182,11 +182,18 @@ Please refer to the [documentation](https://docs.paradedb.com/search/bm25) for a
 Before developing the extension, ensure that you have Rust installed
 (version >1.70), ideally via `rustup` (we've observed issues with installing Rust via Homebrew on macOS).
 
+If you are on macOS and using Postgres.app, you'll first need to add the `pg_config` binary to your path:
+
+```bash
+export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
+```
+
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.11.0
-cargo pgrx init
+# Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
+cargo install --locked cargo-pgrx --version 0.11.0
+cargo pgrx init --pg15=`which pg_config`
 ```
 
 ### Running the Extension

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -116,11 +116,18 @@ Please refer to the [documentation](https://docs.paradedb.com/search/hybrid) for
 Before developing the extension, ensure that you have Rust installed
 (version >1.70), ideally via `rustup` (we've observed issues with installing Rust via Homebrew on macOS).
 
+If you are on macOS and using Postgres.app, you'll first need to add the `pg_config` binary to your path:
+
+```bash
+export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
+```
+
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.11.0
-cargo pgrx init
+# Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
+cargo install --locked cargo-pgrx --version 0.11.0
+cargo pgrx init --pg15=`which pg_config`
 ```
 
 ### Running the Extension


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #362

## What
One of our users had issued testing ParadeDB on macOS using Postgres.app. It turns out, Postgres.app does not add its `pg_config` binary to path automatically, so we need an extra command. 

I also added `--locked` to our `cargo install` commands, this is good practice and will avoid any issues in the future.

## Why

## How

## Tests
