### PR TITLE
chore: Remove support for Postgres 11

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -53,7 +53,6 @@ jobs:
             PG_BM25_VERSION=${{ steps.version.outputs.version }}
             PG_SEARCH_VERSION=${{ steps.version.outputs.version }}
             PGVECTOR_VERSION=0.5.1
-            PGML_VERSION=2.7.12
             PGAUDIT_VERSION=1.7.0
             PG_NET_VERSION=0.7.2
             PG_GRAPHQL_VERSION=1.3.0

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [11, 12, 13, 14, 15, 16]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [11, 12, 13, 14, 15, 16]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [11, 12, 13, 14, 15, 16]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository

--- a/pg_bm25/.gitignore
+++ b/pg_bm25/.gitignore
@@ -17,6 +17,6 @@ results/
 
 # pg_regress
 test/results/
-test/regression.diffs
-test/regression.out
 test/test_logs.log
+regression.diffs
+regression.out

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -7,10 +7,9 @@
 
 ## Overview
 
-`pg_bm25` is a PostgreSQL extension that enables full text search over SQL tables using the BM25 algorithm, the state-of-the-art ranking function
-for full text search. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using `pgrx`.
+`pg_bm25` is a PostgreSQL extension that enables full text search over SQL tables using the BM25 algorithm, the state-of-the-art ranking function for full text search. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using `pgrx`.
 
-`pg_bm25` is supported on PostgreSQL 11+.
+`pg_bm25` is supported on all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 12+.
 
 Check out the `pg_bm25` benchmarks [here](../benchmarks/README.md).
 

--- a/pg_bm25/test/expected/bm25_search.out
+++ b/pg_bm25/test/expected/bm25_search.out
@@ -17,11 +17,11 @@ FROM bm25_search
 WHERE bm25_search @@@ 'category:electronics OR description:keyboard';
  rank_bm25 | id |         description         | rating |  category   | in_stock |                     metadata                     
 -----------+----+-----------------------------+--------+-------------+----------+--------------------------------------------------
-    5.3765 |  2 | Plastic Keyboard            |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}
-   4.93101 |  1 | Ergonomic metal keyboard    |      4 | Electronics | t        | {"color": "Silver", "location": "United States"}
-   2.10964 | 12 | Innovative wireless earbuds |      5 | Electronics | t        | {"color": "Black", "location": "China"}
-   2.10964 | 22 | Fast charging power bank    |      4 | Electronics | t        | {"color": "Black", "location": "United States"}
-   2.10964 | 32 | Bluetooth-enabled speaker   |      3 | Electronics | t        | {"color": "Black", "location": "Canada"}
+ 5.3764954 |  2 | Plastic Keyboard            |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}
+  4.931014 |  1 | Ergonomic metal keyboard    |      4 | Electronics | t        | {"color": "Silver", "location": "United States"}
+ 2.1096356 | 12 | Innovative wireless earbuds |      5 | Electronics | t        | {"color": "Black", "location": "China"}
+ 2.1096356 | 22 | Fast charging power bank    |      4 | Electronics | t        | {"color": "Black", "location": "United States"}
+ 2.1096356 | 32 | Bluetooth-enabled speaker   |      3 | Electronics | t        | {"color": "Black", "location": "Canada"}
 (5 rows)
 
 -- Test JSON search 

--- a/pg_bm25/test/expected/bm25_search.out
+++ b/pg_bm25/test/expected/bm25_search.out
@@ -1,12 +1,3 @@
--- This is needed to ensure consistency of printouts with PostgreSQL versions older than 12. Can be
--- deleted if we drop support for PostgreSQL 11.
-ALTER SYSTEM SET extra_float_digits TO 0;
-select pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
 -- Basic search query
 SELECT *
 FROM bm25_search

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -13,7 +13,7 @@ usage() {
   echo "Options:"
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
-  echo " -v (optional),   PG version(s) separated by comma <11,12,13>"
+  echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
   exit 1
 }
 
@@ -72,10 +72,10 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
       ;;
     Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12")
       ;;
   esac
 else

--- a/pg_bm25/test/sql/bm25_search.sql
+++ b/pg_bm25/test/sql/bm25_search.sql
@@ -1,9 +1,3 @@
--- This is needed to ensure consistency of printouts with PostgreSQL versions older than 12. Can be
--- deleted if we drop support for PostgreSQL 11.
-ALTER SYSTEM SET extra_float_digits TO 0;
-select pg_reload_conf();
-
-
 -- Basic search query
 SELECT *
 FROM bm25_search

--- a/pg_search/.gitignore
+++ b/pg_search/.gitignore
@@ -18,9 +18,9 @@ results/
 # pg_regress
 test/pgvector/
 test/results/
-test/regression.diffs
-test/regression.out
 test/test_logs.log
+regression.diffs
+regression.out
 
 # pgvector
 pgvector/

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -9,7 +9,7 @@
 
 `pg_search` is a PostgreSQL extension that enables hybrid search in Postgres. Hybrid search is a search technique that combines BM25-based full text search with vector-based similarity search. It is built on top of `pg_bm25`, the leading full text search extension for Postgres, and `pgvector`, the leading vector similarity search extension for Postgres, using `pgrx`.
 
-`pg_search` is supported on PostgreSQL 11+.
+`pg_search` is supported on all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 12+.
 
 ## Installation
 

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -18,10 +18,10 @@ if [ $# -eq 0 ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
       ;;
     Linux)
-      PG_VERSIONS=("15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12")
       ;;
   esac
 else

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -9,22 +9,22 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[0.5,0.5]
     ) as score_hybrid
 FROM mock_items
 ORDER BY score_hybrid DESC
 LIMIT 5;
-       description        |  category   | rating | embedding |   score_hybrid    
---------------------------+-------------+--------+-----------+-------------------
- Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.788961044379643
- Plastic Keyboard         | Electronics |      4 | [4,5,6]   | 0.785714285714286
- Artistic ceramic vase    | Home Decor  |      4 | [1,2,3]   |               0.5
- Modern wall clock        | Home Decor  |      4 | [1,2,3]   |               0.5
- Designer wall paintings  | Home Decor  |      5 | [1,2,3]   |               0.5
+       description        |  category   | rating | embedding |    score_hybrid    
+--------------------------+-------------+--------+-----------+--------------------
+ Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.7889610443796431
+ Plastic Keyboard         | Electronics |      4 | [4,5,6]   | 0.7857142857142857
+ Artistic ceramic vase    | Home Decor  |      4 | [1,2,3]   |                0.5
+ Modern wall clock        | Home Decor  |      4 | [1,2,3]   |                0.5
+ Designer wall paintings  | Home Decor  |      5 | [1,2,3]   |                0.5
 (5 rows)
 
 -- All weighted on BM25
@@ -36,22 +36,22 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[1,0]
     ) as score_hybrid
 FROM mock_items
 ORDER BY score_hybrid DESC
 LIMIT 5;
-       description        |  category   | rating | embedding |   score_hybrid    
---------------------------+-------------+--------+-----------+-------------------
- Plastic Keyboard         | Electronics |      4 | [4,5,6]   |                 1
- Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.863636374473572
- White jogging shoes      | Footwear    |      3 | [6,7,8]   |                 0
- Generic shoes            | Footwear    |      4 | [7,8,9]   |                 0
- Sleek running shoes      | Footwear    |      5 | [5,6,7]   |                 0
+       description        |  category   | rating | embedding |    score_hybrid    
+--------------------------+-------------+--------+-----------+--------------------
+ Plastic Keyboard         | Electronics |      4 | [4,5,6]   |                  1
+ Ergonomic metal keyboard | Electronics |      4 | [3,4,5]   | 0.8636363744735718
+ White jogging shoes      | Footwear    |      3 | [6,7,8]   |                  0
+ Generic shoes            | Footwear    |      4 | [7,8,9]   |                  0
+ Sleek running shoes      | Footwear    |      5 | [5,6,7]   |                  0
 (5 rows)
 
 -- All weighted on HNSW
@@ -63,21 +63,21 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[0,1]
     ) as score_hybrid
 FROM mock_items
 ORDER BY score_hybrid DESC
 LIMIT 5;
-       description        |  category  | rating | embedding |   score_hybrid    
---------------------------+------------+--------+-----------+-------------------
- Designer wall paintings  | Home Decor |      5 | [1,2,3]   |                 1
- Handcrafted wooden frame | Home Decor |      5 | [1,2,3]   |                 1
- Artistic ceramic vase    | Home Decor |      4 | [1,2,3]   |                 1
- Modern wall clock        | Home Decor |      4 | [1,2,3]   |                 1
- Interactive board game   | Toys       |      3 | [2,3,4]   | 0.857142857142857
+       description        |  category  | rating | embedding |    score_hybrid    
+--------------------------+------------+--------+-----------+--------------------
+ Designer wall paintings  | Home Decor |      5 | [1,2,3]   |                  1
+ Handcrafted wooden frame | Home Decor |      5 | [1,2,3]   |                  1
+ Artistic ceramic vase    | Home Decor |      4 | [1,2,3]   |                  1
+ Modern wall clock        | Home Decor |      4 | [1,2,3]   |                  1
+ Interactive board game   | Toys       |      3 | [2,3,4]   | 0.8571428571428572
 (5 rows)
 

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -1,12 +1,3 @@
--- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
--- deleted if we drop support for postgres 11.
-ALTER SYSTEM SET extra_float_digits TO 0;
-select pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 -- Hybrid search with equal weights

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -13,7 +13,7 @@ usage() {
   echo "Options:"
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
-  echo " -v (optional),   PG version(s) separated by comma <11,12,13>"
+  echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
   exit 1
 }
 
@@ -72,10 +72,10 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
       ;;
     Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12")
       ;;
   esac
 else

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -1,8 +1,3 @@
--- this is needed to ensure consistency of printouts with postgres versions older than 12. Can be
--- deleted if we drop support for postgres 11.
-ALTER SYSTEM SET extra_float_digits TO 0;
-select pg_reload_conf();
-
 CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -10,9 +10,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[0.5,0.5]
     ) as score_hybrid
@@ -29,9 +29,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[1,0]
     ) as score_hybrid
@@ -48,9 +48,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          '[1,2,3]' <-> embedding, 
-          MIN('[1,2,3]' <-> embedding) OVER (), 
-          MAX('[1,2,3]' <-> embedding) OVER ()
+          ARRAY[1,2,3]::vector <-> embedding, 
+          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
+          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
         ),
         ARRAY[0,1]
     ) as score_hybrid

--- a/pg_sparse/.gitignore
+++ b/pg_sparse/.gitignore
@@ -22,6 +22,6 @@ regression.out
 
 # pg_regress
 test/results/
-test/regression.diffs
-test/regression.out
 test/test_logs.log
+regression.diffs
+regression.out

--- a/pg_sparse/README.md
+++ b/pg_sparse/README.md
@@ -13,6 +13,8 @@ most of which are zero. Storing raw sparse vectors in Postgres and calculating d
 performance costs. `pg_sparse` solves this by compressing the sparse vectors and constructing an HNSW graph over the compressed vector
 representations.
 
+`pg_sparse` is supported on all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 12+.
+
 ## Usage
 
 This toy example demonstrates the usage of `pg_sparse`.

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -13,7 +13,7 @@ usage() {
   echo "Options:"
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
-  echo " -v (optional),   PG version(s) separated by comma <11,12,13>"
+  echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
   exit 1
 }
 
@@ -72,10 +72,10 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16" "11.21")
+      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
       ;;
     Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12" "11")
+      PG_VERSIONS=("16" "15" "14" "13" "12")
       ;;
   esac
 else


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #479 

## What
Postgres 11 is no longer supported by the Postgres development group, and by `pgrx`. This PR removes it. It also removes a hack we had to do in our tests, which is nice!

## Why

## How

## Tests
