### PR TITLE
feat: Set fixed anonymous UUID for PostHog

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ docker run \
   -e POSTGRES_PASSWORD=<password> \
   -e POSTGRES_DB=<dbname> \
   -p 5432:5432 \
+  -v paradedb-data:/var/lib/postgresql/data \
   -d \
   paradedb/paradedb:latest
 ```
 
-Alternatively, you can clone this repo and run our `docker-compose.yml` file. By default, this will start the ParadeDB database at `http://localhost:5432`. Use `psql` to connect:
+The `-v` flag is optional, but recommended. It will persist the ParadeDB PostgreSQL data across restarts. Alternatively, you can clone this repo and run our `docker-compose.yml` file. By default, this will start the ParadeDB database at `http://localhost:5432`. Use `psql` to connect:
 
 ```bash
 psql -h <hostname> -U <user> -d <dbname> -p 5432 -W

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -55,3 +55,5 @@ services:
       POSTGRES_DB: mydatabase
     ports:
       - "5432:5432"
+    volumes:
+      - paradedb-data:/var/lib/postgresql/data

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -57,3 +57,6 @@ services:
       - "5432:5432"
     volumes:
       - paradedb-data:/var/lib/postgresql/data
+
+volumes:
+  paradedb-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,3 +19,6 @@ services:
       - "5432:5432"
     volumes:
       - paradedb-data:/var/lib/postgresql/data
+
+volumes:
+  paradedb-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,4 +17,5 @@ services:
       TELEMETRY: true # Set this variable to 'false' (or remove it) to disable anonymous telemetry
     ports:
       - "5432:5432"
-      - "9700:9700"
+    volumes:
+      - paradedb-data:/var/lib/postgresql/data

--- a/pg_bm25/src/lib.rs
+++ b/pg_bm25/src/lib.rs
@@ -23,7 +23,7 @@ extension_sql_file!("../sql/_bootstrap.sql");
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
     index_access::options::init();
-    telemetry::posthog::init("pg_bm25 Deployment");
+    telemetry::posthog::init("pg_bm25");
     PARADE_LOGS_GLOBAL.init();
 }
 

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -478,7 +478,7 @@ impl ParadeIndex {
             );
         }
 
-        for (_, attribute) in tupdesc.iter().enumerate() {
+        for attribute in tupdesc.iter() {
             if attribute.is_dropped() {
                 continue;
             }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -81,7 +81,7 @@ pg_ctl restart 2> /dev/null
 # the project. We only do this if TELEMETRY is set to "true"
 if [[ ${TELEMETRY:-} == "true" ]]; then
   # For privacy reasons, we generate an anonymous UUID for each new deployment
-  UUID_FILE="/var/lib/postgresql/data/deployment_uuid"
+  UUID_FILE="/var/lib/postgresql/data/paradedb_uuid"
   if [ ! -f "$UUID_FILE" ]; then
       uuidgen > "$UUID_FILE"
   fi
@@ -96,12 +96,12 @@ if [[ ${TELEMETRY:-} == "true" ]]; then
       "commit_sha": "'"${COMMIT_SHA:-}"'"
     }
   }' "$POSTHOG_HOST/capture/" > /dev/null
-fi
 
-# Mark telemetry as handled so we don't try to send it again when
-# initializing our PostgreSQL extensions. We use a file for IPC
-# between this script and our PostgreSQL extensions
-echo "true" > /tmp/telemetry
+  # Mark telemetry as handled so we don't try to send it again when
+  # initializing our PostgreSQL extensions. We use a file for IPC
+  # between this script and our PostgreSQL extensions
+  echo "true" > /tmp/telemetry
+fi
 
 echo "PostgreSQL is up - installing extensions..."
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -83,7 +83,7 @@ if [[ ${TELEMETRY:-} == "true" ]]; then
   # For privacy reasons, we generate an anonymous UUID for each new deployment
   UUID_FILE="/var/lib/postgresql/data/paradedb_uuid"
   if [ ! -f "$UUID_FILE" ]; then
-      uuidgen > "$UUID_FILE"
+    uuidgen > "$UUID_FILE"
   fi
   DISTINCT_ID=$(cat "$UUID_FILE")
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -78,12 +78,20 @@ EOSQL
 pg_ctl restart 2> /dev/null
 
 # We collect basic, anonymous telemetry to help us understand how many people are using
-# the project. We only do this if TELEMETRY is set to "true", and only do it once per deployment
+# the project. We only do this if TELEMETRY is set to "true"
 if [[ ${TELEMETRY:-} == "true" ]]; then
+  # For privacy reasons, we generate an anonymous UUID for each new deployment
+  UUID_FILE="/var/lib/postgresql/data/deployment_uuid"
+  if [ ! -f "$UUID_FILE" ]; then
+      uuidgen > "$UUID_FILE"
+  fi
+  DISTINCT_ID=$(cat "$UUID_FILE")
+
+  # Send the deployment event to PostHog
   curl -s -L --header "Content-Type: application/json" -d '{
     "api_key": "'"$POSTHOG_API_KEY"'",
     "event": "ParadeDB Deployment",
-    "distinct_id": "'"$(uuidgen)"'",
+    "distinct_id": "'"$DISTINCT_ID"'",
     "properties": {
       "commit_sha": "'"${COMMIT_SHA:-}"'"
     }

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -46,7 +46,7 @@ pub fn init(extension_name: &str) {
 
         // For privacy reasons, we generate an anonymous UUID for each new deployment
         let uuid_file = format!("/var/lib/postgresql/data/{}_uuid", extension_name);
-        
+
         // Closure to generate a new UUID and write it to the file
         let generate_and_save_uuid = || {
             let new_uuid = uuid::Uuid::new_v4().to_string();
@@ -56,12 +56,10 @@ pub fn init(extension_name: &str) {
 
         let distinct_id = if Path::new(&uuid_file).exists() {
             match fs::read_to_string(&uuid_file) {
-                Ok(uuid_str) => {
-                    match uuid::Uuid::parse_str(&uuid_str) {
-                        Ok(uuid) => uuid.to_string(),
-                        Err(_) => generate_and_save_uuid(),
-                    }
-                }
+                Ok(uuid_str) => match uuid::Uuid::parse_str(&uuid_str) {
+                    Ok(uuid) => uuid.to_string(),
+                    Err(_) => generate_and_save_uuid(),
+                },
                 Err(_) => generate_and_save_uuid(),
             }
         } else {

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -1,8 +1,8 @@
 use pgrx::*;
-use std::fs;
-use std::path::Path;
 use serde::Deserialize;
 use serde_json::json;
+use std::fs;
+use std::path::Path;
 
 #[derive(Deserialize, Debug)]
 struct Config {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #590 
- 
## What
We now keep an anonymous UUID per-deployment, so we can tell whether a deployment ping is coming from the same anonymous deployment or not.

## Why
Better understanding how many people are using ParadeDB

## How
Write a UUID to a temp file

## Tests
Manually tested