### PR TITLE
fix: Add missing `pgrx init` in `pg_search` extension upgrade test

### DIFF
--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -172,6 +172,7 @@ function run_tests() {
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
     sudo chown -R "$(whoami)" "/usr/share/postgresql/$PG_VERSION/extension/" "/usr/lib/postgresql/$PG_VERSION/lib/"
+    cargo pgrx init "--pg$PG_VERSION=/usr/lib/postgresql/$PG_VERSION/bin/pg_config"
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I added it to `configure.sh` but we don't call it in that part of the test. I feel like this has grown a bit overcomplicated... Could probably streamline things, but that's for another PR

## Why

## How

## Tests
