### PR TITLE
feat: Upgrade to Postgres 16

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -20,6 +20,9 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg_version: [16]
 
     steps:
       - name: Checkout Git Repository
@@ -34,13 +37,13 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-15 postgresql-server-dev-15
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
-        run: cargo pgrx init --pg15=/usr/lib/postgresql/15/bin/pg_config
+        run: cargo pgrx init --pg${{ matrix.pg_Version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       - name: Run Rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo install --locked cargo-pgrx --version 0.11.1
 
       - name: Initialize pgrx for Current PostgreSQL Version
-        run: cargo pgrx init --pg${{ matrix.pg_Version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       - name: Run Rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [15]
+        pg_version: [16]
 
     steps:
       - name: Checkout Git Repository
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [15]
+        pg_version: [16]
 
     steps:
       - name: Retrieve GitHub Release Version

--- a/.github/workflows/publish-pg_analytics.yml
+++ b/.github/workflows/publish-pg_analytics.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            pg_version: 15
+            pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-8-ubuntu-2204-arm
-            pg_version: 15
+            pg_version: 16
             arch: arm64
 
     steps:

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            pg_version: 15
+            pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-8-ubuntu-2204-arm
-            pg_version: 15
+            pg_version: 16
             arch: arm64
 
     steps:

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            pg_version: 15
+            pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-2-ubuntu-2204-arm
-            pg_version: 15
+            pg_version: 16
             arch: arm64
 
     steps:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest-m # Size: 4-cores · 16 GB RAM · 150 GB SSD
     strategy:
       matrix:
-        pg_version: [15]
+        pg_version: [16]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -36,6 +36,8 @@ jobs:
     strategy:
       matrix:
         pg_version: [12, 13, 14, 15, 16]
+    env:
+      default_pg_version: 16
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -43,7 +45,7 @@ jobs:
       - name: Check if Skipping
         id: check_skip
         run: |
-          if [[ "${{ github.event_name }}" = "push" && "${{ matrix.pg_version }}" != "15" ]]; then
+          if [[ "${{ github.event_name }}" = "push" && "${{ matrix.pg_version }}" != "${{ env.default_pg_version }}" ]]; then
             echo "This is a push event to fill Rust cache. Skipping this job."
             echo "skip_remaining_steps=true" >> $GITHUB_OUTPUT
           fi
@@ -112,7 +114,7 @@ jobs:
       # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we
       # clean any cached pg_analytics & dependencies build artifacts before running the tests
       - name: Clean Cached Build Artifacts
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         working-directory: pg_analytics/
         run: cargo clean
 
@@ -121,7 +123,7 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_analytics/test/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."
@@ -149,11 +151,11 @@ jobs:
 
       # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
       - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
       - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -36,6 +36,8 @@ jobs:
     strategy:
       matrix:
         pg_version: [12, 13, 14, 15, 16]
+    env:
+      default_pg_version: 16
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -43,7 +45,7 @@ jobs:
       - name: Check if Skipping
         id: check_skip
         run: |
-          if [[ "${{ github.event_name }}" = "push" && "${{ matrix.pg_version }}" != "15" ]]; then
+          if [[ "${{ github.event_name }}" = "push" && "${{ matrix.pg_version }}" != "${{ env.default_pg_version }}" ]]; then
             echo "This is a push event to fill Rust cache. Skipping this job."
             echo "skip_remaining_steps=true" >> $GITHUB_OUTPUT
           fi
@@ -111,7 +113,7 @@ jobs:
       # only want to restore dependencies (to speed up the build) but not the extension itself (so the tests are representative), we
       # clean any cached pg_bm25 & dependencies build artifacts before running the tests
       - name: Clean Cached Build Artifacts
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         working-directory: pg_bm25/
         run: cargo clean
 
@@ -120,7 +122,7 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_bm25/test/
         run: |
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "15" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."
@@ -148,11 +150,11 @@ jobs:
 
       # We only do it for one of the matrix jobs, because the coverage report is the same for all of them
       - name: Generate Code Coverage Reports
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/coverage-report/
 
       - name: Upload Coverage Reports to Codecov
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '15'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == '${{ env.default_pg_version }}'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PG_VERSION_MAJOR=15
+ARG PG_VERSION_MAJOR=16
 
 ###############################################
 # First Stage: Base

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -15,7 +15,7 @@ ParadeDB aims to be the best of both worlds, providing developers with the simpl
 database with the search capabilities of a world-class search engine.
 
 ParadeDB is not a fork of Postgres, but regular Postgres with custom extensions installed. ParadeDB itself
-ships with Postgres 15.
+ships with Postgres 16.
 
 ## Why ParadeDB
 

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -9,7 +9,7 @@ license = "AGPL-3.0"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg15"]
+default = ["pg16"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -122,12 +122,12 @@ Then, install the PostgreSQL version of your choice using your system package ma
 
 ```bash
 # macOS
-brew install postgresql@15
+brew install postgresql@16
 
 # Ubuntu
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-sudo apt-get update && sudo apt-get install -y postgresql-$15 postgresql-server-dev-15
+sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
 ```
 
 If you are using Postgres.app to manage your macOS PostgreSQL, you'll need to add the `pg_config` binary to your path before continuing:
@@ -141,15 +141,15 @@ export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
 Then, install and initialize `pgrx`:
 
 ```bash
-# Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
+# Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
 cargo install --locked cargo-pgrx --version 0.11.1
-cargo pgrx init --pg15=`which pg_config`
+cargo pgrx init --pg16=`which pg_config`
 ```
 
 ### Configure Shared Preload Libraries
 
 This extension uses Postgres hooks to intercept Postgres queries. In order to enable these hooks, the extension
-must be added to `shared_preload_libraries` inside `postgresql.conf`. If you are using Postgres 15, this file can be found under `~/.pgrx/data-15`.
+must be added to `shared_preload_libraries` inside `postgresql.conf`. If you are using Postgres 16, this file can be found under `~/.pgrx/data-16`.
 
 ```bash
 # Inside postgresql.conf

--- a/pg_analytics/benchmarks/clickbench/benchmark.sh
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sh
@@ -64,7 +64,7 @@ cleanup() {
     # Check if PostgreSQL is in recovery mode. This can happen if one of the quer caused a crash. If
     # so, we need to wait for recovery to finish before we can drop the extension.
     for attempt in {1..5}; do
-      psql -h localhost -p 28815 -d pg_analytics -t -c 'DROP EXTENSION IF EXISTS pg_analytics CASCADE;' &> /dev/null && break
+      psql -h localhost -p 28816 -d pg_analytics -t -c 'DROP EXTENSION IF EXISTS pg_analytics CASCADE;' &> /dev/null && break
       echo "PostgreSQL is in recovery mode (likely due to a crash), waiting for recovery to finish..."
       sleep 5
     done
@@ -147,7 +147,7 @@ if [ "$FLAG_TAG" == "pgrx" ]; then
   echo ""
 
   # Run the benchmarking
-  psql -h localhost -p 28815 -d pg_analytics -t < benchmark.sql
+  psql -h localhost -p 28816 -d pg_analytics -t < benchmark.sql
   # For local benchmarking via pgrx, we don't print the disk usage or parse the results into
   # the format expected by the ClickBench dashboard
 else

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -9,7 +9,7 @@ license = "AGPL-3.0"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg15"]
+default = ["pg16"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -62,7 +62,7 @@ This enables the extension to spawn a background worker process that performs wr
 
 #### Debian/Ubuntu
 
-We provide pre-built binaries for Debian-based Linux for PostgreSQL 15 (more versions coming soon). You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+We provide pre-built binaries for Debian-based Linux for PostgreSQL 16. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
 ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt-out of telemetry by setting `export TELEMETRY=false` (or unsetting the variable) in your shell or in your `~/.bashrc` file before running the extension.
 
@@ -156,12 +156,12 @@ Then, install the PostgreSQL version of your choice using your system package ma
 
 ```bash
 # macOS
-brew install postgresql@15
+brew install postgresql@16
 
 # Ubuntu
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-sudo apt-get update && sudo apt-get install -y postgresql-$15 postgresql-server-dev-15
+sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
 ```
 
 If you are using Postgres.app to manage your macOS PostgreSQL, you'll need to add the `pg_config` binary to your path before continuing:
@@ -173,9 +173,9 @@ export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
 Then, install and initialize pgrx:
 
 ```bash
-# Note: Replace --pg15 with your version of Postgres, if different (i.e. --pg16, --pg14, etc.)
+# Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
 cargo install --locked cargo-pgrx --version 0.11.1
-cargo pgrx init --pg15=`which pg_config`
+cargo pgrx init --pg16=`which pg_config`
 ```
 
 Note: While it is possible to develop using pgrx's own Postgres installation(s), via `cargo pgrx init` without specifying a `pg_config` path, we recommend using your system package manager's Postgres as we've observed inconsistent behaviours when using pgrx's.

--- a/pg_sparse/README.md
+++ b/pg_sparse/README.md
@@ -37,7 +37,7 @@ If you are self-hosting Postgres and would like to use the extension within your
 
 #### Debian/Ubuntu
 
-We provide pre-built binaries for Debian-based Linux for PostgreSQL 15 (more versions coming soon). You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+We provide pre-built binaries for Debian-based Linux for PostgreSQL 16. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
 ParadeDB does not currently collect telemetry from self-hosted `pg_sparse`.
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #429 

## What
This PR sets Postgres 16 as the default Postgres version for ParadeDB, pg_bm25, pg_analytics, and pg_sparse.

## Why
Because it's what users expect now that it's been out for several months.

## How
Updated it everywhere

## Tests
See CI :)