### PR TITLE
fix: pgml symlinks and postgres permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,6 +170,8 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     libprotobuf-c1 \
     libc++1 \
     libc++abi1 \
+    # barman
+    barman \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
     pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \
@@ -220,10 +222,13 @@ COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_M
 # initialization scipt
 COPY ./scripts/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh
 
+RUN ln -s /var/lib/postgresql/data /var/lib/postgresql/.triton && \
+    ln -s /var/lib/postgresql/data /var/lib/postgresql/.cache
+
 # Change the uid of postgres to 26
 RUN usermod -u 26 postgres \
-    && chown -R 26:26 /var/lib/postgresql \
-    && chown -R 26:26 /var/run/postgresql \
-    && chmod 700 /var/lib/postgresql
+    && chown -R 26:999 /var/lib/postgresql \
+    && chown -R 26:999 /var/run/postgresql \
+    && chmod -R 700 /var/lib/postgresql
 
 USER 26

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,6 +172,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     libc++abi1 \
     # barman
     barman \
+    barman-cli-cloud \
     && rm -rf /var/lib/apt/lists/* /tmp/* && \
     # pgml
     pip3 install --no-cache-dir --break-system-packages accelerate==0.22.0 bitsandbytes==0.41.1 catboost==1.2 ctransformers==0.2.27 datasets==2.14.5 deepspeed==0.10.3 huggingface-hub==0.17.1 InstructorEmbedding==1.0.1 lightgbm==4.1.0 orjson==3.9.7 pandas==2.1.0 rich==13.5.2 rouge==1.0.1 sacrebleu==2.3.1 sacremoses==0.0.53 scikit-learn==1.3.0 sentencepiece==0.1.99 sentence-transformers==2.2.2 tokenizers==0.13.3 torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 tqdm==4.66.1 transformers==4.33.1 xgboost==2.0.0 langchain==0.0.287 einops==0.6.1 pynvml==11.5.0 && \


### PR DESCRIPTION
# Ticket(s) Closed
N/A

## What
This PR aims to fix the issue seen when trying to use `paradedb.embed` while deploying with the helm chart. It fixes the postgres user group which was incorrectly set to 26 (`tape` group), and finally, installs [barman](https://docs.pgbarman.org/release/2.13/barman-cloud-backup.1.html), which is the final missing piece to get backups fully working.

## Why
Because while testing, we ran into the issue:
```
RuntimeError: Failed to import transformers.models.pegasus.modeling_pegasus because of the following
error (look up to see its traceback):
Failed to import transformers.generation.utils because of the following error 
(look up to see its traceback):
[Errno 30] Read-only file system: '/var/lib/postgresql/.triton'
```

This happens because the CloudNative operator mounts the root filesystem as read only:
>Automatically set readOnlyRootFilesystem security context for pods

The operator doesn't directly expose a way to modify the pod Security Context, or volume mounts. I experimented setting `TRANSFORMERS_CACHE` and `HF_HOME`, but they aren't respected by pgml. So, the only viable solution left is to symlink to the read write volume, or remove pgml. 

In addition, I discovered that we were setting the postgres user group to 26, which is assigned to the `tape` group, and not `postgres`, which is set to `999` by the official image.

Finally, I take this chance to add the barman binaries to get backups fully working.

## How
- Change postgres group from 26 to 999
- Install barman package
- Create symlinks for the `.triton` and `.cache` directories

## Tests
Tested it works when deploying with the operator, and all steps in the [quickstart](https://docs.paradedb.com/quickstart) work. 