### PR TITLE
fix: Fix `search_path` missing the `paradedb` schema

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -73,6 +73,11 @@ if [ -z "$POSTGRES_ROLE_EXISTS" ]; then
 EOSQL
 fi
 
+# Configure search_path to include the paradedb schema
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+  ALTER USER "$POSTGRES_USER" SET search_path TO public,paradedb;
+EOSQL
+
 # We need to restart the server for the changes above to be reflected
 pg_ctl restart
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We weren't adding our schema, `paradedb`, to the `search_path` in Postgres. As a result, it was only finding the `public` schema, while our extensions were getting installed on the `paradedb` schema, which led to inconsistencies. This fixes it.

## Why

## How

## Tests
Tested locally on both `public` and `paradedb` schemas
