### PR TITLE
fix: Use quotes for multiple features in pgrx package

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Package pg_bm25 Extension with pgrx
         working-directory: pg_bm25/
-        run: cargo pgrx package --features icu telemetry
+        run: cargo pgrx package --features "icu telemetry"
 
       - name: Create .deb Package
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
It appears we need quotes to package with multiple features in `cargo pgrx package`. See: https://github.com/paradedb/paradedb/actions/runs/7618513912/job/20749836886

## Why

## How

## Tests
