### PR TITLE
fix: Memory overflow with very large result sets in `TopDocs` collector

### DIFF
--- a/pg_bm25/src/index_access/mod.rs
+++ b/pg_bm25/src/index_access/mod.rs
@@ -38,7 +38,7 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     amroutine.ambeginscan = Some(scan::ambeginscan);
     amroutine.amrescan = Some(scan::amrescan);
     amroutine.amgettuple = Some(scan::amgettuple);
-    amroutine.amgetbitmap = Some(scan::ambitmapscan);
+    amroutine.amgetbitmap = None;
     amroutine.amendscan = Some(scan::amendscan);
 
     amroutine.into_pg_boxed()

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -30,7 +30,6 @@ pub struct SearchQuery {
 #[derive(Debug, Deserialize, Default)]
 pub struct SearchQueryConfig {
     pub offset: Option<usize>,
-    pub limit: Option<usize>,
     #[serde(default, deserialize_with = "from_csv")]
     pub fuzzy_fields: Vec<String>,
     pub distance: Option<u8>,

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -48,7 +48,12 @@ pub struct TantivyScanState {
     pub query: Box<dyn Query>,
     pub query_parser: QueryParser,
     pub searcher: Searcher,
-    pub iterator: *mut std::vec::IntoIter<(Score, DocAddress)>,
+    pub results: std::vec::IntoIter<(Score, DocAddress)>,
+    pub limit: usize,
+    pub offset: usize,
+    pub current: usize,
+    pub n_results: usize,
+    pub no_more_results: bool,
 }
 
 #[derive(Clone)]
@@ -331,7 +336,12 @@ impl ParadeIndex {
             query: empty_query,
             query_parser,
             searcher,
-            iterator: std::ptr::null_mut(),
+            results: vec![].into_iter(),
+            limit: 1,
+            offset: 0,
+            current: 0,
+            n_results: 0,
+            no_more_results: false,
         }
     }
 

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -21,15 +21,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (5 rows)
 
 -- With limit
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2';
- id |       description        | rating |  category   
-----+--------------------------+--------+-------------
-  1 | Ergonomic metal keyboard |      4 | Electronics
-  2 | Plastic Keyboard         |      4 | Electronics
-(2 rows)
-
--- With limit and trailing &
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics' LIMIT 2;
  id |       description        | rating |  category   
 ----+--------------------------+--------+-------------
   1 | Ergonomic metal keyboard |      4 | Electronics
@@ -37,7 +29,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (2 rows)
 
 -- With limit and offset
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&offset=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::offset=1' LIMIT 2;
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
   2 | Plastic Keyboard            |      4 | Electronics

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -3,11 +3,9 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 -- With trailing delimiter
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::';
 -- With limit
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2';
--- With limit and trailing &
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics' LIMIT 2;
 -- With limit and offset
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::limit=2&offset=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electronics:::offset=1' LIMIT 2;
 -- With fuzzy field
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics:::fuzzy_fields=category';
 -- Without fuzzy field


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This is an attempt at fixing an issue reported in our Slack, where queries would fail when the `limit` was set to a very large number (170K+).

## Why

## How
I believe the issue is that Tantivy is crashing when too many docs are returned. I solved this in the same way that extensions like `pgvector` and `pgembedding` return very large result sets. Instead of searching for `k` results all at once, we set an upper bound on the limit at `MAX_TOP_DOCS = 100000`. If we've returned `100000` tuples and there are still more tuples to be returned, we do another query for the next `100000` results. This repeats until there are no more tuples to be returned. 

## Tests
