### PR TITLE
fix: Clean previous build artifacts to avoid conflicts

### DIFF
--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -92,8 +92,8 @@ jobs:
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 
-      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_bm25 extension. Since we 
-      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we 
+      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_bm25 extension. Since we
+      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we
       # clean any cached pg_bm25 build artifacts before running the tests
       - name: Clean Cached Build Artifacts
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -57,15 +57,16 @@ jobs:
         uses: dtolnay/rust-toolchain@1.73.0
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
-      # save the cache on the main branch, but load it on all branches.
+      # save the cache on the 'dev' branch, but load it on all branches.
       - name: Install Rust Cache
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-"
+          prefix-key: "v1"
           shared-key: ${{ runner.os }}-rust-cache-pg_bm25-${{ HashFiles('Cargo.lock') }}
           cache-targets: true
           cache-on-failure: true
+          cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Remove old postgres, llvm, clang, and install appropriate version
@@ -90,6 +91,14 @@ jobs:
           cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
+
+      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_bm25 extension. Since we 
+      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we 
+      # clean any cached pg_bm25 build artifacts before running the tests
+      - name: Clean Cached Build Artifacts
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        working-directory: pg_bm25/
+        run: cargo clean -p pg_bm25
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_bm25 Integration Tests

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -57,7 +57,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.73.0
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
-      # save the cache on the main branch, but load it on all branches.
+      # save the cache on the 'dev' branch, but load it on all branches.
       - name: Install Rust Cache
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -92,8 +92,8 @@ jobs:
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 
-      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_search extension. Since we 
-      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we 
+      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_search extension. Since we
+      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we
       # clean any cached pg_search build artifacts before running the tests
       - name: Clean Cached Build Artifacts
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -62,10 +62,11 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-"
+          prefix-key: "v1"
           shared-key: ${{ runner.os }}-rust-cache-pg_search-${{ HashFiles('Cargo.lock') }}
           cache-targets: true
           cache-on-failure: true
+          cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Remove old postgres, llvm, clang, and install appropriate version
@@ -90,6 +91,14 @@ jobs:
           cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
+
+      # Our Rust Cache action caches the entire ~/target directory, which includes the pg_search extension. Since we 
+      # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we 
+      # clean any cached pg_search build artifacts before running the tests
+      - name: Clean Cached Build Artifacts
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        working-directory: pg_search/
+        run: cargo clean -p pg_search
 
       # The integration tests also test upgrading the extension when passed the '-u' flag (only on promotion PRs)
       - name: Run pg_search Integration Tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,27 +78,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     sudo \
     gnupg \
-    # gcc \
+    gcc \
     make \
     uuid-runtime \
-    # software-properties-common \
-    # ca-certificates \
-    # libssl-dev \
-    # libopenblas-dev \
-    # python3-dev \
-    # python3-pip \
+    software-properties-common \
+    ca-certificates \
+    libssl-dev \
+    libopenblas-dev \
+    python3-dev \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install apt-fast
 RUN /bin/bash -c "$(curl -sL https://git.io/vokNn)"
 
 # Add PostgreSQL's third party repository to get the latest versions
+RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
-RUN mkdir -p /usr/share/keyrings/
-ADD https://www.postgresql.org/media/keys/ACCC4CF8.asc /usr/share/keyrings/postgres.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-fast update && apt-fast install -y --no-install-recommends \
     postgresql-server-dev-${PG_VERSION_MAJOR} \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,25 +78,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     sudo \
     gnupg \
-    gcc \
+    # gcc \
     make \
     uuid-runtime \
-    software-properties-common \
-    ca-certificates \
-    libssl-dev \
-    libopenblas-dev \
-    python3-dev \
-    python3-pip \
+    # software-properties-common \
+    # ca-certificates \
+    # libssl-dev \
+    # libopenblas-dev \
+    # python3-dev \
+    # python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install apt-fast
 RUN /bin/bash -c "$(curl -sL https://git.io/vokNn)"
 
 # Add PostgreSQL's third party repository to get the latest versions
-RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
+RUN mkdir -p /usr/share/keyrings/
+ADD https://www.postgresql.org/media/keys/ACCC4CF8.asc /usr/share/keyrings/postgres.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-server-dev-${PG_VERSION_MAJOR} \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The issue with the tests and the extension re-installing is due to the Rust cache caching previous extension versions. This should be the actual fix for it!

see here: https://doc.rust-lang.org/cargo/commands/cargo-clean.html

## Why

## How

## Tests
