### PR TITLE
fix: build edge-cases with pgrx =0.11.1

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-15 postgresql-server-dev-15
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg15=/usr/lib/postgresql/15/bin/pg_config

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -46,7 +46,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_bm25/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -46,7 +46,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -46,7 +46,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.0
+        run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_sparse/

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 

--- a/.github/workflows/test-pg_sparse.yml
+++ b/.github/workflows/test-pg_sparse.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.0
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,6 @@ dependencies = [
  "serde_qs",
  "shared",
  "utoipa",
- "whichlang",
 ]
 
 [[package]]
@@ -2087,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3c4b36fbe84329b86c83bfd33b9514a50606f00074f47085f99062a7dd8c9c"
+checksum = "74be28cdc96f9558e475cd4d47852cd49b255d6f896d4fa08d1c4f5c595ac6c8"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.1",
@@ -2112,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6a41e021321a814fac1aa27bd4266208b4507709ecbc28fc99693adfbd0c41"
+checksum = "9ae1d356149028852679e43d6c43fdd7886b5052ee9be3e02bea885433d49409"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -2124,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da1e26800e747d501b8d8bb8aeee4530a07d93a39c3fb2c4229a8feff213b2"
+checksum = "02bc8706534e081424e58c14d06b64ed8ba6bb92d79f19c10b13b50a67c4edef"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -2142,11 +2141,12 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9032b517525ec71579cc68e92905b5f5f63e892c094834202313c42f2f1a669"
+checksum = "52dd0b8c611bbc4b6bd041711c9b9510f07fb62dc3e7965746ae7b5b12314a05"
 dependencies = [
  "bindgen",
+ "clang-sys",
  "eyre",
  "libc",
  "memoffset",
@@ -2160,13 +2160,14 @@ dependencies = [
  "shlex",
  "sptr",
  "syn 1.0.109",
+ "walkdir",
 ]
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4a88203974b887bca8bfdea17ab9936411fb7e84957763dc0124df78d07907"
+checksum = "f50bda0837d9ad915e60a3e8e958134881abf6f1aa6d4cf0878b681af098ba87"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2179,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80deb4310538e6ef14f4cbb30b56eb24b6d7aae66bfd4e516f153987159e65e"
+checksum = "177cb62f1050d2b52d8f59471c00d9320631329f7dfc6739a7a34ce7c0575a22"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2627,6 +2628,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3486,6 +3496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,12 +3595,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "whichlang"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213a57fbc76ff74e9dec77cf62e47fa4e4e01dec898dc09cc6873d992eed2ef9"
 
 [[package]]
 name = "whoami"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,7 +124,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
-RUN cargo install --locked cargo-pgrx --version 0.11.0 && \
+RUN cargo install --locked cargo-pgrx --version 0.11.1 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -33,7 +33,7 @@ lindera-tokenizer = { version = "0.27.1", features = [
 ] }
 memoffset = "0.9.0"
 once_cell = "1.18.0"
-pgrx = "=0.11.0"
+pgrx = "=0.11.1"
 rustc-hash = "1.1.0"
 serde = "1.0.188"
 serde_json = "1.0.105"
@@ -43,4 +43,4 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "paradedb
 utoipa = "3.5.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.0"
+pgrx-tests = "=0.11.1"

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -186,7 +186,7 @@ Then, install and initialize pgrx:
 
 ```bash
 # Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
-cargo install --locked cargo-pgrx --version 0.11.0
+cargo install --locked cargo-pgrx --version 0.11.1
 cargo pgrx init --pg15=`which pg_config`
 ```
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,10 +19,10 @@ pg_test = []
 telemetry = ["shared/telemetry"]
 
 [dependencies]
-pgrx = "=0.11.0"
+pgrx = "=0.11.1"
 serde = "1.0.188"
 serde_json = "1.0.107"
 shared = { version = "0.1.0", path = "../shared" }
 
 [dev-dependencies]
-pgrx-tests = "=0.11.0"
+pgrx-tests = "=0.11.1"

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -122,7 +122,7 @@ Then, install and initialize pgrx:
 
 ```bash
 # Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
-cargo install --locked cargo-pgrx --version 0.11.0
+cargo install --locked cargo-pgrx --version 0.11.1
 cargo pgrx init --pg15=`which pg_config`
 ```
 

--- a/pg_sparse/Cargo.toml
+++ b/pg_sparse/Cargo.toml
@@ -22,7 +22,7 @@ telemetry = ["shared/telemetry"]
 csv = "1.2.2"
 hnswlib = { git = "https://github.com/paradedb/hnswlib.git", rev="16096b04db19ca00ee7250e27680c8d9296c7c37" }
 memoffset = "0.9.0"
-pgrx = "=0.11.0"
+pgrx = "=0.11.1"
 rustc-hash = "1.1.0"
 shared = { version = "0.1.0", path = "../shared" }
 serde = "1.0.188"
@@ -32,4 +32,4 @@ utoipa = "3.5.0"
 
 [dev-dependencies]
 approx = "0.5.1"
-pgrx-tests = "=0.11.0"
+pgrx-tests = "=0.11.1"

--- a/pg_sparse/README.md
+++ b/pg_sparse/README.md
@@ -126,7 +126,7 @@ via Homebrew on macOS).
 Then, install and initialize pgrx:
 
 ```bash
-cargo install --locked cargo-pgrx --version 0.11.0
+cargo install --locked cargo-pgrx --version 0.11.1
 cargo pgrx init --pg15=`which pg_config`
 ```
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,11 +10,11 @@ telemetry = []
 
 [dependencies]
 envy = "0.4.2"
-pgrx = "0.11.0"
+pgrx = "0.11.1"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 serde = "1.0.189"
 serde_json = "1.0.107"
 uuid = "1.5.0"
 
 [dev-dependencies]
-pgrx-tests = "0.11.0"
+pgrx-tests = "0.11.1"


### PR DESCRIPTION
# Ticket(s) Closed

- resolves https://github.com/paradedb/paradedb/issues/556
- (effectively) resolves https://github.com/paradedb/paradedb/issues/559
- resolves https://github.com/pgcentralfoundation/pgrx/issues/1407

## What

Fixes several weird build edge-cases.

## Why

These edge-cases prevent local builds from resolving correctly. These seem to disproportionately afflict CentOS 7, but they can arise in other build environments such as Debian, unless you carefully manage the build environment with e.g. Docker.

## How

Upgrade pgrx to `=0.11.1`.

## Tests

It does update all the workflows, of course, though I do not believe you wish to run a CentOS 7 test server at this time to test the exact edge-case in question.