### PR TITLE
chore: Add missing schema to `pg_sparse`

### DIFF
--- a/pg_bm25/pg_bm25.control
+++ b/pg_bm25/pg_bm25.control
@@ -1,6 +1,7 @@
-comment = 'pg_bm25: PostgreSQL-native, full text search using BM25'
+comment = 'pg_bm25: Full text search for PostgreSQL using BM25'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_bm25'
 relocatable = false
 superuser = true
+trusted = true
 schema = paradedb

--- a/pg_bm25/pg_bm25.control
+++ b/pg_bm25/pg_bm25.control
@@ -3,5 +3,4 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_bm25'
 relocatable = false
 superuser = true
-trusted = true
 schema = paradedb

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -72,10 +72,10 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
       ;;
     Linux)
-      PG_VERSIONS=("15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12" "11")
       ;;
   esac
 else
@@ -119,6 +119,9 @@ function run_tests() {
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET logging_collector TO 'on';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_directory TO '$LOG_DIR';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_filename TO 'test_logs.log';" -d test_db > /dev/null
+
+  # Configure search_path to include the paradedb schema
+  "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER USER $PGUSER SET search_path TO public,paradedb;" -d test_db > /dev/null
 
   # Reload PostgreSQL configuration
   echo "Reloading PostgreSQL configuration..."

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -3,6 +3,5 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = true
-trusted = true
 schema = paradedb
 requires = 'pg_bm25,vector'

--- a/pg_search/pg_search.control
+++ b/pg_search/pg_search.control
@@ -1,7 +1,8 @@
-comment = 'pg_search: Hybrid search over PostgreSQL'
+comment = 'pg_search: Hybrid search for PostgreSQL'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_search'
 relocatable = false
 superuser = true
-requires = 'pg_bm25,vector'
+trusted = true
 schema = paradedb
+requires = 'pg_bm25,vector'

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -72,10 +72,10 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
       ;;
     Linux)
-      PG_VERSIONS=("15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12" "11")
       ;;
   esac
 else
@@ -119,6 +119,9 @@ function run_tests() {
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET logging_collector TO 'on';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_directory TO '$LOG_DIR';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_filename TO 'test_logs.log';" -d test_db > /dev/null
+
+  # Configure search_path to include the paradedb schema
+  "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER USER $PGUSER SET search_path TO public,paradedb;" -d test_db > /dev/null
 
   # Reload PostgreSQL configuration
   echo "Reloading PostgreSQL configuration..."

--- a/pg_sparse/pg_sparse.control
+++ b/pg_sparse/pg_sparse.control
@@ -3,5 +3,4 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_sparse'
 relocatable = false
 superuser = true
-trusted = true
 schema = paradedb

--- a/pg_sparse/pg_sparse.control
+++ b/pg_sparse/pg_sparse.control
@@ -3,3 +3,5 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_sparse'
 relocatable = false
 superuser = true
+trusted = true
+schema = paradedb

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -72,7 +72,7 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("11.21" "12.16" "13.12" "14.9" "15.4" "16.0")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
       ;;
     Linux)
       PG_VERSIONS=("16" "15" "14" "13" "12" "11")
@@ -119,6 +119,9 @@ function run_tests() {
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET logging_collector TO 'on';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_directory TO '$LOG_DIR';" -d test_db > /dev/null
   "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET log_filename TO 'test_logs.log';" -d test_db > /dev/null
+
+  # Configure search_path to include the paradedb schema
+  "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER USER $PGUSER SET search_path TO public,paradedb;" -d test_db > /dev/null
 
   # Reload PostgreSQL configuration
   echo "Reloading PostgreSQL configuration..."


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR adds the missing `schema = paradedb` in the `pg_sparse` .control file, and accordingly adds `paradedb` to the `search_path` for all of our extensions in the integration test framework, so that it can be found correctly. This fixes the issue with `pg_sparse` not fully working, and not passing the tests.

## Why

## How

## Tests
CI now passes!