### PR TITLE
chore: Reenable Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,45 +1,52 @@
-# TODO: Reenable Codecov when we start writing unit tests
-# codecov:
-#   branch: dev
-#   require_ci_to_pass: no
+codecov:
+  branch: dev
+  require_ci_to_pass: no
 
-# coverage:
-#   precision: 2
-#   round: down
-#   range: "0...100" # This ensures that Codecov never fails the CI build
+coverage:
+  precision: 2
+  round: down
+  range: "0...100" # This ensures that Codecov never fails the CI build
 
-#   status:
-#     project:
-#       pg_bm25:
-#         flags: pg_bm25
-#         target: auto
-#         threshold: 1%
-#       pg_search:
-#         flags: pg_search
-#         target: auto
-#         threshold: 1%
-#       pg_sparse:
-#         flags: pg_sparse
-#         target: auto
-#         threshold: 1%
+  status:
+    project:
+      pg_bm25:
+        flags: pg_bm25
+        target: auto
+        threshold: 5%
+      pg_search:
+        flags: pg_search
+        target: auto
+        threshold: 5%
+      pg_sparse:
+        flags: pg_sparse
+        target: auto
+        threshold: 5%
+      shared:
+        flags: shared
+        target: auto
+        threshold: 5%
 
-# comment:
-#   behavior: default
-#   layout: "diff, flags, files"
-#   require_base: no
-#   require_head: no
-#   show_carryforward_flags: true
+comment:
+  behavior: default
+  layout: "diff, flags, files"
+  require_base: no
+  require_head: no
+  show_carryforward_flags: true
 
-# flags:
-#   pg_bm25:
-#     paths:
-#       - pg_bm25/*
-#     carryforward: true
-#   pg_search:
-#     paths:
-#       - pg_search/*
-#     carryforward: true
-#   pg_sparse:
-#     paths:
-#       - pg_sparse/*
-#     carryforward: true
+flags:
+  pg_bm25:
+    paths:
+      - pg_bm25/*
+    carryforward: true
+  pg_search:
+    paths:
+      - pg_search/*
+    carryforward: true
+  pg_sparse:
+    paths:
+      - pg_sparse/*
+    carryforward: true
+  shared:
+    paths:
+      - shared/*
+    carryforward: true

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -121,12 +121,13 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
+      # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
       - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
       - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -121,16 +121,15 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_bm25/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
-      # TODO: Reenable Codecov when we start writing unit tests
-      # - name: Generate Code Coverage Reports
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
+      - name: Generate Code Coverage Reports
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
-      # - name: Upload Coverage Reports to Codecov
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     directory: ./target/coverage-report/
-      #     files: lcov
-      #     fail_ci_if_error: true
+      - name: Upload Coverage Reports to Codecov
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./target/coverage-report/
+          files: lcov
+          fail_ci_if_error: true

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -121,16 +121,15 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
-      # TODO: Reenable Codecov when we start writing unit tests
-      # - name: Generate Code Coverage Reports
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
+      - name: Generate Code Coverage Reports
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
-      # - name: Upload Coverage Reports to Codecov
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     directory: ./target/coverage-report/
-      #     files: lcov
-      #     fail_ci_if_error: true
+      - name: Upload Coverage Reports to Codecov
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./target/coverage-report/
+          files: lcov
+          fail_ci_if_error: true

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -121,12 +121,13 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
+      # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
       - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
       - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -121,16 +121,15 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_sparse/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
-      # TODO: Reenable Codecov when we start writing unit tests
-      # - name: Generate Code Coverage Reports
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
+      - name: Generate Code Coverage Reports
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
-      # - name: Upload Coverage Reports to Codecov
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     directory: ./target/coverage-report/
-      #     files: lcov
-      #     fail_ci_if_error: true
+      - name: Upload Coverage Reports to Codecov
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./target/coverage-report/
+          files: lcov
+          fail_ci_if_error: true

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -121,12 +121,13 @@ jobs:
           mkdir -p target/coverage target/coverage-report
           cd pg_sparse/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
+      # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
       - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
       - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Now that we've started writing unit tests, I am attempting to re-enable Codecov. I have set it to tolerate 0% code coverage, so that it never fails CI. Once we have higher code coverage, we can make this stricter. I've also set a 5% threshold for modifications, to ensure it never fails CI.

TODO:
- [x] We could make it run only on one `pg_version` per PR, instead of all currently

## Why

## How

## Tests
