### PR TITLE
perf: MVCC (auto)vacuum and bulk_delete improvements

### DIFF
--- a/pg_bm25/src/index_access/delete.rs
+++ b/pg_bm25/src/index_access/delete.rs
@@ -9,18 +9,36 @@ pub extern "C" fn ambulkdelete(
     callback: pg_sys::IndexBulkDeleteCallback,
     callback_state: *mut ::std::os::raw::c_void,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
-    let mut stats_binding = stats;
+    let info = unsafe { PgBox::from_pg(info) };
+    let mut stats = unsafe { PgBox::from_pg(stats) };
+    let index_rel: pg_sys::Relation = info.index;
+    let index_relation = unsafe { PgRelation::from_pg(index_rel) };
+    let index_name = &index_relation.name().to_string();
+    let parade_index = get_parade_index(index_name.into());
 
-    if stats_binding.is_null() {
-        stats_binding =
-            unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
+    // let mut stats_binding = stats;
+
+    // if stats_binding.is_null() {
+    //     stats_binding =
+    //         unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
+    // }
+
+    if stats.is_null() {
+        stats = unsafe {
+            PgBox::from_pg(
+                pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast(),
+            )
+        };
     }
 
-    let index_rel: pg_sys::Relation = unsafe { (*info).index };
-    let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    let index_name = index_relation.name().to_string();
+    // let index_rel: pg_sys::Relation = unsafe { (*info).index };
+    // let index_relation = unsafe { PgRelation::from_pg(index_rel) };
+    // let index_name = index_relation.name().to_string();
 
-    let parade_index = get_parade_index(index_name);
-    parade_index.bulk_delete(stats_binding, callback, callback_state);
-    stats_binding
+    // let parade_index = get_parade_index(index_name);
+    // parade_index.bulk_delete(stats_binding, callback, callback_state);
+    // stats_binding
+
+    stats = parade_index.bulk_delete(stats, callback, callback_state);
+    stats.into_pg()
 }

--- a/pg_bm25/src/index_access/delete.rs
+++ b/pg_bm25/src/index_access/delete.rs
@@ -16,13 +16,6 @@ pub extern "C" fn ambulkdelete(
     let index_name = &index_relation.name().to_string();
     let parade_index = get_parade_index(index_name.into());
 
-    // let mut stats_binding = stats;
-
-    // if stats_binding.is_null() {
-    //     stats_binding =
-    //         unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
-    // }
-
     if stats.is_null() {
         stats = unsafe {
             PgBox::from_pg(
@@ -30,14 +23,6 @@ pub extern "C" fn ambulkdelete(
             )
         };
     }
-
-    // let index_rel: pg_sys::Relation = unsafe { (*info).index };
-    // let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    // let index_name = index_relation.name().to_string();
-
-    // let parade_index = get_parade_index(index_name);
-    // parade_index.bulk_delete(stats_binding, callback, callback_state);
-    // stats_binding
 
     stats = parade_index.bulk_delete(stats, callback, callback_state);
     stats.into_pg()

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -200,7 +200,7 @@ pub extern "C" fn amgettuple(
 
             let searcher = &state.searcher;
             let schema = &state.schema;
-            let retrieved_doc = searcher.doc(doc_address).unwrap();
+            let retrieved_doc = searcher.doc(doc_address).expect("could not find doc");
 
             let heap_tid_field = schema
                 .get_field("heap_tid")
@@ -240,8 +240,9 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
 
     let mut cnt = 0i64;
     let iterator = unsafe { state.iterator.as_mut() }.expect("no iterator in state");
+
     for (score, doc_address) in iterator {
-        let retrieved_doc = searcher.doc(doc_address).unwrap();
+        let retrieved_doc = searcher.doc(doc_address).expect("could not find doc");
         let heap_tid_field = schema
             .get_field("heap_tid")
             .expect("field 'heap_tid' not found in schema");

--- a/pg_bm25/src/index_access/vacuum.rs
+++ b/pg_bm25/src/index_access/vacuum.rs
@@ -1,9 +1,35 @@
+use crate::index_access::utils::get_parade_index;
 use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
-    _info: *mut pg_sys::IndexVacuumInfo,
+    info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
+    let info = unsafe { PgBox::from_pg(info) };
+    let mut stats = stats;
+
+    if info.analyze_only {
+        return stats;
+    }
+
+    if stats.is_null() {
+        stats =
+            unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
+    }
+
+    let index_rel: pg_sys::Relation = info.index;
+    let index_relation = unsafe { PgRelation::from_pg(index_rel) };
+    let index_name = index_relation.name().to_string();
+    let parade_index = get_parade_index(index_name);
+
+    let index_writer = parade_index.writer();
+
+    // Cleanup the garbage
+    index_writer
+        .garbage_collect_files()
+        .wait()
+        .expect("Could not collect garbage");
+
     stats
 }

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -296,7 +296,7 @@ impl ParadeIndex {
     fn reader(index: &Index) -> IndexReader {
         index
             .reader_builder()
-            .reload_policy(tantivy::ReloadPolicy::Manual)
+            .reload_policy(tantivy::ReloadPolicy::OnCommit)
             .try_into()
             .expect("failed to create index reader")
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #411

## What
Finished review and rebase of @aragalie's #404. I intended to push to/merge that one, but GitHub closed it and won't let me re-open.

## Why
All the notes from #404 still apply. I've spend the last day studying @aragalie's work to better understand VACUUM operations in Postgres. Carefully following the code paths with a debugger helped me verify that everything is being called as expected.

I can't find much information about @aragalie's change to increment `stats_binding.pages_deleted` instead of ` stats_binding.tuples_removed`, as well as the change to increment `stats_binding.num_pages` instead of `stats_binding.num_index_tuples`. @aragalie, it would be great if you could comment on this change!

Otherwise, the PR seems to work well, and I'd be in favor of merging so I can build off it for an `amdelete` implementation.