### PR TITLE
fix: Move reader to after tokenizer setup when retrieving index

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
       - id: check-ast
       - id: check-toml
       - id: check-executables-have-shebangs
-        exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
       - id: check-shebang-scripts-are-executable
         exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
       - id: check-vcs-permalinks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
       - id: check-executables-have-shebangs
         exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
       - id: check-shebang-scripts-are-executable
+        exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
       - id: check-vcs-permalinks
       - id: detect-private-key
       - id: detect-aws-credentials

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -110,7 +110,11 @@ impl Manager {
 
             if let FieldType::Str(_) = field.1.field_type() {
                 let mut snippet_generator = SnippetGenerator::create(searcher, query, field.0)
-                    .expect("failed to create snippet generator for field: {field_name}");
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "failed to create snippet generator for field: {field_name}... {err}"
+                        )
+                    });
 
                 if let Some(max_num_chars) = highlights_max_num_chars {
                     snippet_generator.set_max_num_chars(max_num_chars);
@@ -130,9 +134,9 @@ impl Manager {
             .as_ref()
             .expect("snippet generators not correctly initialized");
 
-        let snippet_generator = snippet_generator_map
-            .get(field_name)
-            .expect("failed to retrieve snippet generator for field: {field_name}");
+        let snippet_generator = snippet_generator_map.get(field_name).unwrap_or_else(|| {
+            panic!("failed to retrieve snippet generator to highlight field: {field_name}...")
+        });
 
         let snippet = snippet_generator.snippet_from_doc(doc);
 

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -1,5 +1,7 @@
 use pgrx::pg_sys::{IndexBulkDeleteCallback, IndexBulkDeleteResult, ItemPointerData};
 use pgrx::*;
+use serde_json::json;
+use shared::plog;
 use std::collections::HashMap;
 use std::error::Error;
 use std::ffi::{CStr, CString};
@@ -113,9 +115,18 @@ impl ParadeIndex {
         Self::write_index_field_configs(&name, &field_configs)?;
         Self::setup_tokenizers(&mut underlying_index, &field_configs);
 
-        let reader = Self::reader(&underlying_index)
-            .expect("failed to create index reader while creating new index: {name}");
+        let reader = Self::reader(&underlying_index).unwrap_or_else(|_| {
+            panic!("failed to create index reader while creating new index: {name}")
+        });
 
+        plog!(
+            "creating ParadeIndex",
+            json!({
+                "name": name,
+                "fields": fields,
+                "field_configs": field_configs
+            })
+        );
         let new_self = Self {
             name: name.clone(),
             fields,
@@ -190,11 +201,12 @@ impl ParadeIndex {
         let field_configs =
             Self::read_index_field_configs(&name).expect("failed to open index field configs");
 
-        let reader = Self::reader(&underlying_index)
-            .expect("failed to create index reader while retrieving index: {name}");
-
         // We need to setup tokenizers again after retrieving an index from disk.
         Self::setup_tokenizers(&mut underlying_index, &field_configs);
+
+        let reader = Self::reader(&underlying_index).unwrap_or_else(|_| {
+            panic!("failed to create index reader while retrieving index: {name}")
+        });
 
         let new_self = Self {
             name: name.clone(),

--- a/pg_bm25/src/parade_index/mod.rs
+++ b/pg_bm25/src/parade_index/mod.rs
@@ -1,2 +1,5 @@
 pub mod fields;
 pub mod index;
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod tests;

--- a/pg_bm25/src/parade_index/tests/mod.rs
+++ b/pg_bm25/src/parade_index/tests/mod.rs
@@ -1,0 +1,58 @@
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::*;
+    use shared::testing::dblink;
+
+    const SETUP_SQL: &str = include_str!("tokenizer_chinese_compatible_setup.sql");
+    const QUERY_SQL: &str = include_str!("tokenizer_chinese_compatible_query.sql");
+
+    #[pgrx::pg_test]
+    fn test_chinese_compatible_tokenizer() {
+        // In this test, the index is created and the tokenizer is used in the same transaction.
+
+        Spi::run(SETUP_SQL).expect("error running setup query");
+
+        let highlight = Spi::get_one(QUERY_SQL);
+
+        // Assert that the highlight returned by the tokenizer is as expected.
+        assert_eq!(
+            highlight,
+            Ok(Some("<b>张</b>伟")),
+            "incorrect result for chinese compatible tokenizer highlight"
+        );
+    }
+
+    #[pgrx::pg_test]
+    fn test_chinese_compatible_tokenizer_in_new_connection() {
+        // In this test, the index is created and the tokenizer is used in separate connections.
+        // Because we retrieve the index from disk for new connections, we want to make
+        // sure that the tokenizers are set up properly. We're going to make use of a
+        // Postgres extension that lets us create 'sub-connections' to the database.
+
+        // Create the dblink extension if it doesn't already exist.
+        // dblink allows us to establish a 'sub-connection' to the current database
+        // and execute queries. This is necessary, because the test context otherwise
+        // is executed within a single Postgres transaction.
+        Spi::run("CREATE EXTENSION IF NOT EXISTS dblink").expect("error creating dblink extension");
+
+        // Set up the test environment using dblink to run the setup SQL in a separate connection.
+        // The setup SQL is expected to prepare the database with the necessary configuration for the tokenizer.
+        let setup_query = format!("SELECT * FROM {} AS (_ text)", &dblink(SETUP_SQL));
+        Spi::run(&setup_query).expect("error running dblink setup query");
+
+        // Run the test query using dblink to ensure the tokenizer works in a separate connection.
+        // The query SQL is expected to test the tokenizer functionality and return a highlighted result.
+        let test_query = format!(
+            "SELECT * FROM {} AS (highlight_bm25 text)",
+            &dblink(QUERY_SQL)
+        );
+        let highlight = Spi::get_one(&test_query);
+
+        // Assert that the highlight returned by the tokenizer is as expected.
+        assert_eq!(
+            highlight,
+            Ok(Some("<b>张</b>伟")),
+            "incorrect result for chinese compatible tokenizer highlight"
+        );
+    }
+}

--- a/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
+++ b/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
@@ -1,0 +1,1 @@
+SELECT paradedb.highlight_bm25(ctid, 'idx_posts_fts', 'author') from posts where posts @@@ '张';

--- a/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_setup.sql
+++ b/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_setup.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS "source" (
+    "id" SERIAL PRIMARY KEY,
+    "name" VARCHAR(255) NOT NULL,
+    "created_at" TIMESTAMPTZ  DEFAULT now() NOT NULL,
+    "updated_at" TIMESTAMPTZ  DEFAULT now() NOT NULL,
+    "deleted_at" TIMESTAMPTZ,
+    UNIQUE (name)
+);
+
+CREATE TABLE posts (
+    id SERIAL PRIMARY KEY,
+    author TEXT,
+    title TEXT,
+    message TEXT,
+    content JSONB,
+    unix_timestamp_milli BIGINT,
+    like_count INT,
+    dislike_count INT,
+    comment_count INT
+);
+
+INSERT INTO posts (author, title, message, content, unix_timestamp_milli, like_count, dislike_count, comment_count)
+VALUES
+    ('张伟', '第一篇文章', '这是第一篇文章的内容', '{"details": "这里有一些JSON内容"}', EXTRACT(EPOCH FROM now()) * 1000, 25, 1, 5),
+    ('李娜', '第二篇文章', '这是第二篇文章的内容', '{"details": "这里有更多的JSON内容"}', EXTRACT(EPOCH FROM now()) * 1000, 75, 2, 10),
+    ('王芳', '第三篇文章', '这是第三篇文章的信息', '{"details": "还有一些JSON内容"}', EXTRACT(EPOCH FROM now()) * 1000, 15, 0, 3);
+
+
+CREATE INDEX idx_posts_fts
+ON posts
+USING bm25 ((posts.*))
+WITH (
+    text_fields='{
+        author: {tokenizer: {type: "chinese_compatible"}, record: "position"},
+        title: {tokenizer: {type: "chinese_compatible"}, record: "position"},
+        message: {tokenizer: {type: "chinese_compatible"},record: "position"}
+    }',
+    json_fields='{
+        content: {}
+    }',
+    numeric_fields='{
+        unix_timestamp_milli: {},
+        like_count: {},
+        dislike_count: {},
+        comment_count: {}
+    }'
+);
+

--- a/pg_bm25/src/tokenizers/mod.rs
+++ b/pg_bm25/src/tokenizers/mod.rs
@@ -5,6 +5,8 @@ use crate::parade_index::fields::{ParadeOption, ParadeOptionMap, ParadeTokenizer
 use crate::tokenizers::cjk::ChineseTokenizer;
 use crate::tokenizers::code::CodeTokenizer;
 
+use serde_json::json;
+use shared::plog;
 use tantivy::tokenizer::{
     AsciiFoldingFilter, LowerCaser, NgramTokenizer, RawTokenizer, RemoveLongFilter, TextAnalyzer,
     TokenizerManager,
@@ -15,7 +17,12 @@ pub const DEFAULT_REMOVE_TOKEN_LENGTH: usize = 255;
 pub fn create_tokenizer_manager(option_map: &ParadeOptionMap) -> TokenizerManager {
     let tokenizer_manager = TokenizerManager::default();
 
-    for field_options in option_map.values() {
+    for (field_name, field_options) in option_map.iter() {
+        plog!(
+            "attempting to create tokenizer",
+            json!({ "field_name": field_name, "field_options": field_options })
+        );
+
         let parade_tokenizer = match field_options {
             ParadeOption::Text(text_options) => text_options.tokenizer,
             ParadeOption::Json(json_options) => json_options.tokenizer,
@@ -57,6 +64,13 @@ pub fn create_tokenizer_manager(option_map: &ParadeOptionMap) -> TokenizerManage
         };
 
         if let Some(tokenizer) = tokenizer_option {
+            plog!(
+                "registering tokenizer",
+                json!({
+                    "field_name": field_name,
+                    "tokenizer_name": &parade_tokenizer.name()
+                })
+            );
             tokenizer_manager.register(&parade_tokenizer.name(), tokenizer);
         }
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod logs;
 pub mod telemetry;
+pub mod testing;
 
 // We need to re-export the dependencies below, because they're used by our public macros.
 // This lets consumers of the macros use them without needing to also install these dependencies.

--- a/shared/src/logs.rs
+++ b/shared/src/logs.rs
@@ -135,6 +135,7 @@ macro_rules! plog {
                 },
             };
 
+            #[cfg(any(not(test)))] // Don't compile this during unit tests.
             Spi::run_with_args(
                 "INSERT INTO paradedb.logs (level, module, file, line, message, json, pid, backtrace) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                 Some(vec![

--- a/shared/src/testing.rs
+++ b/shared/src/testing.rs
@@ -1,0 +1,59 @@
+use pgrx::Spi;
+
+/// Executes a query on a remote PostgreSQL database using dblink.
+///
+/// `dblink` is a PostgreSQL extension that allows a user to connect to a different PostgreSQL
+/// database from within a database session. It can be used to query data from a remote database
+/// without having to establish a new database connection. This is particularly useful for
+/// accessing databases on other servers or different databases on the same server that the
+/// current session is not connected to.
+///
+/// # Arguments
+/// * `query` - A reference to a string slice that holds the SQL query to be executed on the remote database.
+///
+/// # Returns
+/// A `String` that contains the dblink function call, which can be executed within a PostgreSQL
+/// environment to perform the remote database query.
+///
+/// # Panics
+/// The function panics if:
+/// - It cannot retrieve the current database name.
+/// - It cannot retrieve the current port from the PostgreSQL settings.
+/// - It cannot parse the retrieved port into an unsigned 32-bit integer.
+///
+/// # Examples
+/// ```
+/// let query = "SELECT * FROM my_table WHERE id = 1";
+/// let dblink_query = dblink(query);
+/// println!("DBLink Query: {}", dblink_query);
+/// // Output: DBLink Query: dblink('host=localhost port=5432 dbname=mydb', 'SELECT * FROM my_table WHERE id = 1')
+/// ```
+pub fn dblink(query: &str) -> String {
+    // Retrieve the current database name from the PostgreSQL environment.
+    let current_db_name: String = Spi::get_one("SELECT current_database()::text")
+        .expect("couldn't get current database for postgres connection")
+        .unwrap();
+
+    // Retrieve the current port number on which the PostgreSQL server is listening.
+    let current_port: u32 =
+        Spi::get_one::<String>("SELECT setting FROM pg_settings WHERE name = 'port'")
+            .expect("couldn't get current port for postgres connection")
+            .unwrap()
+            .parse()
+            .expect("couldn't parse current port into u32");
+
+    // Prepare the connection string for dblink. This string contains the host (assumed to be
+    // localhost in this function), the port number, and the database name to connect to.
+    let connection_string = format!(
+        "host=localhost port={} dbname={}",
+        current_port, current_db_name
+    );
+
+    // Escape single quotes in the SQL query since it will be nested inside another SQL string
+    // in the dblink function call. Single quotes in SQL strings are escaped by doubling them.
+    let escaped_query_string = query.replace('\'', "''");
+
+    // Construct the dblink function call with the connection string and the escaped query.
+    // This function call is what can be executed within a PostgreSQL environment.
+    format!("dblink('{connection_string}', '{escaped_query_string}')")
+}


### PR DESCRIPTION
## What
Fixing a panic caused by tokenizers not being found upon index retrieval from disk.

Also some small fixes around testing/pre-commit. `plog!` needs a conditional attribute above its `Spi` call to work during `cargo test`. We also needed one more exclude in our `.pre-commit-config.yaml`.

## Why
The tokenizers for `pg_bm25` are not getting setup correctly when we retrieve an index from disk, which happens on every new connection.

The tokenizers have to be registered before the reader gets created. This is happening correctly when we create a new index, but not when we retrieve from disk.

## How
Move the `ParadeIndex::setup_tokenizers` call to happen _before_ the call to `ParadeIndex::reader()`.

## Tests
I've opted to add a `tests` sub-module as `src/parade_index/tests`. The test is in `mod.rs`, and some SQL files used in the test live right next to it. They are included at compile time with `include_str!`. 

This is a tricky behavior to test, because the `pg_test` framework from PGRX executes a test as a single transaction. I had to jump through some hoops to simulate new connections to the database, but fortunately there's a Postgres built-in way to do that with the `dblink` extension.

We now have two tests for this behavior. We test that tokenizers work properly when used in the same transaction as index creation (so there's no need to retrieve the index from disk), and we also test they work in a query through a brand new connection.
