### PR TITLE
fix: Make our new test setup also work with `cargo pgrx run`

### DIFF
--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -75,14 +75,7 @@ fi
 OS_NAME=$(uname)
 if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
-  case "$OS_NAME" in
-    Darwin)
-      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
-      ;;
-    Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12")
-      ;;
-  esac
+  PG_VERSIONS=("16" "15" "14" "13" "12")
 else
   IFS=',' read -ra PG_VERSIONS <<< "$FLAG_PG_VER"  # Split the argument by comma into an array
 fi

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -16,14 +16,7 @@ PGVECTOR_VERSION=v$(jq -r '.extensions.pgvector.version' "$CONFIGDIR/../conf/thi
 # All pgrx-supported PostgreSQL versions to configure for
 if [ $# -eq 0 ]; then
   # No arguments provided; use default versions
-  case "$OS_NAME" in
-    Darwin)
-      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
-      ;;
-    Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12")
-      ;;
-  esac
+  PG_VERSIONS=("16" "14" "13" "12")
 else
   IFS=',' read -ra PG_VERSIONS <<< "$1"  # Split the argument by comma into an array
 fi
@@ -115,5 +108,25 @@ for version in "${PG_VERSIONS[@]}"; do
       ;;
   esac
 done
+
+# We can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time, so we
+# make one final call to `cargo pgrx init` to load the project's default pgrx PostgreSQL version
+default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
+case "$OS_NAME" in
+  Darwin)
+    # Check arch to set proper pg_config path
+    if [ "$(uname -m)" = "arm64" ]; then
+      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+    elif [ "$(uname -m)" = "x86_64" ]; then
+      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+    else
+      echo "Unknown arch, exiting..."
+      exit 1
+    fi
+    ;;
+  Linux)
+    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+    ;;
+esac
 
 echo "Done! You can now develop pg_search by running 'cargo pgrx run'!"

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -109,24 +109,26 @@ for version in "${PG_VERSIONS[@]}"; do
   esac
 done
 
-# We can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time, so we
-# make one final call to `cargo pgrx init` to load the project's default pgrx PostgreSQL version
+# We can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time, so we make one final call to
+# `cargo pgrx init` to load the project's default pgrx PostgreSQL version (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-case "$OS_NAME" in
-  Darwin)
-    # Check arch to set proper pg_config path
-    if [ "$(uname -m)" = "arm64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
-    elif [ "$(uname -m)" = "x86_64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
-    else
-      echo "Unknown arch, exiting..."
-      exit 1
-    fi
-    ;;
-  Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
-    ;;
-esac
+if [[ " ${PG_VERSIONS[*]} " =~ " $default_pg_version " ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+      ;;
+  esac
+fi
 
 echo "Done! You can now develop pg_search by running 'cargo pgrx run'!"

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -112,7 +112,7 @@ done
 # We can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time, so we make one final call to
 # `cargo pgrx init` to load the project's default pgrx PostgreSQL version (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-if [[ " ${PG_VERSIONS[*]} " =~ " $default_pg_version " ]]; then
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
   case "$OS_NAME" in
     Darwin)
       # Check arch to set proper pg_config path

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -16,7 +16,7 @@ PGVECTOR_VERSION=v$(jq -r '.extensions.pgvector.version' "$CONFIGDIR/../conf/thi
 # All pgrx-supported PostgreSQL versions to configure for
 if [ $# -eq 0 ]; then
   # No arguments provided; use default versions
-  PG_VERSIONS=("16" "14" "13" "12")
+  PG_VERSIONS=("16" "15" "14" "13" "12")
 else
   IFS=',' read -ra PG_VERSIONS <<< "$1"  # Split the argument by comma into an array
 fi

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -75,14 +75,7 @@ fi
 OS_NAME=$(uname)
 if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
-  case "$OS_NAME" in
-    Darwin)
-      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
-      ;;
-    Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12")
-      ;;
-  esac
+  PG_VERSIONS=("16" "15" "14" "13" "12")
 else
   IFS=',' read -ra PG_VERSIONS <<< "$FLAG_PG_VER"  # Split the argument by comma into an array
 fi

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -75,14 +75,7 @@ fi
 OS_NAME=$(uname)
 if [ "$FLAG_PG_VER" = false ]; then
   # No arguments provided; use default versions
-  case "$OS_NAME" in
-    Darwin)
-      PG_VERSIONS=("16.1" "15.5" "14.10" "13.13" "12.17")
-      ;;
-    Linux)
-      PG_VERSIONS=("16" "15" "14" "13" "12")
-      ;;
-  esac
+  PG_VERSIONS=("16" "15" "14" "13" "12")
 else
   IFS=',' read -ra PG_VERSIONS <<< "$FLAG_PG_VER"  # Split the argument by comma into an array
 fi


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I had forgotten to clean up the PG versions for macOS following the recent change, and set `pgrx init` to the current default project at the end to make it work on `cargo pgrx run` by default. This fixes that.

I also re-test locally with `pgvector` and it works great.

## Why

## How

## Tests
