### PR TITLE
feat: Add 'key_field' configuration to index to replace use of 'ctid'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1949,7 +1949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -1957,6 +1957,7 @@ name = "pg_bm25"
 version = "0.0.0"
 dependencies = [
  "csv",
+ "indexmap 2.1.0",
  "json5",
  "lindera-core",
  "lindera-dictionary",
@@ -3175,7 +3176,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3329,7 +3330,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82b1bc5417102a73e8464c686eef947bdfb99fcdfc0a4f228e81afa9526470a"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_json",
  "utoipa-gen",

--- a/benchmarks/benchmark-paradedb.sh
+++ b/benchmarks/benchmark-paradedb.sh
@@ -140,9 +140,11 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   echo "-- Creating temporary table with $SIZE rows..."
   db_query "CREATE TABLE $TABLE_NAME AS SELECT * FROM wikipedia_articles LIMIT $SIZE;"
 
+  db_query "ALTER TABLE $TABLE_NAME ADD COLUMN id SERIAL"
+
   # Time indexing
   echo "-- Timing indexing..."
-  start_time=$( { time db_query "CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING bm25 (($TABLE_NAME.*)) WITH (text_fields='{\"url\": {}, \"title\": {}, \"body\": {}}');" > query_output.log 2> query_error.log ; } 2>&1 )
+  start_time=$( { time db_query "CREATE INDEX $INDEX_NAME ON $TABLE_NAME USING bm25 (($TABLE_NAME.*)) WITH (key_field='id', text_fields='{\"url\": {}, \"title\": {}, \"body\": {}}');" > query_output.log 2> query_error.log ; } 2>&1 )
   index_time=$(echo "$start_time" | grep real | awk '{ split($2, array, "m|s"); print array[1]*60000 + array[2]*1000 }')
 
   # Time search

--- a/docs/indexing/bm25.mdx
+++ b/docs/indexing/bm25.mdx
@@ -20,6 +20,7 @@ CREATE INDEX <index_name>
 ON <schema_name>.<table_name>
 USING bm25 ((<table_name>.*))
 WITH (
+  key_field='<key_field>'
   text_fields='<text_fields>',
   numeric_fields='<numeric_fields>',
   boolean_fields='<boolean_fields>',
@@ -34,6 +35,7 @@ CREATE INDEX idx_mock_items
 ON mock_items
 USING bm25 ((mock_items.*))
 WITH (
+  key_field='<key_field>'
   text_fields='{
     description: {tokenizer: {type: "en_stem"}}, category: {fast: true}
   }'
@@ -54,6 +56,11 @@ Each input to `WITH ()` accepts a [JSON5](https://json5.org)-formatted string. K
 <ParamField body="schema_name">
   The name of the schema, or namespace, of the table. The schema name only needs
   to be provided if the table is not in the `public` schema.
+</ParamField>
+<ParamField body="key_field">
+  The name of a column in the table that represents a unique identifier for each record. Usually, this
+  is the same column that is the primary key of table. Currently, only integer IDs are supported, so
+  if necessary you may consider creating a dedicated column to use e.g: `ALTER TABLE mock_items ADD COLUMN bm25_id SERIAL`.
 </ParamField>
 <ParamField body="text_fields">
   A JSON string which specifies which text columns should be indexed and how they should be indexed.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -84,6 +84,17 @@ Under the hood, this command creates a Postgres-native index called `idx_mock_it
 an inverted index of the `mock_items` table. [Custom index configuration options](/indexing/bm25), such as
 tokenizers, can be specified in the `WITH` option.
 
+Note the mandatory `key_field` option in the `WITH` code. Every `bm25` index needs a `key_field`, which should
+be the name of a column that will function as a row's unique identifier within the index. Usually, the `key_field`
+can just be the name of your table's primary key column.
+
+Currently, only integer IDs are supported in the `key_field` column, so if you're primary key is a composite
+or a string, just add another column with serial IDs to your table:
+
+```sql
+ALTER TABLE mock_items ADD COLUMN bm25_id SERIAL
+````
+
 Let's execute a full-text search:
 
 ```sql

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -69,6 +69,7 @@ CREATE INDEX idx_mock_items
 ON mock_items
 USING bm25 ((mock_items.*))
 WITH (
+  key_field='id',
   text_fields='{"description": {"tokenizer": {"type": "en_stem"}}, "category": {}}'
 );
 ```
@@ -143,7 +144,7 @@ SELECT
     category,
     rating,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding,
           MIN('[1,2,3]' <-> embedding) OVER (),

--- a/docs/search/highlighting.mdx
+++ b/docs/search/highlighting.mdx
@@ -14,7 +14,7 @@ The `paradedb.highlight_bm25` function returns highlighted fragments of text tha
 query. This function only works over text fields.
 
 ```sql
-SELECT *, paradedb.highlight_bm25(ctid, '<index_name>', '<column_name>')
+SELECT *, paradedb.highlight_bm25(id, '<index_name>', '<column_name>')
 FROM <table_name>
 WHERE <table_name> @@@ '<query>'
 ```
@@ -43,7 +43,7 @@ Specify a number for `max_num_chars` to set the maximum number of characters in 
 highlighted snippet of text.
 
 ```sql
-SELECT description, rating, category, paradedb.rank_bm25(ctid), paradedb.highlight_bm25(ctid, 'idx_mock_items', 'description')
+SELECT description, rating, category, paradedb.rank_bm25(id), paradedb.highlight_bm25(id, 'idx_mock_items', 'description')
 FROM mock_items
 WHERE mock_items @@@ 'description:keyboard OR category:electronics:::max_num_chars=14'
 LIMIT 5;

--- a/docs/search/hybrid.mdx
+++ b/docs/search/hybrid.mdx
@@ -23,7 +23,7 @@ SELECT
     category,
     rating,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, '[index_name]', '[query]'),
+        paradedb.minmax_bm25(id, '[index_name]', '[query]'),
         1 - paradedb.minmax_norm(
           [l2_distance],
           MIN([l2_distance]) OVER (),

--- a/docs/search/scoring.mdx
+++ b/docs/search/scoring.mdx
@@ -8,11 +8,11 @@ BM25 scores measure how relevant a score is for a given query. Higher scores ind
 
 ## Basic Usage
 
-The `paradedb.rank_bm25` function creates a column that contains each row's BM25 score. It makes use of the
-hidden `ctid` Postgres system column to assign a score to every row.
+The `paradedb.rank_bm25` function creates a column that contains each row's BM25 score. It accepts a key
+column as an argument, which usually is the primary key column of your table.
 
 ```sql
-SELECT *, paradedb.rank_bm25(ctid)
+SELECT *, paradedb.rank_bm25(<key_field>)
 FROM <table_name>
 WHERE <table_name> @@@ '<query>'
 ```

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -20,6 +20,7 @@ telemetry = ["shared/telemetry"]
 
 [dependencies]
 csv = "1.2.2"
+indexmap = "2.1.0"
 json5 = "0.4.1"
 lindera-core = "0.27.1"
 lindera-dictionary = "0.27.1"

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -84,7 +84,7 @@ To index the table, use the following SQL command:
 CREATE INDEX idx_mock_items
 ON mock_items
 USING bm25 ((mock_items.*))
-WITH (text_fields='{"description": {}, "category": {}}');
+WITH (key_field='id', text_fields='{"description": {}, "category": {}}');
 ```
 
 Once the indexing is complete, you can run various search functions on it.

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -87,6 +87,9 @@ USING bm25 ((mock_items.*))
 WITH (key_field='id', text_fields='{"description": {}, "category": {}}');
 ```
 
+Note the mandatory `key_field` option in the `WITH` code. Every `bm25` index needs a `key_field`, which should be the name of a column that will function as a row's unique identifier within the index. Usually, the `key_field` can just be the name of your table's primary key column.
+
+
 Once the indexing is complete, you can run various search functions on it.
 
 ### Basic Search

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -89,7 +89,6 @@ WITH (key_field='id', text_fields='{"description": {}, "category": {}}');
 
 Note the mandatory `key_field` option in the `WITH` code. Every `bm25` index needs a `key_field`, which should be the name of a column that will function as a row's unique identifier within the index. Usually, the `key_field` can just be the name of your table's primary key column.
 
-
 Once the indexing is complete, you can run various search functions on it.
 
 ### Basic Search

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -116,7 +116,7 @@ This will return:
 Scoring and highlighting are supported:
 
 ```sql
-SELECT description, rating, category, paradedb.rank_bm25(ctid), paradedb.highlight_bm25(ctid, 'idx_mock_items', 'description')
+SELECT description, rating, category, paradedb.rank_bm25(id), paradedb.highlight_bm25(id, 'idx_mock_items', 'description')
 FROM mock_items
 WHERE mock_items @@@ 'description:keyboard OR category:electronics'
 LIMIT 5;

--- a/pg_bm25/sql/_bootstrap.sql
+++ b/pg_bm25/sql/_bootstrap.sql
@@ -1,12 +1,14 @@
 GRANT ALL ON SCHEMA paradedb TO PUBLIC;
 
-CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table()
+CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb')
 LANGUAGE plpgsql
 AS $$
+DECLARE
+    full_table_name TEXT := schema_name || '.' || table_name;
+    data_to_insert RECORD;
 BEGIN
-    IF NOT EXISTS (SELECT FROM pg_catalog.pg_tables
-                   WHERE schemaname = 'paradedb' AND tablename = 'bm25_test_table') THEN
-        CREATE TABLE paradedb.bm25_test_table (
+    IF NOT EXISTS (SELECT FROM pg_catalog.pg_tables WHERE schemaname = schema_name AND tablename = table_name) THEN
+        EXECUTE 'CREATE TABLE ' || full_table_name || ' (
             id SERIAL PRIMARY KEY,
             description TEXT,
             rating INTEGER CHECK (
@@ -16,53 +18,58 @@ BEGIN
             category VARCHAR(255),
             in_stock BOOLEAN,
             metadata JSONB
-        );
+        )';
 
-        INSERT INTO paradedb.bm25_test_table (description, rating, category, in_stock, metadata)
-        VALUES
-            ('Ergonomic metal keyboard', 4, 'Electronics', true, '{"color": "Silver", "location": "United States"}'::JSONB),
-            ('Plastic Keyboard', 4, 'Electronics', false, '{"color": "Black", "location": "Canada"}'::JSONB),
-            ('Sleek running shoes', 5, 'Footwear', true, '{"color": "Blue", "location": "China"}'::JSONB),
-            ('White jogging shoes', 3, 'Footwear', false, '{"color": "White", "location": "United States"}'::JSONB),
-            ('Generic shoes', 4, 'Footwear', true, '{"color": "Brown", "location": "Canada"}'::JSONB),
-            ('Compact digital camera', 5, 'Photography', false, '{"color": "Black", "location": "China"}'::JSONB),
-            ('Hardcover book on history', 2, 'Books', true, '{"color": "Brown", "location": "United States"}'::JSONB),
-            ('Organic green tea', 3, 'Groceries', true, '{"color": "Green", "location": "Canada"}'::JSONB),
-            ('Modern wall clock', 4, 'Home Decor', false, '{"color": "Silver", "location": "China"}'::JSONB),
-            ('Colorful kids toy', 1, 'Toys', true, '{"color": "Multicolor", "location": "United States"}'::JSONB),
-            ('Soft cotton shirt', 5, 'Apparel', true, '{"color": "Blue", "location": "Canada"}'::JSONB),
-            ('Innovative wireless earbuds', 5, 'Electronics', true, '{"color": "Black", "location": "China"}'::JSONB),
-            ('Sturdy hiking boots', 4, 'Footwear', true, '{"color": "Brown", "location": "United States"}'::JSONB),
-            ('Elegant glass table', 3, 'Furniture', true, '{"color": "Clear", "location": "Canada"}'::JSONB),
-            ('Refreshing face wash', 2, 'Beauty', false, '{"color": "White", "location": "China"}'::JSONB),
-            ('High-resolution DSLR', 4, 'Photography', true, '{"color": "Black", "location": "United States"}'::JSONB),
-            ('Paperback romantic novel', 3, 'Books', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
-            ('Freshly ground coffee beans', 5, 'Groceries', true, '{"color": "Brown", "location": "China"}'::JSONB),
-            ('Artistic ceramic vase', 4, 'Home Decor', false, '{"color": "Multicolor", "location": "United States"}'::JSONB),
-            ('Interactive board game', 3, 'Toys', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
-            ('Slim-fit denim jeans', 5, 'Apparel', false, '{"color": "Blue", "location": "China"}'::JSONB),
-            ('Fast charging power bank', 4, 'Electronics', true, '{"color": "Black", "location": "United States"}'::JSONB),
-            ('Comfortable slippers', 3, 'Footwear', true, '{"color": "Brown", "location": "Canada"}'::JSONB),
-            ('Classic leather sofa', 5, 'Furniture', false, '{"color": "Brown", "location": "China"}'::JSONB),
-            ('Anti-aging serum', 4, 'Beauty', true, '{"color": "White", "location": "United States"}'::JSONB),
-            ('Portable tripod stand', 4, 'Photography', true, '{"color": "Black", "location": "Canada"}'::JSONB),
-            ('Mystery detective novel', 2, 'Books', false, '{"color": "Multicolor", "location": "China"}'::JSONB),
-            ('Organic breakfast cereal', 5, 'Groceries', true, '{"color": "Brown", "location": "United States"}'::JSONB),
-            ('Designer wall paintings', 5, 'Home Decor', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
-            ('Robot building kit', 4, 'Toys', true, '{"color": "Multicolor", "location": "China"}'::JSONB),
-            ('Sporty tank top', 4, 'Apparel', true, '{"color": "Blue", "location": "United States"}'::JSONB),
-            ('Bluetooth-enabled speaker', 3, 'Electronics', true, '{"color": "Black", "location": "Canada"}'::JSONB),
-            ('Winter woolen socks', 5, 'Footwear', false, '{"color": "Gray", "location": "China"}'::JSONB),
-            ('Rustic bookshelf', 4, 'Furniture', true, '{"color": "Brown", "location": "United States"}'::JSONB),
-            ('Moisturizing lip balm', 4, 'Beauty', true, '{"color": "Pink", "location": "Canada"}'::JSONB),
-            ('Lightweight camera bag', 5, 'Photography', false, '{"color": "Black", "location": "China"}'::JSONB),
-            ('Historical fiction book', 3, 'Books', true, '{"color": "Multicolor", "location": "United States"}'::JSONB),
-            ('Pure honey jar', 4, 'Groceries', true, '{"color": "Yellow", "location": "Canada"}'::JSONB),
-            ('Handcrafted wooden frame', 5, 'Home Decor', false, '{"color": "Brown", "location": "China"}'::JSONB),
-            ('Plush teddy bear', 4, 'Toys', true, '{"color": "Brown", "location": "United States"}'::JSONB),
-            ('Warm woolen sweater', 3, 'Apparel', false, '{"color": "Red", "location": "Canada"}'::JSONB);
+        FOR data_to_insert IN
+            SELECT * FROM (VALUES
+                ('Ergonomic metal keyboard', 4, 'Electronics', true, '{"color": "Silver", "location": "United States"}'::JSONB),
+                ('Plastic Keyboard', 4, 'Electronics', false, '{"color": "Black", "location": "Canada"}'::JSONB),
+                ('Sleek running shoes', 5, 'Footwear', true, '{"color": "Blue", "location": "China"}'::JSONB),
+                ('White jogging shoes', 3, 'Footwear', false, '{"color": "White", "location": "United States"}'::JSONB),
+                ('Generic shoes', 4, 'Footwear', true, '{"color": "Brown", "location": "Canada"}'::JSONB),
+                ('Compact digital camera', 5, 'Photography', false, '{"color": "Black", "location": "China"}'::JSONB),
+                ('Hardcover book on history', 2, 'Books', true, '{"color": "Brown", "location": "United States"}'::JSONB),
+                ('Organic green tea', 3, 'Groceries', true, '{"color": "Green", "location": "Canada"}'::JSONB),
+                ('Modern wall clock', 4, 'Home Decor', false, '{"color": "Silver", "location": "China"}'::JSONB),
+                ('Colorful kids toy', 1, 'Toys', true, '{"color": "Multicolor", "location": "United States"}'::JSONB),
+                ('Soft cotton shirt', 5, 'Apparel', true, '{"color": "Blue", "location": "Canada"}'::JSONB),
+                ('Innovative wireless earbuds', 5, 'Electronics', true, '{"color": "Black", "location": "China"}'::JSONB),
+                ('Sturdy hiking boots', 4, 'Footwear', true, '{"color": "Brown", "location": "United States"}'::JSONB),
+                ('Elegant glass table', 3, 'Furniture', true, '{"color": "Clear", "location": "Canada"}'::JSONB),
+                ('Refreshing face wash', 2, 'Beauty', false, '{"color": "White", "location": "China"}'::JSONB),
+                ('High-resolution DSLR', 4, 'Photography', true, '{"color": "Black", "location": "United States"}'::JSONB),
+                ('Paperback romantic novel', 3, 'Books', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
+                ('Freshly ground coffee beans', 5, 'Groceries', true, '{"color": "Brown", "location": "China"}'::JSONB),
+                ('Artistic ceramic vase', 4, 'Home Decor', false, '{"color": "Multicolor", "location": "United States"}'::JSONB),
+                ('Interactive board game', 3, 'Toys', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
+                ('Slim-fit denim jeans', 5, 'Apparel', false, '{"color": "Blue", "location": "China"}'::JSONB),
+                ('Fast charging power bank', 4, 'Electronics', true, '{"color": "Black", "location": "United States"}'::JSONB),
+                ('Comfortable slippers', 3, 'Footwear', true, '{"color": "Brown", "location": "Canada"}'::JSONB),
+                ('Classic leather sofa', 5, 'Furniture', false, '{"color": "Brown", "location": "China"}'::JSONB),
+                ('Anti-aging serum', 4, 'Beauty', true, '{"color": "White", "location": "United States"}'::JSONB),
+                ('Portable tripod stand', 4, 'Photography', true, '{"color": "Black", "location": "Canada"}'::JSONB),
+                ('Mystery detective novel', 2, 'Books', false, '{"color": "Multicolor", "location": "China"}'::JSONB),
+                ('Organic breakfast cereal', 5, 'Groceries', true, '{"color": "Brown", "location": "United States"}'::JSONB),
+                ('Designer wall paintings', 5, 'Home Decor', true, '{"color": "Multicolor", "location": "Canada"}'::JSONB),
+                ('Robot building kit', 4, 'Toys', true, '{"color": "Multicolor", "location": "China"}'::JSONB),
+                ('Sporty tank top', 4, 'Apparel', true, '{"color": "Blue", "location": "United States"}'::JSONB),
+                ('Bluetooth-enabled speaker', 3, 'Electronics', true, '{"color": "Black", "location": "Canada"}'::JSONB),
+                ('Winter woolen socks', 5, 'Footwear', false, '{"color": "Gray", "location": "China"}'::JSONB),
+                ('Rustic bookshelf', 4, 'Furniture', true, '{"color": "Brown", "location": "United States"}'::JSONB),
+                ('Moisturizing lip balm', 4, 'Beauty', true, '{"color": "Pink", "location": "Canada"}'::JSONB),
+                ('Lightweight camera bag', 5, 'Photography', false, '{"color": "Black", "location": "China"}'::JSONB),
+                ('Historical fiction book', 3, 'Books', true, '{"color": "Multicolor", "location": "United States"}'::JSONB),
+                ('Pure honey jar', 4, 'Groceries', true, '{"color": "Yellow", "location": "Canada"}'::JSONB),
+                ('Handcrafted wooden frame', 5, 'Home Decor', false, '{"color": "Brown", "location": "China"}'::JSONB),
+                ('Plush teddy bear', 4, 'Toys', true, '{"color": "Brown", "location": "United States"}'::JSONB),
+                ('Warm woolen sweater', 3, 'Apparel', false, '{"color": "Red", "location": "Canada"}'::JSONB)
+                ) AS t(description, rating, category, in_stock, metadata)
+        LOOP
+            EXECUTE 'INSERT INTO ' || full_table_name || ' (description, rating, category, in_stock, metadata) VALUES ($1, $2, $3, $4, $5)'
+            USING data_to_insert.description, data_to_insert.rating, data_to_insert.category, data_to_insert.in_stock, data_to_insert.metadata;
+        END LOOP;
+
     ELSE
-        RAISE WARNING 'The table paradedb.bm25_test_table already exists, skipping.';
+        RAISE WARNING 'The table % already exists, skipping.', full_table_name;
     END IF;
 END $$;
-

--- a/pg_bm25/src/api/aggregation.rs
+++ b/pg_bm25/src/api/aggregation.rs
@@ -11,7 +11,7 @@ use crate::index_access::utils::get_parade_index;
 #[pg_extern]
 pub fn aggregation(index_name: &str, query: &str) -> JsonB {
     // Get Parade index
-    let parade_index = get_parade_index(index_name.to_string());
+    let parade_index = get_parade_index(index_name);
 
     // Initialize aggregation searcher + collector
     let searcher = parade_index.searcher();

--- a/pg_bm25/src/api/index.rs
+++ b/pg_bm25/src/api/index.rs
@@ -98,17 +98,18 @@ mod tests {
             .map(|schema| schema.0.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(schemas.len(), 7);
+        assert_eq!(schemas.len(), 8);
         assert_eq!(
             names,
             vec![
+                "song_id",
                 "title",
                 "album",
                 "release_year",
                 "genre",
                 "description",
                 "lyrics",
-                "heap_tid"
+                "ctid"
             ]
         );
     }

--- a/pg_bm25/src/api/index.rs
+++ b/pg_bm25/src/api/index.rs
@@ -20,7 +20,7 @@ pub fn schema_bm25(
     name!(record, Option<String>),
     name!(normalizer, Option<String>),
 )> {
-    let parade_index = get_parade_index(index_name.to_string());
+    let parade_index = get_parade_index(index_name);
     let schema = parade_index.schema();
 
     let mut field_rows = Vec::new();

--- a/pg_bm25/src/api/search.rs
+++ b/pg_bm25/src/api/search.rs
@@ -1,34 +1,21 @@
-use pgrx::{pg_sys::ItemPointerData, *};
-use rustc_hash::{FxHashMap, FxHashSet};
+use pgrx::*;
 
 use crate::manager::get_current_executor_manager;
-use crate::operator::scan_index;
 use crate::parade_index::index::ParadeIndex;
 
 #[pg_extern]
-pub fn rank_bm25(ctid: Option<ItemPointerData>) -> f32 {
-    match ctid {
-        Some(ctid) => get_current_executor_manager()
-            .get_score(ctid)
-            .unwrap_or(0.0f32),
-        None => 0.0f32,
-    }
+pub fn rank_bm25(bm25_id: i64) -> f32 {
+    get_current_executor_manager()
+        .get_score(bm25_id)
+        .unwrap_or(0.0f32)
 }
 
 #[pg_extern]
-pub fn highlight_bm25(
-    ctid: Option<ItemPointerData>,
-    index_name: String,
-    field_name: String,
-) -> String {
-    let ctid = match ctid {
-        Some(ctid) => ctid,
-        _ => return "".into(),
-    };
+pub fn highlight_bm25(bm25_id: i64, index_name: String, field_name: String) -> String {
     let manager = get_current_executor_manager();
-    let parade_index = ParadeIndex::from_index_name(index_name);
+    let parade_index = ParadeIndex::from_index_name(&index_name);
     let doc_address = manager
-        .get_doc_address(ctid)
+        .get_doc_address(bm25_id)
         .expect("could not lookup doc address in manager in highlight_bm25");
     let retrieved_doc = parade_index
         .searcher()
@@ -43,45 +30,38 @@ pub fn highlight_bm25(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[pg_extern]
 pub fn minmax_bm25(
-    ctid: pg_sys::ItemPointerData,
-    index_name: &str,
-    query: &str,
-    fcinfo: pg_sys::FunctionCallInfo,
+    bm25_id: i64,
+    _index_name: &str,
+    _query: &str,
+    _fcinfo: pg_sys::FunctionCallInfo,
 ) -> f32 {
-    let indexrel =
-        PgRelation::open_with_name_and_share_lock(index_name).expect("could not open index");
-    let index_oid = indexrel.oid();
-    let tid = Some(item_pointer_to_u64(ctid));
+    // let indexrel =
+    //     PgRelation::open_with_name_and_share_lock(index_name).expect("could not open index");
+    // let index_oid = indexrel.oid();
+    // let mut lookup_by_query = pg_func_extra(fcinfo, || {
+    //     FxHashMap::<(pg_sys::Oid, Option<String>), FxHashSet<u64>>::default()
+    // });
 
-    match tid {
-        Some(tid) => unsafe {
-            let mut lookup_by_query = pg_func_extra(fcinfo, || {
-                FxHashMap::<(pg_sys::Oid, Option<String>), FxHashSet<u64>>::default()
-            });
+    // lookup_by_query
+    //     .entry((index_oid, Some(String::from(query))))
+    //     .or_insert_with(|| scan_index(query, index_oid))
+    //     .contains(&bm25_id);
 
-            lookup_by_query
-                .entry((index_oid, Some(String::from(query))))
-                .or_insert_with(|| scan_index(query, index_oid))
-                .contains(&tid);
+    let max_score = get_current_executor_manager().get_max_score();
+    let min_score = get_current_executor_manager().get_min_score();
+    let raw_score = get_current_executor_manager()
+        .get_score(bm25_id)
+        .unwrap_or(0.0);
 
-            let max_score = get_current_executor_manager().get_max_score();
-            let min_score = get_current_executor_manager().get_min_score();
-            let raw_score = get_current_executor_manager()
-                .get_score(ctid)
-                .unwrap_or(0.0);
-
-            if raw_score == 0.0 && min_score == max_score {
-                return 0.0;
-            }
-
-            if min_score == max_score {
-                return 1.0;
-            }
-
-            (raw_score - min_score) / (max_score - min_score)
-        },
-        None => 0.0,
+    if raw_score == 0.0 && min_score == max_score {
+        return 0.0;
     }
+
+    if min_score == max_score {
+        return 1.0;
+    }
+
+    (raw_score - min_score) / (max_score - min_score)
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_bm25/src/api/search.rs
+++ b/pg_bm25/src/api/search.rs
@@ -82,7 +82,7 @@ mod tests {
         let ctid = ctid.unwrap();
         assert_eq!(ctid.ip_posid, 3);
 
-        let query = "SELECT paradedb.rank_bm25(ctid) FROM one_republic_songs WHERE one_republic_songs @@@ 'lyrics:im AND description:song'";
+        let query = "SELECT paradedb.rank_bm25(song_id) FROM one_republic_songs WHERE one_republic_songs @@@ 'lyrics:im AND description:song'";
         let rank = Spi::get_one::<f32>(query)
             .expect("failed to rank query")
             .unwrap();
@@ -94,7 +94,7 @@ mod tests {
         Spi::run(SETUP_SQL).expect("failed to create index and table");
 
         let query = r#"
-SELECT paradedb.highlight_bm25(ctid, 'idx_one_republic', 'lyrics')
+SELECT paradedb.highlight_bm25(song_id, 'idx_one_republic', 'lyrics')
 FROM one_republic_songs
 WHERE one_republic_songs @@@ 'lyrics:im:::max_num_chars=10';
         "#;

--- a/pg_bm25/src/index_access/delete.rs
+++ b/pg_bm25/src/index_access/delete.rs
@@ -13,8 +13,8 @@ pub extern "C" fn ambulkdelete(
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    let index_name = &index_relation.name().to_string();
-    let parade_index = get_parade_index(index_name.into());
+    let index_name = index_relation.name();
+    let parade_index = get_parade_index(index_name);
 
     if stats.is_null() {
         stats = unsafe {

--- a/pg_bm25/src/index_access/insert.rs
+++ b/pg_bm25/src/index_access/insert.rs
@@ -38,10 +38,10 @@ pub unsafe extern "C" fn aminsert(
 unsafe fn aminsert_internal(
     index_relation: pg_sys::Relation,
     values: *mut pg_sys::Datum,
-    heap_tid: pg_sys::ItemPointer,
+    ctid: pg_sys::ItemPointer,
 ) -> bool {
     let index_relation_ref: PgRelation = PgRelation::from_pg(index_relation);
-    let index_name = index_relation_ref.name().to_string();
+    let index_name = index_relation_ref.name();
 
     let tupdesc = lookup_index_tupdesc(&index_relation_ref);
     let attributes = categorize_tupdesc(&tupdesc);
@@ -54,7 +54,7 @@ unsafe fn aminsert_internal(
 
     // Insert row to parade index
     let mut parade_index = get_parade_index(index_name);
-    parade_index.insert(*heap_tid, builder);
+    parade_index.insert(*ctid, builder);
 
     true
 }

--- a/pg_bm25/src/index_access/options.rs
+++ b/pg_bm25/src/index_access/options.rs
@@ -35,6 +35,7 @@ pub struct ParadeOptions {
     numeric_fields_offset: i32,
     boolean_fields_offset: i32,
     json_fields_offset: i32,
+    key_field_offset: i32,
 }
 
 #[pg_guard]
@@ -85,6 +86,11 @@ extern "C" fn validate_json_fields(value: *const std::os::raw::c_char) {
         from_str(&json_str).expect("failed to validate boolean_fields");
 }
 
+#[pg_guard]
+extern "C" fn validate_key_field(value: *const std::os::raw::c_char) {
+    cstr_to_rust_str(value);
+}
+
 #[inline]
 fn cstr_to_rust_str(value: *const std::os::raw::c_char) -> String {
     if value.is_null() {
@@ -98,7 +104,7 @@ fn cstr_to_rust_str(value: *const std::os::raw::c_char) -> String {
 }
 
 // For now, we support changing the tokenizer between default, raw, and en_stem
-const NUM_REL_OPTS: usize = 4;
+const NUM_REL_OPTS: usize = 5;
 #[pg_guard]
 pub unsafe extern "C" fn amoptions(
     reloptions: pg_sys::Datum,
@@ -124,6 +130,11 @@ pub unsafe extern "C" fn amoptions(
             optname: "json_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type_RELOPT_TYPE_STRING,
             offset: offset_of!(ParadeOptions, json_fields_offset) as i32,
+        },
+        pg_sys::relopt_parse_elt {
+            optname: "key_field".as_pg_cstr(),
+            opttype: pg_sys::relopt_type_RELOPT_TYPE_STRING,
+            offset: offset_of!(ParadeOptions, key_field_offset) as i32,
         },
     ];
     build_relopts(reloptions, validate, options)
@@ -224,6 +235,14 @@ impl ParadeOptions {
             .expect("failed to parse json_fields")
     }
 
+    pub fn get_key_field(&self) -> String {
+        let key_field = self.get_str(self.key_field_offset, "".to_string());
+        if key_field == "" {
+            panic!("no key_field supplied for bm25 index")
+        }
+        key_field
+    }
+
     fn get_str(&self, offset: i32, default: String) -> String {
         if offset == 0 {
             default
@@ -280,6 +299,17 @@ pub unsafe fn init() {
         "JSON string specifying how JSON fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_json_fields),
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        {
+            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
+        },
+    );
+    pg_sys::add_string_reloption(
+        RELOPT_KIND_PDB,
+        "key_field".as_pg_cstr(),
+        "Column name as a string specify the unique identifier for a row".as_pg_cstr(),
+        std::ptr::null(),
+        Some(validate_key_field),
         #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE

--- a/pg_bm25/src/index_access/options.rs
+++ b/pg_bm25/src/index_access/options.rs
@@ -237,7 +237,7 @@ impl ParadeOptions {
 
     pub fn get_key_field(&self) -> String {
         let key_field = self.get_str(self.key_field_offset, "".to_string());
-        if key_field == "" {
+        if key_field.is_empty() {
             panic!("no key_field supplied for bm25 index")
         }
         key_field

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -21,7 +21,7 @@ pub extern "C" fn ambeginscan(
     let mut scandesc: PgBox<pg_sys::IndexScanDescData> =
         unsafe { PgBox::from_pg(pg_sys::RelationGetIndexScan(indexrel, nkeys, norderbys)) };
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
-    let index_name = index_relation.name().to_string();
+    let index_name = index_relation.name();
 
     // Create the index and scan
     let parade_index = get_parade_index(index_name);
@@ -205,23 +205,40 @@ pub extern "C" fn amgettuple(
             let searcher = &state.searcher;
             let schema = &state.schema;
             let retrieved_doc = searcher.doc(doc_address).expect("could not find doc");
+            let _v: Vec<_> = schema.fields().collect();
 
-            let heap_tid_field = schema
-                .get_field("heap_tid")
-                .expect("field 'heap_tid' not found in schema");
+            let ctid_name = "ctid";
+            let ctid_field = schema.get_field(ctid_name).unwrap_or_else(|err| {
+                panic!("error retrieving {ctid_name} field from schema: {err:?}")
+            });
+            let ctid_field_value = retrieved_doc
+                .get_first(ctid_field)
+                .unwrap_or_else(|| panic!("cannot find {ctid_name} field on retrieved document"));
 
-            if let tantivy::schema::Value::U64(heap_tid_value) = retrieved_doc
-                .get_first(heap_tid_field)
-                .expect("heap_tid field not found in doc")
-            {
-                u64_to_item_pointer(*heap_tid_value, tid);
+            let key_field_name = &state.key_field_name;
+            let key_field = schema
+                .get_field(key_field_name)
+                .unwrap_or_else(|_| panic!("field '{key_field_name}' not found in schema"));
+            let key_field_value = retrieved_doc.get_first(key_field).unwrap_or_else(|| {
+                panic!("cannot find id field '{key_field_name}' on retrieved document")
+            });
+
+            match ctid_field_value {
+                tantivy::schema::Value::U64(val) => {
+                    u64_to_item_pointer(*val, tid);
+                    if unsafe { !item_pointer_is_valid(tid) } {
+                        panic!("invalid item pointer: {:?}", item_pointer_get_both(*tid));
+                    }
+                }
+                _ => panic!("incorrect type in {ctid_name} field: {ctid_field_value:?}"),
+            };
+
+            if let tantivy::schema::Value::I64(val) = key_field_value {
+                write_to_manager(*val, score, doc_address);
+            } else {
+                panic!("incorrect type in {key_field_name} field: {key_field_value:?}")
             }
 
-            if unsafe { !item_pointer_is_valid(tid) } {
-                panic!("invalid item pointer: {:?}", item_pointer_get_both(*tid));
-            }
-
-            write_to_manager(*tid, score, doc_address);
             true
         }
         None => false,
@@ -247,23 +264,40 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
 
     for (score, doc_address) in iterator {
         let retrieved_doc = searcher.doc(doc_address).expect("could not find doc");
-        let heap_tid_field = schema
-            .get_field("heap_tid")
-            .expect("field 'heap_tid' not found in schema");
 
-        if let tantivy::schema::Value::U64(heap_tid_value) = retrieved_doc
-            .get_first(heap_tid_field)
-            .expect("heap_tid field not found in doc")
-        {
-            let mut tid = pg_sys::ItemPointerData::default();
-            u64_to_item_pointer(*heap_tid_value, &mut tid);
+        let key_field_name = &state.key_field_name;
+        let key_field = schema
+            .get_field(key_field_name)
+            .unwrap_or_else(|_| panic!("field '{key_field_name}' not found in schema"));
+        let key_field_value = retrieved_doc.get_first(key_field).unwrap_or_else(|| {
+            panic!("cannot find id field '{key_field_name}' on retrieved document")
+        });
 
-            unsafe {
-                pg_sys::tbm_add_tuples(tbm, &mut tid, 1, false);
+        let ctid_name = "ctid";
+        let ctid_field = schema.get_field(ctid_name).unwrap_or_else(|err| {
+            panic!("error retrieving {ctid_name} field from schema: {err:?}")
+        });
+        let ctid_field_value = retrieved_doc
+            .get_first(ctid_field)
+            .unwrap_or_else(|| panic!("cannot find {ctid_name} field on retrieved document"));
+
+        match ctid_field_value {
+            tantivy::schema::Value::U64(val) => {
+                //
+                let mut tid = pg_sys::ItemPointerData::default();
+                u64_to_item_pointer(*val, &mut tid);
+                unsafe {
+                    pg_sys::tbm_add_tuples(tbm, &mut tid, 1, false);
+                }
             }
+            _ => panic!("incorrect type in {ctid_name} field: {ctid_field_value:?}"),
+        };
 
-            write_to_manager(tid, score, doc_address);
+        if let tantivy::schema::Value::I64(val) = key_field_value {
+            write_to_manager(*val, score, doc_address);
             cnt += 1;
+        } else {
+            panic!("incorrect type in {key_field_name} field: {key_field_value:?}")
         }
     }
 
@@ -271,13 +305,13 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
 }
 
 #[inline]
-fn write_to_manager(ctid: pg_sys::ItemPointerData, score: f32, doc_address: DocAddress) {
+fn write_to_manager(bm25_id: i64, score: f32, doc_address: DocAddress) {
     let manager = get_current_executor_manager();
     // Add score
-    manager.add_score(item_pointer_get_both(ctid), score);
+    manager.add_score(bm25_id, score);
 
     // Add doc address
-    manager.add_doc_address(item_pointer_get_both(ctid), doc_address);
+    manager.add_doc_address(bm25_id, doc_address);
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_bm25/src/index_access/scan.rs
+++ b/pg_bm25/src/index_access/scan.rs
@@ -283,7 +283,6 @@ pub extern "C" fn ambitmapscan(scan: pg_sys::IndexScanDesc, tbm: *mut pg_sys::TI
 
         match ctid_field_value {
             tantivy::schema::Value::U64(val) => {
-                //
                 let mut tid = pg_sys::ItemPointerData::default();
                 u64_to_item_pointer(*val, &mut tid);
                 unsafe {

--- a/pg_bm25/src/index_access/utils.rs
+++ b/pg_bm25/src/index_access/utils.rs
@@ -70,7 +70,7 @@ pub fn create_parade_index(
     ParadeIndex::new(index_name, heap_relation, options)
 }
 
-pub fn get_parade_index(index_name: String) -> ParadeIndex {
+pub fn get_parade_index(index_name: &str) -> ParadeIndex {
     ParadeIndex::from_index_name(index_name)
 }
 

--- a/pg_bm25/src/index_access/vacuum.rs
+++ b/pg_bm25/src/index_access/vacuum.rs
@@ -20,7 +20,7 @@ pub extern "C" fn amvacuumcleanup(
 
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    let index_name = index_relation.name().to_string();
+    let index_name = index_relation.name();
     let parade_index = get_parade_index(index_name);
 
     // Cleanup the garbage

--- a/pg_bm25/src/manager/mod.rs
+++ b/pg_bm25/src/manager/mod.rs
@@ -161,15 +161,6 @@ mod tests {
     #[pgrx::pg_test]
     fn test_current_executor_manager() {
         let expected = get_fresh_executor_manager();
-        // let item_ptr = ItemPointerData {
-        //     ip_blkid: BlockIdData {
-        //         bi_hi: 10,
-        //         bi_lo: 0,
-        //     },
-        //     ip_posid: 8,
-        // };
-        // let ctid = item_pointer_get_both(item_ptr);
-
         let key = 25;
 
         expected.add_score(key, 3.3);
@@ -187,23 +178,6 @@ mod tests {
 
     #[pgrx::pg_test]
     fn test_add_score() {
-        //     let first_item_ptr = ItemPointerData {
-        //         ip_blkid: BlockIdData {
-        //             bi_hi: 10,
-        //             bi_lo: 0,
-        //         },
-        //         ip_posid: 8,
-        //     };
-        //     let second_item_ptr = ItemPointerData {
-        //         ip_blkid: BlockIdData {
-        //             bi_hi: 88,
-        //             bi_lo: 22,
-        //         },
-        //         ip_posid: 3,
-        //     };
-        //     let first_ctid = item_pointer_get_both(first_item_ptr);
-        //     let second_ctid = item_pointer_get_both(second_item_ptr);
-
         let first_key = 25;
         let second_key = 35;
 

--- a/pg_bm25/src/parade_index/fields.rs
+++ b/pg_bm25/src/parade_index/fields.rs
@@ -306,9 +306,6 @@ pub enum ParadeOption {
 }
 
 pub type ParadeOptionMap = HashMap<String, ParadeOption>;
-pub type ParadeFieldConfigSerialized = String;
-pub type ParadeFieldConfigSerializedResult = serde_json::Result<ParadeFieldConfigSerialized>;
-pub type ParadeFieldConfigDeserializedResult = serde_json::Result<ParadeOptionMap>;
 
 // TODO: Enable DateTime and IP fields
 

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -50,11 +50,11 @@ impl TryFrom<&JsonBuilderValue> for ParadeIndexId {
 
     fn try_from(value: &JsonBuilderValue) -> Result<Self, Self::Error> {
         match value {
-            JsonBuilderValue::i16(v) => Ok(ParadeIndexId::Number(v.clone() as i64)),
-            JsonBuilderValue::i32(v) => Ok(ParadeIndexId::Number(v.clone() as i64)),
-            JsonBuilderValue::i64(v) => Ok(ParadeIndexId::Number(v.clone() as i64)),
-            JsonBuilderValue::u32(v) => Ok(ParadeIndexId::Number(v.clone() as i64)),
-            JsonBuilderValue::u64(v) => Ok(ParadeIndexId::Number(v.clone() as i64)),
+            JsonBuilderValue::i16(v) => Ok(ParadeIndexId::Number(*v as i64)),
+            JsonBuilderValue::i32(v) => Ok(ParadeIndexId::Number(*v as i64)),
+            JsonBuilderValue::i64(v) => Ok(ParadeIndexId::Number(*v)),
+            JsonBuilderValue::u32(v) => Ok(ParadeIndexId::Number(*v as i64)),
+            JsonBuilderValue::u64(v) => Ok(ParadeIndexId::Number(*v as i64)),
             _ => Err(format!("Unsupported conversion: {:#?}", value).into()),
         }
     }
@@ -208,7 +208,7 @@ impl ParadeIndex {
     pub fn from_index_name(name: &str) -> Self {
         unsafe {
             // First check cache to see if we can retrieve the index from memory.
-            if let Some(new_self) = Self::from_cached_index(&name) {
+            if let Some(new_self) = Self::from_cached_index(name) {
                 return new_self;
             }
         }

--- a/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
+++ b/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_query.sql
@@ -1,1 +1,1 @@
-SELECT paradedb.highlight_bm25(ctid, 'idx_posts_fts', 'author') from posts where posts @@@ 'author:张';
+SELECT paradedb.highlight_bm25(posts.id, 'idx_posts_fts', 'author') from posts where posts @@@ 'author:张';

--- a/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_setup.sql
+++ b/pg_bm25/src/parade_index/tests/tokenizer_chinese_compatible_setup.sql
@@ -19,6 +19,7 @@ CREATE TABLE posts (
     comment_count INT
 );
 
+
 INSERT INTO posts (author, title, message, content, unix_timestamp_milli, like_count, dislike_count, comment_count)
 VALUES
     ('张伟', '第一篇文章', '这是第一篇文章的内容', '{"details": "这里有一些JSON内容"}', EXTRACT(EPOCH FROM now()) * 1000, 25, 1, 5),
@@ -30,6 +31,7 @@ CREATE INDEX idx_posts_fts
 ON posts
 USING bm25 ((posts.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "chinese_compatible"}, record: "position"},
         title: {tokenizer: {type: "chinese_compatible"}, record: "position"},

--- a/pg_bm25/test/expected/bm25_search.out
+++ b/pg_bm25/test/expected/bm25_search.out
@@ -12,7 +12,7 @@ WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
 (5 rows)
 
 -- With BM25 scoring
-SELECT paradedb.rank_bm25(ctid), * 
+SELECT paradedb.rank_bm25(bm25_search.id), * 
 FROM bm25_search 
 WHERE bm25_search @@@ 'category:electronics OR description:keyboard';
  rank_bm25 | id |         description         | rating |  category   | in_stock |                     metadata                     
@@ -44,7 +44,7 @@ FROM bm25_search
 WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
  id |         description         | rating |  category   | in_stock |                    metadata                     
 ----+-----------------------------+--------+-------------+----------+-------------------------------------------------
-    | New keyboard                |      5 | Electronics |          | 
+ 42 | New keyboard                |      5 | Electronics |          | 
   2 | PVC Keyboard                |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}
  12 | Innovative wireless earbuds |      5 | Electronics | t        | {"color": "Black", "location": "China"}
  22 | Fast charging power bank    |      4 | Electronics | t        | {"color": "Black", "location": "United States"}

--- a/pg_bm25/test/expected/index_config.out
+++ b/pg_bm25/test/expected/index_config.out
@@ -1,110 +1,122 @@
 -- Invalid CREATE INDEX
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*));
+ERROR:  no key_field supplied for bm25 index
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id');
 ERROR:  no text_fields, numeric_fields, boolean_fields, or json_fields were specified
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (invalid_field='{}');
 ERROR:  unrecognized parameter "invalid_field"
 -- Default text field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
 -------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ id          | I64        | t      | t       | f    | t          |             |           |          | 
  description | Str        | t      | t       | f    | t          |             | default   | position | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Text field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
--------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- description | Str        | t      | t       | t    | t          |             | en_stem   | freq   | raw
- heap_tid    | U64        | t      | t       | f    | t          |             |           |        | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Multiple text fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
--------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
- description | Str        | t      | t       | t    | t          |             | en_stem   | freq     | raw
- category    | Str        | t      | t       | f    | t          |             | default   | position | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
+ ctid        | U64        | t      | t       | f    | t          |             |           |          | 
 (3 rows)
 
 DROP INDEX idxindexconfig;
--- Default numeric field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (numeric_fields='{"rating": {}}');
+-- Text field with options
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- rating   | I64        | t      | t       | t    | f          |             |           |        | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
-(2 rows)
+    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
+-------------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
+ id          | I64        | t      | t       | f    | t          |             |           |        | 
+ description | Str        | t      | t       | t    | t          |             | en_stem   | freq   | raw
+ ctid        | U64        | t      | t       | f    | t          |             |           |        | 
+(3 rows)
 
 DROP INDEX idxindexconfig;
--- Numeric field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (numeric_fields='{"rating": {"fast": false}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- rating   | I64        | t      | t       | f    | f          |             |           |        | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Default boolean field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (boolean_fields='{"in_stock": {}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- in_stock | Bool       | t      | t       | t    | f          |             |           |        | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Boolean field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (boolean_fields='{"in_stock": {"fast": false}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
- in_stock | Bool       | t      | t       | f    | f          |             |           |        | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |        | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Default Json field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{"metadata": {}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
- metadata | JsonObject | t      | t       | f    | f          | t           | default   | position | 
- heap_tid | U64        | t      | t       | f    | t          |             |           |          | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Json field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
-SELECT * from paradedb.schema_bm25('idxindexconfig');
-   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
-----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
- metadata | JsonObject | t      | t       | t    | f          | f           | raw       | position | raw
- heap_tid | U64        | t      | t       | f    | t          |             |           |          | 
-(2 rows)
-
-DROP INDEX idxindexconfig;
--- Multiple fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
+-- Multiple text fields
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
 -------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ id          | I64        | t      | t       | f    | t          |             |           |          | 
+ description | Str        | t      | t       | t    | t          |             | en_stem   | freq     | raw
+ category    | Str        | t      | t       | f    | t          |             | default   | position | 
+ ctid        | U64        | t      | t       | f    | t          |             |           |          | 
+(4 rows)
+
+DROP INDEX idxindexconfig;
+-- Default numeric field
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', numeric_fields='{"rating": {}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+  name  | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
+--------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
+ id     | I64        | t      | t       | f    | t          |             |           |        | 
+ rating | I64        | t      | t       | t    | f          |             |           |        | 
+ ctid   | U64        | t      | t       | f    | t          |             |           |        | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Numeric field with options
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', numeric_fields='{"rating": {"fast": false}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+  name  | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
+--------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
+ id     | I64        | t      | t       | f    | t          |             |           |        | 
+ rating | I64        | t      | t       | f    | f          |             |           |        | 
+ ctid   | U64        | t      | t       | f    | t          |             |           |        | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Default boolean field
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', boolean_fields='{"in_stock": {}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
+ id       | I64        | t      | t       | f    | t          |             |           |        | 
+ in_stock | Bool       | t      | t       | t    | f          |             |           |        | 
+ ctid     | U64        | t      | t       | f    | t          |             |           |        | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Boolean field with options
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', boolean_fields='{"in_stock": {"fast": false}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer | record | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+--------+------------
+ id       | I64        | t      | t       | f    | t          |             |           |        | 
+ in_stock | Bool       | t      | t       | f    | f          |             |           |        | 
+ ctid     | U64        | t      | t       | f    | t          |             |           |        | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Default Json field
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', json_fields='{"metadata": {}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ id       | I64        | t      | t       | f    | t          |             |           |          | 
+ metadata | JsonObject | t      | t       | f    | f          | t           | default   | position | 
+ ctid     | U64        | t      | t       | f    | t          |             |           |          | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Json field with options
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+   name   | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+----------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ id       | I64        | t      | t       | f    | t          |             |           |          | 
+ metadata | JsonObject | t      | t       | t    | f          | f           | raw       | position | raw
+ ctid     | U64        | t      | t       | f    | t          |             |           |          | 
+(3 rows)
+
+DROP INDEX idxindexconfig;
+-- Multiple fields
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
+SELECT * from paradedb.schema_bm25('idxindexconfig');
+    name     | field_type | stored | indexed | fast | fieldnorms | expand_dots | tokenizer |  record  | normalizer 
+-------------+------------+--------+---------+------+------------+-------------+-----------+----------+------------
+ id          | I64        | t      | t       | f    | t          |             |           |          | 
  description | Str        | t      | t       | f    | t          |             | default   | position | 
  rating      | I64        | t      | t       | t    | f          |             |           |          | 
  category    | Str        | t      | t       | f    | t          |             | default   | position | 
  in_stock    | Bool       | t      | t       | t    | f          |             |           |          | 
  metadata    | JsonObject | t      | t       | f    | f          | t           | default   | position | 
- heap_tid    | U64        | t      | t       | f    | t          |             |           |          | 
-(6 rows)
+ ctid        | U64        | t      | t       | f    | t          |             |           |          | 
+(7 rows)
 
 DROP INDEX idxindexconfig;

--- a/pg_bm25/test/expected/lindera.out
+++ b/pg_bm25/test/expected/lindera.out
@@ -14,6 +14,7 @@ CREATE INDEX idx_korean
 ON korean
 USING bm25 ((korean.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "korean_lindera"}, record: "position"},
         title: {tokenizer: {type: "korean_lindera"}, record: "position"},
@@ -54,6 +55,7 @@ CREATE INDEX idx_chinese
 ON chinese
 USING bm25 ((chinese.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "chinese_lindera"}, record: "position"},
         title: {tokenizer: {type: "chinese_lindera"}, record: "position"},
@@ -94,6 +96,7 @@ CREATE INDEX idx_japanese
 ON japanese
 USING bm25 ((japanese.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "japanese_lindera"}, record: "position"},
         title: {tokenizer: {type: "japanese_lindera"}, record: "position"},

--- a/pg_bm25/test/expected/quoted_table_name.out
+++ b/pg_bm25/test/expected/quoted_table_name.out
@@ -1,4 +1,4 @@
-CREATE TABLE "Activity" (name TEXT, age INTEGER);
+CREATE TABLE "Activity" (key SERIAL, name TEXT, age INTEGER);
 INSERT INTO "Activity" (name, age) VALUES ('Alice', 29);
 INSERT INTO "Activity" (name, age) VALUES ('Bob', 34);
 INSERT INTO "Activity" (name, age) VALUES ('Charlie', 45);
@@ -8,10 +8,10 @@ INSERT INTO "Activity" (name, age) VALUES ('George', 41);
 INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
 INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
 INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
-CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
+CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (key_field='key', text_fields='{"name": {}}');
 SELECT * FROM "Activity" WHERE "Activity" @@@ 'name:alice';
- name  | age 
--------+-----
- Alice |  29
+ key | name  | age 
+-----+-------+-----
+   1 | Alice |  29
 (1 row)
 

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -87,7 +87,7 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 (2 rows)
 
 -- Default highlighting without max_num_chars
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(search_config.id, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(search_config.id) DESC LIMIT 5;
          description         | rating |  category   |         highlight_bm25          
 -----------------------------+--------+-------------+---------------------------------
  Plastic Keyboard            |      4 | Electronics | Plastic <b>Keyboard</b>
@@ -98,7 +98,7 @@ SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchco
 (5 rows)
 
 -- max_num_chars is set to 14 
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(search_config.id, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(search_config.id) DESC LIMIT 5;
          description         | rating |  category   |    highlight_bm25     
 -----------------------------+--------+-------------+-----------------------
  Plastic Keyboard            |      4 | Electronics | <b>Keyboard</b>

--- a/pg_bm25/test/expected/text_arrays.out
+++ b/pg_bm25/test/expected/text_arrays.out
@@ -9,7 +9,7 @@ INSERT INTO example_table (text_array, varchar_array) VALUES
 ('{"single element"}', '{"single varchar element"}');
 CREATE INDEX ON example_table
 USING bm25 ((example_table.*))
-WITH (text_fields='{text_array: {}, varchar_array: {}}');
+WITH (key_field='id', text_fields='{text_array: {}, varchar_array: {}}');
 SELECT * FROM example_table WHERE example_table @@@ 'text_array:text1';
  id |     text_array      |  varchar_array  
 ----+---------------------+-----------------

--- a/pg_bm25/test/expected/tokenizer_config.out
+++ b/pg_bm25/test/expected/tokenizer_config.out
@@ -1,5 +1,5 @@
 -- Default tokenizer
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
  id | description | rating | category | in_stock | metadata 
 ----+-------------+--------+----------+----------+----------
@@ -7,7 +7,7 @@ SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
 
 DROP INDEX idxtokenizerconfig;
 -- en_stem
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {"tokenizer": { "type": "en_stem" }}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {"tokenizer": { "type": "en_stem" }}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
  id |         description         | rating |  category   | in_stock |                metadata                 
 ----+-----------------------------+--------+-------------+----------+-----------------------------------------
@@ -16,7 +16,7 @@ SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
 
 DROP INDEX idxtokenizerconfig;
 -- ngram
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 8, "prefix_only": false}}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 8, "prefix_only": false}}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:boa';
  id |       description        | rating |  category   | in_stock |                     metadata                     
 ----+--------------------------+--------+-------------+----------+--------------------------------------------------
@@ -27,12 +27,12 @@ SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:boa';
 
 DROP INDEX idxtokenizerconfig;
 -- chinese_compatible
-CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
+CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
 INSERT INTO tokenizer_config (description, rating, category) VALUES ('电脑', 4, 'Electronics');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:电脑';
  id | description | rating |  category   | in_stock | metadata 
 ----+-------------+--------+-------------+----------+----------
-    | 电脑        |      4 | Electronics |          | 
+ 42 | 电脑        |      4 | Electronics |          | 
 (1 row)
 
 DROP INDEX idxtokenizerconfig;

--- a/pg_bm25/test/fixtures.sql
+++ b/pg_bm25/test/fixtures.sql
@@ -1,14 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pg_bm25;
 
-CALL paradedb.create_bm25_test_table();
+CALL paradedb.create_bm25_test_table(); -- creates table named "paradeb.bm25_test_table" by default
 
-CREATE TABLE index_config AS SELECT * FROM paradedb.bm25_test_table;
-CREATE TABLE search_config AS SELECT * FROM paradedb.bm25_test_table;
-CREATE TABLE tokenizer_config AS SELECT * FROM paradedb.bm25_test_table;
-CREATE TABLE bm25_search AS SELECT * FROM paradedb.bm25_test_table;
-CREATE TABLE aggregations AS SELECT * FROM paradedb.bm25_test_table;
+CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
+CALL paradedb.create_bm25_test_table(table_name => 'search_config', schema_name => 'paradedb');
+CALL paradedb.create_bm25_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb');
+CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+CALL paradedb.create_bm25_test_table(table_name => 'aggregations', schema_name => 'paradedb');
 
-CREATE INDEX idxmockitems ON paradedb.bm25_test_table USING bm25((bm25_test_table.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
-CREATE INDEX idxsearchconfig ON search_config USING bm25 ((search_config.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
-CREATE INDEX idxbm25search ON bm25_search USING bm25 ((bm25_search.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
-CREATE INDEX idxaggregations ON bm25_search USING bm25 ((bm25_search.*)) WITH (text_fields='{"description": {"fast": true}, "category": {"fast": true}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxmockitems ON paradedb.bm25_test_table USING bm25((bm25_test_table.*)) WITH (key_field='id', text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxsearchconfig ON search_config USING bm25 ((search_config.*)) WITH (key_field='id', text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxbm25search ON bm25_search USING bm25 ((bm25_search.*)) WITH (key_field='id', text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');
+CREATE INDEX idxaggregations ON bm25_search USING bm25 ((bm25_search.*)) WITH (key_field='id', text_fields='{"description": {"fast": true}, "category": {"fast": true}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');

--- a/pg_bm25/test/sql/bm25_search.sql
+++ b/pg_bm25/test/sql/bm25_search.sql
@@ -4,7 +4,7 @@ FROM bm25_search
 WHERE bm25_search @@@ 'description:keyboard OR category:electronics';
 
 -- With BM25 scoring
-SELECT paradedb.rank_bm25(ctid), * 
+SELECT paradedb.rank_bm25(bm25_search.id), * 
 FROM bm25_search 
 WHERE bm25_search @@@ 'category:electronics OR description:keyboard';
 

--- a/pg_bm25/test/sql/index_config.sql
+++ b/pg_bm25/test/sql/index_config.sql
@@ -1,53 +1,54 @@
 -- Invalid CREATE INDEX
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*));
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id');
 CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (invalid_field='{}');
 
 -- Default text field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Text field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {"fast": true, "tokenizer": { "type": "en_stem" }, "record": "freq", "normalizer": "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Multiple text fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{"description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"}, category: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Default numeric field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (numeric_fields='{"rating": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', numeric_fields='{"rating": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Numeric field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (numeric_fields='{"rating": {"fast": false}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', numeric_fields='{"rating": {"fast": false}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Default boolean field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (boolean_fields='{"in_stock": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', boolean_fields='{"in_stock": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Boolean field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (boolean_fields='{"in_stock": {"fast": false}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', boolean_fields='{"in_stock": {"fast": false}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Default Json field
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{"metadata": {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', json_fields='{"metadata": {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Json field with options
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', json_fields='{metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;
 
 -- Multiple fields
-CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
+CREATE INDEX idxindexconfig ON index_config USING bm25 ((index_config.*)) WITH (key_field='id', text_fields='{description: {}, category: {}}', numeric_fields='{rating: {}}', boolean_fields='{in_stock: {}}', json_fields='{metadata: {}}');
 SELECT * from paradedb.schema_bm25('idxindexconfig');
 DROP INDEX idxindexconfig;

--- a/pg_bm25/test/sql/lindera.sql
+++ b/pg_bm25/test/sql/lindera.sql
@@ -16,6 +16,7 @@ CREATE INDEX idx_korean
 ON korean
 USING bm25 ((korean.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "korean_lindera"}, record: "position"},
         title: {tokenizer: {type: "korean_lindera"}, record: "position"},
@@ -45,6 +46,7 @@ CREATE INDEX idx_chinese
 ON chinese
 USING bm25 ((chinese.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "chinese_lindera"}, record: "position"},
         title: {tokenizer: {type: "chinese_lindera"}, record: "position"},
@@ -74,6 +76,7 @@ CREATE INDEX idx_japanese
 ON japanese
 USING bm25 ((japanese.*))
 WITH (
+    key_field='id',
     text_fields='{
         author: {tokenizer: {type: "japanese_lindera"}, record: "position"},
         title: {tokenizer: {type: "japanese_lindera"}, record: "position"},

--- a/pg_bm25/test/sql/quoted_table_name.sql
+++ b/pg_bm25/test/sql/quoted_table_name.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "Activity" (name TEXT, age INTEGER);
+CREATE TABLE "Activity" (key SERIAL, name TEXT, age INTEGER);
 INSERT INTO "Activity" (name, age) VALUES ('Alice', 29);
 INSERT INTO "Activity" (name, age) VALUES ('Bob', 34);
 INSERT INTO "Activity" (name, age) VALUES ('Charlie', 45);
@@ -8,6 +8,6 @@ INSERT INTO "Activity" (name, age) VALUES ('George', 41);
 INSERT INTO "Activity" (name, age) VALUES ('Hannah', 22);
 INSERT INTO "Activity" (name, age) VALUES ('Ivan', 30);
 INSERT INTO "Activity" (name, age) VALUES ('Julia', 25);
-CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (text_fields='{"name": {}}');
+CREATE INDEX ON "Activity" USING bm25(("Activity".*)) WITH (key_field='key', text_fields='{"name": {}}');
 SELECT * FROM "Activity" WHERE "Activity" @@@ 'name:alice';
 

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -21,6 +21,6 @@ SELECT id, description, rating, category FROM search_config WHERE search_config 
 -- With regex field 
 SELECT id, description, rating, category FROM search_config WHERE search_config @@@ 'com:::regex_fields=description';
 -- Default highlighting without max_num_chars
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(search_config.id, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics' ORDER BY paradedb.rank_bm25(search_config.id) DESC LIMIT 5;
 -- max_num_chars is set to 14 
-SELECT description, rating, category, paradedb.highlight_bm25(ctid, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(ctid) DESC LIMIT 5;
+SELECT description, rating, category, paradedb.highlight_bm25(search_config.id, 'idxsearchconfig', 'description') FROM search_config WHERE search_config @@@ 'description:keyboard OR category:electronics:::max_num_chars=14' ORDER BY paradedb.rank_bm25(search_config.id) DESC LIMIT 5;

--- a/pg_bm25/test/sql/text_arrays.sql
+++ b/pg_bm25/test/sql/text_arrays.sql
@@ -11,7 +11,7 @@ INSERT INTO example_table (text_array, varchar_array) VALUES
 
 CREATE INDEX ON example_table
 USING bm25 ((example_table.*))
-WITH (text_fields='{text_array: {}, varchar_array: {}}');
+WITH (key_field='id', text_fields='{text_array: {}, varchar_array: {}}');
 
 SELECT * FROM example_table WHERE example_table @@@ 'text_array:text1';
 SELECT * FROM example_table WHERE example_table @@@ 'text_array:"single element"';

--- a/pg_bm25/test/sql/tokenizer_config.sql
+++ b/pg_bm25/test/sql/tokenizer_config.sql
@@ -1,20 +1,20 @@
 -- Default tokenizer
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
 DROP INDEX idxtokenizerconfig;
 
 -- en_stem
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {"tokenizer": { "type": "en_stem" }}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {"tokenizer": { "type": "en_stem" }}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:earbud';
 DROP INDEX idxtokenizerconfig;
 
 -- ngram
-CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (text_fields='{"description": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 8, "prefix_only": false}}}');
+CREATE INDEX idxtokenizerconfig ON tokenizer_config USING bm25 ((tokenizer_config.*)) WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 8, "prefix_only": false}}}');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:boa';
 DROP INDEX idxtokenizerconfig;
 
 -- chinese_compatible
-CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
+CREATE INDEX idxtokenizerconfig  ON tokenizer_config  USING bm25 ((tokenizer_config.*))  WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}');
 INSERT INTO tokenizer_config (description, rating, category) VALUES ('电脑', 4, 'Electronics');
 SELECT * FROM tokenizer_config WHERE tokenizer_config @@@ 'description:电脑';
 DROP INDEX idxtokenizerconfig;

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -73,7 +73,7 @@ To perform a hybrid search, you'll first need to create a BM25 and a HNSW index 
 CREATE INDEX idx_mock_items
 ON mock_items
 USING bm25 ((mock_items.*))
-WITH (text_fields='{"description": {}, "category": {}}');
+WITH (key_field='id', text_fields='{"description": {}, "category": {}}');
 
 -- HNSW index
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
@@ -91,7 +91,7 @@ SELECT
     category,
     rating,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding,
           MIN('[1,2,3]' <-> embedding) OVER (),

--- a/pg_search/test/expected/search.out
+++ b/pg_search/test/expected/search.out
@@ -1,4 +1,4 @@
-CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
+CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (key_field='id', text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 -- Hybrid search with equal weights
 SELECT
@@ -7,7 +7,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 
@@ -34,7 +34,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 
@@ -61,7 +61,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 

--- a/pg_search/test/sql/search.sql
+++ b/pg_search/test/sql/search.sql
@@ -1,4 +1,4 @@
-CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
+CREATE INDEX idx_mock_items ON mock_items USING bm25 ((mock_items.*)) WITH (key_field='id', text_fields='{"description": {}, "category": {}}', numeric_fields='{"rating": {}}', boolean_fields='{"in_stock": {}}', json_fields='{"metadata": {}}');;;
 CREATE INDEX ON mock_items USING hnsw (embedding vector_l2_ops);
 
 -- Hybrid search with equal weights
@@ -8,7 +8,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 
@@ -27,7 +27,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 
@@ -46,7 +46,7 @@ SELECT
     rating,
     embedding,
     paradedb.weighted_mean(
-        paradedb.minmax_bm25(ctid, 'idx_mock_items', 'description:keyboard'),
+        paradedb.minmax_bm25(id, 'idx_mock_items', 'description:keyboard'),
         1 - paradedb.minmax_norm(
           '[1,2,3]' <-> embedding, 
           MIN('[1,2,3]' <-> embedding) OVER (), 

--- a/shared/src/sql/index_setup.sql
+++ b/shared/src/sql/index_setup.sql
@@ -27,6 +27,7 @@ CREATE INDEX idx_one_republic
 ON one_republic_songs
 USING bm25 ((one_republic_songs.*))
 WITH (
+    key_field='song_id',
     text_fields='{
         title: {},
         album: {},


### PR DESCRIPTION
## What
An index should now be created like this:

```sql
CREATE INDEX idx_mock_items
ON mock_items
USING bm25 ((mock_items.*))
WITH (key_field='id', text_fields='{"description": {}, "category": {}}');
```

Note the new, mandatory 'key_field' parameter.

## Why
Currently, we're enabling `rank_bm25` and `highlight_bm25` to match rows by passing them a `ctid` parameter, which we're using as the lookup key in the Tantivy index.

This is an anti-pattern. The ctid is not a stable identifier, and we shouldn't be exposing it to the user. This is also incompatible with complex queries like `JOIN` queries that use intermediate tables, because those tables don't have a `ctid`.

## How
This required a refactor that touched a large surface area of `pg_bm25`. I attempted to do some parallel code cleanup to make this kind of refactor easier in the future.

One significant cleanup is that we now serialize the entire `ParadeIndex` to disk with custom serde implementations. This will make it much easier to extend `ParadeIndex`.

I've also parametrized the table name and schema name for the test table helper. With no parameters, it still defaults to `paradedb.bm25_test_table`, so any current usage of it is still valid.
```
CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'paradedb');
```


## Tests
Tests across the board have been updated to use the new interface.
