### PR TITLE
fix: Fix `runtests.sh` and `configure.sh` issues with `pgvector`

### DIFF
--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -87,11 +87,6 @@ jobs:
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 
-      - name: Initialize pgrx for Current PostgreSQL Version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        working-directory: pg_bm25/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_bm25 Integration Tests
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -32,8 +32,7 @@ concurrency:
 jobs:
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }}
-    # runs-on: ubuntu-latest
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         pg_version: [12, 13, 14, 15, 16]
@@ -65,53 +64,28 @@ jobs:
           cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
-      # - name: Remove old postgres, llvm, clang, and install appropriate version
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: |
-      #     sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
-      #     apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
-      #     sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
+      - name: Remove old postgres, llvm, clang, and install appropriate version
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: |
+          sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+          apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
+          sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
 
-      # - name: Install & Configure Supported PostgreSQL Version
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: |
-      #     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-      #     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      #     sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-      #     sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
-      #     echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
-
-      - name: install postgres
-        run: brew install postgresql@12 postgresql@13 postgresql@14 postgresql@15 postgresql@16
-
-      # - name: Install pgrx, grcov & llvm-tools-preview
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   run: |
-      #     cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
-      #     cargo install -j $(nproc) --locked grcov
-      #     rustup component add llvm-tools-preview
+      - name: Install & Configure Supported PostgreSQL Version
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: |
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: cargo install cargo-pgrx --version 0.11.0
-
-      # - name: Initialize pgrx for Current PostgreSQL Version
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   working-directory: pg_search/
-      #   run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-
-      - name: Initialize pgrx for Current PostgreSQL Version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        working-directory: pg_search/
         run: |
-          if [ "$(uname -m)" = "arm64" ]; then
-            cargo pgrx init --pg${{ matrix.pg_version }}=/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
-          elif [ "$(uname -m)" = "x86_64" ]; then
-            cargo pgrx init --pg${{ matrix.pg_version }}=/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
-          else
-            echo "Unknown arch, exiting..."
-            exit 1
-          fi
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
+          cargo install -j $(nproc) --locked grcov
+          rustup component add llvm-tools-preview
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests
@@ -134,25 +108,25 @@ jobs:
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi
 
-      # - name: Run pg_search Unit Tests
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-      #   env:
-      #     LLVM_PROFILE_FILE: target/coverage/pg_search-%p-%m.profraw
-      #     RUST_BACKTRACE: 1
-      #   run: |
-      #     mkdir -p target/coverage target/coverage-report
-      #     cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
+      - name: Run pg_search Unit Tests
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        env:
+          LLVM_PROFILE_FILE: target/coverage/pg_search-%p-%m.profraw
+          RUST_BACKTRACE: 1
+        run: |
+          mkdir -p target/coverage target/coverage-report
+          cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
-      # # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
-      # - name: Generate Code Coverage Reports
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
-      #   run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
+      # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
+      - name: Generate Code Coverage Reports
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
-      # - name: Upload Coverage Reports to Codecov
-      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     directory: ./target/coverage-report/
-      #     files: lcov
-      #     fail_ci_if_error: true
+      - name: Upload Coverage Reports to Codecov
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./target/coverage-report/
+          files: lcov
+          fail_ci_if_error: true

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -106,7 +106,15 @@ jobs:
       - name: Initialize pgrx for Current PostgreSQL Version
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
+        run: |
+          if [ "$(uname -m)" = "arm64" ]; then
+            cargo pgrx init --pg${{ matrix.pg_version }}=/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
+          elif [ "$(uname -m)" = "x86_64" ]; then
+            cargo pgrx init --pg${{ matrix.pg_version }}=/usr/local/bin/pg_config
+          else
+            echo "Unknown arch, exiting..."
+            exit 1
+          fi 
 
 
       # - name: Setup upterm session

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -84,12 +84,16 @@ jobs:
       - name: install postgres
         run: brew install postgresql@12 postgresql@13 postgresql@14 postgresql@15 postgresql@16
 
+      # - name: Install pgrx, grcov & llvm-tools-preview
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      #   run: |
+      #     cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
+      #     cargo install -j $(nproc) --locked grcov
+      #     rustup component add llvm-tools-preview
+
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
-        # cargo install -j $(nproc) --locked grcov
-        # rustup component add llvm-tools-preview
+        run: cargo install cargo-pgrx --version 0.11.0
 
       # - name: Initialize pgrx for Current PostgreSQL Version
       #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -35,8 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # pg_version: [12, 13, 14, 15, 16]
-        pg_version: [15]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -92,12 +91,6 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-
-
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -36,8 +36,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # pg_version: [12, 13, 14, 15, 16]
-        pg_version: [15]
+        pg_version: [12, 13, 14, 15, 16]
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -82,21 +81,15 @@ jobs:
       #     sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
       #     echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
       - name: install postgres
-        run: brew install postgresql@15
-
-
+        run: brew install postgresql@12 postgresql@13 postgresql@14 postgresql@15 postgresql@16
 
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
           cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
-          cargo install -j $(nproc) --locked grcov
-          rustup component add llvm-tools-preview
+        # cargo install -j $(nproc) --locked grcov
+        # rustup component add llvm-tools-preview
 
       # - name: Initialize pgrx for Current PostgreSQL Version
       #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
@@ -110,15 +103,11 @@ jobs:
           if [ "$(uname -m)" = "arm64" ]; then
             cargo pgrx init --pg${{ matrix.pg_version }}=/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
           elif [ "$(uname -m)" = "x86_64" ]; then
-            cargo pgrx init --pg${{ matrix.pg_version }}=/usr/local/bin/pg_config
+            cargo pgrx init --pg${{ matrix.pg_version }}=/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
           else
             echo "Unknown arch, exiting..."
             exit 1
-          fi 
-
-
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
+          fi
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [12, 13, 14, 15, 16]
+        # pg_version: [12, 13, 14, 15, 16]
+        pg_version: [15]
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -91,6 +92,12 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+
+
+
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -32,10 +32,12 @@ concurrency:
 jobs:
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }}
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
-        pg_version: [12, 13, 14, 15, 16]
+        # pg_version: [12, 13, 14, 15, 16]
+        pg_version: [15]
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -64,21 +66,30 @@ jobs:
           cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
-      - name: Remove old postgres, llvm, clang, and install appropriate version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: |
-          sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
-          apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
-          sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
+      # - name: Remove old postgres, llvm, clang, and install appropriate version
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      #   run: |
+      #     sudo apt-get remove -y '^postgres.*' '^libpq.*' '^mono-llvm.*'
+      #     apt list --installed 'clang*' 'llvm*' 'libclang*' 'libllvm*' | awk -F/ -e '{print $1}' | grep -P '\d' | grep -vP '\D15(\D.*)?$' | xargs sudo apt remove -y
+      #     sudo apt-get install -y llvm-15-dev libclang-15-dev clang-15 gcc
 
-      - name: Install & Configure Supported PostgreSQL Version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+      # - name: Install & Configure Supported PostgreSQL Version
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      #   run: |
+      #     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      #     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      #     sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+      #     sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/
+      #     echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+
+
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
+      - name: install postgres
+        run: brew install postgresql@15
+
+
 
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
@@ -87,10 +98,19 @@ jobs:
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 
+      # - name: Initialize pgrx for Current PostgreSQL Version
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      #   working-directory: pg_search/
+      #   run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+
       - name: Initialize pgrx for Current PostgreSQL Version
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+        run: cargo pgrx init --pg${{ matrix.pg_version }}=/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config
+
+
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests
@@ -113,25 +133,25 @@ jobs:
             ./test/runtests.sh -p sequential -v "${{ matrix.pg_version }}"
           fi
 
-      - name: Run pg_search Unit Tests
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        env:
-          LLVM_PROFILE_FILE: target/coverage/pg_search-%p-%m.profraw
-          RUST_BACKTRACE: 1
-        run: |
-          mkdir -p target/coverage target/coverage-report
-          cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
+      # - name: Run pg_search Unit Tests
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      #   env:
+      #     LLVM_PROFILE_FILE: target/coverage/pg_search-%p-%m.profraw
+      #     RUST_BACKTRACE: 1
+      #   run: |
+      #     mkdir -p target/coverage target/coverage-report
+      #     cd pg_search/ && cargo pgrx test --features pg${{ matrix.pg_version }} --profile dev
 
-      # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
-      - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
-        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
+      # # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
+      # - name: Generate Code Coverage Reports
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+      #   run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
-      - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./target/coverage-report/
-          files: lcov
-          fail_ci_if_error: true
+      # - name: Upload Coverage Reports to Codecov
+      #   if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     directory: ./target/coverage-report/
+      #     files: lcov
+      #     fail_ci_if_error: true

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -87,11 +87,6 @@ jobs:
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 
-      - name: Initialize pgrx for Current PostgreSQL Version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        working-directory: pg_sparse/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_sparse Integration Tests
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -51,11 +51,13 @@ for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
-      make clean && make
+      make clean
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
+        make PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"
         make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"
       elif [ "$(uname -m)" = "x86_64" ]; then
+        make PG_CONFIG="/usr/local/opt/postgresql@$version/bin/pg_config"
         make install PG_CONFIG="/usr/local/opt/postgresql@$version/bin/pg_config"
       else
         echo "Unknown arch, exiting..."

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -44,9 +44,6 @@ git fetch --tags
 git checkout "$PGVECTOR_VERSION"
 
 # Install pgvector for all specified pgrx-compatible PostgreSQL versions
-
-# TODO: does this fix it?
-
 for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."
   case "$OS_NAME" in

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -54,13 +54,13 @@ for version in "${PG_VERSIONS[@]}"; do
       make clean && make
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
-        make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"      
+        make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"
       elif [ "$(uname -m)" = "x86_64" ]; then
-        make install PG_CONFIG="/usr/local/bin/pg_config"      
+        make install PG_CONFIG="/usr/local/opt/postgresql@$version/bin/pg_config"
       else
         echo "Unknown arch, exiting..."
         exit 1
-      fi      
+      fi
       ;;
     Linux)
       sudo make clean
@@ -82,7 +82,7 @@ for version in "${PG_VERSIONS[@]}"; do
       if [ "$(uname -m)" = "arm64" ]; then
         cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
       elif [ "$(uname -m)" = "x86_64" ]; then
-        cargo pgrx install --pg-config="/usr/local/bin/pg_config" --profile dev       
+        cargo pgrx install --pg-config="/usr/local/opt/postgresql@$version/bin/pg_config" --profile dev
       else
         echo "Unknown arch, exiting..."
         exit 1

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -43,13 +43,16 @@ cd pgvector/
 git fetch --tags
 git checkout "$PGVECTOR_VERSION"
 
-# Install pgvector for all specified pgrx-compatible PostgreSQL versions
+# Install pgvector for all specified pgrx-compatible PostgreSQL versions. We compile
+# pgvector without specifying PG_CONFIG, so that it won't redefine macros that are
+# already defined in the pgrx environment, but we specify PG_CONFIG when installing
+# pgvector to make it available to the pgrx environment at runtime.
 for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
       make clean
-      make && make install PG_CONFIG="$HOME/.pgrx/$version/pgrx-install/bin/pg_config"
+      make && make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"      
       ;;
     Linux)
       sudo make clean
@@ -67,7 +70,7 @@ for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pg_bm25 for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
-      cargo pgrx install --pg-config="$HOME/.pgrx/$version/pgrx-install/bin/pg_config" --profile dev
+      cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
       ;;
     Linux)
       cargo pgrx install --pg-config="/usr/lib/postgresql/$version/bin/pg_config" --profile dev

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -44,8 +44,8 @@ git fetch --tags
 git checkout "$PGVECTOR_VERSION"
 
 # Configure pgvector like a pgrx extension for compatibility
-sed -i '' -e 's/relocatable = true/relocatable = false/' pg_search.control
-awk '{print} /relocatable = false/ {print "superuser = true\nschema = paradedb"}' pg_search.control > temp && mv temp pg_search.control
+sed -i '' -e 's/relocatable = true/relocatable = false/' vector.control
+awk '{print} /relocatable = false/ {print "superuser = true\nschema = paradedb"}' vector.control > temp && mv temp vector.control
 
 # Install pgvector for all specified pgrx-compatible PostgreSQL versions
 for version in "${PG_VERSIONS[@]}"; do

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -43,21 +43,20 @@ cd pgvector/
 git fetch --tags
 git checkout "$PGVECTOR_VERSION"
 
-# Configure pgvector like a pgrx extension for compatibility
-sed -i '' -e 's/relocatable = true/relocatable = false/' vector.control
-awk '{print} /relocatable = false/ {print "superuser = true\nschema = paradedb"}' vector.control > temp && mv temp vector.control
-
 # Install pgvector for all specified pgrx-compatible PostgreSQL versions
+
+# TODO: does this fix it?
+
 for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
       make clean
-      PG_CONFIG="$HOME/.pgrx/$version/pgrx-install/bin/pg_config" make && PG_CONFIG="$HOME/.pgrx/$version/pgrx-install/bin/pg_config" make install
+      make && make install PG_CONFIG="$HOME/.pgrx/$version/pgrx-install/bin/pg_config"
       ;;
     Linux)
       sudo make clean
-      sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make && sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make install
+      sudo make && sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make install
       ;;
   esac
 done

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -65,6 +65,7 @@ for version in "${PG_VERSIONS[@]}"; do
       fi
       ;;
     Linux)
+      # TODO: should I go back to sudo make PG_CONFIG here, then?
       sudo make clean
       sudo make && sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make install
       ;;

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -43,6 +43,10 @@ cd pgvector/
 git fetch --tags
 git checkout "$PGVECTOR_VERSION"
 
+# Configure pgvector like a pgrx extension for compatibility
+sed -i '' -e 's/relocatable = true/relocatable = false/' pg_search.control
+awk '{print} /relocatable = false/ {print "superuser = true\nschema = paradedb"}' pg_search.control > temp && mv temp pg_search.control
+
 # Install pgvector for all specified pgrx-compatible PostgreSQL versions
 for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -51,8 +51,16 @@ for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pgvector for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
-      make clean
-      make && make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"      
+      make clean && make
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        make install PG_CONFIG="/opt/homebrew/opt/postgresql@$version/bin/pg_config"      
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        make install PG_CONFIG="/usr/local/bin/pg_config"      
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi      
       ;;
     Linux)
       sudo make clean
@@ -70,7 +78,15 @@ for version in "${PG_VERSIONS[@]}"; do
   echo "Installing pg_bm25 for pgrx PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
-      cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx install --pg-config="/usr/local/bin/pg_config" --profile dev       
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
       ;;
     Linux)
       cargo pgrx install --pg-config="/usr/lib/postgresql/$version/bin/pg_config" --profile dev

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -28,7 +28,23 @@ else
   IFS=',' read -ra PG_VERSIONS <<< "$1"  # Split the argument by comma into an array
 fi
 
-echo "Installing pgvector and pg_bm25 into your pgrx environment..."
+echo "Installing system PostgreSQL..."
+echo ""
+
+# We install, if necessary, all supported PostgreSQL versions into the system
+for version in "${PG_VERSIONS[@]}"; do
+  echo "Installing PostgreSQL $version..."
+  case "$OS_NAME" in
+    Darwin)
+      brew install postgresql@"$version" > /dev/null
+      ;;
+    Linux)
+      sudo apt-get install -y "postgresql-$version" "postgresql-server-dev-$version" > /dev/null
+      ;;
+  esac
+done
+
+echo "Installing pgvector and pg_bm25 into your system PostgreSQL environment..."
 echo ""
 
 # Clone pgvector if it doesn't exist
@@ -48,7 +64,7 @@ git checkout "$PGVECTOR_VERSION"
 # already defined in the pgrx environment, but we specify PG_CONFIG when installing
 # pgvector to make it available to the pgrx environment at runtime.
 for version in "${PG_VERSIONS[@]}"; do
-  echo "Installing pgvector for pgrx PostgreSQL $version..."
+  echo "Installing pgvector for PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
       make clean
@@ -65,9 +81,9 @@ for version in "${PG_VERSIONS[@]}"; do
       fi
       ;;
     Linux)
-      # TODO: should I go back to sudo make PG_CONFIG here, then?
       sudo make clean
-      sudo make && sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make install
+      sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make
+      sudo PG_CONFIG="/usr/lib/postgresql/$version/bin/pg_config" make install
       ;;
   esac
 done
@@ -78,13 +94,15 @@ cd "$CONFIGDIR/../../pg_bm25"
 
 # Build and install pg_bm25 into the pgrx environment
 for version in "${PG_VERSIONS[@]}"; do
-  echo "Installing pg_bm25 for pgrx PostgreSQL $version..."
+  echo "Installing pg_bm25 for PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$version=/opt/homebrew/opt/postgresql@$version/bin/pg_config"
         cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
       elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$version=/usr/local/opt/postgresql@$version/bin/pg_config"
         cargo pgrx install --pg-config="/usr/local/opt/postgresql@$version/bin/pg_config" --profile dev
       else
         echo "Unknown arch, exiting..."
@@ -92,6 +110,7 @@ for version in "${PG_VERSIONS[@]}"; do
       fi
       ;;
     Linux)
+      cargo pgrx init "--pg$version=/usr/lib/postgresql/$version/bin/pg_config"
       cargo pgrx install --pg-config="/usr/lib/postgresql/$version/bin/pg_config" --profile dev
       ;;
   esac

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -9,9 +9,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[0.5,0.5]
     ) as score_hybrid
@@ -36,9 +36,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[1,0]
     ) as score_hybrid
@@ -63,9 +63,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[0,1]
     ) as score_hybrid

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -188,7 +188,7 @@ function run_tests() {
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
   # Display the results of the tests, to help with debugging
-  cat "$TESTDIR/../results/search.out"
+  cat "/home/runner/work/paradedb/paradedb/pg_search/regression.out"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -187,6 +187,9 @@ function run_tests() {
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
+  # Display the results of the tests, to help with debugging
+  cat "$TESTDIR/../results/searc.out"
+
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.
   # echo "Displaying PostgreSQL ERROR logs from tests..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -188,7 +188,7 @@ function run_tests() {
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
   # Display the results of the tests, to help with debugging
-  cat "$TESTDIR/../results/searc.out"
+  cat "$TESTDIR/../results/search.out"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -95,8 +95,17 @@ function run_tests() {
   # Get the paths to the psql & pg_regress binaries for the current PostgreSQL version
   case "$OS_NAME" in
     Darwin)
-      PG_BIN_PATH="/opt/homebrew/opt/postgresql@$version/bin"
-      REGRESS="/opt/homebrew/opt/postgresql@$version/lib/postgresql/pgxs/src/test/regress/pg_regress"
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        PG_BIN_PATH="/opt/homebrew/opt/postgresql@$version/bin"
+        REGRESS="/opt/homebrew/opt/postgresql@$version/lib/postgresql/pgxs/src/test/regress/pg_regress"
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        PG_BIN_PATH="/usr/local/bin"
+        REGRESS="/usr/local/lib/postgresql/pgxs/src/test/regress/pg_regress"        
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
       ;;
     Linux)
       PG_BIN_PATH="/usr/lib/postgresql/$PG_VERSION/bin"

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -187,9 +187,6 @@ function run_tests() {
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
-  # Display the results of the tests, to help with debugging
-  cat "/home/runner/work/paradedb/paradedb/pg_search/regression.out"
-
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.
   # echo "Displaying PostgreSQL ERROR logs from tests..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -98,10 +98,20 @@ function run_tests() {
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
         PG_BIN_PATH="/opt/homebrew/opt/postgresql@$PG_VERSION/bin"
-        REGRESS="/opt/homebrew/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
+        # For some reason, the path structure is different specifically for PostgreSQL 14 on macOS
+        if [ "$PG_VERSION" = "14" ]; then
+          REGRESS="/opt/homebrew/opt/postgresql@$PG_VERSION/lib/postgresql@$PG_VERSION/pgxs/src/test/regress/pg_regress"
+        else
+          REGRESS="/opt/homebrew/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
+        fi
       elif [ "$(uname -m)" = "x86_64" ]; then
         PG_BIN_PATH="/usr/local/opt/postgresql@$PG_VERSION/bin"
-        REGRESS="/usr/local/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
+        # For some reason, the path structure is different specifically for PostgreSQL 14 on macOS
+        if [ "$PG_VERSION" = "14" ]; then
+          REGRESS="/usr/local/opt/postgresql@$PG_VERSION/lib/postgresql@$PG_VERSION/pgxs/src/test/regress/pg_regress"
+        else
+          REGRESS="/usr/local/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
+        fi
       else
         echo "Unknown arch, exiting..."
         exit 1

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -97,11 +97,11 @@ function run_tests() {
     Darwin)
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
-        PG_BIN_PATH="/opt/homebrew/opt/postgresql@$version/bin"
-        REGRESS="/opt/homebrew/opt/postgresql@$version/lib/postgresql/pgxs/src/test/regress/pg_regress"
+        PG_BIN_PATH="/opt/homebrew/opt/postgresql@$PG_VERSION/bin"
+        REGRESS="/opt/homebrew/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
       elif [ "$(uname -m)" = "x86_64" ]; then
-        PG_BIN_PATH="/usr/local/bin"
-        REGRESS="/usr/local/lib/postgresql/pgxs/src/test/regress/pg_regress"        
+        PG_BIN_PATH="/usr/local/opt/postgresql@$PG_VERSION/bin"
+        REGRESS="/usr/local/opt/postgresql@$PG_VERSION/lib/postgresql/pgxs/src/test/regress/pg_regress"
       else
         echo "Unknown arch, exiting..."
         exit 1

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -95,8 +95,8 @@ function run_tests() {
   # Get the paths to the psql & pg_regress binaries for the current PostgreSQL version
   case "$OS_NAME" in
     Darwin)
-      PG_BIN_PATH="$HOME/.pgrx/$PG_VERSION/pgrx-install/bin"
-      REGRESS="$HOME/.pgrx/$PG_VERSION/pgrx-install/lib/postgresql/pgxs/src/test/regress/pg_regress"
+      PG_BIN_PATH="/opt/homebrew/opt/postgresql@$version/bin"
+      REGRESS="/opt/homebrew/opt/postgresql@$version/lib/postgresql/pgxs/src/test/regress/pg_regress"
       ;;
     Linux)
       PG_BIN_PATH="/usr/lib/postgresql/$PG_VERSION/bin"

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -10,9 +10,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[0.5,0.5]
     ) as score_hybrid
@@ -29,9 +29,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[1,0]
     ) as score_hybrid
@@ -48,9 +48,9 @@ SELECT
     paradedb.weighted_mean(
         paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
-          ARRAY[1,2,3]::vector <-> embedding, 
-          MIN(ARRAY[1,2,3]::vector <-> embedding) OVER (), 
-          MAX(ARRAY[1,2,3]::vector <-> embedding) OVER ()
+          '[1,2,3]' <-> embedding, 
+          MIN('[1,2,3]' <-> embedding) OVER (), 
+          MAX('[1,2,3]' <-> embedding) OVER ()
         ),
         ARRAY[0,1]
     ) as score_hybrid

--- a/pg_sparse/README.md
+++ b/pg_sparse/README.md
@@ -126,8 +126,8 @@ via Homebrew on macOS).
 Then, install and initialize pgrx:
 
 ```bash
-cargo install cargo-pgrx --version 0.11.0
-cargo pgrx init
+cargo install --locked cargo-pgrx --version 0.11.0
+cargo pgrx init --pg15=`which pg_config`
 ```
 
 ### Running the Extension


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This PR fixes an issue where our `runtests.sh` and `configure.sh` scripts were not properly interoperating non-pgrx extensions and pgrx extensions. This led to issues testing `pgvector` with `cargo pgrx run`.

This should now be fixed. Our scripts uses the system-wide Postgres installs, which also has the nice side effect of making them faster. It also properly splits paths based on the `arch` on macOS, which was necessary.

TODOs
- [x] Update the other `runtests.sh` with the new paths

## Why
Fix `pgvector` in `cargo pgrx run`!

## How
See above^

## Tests
Tested both in CI and manually for Linux Ubuntu and for macOS. I reverted the CI to only do Linux, but did macOS in CI just for testing on a clean environment, in addition to on my local Mac