### PR TITLE
fix: Stabilize result order on tied BM25 scores

### DIFF
--- a/pg_bm25/src/api/search.rs
+++ b/pg_bm25/src/api/search.rs
@@ -19,7 +19,7 @@ pub fn rank_bm25(
 
     let mut field_rows = Vec::new();
     for (score, _) in top_docs.into_iter() {
-        field_rows.push((score.key as i64, score.bm25));
+        field_rows.push((score.key, score.bm25));
     }
     TableIterator::new(field_rows)
 }

--- a/pg_bm25/src/parade_index/mod.rs
+++ b/pg_bm25/src/parade_index/mod.rs
@@ -1,5 +1,6 @@
 pub mod fields;
 pub mod index;
+pub mod score;
 pub mod state;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_bm25/src/parade_index/score.rs
+++ b/pg_bm25/src/parade_index/score.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, PartialOrd, PartialEq, Serialize, Deserialize)]
+pub struct ParadeIndexScore {
+    pub bm25: f32,
+    pub key: u64,
+}

--- a/pg_bm25/src/parade_index/score.rs
+++ b/pg_bm25/src/parade_index/score.rs
@@ -3,5 +3,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Copy, Clone, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub struct ParadeIndexScore {
     pub bm25: f32,
-    pub key: u64,
+    pub key: i64,
 }

--- a/pg_bm25/src/parade_index/score.rs
+++ b/pg_bm25/src/parade_index/score.rs
@@ -1,7 +1,29 @@
+use std::cmp::Ordering;
+
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct ParadeIndexScore {
     pub bm25: f32,
     pub key: i64,
+}
+
+// We do these custom trait impls, because we want these to be sorted so:
+// - it's ordered descending by bm25 score.
+// - in case of a tie, it's ordered by ascending key.
+
+impl PartialEq for ParadeIndexScore {
+    fn eq(&self, other: &Self) -> bool {
+        self.bm25 == other.bm25 && self.key == other.key
+    }
+}
+
+impl PartialOrd for ParadeIndexScore {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self.bm25 == other.bm25 {
+            other.key.partial_cmp(&self.key)
+        } else {
+            self.bm25.partial_cmp(&other.bm25)
+        }
+    }
 }

--- a/pg_bm25/src/parade_index/score.rs
+++ b/pg_bm25/src/parade_index/score.rs
@@ -8,9 +8,9 @@ pub struct ParadeIndexScore {
     pub key: i64,
 }
 
-// We do these custom trait impls, because we want these to be sorted so:
-// - it's ordered descending by bm25 score.
-// - in case of a tie, it's ordered by ascending key.
+// We do these custom trait impls, because we want these to be sortable so:
+// - they're ordered descending by bm25 score.
+// - in case of a tie, they're ordered by ascending key.
 
 impl PartialEq for ParadeIndexScore {
     fn eq(&self, other: &Self) -> bool {

--- a/pg_bm25/src/parade_index/state.rs
+++ b/pg_bm25/src/parade_index/state.rs
@@ -89,6 +89,8 @@ impl TantivyScanState {
                 // We can now define our actual scoring function
                 move |doc: DocId, original_score: Score| ParadeIndexScore {
                     bm25: original_score,
+                    // We want the results to be in ascending order by key.
+                    // So we invert the key index.
                     key: key_field_reader.get_val(doc),
                 }
             },

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -1,72 +1,88 @@
 -- Basic seach query
-SELECT id, description, rating, category FROM search_config.search('category:electronics') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('category:electronics');
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
-  1 | Ergonomic metal keyboard    |      4 | Electronics
-  2 | Plastic Keyboard            |      4 | Electronics
- 12 | Innovative wireless earbuds |      5 | Electronics
- 22 | Fast charging power bank    |      4 | Electronics
  32 | Bluetooth-enabled speaker   |      3 | Electronics
+ 22 | Fast charging power bank    |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
+  1 | Ergonomic metal keyboard    |      4 | Electronics
 (5 rows)
 
--- With fuzzy field
-SELECT id, description, rating, category FROM search_config.search('category:electornics', fuzzy_fields => 'category') ORDER BY id;
+-- With limit
+SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2);
+ id |        description        | rating |  category   
+----+---------------------------+--------+-------------
+ 32 | Bluetooth-enabled speaker |      3 | Electronics
+ 22 | Fast charging power bank  |      4 | Electronics
+(2 rows)
+
+-- With limit and offset
+SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2, offset_rows => 1);
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
-  1 | Ergonomic metal keyboard    |      4 | Electronics
-  2 | Plastic Keyboard            |      4 | Electronics
- 12 | Innovative wireless earbuds |      5 | Electronics
  22 | Fast charging power bank    |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+(2 rows)
+
+-- With fuzzy field
+SELECT id, description, rating, category FROM search_config.search('category:electornics', fuzzy_fields => 'category');
+ id |         description         | rating |  category   
+----+-----------------------------+--------+-------------
  32 | Bluetooth-enabled speaker   |      3 | Electronics
+ 22 | Fast charging power bank    |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
+  1 | Ergonomic metal keyboard    |      4 | Electronics
 (5 rows)
 
 -- Without fuzzy field
-SELECT id, description, rating, category FROM search_config.search('category:electornics') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('category:electornics');
  id | description | rating | category 
 ----+-------------+--------+----------
 (0 rows)
 
 -- With fuzzy field and transpose_cost_one=false and distance=1
-SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => false, distance => 1) ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => false, distance => 1);
  id | description | rating | category 
 ----+-------------+--------+----------
 (0 rows)
 
 -- With fuzzy field and transpose_cost_one=true and distance=1
-SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => true, distance => 1) ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => true, distance => 1);
  id |       description        | rating |  category   
 ----+--------------------------+--------+-------------
-  1 | Ergonomic metal keyboard |      4 | Electronics
   2 | Plastic Keyboard         |      4 | Electronics
+  1 | Ergonomic metal keyboard |      4 | Electronics
 (2 rows)
 
 -- With regex field 
-SELECT id, description, rating, category FROM search_config.search('com', regex_fields => 'description') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('com', regex_fields => 'description');
  id |      description       | rating |  category   
 ----+------------------------+--------+-------------
-  6 | Compact digital camera |      5 | Photography
  23 | Comfortable slippers   |      3 | Footwear
+  6 | Compact digital camera |      5 | Photography
 (2 rows)
 
 -- Default highlighting without max_num_chars
-SELECT s.id, description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics') as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description') as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics') as r ON s.id = r.id ORDER BY s.id DESC LIMIT 5;
- id |         description         | rating |  category   |         highlight_bm25          
-----+-----------------------------+--------+-------------+---------------------------------
- 32 | Bluetooth-enabled speaker   |      3 | Electronics | 
- 22 | Fast charging power bank    |      4 | Electronics | 
- 12 | Innovative wireless earbuds |      5 | Electronics | 
-  2 | Plastic Keyboard            |      4 | Electronics | Plastic <b>Keyboard</b>
-  1 | Ergonomic metal keyboard    |      4 | Electronics | Ergonomic metal <b>keyboard</b>
+SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics') as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description') as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics') as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;
+         description         | rating |  category   |         highlight_bm25          
+-----------------------------+--------+-------------+---------------------------------
+ Plastic Keyboard            |      4 | Electronics | Plastic <b>Keyboard</b>
+ Ergonomic metal keyboard    |      4 | Electronics | Ergonomic metal <b>keyboard</b>
+ Innovative wireless earbuds |      5 | Electronics | 
+ Fast charging power bank    |      4 | Electronics | 
+ Bluetooth-enabled speaker   |      3 | Electronics | 
 (5 rows)
 
 -- max_num_chars is set to 14 
-SELECT s.id, description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics', max_num_chars => 14) as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description', max_num_chars => 14) as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics', max_num_chars => 14) as r ON s.id = r.id ORDER BY s.id DESC LIMIT 5;
- id |         description         | rating |  category   |    highlight_bm25     
-----+-----------------------------+--------+-------------+-----------------------
- 32 | Bluetooth-enabled speaker   |      3 | Electronics | 
- 22 | Fast charging power bank    |      4 | Electronics | 
- 12 | Innovative wireless earbuds |      5 | Electronics | 
-  2 | Plastic Keyboard            |      4 | Electronics | <b>Keyboard</b>
-  1 | Ergonomic metal keyboard    |      4 | Electronics | metal <b>keyboard</b>
+SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics', max_num_chars => 14) as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description', max_num_chars => 14) as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics', max_num_chars => 14) as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;
+         description         | rating |  category   |    highlight_bm25     
+-----------------------------+--------+-------------+-----------------------
+ Plastic Keyboard            |      4 | Electronics | <b>Keyboard</b>
+ Ergonomic metal keyboard    |      4 | Electronics | metal <b>keyboard</b>
+ Innovative wireless earbuds |      5 | Electronics | 
+ Fast charging power bank    |      4 | Electronics | 
+ Bluetooth-enabled speaker   |      3 | Electronics | 
 (5 rows)
 

--- a/pg_bm25/test/expected/search_config.out
+++ b/pg_bm25/test/expected/search_config.out
@@ -2,26 +2,26 @@
 SELECT id, description, rating, category FROM search_config.search('category:electronics');
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
- 32 | Bluetooth-enabled speaker   |      3 | Electronics
- 22 | Fast charging power bank    |      4 | Electronics
- 12 | Innovative wireless earbuds |      5 | Electronics
-  2 | Plastic Keyboard            |      4 | Electronics
   1 | Ergonomic metal keyboard    |      4 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+ 22 | Fast charging power bank    |      4 | Electronics
+ 32 | Bluetooth-enabled speaker   |      3 | Electronics
 (5 rows)
 
 -- With limit
 SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2);
- id |        description        | rating |  category   
-----+---------------------------+--------+-------------
- 32 | Bluetooth-enabled speaker |      3 | Electronics
- 22 | Fast charging power bank  |      4 | Electronics
+ id |       description        | rating |  category   
+----+--------------------------+--------+-------------
+  1 | Ergonomic metal keyboard |      4 | Electronics
+  2 | Plastic Keyboard         |      4 | Electronics
 (2 rows)
 
 -- With limit and offset
 SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2, offset_rows => 1);
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
- 22 | Fast charging power bank    |      4 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
  12 | Innovative wireless earbuds |      5 | Electronics
 (2 rows)
 
@@ -29,11 +29,11 @@ SELECT id, description, rating, category FROM search_config.search('category:ele
 SELECT id, description, rating, category FROM search_config.search('category:electornics', fuzzy_fields => 'category');
  id |         description         | rating |  category   
 ----+-----------------------------+--------+-------------
- 32 | Bluetooth-enabled speaker   |      3 | Electronics
- 22 | Fast charging power bank    |      4 | Electronics
- 12 | Innovative wireless earbuds |      5 | Electronics
-  2 | Plastic Keyboard            |      4 | Electronics
   1 | Ergonomic metal keyboard    |      4 | Electronics
+  2 | Plastic Keyboard            |      4 | Electronics
+ 12 | Innovative wireless earbuds |      5 | Electronics
+ 22 | Fast charging power bank    |      4 | Electronics
+ 32 | Bluetooth-enabled speaker   |      3 | Electronics
 (5 rows)
 
 -- Without fuzzy field
@@ -52,16 +52,16 @@ SELECT id, description, rating, category FROM search_config.search('description:
 SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => true, distance => 1);
  id |       description        | rating |  category   
 ----+--------------------------+--------+-------------
-  2 | Plastic Keyboard         |      4 | Electronics
   1 | Ergonomic metal keyboard |      4 | Electronics
+  2 | Plastic Keyboard         |      4 | Electronics
 (2 rows)
 
 -- With regex field 
 SELECT id, description, rating, category FROM search_config.search('com', regex_fields => 'description');
  id |      description       | rating |  category   
 ----+------------------------+--------+-------------
- 23 | Comfortable slippers   |      3 | Footwear
   6 | Compact digital camera |      5 | Photography
+ 23 | Comfortable slippers   |      3 | Footwear
 (2 rows)
 
 -- Default highlighting without max_num_chars

--- a/pg_bm25/test/sql/search_config.sql
+++ b/pg_bm25/test/sql/search_config.sql
@@ -1,16 +1,20 @@
 -- Basic seach query
-SELECT id, description, rating, category FROM search_config.search('category:electronics') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('category:electronics');
+-- With limit
+SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2);
+-- With limit and offset
+SELECT id, description, rating, category FROM search_config.search('category:electronics', limit_rows => 2, offset_rows => 1);
 -- With fuzzy field
-SELECT id, description, rating, category FROM search_config.search('category:electornics', fuzzy_fields => 'category') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('category:electornics', fuzzy_fields => 'category');
 -- Without fuzzy field
-SELECT id, description, rating, category FROM search_config.search('category:electornics') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('category:electornics');
 -- With fuzzy field and transpose_cost_one=false and distance=1
-SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => false, distance => 1) ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => false, distance => 1);
 -- With fuzzy field and transpose_cost_one=true and distance=1
-SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => true, distance => 1) ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('description:keybaord', fuzzy_fields => 'description', transpose_cost_one => true, distance => 1);
 -- With regex field 
-SELECT id, description, rating, category FROM search_config.search('com', regex_fields => 'description') ORDER BY id;
+SELECT id, description, rating, category FROM search_config.search('com', regex_fields => 'description');
 -- Default highlighting without max_num_chars
-SELECT s.id, description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics') as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description') as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics') as r ON s.id = r.id ORDER BY s.id DESC LIMIT 5;
+SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics') as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description') as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics') as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;
 -- max_num_chars is set to 14 
-SELECT s.id, description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics', max_num_chars => 14) as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description', max_num_chars => 14) as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics', max_num_chars => 14) as r ON s.id = r.id ORDER BY s.id DESC LIMIT 5;
+SELECT description, rating, category, highlight_bm25 FROM search_config.search('description:keyboard OR category:electronics', max_num_chars => 14) as s LEFT JOIN search_config.highlight('description:keyboard OR category:electronics', highlight_field => 'description', max_num_chars => 14) as h ON s.id = H.id LEFT JOIN search_config.rank('description:keyboard OR category:electronics', max_num_chars => 14) as r ON s.id = r.id ORDER BY rank_bm25 DESC LIMIT 5;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #691

## What
An implementation of a stable sorting for `bm25` results.

## Why
After the introduction of the multi-threaded writer in #673, we found that result ordering is not entirely stable, because in the case of ties with the BM25 score, Tantivy falls back to the document address in the index.

The document address is not a stable order across machines (because of the multi-threaded insert), which makes CI testing difficult. It also means that the order of tied results changes as rows are updated, as updated document receives a new document address.

This would cause what might look like "wrong rows" when using `limit_rows` and `offset_rows`, because the result set would be a slice of an incorrect ordering.

## How
Fortunately, I was able to use the `tweak_score` method of the `TopDocs` collector, along with a custom `PartialOrd` implementation, to stabilize the sort order based on the value of the `key_field`. For example:

```
 id |         description         | rank_bm25 
----+-----------------------------+-----------
  2 | Plastic Keyboard            | 5.3764954
  1 | Ergonomic metal keyboard    |  4.931014
 12 | Innovative wireless earbuds | 2.1096356
 22 | Fast charging power bank    | 2.1096356
 32 | Bluetooth-enabled speaker   | 2.1096356
(5 rows)
```

As you can see, the bottom three results have the same score, thus ordered numerically by their `id`, which is the `key_field` for the index.

## Tests
Our tests have been accommodating unstable ordering until now. I've adjusted them to expect this new stable order.
