### PR TITLE
feat: Tables created/modified get shared w all connections

### DIFF
--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -31,8 +31,6 @@ This toy example demonstrates how to get started.
 
 ```sql
 CREATE EXTENSION pg_analytics;
--- This needs to be run once per connection
-CALL paradedb.init();
 -- Create a deltalake table
 CREATE TABLE t (a int) USING deltalake;
 -- pg_analytics supercharges the performance of any
@@ -47,7 +45,7 @@ You can interact with `deltalake` tables the same way as with normal Postgres ta
 
 ### Context Refresh
 
-If `deltalake` tables are created or modified in other Postgres connections, `CALL paradedb.init();` must be re-run for the changes to be received by the current connection.
+If `deltalake` tables are created or modified in other Postgres connections, `CALL paradedb.init();` must be run for the changes to be received by the current connection.
 
 ### Storage Optimization
 

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -43,10 +43,6 @@ SELECT COUNT(*) FROM t;
 
 You can interact with `deltalake` tables the same way as with normal Postgres tables. However, there are a few operations specific to `deltalake` tables.
 
-### Context Refresh
-
-If `deltalake` tables are created or modified in other Postgres connections, `CALL paradedb.init();` must be run for the changes to be received by the current connection.
-
 ### Storage Optimization
 
 When `deltalake` tables are dropped, they remain on disk until `VACUUM` is run. This operation physically

--- a/pg_analytics/benchmarks/clickbench/benchmark.sh
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sh
@@ -187,7 +187,7 @@ else
   echo "Loading dataset..."
   export PGPASSWORD='mypassword'
   psql -h localhost -U myuser -d mydatabase -p 5432 -t < create.sql
-  psql -h localhost -U myuser -d mydatabase -p 5432 -t -c 'CALL paradedb.init();' -c '\timing' -c "\\copy hits FROM 'hits.tsv'"
+  psql -h localhost -U myuser -d mydatabase -p 5432 -t -c '\timing' -c "\\copy hits FROM 'hits.tsv'"
 
   echo ""
   echo "Running queries..."

--- a/pg_analytics/benchmarks/clickbench/benchmark.sql
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sql
@@ -2,9 +2,6 @@
 DROP EXTENSION IF EXISTS pg_analytics CASCADE;
 CREATE EXTENSION pg_analytics;
 
-\echo Initialize ParadeDB context...
-CALL paradedb.init();
-
 \echo Creating persistent table...
 \i create.sql
 

--- a/pg_analytics/benchmarks/clickbench/create.sql
+++ b/pg_analytics/benchmarks/clickbench/create.sql
@@ -1,4 +1,3 @@
-CALL paradedb.init();
 CREATE TABLE IF NOT EXISTS hits
 (
     WatchID BIGINT NOT NULL,

--- a/pg_analytics/benchmarks/clickbench/run.sh
+++ b/pg_analytics/benchmarks/clickbench/run.sh
@@ -13,6 +13,6 @@ while IFS= read -r query; do
   echo "$query";
   # shellcheck disable=SC2034
   for i in $(seq 1 $TRIES); do
-    psql -h localhost -U myuser -d mydatabase -p 5432 -t -c "CALL paradedb.init();" -c '\timing' -c "$query" | grep 'Time'
+    psql -h localhost -U myuser -d mydatabase -p 5432 -t -c '\timing' -c "$query" | grep 'Time'
   done;
 done < queries.sql

--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -1,4 +1,3 @@
-use async_std::task;
 use deltalake::datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use deltalake::datafusion::prelude::{SessionConfig, SessionContext};
 use pgrx::*;
@@ -18,35 +17,5 @@ extension_sql!(
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn init() {
-    init_impl().expect("Failed to initialize context");
-}
-
-#[inline]
-fn init_impl() -> Result<(), ParadeError> {
-    let session_config = SessionConfig::from_env()?.with_information_schema(true);
-
-    let rn_config = RuntimeConfig::new();
-    let runtime_env = RuntimeEnv::new(rn_config)?;
-
-    DatafusionContext::with_write_lock(|mut context_lock| {
-        let mut context = SessionContext::new_with_config_rt(session_config, Arc::new(runtime_env));
-
-        // Create schema directory if it doesn't exist
-        ParadeDirectory::create_delta_path()?;
-
-        // Register catalog list
-        context.register_catalog_list(Arc::new(ParadeCatalogList::try_new()?));
-
-        // Create and register catalog
-        let catalog = ParadeCatalog::try_new()?;
-        task::block_on(catalog.init())?;
-        context.register_catalog(PARADE_CATALOG, Arc::new(catalog));
-
-        // Set context
-        *context_lock = Some(context);
-
-        Ok::<(), ParadeError>(())
-    })?;
-
-    Ok(())
+    let _ = DatafusionContext::init().expect("Failed to initialize context");
 }

--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -1,12 +1,6 @@
-use deltalake::datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use deltalake::datafusion::prelude::{SessionConfig, SessionContext};
 use pgrx::*;
-use std::sync::Arc;
 
-use crate::datafusion::catalog::{ParadeCatalog, ParadeCatalogList, PARADE_CATALOG};
 use crate::datafusion::context::DatafusionContext;
-use crate::datafusion::directory::ParadeDirectory;
-use crate::errors::ParadeError;
 
 extension_sql!(
     r#"

--- a/pg_analytics/src/datafusion/table.rs
+++ b/pg_analytics/src/datafusion/table.rs
@@ -1,9 +1,9 @@
 use async_std::task;
-
 use deltalake::datafusion::arrow::datatypes::Schema as ArrowSchema;
+use deltalake::datafusion::catalog::schema::SchemaProvider;
 use deltalake::datafusion::common::DFSchema;
 use deltalake::datafusion::datasource::provider_as_source;
-use deltalake::datafusion::logical_expr::TableSource;
+use deltalake::datafusion::datasource::TableProvider;
 use deltalake::datafusion::sql::TableReference;
 use pgrx::*;
 use std::sync::Arc;
@@ -11,61 +11,27 @@ use std::sync::Arc;
 use crate::datafusion::context::DatafusionContext;
 use crate::errors::ParadeError;
 
-pub struct ParadeTable {
-    table_name: String,
-    schema_name: String,
+pub trait DeltaTableProvider {
+    fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError>;
 }
 
-impl ParadeTable {
-    pub fn from_pg(pg_relation: &PgRelation) -> Result<Self, ParadeError> {
-        let table_name = pg_relation.name().to_string();
-        let schema_name = pg_relation.namespace().to_string();
+impl DeltaTableProvider for PgRelation {
+    fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError> {
+        let table_name = self.name();
+        let schema_name = self.namespace();
 
-        Ok(Self {
-            table_name,
-            schema_name,
-        })
-    }
+        let provider = DatafusionContext::with_schema_provider(schema_name, |provider| {
+            let delta_table = task::block_on(provider.get_delta_table(table_name))?;
+            Ok(provider.register_table(
+                table_name.to_string(),
+                Arc::new(delta_table) as Arc<dyn TableProvider>,
+            )?)
+        })?;
 
-    pub fn table_name(&self) -> Result<String, ParadeError> {
-        Ok(self.table_name.clone())
-    }
+        let source = provider_as_source(provider.ok_or(ParadeError::NotFound)?);
+        let reference = TableReference::partial(schema_name, table_name);
+        let df_schema = DFSchema::try_from_qualified_schema(reference, source.schema().as_ref())?;
 
-    pub fn schema_name(&self) -> Result<String, ParadeError> {
-        Ok(self.schema_name.clone())
-    }
-
-    pub fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError> {
-        let df_schema = self.df_schema()?;
         Ok(Arc::new(df_schema.into()))
-    }
-
-    fn df_schema(&self) -> Result<DFSchema, ParadeError> {
-        let source = Self::source(self)?;
-        let reference = TableReference::partial(self.schema_name.clone(), self.table_name.clone());
-
-        Ok(DFSchema::try_from_qualified_schema(
-            reference,
-            source.schema().as_ref(),
-        )?)
-    }
-
-    fn source(&self) -> Result<Arc<dyn TableSource>, ParadeError> {
-        DatafusionContext::with_session_context(|context| {
-            let reference =
-                TableReference::partial(self.schema_name.clone(), self.table_name.clone());
-
-            match context.table_exist(&reference) {
-                Ok(true) => {
-                    let table_provider = task::block_on(context.table_provider(reference))?;
-                    Ok(provider_as_source(table_provider))
-                }
-                Ok(false) => Err(ParadeError::ContextNotInitialized(format!(
-                    "Table {}.{} not found. Please run `CALL paradedb.init();`.",
-                    self.schema_name, self.table_name
-                ))),
-                Err(err) => Err(ParadeError::DataFusion(err)),
-            }
-        })
     }
 }

--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -25,9 +25,6 @@ pub enum ParadeError {
     NotFound,
 
     #[error("{0}")]
-    ContextNotInitialized(String),
-
-    #[error("{0}")]
     NotSupported(String),
 
     #[error("{0}")]

--- a/pg_analytics/test/fixtures.sql
+++ b/pg_analytics/test/fixtures.sql
@@ -1,8 +1,6 @@
 DROP EXTENSION IF EXISTS pg_analytics;
 CREATE EXTENSION IF NOT EXISTS pg_analytics;
 
-CALL paradedb.init();
-
 CREATE TABLE analytics_test (
     id SERIAL PRIMARY KEY,
     event_date DATE,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #730 

## What
A table created/modified in one connection is now visible to all other connections. The user never has to call `paradedb.init()` themselves anymore.

## Why
Having to call `paradedb.init()` was annoying and goes against the behavior users expect from Postgres MVCC.

## How
The `get_delta_table` function now checks to see if a table exists. If it does not, it attempts to open and register a delta table. If it does, it calls `load` on the table, which updates the delta table to the latest state in the delta logs.

## Tests
Open two connections. In one connection, create/modify a deltalake table. In another connection, SELECT the table - it should be up to date with the first connection.