### PR TITLE
fix: Remove lenient parsing and default record to freqs/positions

### DIFF
--- a/docs/search/autocomplete.mdx
+++ b/docs/search/autocomplete.mdx
@@ -7,6 +7,8 @@ title: Autocomplete
 Autocomplete, or regex search, enables users to obtain search results when only part of a word, phrase,
 or pattern has been provided. This is especially useful for building search-as-you-type user interfaces.
 
+When using regex search, you should not include the field name in the search query.
+
 ## Basic Usage
 
 ```sql

--- a/docs/search/bm25.mdx
+++ b/docs/search/bm25.mdx
@@ -69,13 +69,13 @@ the relevance scores of results.
 `AND`, `OR`, and `NOT` can be used to combine and filter multiple terms.
 
 ```sql
-'keyboard OR toy NOT metal'
+'description:keyboard OR toy NOT metal'
 ```
 
 Use parentheses to group terms and control the order of operations.
 
 ```sql
-'(keyboard OR toy) AND metal'
+'(description:keyboard OR category:toy) AND description:metal'
 ```
 
 ### Set Operator
@@ -116,7 +116,7 @@ SQL's `LIMIT` and `OFFSET` options.
 ```sql
 SELECT *
 FROM mock_items
-WHERE mock_items @@@ 'keyboard:::limit=100&offset=50'
+WHERE mock_items @@@ 'description:keyboard:::limit=100&offset=50'
 ```
 
 ## Filtering
@@ -128,7 +128,7 @@ The standard SQL `WHERE` clause is used perform range and filter queries:
 ```sql
 SELECT *
 FROM mock_items
-WHERE mock_items @@@ 'keyboard'
+WHERE mock_items @@@ 'description:keyboard'
 AND rating>=3;
 ```
 
@@ -137,6 +137,6 @@ AND rating>=3;
 ```sql
 SELECT *
 FROM your_table
-WHERE mock_items @@@ 'keyboard'
+WHERE mock_items @@@ 'description:keyboard'
 WHERE purchase_date > '2023-01-01 12:00:00-05';
 ```

--- a/docs/search/fuzzy.mdx
+++ b/docs/search/fuzzy.mdx
@@ -20,7 +20,7 @@ WHERE <table_name> @@@ '<query>:::<fuzzy_field_options>'
 ```sql
 SELECT *
 FROM mock_items
-WHERE mock_items @@@ 'keybroadd:::fuzzy_fields=description,category'
+WHERE mock_items @@@ 'description:keybroadd:::fuzzy_fields=description,category'
 ```
 </Accordion>
 

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -139,7 +139,9 @@ pub extern "C" fn amrescan(
         }
 
         // Construct the query using the lenient parser to tolerate minor errors in the input.
-        query_parser.parse_query_lenient(&query_config.query).0
+        query_parser
+            .parse_query(&query_config.query)
+            .expect("error parsing query")
     };
 
     // Execute the constructed search query on Tantivy.

--- a/pg_bm25/src/parade_index/fields.rs
+++ b/pg_bm25/src/parade_index/fields.rs
@@ -108,7 +108,7 @@ pub struct ParadeTextOptions {
     #[serde(default)]
     pub tokenizer: ParadeTokenizer,
     #[schema(value_type = IndexRecordOptionSchema)]
-    #[serde(default)]
+    #[serde(default = "default_as_freqs_and_positions")]
     record: IndexRecordOption,
     #[serde(default)]
     normalizer: ParadeNormalizer,
@@ -243,7 +243,7 @@ pub struct ParadeJsonOptions {
     #[serde(default)]
     pub tokenizer: ParadeTokenizer,
     #[schema(value_type = IndexRecordOptionSchema)]
-    #[serde(default)]
+    #[serde(default = "default_as_freqs_and_positions")]
     record: IndexRecordOption,
     #[serde(default)]
     normalizer: ParadeNormalizer,
@@ -305,4 +305,8 @@ pub type ParadeFieldConfigDeserializedResult = serde_json::Result<ParadeOptionMa
 
 fn default_as_true() -> bool {
     true
+}
+
+fn default_as_freqs_and_positions() -> IndexRecordOption {
+    IndexRecordOption::WithFreqsAndPositions
 }

--- a/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
+++ b/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
@@ -1,1 +1,1 @@
-SELECT paradedb.highlight_bm25(ctid, 'idx_posts_fts', 'author') from posts where posts @@@ '张';
+SELECT paradedb.highlight_bm25(ctid, 'idx_posts_fts', 'author') from posts where posts @@@ 'author:张';

--- a/pg_bm25/test/expected/bm25_search.out
+++ b/pg_bm25/test/expected/bm25_search.out
@@ -1,7 +1,7 @@
 -- Basic search query
 SELECT *
 FROM bm25_search
-WHERE bm25_search @@@ 'description:keyboard OR category:electronics OR rating>2';
+WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
  id |         description         | rating |  category   | in_stock |                     metadata                     
 ----+-----------------------------+--------+-------------+----------+--------------------------------------------------
   2 | Plastic Keyboard            |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}
@@ -41,7 +41,7 @@ DELETE FROM bm25_search WHERE id = 1;
 UPDATE bm25_search SET description = 'PVC Keyboard' WHERE id = 2;
 SELECT *
 FROM bm25_search
-WHERE bm25_search @@@ 'description:keyboard OR category:electronics OR rating>2';
+WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
  id |         description         | rating |  category   | in_stock |                    metadata                     
 ----+-----------------------------+--------+-------------+----------+-------------------------------------------------
     | New keyboard                |      5 | Electronics |          | 

--- a/pg_bm25/test/expected/index_config.out
+++ b/pg_bm25/test/expected/index_config.out
@@ -6,10 +6,10 @@ ERROR:  unrecognized parameter "invalid_field"
 -- Default text field
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
--------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- description | Str        | t      | t       | f    | t          |             | default   | basic  | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |        | 
+    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+-------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ description | Str        | t      | t       | f    | t          |             | default   | position | 
+ heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
 (2 rows)
 
 DROP INDEX idxindexconfig;
@@ -26,11 +26,11 @@ DROP INDEX idxindexconfig;
 -- Multiple text fields
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
--------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- description | Str        | t      | t       | t    | t          |             | en_stem   | freq   | raw
- category    | Str        | t      | t       | f    | t          |             | default   | basic  | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |        | 
+    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+-------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ description | Str        | t      | t       | t    | t          |             | en_stem   | freq     | raw
+ category    | Str        | t      | t       | f    | t          |             | default   | position | 
+ heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
 (3 rows)
 
 DROP INDEX idxindexconfig;
@@ -77,34 +77,34 @@ DROP INDEX idxindexconfig;
 -- Default Json field
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{"metadata": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- metadata | JsonObject | t      | t       | f    | f          | t           | default   | basic  | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ metadata | JsonObject | t      | t       | f    | f          | t           | default   | position | 
+ heap_tid | U64        | t      | t       | f    | t          |             |           |          | 
 (2 rows)
 
 DROP INDEX idxindexconfig;
 -- Json field with options
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- metadata | JsonObject | t      | t       | t    | f          | f           | raw       | basic  | raw
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ metadata | JsonObject | t      | t       | t    | f          | f           | raw       | position | raw
+ heap_tid | U64        | t      | t       | f    | t          |             |           |          | 
 (2 rows)
 
 DROP INDEX idxindexconfig;
 -- Multiple fields
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
--------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- description | Str        | t      | t       | f    | t          |             | default   | basic  | 
- rating      | I64        | t      | t       | t    | f          |             |           |        | 
- category    | Str        | t      | t       | f    | t          |             | default   | basic  | 
- in_stock    | Bool       | t      | t       | t    | f          |             |           |        | 
- metadata    | JsonObject | t      | t       | f    | f          | t           | default   | basic  | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |        | 
+    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+-------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ description | Str        | t      | t       | f    | t          |             | default   | position | 
+ rating      | I64        | t      | t       | t    | f          |             |           |          | 
+ category    | Str        | t      | t       | f    | t          |             | default   | position | 
+ in_stock    | Bool       | t      | t       | t    | f          |             |           |          | 
+ metadata    | JsonObject | t      | t       | f    | f          | t           | default   | position | 
+ heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
 (6 rows)
 
 DROP INDEX idxindexconfig;

--- a/pg_bm25/test/expected/quoted_table_name.out
+++ b/pg_bm25/test/expected/quoted_table_name.out
@@ -9,7 +9,7 @@ INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
 INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
 INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
 CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
-SELECT * FROM "Activity" WHERE "Activity" @@@ 'alice';
+SELECT * FROM "Activity" WHERE "Activity" @@@ 'name:alice';
  name  | age 
 -------+-----
  Alice |  29

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -62,13 +62,13 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (0 rows)
 
 -- With fuzzy field and transpose_cost_one=false and distance=1
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
  id | description | rating | category 
 ----+-------------+--------+----------
 (0 rows)
 
 -- With fuzzy field and transpose_cost_one=true and distance=1
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
  id |       description        | rating |  category   
 ----+--------------------------+--------+-------------
   1 | Ergonomic metal keyboard |      4 | Electronics
@@ -76,7 +76,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (2 rows)
 
 -- With fuzzy and regex field
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description&fuzzy_fields=description';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:com:::regex_fields=description&fuzzy_fields=description';
 ERROR:  cannot search with both regex_fields and fuzzy_fields
 -- With regex field 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';

--- a/pg_bm25/test/expected/tokenizer_config.out
+++ b/pg_bm25/test/expected/tokenizer_config.out
@@ -29,7 +29,7 @@ DROP INDEX idxtokenizerconfig;
 -- chinese_compatible
 CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
 INSERT INTO tokenizer_config (description, rating, category) VALUES ('电脑', 4, 'Electronics');
-SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ '电脑';
+SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:电脑';
  id | description | rating |  category   | in_stock | metadata 
 ----+-------------+--------+-------------+----------+----------
     | 电脑        |      4 | Electronics |          | 

--- a/pg_bm25/test/sql/bm25_search.sql
+++ b/pg_bm25/test/sql/bm25_search.sql
@@ -1,7 +1,7 @@
 -- Basic search query
 SELECT *
 FROM bm25_search
-WHERE bm25_search @@@ 'description:keyboard OR category:electronics OR rating>2';
+WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
 
 -- With BM25 scoring
 SELECT paradedb.rank_bm25(ctid), * 
@@ -19,7 +19,7 @@ DELETE FROM bm25_search WHERE id = 1;
 UPDATE bm25_search SET description = 'PVC Keyboard' WHERE id = 2;
 SELECT *
 FROM bm25_search
-WHERE bm25_search @@@ 'description:keyboard OR category:electronics OR rating>2';
+WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
 
 -- Test search in another namespace/schema
 SELECT *

--- a/pg_bm25/test/sql/quoted_table_name.sql
+++ b/pg_bm25/test/sql/quoted_table_name.sql
@@ -9,5 +9,5 @@ INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
 INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
 INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
 CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
-SELECT * FROM "Activity" WHERE "Activity" @@@ 'alice';
+SELECT * FROM "Activity" WHERE "Activity" @@@ 'name:alice';
 

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -13,11 +13,11 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 -- Without fuzzy field
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'category:electornics';
 -- With fuzzy field and transpose_cost_one=false and distance=1
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:keybaord:::fuzzy_fields=description&transpose_cost_one=false&distance=1';
 -- With fuzzy field and transpose_cost_one=true and distance=1
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:keybaord:::fuzzy_fields=description&transpose_cost_one=true&distance=1';
 -- With fuzzy and regex field
-SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description&fuzzy_fields=description';
+SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'description:com:::regex_fields=description&fuzzy_fields=description';
 -- With regex field 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';
 -- Default highlighting without max_num_chars

--- a/pg_bm25/test/sql/tokenizer_config.sql
+++ b/pg_bm25/test/sql/tokenizer_config.sql
@@ -16,6 +16,6 @@ DROP INDEX idxtokenizerconfig;
 -- chinese_compatible
 CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
 INSERT INTO tokenizer_config (description, rating, category) VALUES ('电脑', 4, 'Electronics');
-SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ '电脑';
+SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:电脑';
 DROP INDEX idxtokenizerconfig;
 


### PR DESCRIPTION
## What
As discussed in our community Slack, we've realized that ngrams (and likely other) tokenizers aren't returning the expected results.

## Why
We were using Tantivy's `parse_query_lenient`, which was ignoring some configuration issues... Namely, we were using `IndexRecordOption::Basic` when we should have been using `IndexRecordOption::WithFreqsAndPositions`.

`WithFreqsAndPositions` is necessary for proper scoring and tokenization. We should pretty much always be using it. It takes up more index space than `Basic`, but since it's required for most of our `bm25` functionality, we should make it the default. W can save index space optimization as a project for later.

## How
Use `parse_query` so parsing errors aren't silent, and make `WithFreqsAndPositions` the default for our `record` configuration.

## Tests
I've added a test for the `shoes` case that uncovered this issue.
