### PR TITLE
chore: Convert from Buildjet to Ubicloud

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -25,7 +25,7 @@ jobs:
           - runner: ubuntu-latest
             pg_version: 15
             arch: amd64
-          - runner: buildjet-8vcpu-ubuntu-2204-arm
+          - runner: ubicloud-standard-8-ubuntu-2204-arm
             pg_version: 15
             arch: arm64
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -25,7 +25,7 @@ jobs:
           - runner: ubuntu-latest
             pg_version: 15
             arch: amd64
-          - runner: buildjet-4vcpu-ubuntu-2204-arm
+          - runner: ubicloud-standard-4-ubuntu-2204-arm
             pg_version: 15
             arch: arm64
 

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -25,7 +25,7 @@ jobs:
           - runner: ubuntu-latest
             pg_version: 15
             arch: amd64
-          - runner: buildjet-8vcpu-ubuntu-2204-arm
+          - runner: ubicloud-standard-8-ubuntu-2204-arm
             pg_version: 15
             arch: arm64
 

--- a/.github/workflows/publish-third-party-pg_extensions.yml
+++ b/.github/workflows/publish-third-party-pg_extensions.yml
@@ -30,7 +30,7 @@ jobs:
           - runner: ubuntu-latest
             pg_version: 15
             arch: amd64
-          - runner: buildjet-4vcpu-ubuntu-2204-arm
+          - runner: ubicloud-standard-4-ubuntu-2204-arm
             pg_version: 15
             arch: arm64
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Ubicloud is much cheaper, so converting to that. Functionality should be the same.

## Why

## How

## Tests
