### PR TITLE
docs: fix bm25 README typo should be `ctid` instead of `id`

### DIFF
--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -118,7 +118,7 @@ This will return:
 Scoring and highlighting are supported:
 
 ```sql
-SELECT description, rating, category, paradedb.rank_bm25(id), paradedb.highlight_bm25(id, 'idx_mock_items', 'description')
+SELECT description, rating, category, paradedb.rank_bm25(ctid), paradedb.highlight_bm25(ctid, 'idx_mock_items', 'description')
 FROM mock_items
 WHERE mock_items @@@ 'description:keyboard OR category:electronics'
 LIMIT 5;


### PR DESCRIPTION
doc fix as the web example