### PR TITLE
chore: Upgrade to 0.4.1, not 0.3.13

### DIFF
--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -67,7 +67,7 @@ Note: If you are using a managed Postgres service like Amazon RDS, you will not 
 
 #### Windows
 
-Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
+At this time, Windows is only supported via WSL. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
 
 ## Usage
 

--- a/pg_bm25/sql/pg_bm25--0.3.12--0.3.13.sql
+++ b/pg_bm25/sql/pg_bm25--0.3.12--0.3.13.sql
@@ -1,1 +1,0 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.13'" to load this file. \quit

--- a/pg_bm25/sql/pg_bm25--0.3.12--0.4.1.sql
+++ b/pg_bm25/sql/pg_bm25--0.3.12--0.4.1.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.1'" to load this file. \quit

--- a/pg_sparse/sql/svector--0.3.12--0.3.13.sql
+++ b/pg_sparse/sql/svector--0.3.12--0.3.13.sql
@@ -1,1 +1,0 @@
-\echo Use "ALTER EXTENSION svector UPDATE TO '0.3.13'" to load this file. \quit

--- a/pg_sparse/sql/svector--0.3.12--0.4.1.sql
+++ b/pg_sparse/sql/svector--0.3.12--0.4.1.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION svector UPDATE TO '0.4.1'" to load this file. \quit


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Given the refactor, we've decided to version to 0.4.1, so that PR adapts the upgrade scripts

## Why

## How

## Tests
