### PR TITLE
fix: `minmax_bm25` docs

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -143,7 +143,7 @@ SELECT
     category,
     rating,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'keyboard'),
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding,
           MIN('[1,2,3]' <-> embedding) OVER (),

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -91,7 +91,7 @@ SELECT
     category,
     rating,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'keyboard'),
+        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding,
           MIN('[1,2,3]' <-> embedding) OVER (),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We were still using the old query syntax on the docs for `minmax_bm25`.

## Why

## How

## Tests
