### PR TITLE
feat: Add missing lint workflows that are only caught in pre-commit

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,35 +1,27 @@
-# workflows/lint-file-endings.yml
+# workflows/lint-format.yml
 #
-# Lint File Endings
-# Lint the project's file endings.
+# Lint Format
+# Lint the project's file trailing spaces, line endings, and format.
 
-name: Lint File Endings
+name: Lint Format
 
 on:
   pull_request:
   workflow_dispatch:
 
+# Need to add trailing white spaces to this one
 concurrency:
-  group: lint-file-endings-${{ github.head_ref || github.ref }}
+  group: lint-format-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lint-file-endings:
-    name: Lint File Endings
+  lint-format:
+    name: Lint File Endings & Trailing Whitespaces
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
-
-      - name: Check for CRLF Files
-        run: |
-          FILES=$(git ls-files --eol | grep crlf || true)
-          if [[ ! -z "$FILES" ]]; then
-            echo "The following files have incorrect line endings:"
-            echo "$FILES"
-            false
-          fi
 
       - name: Install fd Search Tool
         run: |
@@ -41,6 +33,24 @@ jobs:
 
       - name: Add Trailing Newlines
         run: .github/workflows/helpers/lint_trailing_newlines.sh
+
+      - name: Check for CRLF Files
+        run: |
+          FILES=$(git ls-files --eol | grep crlf || true)
+          if [[ ! -z "$FILES" ]]; then
+            echo "The following files have incorrect line endings:"
+            echo "$FILES"
+            false
+          fi
+
+      - name: Check for Trailing Whitespaces
+        run: |
+          FILES=$(git grep -Ilr '[[:blank:]]$' || true)
+          if [[ ! -z "$FILES" ]]; then
+            echo "The following files have trailing whitespaces:"
+            echo "$FILES"
+            false
+          fi
 
       - name: Print Modified Files
         run: |

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -43,13 +43,15 @@ jobs:
             false
           fi
 
+      # We ignore .out and .sql files, which are used by pg_regress for testing
+      # and need a very specific format
       - name: Check for Trailing Whitespaces
         run: |
-          FILES=$(git grep -Ilr '[[:blank:]]$' || true)
+          FILES=$(git grep -Ilr '[[:blank:]]$' -- ':(exclude)*.out' ':(exclude)*.sql' || true)
           if [[ ! -z "$FILES" ]]; then
             echo "The following files have trailing whitespaces:"
             echo "$FILES"
-            false
+            exit 1
           fi
 
       - name: Print Modified Files

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -36,4 +36,4 @@ jobs:
         run: markdownlint '**/*.md'
 
       - name: Run Pettier
-        run: prettier --check '{**/**.md,**/**.mdx}'
+        run: prettier --check '{**/*.md,**/*.mdx}'

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -8,8 +8,8 @@ name: Lint Python
 on:
   pull_request:
     paths:
-      - "**/*.sh"
-      - ".github/workflows/lint-bash.yml"
+      - "**/*.py"
+      - ".github/workflows/lint-python.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     paths:
       - "**/*.js"
-      - "**/*.jsx"
       - "**/*.ts"
       - "**/*.tsx"
       - "**/*.css"

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   lint-typescript:
-    name: Lint Python Files
+    name: Lint TypeScript Files
     runs-on: ubuntu-latest
 
     steps:
@@ -31,13 +31,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up NodeJS Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
 
-      - name: Install Prettier & ESLint
-        run: npm install -g prettier eslint
+      - name: Install Dependencies
+        working-directory: dashboard/
+        run: npm install
 
-      - name: Check if TypeScript Files are ESLint Formatted
-        run: eslint '{**/*.js,**/*.ts,**/*.tsx}'
+      - name: Run ESLint
+        run: npx eslint "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx"
 
-      - name: Check if TypeScript Files are Prettier Formatted
-        run: prettier --check '{**/*.js,**/*.ts,**/*.tsx,**/*.css,**/*.json}'
+      - name: Run Prettier Check
+        run: npx prettier --check "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx" "**/*.css" "**/*.json"

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm install
 
       - name: Run ESLint
-        run: npx eslint "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx"
+        run: npx eslint "**/*.js" "**/*.ts" "**/*.tsx"
 
       - name: Run Prettier Check
-        run: npx prettier --check "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx" "**/*.css" "**/*.json"
+        run: npx prettier --check "**/*.js" "**/*.ts" "**/*.tsx" "**/*.css" "**/*.json"

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -1,0 +1,43 @@
+# workflows/lint-typescript.yml
+#
+# Lint TypeScript
+# Lint TypeScript and related files (i.e. .json, .css, etc.) using ESLint and Prettier.
+
+name: Lint TypeScript
+
+on:
+  pull_request:
+    paths:
+      - "**/*.js"
+      - "**/*.jsx"
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.css"
+      - "**/*.json"
+      - ".github/workflows/lint-typescript.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: lint-typescript-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint-typescript:
+    name: Lint Python Files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Set up NodeJS Environment
+        uses: actions/setup-node@v3
+
+      - name: Install Prettier & ESLint
+        run: npm install -g prettier eslint
+
+      - name: Check if TypeScript Files are ESLint Formatted
+        run: eslint '{**/*.js,**/*.ts,**/*.tsx}'
+
+      - name: Check if TypeScript Files are Prettier Formatted
+        run: prettier --check '{**/*.js,**/*.ts,**/*.tsx,**/*.css,**/*.json}'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR adds missing linting workflows to our repo. We were not linting for trailing whitespaces and for TypeScript/JSON/etc. files, which led to all CI passing while pre-commit hooks not passing. This should not standardize everything!

## Why

## How

## Tests
