### PR TITLE
fix: Make `paradedb.init()` optional

### DIFF
--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -31,8 +31,6 @@ This toy example demonstrates how to get started.
 
 ```sql
 CREATE EXTENSION pg_analytics;
--- This needs to be run once per connection
-CALL paradedb.init();
 -- Create a deltalake table
 CREATE TABLE t (a int) USING deltalake;
 -- pg_analytics supercharges the performance of any
@@ -47,7 +45,7 @@ You can interact with `deltalake` tables the same way as with normal Postgres ta
 
 ### Context Refresh
 
-If `deltalake` tables are created or modified in other Postgres connections, `CALL paradedb.init();` must be re-run for the changes to be received by the current connection.
+If `deltalake` tables are created or modified in other Postgres connections, `CALL paradedb.init();` must be run for the changes to be received by the current connection.
 
 ### Storage Optimization
 

--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -1,4 +1,3 @@
-use async_std::task;
 use deltalake::datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use deltalake::datafusion::prelude::{SessionConfig, SessionContext};
 use pgrx::*;
@@ -18,35 +17,5 @@ extension_sql!(
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn init() {
-    init_impl().expect("Failed to initialize context");
-}
-
-#[inline]
-fn init_impl() -> Result<(), ParadeError> {
-    let session_config = SessionConfig::from_env()?.with_information_schema(true);
-
-    let rn_config = RuntimeConfig::new();
-    let runtime_env = RuntimeEnv::new(rn_config)?;
-
-    DatafusionContext::with_write_lock(|mut context_lock| {
-        let mut context = SessionContext::new_with_config_rt(session_config, Arc::new(runtime_env));
-
-        // Create schema directory if it doesn't exist
-        ParadeDirectory::create_delta_path()?;
-
-        // Register catalog list
-        context.register_catalog_list(Arc::new(ParadeCatalogList::try_new()?));
-
-        // Create and register catalog
-        let catalog = ParadeCatalog::try_new()?;
-        task::block_on(catalog.init())?;
-        context.register_catalog(PARADE_CATALOG, Arc::new(catalog));
-
-        // Set context
-        *context_lock = Some(context);
-
-        Ok::<(), ParadeError>(())
-    })?;
-
-    Ok(())
+    let _ = DatafusionContext::init().expect("Failed to initialize context");
 }

--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -1,12 +1,6 @@
-use deltalake::datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use deltalake::datafusion::prelude::{SessionConfig, SessionContext};
 use pgrx::*;
-use std::sync::Arc;
 
-use crate::datafusion::catalog::{ParadeCatalog, ParadeCatalogList, PARADE_CATALOG};
 use crate::datafusion::context::DatafusionContext;
-use crate::datafusion::directory::ParadeDirectory;
-use crate::errors::ParadeError;
 
 extension_sql!(
     r#"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
`deltalake` tables can be operated on without the user needing to run `CALL paradedb.init();` themselves.

## Why
One less command for the user to run and mirrors the expected behavior of Postgres. Now the underlying `init` function is run automatically if the context is found to be `None`. In my testing the time taken by `init` is very small.

## How
Moved `init` to `DatafusionContext`.

## Tests
