### PR TITLE
feat: Make benchmarks run in pgrx

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,7 @@ rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 # Enable code coverage on Linux only, for CI builds
 [target.'cfg(target_os="linux")']
 rustflags = ["-Cinstrument-coverage"]
+
+# Enable performance benchmarking directly in Cargo
+[alias]
+benchmark_bm25 = "run --bin benchmark_bm25"

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -8,3 +8,4 @@
 # Outputs
 out/
 typesense-data/
+query_error.log

--- a/benchmarks/benchmark-paradedb.sh
+++ b/benchmarks/benchmark-paradedb.sh
@@ -11,7 +11,7 @@ usage() {
   echo "Usage: $0 [OPTIONS]"
   echo "Options:"
   echo " -h (optional),   Display this help message"
-  echo " -t (optional),   Docker tag to use for paradedb/paradedb:tag. Use 'local' to build from source. Default: 'latest'"
+  echo " -t (optional),   Docker tag to use for paradedb/paradedb:tag. Use 'local' to build from source. Use 'pgrx' to run against pgrx instead of Docker. Default: 'latest'"
   exit 1
 }
 
@@ -34,14 +34,16 @@ do
   esac
 done
 
+# Determine the base directory of the script
+BASEDIR=$(dirname "$0")
+cd "$BASEDIR/"
+
+# Vars
 PORT=5431
 OUTPUT_CSV=out/benchmark_paradedb.csv
 
 # Ensure the "out" directory exists
 mkdir -p out/
-
-# shellcheck disable=SC1091
-source "helpers/get_data.sh"
 
 # Cleanup function to stop and remove the Docker container
 cleanup() {
@@ -52,10 +54,17 @@ cleanup() {
   fi
   echo ""
   echo "Cleaning up benchmark environment..."
-  if docker ps -q --filter "name=paradedb" | grep -q .; then
-    docker kill paradedb > /dev/null 2>&1
+  if [ "$FLAG_TAG" == "pgrx" ]; then
+    db_query "DROP EXTENSION pg_bm25 CASCADE;"
+    cd ../pg_bm25/
+    cargo pgrx stop
+    cd ../benchmarks/
+  else
+    if docker ps -q --filter "name=paradedb" | grep -q .; then
+      docker kill paradedb > /dev/null 2>&1
+    fi
+    docker rm paradedb > /dev/null 2>&1
   fi
-  docker rm paradedb > /dev/null 2>&1
   rm -rf query_output.log
   echo "Done, goodbye!"
 }
@@ -69,9 +78,16 @@ echo "* Benchmarking ParadeDB version: $FLAG_TAG"
 echo "*******************************************************"
 echo ""
 
-# If the tag is "local", build ParadeDB from source to test the current commit
-if [ "$FLAG_TAG" == "local" ]; then
-  echo "Building ParadeDB From Source..."
+# If the tag is "pgrx", run the benchmark against pgrx instead of Docker. If the tag
+# is "local", build ParadeDB from source to test the current commit
+if [ "$FLAG_TAG" == "pgrx" ]; then
+  echo "Building pg_bm25 Extension from Source..."
+  cd ../pg_bm25/
+  cargo build
+  cargo pgrx start
+  cd ../benchmarks/
+elif [ "$FLAG_TAG" == "local" ]; then
+  echo "Building ParadeDB Dockerfile from Source..."
   docker build -t paradedb/paradedb:"$FLAG_TAG" \
     -f "../docker/Dockerfile" \
     --build-arg PG_VERSION_MAJOR="15" \
@@ -109,24 +125,47 @@ if [ "$FLAG_TAG" == "local" ]; then
     --build-arg MYSQL_FDW_VERSION="2.9.1" \
     "../"
   echo ""
+else
+  echo "Pulling ParadeDB $FLAG_TAG from Docker Hub..."
 fi
 
-# Install and run Docker container for ParadeDB in detached mode
-echo "Spinning up ParadeDB $FLAG_TAG server..."
-docker run \
-  -d \
-  --name paradedb \
-  -e POSTGRES_USER=myuser \
-  -e POSTGRES_PASSWORD=mypassword \
-  -e POSTGRES_DB=mydatabase \
-  -p $PORT:5432 \
-  paradedb/paradedb:"$FLAG_TAG"
+# If the tag is "pgrx", define the right parameters to run the benchmarks
+# against pgrx instead of Docker. Otherwise, spin up a Docker container in detached mode
+if [ "$FLAG_TAG" == "pgrx" ]; then
+  export HOST="localhost"
+  export PORT="28815"
+  export DATABASE="pg_bm25"
+  export USER=""
+  export PASSWORD=""
+  export USING_PGRX="true"
+else
+  echo "Spinning up ParadeDB $FLAG_TAG Docker container..."
+  docker run \
+    -d \
+    --name paradedb \
+    -e POSTGRES_USER=myuser \
+    -e POSTGRES_PASSWORD=mypassword \
+    -e POSTGRES_DB=mydatabase \
+    -p $PORT:5432 \
+    paradedb/paradedb:"$FLAG_TAG"
 
-# Wait for Docker container to spin up
-echo ""
-echo "Waiting for server to spin up..."
-sleep 5
-echo "Done!"
+  # Wait for Docker container to spin up
+  echo ""
+  echo "Waiting for Docker container to spin up..."
+  sleep 5
+  echo "Done!"
+fi
+
+# Source the script to load data into the database
+# shellcheck disable=SC1091
+source "helpers/get_data.sh"
+
+# If we're using pgrx, we need to manually create the pg_bm25 extension
+if [ "$FLAG_TAG" == "pgrx" ]; then
+  echo ""
+  echo "Creating pg_bm25 extension..."
+  db_query "CREATE EXTENSION pg_bm25;"
+fi
 
 # Load data into database
 echo ""
@@ -137,8 +176,14 @@ echo "Done!"
 # Output file for recording times
 echo "Table Size,Index Time,Search Time" > "$OUTPUT_CSV"
 
-# Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
-TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 1500000 2000000 2500000 3000000 3500000 4000000 4500000 5000000)
+# If the tag is "pgrx", we only run a single test for 1M rows. Otherwise, we run the full list
+# of tests between 10,000 and 5M rows
+if [ "$FLAG_TAG" == "pgrx" ]; then
+  TABLE_SIZES=(100000)
+else
+  # Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
+  TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 1500000 2000000 2500000 3000000 3500000 4000000 4500000 5000000)
+fi
 
 for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""
@@ -148,8 +193,11 @@ for SIZE in "${TABLE_SIZES[@]}"; do
 
   # Create temporary table with limit
   echo "-- Creating temporary table with $SIZE rows..."
-  db_query "CREATE TABLE $TABLE_NAME AS SELECT * FROM wikipedia_articles LIMIT $SIZE;"
-  db_query "ALTER TABLE $TABLE_NAME ADD COLUMN id SERIAL"
+  db_query "CREATE TABLE IF NOT EXISTS $TABLE_NAME AS SELECT * FROM wikipedia_articles LIMIT $SIZE;"
+  db_query "ALTER TABLE $TABLE_NAME ADD COLUMN IF NOT EXISTS id SERIAL"
+
+
+
 
   # Time indexing
   echo "-- Timing indexing..."

--- a/benchmarks/helpers/get_data.sh
+++ b/benchmarks/helpers/get_data.sh
@@ -55,10 +55,7 @@ load_data () {
   db_query "DROP TABLE IF EXISTS temp_json;"
   db_query "CREATE TABLE temp_json ( j JSONB );"
   # db_query "COPY temp_json FROM STDIN CSV QUOTE E'\x01' DELIMITER E'\x02';" < "$WIKI_ARTICLES_FILE"
-
-
   head -n 100000 "$WIKI_ARTICLES_FILE" | db_query "COPY temp_json FROM STDIN CSV QUOTE E'\x01' DELIMITER E'\x02';"
-
 
   echo "-- Loading JSON data into the wikipedia_articles table..."
   if $USING_PGRX; then

--- a/benchmarks/helpers/load_data.sql
+++ b/benchmarks/helpers/load_data.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-CREATE TABLE wikipedia_articles ( url TEXT, title TEXT, body TEXT );
+CREATE TABLE IF NOT EXISTS wikipedia_articles ( url TEXT, title TEXT, body TEXT );
 
 -- This is executed directly from the command line with the -c option
 -- CREATE TEMPORARY TABLE temp_json ( j JSONB ) ON COMMIT DROP;

--- a/pg_bm25/src/bin/benchmark_bm25.rs
+++ b/pg_bm25/src/bin/benchmark_bm25.rs
@@ -1,0 +1,8 @@
+fn main() {
+    std::process::Command::new("sh")
+        .arg("../benchmarks/benchmark-paradedb.sh")
+        .arg("-t")
+        .arg("pgrx")
+        .status()
+        .expect("Failed to execute benchmark script");
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This was suggested by @neilyio as a way to more easily do quick iterative benchmarks for our development environment. I think it's a good idea, and something we should do. Our benchmarks need a lot of love, anyways.

The goal is to make `cargo wikibench` do a small benchmark of our Wikipedia search example over the `pgrx` database.

## Why
More easily benchmark `pg_bm25` across code iterations

## How
^

## Tests
You can try for yourself with `cargo wikibench`!