### PR TITLE
chore: Introduce CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,16 @@
 Welcome! We're excited that you're interested in contributing to ParadeDB and want
 to make the process as smooth as possible.
 
+ParadeDB is an open-source project, and you can contribute to it in many ways. You can help with ideas, code, issues, or documentation. We welcome all contributions, big or small, and are here to guide you along the way.
+
+## Technical Info
+
 Before submitting a pull request, please review this document, which outlines what
 conventions to follow when submitting changes. If you have any questions not covered
 in this document, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ)
 or via [email](support@paradedb.com).
 
-## Development Workflow
+### Development Workflow
 
 ParadeDB is structured as a monorepo containing all the projects, PostgreSQL extension(s), and other
 tools which together make ParadeDB. For development instructions regarding a specific project or Postgres extension,
@@ -21,7 +25,7 @@ All development of ParadeDB is done via Docker and Compose. Our Docker setup is 
 
 - The `docker-compose.yml` file pulls the latest published ParadeDB image from DockerHub. It is used for hobby production deployments. We recommend using it to deploy ParadeDB in your own infrastructure.
 
-## Pull Request Worfklow
+### Pull Request Worfklow
 
 All changes to ParadeDB happen through Github Pull Requests. Here is the recommended
 flow for making a change:
@@ -38,7 +42,7 @@ flow for making a change:
    and follows the [Conventional Commits spec](https://github.com/amannn/action-semantic-pull-request).
 7. Congratulations! Our team will review your pull request.
 
-## Documentation
+### Documentation
 
 ParadeDB's public-facing documentation is stored in the `docs` folder. If you are
 adding a new feature that requires new documentation, please open a separate pull
@@ -46,7 +50,44 @@ request containing changes to the documentation only. Once your main pull reques
 is merged, the ParadeDB team will review and eventually merge your documentation
 changes as well.
 
-## Licensing
+## Legal Info
+
+### Contributor License Agreement
+
+In order for us, Retake, Inc. (dba ParadeDB) to accept patches and other contributions from you, you need to adopt our ParadeDB Contributor License Agreement (the "**CLA**"). The current version of the CLA can be found [here]().
+
+By adopting the CLA, you state the following:
+
+- You obviously wish and are willingly licensing your contributions to us for our open source projects under the terms of the CLA,
+
+- You have read the terms and conditions of the CLA and agree with them in full,
+
+- You are legally able to provide and license your contributions as stated,
+
+- We may use your contributions for our open source projects and for any other our project too,
+
+- We rely on your assurances concerning the rights of third parties in relation to your contributions.
+
+If you agree with these principles, please read and adopt our CLA. By providing us your contributions, you hereby declare that you have already read and adopt our CLA, and we may freely merge your contributions with our corresponding open source project and use it in further in accordance with terms and conditions of the CLA.
+
+If you have already adopted terms and conditions of the CLA, you are able to provide your contributes. When you submit your pull request, please add the following information into it:
+
+```bash
+I hereby agree to the terms of the CLA available at: [link].
+```
+
+Replace the bracketed text as follows:
+
+- [link] is the link at the current version of the CLA (you may add here a link https://yandex.ru/legal/cla/?lang=en (in English) or a link https://yandex.ru/legal/cla/?lang=ru (in Russian).
+
+It is enough to provide us such notification once.
+
+As an alternative, you can provide DCO instead of CLA. You can find the text of DCO here: https://developercertificate.org/
+It is enough to read and copy it verbatim to your pull request.
+
+If you don't agree with the CLA and don't want to provide DCO, you still can open a pull request to provide your contributions.
+
+## License
 
 By contributing to ParadeDB, you agree that your contributions will be licensed
 under the [GNU Affero General Public License v3.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,6 @@
 Welcome! We're excited that you're interested in contributing to ParadeDB and want
 to make the process as smooth as possible.
 
-ParadeDB is an open-source project, and you can contribute to it in many ways. You can help with ideas, code, issues, or documentation. We welcome all contributions, big or small, and are here to guide you along the way.
-
 ## Technical Info
 
 Before submitting a pull request, please review this document, which outlines what
@@ -56,13 +54,12 @@ changes as well.
 
 In order for us, Retake, Inc. (dba ParadeDB) to accept patches and other contributions from you, you need to adopt our ParadeDB Contributor License Agreement (the "**CLA**"). The current version of the CLA can be found [here](https://cla-assistant.io/paradedb/paradedb).
 
-ParadeDB uses a tool called CLA Assistant to help us keep track of the CLA status of contributors. CLA Assistant will post a comment to your pull request, indicating whether you have signed the CLA or not. If you have not signed the CLA, you will need to do so before we can accept your contribution. Signing the CLA is a one-time process and is valid for all future contributions to ParadeDB, and can be done in under a minute by signing in with your GitHub account.
+ParadeDB uses a tool called CLA Assistant to help us keep track of the CLA status of contributors. CLA Assistant will post a comment to your pull request, indicating whether you have signed the CLA or not. If you have not signed the CLA, you will need to do so before we can accept your contribution. Signing the CLA is a one-time process, is valid for all future contributions to ParadeDB, and can be done in under a minute by signing in with your GitHub account.
 
-As an alternative, you can provide a DCO instead of a CLA. You can find the text of the DCO [here(https://developercertificate.org/). If you'd like to provide a DCO, please read and copy it verbatim to your pull request.
+As an alternative, you can provide a DCO instead of a CLA. You can find the text of the DCO [here](https://developercertificate.org/). If you'd like to provide a DCO, please read and copy it verbatim to your pull request.
 
 If you have any questions about the CLA or DCO, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ) or via email at [legal@paradedb.com](mailto:legal@paradedb.com).
 
-## License
+### License
 
-By contributing to ParadeDB, you agree that your contributions will be licensed
-under the [GNU Affero General Public License v3.0](LICENSE).
+By contributing to ParadeDB, you agree that your contributions will be licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,38 +54,13 @@ changes as well.
 
 ### Contributor License Agreement
 
-In order for us, Retake, Inc. (dba ParadeDB) to accept patches and other contributions from you, you need to adopt our ParadeDB Contributor License Agreement (the "**CLA**"). The current version of the CLA can be found [here]().
+In order for us, Retake, Inc. (dba ParadeDB) to accept patches and other contributions from you, you need to adopt our ParadeDB Contributor License Agreement (the "**CLA**"). The current version of the CLA can be found [here](https://cla-assistant.io/paradedb/paradedb).
 
-By adopting the CLA, you state the following:
+ParadeDB uses a tool called CLA Assistant to help us keep track of the CLA status of contributors. CLA Assistant will post a comment to your pull request, indicating whether you have signed the CLA or not. If you have not signed the CLA, you will need to do so before we can accept your contribution. Signing the CLA is a one-time process and is valid for all future contributions to ParadeDB, and can be done in under a minute by signing in with your GitHub account.
 
-- You obviously wish and are willingly licensing your contributions to us for our open source projects under the terms of the CLA,
+As an alternative, you can provide a DCO instead of a CLA. You can find the text of the DCO [here(https://developercertificate.org/). If you'd like to provide a DCO, please read and copy it verbatim to your pull request.
 
-- You have read the terms and conditions of the CLA and agree with them in full,
-
-- You are legally able to provide and license your contributions as stated,
-
-- We may use your contributions for our open source projects and for any other our project too,
-
-- We rely on your assurances concerning the rights of third parties in relation to your contributions.
-
-If you agree with these principles, please read and adopt our CLA. By providing us your contributions, you hereby declare that you have already read and adopt our CLA, and we may freely merge your contributions with our corresponding open source project and use it in further in accordance with terms and conditions of the CLA.
-
-If you have already adopted terms and conditions of the CLA, you are able to provide your contributes. When you submit your pull request, please add the following information into it:
-
-```bash
-I hereby agree to the terms of the CLA available at: [link].
-```
-
-Replace the bracketed text as follows:
-
-- [link] is the link at the current version of the CLA (you may add here a link https://yandex.ru/legal/cla/?lang=en (in English) or a link https://yandex.ru/legal/cla/?lang=ru (in Russian).
-
-It is enough to provide us such notification once.
-
-As an alternative, you can provide DCO instead of CLA. You can find the text of DCO here: https://developercertificate.org/
-It is enough to read and copy it verbatim to your pull request.
-
-If you don't agree with the CLA and don't want to provide DCO, you still can open a pull request to provide your contributions.
+If you have any questions about the CLA or DCO, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ) or via email at [legal@paradedb.com](mailto:legal@paradedb.com).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ Thank you for helping us make ParadeDB better for everyone :heart:.
 
 ## License
 
-ParadeDB is licensed under the [GNU Affero General Public License v3.0](LICENSE). The `pg_sparse` extension is licensed under the [PostgreSQL License](pg_sparse/LICENSE).
+ParadeDB is licensed under the [GNU Affero General Public License v3.0](LICENSE) and as commercial software, with the exception of `pg_sparse` which is licensed under the [PostgreSQL License](pg_sparse/LICENSE). For commercial licensing, please contact us at [hello@paradedb.com](mailto:hello@paradedb.com).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Conversations with experts in open-source and observing other companies doing open-source has led us to realize that we should have a CLA. This introduces the CLA, clarifies the option of purchasing a commercial license, and modifies the contribution guidelines.

The CLA is already configured via `cla-assistant`

## Why
Properly set up contributions for licensing

## How
Via CLA assistant

## Tests
You can see it display in other existing PRs