### PR TITLE
feat: Reset `pgrx` environment post-tests

### DIFF
--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -223,3 +223,25 @@ done
 
 # Wait for all child processes to finish
 wait
+
+# Once the tests are done, we reset the pgrx environment to use the project's default, since we
+# can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
+default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+      ;;
+  esac
+fi

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -240,6 +240,6 @@ case "$OS_NAME" in
     fi
     ;;
   Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
     ;;
 esac

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -227,19 +227,21 @@ wait
 # Once the tests are done, we reset the pgrx environment to use the project's default, since we
 # can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-case "$OS_NAME" in
-  Darwin)
-    # Check arch to set proper pg_config path
-    if [ "$(uname -m)" = "arm64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    elif [ "$(uname -m)" = "x86_64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    else
-      echo "Unknown arch, exiting..."
-      exit 1
-    fi
-    ;;
-  Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
-    ;;
-esac
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null
+      ;;
+  esac
+fi

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -29,10 +29,10 @@ for version in "${PG_VERSIONS[@]}"; do
   echo "Installing PostgreSQL $version..."
   case "$OS_NAME" in
     Darwin)
-      brew install postgresql@"$version" > /dev/null
+      brew install postgresql@"$version" > /dev/null 2>&1
       ;;
     Linux)
-      sudo apt-get install -y "postgresql-$version" "postgresql-server-dev-$version" > /dev/null
+      sudo apt-get install -y "postgresql-$version" "postgresql-server-dev-$version" > /dev/null 2>&1
       ;;
   esac
 done
@@ -92,10 +92,10 @@ for version in "${PG_VERSIONS[@]}"; do
     Darwin)
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
-        cargo pgrx init "--pg$version=/opt/homebrew/opt/postgresql@$version/bin/pg_config"
+        cargo pgrx init "--pg$version=/opt/homebrew/opt/postgresql@$version/bin/pg_config" > /dev/null
         cargo pgrx install --pg-config="/opt/homebrew/opt/postgresql@$version/bin/pg_config" --profile dev
       elif [ "$(uname -m)" = "x86_64" ]; then
-        cargo pgrx init "--pg$version=/usr/local/opt/postgresql@$version/bin/pg_config"
+        cargo pgrx init "--pg$version=/usr/local/opt/postgresql@$version/bin/pg_config" > /dev/null
         cargo pgrx install --pg-config="/usr/local/opt/postgresql@$version/bin/pg_config" --profile dev
       else
         echo "Unknown arch, exiting..."

--- a/pg_search/configure.sh
+++ b/pg_search/configure.sh
@@ -117,16 +117,16 @@ if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
     Darwin)
       # Check arch to set proper pg_config path
       if [ "$(uname -m)" = "arm64" ]; then
-        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
       elif [ "$(uname -m)" = "x86_64" ]; then
-        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
       else
         echo "Unknown arch, exiting..."
         exit 1
       fi
       ;;
     Linux)
-      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null
       ;;
   esac
 fi

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -223,3 +223,25 @@ done
 
 # Wait for all child processes to finish
 wait
+
+# Once the tests are done, we reset the pgrx environment to use the project's default, since we
+# can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
+default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+      ;;
+  esac
+fi

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -172,7 +172,7 @@ function run_tests() {
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
     sudo chown -R "$(whoami)" "/usr/share/postgresql/$PG_VERSION/extension/" "/usr/lib/postgresql/$PG_VERSION/lib/"
-    cargo pgrx init "--pg$PG_VERSION=/usr/lib/postgresql/$PG_VERSION/bin/pg_config"
+    cargo pgrx init "--pg$PG_VERSION=/usr/lib/postgresql/$PG_VERSION/bin/pg_config" > /dev/null
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
@@ -227,21 +227,19 @@ wait
 # Once the tests are done, we reset the pgrx environment to use the project's default, since we
 # can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
-  case "$OS_NAME" in
-    Darwin)
-      # Check arch to set proper pg_config path
-      if [ "$(uname -m)" = "arm64" ]; then
-        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
-      elif [ "$(uname -m)" = "x86_64" ]; then
-        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
-      else
-        echo "Unknown arch, exiting..."
-        exit 1
-      fi
-      ;;
-    Linux)
-      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
-      ;;
-  esac
-fi
+case "$OS_NAME" in
+  Darwin)
+    # Check arch to set proper pg_config path
+    if [ "$(uname -m)" = "arm64" ]; then
+      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    elif [ "$(uname -m)" = "x86_64" ]; then
+      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    else
+      echo "Unknown arch, exiting..."
+      exit 1
+    fi
+    ;;
+  Linux)
+    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    ;;
+esac

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -240,6 +240,6 @@ case "$OS_NAME" in
     fi
     ;;
   Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
     ;;
 esac

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -227,19 +227,21 @@ wait
 # Once the tests are done, we reset the pgrx environment to use the project's default, since we
 # can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-case "$OS_NAME" in
-  Darwin)
-    # Check arch to set proper pg_config path
-    if [ "$(uname -m)" = "arm64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    elif [ "$(uname -m)" = "x86_64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    else
-      echo "Unknown arch, exiting..."
-      exit 1
-    fi
-    ;;
-  Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
-    ;;
-esac
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null
+      ;;
+  esac
+fi

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -223,3 +223,25 @@ done
 
 # Wait for all child processes to finish
 wait
+
+# Once the tests are done, we reset the pgrx environment to use the project's default, since we
+# can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
+default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config"
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config"
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
+      ;;
+  esac
+fi

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -223,23 +223,24 @@ done
 
 # Wait for all child processes to finish
 wait
-
 # Once the tests are done, we reset the pgrx environment to use the project's default, since we
 # can only keep one "version" of `cargo pgrx init` in the pgrx environment at a time (for local development)
 default_pg_version="$(grep 'default' Cargo.toml | cut -d'[' -f2 | tr -d '[]" ' | grep -o '[0-9]\+')"
-case "$OS_NAME" in
-  Darwin)
-    # Check arch to set proper pg_config path
-    if [ "$(uname -m)" = "arm64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    elif [ "$(uname -m)" = "x86_64" ]; then
-      cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null 2>&1
-    else
-      echo "Unknown arch, exiting..."
-      exit 1
-    fi
-    ;;
-  Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
-    ;;
-esac
+if [[ ${PG_VERSIONS[*]} =~ $default_pg_version ]]; then
+  case "$OS_NAME" in
+    Darwin)
+      # Check arch to set proper pg_config path
+      if [ "$(uname -m)" = "arm64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/opt/homebrew/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      elif [ "$(uname -m)" = "x86_64" ]; then
+        cargo pgrx init "--pg$default_pg_version=/usr/local/opt/postgresql@$default_pg_version/bin/pg_config" > /dev/null
+      else
+        echo "Unknown arch, exiting..."
+        exit 1
+      fi
+      ;;
+    Linux)
+      cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null
+      ;;
+  esac
+fi

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -240,6 +240,6 @@ case "$OS_NAME" in
     fi
     ;;
   Linux)
-    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config" > /dev/null 2>&1
+    cargo pgrx init "--pg$default_pg_version=/usr/lib/postgresql/$default_pg_version/bin/pg_config"
     ;;
 esac


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
From a recent PR, I set the tests to call their own `cargo pgrx init` to properly associate with system Postgres of the version they're testing against.

In order for the engineer to not need to re-call `cargo pgrx init` themselves after running the tests, we need to re-set it to the default project version after writing the tests. This does that.

## Why

## How

## Tests
