### PR TITLE
feat: add support for date fields

### DIFF
--- a/pg_bm25/sql/_bootstrap.sql
+++ b/pg_bm25/sql/_bootstrap.sql
@@ -99,6 +99,7 @@ END $$;
 --   numeric_fields: JSON object representing the numeric fields for the index.
 --   boolean_fields: JSON object representing the boolean fields for the index.
 --   json_fields: JSON object representing the json fields for the index.
+--   date_fields: JSON object representing the date fields for the index.
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
     index_name text DEFAULT '',
     table_name text DEFAULT '',
@@ -107,7 +108,8 @@ CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
     text_fields text DEFAULT '{}',
     numeric_fields text DEFAULT '{}',
     boolean_fields text DEFAULT '{}',
-    json_fields text DEFAULT '{}'
+    json_fields text DEFAULT '{}',
+    date_fields text DEFAULT '{}'
 )
 LANGUAGE plpgsql AS $$
 DECLARE
@@ -129,8 +131,8 @@ BEGIN
         RAISE EXCEPTION 'no key_field parameter given for bm25 index "%"', index_name;
     END IF;
 
-    IF text_fields = '{}' AND numeric_fields = '{}' AND boolean_fields = '{}' AND json_fields = '{}' THEN
-        RAISE EXCEPTION 'no text_fields, numeric_fields, boolean_fields, or json_fields were specified for index %', index_name;
+    IF text_fields = '{}' AND numeric_fields = '{}' AND boolean_fields = '{}' AND json_fields = '{}' AND date_fields = '{}' THEN
+        RAISE EXCEPTION 'no text_fields, numeric_fields, boolean_fields, json_fields or date_fields were specified for index %', index_name;
     END IF;
 
     index_json := jsonb_build_object(
@@ -148,8 +150,8 @@ BEGIN
 
     -- Create a new BM25 index on the specified table.
     -- The index is created dynamically based on the function parameters.
-    EXECUTE format('CREATE INDEX %s_bm25_index ON %I.%I USING bm25 ((%I.*)) WITH (key_field=%L, text_fields=%L, numeric_fields=%L, boolean_fields=%L, json_fields=%L);',
-                   index_name, schema_name, table_name, table_name, key_field, text_fields, numeric_fields, boolean_fields, json_fields);
+    EXECUTE format('CREATE INDEX %s_bm25_index ON %I.%I USING bm25 ((%I.*)) WITH (key_field=%L, text_fields=%L, numeric_fields=%L, boolean_fields=%L, json_fields=%L, date_fields=%L);',
+                   index_name, schema_name, table_name, table_name, key_field, text_fields, numeric_fields, boolean_fields, json_fields, date_fields);
 
     -- Dynamically create a new function for performing searches on the indexed table.
     -- The variable '__paradedb_search_config__' is available to the function_body parameter.

--- a/pg_bm25/src/parade_index/fields.rs
+++ b/pg_bm25/src/parade_index/fields.rs
@@ -379,12 +379,62 @@ impl From<ParadeJsonOptions> for JsonObjectOptions {
     }
 }
 
+// Date options
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub struct ParadeDateOptions {
+    #[serde(default = "default_as_true")]
+    indexed: bool,
+    #[serde(default = "default_as_true")]
+    fast: bool,
+    #[serde(default = "default_as_true")]
+    stored: bool,
+    #[serde(default = "default_as_true")]
+    fieldnorms: bool,
+    #[serde(default)]
+    precision: DateTimePrecision,
+}
+
+impl Default for ParadeDateOptions {
+    fn default() -> Self {
+        Self {
+            indexed: true,
+            fast: false,
+            stored: true,
+            fieldnorms: true,
+            // Default used by Tantivy
+            precision: DateTimePrecision::Nanoseconds,
+        }
+    }
+}
+
+impl From<ParadeDateOptions> for DateOptions {
+    fn from(parade_options: ParadeDateOptions) -> Self {
+        let mut date_options = DateOptions::default();
+
+        if parade_options.stored {
+            date_options = date_options.set_stored();
+        }
+        if parade_options.fast {
+            date_options = date_options.set_fast();
+        }
+        if parade_options.fieldnorms {
+            date_options = date_options.set_fieldnorm();
+        }
+        if parade_options.indexed {
+            let precision = date_options.get_precision();
+            date_options = date_options.set_precision(precision).set_indexed();
+        }
+        date_options
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum ParadeOption {
     Text(ParadeTextOptions),
     Json(ParadeJsonOptions),
     Numeric(ParadeNumericOptions),
     Boolean(ParadeBooleanOptions),
+    Date(ParadeDateOptions),
 }
 
 pub type ParadeOptionMap = HashMap<String, ParadeOption>;

--- a/pg_bm25/src/parade_index/fields.rs
+++ b/pg_bm25/src/parade_index/fields.rs
@@ -402,7 +402,7 @@ impl Default for ParadeDateOptions {
             stored: true,
             fieldnorms: true,
             // Default used by Tantivy
-            precision: DateTimePrecision::Nanoseconds,
+            precision: DateTimePrecision::Seconds,
         }
     }
 }
@@ -439,7 +439,7 @@ pub enum ParadeOption {
 
 pub type ParadeOptionMap = HashMap<String, ParadeOption>;
 
-// TODO: Enable DateTime and IP fields
+// TODO: Enable IP fields
 
 fn default_as_true() -> bool {
     true

--- a/pg_bm25/src/parade_index/index.rs
+++ b/pg_bm25/src/parade_index/index.rs
@@ -579,13 +579,10 @@ impl ParadeIndex {
                             })
                         }
                     }
-                    PgBuiltInOids::DATEOID
-                    | PgBuiltInOids::TIMEOID
-                    | PgBuiltInOids::TIMESTAMPOID => {
+                    PgBuiltInOids::TIMESTAMPOID | PgBuiltInOids::TIMESTAMPTZOID=> {
                         if is_key_field {
                             panic!("bm25 id column must be an integer type, received datetime")
                         } else {
-                            info!("Got a date or time, with attname: {}", attname);
                             date_fields.get(attname).map(|options| {
                                 let date_options: DateOptions = (*options).into();
                                 schema_builder.add_date_field(attname, date_options)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #365 

## What
This PR adds support for indexing and searching over date fields.

## Why
Because they are a commonly used data type in postgres and would be good to have in pg_bm25.

## How
Add to `amoptions` where necessary, update bootstrap.sql file, add to ParadeIndex.

## Tests
Still need to add tests.