### PR TITLE
fix: search prefix option

### DIFF
--- a/pg_bm25/sql/_bootstrap.sql
+++ b/pg_bm25/sql/_bootstrap.sql
@@ -236,7 +236,7 @@ BEGIN
             fuzzy_fields text DEFAULT NULL, -- Fields where fuzzy search is applied
             distance integer DEFAULT NULL, -- Distance parameter for fuzzy search
             transpose_cost_one boolean DEFAULT NULL, -- Transpose cost parameter for fuzzy search
-            prefix text DEFAULT NULL, -- Prefix parameter for searches
+            prefix boolean DEFAULT NULL, -- Prefix parameter for searches
             regex_fields text DEFAULT NULL, -- Fields where regex search is applied
             max_num_chars integer DEFAULT NULL, -- Maximum character limit for searches
             highlight_field text DEFAULT NULL -- Field name to highlight (highlight func only)

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -86,3 +86,23 @@ SELECT description, rating, category, highlight_bm25 FROM search_config.search('
  Bluetooth-enabled speaker   |      3 | Electronics | 
 (5 rows)
 
+--- With fuzzy field prefix disabled
+SELECT id, description, category, rating FROM search_config.search('key', fuzzy_fields => 'description,category', distance => 2, transpose_cost_one => false, prefix => false, limit_rows => 5);
+ id |    description     | category  | rating 
+----+--------------------+-----------+--------
+  8 | Organic green tea  | Groceries |      3
+ 10 | Colorful kids toy  | Toys      |      1
+ 30 | Robot building kit | Toys      |      4
+(3 rows)
+
+--- With fuzzy field prefix enabled
+SELECT id, description, category, rating FROM search_config.search('key', fuzzy_fields => 'description,category', distance => 2, transpose_cost_one => false, prefix => true, limit_rows => 5);
+ id |         description         |  category   | rating 
+----+-----------------------------+-------------+--------
+  1 | Ergonomic metal keyboard    | Electronics |      4
+  2 | Plastic Keyboard            | Electronics |      4
+ 10 | Colorful kids toy           | Toys        |      1
+ 40 | Plush teddy bear            | Toys        |      4
+ 12 | Innovative wireless earbuds | Electronics |      5
+(5 rows)
+

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -18,3 +18,8 @@ SELECT id, description, rating, category FROM search_config.search('com', regex_
 SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics') as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description') as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics') as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;
 -- max_num_chars is set to 14 
 SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics', max_num_chars => 14) as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description', max_num_chars => 14) as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics', max_num_chars => 14) as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;
+--- With fuzzy field prefix disabled
+SELECT id, description, category, rating FROM search_config.search('key', fuzzy_fields => 'description,category', distance => 2, transpose_cost_one => false, prefix => false, limit_rows => 5);
+--- With fuzzy field prefix enabled
+SELECT id, description, category, rating FROM search_config.search('key', fuzzy_fields => 'description,category', distance => 2, transpose_cost_one => false, prefix => true, limit_rows => 5);
+


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #689 

## What
This PR fixes the `create_bm25` definition to use the correct type on the `prefix` search option for fuzzy search.

## Why
Because it was incorrectly set as a TEXT field, which caused the following error to show up:
```
<index>.search(unknown, fuzzy_fields => unknown, prefix => boolean) does not exist
```

## How
Fix type to boolean.

## Tests
Tested the fix works, you can use:
```SQL
--- Test with prefix disabled
SELECT *
FROM search_idx.search(
  'key',
  fuzzy_fields => 'description,category',
  distance => 2,
  transpose_cost_one => false,
  prefix => false);
 id |    description     | rating | category  | in_stock |                       metadata                       
----+--------------------+--------+-----------+----------+------------------------------------------------------
 10 | Colorful kids toy  |      1 | Toys      | t        | {"color": "Multicolor", "location": "United States"}
  8 | Organic green tea  |      3 | Groceries | t        | {"color": "Green", "location": "Canada"}
 30 | Robot building kit |      4 | Toys      | t        | {"color": "Multicolor", "location": "China"}



--- Test with prefix enabled
SELECT *
FROM search_idx.search(
  'key',
  fuzzy_fields => 'description,category',
  distance => 2,
  transpose_cost_one => false,
  prefix => true);
 id |         description         | rating |  category   | in_stock |                       metadata                       
----+-----------------------------+--------+-------------+----------+------------------------------------------------------
  1 | Ergonomic metal keyboard    |      4 | Electronics | t        | {"color": "Silver", "location": "United States"}
  2 | Plastic Keyboard            |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}
 10 | Colorful kids toy           |      1 | Toys        | t        | {"color": "Multicolor", "location": "United States"}
.
.
.



```