### PR TITLE
chore: Upgrade to `pgrx` `0.11.2`

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.1
+        run: cargo install --locked cargo-pgrx --version 0.11.2
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config

--- a/.github/workflows/publish-pg_analytics.yml
+++ b/.github/workflows/publish-pg_analytics.yml
@@ -62,7 +62,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.2
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_analytics/

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -61,7 +61,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version 0.11.1
+        run: cargo install --locked cargo-pgrx --version 0.11.2
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_bm25/

--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.2
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.1
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.2
           cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74be28cdc96f9558e475cd4d47852cd49b255d6f896d4fa08d1c4f5c595ac6c8"
+checksum = "cb44171122605250e719ca2ae49afb357bdb2fce4b3c876fcf2225165237328a"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.2",
@@ -3943,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae1d356149028852679e43d6c43fdd7886b5052ee9be3e02bea885433d49409"
+checksum = "a18ac8628b7de2f29a93d0abdbdcaee95a0e0ef4b59fd4de99cc117e166e843b"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -3955,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bc8706534e081424e58c14d06b64ed8ba6bb92d79f19c10b13b50a67c4edef"
+checksum = "acd45ac6eb1142c5690df63c4e0bdfb74f27c9f93a7af84f064dc2c0a2c2d6f7"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -3973,9 +3973,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dd0b8c611bbc4b6bd041711c9b9510f07fb62dc3e7965746ae7b5b12314a05"
+checksum = "81c6207939582934fc26fceb651cb5338e363c06ddc6b2d50ca71867f7c70ffe"
 dependencies = [
  "bindgen 0.68.1",
  "clang-sys",
@@ -3997,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50bda0837d9ad915e60a3e8e958134881abf6f1aa6d4cf0878b681af098ba87"
+checksum = "a50083de83b1fac2484e8f2c2a7da5fed0193904e2578fa6c4ce02262c455c2b"
 dependencies = [
  "convert_case",
  "eyre",
@@ -4012,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177cb62f1050d2b52d8f59471c00d9320631329f7dfc6739a7a34ce7c0575a22"
+checksum = "6ba0115cd80d9e3ca1d5d2a8ab8b7320d6ed614a53d025b86152696a8b3caa75"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
-RUN cargo install --locked cargo-pgrx --version 0.11.1 && \
+RUN cargo install --locked cargo-pgrx --version 0.11.2 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################
@@ -112,7 +112,7 @@ COPY shared/ /tmp/shared
 # Note: We require Rust nightly to build pg_analytics with SIMD support
 RUN rustup update nightly && \
     rustup override set nightly && \
-    cargo install --locked cargo-pgrx --version 0.11.1 --force && \
+    cargo install --locked cargo-pgrx --version 0.11.2 --force && \
     cargo pgrx package --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ###############################################

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -20,7 +20,7 @@ telemetry = ["shared/telemetry"]
 simd = ["datafusion/simd"]
 
 [dependencies]
-pgrx = "=0.11.1"
+pgrx = "=0.11.2"
 serde = "1.0.193"
 serde_json = "1.0.107"
 shared = { version = "0.1.0", path = "../shared" }
@@ -34,7 +34,7 @@ chrono = "0.4.31"
 thiserror = "1.0.56"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.1"
+pgrx-tests = "=0.11.2"
 
 [package.metadata.pgrx]
 pg_sys_includes = ["pg_query_parse.h", "pg_plan.h"]

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -142,7 +142,7 @@ Then, install and initialize `pgrx`:
 
 ```bash
 # Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
-cargo install --locked cargo-pgrx --version 0.11.1
+cargo install --locked cargo-pgrx --version 0.11.2
 cargo pgrx init --pg16=`which pg_config`
 ```
 
@@ -178,7 +178,7 @@ rustup override set nightly
 Then, reinstall `pgrx` for the new version of Rust:
 
 ```bash
-cargo install --locked cargo-pgrx --version 0.11.1 --force
+cargo install --locked cargo-pgrx --version 0.11.2 --force
 ```
 
 Finally, run to build in release mode with SIMD:

--- a/pg_analytics/benchmarks/clickbench/benchmark.sh
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sh
@@ -133,7 +133,7 @@ if [ "$FLAG_TAG" == "pgrx" ]; then
     rustup default nightly
 
     echo "Reinstalling cargo-pgrx on Rust nightly toolchain..."
-    cargo install --locked cargo-pgrx --version 0.11.1 --force
+    cargo install --locked cargo-pgrx --version 0.11.2 --force
   else
     echo "Already on Rust nightly toolchain, skipping toolchain switch..."
   fi

--- a/pg_analytics/src/datafusion/catalog.rs
+++ b/pg_analytics/src/datafusion/catalog.rs
@@ -39,9 +39,9 @@ impl ParadeCatalog {
                     .ok_or_else(|| ParadeError::NotFound)?
                     .to_str()
                     .ok_or_else(|| ParadeError::NotFound)?
-                    .parse()?;
+                    .parse::<u32>()?;
 
-                let pg_oid = unsafe { pg_sys::Oid::from_u32_unchecked(schema_oid) };
+                let pg_oid = pg_sys::Oid::from(schema_oid);
 
                 let schema_name = unsafe {
                     let schema_name = pg_sys::get_namespace_name(pg_oid);

--- a/pg_analytics/src/datafusion/schema.rs
+++ b/pg_analytics/src/datafusion/schema.rs
@@ -63,8 +63,8 @@ impl ParadeSchemaProvider {
                 .ok_or_else(|| ParadeError::NotFound)?
                 .to_string();
 
-            if let Ok(oid) = table_oid.parse() {
-                let pg_oid = unsafe { pg_sys::Oid::from_u32_unchecked(oid) };
+            if let Ok(oid) = table_oid.parse::<u32>() {
+                let pg_oid = pg_sys::Oid::from(oid);
                 let relation = unsafe { pg_sys::RelationIdGetRelation(pg_oid) };
 
                 if relation.is_null() {
@@ -227,8 +227,8 @@ impl ParadeSchemaProvider {
                 .ok_or_else(|| ParadeError::NotFound)?
                 .to_string();
 
-            if let Ok(oid) = table_oid.parse() {
-                let pg_oid = unsafe { pg_sys::Oid::from_u32_unchecked(oid) };
+            if let Ok(oid) = table_oid.parse::<u32>() {
+                let pg_oid = pg_sys::Oid::from(oid);
                 let relation = unsafe { pg_sys::RelationIdGetRelation(pg_oid) };
 
                 // If the relation is null, delete the directory

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -40,7 +40,7 @@ lindera-tokenizer = { version = "0.27.1", features = [
 ] }
 memoffset = "0.9.0"
 once_cell = "1.18.0"
-pgrx = "=0.11.1"
+pgrx = "=0.11.2"
 reqwest = "0.11.22"
 rustc-hash = "1.1.0"
 serde = "1.0.188"
@@ -53,7 +53,7 @@ tiny_http = "0.12.0"
 utoipa = "3.5.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.1"
+pgrx-tests = "=0.11.2"
 
 [dependencies.rust_icu_ubrk]
 version = "4.2.3"

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -174,7 +174,7 @@ Then, install and initialize pgrx:
 
 ```bash
 # Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
-cargo install --locked cargo-pgrx --version 0.11.1
+cargo install --locked cargo-pgrx --version 0.11.2
 cargo pgrx init --pg16=`which pg_config`
 ```
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,11 +10,11 @@ telemetry = []
 
 [dependencies]
 envy = "0.4.2"
-pgrx = "0.11.1"
+pgrx = "0.11.2"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 serde = "1.0.189"
 serde_json = "1.0.107"
 uuid = "1.5.0"
 
 [dev-dependencies]
-pgrx-tests = "0.11.1"
+pgrx-tests = "0.11.2"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We've been on an outdated versions of `pgrx` for a while, and this has been their latest version for over a month. I figured it might be worth upgrading while I'm also upgrading Postgres itself.

## Why
^

## How
Simply replace everywhere + fix some deprecated functions

## Tests
See CI