### PR TITLE
fix: Replace `checkinstall` w/ dpkg-deb

### DIFF
--- a/.github/workflows/publish-pg_analytics.yml
+++ b/.github/workflows/publish-pg_analytics.yml
@@ -100,7 +100,10 @@ jobs:
           CONTROL_FILE="${package_dir}/DEBIAN/control"
           echo 'Package: pg-analytics' >> $CONTROL_FILE
           echo 'Version:' ${deb_version} >> $CONTROL_FILE
+          echo 'Section: database' >> $CONTROL_FILE
+          echo 'Priority: optional' >> $CONTROL_FILE
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
+          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Real-time analytics for PostgreSQL using columnar storage and vectorized execution' >> $CONTROL_FILE
 

--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -99,7 +99,10 @@ jobs:
           CONTROL_FILE="${package_dir}/DEBIAN/control"
           echo 'Package: pg-bm25' >> $CONTROL_FILE
           echo 'Version:' ${deb_version} >> $CONTROL_FILE
+          echo 'Section: database' >> $CONTROL_FILE
+          echo 'Priority: optional' >> $CONTROL_FILE
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
+          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Full text search for PostgreSQL using BM25' >> $CONTROL_FILE
 

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -111,7 +111,7 @@ jobs:
           Architecture: ${{ matrix.arch }}
           Depends: postgresql-${{ matrix.pg_version }}
           Maintainer: ParadeDB <support@paradedb.com>
-          Description: pg_sparse: Sparse vector data type and sparse HNSW access methods
+          Description: Sparse vector data type and sparse HNSW access methods
           EOF
 
           # Build the package

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -115,7 +115,7 @@ jobs:
           EOF
 
           # Build the package
-          dpkg-deb --build "$PKGDIR" "/tmp/pg-sparse_${{ steps.version.outputs.version }}_all.deb"
+          dpkg-deb --build "$PKGDIR" "/tmp/pg-sparse_${{ steps.version.outputs.version }}_1_${{ matrix.arch }}.deb"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -115,7 +115,7 @@ jobs:
           EOF
 
           # Build the package
-          dpkg-deb --build "$PKGDIR" "/tmp/pg_sparse_${{ steps.version.outputs.version }}_1_${{ matrix.arch }}.deb"
+          dpkg-deb --build "$PKGDIR" "/tmp/pg_sparse_${{ steps.version.outputs.version }}-1_${{ matrix.arch }}.deb"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -115,7 +115,7 @@ jobs:
           EOF
 
           # Build the package
-          dpkg-deb --build "$PKGDIR" "/tmp/pg_sparse_${{ steps.version.outputs.version }}-1_${{ matrix.arch }}.deb"
+          dpkg-deb --build "$PKGDIR" "/tmp/pg-sparse_${{ steps.version.outputs.version }}-1_${{ matrix.arch }}.deb"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -115,7 +115,7 @@ jobs:
           EOF
 
           # Build the package
-          dpkg-deb --build "$PKGDIR" "/tmp/pg-sparse_${{ steps.version.outputs.version }}_1_${{ matrix.arch }}.deb"
+          dpkg-deb --build "$PKGDIR" "/tmp/pg_sparse_${{ steps.version.outputs.version }}_1_${{ matrix.arch }}.deb"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_sparse.yml
+++ b/.github/workflows/publish-pg_sparse.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} checkinstall
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
           # Update permissions for PostgreSQL directories for extensions installation
           sudo chown -R $(whoami) \
@@ -89,9 +89,33 @@ jobs:
           # setting OPTFLAGS to an empty string
           OPTFLAGS=""
 
-          # Build & package pg_sparse
+          # Build pg_sparse
           make USE_PGXS=1 OPTFLAGS="$OPTFLAGS" "-j$(nproc)"
-          checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp -- make USE_PGXS=1 install
+
+          # Create a temporary directory for packaging
+          PKGDIR=/tmp/pg_sparse_pkg
+          mkdir -p "$PKGDIR"
+
+          # Install the built files to the package directory
+          make USE_PGXS=1 DESTDIR="$PKGDIR" install
+
+          # Create DEBIAN control directory
+          mkdir -p "$PKGDIR/DEBIAN"
+
+          # Create a control file with package information
+          cat <<EOF >"$PKGDIR/DEBIAN/control"
+          Package: pg-sparse
+          Version: ${{ steps.version.outputs.version }}
+          Section: database
+          Priority: optional
+          Architecture: ${{ matrix.arch }}
+          Depends: postgresql-${{ matrix.pg_version }}
+          Maintainer: ParadeDB <support@paradedb.com>
+          Description: pg_sparse: Sparse vector data type and sparse HNSW access methods
+          EOF
+
+          # Build the package
+          dpkg-deb --build "$PKGDIR" "/tmp/pg-sparse_${{ steps.version.outputs.version }}_all.deb"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install Rust (specific version) and other build dependencies
 RUN apt-fast update && apt-fast install -y --no-install-recommends \
     build-essential \
-    checkinstall \
     clang \
     git \
     cmake \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I discovered recently that `checkinstall` is actually not been maintained at all for like... years. Well, it just broke a few days ago. Time to move on to `dpkg-deb`.

I might do another PR to cleanup and centralize the way we build & publish our extensions, since they now all use `dpkg-deb` but this recent one is cleaner than the previous two.

## Why
^

## How
^

## Tests
Tested publishing `pg_sparse` for v0.5.2, which had failed. It is now published properly.