### PR TITLE
fix: Use almost equal comparison to convert arrays into svector

### DIFF
--- a/pg_sparse/test/expected/cast.out
+++ b/pg_sparse/test/expected/cast.out
@@ -1,31 +1,31 @@
-SELECT ARRAY[1,2,3]::svector;
-  array  
----------
- [1,2,3]
+SELECT ARRAY[0,1,2,3]::svector;
+   array   
+-----------
+ [0,1,2,3]
 (1 row)
 
-SELECT ARRAY[1.0,2.0,3.0]::svector;
-  array  
----------
- [1,2,3]
+SELECT ARRAY[0.0,1.0,2.0,3.0]::svector;
+   array   
+-----------
+ [0,1,2,3]
 (1 row)
 
-SELECT ARRAY[1,2,3]::float4[]::svector;
-  array  
----------
- [1,2,3]
+SELECT ARRAY[0,1,2,3]::float4[]::svector;
+   array   
+-----------
+ [0,1,2,3]
 (1 row)
 
-SELECT ARRAY[1,2,3]::float8[]::svector;
-  array  
----------
- [1,2,3]
+SELECT ARRAY[0,1,2,3]::float8[]::svector;
+   array   
+-----------
+ [0,1,2,3]
 (1 row)
 
-SELECT ARRAY[1,2,3]::numeric[]::svector;
-  array  
----------
- [1,2,3]
+SELECT ARRAY[0,1,2,3]::numeric[]::svector;
+   array   
+-----------
+ [0,1,2,3]
 (1 row)
 
 SELECT '{NULL}'::real[]::svector;

--- a/pg_sparse/test/expected/shnsw_ip.out
+++ b/pg_sparse/test/expected/shnsw_ip.out
@@ -32,3 +32,15 @@ SELECT * FROM t ORDER BY val <#> '[3,3,0,3]';
 (4 rows)
 
 DROP TABLE t;
+CREATE TABLE t (val svector(4));
+INSERT INTO t (val) VALUES ('{0,0,0,1}'::float4[]::svector), ('{3,4,0,2}'::float4[]::svector), ('{0,2,0,1}'::float4[]::svector);
+CREATE INDEX ON t USING shnsw (val svector_ip_ops);
+SELECT * FROM t ORDER BY val <#> '[3,3,0,3]';
+    val    
+-----------
+ [3,4,0,2]
+ [0,2,0,1]
+ [0,0,0,1]
+(3 rows)
+
+DROP TABLE t;

--- a/pg_sparse/test/sql/cast.sql
+++ b/pg_sparse/test/sql/cast.sql
@@ -1,8 +1,8 @@
-SELECT ARRAY[1,2,3]::svector;
-SELECT ARRAY[1.0,2.0,3.0]::svector;
-SELECT ARRAY[1,2,3]::float4[]::svector;
-SELECT ARRAY[1,2,3]::float8[]::svector;
-SELECT ARRAY[1,2,3]::numeric[]::svector;
+SELECT ARRAY[0,1,2,3]::svector;
+SELECT ARRAY[0.0,1.0,2.0,3.0]::svector;
+SELECT ARRAY[0,1,2,3]::float4[]::svector;
+SELECT ARRAY[0,1,2,3]::float8[]::svector;
+SELECT ARRAY[0,1,2,3]::numeric[]::svector;
 SELECT '{NULL}'::real[]::svector;
 SELECT '{NaN}'::real[]::svector;
 SELECT '{Infinity}'::real[]::svector;

--- a/pg_sparse/test/sql/shnsw_ip.sql
+++ b/pg_sparse/test/sql/shnsw_ip.sql
@@ -17,3 +17,10 @@ CREATE INDEX ON t USING shnsw (val svector_ip_ops);
 SELECT * FROM t ORDER BY val <#> '[3,3,0,3]';
 
 DROP TABLE t;
+
+CREATE TABLE t (val svector(4));
+INSERT INTO t (val) VALUES ('{0,0,0,1}'::float4[]::svector), ('{3,4,0,2}'::float4[]::svector), ('{0,2,0,1}'::float4[]::svector);
+CREATE INDEX ON t USING shnsw (val svector_ip_ops);
+SELECT * FROM t ORDER BY val <#> '[3,3,0,3]';
+
+DROP TABLE t;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Converting `float4[]`, `float8[]` and `numeric[]` arrays was broken, due to a typo in the indexing and also to a direct zero comparison leading to indexing many zero values.

## Why

## How

## Tests

Example of failing test:

```sql
SELECT ARRAY[0,1,2,3]::float4[]::svector
   array   
-----------
 [0,1,2,0]
(1 row)
```