### PR TITLE
chore: Properly do flags in Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,19 +10,19 @@ coverage:
   status:
     project:
       pg_bm25:
-        flags: pg_bm25
+        flags: [pg_bm25]
         target: auto
         threshold: 5%
       pg_search:
-        flags: pg_search
+        flags: [pg_search]
         target: auto
         threshold: 5%
       pg_sparse:
-        flags: pg_sparse
+        flags: [pg_sparse]
         target: auto
         threshold: 5%
       shared:
-        flags: shared
+        flags: [shared]
         target: auto
         threshold: 5%
 

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -133,4 +133,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/
           files: lcov
+          flags: pg_bm25
           fail_ci_if_error: true

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -133,4 +133,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/
           files: lcov
+          flags: pg_search
           fail_ci_if_error: true

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -133,4 +133,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/
           files: lcov
+          flags: pg_sparse
           fail_ci_if_error: true


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
It turns out our Codecov file was slightly wrong. You can test it with:
```
curl -X POST --data-binary @codecov.yml https://codecov.io/validate
```

I thus fixed the flags issue, and added the flags parameter to the CI uploader. This should enable us to properly get reports broken down per-subfolder, and thus get Markdown badges per-subfolder.

Ref: https://docs.codecov.com/docs/flags && https://community.codecov.com/t/coverage-badge-on-a-per-directory-basis/3158

## Why

## How

## Tests
