### PR TITLE
chore: Fix the benchmarks

### DIFF
--- a/.github/workflows/benchmark-paradedb.yml
+++ b/.github/workflows/benchmark-paradedb.yml
@@ -9,13 +9,14 @@ name: Benchmark ParadeDB
 on:
   schedule:
     - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
-  pull_request:
-    branches:
-      - dev
-      - staging
-      - main
-    paths:
-      - "benchmarks/**"
+  # TODO: Reenable this once we've fixed the benchmarks
+  # pull_request:
+  #   branches:
+  #     - dev
+  #     - staging
+  #     - main
+  #   paths:
+  #     - "benchmarks/**"
   workflow_dispatch:
     inputs:
       name:

--- a/benchmarks/helpers/get_data.sh
+++ b/benchmarks/helpers/get_data.sh
@@ -19,7 +19,8 @@ db_query () {
 # Helper function to download the benchmarking dataset
 download_data () {
   if [ ! -f "$WIKI_ARTICLES_FILE" ]; then
-    if wget -nv https://www.dropbox.com/s/wwnfnu441w1ec9p/$WIKI_ARTICLES_FILE.bz2 -O $WIKI_ARTICLES_FILE.bz2; then
+    # We maintain our own copy of the dataset on S3 to avoid Dropbox rate limits
+    if wget -nv https://paradedb-benchmarks.s3.amazonaws.com/wiki-articles.json.bz2 -O $WIKI_ARTICLES_FILE.bz2; then
       echo "-- Unzipping $WIKI_ARTICLES_FILE..."
       bunzip2 $WIKI_ARTICLES_FILE.bz2
     else


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Use our own S3-stored dataset for benchmarks, to stop hitting the Dropbox rate limit, and disable on PR until we've gotten the global writer PR in, which will fix it.

## Why

## How

## Tests
