### PR TITLE
fix: Properly update `pg_sparse` version in CI

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -10,6 +10,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to set for the pg_bm25 release. This publishes the current commit tagged with the provided version, to the correspoding GitHub Release"
+        required: true
+        default: ""
 
 concurrency:
   group: publish-pg_bm25-${{ github.head_ref || github.ref }}
@@ -39,7 +44,12 @@ jobs:
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version
         run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          # If no workflow_dispatch version is provided, we use workflow tag trigger version
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+          else
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          fi
           echo "ubuntu_version=$(lsb_release -rs | sed 's/\.//')" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -10,6 +10,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to set for the pg_search release. This publishes the current commit tagged with the provided version, to the correspoding GitHub Release"
+        required: true
+        default: ""
 
 concurrency:
   group: publish-pg_search-${{ github.head_ref || github.ref }}
@@ -39,7 +44,12 @@ jobs:
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version
         run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          # If no workflow_dispatch version is provided, we use workflow tag trigger version
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+          else
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          fi
           echo "ubuntu_version=$(lsb_release -rs | sed 's/\.//')" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -10,6 +10,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The pg_sparse version to publish"
+        required: true
+        default: ""
 
 concurrency:
   group: publish-pg_sparse-${{ github.head_ref || github.ref }}
@@ -36,7 +41,12 @@ jobs:
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version
         run: |
-          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          # If no workflow_dispatch version is provided, we use workflow tag trigger version
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+          else
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          fi
           echo "ubuntu_version=$(lsb_release -rs | sed 's/\.//')" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT       
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "The pg_sparse version to publish"
+        description: "The version to set for the pg_sparse release. This publishes the current commit tagged with the provided version, to the correspoding GitHub Release"
         required: true
         default: ""
 

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -60,7 +60,10 @@ jobs:
 
       - name: Update Version in svector.control
         working-directory: pg_sparse/
-        run: sed -i "s/default_version = '.*'/default_version = '\${{ steps.version.outputs.version }}'/" svector.control
+        run: |
+          sed -i "s/^default_version = .*/default_version = '${{ steps.version.outputs.version }}'/" svector.control
+          sed -i "s/^EXTVERSION = .*/EXTVERSION = ${{ steps.version.outputs.version }}/" Makefile
+          cat svector.control
 
       - name: Build & Package pg_sparse as a .deb
         env:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Unfortunately, the way we were updating the `pg_sparse` version in deployment vs test was different, and the deployment one was wrong. This fixes it. This issue was caught by our extension upgrade test (yay!)

## Why

## How

## Tests
