### PR TITLE
chore: Move `fields` to `table.rs`

### DIFF
--- a/pg_analytics/src/datafusion/table.rs
+++ b/pg_analytics/src/datafusion/table.rs
@@ -1,5 +1,5 @@
 use async_std::task;
-use deltalake::datafusion::arrow::datatypes::Schema as ArrowSchema;
+use deltalake::datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use deltalake::datafusion::catalog::schema::SchemaProvider;
 use deltalake::datafusion::common::DFSchema;
 use deltalake::datafusion::datasource::provider_as_source;
@@ -9,13 +9,55 @@ use pgrx::*;
 use std::sync::Arc;
 
 use crate::datafusion::context::DatafusionContext;
+use crate::datafusion::datatype::{DatafusionTypeTranslator, PostgresTypeTranslator};
 use crate::errors::ParadeError;
 
 pub trait DeltaTableProvider {
+    fn fields(&self) -> Result<Vec<Field>, ParadeError>;
     fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError>;
 }
 
 impl DeltaTableProvider for PgRelation {
+    fn fields(&self) -> Result<Vec<Field>, ParadeError> {
+        let tupdesc = self.tuple_desc();
+        let mut fields = Vec::with_capacity(tupdesc.len());
+
+        for attribute in tupdesc.iter() {
+            if attribute.is_dropped() {
+                continue;
+            }
+
+            let attname = attribute.name();
+            let attribute_type_oid = attribute.type_oid();
+            // Setting it to true because of a likely bug in Datafusion where inserts
+            // fail on nullability = false fields
+            let nullability = true;
+
+            let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
+            let (base_oid, is_array) = if array_type != pg_sys::InvalidOid {
+                (PgOid::from(array_type), true)
+            } else {
+                (attribute_type_oid, false)
+            };
+
+            if is_array {
+                return Err(ParadeError::Generic(
+                    "Array types not yet supported".to_string(),
+                ));
+            }
+
+            let field = Field::new(
+                attname,
+                DataType::from_sql_data_type(base_oid.to_sql_data_type(attribute.type_mod())?)?,
+                nullability,
+            );
+
+            fields.push(field);
+        }
+
+        Ok(fields)
+    }
+
     fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError> {
         let table_name = self.name();
         let schema_name = self.namespace();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We can bind `fields` directly to `PgRelation`, so any `PgRelation` can emit Datafusion fields.

```rust
let pg_relation = PgRelation::from_pg(relation);
let fields = pg_relation.fields()?;
```

## Why

## How

## Tests
