### PR TITLE
fix: Manually reload index and encapsulate Tantivy writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "hnswlib"
 version = "0.1.0"
-source = "git+https://github.com/paradedb/hnswlib.git?rev=6ed0bd0ceb67c09d3ea59dec2539208c4b8bd094#6ed0bd0ceb67c09d3ea59dec2539208c4b8bd094"
+source = "git+https://github.com/paradedb/hnswlib.git?rev=16096b04db19ca00ee7250e27680c8d9296c7c37#16096b04db19ca00ee7250e27680c8d9296c7c37"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/pg_bm25/src/index_access/build.rs
+++ b/pg_bm25/src/index_access/build.rs
@@ -9,7 +9,6 @@ use crate::parade_index::index::ParadeIndex;
 
 // For now just pass the count and parade
 // index on the build callback state
-#[allow(dead_code)]
 struct BuildState<'a> {
     count: usize,
     parade_index: &'a mut ParadeIndex,

--- a/pg_bm25/src/index_access/build.rs
+++ b/pg_bm25/src/index_access/build.rs
@@ -1,6 +1,5 @@
 use pgrx::*;
 use std::panic::{self, AssertUnwindSafe};
-use tantivy::SingleSegmentIndexWriter;
 
 use crate::index_access::options::ParadeOptions;
 use crate::index_access::utils::{
@@ -8,22 +7,19 @@ use crate::index_access::utils::{
 };
 use crate::parade_index::index::ParadeIndex;
 
-const INDEX_WRITER_MEM_BUDGET: usize = 50_000_000;
-
 // For now just pass the count and parade
 // index on the build callback state
+#[allow(dead_code)]
 struct BuildState<'a> {
     count: usize,
     parade_index: &'a mut ParadeIndex,
-    writer: &'a mut SingleSegmentIndexWriter,
     memcxt: PgMemoryContexts,
 }
 
 impl<'a> BuildState<'a> {
-    fn new(parade_index: &'a mut ParadeIndex, writer: &'a mut SingleSegmentIndexWriter) -> Self {
+    fn new(parade_index: &'a mut ParadeIndex) -> Self {
         BuildState {
             parade_index,
-            writer,
             count: 0,
             memcxt: PgMemoryContexts::new("ParadeDB build context"),
         }
@@ -59,19 +55,12 @@ pub extern "C" fn ambuild(
     )
     .unwrap();
 
-    let tantivy_index = parade_index.copy_tantivy_index();
-    let mut writer = SingleSegmentIndexWriter::new(tantivy_index, INDEX_WRITER_MEM_BUDGET)
-        .expect("failed to create index writer");
-
     let ntuples = do_heap_scan(
         index_info,
         &heap_relation,
         &index_relation,
         &mut parade_index,
-        &mut writer,
     );
-
-    writer.finalize().expect("failed to finalize writer");
 
     let mut result = unsafe { PgBox::<pg_sys::IndexBuildResult>::alloc0() };
     result.heap_tuples = ntuples as f64;
@@ -88,9 +77,8 @@ fn do_heap_scan<'a>(
     heap_relation: &'a PgRelation,
     index_relation: &'a PgRelation,
     parade_index: &mut ParadeIndex,
-    writer: &mut SingleSegmentIndexWriter,
 ) -> usize {
-    let mut state = BuildState::new(parade_index, writer);
+    let mut state = BuildState::new(parade_index);
     let _ = panic::catch_unwind(AssertUnwindSafe(|| unsafe {
         pg_sys::IndexBuildHeapScan(
             heap_relation.as_ptr(),
@@ -155,7 +143,7 @@ unsafe extern "C" fn build_callback_internal(
     let builder = row_to_json(values[0], &tupdesc, natts, &dropped, &attributes);
 
     // Insert row to parade index
-    state.parade_index.insert(state.writer, ctid, builder);
+    state.parade_index.insert(ctid, builder);
 
     old_context.set_as_current();
     state.memcxt.reset();

--- a/pg_bm25/src/index_access/delete.rs
+++ b/pg_bm25/src/index_access/delete.rs
@@ -16,6 +16,13 @@ pub extern "C" fn ambulkdelete(
     let index_name = &index_relation.name().to_string();
     let parade_index = get_parade_index(index_name.into());
 
+    // let mut stats_binding = stats;
+
+    // if stats_binding.is_null() {
+    //     stats_binding =
+    //         unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
+    // }
+
     if stats.is_null() {
         stats = unsafe {
             PgBox::from_pg(
@@ -23,6 +30,14 @@ pub extern "C" fn ambulkdelete(
             )
         };
     }
+
+    // let index_rel: pg_sys::Relation = unsafe { (*info).index };
+    // let index_relation = unsafe { PgRelation::from_pg(index_rel) };
+    // let index_name = index_relation.name().to_string();
+
+    // let parade_index = get_parade_index(index_name);
+    // parade_index.bulk_delete(stats_binding, callback, callback_state);
+    // stats_binding
 
     stats = parade_index.bulk_delete(stats, callback, callback_state);
     stats.into_pg()

--- a/pg_bm25/src/index_access/delete.rs
+++ b/pg_bm25/src/index_access/delete.rs
@@ -16,13 +16,6 @@ pub extern "C" fn ambulkdelete(
     let index_name = &index_relation.name().to_string();
     let parade_index = get_parade_index(index_name.into());
 
-    // let mut stats_binding = stats;
-
-    // if stats_binding.is_null() {
-    //     stats_binding =
-    //         unsafe { pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast() };
-    // }
-
     if stats.is_null() {
         stats = unsafe {
             PgBox::from_pg(
@@ -30,14 +23,6 @@ pub extern "C" fn ambulkdelete(
             )
         };
     }
-
-    // let index_rel: pg_sys::Relation = unsafe { (*info).index };
-    // let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    // let index_name = index_relation.name().to_string();
-
-    // let parade_index = get_parade_index(index_name);
-    // parade_index.bulk_delete(stats_binding, callback, callback_state);
-    // stats_binding
 
     stats = parade_index.bulk_delete(stats, callback, callback_state);
     stats.into_pg()

--- a/pg_bm25/src/index_access/insert.rs
+++ b/pg_bm25/src/index_access/insert.rs
@@ -1,11 +1,8 @@
 use pgrx::*;
-use tantivy::SingleSegmentIndexWriter;
 
 use crate::index_access::utils::{
     categorize_tupdesc, get_parade_index, lookup_index_tupdesc, row_to_json,
 };
-
-const INDEX_WRITER_MEM_BUDGET: usize = 50_000_000;
 
 #[allow(clippy::too_many_arguments)]
 #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
@@ -57,11 +54,7 @@ unsafe fn aminsert_internal(
 
     // Insert row to parade index
     let mut parade_index = get_parade_index(index_name);
-    let tantivy_index = parade_index.copy_tantivy_index();
-    let mut writer = SingleSegmentIndexWriter::new(tantivy_index, INDEX_WRITER_MEM_BUDGET)
-        .expect("failed to create index writer");
-    parade_index.insert(&mut writer, *heap_tid, builder);
-    writer.commit().expect("failed to commit writer");
+    parade_index.insert(*heap_tid, builder);
 
     true
 }

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -87,10 +87,14 @@ pub extern "C" fn amrescan(
     let schema = &state.schema;
 
     // Extract limit and offset from the query config or set defaults.
-    let limit = query_config
-        .config
-        .limit
-        .unwrap_or(searcher.num_docs() as usize);
+    let limit = query_config.config.limit.unwrap_or({
+        let num_docs = searcher.num_docs() as usize;
+        if num_docs > 0 {
+            num_docs // The collector will panic if it's passed a limit of 0.
+        } else {
+            1 // Since there's no docs to return anyways, just use 1.
+        }
+    });
     let offset = query_config.config.offset.unwrap_or(0);
 
     // Construct the actual Tantivy search query based on the mode determined above.

--- a/pg_bm25/src/index_access/vacuum.rs
+++ b/pg_bm25/src/index_access/vacuum.rs
@@ -23,13 +23,8 @@ pub extern "C" fn amvacuumcleanup(
     let index_name = index_relation.name().to_string();
     let parade_index = get_parade_index(index_name);
 
-    let index_writer = parade_index.writer();
-
     // Cleanup the garbage
-    index_writer
-        .garbage_collect_files()
-        .wait()
-        .expect("Could not collect garbage");
+    parade_index.garbage_collect_files();
 
     stats
 }

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -320,7 +320,6 @@ impl ParadeIndex {
 
     fn single_segment_writer(&self) -> Result<SingleSegmentIndexWriter, TantivyError> {
         SingleSegmentIndexWriter::new(self.underlying_index.clone(), INDEX_TANTIVY_MEMORY_BUDGET)
-        // .expect("Could not create index writer for index: {}", self.name);
     }
 
     pub fn writer(&self) -> Result<IndexWriter, TantivyError> {

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -9,9 +9,9 @@ use std::path::Path;
 use tantivy::{
     query::{Query, QueryParser},
     schema::*,
-    DocAddress, Document, Index, IndexSettings, Score, Searcher, SingleSegmentIndexWriter, Term,
+    DocAddress, Document, Index, IndexSettings, Score, Searcher, Term,
 };
-use tantivy::{IndexReader, IndexWriter};
+use tantivy::{IndexReader, IndexWriter, SingleSegmentIndexWriter, TantivyError};
 
 use crate::index_access::options::ParadeOptions;
 use crate::json::builder::JsonBuilder;
@@ -51,6 +51,7 @@ pub struct TantivyScanState {
 
 #[derive(Clone)]
 pub struct ParadeIndex {
+    pub name: String,
     pub fields: HashMap<String, Field>,
     pub field_configs: ParadeOptionMap,
     reader: IndexReader,
@@ -113,13 +114,14 @@ impl ParadeIndex {
         Self::setup_tokenizers(&mut underlying_index, &field_configs);
 
         let reader = Self::reader(&underlying_index)
-            .expect("failed to create index reader while creating new index");
+            .expect("failed to create index reader while creating new index: {name}");
 
         let new_self = Self {
+            name: name.clone(),
             fields,
             field_configs,
-            underlying_index,
             reader,
+            underlying_index,
         };
         unsafe {
             new_self.into_cached_index(name);
@@ -131,6 +133,13 @@ impl ParadeIndex {
     fn setup_tokenizers(underlying_index: &mut Index, field_configs: &ParadeOptionMap) {
         underlying_index.set_tokenizers(create_tokenizer_manager(field_configs));
         underlying_index.set_fast_field_tokenizers(create_normalizer_manager());
+    }
+
+    fn reader(index: &Index) -> Result<IndexReader, TantivyError> {
+        index
+            .reader_builder()
+            .reload_policy(tantivy::ReloadPolicy::Manual)
+            .try_into()
     }
 
     unsafe fn from_cached_index(name: &str) -> Option<Self> {
@@ -181,19 +190,21 @@ impl ParadeIndex {
         let field_configs =
             Self::read_index_field_configs(&name).expect("failed to open index field configs");
 
+        let reader = Self::reader(&underlying_index)
+            .expect("failed to create index reader while retrieving index: {name}");
+
         // We need to setup tokenizers again after retrieving an index from disk.
         Self::setup_tokenizers(&mut underlying_index, &field_configs);
 
-        let reader = Self::reader(&underlying_index)
-            .expect("failed to create index reader while retrieving index from disk");
-
         let new_self = Self {
+            name: name.clone(),
             fields,
             field_configs,
-            underlying_index,
             reader,
+            underlying_index,
         };
 
+        // Since we've re-fetched the index, save it to the cache.
         unsafe {
             new_self.into_cached_index(name);
         }
@@ -201,13 +212,11 @@ impl ParadeIndex {
         new_self
     }
 
-    pub fn insert(
-        &mut self,
-        writer: &mut SingleSegmentIndexWriter,
-        heap_tid: ItemPointerData,
-        builder: JsonBuilder,
-    ) {
+    pub fn insert(&mut self, heap_tid: ItemPointerData, builder: JsonBuilder) {
         let mut doc: Document = Document::new();
+        let mut writer = self
+            .single_segment_writer()
+            .expect("Could not retrieve single segment writer for insert");
 
         for (col_name, value) in builder.values {
             let field_option = self.fields.get(col_name.trim_matches('"'));
@@ -219,6 +228,9 @@ impl ParadeIndex {
         let field_option = self.fields.get("heap_tid");
         doc.add_u64(*field_option.unwrap(), item_pointer_to_u64(heap_tid));
         writer.add_document(doc).expect("failed to add document");
+
+        writer.commit().unwrap();
+        self.reload();
     }
 
     pub fn bulk_delete(
@@ -278,6 +290,7 @@ impl ParadeIndex {
     }
 
     pub fn scan(&self) -> TantivyScanState {
+        self.reload();
         let schema = self.underlying_index.schema();
 
         let searcher = self.searcher();
@@ -297,10 +310,6 @@ impl ParadeIndex {
         }
     }
 
-    pub fn copy_tantivy_index(&self) -> tantivy::Index {
-        self.underlying_index.clone()
-    }
-
     pub fn schema(&self) -> Schema {
         self.underlying_index.schema()
     }
@@ -309,17 +318,28 @@ impl ParadeIndex {
         self.reader.searcher()
     }
 
-    pub fn writer(&self) -> IndexWriter {
-        self.underlying_index
-            .writer(INDEX_TANTIVY_MEMORY_BUDGET)
-            .unwrap()
+    fn single_segment_writer(&self) -> Result<SingleSegmentIndexWriter, TantivyError> {
+        SingleSegmentIndexWriter::new(self.underlying_index.clone(), INDEX_TANTIVY_MEMORY_BUDGET)
+        // .expect("Could not create index writer for index: {}", self.name);
     }
 
-    fn reader(index: &Index) -> Result<IndexReader, tantivy::TantivyError> {
-        index
-            .reader_builder()
-            .reload_policy(tantivy::ReloadPolicy::OnCommit)
-            .try_into()
+    pub fn writer(&self) -> Result<IndexWriter, TantivyError> {
+        self.underlying_index.writer(INDEX_TANTIVY_MEMORY_BUDGET)
+    }
+
+    pub fn reload(&self) {
+        self.reader.reload().unwrap();
+    }
+
+    pub fn garbage_collect_files(&self) {
+        let index_writer = self
+            .writer()
+            .expect("Could not create writer to garbage collect files");
+
+        index_writer
+            .garbage_collect_files()
+            .wait()
+            .expect("Could not collect garbage");
     }
 
     fn get_data_directory(name: &str) -> String {

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -124,7 +124,7 @@ impl ParadeIndex {
             underlying_index,
         };
         unsafe {
-            new_self.into_cached_index(name);
+            new_self.to_cached_index(name);
         }
 
         Ok(new_self)
@@ -155,7 +155,7 @@ impl ParadeIndex {
         PARADE_INDEX_MEMORY.as_ref()?.get(name).cloned()
     }
 
-    unsafe fn into_cached_index(&self, name: String) {
+    unsafe fn to_cached_index(&self, name: String) {
         if PARADE_INDEX_MEMORY.is_none() {
             PARADE_INDEX_MEMORY = Some(HashMap::new());
         }
@@ -206,7 +206,7 @@ impl ParadeIndex {
 
         // Since we've re-fetched the index, save it to the cache.
         unsafe {
-            new_self.into_cached_index(name);
+            new_self.to_cached_index(name);
         }
 
         new_self


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #348 

## What
What's happening in #348 is that rows are getting marked "dead" in Postgres due to the `UPDATE` call, but we don't synchronously commit the changes to Tantivy index + reload.

## How
Manually call `.reload` on the tantivy reader after write and before scan.
