### PR TITLE
fix: Move to 8vcpu for arm64 runner

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -25,7 +25,7 @@ jobs:
           - runner: ubuntu-latest
             pg_version: 15
             arch: amd64
-          - runner: buildjet-4vcpu-ubuntu-2204-arm
+          - runner: buildjet-8vcpu-ubuntu-2204-arm
             pg_version: 15
             arch: arm64
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Building pg_bm25 keeps failing because the runner runs out of memory on arm64... This makes it one quanta bigger, so that this doesn't happen again.

## Why

## How

## Tests
