### PR TITLE
fix: improve error message when not on preload list

### DIFF
--- a/pg_bm25/src/writer/client.rs
+++ b/pg_bm25/src/writer/client.rs
@@ -43,9 +43,7 @@ impl<T: Serialize> Client<T> {
     }
 
     pub fn from_writer_addr() -> Self {
-        let lock = panic::catch_unwind(|| {
-            WRITER_STATUS.share()
-        });
+        let lock = panic::catch_unwind(|| WRITER_STATUS.share());
 
         let addr = match lock {
             Ok(lock) => lock.addr(),

--- a/pg_bm25/src/writer/client.rs
+++ b/pg_bm25/src/writer/client.rs
@@ -2,7 +2,7 @@ use crate::WRITER_STATUS;
 
 use super::{transfer::WriterTransferProducer, IndexEntry, ServerRequest};
 use serde::Serialize;
-use std::{marker::PhantomData, net::SocketAddr};
+use std::{marker::PhantomData, net::SocketAddr, panic};
 use thiserror::Error;
 
 pub struct Client<T: Serialize> {
@@ -43,7 +43,17 @@ impl<T: Serialize> Client<T> {
     }
 
     pub fn from_writer_addr() -> Self {
-        let addr = WRITER_STATUS.share().addr();
+        let lock = panic::catch_unwind(|| {
+            WRITER_STATUS.share()
+        });
+
+        let addr = match lock {
+            Ok(lock) => lock.addr(),
+            Err(_) => {
+                panic!("Could not get lock on writer. Have you added the extension to the shared preload library list?");
+            }
+        };
+
         Self::new(addr)
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What
Improve the error message when an index is created but the extension is not on the shared preload libraries list.

## Why
Because the existing error doesn't really give helpful information.
```
ERROR:  Can't give out share, lock is in an empty state
CONTEXT:  SQL statement "SELECT paradedb.drop_bm25_internal(format('%s_bm25_index', index_name))"
PL/pgSQL function paradedb.drop_bm25(text,text) line 10 at PERFORM
SQL statement "CALL paradedb.drop_bm25(index_name, schema_name => schema_name)"
PL/pgSQL function paradedb.create_bm25(text,text,text,text,text,text,text,text) line 33 at CALL
```

New error message:
```
ERROR:  Could not get lock on writer. Have you added the extension to the shared preload library list?
CONTEXT:  SQL statement "SELECT paradedb.drop_bm25_internal(format('%s_bm25_index', index_name))"
PL/pgSQL function paradedb.drop_bm25(text,text) line 10 at PERFORM
SQL statement "CALL paradedb.drop_bm25(index_name, schema_name => schema_name)"
PL/pgSQL function paradedb.create_bm25(text,text,text,text,text,text,text,text) line 33 at CALL
```
## How
This error happens when the [lock](https://docs.rs/pgrx/latest/pgrx/lwlock/struct.PgLwLock.html) is empty and the `share` function is called. However, the lock doesn't expose any way to handle the error or check if it's empty. So we resort to capturing the panic with `catch_unwind`.

## Tests
