### PR TITLE
feat: Switch Dockerfile base image from `bookworm` to `alpine` (which is based on `bookworm`)

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,3 @@
 ignored:
   - DL3008 # Pin versions in apt-get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
+  - DL3018 # Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN apk update && apk add --no-cache \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apk update && apk add --no-cache \
-    postgresql-server-dev-${PG_VERSION_MAJOR} \
+    postgresql${PG_VERSION_MAJOR}-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ###############################################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install common dependencies to builder and runtime
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apk update && apk add --no-cache \
     curl \
     wget \
     sudo \
@@ -86,14 +86,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install apt-fast
-RUN /bin/bash -c "$(curl -sL https://git.io/vokNn)"
-
-# Add PostgreSQL's third party repository to get the latest versions
-RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
+RUN apk update && apk add --no-cache \
     postgresql-server-dev-${PG_VERSION_MAJOR} \
     && rm -rf /var/lib/apt/lists/*
 
@@ -106,7 +99,7 @@ FROM base as builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Rust and other build dependencies
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
+RUN apk update && apk add --no-cache \
     build-essential \
     checkinstall \
     clang \
@@ -178,7 +171,7 @@ FROM base as paradedb
 ARG TARGETARCH
 
 # Install barman (for backups, and postgis runtime dependencies
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
+RUN apk update && apk add --no-cache \
     # postgis
     libgeos-c1v5 \
     libproj-dev \
@@ -221,7 +214,7 @@ RUN curl -L "https://github.com/paradedb/third-party-pg_extensions/releases/down
     curl -L "https://github.com/supabase/pg_net/releases/download/v${PG_NET_VERSION}/pg_net-v${PG_NET_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_net.deb && \
     curl -L "https://github.com/supabase/pg_graphql/releases/download/v${PG_GRAPHQL_VERSION}/pg_graphql-v${PG_GRAPHQL_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_graphql.deb && \
     curl -L "https://github.com/supabase/pg_jsonschema/releases/download/v${PG_JSONSCHEMA_VERSION}/pg_jsonschema-v${PG_JSONSCHEMA_VERSION}-pg${PG_VERSION_MAJOR}-$TARGETARCH-linux-gnu.deb" -o /tmp/pg_jsonschema.deb && \
-    apt-fast update && apt-fast install -y --no-install-recommends /tmp/*.deb \
+    apk update && apk add --no-cache /tmp/*.deb \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Copy the ParadeDB extensions from their builder stages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG PG_VERSION_MAJOR
 # First Stage: Base
 ###############################################
 
-FROM postgres:${PG_VERSION_MAJOR}-bookworm as base
+FROM postgres:${PG_VERSION_MAJOR}-alpine as base
 
 # Declare all the build arguments and set them to
 # environment variables for use in build and runtime

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,13 +77,12 @@ RUN apk update && apk add --no-cache \
     sudo \
     gnupg \
     gcc \
-    uuid-runtime \
-    software-properties-common \
+    uuidgen \
     ca-certificates \
-    libssl-dev \
-    libopenblas-dev \
+    openssl-dev \
+    openblas-dev \
     python3-dev \
-    python3-pip \
+    py3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Alpine is the smaller, more compact and safer version of `bookworm`. DockerHub suggests switching to it for a much smaller image size and much much less security warnings. If this is just a drop-in replacement, I figured why not.

![Capture d’écran, le 2023-11-16 à 16 52 08](https://github.com/paradedb/paradedb/assets/21990816/ce5dc506-7f7d-4821-9570-9706a258ab2c)

## Why

## How

## Tests
