### PR TITLE
fix: Table names with quotes not being indexed

### DIFF
--- a/pg_bm25/src/index_access/build.rs
+++ b/pg_bm25/src/index_access/build.rs
@@ -35,8 +35,6 @@ pub extern "C" fn ambuild(
     let heap_relation = unsafe { PgRelation::from_pg(heaprel) };
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
     let index_name = index_relation.name().to_string();
-    let table_name = heap_relation.name().to_string();
-    let schema_name = heap_relation.namespace().to_string();
 
     // rdopts are passed on to create_parade_index
     let rdopts: PgBox<ParadeOptions> = if !index_relation.rd_options.is_null() {
@@ -47,12 +45,7 @@ pub extern "C" fn ambuild(
     };
 
     // Create ParadeDB Index
-    let mut parade_index = create_parade_index(
-        index_name.clone(),
-        format!("{}.{}", schema_name, table_name),
-        rdopts,
-    )
-    .unwrap();
+    let mut parade_index = create_parade_index(index_name.clone(), &heap_relation, rdopts).unwrap();
 
     let ntuples = do_heap_scan(
         index_info,

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -64,10 +64,10 @@ impl FromStr for SearchQuery {
 
 pub fn create_parade_index(
     index_name: String,
-    table_name: String,
+    heap_relation: &PgRelation,
     options: PgBox<ParadeOptions>,
 ) -> Result<ParadeIndex, Box<dyn Error>> {
-    ParadeIndex::new(index_name, table_name, options)
+    ParadeIndex::new(index_name, heap_relation, options)
 }
 
 pub fn get_parade_index(index_name: String) -> ParadeIndex {

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -61,7 +61,7 @@ pub struct ParadeIndex {
 impl ParadeIndex {
     pub fn new(
         name: String,
-        table_name: String,
+        heap_relation: &PgRelation,
         options: PgBox<ParadeOptions>,
     ) -> Result<Self, Box<dyn Error>> {
         let dir = Self::get_data_directory(&name);
@@ -72,7 +72,7 @@ impl ParadeIndex {
 
         create_dir_all(path).expect("failed to create paradedb directory");
 
-        let result = Self::build_index_schema(&table_name, &options);
+        let result = Self::build_index_schema(heap_relation, &options);
         let (schema, fields) = match result {
             Ok((s, f)) => (s, f),
             Err(e) => {
@@ -407,14 +407,10 @@ impl ParadeIndex {
     }
 
     fn build_index_schema(
-        name: &str,
+        heap_relation: &PgRelation,
         options: &PgBox<ParadeOptions>,
     ) -> Result<(Schema, HashMap<String, Field>), String> {
-        let indexrel = unsafe {
-            PgRelation::open_with_name(name)
-                .unwrap_or_else(|_| panic!("failed to open relation {}", name))
-        };
-        let tupdesc = indexrel.tuple_desc();
+        let tupdesc = heap_relation.tuple_desc();
         let mut schema_builder = Schema::builder();
         let mut fields: HashMap<String, Field> = HashMap::new();
 

--- a/pg_bm25/test/expected/quoted_table_name.out
+++ b/pg_bm25/test/expected/quoted_table_name.out
@@ -1,0 +1,17 @@
+CREATE TABLE "Activity" (name TEXT, age INTEGER);
+INSERT INTO "Activity" (name, age) VALUES ('Alice', 29);
+INSERT INTO "Activity" (name, age) VALUES ('Bob', 34);
+INSERT INTO "Activity" (name, age) VALUES ('Charlie', 45);
+INSERT INTO "Activity" (name, age) VALUES ('Diana', 27);
+INSERT INTO "Activity" (name, age) VALUES ('Fiona', 38);
+INSERT INTO "Activity" (name, age) VALUES ('George', 41);
+INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
+INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
+INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
+CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
+SELECT * FROM "Activity" WHERE "Activity" @@@ 'alice';
+ name  | age 
+-------+-----
+ Alice |  29
+(1 row)
+

--- a/pg_bm25/test/sql/quoted_table_name.sql
+++ b/pg_bm25/test/sql/quoted_table_name.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "Activity" (name TEXT, age INTEGER);
+INSERT INTO "Activity" (name, age) VALUES ('Alice', 29);
+INSERT INTO "Activity" (name, age) VALUES ('Bob', 34);
+INSERT INTO "Activity" (name, age) VALUES ('Charlie', 45);
+INSERT INTO "Activity" (name, age) VALUES ('Diana', 27);
+INSERT INTO "Activity" (name, age) VALUES ('Fiona', 38);
+INSERT INTO "Activity" (name, age) VALUES ('George', 41);
+INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
+INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
+INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
+CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
+SELECT * FROM "Activity" WHERE "Activity" @@@ 'alice';
+


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #500 

## What
- Fixed a bug where table names with quotes ie `"Activity"` were not getting indexed
- The reason is that we would pull the name of the table inside `build.rs`, and pgrx would strip the quotes out

## Why

## How
- Fixed it by directly passing a `PgRelation` reference instead of the table name to our build function

## Tests
- Added a regression test