### PR TITLE
chore: Remove Postgres 10/11

### DIFF
--- a/pg_bm25/src/index_access/build.rs
+++ b/pg_bm25/src/index_access/build.rs
@@ -90,7 +90,7 @@ fn do_heap_scan<'a>(
     state.count
 }
 
-#[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12"))]
+#[cfg(feature = "pg12")]
 #[pg_guard]
 unsafe extern "C" fn build_callback(
     index: pg_sys::Relation,

--- a/pg_bm25/src/index_access/cost.rs
+++ b/pg_bm25/src/index_access/cost.rs
@@ -30,9 +30,6 @@ pub unsafe extern "C" fn amcostestimate(
     *index_total_cost = 0.0;
     *index_selectivity = 1.0;
 
-    #[cfg(any(feature = "pg10", feature = "pg11"))]
-    let index_clauses = PgList::<pg_sys::RestrictInfo>::from_pg(path.indexclauses);
-
     #[cfg(any(
         feature = "pg12",
         feature = "pg13",
@@ -43,9 +40,6 @@ pub unsafe extern "C" fn amcostestimate(
     let index_clauses = PgList::<pg_sys::IndexClause>::from_pg(path.indexclauses);
 
     for clause in index_clauses.iter_ptr() {
-        #[cfg(any(feature = "pg10", feature = "pg11"))]
-        let ri = clause.as_ref().expect("restrict info is NULL");
-
         #[cfg(any(
             feature = "pg12",
             feature = "pg13",

--- a/pg_bm25/src/index_access/insert.rs
+++ b/pg_bm25/src/index_access/insert.rs
@@ -20,7 +20,7 @@ pub unsafe extern "C" fn aminsert(
     aminsert_internal(index_relation, values, heap_tid)
 }
 
-#[cfg(any(feature = "pg11", feature = "pg12", feature = "pg13"))]
+#[cfg(any(feature = "pg12", feature = "pg13"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,

--- a/pg_bm25/src/index_access/options.rs
+++ b/pg_bm25/src/index_access/options.rs
@@ -148,7 +148,7 @@ unsafe fn build_relopts(
 }
 
 // build_reloptions is not available when pg<13, so we need our own
-#[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12"))]
+#[cfg(feature = "pg12")]
 unsafe fn build_relopts(
     reloptions: pg_sys::Datum,
     validate: bool,

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -191,8 +191,6 @@ pub extern "C" fn amgettuple(
 
     match iter.next() {
         Some((score, doc_address)) => {
-            #[cfg(any(feature = "pg10", feature = "pg11"))]
-            let tid = &mut scan.xs_ctup.t_self;
             #[cfg(any(
                 feature = "pg12",
                 feature = "pg13",

--- a/pg_bm25/src/operator/mod.rs
+++ b/pg_bm25/src/operator/mod.rs
@@ -65,15 +65,6 @@ pub fn scan_index(query: &str, index_oid: pg_sys::Oid) -> FxHashSet<u64> {
         loop {
             check_for_interrupts!();
 
-            #[cfg(any(feature = "pg10", feature = "pg11"))]
-            let tid = {
-                let htup = pg_sys::index_getnext(scan, pg_sys::ScanDirection_ForwardScanDirection);
-                if htup.is_null() {
-                    break;
-                }
-                item_pointer_to_u64(htup.as_ref().unwrap().t_self)
-            };
-
             #[cfg(any(
                 feature = "pg12",
                 feature = "pg13",

--- a/pg_sparse/src/index_access/build.rs
+++ b/pg_sparse/src/index_access/build.rs
@@ -73,7 +73,7 @@ fn do_heap_scan<'a>(
     state.count
 }
 
-#[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12"))]
+#[cfg(feature = "pg12")]
 #[pg_guard]
 unsafe extern "C" fn build_callback(
     index: pg_sys::Relation,

--- a/pg_sparse/src/index_access/cost.rs
+++ b/pg_sparse/src/index_access/cost.rs
@@ -37,16 +37,6 @@ pub unsafe extern "C" fn amcostestimate(
         let ef_search = rdopts.ef_search as f64;
         let mut generic_costs = pg_sys::GenericCosts::default();
 
-        #[cfg(feature = "pg11")]
-        {
-            pg_sys::genericcostestimate(
-                root,
-                path,
-                loop_count,
-                std::ptr::null_mut(),
-                &mut generic_costs,
-            );
-        }
         #[cfg(any(
             feature = "pg12",
             feature = "pg13",

--- a/pg_sparse/src/index_access/insert.rs
+++ b/pg_sparse/src/index_access/insert.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn aminsert(
     aminsert_internal(index_relation, values, heap_tid)
 }
 
-#[cfg(any(feature = "pg11", feature = "pg12", feature = "pg13"))]
+#[cfg(any(feature = "pg12", feature = "pg13"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,

--- a/pg_sparse/src/index_access/options.rs
+++ b/pg_sparse/src/index_access/options.rs
@@ -99,7 +99,7 @@ unsafe fn build_relopts(
 }
 
 // build_reloptions is not available when pg<13, so we need our own
-#[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12"))]
+#[cfg(feature = "pg12")]
 unsafe fn build_relopts(
     reloptions: pg_sys::Datum,
     validate: bool,

--- a/pg_sparse/src/index_access/scan.rs
+++ b/pg_sparse/src/index_access/scan.rs
@@ -129,8 +129,6 @@ pub extern "C" fn amgettuple(
     }
 
     // Iterate through results
-    #[cfg(any(feature = "pg10", feature = "pg11"))]
-    let tid = &mut scan.xs_ctup.t_self;
     #[cfg(any(
         feature = "pg12",
         feature = "pg13",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This is more of an open question: Postgres' official development group is no longer supporting Postgres 11, and so pgrx dropped it as well. Thus, we dropped it (no longer in our Cargo.toml files). Right now, our code probably works for pg11, because it was recently removed. But since we won't be testing it on Postgres 11 anymore, it probably won't at some point.

I propose we remove all support for Postgres 11 formally so users don't get confused. This also enables us to simplify our code a bit. What do you think?

## Why

## How

## Tests
