### PR TITLE
feat: add retention telemetry

### DIFF
--- a/pg_bm25/src/lib.rs
+++ b/pg_bm25/src/lib.rs
@@ -33,7 +33,8 @@ unsafe impl PGRXSharedMemory for WriterStatus {}
 
 // This is a flag that can be set by the user in a session to enable logs.
 // You need to initialize this in every extension that uses `plog!`.
-static PARADE_LOGS_GLOBAL: ParadeLogsGlobal = ParadeLogsGlobal::new("pg_bm25");
+static PARADE_LOGS_GLOBAL: ParadeLogsGlobal =
+    ParadeLogsGlobal::new(shared::constants::PG_BM25_NAME);
 
 // This is global shared state for the writer background worker.
 static WRITER_STATUS: PgLwLock<WriterStatus> = PgLwLock::new();
@@ -48,7 +49,7 @@ extension_sql_file!("../sql/_bootstrap.sql");
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
     index_access::options::init();
-    telemetry::posthog::init("pg_bm25");
+    telemetry::posthog::init(shared::constants::PG_BM25_NAME);
     PARADE_LOGS_GLOBAL.init();
 
     // Set up the writer bgworker shared state.
@@ -162,6 +163,6 @@ pub mod pg_test {
 mod tests {
     #[pgrx::pg_test]
     fn test_parade_logs() {
-        shared::test_plog!("pg_bm25");
+        shared::test_plog!(shared::constants::PG_BM25_NAME);
     }
 }

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -3,7 +3,7 @@ use pgrx::pg_sys::ItemPointerData;
 use pgrx::*;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use shared::plog;
+use shared::{plog, telemetry};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::{self, File};
@@ -173,6 +173,10 @@ impl ParadeIndex {
         unsafe {
             new_self.into_cached_index();
         }
+
+        // Send a telemetry event on each new connection. Since the reference to the index
+        // is cached, we expect to capture one event per connection.
+        telemetry::posthog::connection_start();
 
         // We need to return the Self that is borrowed from the cache.
         let new_self_ref = Self::from_index_name(name.to_string().as_ref());

--- a/shared/src/constants.rs
+++ b/shared/src/constants.rs
@@ -1,0 +1,4 @@
+// Note: The ParadeDB name is capitalized to maintain
+// consistency with the existing telemetry.
+pub const PARADEDB_NAME: &str = "ParadeDB";
+pub const PG_BM25_NAME: &str = "pg_bm25";

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod constants;
 pub mod logs;
 pub mod telemetry;
 pub mod testing;

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -96,20 +96,17 @@ pub fn connection_start() {
         if config.telemetry.as_deref() == Some("true") {
             let uuid_dir = "/var/lib/postgresql/data";
             let extension_name;
-            let file_content;
-
-            if Path::new(uuid_dir)
+            let file_content = if Path::new(uuid_dir)
                 .join(format!("{}_uuid", PARADEDB_NAME.to_lowercase()))
                 .exists()
             {
                 extension_name = PARADEDB_NAME;
-                file_content = fs::read_to_string(
+                fs::read_to_string(
                     Path::new(uuid_dir).join(format!("{}_uuid", PARADEDB_NAME.to_lowercase())),
                 )
             } else {
                 extension_name = PG_BM25_NAME;
-                file_content =
-                    fs::read_to_string(Path::new(uuid_dir).join(format!("{}_uuid", PG_BM25_NAME)))
+                fs::read_to_string(Path::new(uuid_dir).join(format!("{}_uuid", PG_BM25_NAME)))
             };
 
             let distinct_id = match file_content {

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -4,6 +4,8 @@ use serde_json::json;
 use std::fs;
 use std::path::Path;
 
+use crate::constants::{PARADEDB_NAME, PG_BM25_NAME};
+
 #[derive(Deserialize, Debug)]
 struct Config {
     telemetry_handled: Option<String>, // Option because it won't be set if running the extension standalone
@@ -96,12 +98,18 @@ pub fn connection_start() {
             let extension_name;
             let file_content;
 
-            if Path::new(uuid_dir).join("paradedb_uuid").exists() {
-                extension_name = "ParadeDB";
-                file_content = fs::read_to_string(Path::new(uuid_dir).join("paradedb_uuid"))
+            if Path::new(uuid_dir)
+                .join(format!("{}_uuid", PARADEDB_NAME.to_lowercase()))
+                .exists()
+            {
+                extension_name = PARADEDB_NAME;
+                file_content = fs::read_to_string(
+                    Path::new(uuid_dir).join(format!("{}_uuid", PARADEDB_NAME.to_lowercase())),
+                )
             } else {
-                extension_name = "pg_bm25";
-                file_content = fs::read_to_string(Path::new(uuid_dir).join("pg_bm25_uuid"))
+                extension_name = PG_BM25_NAME;
+                file_content =
+                    fs::read_to_string(Path::new(uuid_dir).join(format!("{}_uuid", PG_BM25_NAME)))
             };
 
             let distinct_id = match file_content {

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -92,6 +92,9 @@ pub fn init(extension_name: &str) {
 }
 
 pub fn connection_start() {
+    // This function shares configuration with the `init` function on this file.
+    // The TELEMETRY environment variable controls both functions, allowing it to be used
+    // for opting out of all telemetry.
     if let Some(config) = Config::from_env() {
         if config.telemetry.as_deref() == Some("true") {
             let uuid_dir = "/var/lib/postgresql/data";


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What
This PR adds basic telemetry for tracking user retention. An event is sent when the `ParadeIndex` is created, and since it is cached for subsequent uses, the event is sent once per connection.

## Why
To get insight into user retention and extension usage. This event will also allow us to use the Retention insight in PostHog.

## How
- Call telemetry function when `ParadeIndex` is created.
- Try to read the uuid file from the possible extension names.
- Send connection start event to Posthog.
- Abstract extension names into shared constants file.

## Tests
Manully tested, see PostHog dashboard. However I didn't test with `pg_bm25` deployments yet, only ParadeDB deployments.

![image](https://github.com/paradedb/paradedb/assets/19579265/5789da97-3e4a-49ec-8235-5f6b37ee255a)


We can start using the retention insight:

![image](https://github.com/paradedb/paradedb/assets/19579265/5bd78839-9d2b-462b-9575-b9c5b3a78e12)
