### PR TITLE
feat: Add EXPLAIN to the tsvector benchmarking, so we can see the query plan

### DIFF
--- a/benchmarks/benchmark-paradedb.sh
+++ b/benchmarks/benchmark-paradedb.sh
@@ -85,6 +85,10 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   # Record times to CSV
   echo "$SIZE,$index_time,$search_time" >> $OUTPUT_CSV
 
+  # Print query plan
+  echo "-- Printing query plan..."
+  db_query "EXPLAIN SELECT * FROM $TABLE_NAME WHERE $TABLE_NAME @@@ 'Canada' LIMIT 10" 
+
   # Cleanup: drop temporary table and index
   echo "-- Cleaning up..."
   db_query "DROP TABLE $TABLE_NAME;"

--- a/benchmarks/benchmark-paradedb.sh
+++ b/benchmarks/benchmark-paradedb.sh
@@ -87,7 +87,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
 
   # Print query plan
   echo "-- Printing query plan..."
-  db_query "EXPLAIN SELECT * FROM $TABLE_NAME WHERE $TABLE_NAME @@@ 'Canada' LIMIT 10" 
+  db_query "EXPLAIN SELECT * FROM $TABLE_NAME WHERE $TABLE_NAME @@@ 'Canada' LIMIT 10"
 
   # Cleanup: drop temporary table and index
   echo "-- Cleaning up..."

--- a/benchmarks/benchmark-tsquery.sh
+++ b/benchmarks/benchmark-tsquery.sh
@@ -78,9 +78,9 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   start_time=$( (time db_query "UPDATE $TABLE_NAME SET search_vector = to_tsvector('english', title) || to_tsvector('english', body); CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING gin(search_vector);" > /dev/null) 2>&1 )
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
-  # Time search
+  # Time search (with EXPLAIN to get the query plan)
   echo "-- Timing search..."
-  start_time=$( (time db_query "SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
+  start_time=$( (time db_query "EXPLAIN SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Record times to CSV

--- a/benchmarks/benchmark-tsquery.sh
+++ b/benchmarks/benchmark-tsquery.sh
@@ -78,13 +78,16 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   start_time=$( (time db_query "UPDATE $TABLE_NAME SET search_vector = to_tsvector('english', title) || to_tsvector('english', body); CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING gin(search_vector);" > /dev/null) 2>&1 )
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
-  # Time search (with EXPLAIN to get the query plan)
+  # Time search
   echo "-- Timing search..."
-  start_time=$( (time db_query "EXPLAIN SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
+  start_time=$( (time db_query "SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;" > /dev/null) 2>&1 )
   search_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Record times to CSV
   echo "$SIZE,$index_time,$search_time" >> $OUTPUT_CSV
+
+  # Print query plan
+  db_query "EXPLAIN SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;"
 
   # Cleanup: drop temporary table
   echo "-- Cleaning up..."

--- a/benchmarks/benchmark-tsquery.sh
+++ b/benchmarks/benchmark-tsquery.sh
@@ -87,6 +87,7 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   echo "$SIZE,$index_time,$search_time" >> $OUTPUT_CSV
 
   # Print query plan
+  echo "-- Printing query plan..."
   db_query "EXPLAIN SELECT title, body, ts_rank_cd(search_vector, query) as rank FROM $TABLE_NAME, to_tsquery('Canada') query WHERE query @@ search_vector ORDER BY rank DESC LIMIT 10;"
 
   # Cleanup: drop temporary table


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
All in the title. A user mentioned the benchmarking might be defaulting to not using GIN index. This will help us see that.

## Why

## How

## Tests
