### PR TITLE
fix: Use official Shellcheck repo in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.11
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
       - id: beautysh
         args: ["--indent-size", "2"]
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.5
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.9.0
     hooks:
       - id: shellcheck
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: check-ast
       - id: check-toml
       - id: check-executables-have-shebangs
+        exclude: '\.rs$'
       - id: check-shebang-scripts-are-executable
       - id: check-vcs-permalinks
       - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: check-ast
       - id: check-toml
       - id: check-executables-have-shebangs
-        exclude: '\.rs$'
+        exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
       - id: check-shebang-scripts-are-executable
       - id: check-vcs-permalinks
       - id: detect-private-key


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We were using a poorly supported Python-based Shellcheck pre-commit hook. Turns out Shellcheck itself supports it natively, as per their README: https://github.com/koalaman/shellcheck

The downside is this hook expects Docker. But then again, we all run Docker all the time anyways.

## Why

## How

## Tests
