### PR TITLE
feat: Test whether our extensions can upgrade as part of our CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@ rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 
 # Enable code coverage on Linux only, for CI builds
 [target.'cfg(target_os="linux")']
-rustflags = ["-Cinstrument-coverage"]
+rustflags = ["-Cinstrument-coverage", "-C", "link-arg=-fuse-ld=lld"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@ rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 
 # Enable code coverage on Linux only, for CI builds
 [target.'cfg(target_os="linux")']
-rustflags = ["-Cinstrument-coverage", "-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-Cinstrument-coverage"]

--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -45,3 +45,8 @@ jobs:
       - name: Print Results
         working-directory: benchmarks/out/
         run: cat benchmark_${{ steps.system.outputs.system_to_benchmark }}.csv
+
+      - name: Notify Slack on Failure
+        if: failure()
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Benchmark ParadeDB Workflow failed on ${{ steps.system.outputs.system_to_benchmark }} -- investigate immediately!"}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -74,8 +74,9 @@ jobs:
             else
               echo "Using the provided new version (likely a manual major or minor version increment)..."
               NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
+              echo "$NEW_VERSION"
             fi
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u "$NEW_VERSION"
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Run pg_bm25 Integration Tests
         working-directory: pg_bm25/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi
 
       - name: Run pg_bm25 Unit Tests

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [12, 13, 14, 15, 16]
+        # pg_version: [12, 13, 14, 15, 16]
+        pg_version: [15]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run pg_bm25 Integration Tests
         working-directory: pg_bm25/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -91,8 +91,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          gh release download --repo paradedb/paradedb --pattern "pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb" -R paradedb/paradedb
-          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
+          latest_release=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest")
+          asset_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name == "pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb") | .browser_download_url')
+          wget "$asset_url" -O pg_bm25.deb
+          sudo dpkg -i pg_bm25.deb
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -98,7 +98,10 @@ jobs:
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
-        run: PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
+        run: |
+          sudo systemctl start postgresql
+          sudo -u postgres createdb test_db
+          PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
 
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -63,7 +63,7 @@ jobs:
           if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           fi
 
       - name: Run pg_bm25 Unit Tests

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -100,6 +100,10 @@ jobs:
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         run: sudo systemctl start postgresql@${{ matrix.pg_version }}-main
 
+      - name: ssh
+        run: lhotari/action-upterm@v1
+
+
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         run: PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -98,14 +98,16 @@ jobs:
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
-        run: sudo systemctl start postgresql@${{ matrix.pg_version }}-main
-
-      - name: ssh
-        uses: lhotari/action-upterm@v1
+        run: |
+          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
+          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
-        run: PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
+        working-directory: /var/lib/postgresql/
+        run: |
+          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_bm25 VERSION '$CURRENT_VERSION';"
 
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
@@ -116,6 +118,7 @@ jobs:
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
       - name: Upgrade pg_bm25 Extension to New Version
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        working-directory: /var/lib/postgresql/
         run: |
           if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
             echo "New version not provided, assuming the next release is incrementing patch..."
@@ -125,4 +128,4 @@ jobs:
             echo "Using the provided new version (likely a manual major or minor version increment)..."
             NEW_VERSION="${{ github.event.inputs.new_version }}"
           fi
-          PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'ALTER EXTENSION pg_bm25 UPDATE TO "$NEW_VERSION";'
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_bm25 UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -112,7 +112,9 @@ jobs:
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         working-directory: pg_bm25/
-        run: sudo usermod -a -G postgres $(whoami) && cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
+        run: |
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
+          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
 
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -88,6 +88,8 @@ jobs:
       # TODO: swap 'dev' with 'main' once it's tested
       - name: Download & Install Latest pg_bm25 from GitHub Release
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
           gh release download --repo paradedb/paradedb --pattern "pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb" -R paradedb/paradedb
           sudo dpkg -i pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         working-directory: pg_bm25/
-        run: cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
+        run: sudo cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
 
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -91,8 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          gh release download --repo paradedb/paradedb --pattern "pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb" -R paradedb/paradedb
-          sudo dpkg -i pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
+          gh release download --repo paradedb/paradedb --pattern "pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb" -R paradedb/paradedb
+          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -101,8 +101,7 @@ jobs:
         run: sudo systemctl start postgresql@${{ matrix.pg_version }}-main
 
       - name: ssh
-        run: lhotari/action-upterm@v1
-
+        uses: lhotari/action-upterm@v1
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -91,10 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          latest_release=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest")
-          asset_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name == "pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb") | .browser_download_url')
-          wget "$asset_url" -O pg_bm25.deb
-          sudo dpkg -i pg_bm25.deb
+          curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb")) | .browser_download_url'
+          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -61,17 +61,17 @@ jobs:
         working-directory: pg_bm25/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
-      - name: Run pg_bm25 Integration Tests
-        working-directory: pg_bm25/
-        run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+      # - name: Run pg_bm25 Integration Tests
+      #   working-directory: pg_bm25/
+      #   run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
 
-      - name: Run pg_bm25 Unit Tests
-        env:
-          LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
-          RUST_BACKTRACE: 1
-        run: |
-          mkdir -p target/coverage target/coverage-report
-          cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }}
+      # - name: Run pg_bm25 Unit Tests
+      #   env:
+      #     LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
+      #     RUST_BACKTRACE: 1
+      #   run: |
+      #     mkdir -p target/coverage target/coverage-report
+      #     cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }}
 
       # TODO: Reenable Codecov when we start writing unit tests
       # - name: Generate Code Coverage Reports

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         working-directory: pg_bm25/
-        run: cargo pgrx install --release --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+        run: cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
 
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -16,11 +16,6 @@ on:
       - "!pg_bm25/README.md"
       - ".github/workflows/test-pg_bm25.yml"
   workflow_dispatch:
-    inputs:
-      new_version:
-        description: "Upcoming pg_bm25 version to test upgrading against"
-        required: false
-        default: ""
 
 concurrency:
   group: test-pg_bm25-${{ github.head_ref || github.ref }}
@@ -61,9 +56,15 @@ jobs:
         working-directory: pg_bm25/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
+      # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_bm25 Integration Tests
         working-directory: pg_bm25/
-        run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+          else
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+          fi
 
       - name: Run pg_bm25 Unit Tests
         env:
@@ -84,52 +85,3 @@ jobs:
       #     directory: ./target/coverage-report/
       #     files: lcov
       #     fail_ci_if_error: true
-
-      #############################
-      # Extension Upgrade Testing #
-      #############################
-
-      - name: Download & Install Latest pg_bm25 from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-        run: |
-          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
-          curl -LOJ $DOWNLOAD_URL
-          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
-
-      - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        run: |
-          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
-          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
-
-      - name: Install pg_bm25 Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_bm25 VERSION '$CURRENT_VERSION';"
-
-      - name: Build pg_bm25 Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: pg_bm25/
-        run: |
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
-          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
-
-      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
-      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
-      - name: Upgrade pg_bm25 Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
-            echo "New version not provided, assuming the next release is incrementing patch..."
-            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
-            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
-          else
-            echo "Using the provided new version (likely a manual major or minor version increment)..."
-            NEW_VERSION="${{ github.event.inputs.new_version }}"
-          fi
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_bm25 UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -91,8 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb")) | .browser_download_url'
-          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
+          curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url'
+          sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -1,7 +1,7 @@
 # workflows/test-pg_bm25.yml
 #
 # Test pg_bm25
-# Run unit and packaging tests for the pg_bm25 extension.
+# Run unit and integration tests for the pg_bm25 extension.
 
 name: Test pg_bm25
 
@@ -32,8 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # pg_version: [12, 13, 14, 15, 16]
-        pg_version: [15]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       - name: Checkout Git Repository
@@ -41,7 +40,7 @@ jobs:
 
       - name: Remove old postgres, llvm, clang, and install appropriate version
         run: |
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
           apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
           sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
 
@@ -62,17 +61,17 @@ jobs:
         working-directory: pg_bm25/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
-      # - name: Run pg_bm25 Integration Tests
-      #   working-directory: pg_bm25/
-      #   run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+      - name: Run pg_bm25 Integration Tests
+        working-directory: pg_bm25/
+        run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
 
-      # - name: Run pg_bm25 Unit Tests
-      #   env:
-      #     LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
-      #     RUST_BACKTRACE: 1
-      #   run: |
-      #     mkdir -p target/coverage target/coverage-report
-      #     cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }}
+      - name: Run pg_bm25 Unit Tests
+        env:
+          LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
+          RUST_BACKTRACE: 1
+        run: |
+          mkdir -p target/coverage target/coverage-report
+          cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }}
 
       # TODO: Reenable Codecov when we start writing unit tests
       # - name: Generate Code Coverage Reports
@@ -86,9 +85,12 @@ jobs:
       #     files: lcov
       #     fail_ci_if_error: true
 
-      # TODO: swap 'dev' with 'main' once it's tested
+      #############################
+      # Extension Upgrade Testing #
+      #############################
+
       - name: Download & Install Latest pg_bm25 from GitHub Release
-        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
@@ -97,20 +99,20 @@ jobs:
           sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
         run: |
           sudo systemctl start postgresql@${{ matrix.pg_version }}-main
           sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
 
       - name: Install pg_bm25 Extension (Old Version)
-        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
         working-directory: /var/lib/postgresql/
         run: |
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_bm25 VERSION '$CURRENT_VERSION';"
 
       - name: Build pg_bm25 Extension (New Version)
-        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
         working-directory: pg_bm25/
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
@@ -119,7 +121,7 @@ jobs:
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
       - name: Upgrade pg_bm25 Extension to New Version
-        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
         working-directory: /var/lib/postgresql/
         run: |
           if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -90,7 +90,7 @@ jobs:
       #############################
 
       - name: Download & Install Latest pg_bm25 from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
@@ -99,20 +99,20 @@ jobs:
           sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         run: |
           sudo systemctl start postgresql@${{ matrix.pg_version }}-main
           sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
 
       - name: Install pg_bm25 Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_bm25 VERSION '$CURRENT_VERSION';"
 
       - name: Build pg_bm25 Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: pg_bm25/
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
@@ -121,7 +121,7 @@ jobs:
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
       - name: Upgrade pg_bm25 Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -96,12 +96,13 @@ jobs:
           curl -LOJ $DOWNLOAD_URL
           sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
+      - name: Start PostgreSQL ${{ matrix.pg_version }}
+        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        run: sudo systemctl start postgresql@${{ matrix.pg_version }}-main
+
       - name: Install pg_bm25 Extension (Old Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
-        run: |
-          sudo systemctl start postgresql
-          sudo -u postgres createdb test_db
-          PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
+        run: PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
 
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run pg_bm25 Integration Tests
         working-directory: pg_bm25/
         run: |
-          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -92,7 +92,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url'
+          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
+          curl -LOJ $DOWNLOAD_URL
           sudo dpkg -i pg_bm25-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Install pg_bm25 Extension (Old Version)

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -16,6 +16,11 @@ on:
       - "!pg_bm25/README.md"
       - ".github/workflows/test-pg_bm25.yml"
   workflow_dispatch:
+    inputs:
+      new_version:
+        description: "Upcoming pg_bm25 version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_bm25-${{ github.head_ref || github.ref }}
@@ -43,7 +48,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
@@ -79,3 +84,34 @@ jobs:
       #     directory: ./target/coverage-report/
       #     files: lcov
       #     fail_ci_if_error: true
+
+      # TODO: swap 'dev' with 'main' once it's tested
+      - name: Download & Install Latest pg_bm25 from GitHub Release
+        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        run: |
+          gh release download --repo paradedb/paradedb --pattern "pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb" -R paradedb/paradedb
+          sudo dpkg -i pg_bm25-*-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-amd64-linux-gnu.deb
+
+      - name: Install pg_bm25 Extension (Old Version)
+        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        run: PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'CREATE EXTENSION pg_bm25 VERSION "${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}";'
+
+      - name: Build pg_bm25 Extension (New Version)
+        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        working-directory: pg_bm25/
+        run: cargo pgrx install --release --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+
+      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
+      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
+      - name: Upgrade pg_bm25 Extension to New Version
+        if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
+        run: |
+          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
+            echo "New version not provided, assuming the next release is incrementing patch..."
+            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+          else
+            echo "Using the provided new version (likely a manual major or minor version increment)..."
+            NEW_VERSION="${{ github.event.inputs.new_version }}"
+          fi
+          PGPASSWORD=postgres psql -h localhost -U postgres -d test_db -c 'ALTER EXTENSION pg_bm25 UPDATE TO "$NEW_VERSION";'

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -16,6 +16,11 @@ on:
       - "!pg_bm25/README.md"
       - ".github/workflows/test-pg_bm25.yml"
   workflow_dispatch:
+    inputs:
+      test_upgrade_version:
+        description: "Upcoming pg_bm25 version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_bm25-${{ github.head_ref || github.ref }}
@@ -61,7 +66,16 @@ jobs:
         working-directory: pg_bm25/
         run: |
           if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            # Retrieve the version to test upgrading to
+            if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
+              echo "New version not provided, assuming the next release is incrementing patch..."
+              NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+              NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+            else
+              echo "Using the provided new version (likely a manual major or minor version increment)..."
+              NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
+            fi
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build pg_bm25 Extension (New Version)
         if: github.base_ref == 'dev' || github.event.inputs.new_version != ''
         working-directory: pg_bm25/
-        run: sudo cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
+        run: sudo usermod -a -G postgres $(whoami) && cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
 
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Run pg_search Integration Tests
         working-directory: pg_search/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi
 
       - name: Run pg_search Unit Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -1,7 +1,7 @@
 # workflows/test-pg_search.yml
 #
 # Test pg_search
-# Run unit and packaging tests for the pg_search extension.
+# Run unit and integration tests for the pg_search extension.
 
 name: Test pg_search
 
@@ -16,6 +16,11 @@ on:
       - "!pg_search/README.md"
       - ".github/workflows/test-pg_search.yml"
   workflow_dispatch:
+    inputs:
+      new_version:
+        description: "Upcoming pg_search version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_search-${{ github.head_ref || github.ref }}
@@ -35,7 +40,7 @@ jobs:
 
       - name: Remove old postgres, llvm, clang, and install appropriate version
         run: |
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
           apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
           sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
 
@@ -79,3 +84,52 @@ jobs:
       #     directory: ./target/coverage-report/
       #     files: lcov
       #     fail_ci_if_error: true
+
+      #############################
+      # Extension Upgrade Testing #
+      #############################
+
+      - name: Download & Install Latest pg_search from GitHub Release
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+        run: |
+          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_search-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
+          curl -LOJ $DOWNLOAD_URL
+          sudo dpkg -i pg_search-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
+
+      - name: Start PostgreSQL ${{ matrix.pg_version }}
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        run: |
+          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
+          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
+
+      - name: Install pg_search Extension (Old Version)
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: /var/lib/postgresql/
+        run: |
+          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_search VERSION '$CURRENT_VERSION';"
+
+      - name: Build pg_bm25 Extension (New Version)
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: pg_search/
+        run: |
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
+          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
+
+      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
+      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
+      - name: Upgrade pg_search Extension to New Version
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: /var/lib/postgresql/
+        run: |
+          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
+            echo "New version not provided, assuming the next release is incrementing patch..."
+            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+          else
+            echo "Using the provided new version (likely a manual major or minor version increment)..."
+            NEW_VERSION="${{ github.event.inputs.new_version }}"
+          fi
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_search UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -16,11 +16,6 @@ on:
       - "!pg_search/README.md"
       - ".github/workflows/test-pg_search.yml"
   workflow_dispatch:
-    inputs:
-      new_version:
-        description: "Upcoming pg_search version to test upgrading against"
-        required: false
-        default: ""
 
 concurrency:
   group: test-pg_search-${{ github.head_ref || github.ref }}
@@ -61,9 +56,15 @@ jobs:
         working-directory: pg_search/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
+      # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests
         working-directory: pg_search/
-        run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+          else
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+          fi
 
       - name: Run pg_search Unit Tests
         env:
@@ -84,52 +85,3 @@ jobs:
       #     directory: ./target/coverage-report/
       #     files: lcov
       #     fail_ci_if_error: true
-
-      #############################
-      # Extension Upgrade Testing #
-      #############################
-
-      - name: Download & Install Latest pg_search from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-        run: |
-          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_search-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
-          curl -LOJ $DOWNLOAD_URL
-          sudo dpkg -i pg_search-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
-
-      - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        run: |
-          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
-          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
-
-      - name: Install pg_search Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_search VERSION '$CURRENT_VERSION';"
-
-      - name: Build pg_search Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: pg_search/
-        run: |
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
-          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
-
-      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
-      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
-      - name: Upgrade pg_search Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
-            echo "New version not provided, assuming the next release is incrementing patch..."
-            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
-            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
-          else
-            echo "Using the provided new version (likely a manual major or minor version increment)..."
-            NEW_VERSION="${{ github.event.inputs.new_version }}"
-          fi
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_search UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -111,7 +111,7 @@ jobs:
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_search VERSION '$CURRENT_VERSION';"
 
-      - name: Build pg_bm25 Extension (New Version)
+      - name: Build pg_search Extension (New Version)
         if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: pg_search/
         run: |

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -90,7 +90,7 @@ jobs:
       #############################
 
       - name: Download & Install Latest pg_search from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
@@ -99,20 +99,20 @@ jobs:
           sudo dpkg -i pg_search-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         run: |
           sudo systemctl start postgresql@${{ matrix.pg_version }}-main
           sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
 
       - name: Install pg_search Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_search VERSION '$CURRENT_VERSION';"
 
       - name: Build pg_bm25 Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: pg_search/
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
@@ -121,7 +121,7 @@ jobs:
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
       - name: Upgrade pg_search Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -71,11 +71,12 @@ jobs:
               echo "New version not provided, assuming the next release is incrementing patch..."
               NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
               NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+              echo "$NEW_VERSION"
             else
               echo "Using the provided new version (likely a manual major or minor version increment)..."
               NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
             fi
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u "$NEW_VERSION"
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run pg_search Integration Tests
         working-directory: pg_search/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -16,6 +16,11 @@ on:
       - "!pg_search/README.md"
       - ".github/workflows/test-pg_search.yml"
   workflow_dispatch:
+    inputs:
+      test_upgrade_version:
+        description: "Upcoming pg_search version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_search-${{ github.head_ref || github.ref }}
@@ -61,7 +66,16 @@ jobs:
         working-directory: pg_search/
         run: |
           if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            # Retrieve the version to test upgrading to
+            if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
+              echo "New version not provided, assuming the next release is incrementing patch..."
+              NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+              NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+            else
+              echo "Using the provided new version (likely a manual major or minor version increment)..."
+              NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
+            fi
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -63,7 +63,7 @@ jobs:
           if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           fi
 
       - name: Run pg_search Unit Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run pg_search Integration Tests
         working-directory: pg_search/
         run: |
-          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -78,7 +78,7 @@ jobs:
       #############################
 
       - name: Download & Install Latest pg_sparse from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
@@ -87,20 +87,20 @@ jobs:
           sudo dpkg -i pg_sparse-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
 
       - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         run: |
           sudo systemctl start postgresql@${{ matrix.pg_version }}-main
           sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
 
       - name: Install pg_sparse Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_sparse VERSION '$CURRENT_VERSION';"
 
       - name: Build pg_bm25 Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: pg_sparse/
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
@@ -109,7 +109,7 @@ jobs:
       # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
       # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
       - name: Upgrade pg_sparse Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: /var/lib/postgresql/
         run: |
           if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -63,7 +63,7 @@ jobs:
           if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           fi
 
       - name: Run pg_sparse Unit Tests

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -16,6 +16,11 @@ on:
       - "!pg_sparse/README.md"
       - ".github/workflows/test-pg_sparse.yml"
   workflow_dispatch:
+    inputs:
+      test_upgrade_version:
+        description: "Upcoming pg_sparse version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_sparse-${{ github.head_ref || github.ref }}
@@ -61,7 +66,16 @@ jobs:
         working-directory: pg_sparse/
         run: |
           if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            # Retrieve the version to test upgrading to
+            if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
+              echo "New version not provided, assuming the next release is incrementing patch..."
+              NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+              NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+            else
+              echo "Using the provided new version (likely a manual major or minor version increment)..."
+              NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
+            fi
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -16,11 +16,6 @@ on:
       - "!pg_sparse/README.md"
       - ".github/workflows/test-pg_sparse.yml"
   workflow_dispatch:
-    inputs:
-      new_version:
-        description: "Upcoming pg_sparse version to test upgrading against"
-        required: false
-        default: ""
 
 concurrency:
   group: test-pg_sparse-${{ github.head_ref || github.ref }}
@@ -61,9 +56,15 @@ jobs:
         working-directory: pg_sparse/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
+      # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_sparse Integration Tests
         working-directory: pg_sparse/
-        run: ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+          else
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
+          fi
 
       - name: Run pg_sparse Unit Tests
         env:
@@ -72,52 +73,3 @@ jobs:
         run: |
           mkdir -p target/coverage target/coverage-report
           cd pg_sparse/ && cargo pgrx test --features pg${{ matrix.pg_version }}
-
-      #############################
-      # Extension Upgrade Testing #
-      #############################
-
-      - name: Download & Install Latest pg_sparse from GitHub Release
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-        run: |
-          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_sparse-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
-          curl -LOJ $DOWNLOAD_URL
-          sudo dpkg -i pg_sparse-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
-
-      - name: Start PostgreSQL ${{ matrix.pg_version }}
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        run: |
-          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
-          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
-
-      - name: Install pg_sparse Extension (Old Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_sparse VERSION '$CURRENT_VERSION';"
-
-      - name: Build pg_sparse Extension (New Version)
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: pg_sparse/
-        run: |
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
-          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
-
-      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
-      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
-      - name: Upgrade pg_sparse Extension to New Version
-        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
-        working-directory: /var/lib/postgresql/
-        run: |
-          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
-            echo "New version not provided, assuming the next release is incrementing patch..."
-            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
-            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
-          else
-            echo "Using the provided new version (likely a manual major or minor version increment)..."
-            NEW_VERSION="${{ github.event.inputs.new_version }}"
-          fi
-          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_sparse UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Run pg_sparse Integration Tests
         working-directory: pg_sparse/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi
 
       - name: Run pg_sparse Unit Tests

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run pg_sparse Integration Tests
         working-directory: pg_sparse/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }} == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -71,11 +71,12 @@ jobs:
               echo "New version not provided, assuming the next release is incrementing patch..."
               NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
               NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+              echo "$NEW_VERSION"
             else
               echo "Using the provided new version (likely a manual major or minor version increment)..."
               NEW_VERSION="${{ github.event.inputs.test_upgrade_version }}"
             fi
-            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u $NEW_VERSION
+            ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}" -u "$NEW_VERSION"
           else
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run pg_sparse Integration Tests
         working-directory: pg_sparse/
         run: |
-          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -1,7 +1,7 @@
 # workflows/test-pg_sparse.yml
 #
 # Test pg_sparse
-# Run unit and packaging tests for the pg_sparse extension.
+# Run unit and integration tests for the pg_sparse extension.
 
 name: Test pg_sparse
 
@@ -16,6 +16,11 @@ on:
       - "!pg_sparse/README.md"
       - ".github/workflows/test-pg_sparse.yml"
   workflow_dispatch:
+    inputs:
+      new_version:
+        description: "Upcoming pg_sparse version to test upgrading against"
+        required: false
+        default: ""
 
 concurrency:
   group: test-pg_sparse-${{ github.head_ref || github.ref }}
@@ -35,7 +40,7 @@ jobs:
 
       - name: Remove old postgres, llvm, clang, and install appropriate version
         run: |
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
           apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
           sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
 
@@ -67,3 +72,52 @@ jobs:
         run: |
           mkdir -p target/coverage target/coverage-report
           cd pg_sparse/ && cargo pgrx test --features pg${{ matrix.pg_version }}
+
+      #############################
+      # Extension Upgrade Testing #
+      #############################
+
+      - name: Download & Install Latest pg_sparse from GitHub Release
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+        run: |
+          DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/paradedb/paradedb/releases/latest" | jq -r '.assets[] | select(.browser_download_url | contains("pg_sparse-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb")) | .browser_download_url')
+          curl -LOJ $DOWNLOAD_URL
+          sudo dpkg -i pg_sparse-v${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}-pg${{ matrix.pg_version }}-amd64-linux-gnu.deb
+
+      - name: Start PostgreSQL ${{ matrix.pg_version }}
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        run: |
+          sudo systemctl start postgresql@${{ matrix.pg_version }}-main
+          sudo -u postgres psql -U postgres -d postgres -p 5433 -w -c 'CREATE DATABASE test_db;'
+
+      - name: Install pg_sparse Extension (Old Version)
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: /var/lib/postgresql/
+        run: |
+          CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_sparse VERSION '$CURRENT_VERSION';"
+
+      - name: Build pg_bm25 Extension (New Version)
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: pg_sparse/
+        run: |
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
+          cargo pgrx install --pg-config=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config --release
+
+      # If making a major or minor version change (which happens by manually updating the version variables in GitHub Variables), then we need to
+      # manually provide the new version in a workflow_dispatch event to test upgrading to the new version as part of our promotion process.
+      - name: Upgrade pg_sparse Extension to New Version
+        if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && ${{ matrix.pg_version }} == 15
+        working-directory: /var/lib/postgresql/
+        run: |
+          if [[ "${{ github.event.inputs.new_version }}" == "" ]]; then
+            echo "New version not provided, assuming the next release is incrementing patch..."
+            NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
+            NEW_VERSION=${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}
+          else
+            echo "Using the provided new version (likely a manual major or minor version increment)..."
+            NEW_VERSION="${{ github.event.inputs.new_version }}"
+          fi
+          sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "ALTER EXTENSION pg_sparse UPDATE TO '$NEW_VERSION';"

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -99,7 +99,7 @@ jobs:
           CURRENT_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
           sudo -u postgres psql -U postgres -d test_db -p 5433 -w -c "CREATE EXTENSION pg_sparse VERSION '$CURRENT_VERSION';"
 
-      - name: Build pg_bm25 Extension (New Version)
+      - name: Build pg_sparse Extension (New Version)
         if: (github.base_ref == 'main' || github.event.inputs.new_version != '') && (matrix.pg_version == 15)
         working-directory: pg_sparse/
         run: |

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} postgresql-client-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_bm25 extension version v$BASE_RELEASE into the test database..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -135,8 +135,8 @@ function run_tests() {
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
   if [ -n "$FLAG_UPGRADE_VER" ]; then
     echo "Running extension upgrade test..."
-    # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="0.3.5"
+    # First, download & install the first release at which we started supporting upgrades (v0.3.6)
+    BASE_RELEASE="0.3.6"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
     sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -147,14 +147,14 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
 
     # Fourth, upgrade the extension installed on the test database to the current version
     "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_bm25 UPDATE;" -d test_db > /dev/null
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_bm25 extension onto the test database..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
   fi
 
   # Get a list of all tests

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -77,7 +77,7 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
+      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
       ;;
     Linux)
       PG_VERSIONS=("16" "15" "14" "13" "12")
@@ -139,18 +139,18 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
+    dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_bm25 extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_bm25 UPDATE;" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_bm25 UPDATE;" -d test_db
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_bm25 extension onto the test database..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -14,6 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
+  echo " -u (optional),   Upgrade the extension to the latest version before running tests (only meant for use in CI)"
   exit 1
 }
 
@@ -26,9 +27,10 @@ fi
 # Instantiate vars
 FLAG_PG_VER=false
 FLAG_PROCESS_TYPE=false
+FLAG_UPGRADE=false
 
 # Assign flags to vars and check
-while getopts "hp:v:" flag
+while getopts "hup:v:" flag
 do
   case $flag in
     h)
@@ -45,6 +47,9 @@ do
       ;;
     v)
       FLAG_PG_VER=$OPTARG
+      ;;
+    u)
+      FLAG_UPGRADE=true
       ;;
     *)
       usage
@@ -127,26 +132,30 @@ function run_tests() {
   echo "Reloading PostgreSQL configuration..."
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
+  # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
+  if [ "FLAG_UPGRADE" = true ]; then
+    echo "Running extension upgrade test..."
+    # First, download & install the first release at which we started supporting upgrades (v0.3.5)
+    BASE_RELEASE="v0.3.5"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ $DOWNLOAD_URL
+    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
+    # Second, load the extension into the test database
+    echo "Loading pg_bm25 extension version $BASE_VERSION into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_VERSION';" -d test_db > /dev/null
 
+    # Third, build & install the current version of the extension
+    echo "Building & installing the current version of the pg_bm25 extension..."
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
 
-  # If we want to test upgrading
-  # First download the release
-  # then install it
-  # then load it into the test database
-  # then upgrade it
-  # then run the fictures tests
-
-
-
-  # Use cargo-pgx to install the extension for the specified version
-  echo "Installing pg_bm25 extension onto the test database..."
-  cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
-
-
-
-
-
+    # Fourth, upgrade the extension installed on the test database to the current version
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_bm25 UPDATE;" -d test_db > /dev/null
+  else
+    # Use cargo-pgx to install the extension for the specified version
+    echo "Installing pg_bm25 extension onto the test database..."
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+  fi
 
   # Get a list of all tests
   while IFS= read -r line; do

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -133,12 +133,12 @@ function run_tests() {
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
-  if [ "FLAG_UPGRADE" = true ]; then
+  if [ "$FLAG_UPGRADE" = true ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="v0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
-    curl -LOJ $DOWNLOAD_URL
+    curl -LOJ "$DOWNLOAD_URL"
     sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -127,9 +127,26 @@ function run_tests() {
   echo "Reloading PostgreSQL configuration..."
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
+
+
+
+  # If we want to test upgrading
+  # First download the release
+  # then install it
+  # then load it into the test database
+  # then upgrade it
+  # then run the fictures tests
+
+
+
   # Use cargo-pgx to install the extension for the specified version
   echo "Installing pg_bm25 extension onto the test database..."
-  cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+  cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+
+
+
+
+
 
   # Get a list of all tests
   while IFS= read -r line; do

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
     echo "Loading pg_bm25 extension version v$BASE_RELEASE into the test database..."
@@ -147,6 +147,7 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."
+    sudo chown -R $(whoami) /usr/share/postgresql/$PG_VERSION/extension/ /usr/lib/postgresql/$PG_VERSION/lib/
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Upgrade the extension to the latest version before running tests (only meant for use in CI)"
+  echo " -u (optional),   Test upgrading the extension from initial to current version before running tests (only meant for use in CI)"
   exit 1
 }
 

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI)"
+  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI) <0.3.7>"
   exit 1
 }
 
@@ -30,7 +30,7 @@ FLAG_PROCESS_TYPE=false
 FLAG_UPGRADE_VER=""
 
 # Assign flags to vars and check
-while getopts "hup:v:" flag
+while getopts "hp:v:u:" flag
 do
   case $flag in
     h)

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -136,14 +136,14 @@ function run_tests() {
   if [ "$FLAG_UPGRADE" = true ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_bm25-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
-    curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_bm25-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    BASE_RELEASE="0.3.5"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ "$DOWNLOAD_URL" > /dev/null
+    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
-    echo "Loading pg_bm25 extension version $BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    echo "Loading pg_bm25 extension version v$BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -137,9 +137,9 @@ function run_tests() {
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_bm25-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_bm25-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_bm25 extension version $BASE_VERSION into the test database..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -142,8 +142,8 @@ function run_tests() {
     sudo dpkg -i "pg_bm25-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
-    echo "Loading pg_bm25 extension version $BASE_VERSION into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_VERSION';" -d test_db > /dev/null
+    echo "Loading pg_bm25 extension version $BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -143,7 +143,7 @@ function run_tests() {
 
     # Second, load the extension into the test database
     echo "Loading pg_bm25 extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_bm25 extension..."

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -18,7 +18,7 @@ if [ $# -eq 0 ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
+      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
       ;;
     Linux)
       PG_VERSIONS=("16" "15" "14" "13" "12")

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -147,7 +147,7 @@ function run_tests() {
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -139,8 +139,8 @@ function run_tests() {
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
   if [ -n "$FLAG_UPGRADE_VER" ]; then
     echo "Running extension upgrade test..."
-    # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="0.3.5"
+    # First, download & install the first release at which we started supporting upgrades (v0.3.6)
+    BASE_RELEASE="0.3.6"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
     sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -151,7 +151,7 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
 
     # Fourth, upgrade the extension installed on the test database to the current version
     "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE;" -d test_db > /dev/null

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -133,7 +133,7 @@ function run_tests() {
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
   # Install dependencies
-  echo "Installing dependencies (pg_search and pgvector) onto the test database..."
+  echo "Installing dependencies (pg_bm25 and pgvector) onto the test database..."
   "$TESTDIR/../configure.sh" "$PG_VERSION" > /dev/null
 
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Test upgrading the extension from initial to current version before running tests (only meant for use in CI)"
+  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI)"
   exit 1
 }
 
@@ -27,7 +27,7 @@ fi
 # Instantiate vars
 FLAG_PG_VER=false
 FLAG_PROCESS_TYPE=false
-FLAG_UPGRADE=false
+FLAG_UPGRADE_VER=""
 
 # Assign flags to vars and check
 while getopts "hup:v:" flag
@@ -49,7 +49,7 @@ do
       FLAG_PG_VER=$OPTARG
       ;;
     u)
-      FLAG_UPGRADE=true
+      FLAG_UPGRADE_VER=$OPTARG
       ;;
     *)
       usage
@@ -137,7 +137,7 @@ function run_tests() {
   "$TESTDIR/../configure.sh" "$PG_VERSION" > /dev/null
 
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
-  if [ "$FLAG_UPGRADE" = true ]; then
+  if [ -n "$FLAG_UPGRADE_VER" ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="0.3.5"
@@ -151,11 +151,11 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
-    sudo chown -R $(whoami) /usr/share/postgresql/$PG_VERSION/extension/ /usr/lib/postgresql/$PG_VERSION/lib/
+    sudo chown -R "$(whoami)" "/usr/share/postgresql/$PG_VERSION/extension/" "/usr/lib/postgresql/$PG_VERSION/lib/"
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE;" -d test_db
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE TO '$FLAG_UPGRADE_VER';" -d test_db
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_search extension onto the test database..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -146,8 +146,8 @@ function run_tests() {
     sudo dpkg -i "pg_search-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
-    echo "Loading pg_search extension version $BASE_VERSION into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_VERSION';" -d test_db > /dev/null
+    echo "Loading pg_search extension version $BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -143,7 +143,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Upgrade the extension to the latest version before running tests (only meant for use in CI)"
+  echo " -u (optional),   Test upgrading the extension from initial to current version before running tests (only meant for use in CI)"
   exit 1
 }
 

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -127,6 +127,18 @@ function run_tests() {
   echo "Reloading PostgreSQL configuration..."
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
+
+
+
+  # If we want to test upgrading
+  # First download the release
+  # then install it
+  # then load it into the test database
+  # then upgrade it
+  # then run the fictures tests
+  # but need to take into account the pg_bm25 dependency as well
+
+
   # Install dependencies
   echo "Installing dependencies (pg_bm25 and pgvector) onto the test database..."
   "$TESTDIR/../configure.sh" "$PG_VERSION" > /dev/null
@@ -134,6 +146,10 @@ function run_tests() {
   # Use cargo-pgx to install the extension for the specified version
   echo "Installing pg_search extension onto the test database..."
   cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+
+
+
+
 
   # Get a list of all tests
   while IFS= read -r line; do

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -141,9 +141,9 @@ function run_tests() {
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_search-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_search-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version $BASE_VERSION into the test database..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI)"
+  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI) <0.3.7>"
   exit 1
 }
 
@@ -30,7 +30,7 @@ FLAG_PROCESS_TYPE=false
 FLAG_UPGRADE_VER=""
 
 # Assign flags to vars and check
-while getopts "hup:v:" flag
+while getopts "hp:v:u:" flag
 do
   case $flag in
     h)

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -14,6 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
+  echo " -u (optional),   Upgrade the extension to the latest version before running tests (only meant for use in CI)"
   exit 1
 }
 
@@ -26,9 +27,10 @@ fi
 # Instantiate vars
 FLAG_PG_VER=false
 FLAG_PROCESS_TYPE=false
+FLAG_UPGRADE=false
 
 # Assign flags to vars and check
-while getopts "hp:v:" flag
+while getopts "hup:v:" flag
 do
   case $flag in
     h)
@@ -45,6 +47,9 @@ do
       ;;
     v)
       FLAG_PG_VER=$OPTARG
+      ;;
+    u)
+      FLAG_UPGRADE=true
       ;;
     *)
       usage
@@ -127,29 +132,34 @@ function run_tests() {
   echo "Reloading PostgreSQL configuration..."
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
-
-
-
-  # If we want to test upgrading
-  # First download the release
-  # then install it
-  # then load it into the test database
-  # then upgrade it
-  # then run the fictures tests
-  # but need to take into account the pg_bm25 dependency as well
-
-
   # Install dependencies
-  echo "Installing dependencies (pg_bm25 and pgvector) onto the test database..."
+  echo "Installing dependencies (pg_search and pgvector) onto the test database..."
   "$TESTDIR/../configure.sh" "$PG_VERSION" > /dev/null
 
-  # Use cargo-pgx to install the extension for the specified version
-  echo "Installing pg_search extension onto the test database..."
-  cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+  # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
+  if [ "$FLAG_UPGRADE" = true ]; then
+    echo "Running extension upgrade test..."
+    # First, download & install the first release at which we started supporting upgrades (v0.3.5)
+    BASE_RELEASE="v0.3.5"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ "$DOWNLOAD_URL"
+    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
+    # Second, load the extension into the test database
+    echo "Loading pg_search extension version $BASE_VERSION into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_VERSION';" -d test_db > /dev/null
 
+    # Third, build & install the current version of the extension
+    echo "Building & installing the current version of the pg_search extension..."
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
 
-
+    # Fourth, upgrade the extension installed on the test database to the current version
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE;" -d test_db > /dev/null
+  else
+    # Use cargo-pgx to install the extension for the specified version
+    echo "Installing pg_search extension onto the test database..."
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+  fi
 
   # Get a list of all tests
   while IFS= read -r line; do

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -140,14 +140,14 @@ function run_tests() {
   if [ "$FLAG_UPGRADE" = true ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_search-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
-    curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_search-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    BASE_RELEASE="0.3.5"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ "$DOWNLOAD_URL" > /dev/null
+    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
-    echo "Loading pg_search extension version $BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -77,7 +77,7 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
+      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
       ;;
     Linux)
       PG_VERSIONS=("16" "15" "14" "13" "12")
@@ -143,18 +143,18 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
+    dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE' CASCADE;" -d test_db
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE;" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE;" -d test_db
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_search extension onto the test database..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -143,7 +143,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."
@@ -151,6 +151,7 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
+    sudo chown -R $(whoami) /usr/share/postgresql/$PG_VERSION/extension/ /usr/lib/postgresql/$PG_VERSION/lib/
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Test upgrading the extension from initial to current version before running tests (only meant for use in CI)"
+  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI)"
   exit 1
 }
 
@@ -27,7 +27,7 @@ fi
 # Instantiate vars
 FLAG_PG_VER=false
 FLAG_PROCESS_TYPE=false
-FLAG_UPGRADE=false
+FLAG_UPGRADE_VER=""
 
 # Assign flags to vars and check
 while getopts "hup:v:" flag
@@ -49,7 +49,7 @@ do
       FLAG_PG_VER=$OPTARG
       ;;
     u)
-      FLAG_UPGRADE=true
+      FLAG_UPGRADE_VER=$OPTARG
       ;;
     *)
       usage
@@ -133,7 +133,7 @@ function run_tests() {
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
-  if [ "$FLAG_UPGRADE" = true ]; then
+  if [ -n "$FLAG_UPGRADE_VER" ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="0.3.5"
@@ -147,11 +147,11 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."
-    sudo chown -R $(whoami) /usr/share/postgresql/$PG_VERSION/extension/ /usr/lib/postgresql/$PG_VERSION/lib/
+    sudo chown -R "$(whoami)" "/usr/share/postgresql/$PG_VERSION/extension/" "/usr/lib/postgresql/$PG_VERSION/lib/"
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_sparse UPDATE;" -d test_db
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_sparse UPDATE TO '$FLAG_UPGRADE_VER';" -d test_db
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_sparse extension onto the test database..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_sparse extension version v$BASE_RELEASE into the test database..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -77,7 +77,7 @@ if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
   case "$OS_NAME" in
     Darwin)
-      PG_VERSIONS=("16.0" "15.4" "14.9" "13.12" "12.16")
+      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
       ;;
     Linux)
       PG_VERSIONS=("16" "15" "14" "13" "12")
@@ -139,18 +139,18 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
+    dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_sparse extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_RELEASE';" -d test_db
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_sparse UPDATE;" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_sparse UPDATE;" -d test_db
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_sparse extension onto the test database..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Upgrade the extension to the latest version before running tests (only meant for use in CI)"
+  echo " -u (optional),   Test upgrading the extension from initial to current version before running tests (only meant for use in CI)"
   exit 1
 }
 

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -147,14 +147,14 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
 
     # Fourth, upgrade the extension installed on the test database to the current version
     "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_sparse UPDATE;" -d test_db > /dev/null
   else
     # Use cargo-pgx to install the extension for the specified version
     echo "Installing pg_sparse extension onto the test database..."
-    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile ci > /dev/null
+    cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
   fi
 
   # Get a list of all tests

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
     BASE_RELEASE="0.3.5"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
     echo "Loading pg_sparse extension version v$BASE_RELEASE into the test database..."
@@ -147,6 +147,7 @@ function run_tests() {
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."
+    sudo chown -R $(whoami) /usr/share/postgresql/$PG_VERSION/extension/ /usr/lib/postgresql/$PG_VERSION/lib/
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -136,14 +136,14 @@ function run_tests() {
   if [ "$FLAG_UPGRADE" = true ]; then
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_sparse-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
-    curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_sparse-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    BASE_RELEASE="0.3.5"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ "$DOWNLOAD_URL" > /dev/null
+    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
 
     # Second, load the extension into the test database
-    echo "Loading pg_sparse extension version $BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_RELEASE';" -d test_db > /dev/null
+    echo "Loading pg_sparse extension version v$BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -142,8 +142,8 @@ function run_tests() {
     sudo dpkg -i "pg_sparse-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
-    echo "Loading pg_sparse extension version $BASE_VERSION into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_VERSION';" -d test_db > /dev/null
+    echo "Loading pg_sparse extension version $BASE_RELEASE into the test database..."
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -14,7 +14,7 @@ usage() {
   echo " -h (optional),   Display this help message"
   echo " -p (required),   Processing type, either <sequential> or <threaded>"
   echo " -v (optional),   PG version(s) separated by comma <12,13,14>"
-  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI)"
+  echo " -u (optional),   Version to test upgrading to before running tests (only meant for use in CI) <0.3.7>"
   exit 1
 }
 
@@ -30,7 +30,7 @@ FLAG_PROCESS_TYPE=false
 FLAG_UPGRADE_VER=""
 
 # Assign flags to vars and check
-while getopts "hup:v:" flag
+while getopts "hp:v:u:" flag
 do
   case $flag in
     h)

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -137,9 +137,9 @@ function run_tests() {
     echo "Running extension upgrade test..."
     # First, download & install the first release at which we started supporting upgrades (v0.3.5)
     BASE_RELEASE="v0.3.5"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/$BASE_RELEASE/pg_sparse-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL"
-    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    sudo dpkg -i "pg_sparse-$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
 
     # Second, load the extension into the test database
     echo "Loading pg_sparse extension version $BASE_VERSION into the test database..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -127,9 +127,26 @@ function run_tests() {
   echo "Reloading PostgreSQL configuration..."
   "$PG_BIN_PATH/pg_ctl" restart > /dev/null
 
+
+
+
+  # If we want to test upgrading
+  # First download the release
+  # then install it
+  # then load it into the test database
+  # then upgrade it
+  # then run the fictures tests
+
+
+
   # Use cargo-pgx to install the extension for the specified version
   echo "Installing pg_sparse extension onto the test database..."
   cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release > /dev/null
+
+
+
+
+
 
   # Get a list of all tests
   while IFS= read -r line; do

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -135,8 +135,8 @@ function run_tests() {
   # This block runs a test whether our extension can upgrade to the current version, and then runs our integrationg tests
   if [ -n "$FLAG_UPGRADE_VER" ]; then
     echo "Running extension upgrade test..."
-    # First, download & install the first release at which we started supporting upgrades (v0.3.5)
-    BASE_RELEASE="0.3.5"
+    # First, download & install the first release at which we started supporting upgrades (v0.3.6)
+    BASE_RELEASE="0.3.6"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
     sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -143,7 +143,7 @@ function run_tests() {
 
     # Second, load the extension into the test database
     echo "Loading pg_sparse extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION 'v$BASE_RELEASE';" -d test_db > /dev/null
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_sparse VERSION '$BASE_RELEASE';" -d test_db > /dev/null
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_sparse extension..."


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We've realized that we hadn't been building any ways for extensions to upgrade. This involves creating a `.sql` file with custom commands. To make sure we don't forget, and that our upgrade scripts work, I've added some steps in our CI to test whether our extensions can upgrade as part of the promoting to `main`, which is when we release a new versions.

This PR also adds a Slack webhook to notify us if/when our benchmark workflow fails. It had been failing for a few days without us realizing, leading to some error not being caught as quickly as it could've.

- [x] Test that it works for all 3 extensions

## Why
^

## How
Simply install an old version + test upgrading

## Tests
Manual testing done for all 3 extensions