### PR TITLE
fix: Add pg_sparse to pg_search upgrade test

### DIFF
--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -192,7 +192,10 @@ function run_tests() {
   # Execute tests using pg_regress
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
-  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
+  if [ -f "$LOG_DIR/../regression.diffs" ]; then
+    echo "Some test(s) failed! Printing the diff between the expected and actual test results..."
+    cat "$LOG_DIR/../regression.diffs"
+  fi
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -190,6 +190,9 @@ function run_tests() {
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
+  echo "Printing the diff between the expected and actual test results, if any..."
+  cat "$LOG_DIR/../regression.diffs"
+
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.
   # echo "Displaying PostgreSQL ERROR logs from tests..."

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -123,6 +123,9 @@ function run_tests() {
   # Ensure a clean environment
   trap '$PG_BIN_PATH/pg_ctl stop -m i; rm -f "$PWFILE"' sigint sigterm exit  # <-- Also remove the password file on exit
   rm -rf "$TMPDIR"
+  rm -rf "$LOG_DIR/test_logs.log"
+  rm -rf "$LOG_DIR/../regression.diffs"
+  rm -rf "$LOG_DIR/../regression.out"
   unset TESTS
 
   # Initialize the test database

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -192,9 +192,7 @@ function run_tests() {
   # Execute tests using pg_regress
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
-
-  echo "Printing the diff between the expected and actual test results, if any..."
-  cat "$LOG_DIR/../regression.diffs"
+  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -206,7 +206,10 @@ function run_tests() {
   # Execute tests using pg_regress
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
-  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
+  if [ -f "$LOG_DIR/../regression.diffs" ]; then
+    echo "Some test(s) failed! Printing the diff between the expected and actual test results..."
+    cat "$LOG_DIR/../regression.diffs"
+  fi
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -123,6 +123,9 @@ function run_tests() {
   # Ensure a clean environment
   trap '$PG_BIN_PATH/pg_ctl stop -m i; rm -f "$PWFILE"' sigint sigterm exit  # <-- Also remove the password file on exit
   rm -rf "$TMPDIR"
+  rm -rf "$LOG_DIR/test_logs.log"
+  rm -rf "$LOG_DIR/../regression.diffs"
+  rm -rf "$LOG_DIR/../regression.out"
   unset TESTS
 
   # Initialize the test database

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -204,6 +204,9 @@ function run_tests() {
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
 
+  echo "Printing the diff between the expected and actual test results, if any..."
+  cat "$LOG_DIR/../regression.diffs"
+
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.
   # echo "Displaying PostgreSQL ERROR logs from tests..."

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -206,9 +206,7 @@ function run_tests() {
   # Execute tests using pg_regress
   echo "Running tests..."
   ${REGRESS} --use-existing --dbname=test_db --inputdir="${TESTDIR}" "${TESTS[@]}"
-
-  echo "Printing the diff between the expected and actual test results, if any..."
-  cat "$LOG_DIR/../regression.diffs"
+  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_search/test/runtests.sh
+++ b/pg_search/test/runtests.sh
@@ -152,11 +152,15 @@ function run_tests() {
 
     # First, download & install dependencies for the first release at which we started supporting upgrades (v0.3.3)
     BASE_RELEASE="0.3.3"
-    echo "Installing dependencies (pg_bm25 v$BASE_RELEASE and pgvector) onto the test database..."
+    echo "Installing dependencies (pg_bm25 v$BASE_RELEASE, pg_sparse v$BASE_RELEASE, and pgvector) onto the test database..."
     # pg_bm25
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
     sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
+    # pg_sparse
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb"
+    curl -LOJ "$DOWNLOAD_URL" > /dev/null
+    sudo dpkg -i "pg_sparse-v$BASE_RELEASE-pg$PG_VERSION-amd64-linux-gnu.deb" > /dev/null
     # pgvector
     sudo apt-get install -y postgresql-15-pgvector > /dev/null
 

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -87,8 +87,6 @@ function run_tests() {
   trap 'pg_ctl stop -m i; rm -f "$PWFILE"' sigint sigterm exit  # <-- Also remove the password file on exit
   rm -rf "$TMPDIR"
   rm -rf "$LOG_DIR/test_logs.log"
-  rm -rf "$LOG_DIR/../regression.diffs"
-  rm -rf "$LOG_DIR/../regression.out"
   unset TESTS
 
   # Initialize the test database
@@ -138,9 +136,6 @@ function run_tests() {
   # We always test on the upcoming version, which means that this test also acts as an extension upgrade test
   echo "Running tests..."
   make installcheck
-
-  echo "Printing the diff between the expected and actual test results, if any..."
-  cat "$LOG_DIR/../regression.diffs"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -136,6 +136,9 @@ function run_tests() {
   echo "Running tests..."
   make installcheck
 
+  echo "Printing the diff between the expected and actual test results, if any..."
+  cat "$LOG_DIR/../regression.diffs"
+
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.
   # echo "Displaying PostgreSQL ERROR logs from tests..."

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -87,6 +87,8 @@ function run_tests() {
   trap 'pg_ctl stop -m i; rm -f "$PWFILE"' sigint sigterm exit  # <-- Also remove the password file on exit
   rm -rf "$TMPDIR"
   rm -rf "$LOG_DIR/test_logs.log"
+  rm -rf "$LOG_DIR/../regression.diffs"
+  rm -rf "$LOG_DIR/../regression.out"
   unset TESTS
 
   # Initialize the test database
@@ -136,6 +138,7 @@ function run_tests() {
   # We always test on the upcoming version, which means that this test also acts as an extension upgrade test
   echo "Running tests..."
   make installcheck
+  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -138,7 +138,10 @@ function run_tests() {
   # We always test on the upcoming version, which means that this test also acts as an extension upgrade test
   echo "Running tests..."
   make installcheck
-  [ -f "$LOG_DIR/../regression.diffs" ] && echo "Some test(s) failed! Printing the diff between the expected and actual test results..." && cat "$LOG_DIR/../regression.diffs"
+  if [ -f "$LOG_DIR/../regression.diffs" ]; then
+    echo "Some test(s) failed! Printing the diff between the expected and actual test results..."
+    cat "$LOG_DIR/../regression.diffs"
+  fi
 
   # Uncomment this to display test ERROR logs if you need to debug. Note that many of these errors are
   # expected, since we are testing error handling/invalid cases in our regression tests.

--- a/pg_sparse/test/runtests.sh
+++ b/pg_sparse/test/runtests.sh
@@ -86,6 +86,9 @@ function run_tests() {
   # Ensure a clean environment
   trap 'pg_ctl stop -m i; rm -f "$PWFILE"' sigint sigterm exit  # <-- Also remove the password file on exit
   rm -rf "$TMPDIR"
+  rm -rf "$LOG_DIR/test_logs.log"
+  rm -rf "$LOG_DIR/../regression.diffs"
+  rm -rf "$LOG_DIR/../regression.out"
   unset TESTS
 
   # Initialize the test database


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This was missing, so the `pg_search` upgrade test was failing.

## Why

## How

## Tests
