### PR TITLE
fix: Set `search_path` to across sessions and users

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -72,9 +72,16 @@ EOSQL
 fi
 
 # Configure search_path to include the paradedb schema
+# We SET it for the entire DB (for all users), and default to public (by listing it first)
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-  ALTER USER "$POSTGRES_USER" SET search_path TO public,paradedb;
+  ALTER DATABASE "$POSTGRES_DB" SET search_path TO public,paradedb;
 EOSQL
+
+
+# SET search_path TO paradedb,public;
+# SET search_path TO public,paradedb;
+
+
 
 # We need to restart the server for the changes above to be reflected
 pg_ctl restart

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -111,6 +111,9 @@ for extension in "${!extensions[@]}"; do
   fi
 done
 
-# We run VACUUM FULL on the mock_items table to ensure that the table is accessible to all users, since
-# it gets created by the pg_bm25 extension SQL script
+# As part of the pg_bm25 extension, we ship a dummy data table, mock_items, that users can use to immediately
+# get started running search queries. Since we install the pg_bm25 extension here, before any active psql session,
+# we need to run VACUUM FULL on the mock_items table to ensure that the table is accessible to all users across
+# all schemas when they connect via psql. We only need to do this with tables that are created by extensions installed
+# in this script, as part of the Postgres initialization process.
 PGPASSWORD=$POSTGRES_PASSWORD psql -c "VACUUM FULL mock_items" -d "$POSTGRES_DB" -U "$POSTGRES_USER"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -77,12 +77,6 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   ALTER DATABASE "$POSTGRES_DB" SET search_path TO public,paradedb;
 EOSQL
 
-
-# SET search_path TO paradedb,public;
-# SET search_path TO public,paradedb;
-
-
-
 # We need to restart the server for the changes above to be reflected
 pg_ctl restart
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR does 4 things:
- First, we document the use of the POSTGRES_USER and of the role `postgres`, which are both necessary and were previously used by undocumented
- Second, we add `public,paradedb` to the `search_path`. This makes it so the Postgres cluster will default to the `public` schema, but be able to query across both schemas
- Third, we add the same schemas to the `template1` database. This is the database template on which all future databases created by the user in the cluster are mapped. This ensures that the previous point will apply not just to the database the cluster starts with, but to all databases the user creates themselves
- Fourth, We run a vacuum command after installing the `pg_bm25` extension on its dummy data table. This is because we were having some issues with the CTID for that table specifically when querying across schemas, since it gets installed via the extension directly. All other tables do not face this issue.

To be honest, maybe point #4 is a hack, but I'm out of other ideas...

## Why

## How

## Tests
All tested manually