### PR TITLE
feat: Make ParadeDB extensions not require superuser

### DIFF
--- a/pg_bm25/pg_bm25.control
+++ b/pg_bm25/pg_bm25.control
@@ -2,5 +2,5 @@ comment = 'pg_bm25: Full text search for PostgreSQL using BM25'
 default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/pg_bm25'
 relocatable = false
-superuser = true
+superuser = false
 schema = paradedb

--- a/pg_sparse/svector.control
+++ b/pg_sparse/svector.control
@@ -2,4 +2,5 @@ comment = 'pg_sparse: Sparse vector data type and sparse HNSW access methods'
 default_version = '0.4.1'
 module_pathname = '$libdir/svector'
 relocatable = true
-superuser = true
+superuser = false
+schema = paradedb

--- a/pg_sparse/svector.control
+++ b/pg_sparse/svector.control
@@ -3,4 +3,3 @@ default_version = '0.4.1'
 module_pathname = '$libdir/svector'
 relocatable = true
 superuser = false
-schema = paradedb


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #557

## What
This makes it so that using ParadeDB extensions does not require superuser permissions. It was not needed already, but somehow was being enforced.

## Why

## How

## Tests
