### PR TITLE
feat: Reducing docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,12 @@ ARG POSTHOG_HOST
 ARG COMMIT_SHA
 ARG TELEMETRY
 ARG BUILD_DATE
+ARG RUST_VERSION=1.73.0
+ARG PGRX_VERSION=0.11.2
 
 ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
+    RUST_VERSION=${RUST_VERSION} \
+    PGRX_VERSION=${PGRX_VERSION} \
     POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     POSTHOG_HOST=${POSTHOG_HOST} \
     COMMIT_SHA=${COMMIT_SHA} \
@@ -64,11 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && /root/.cargo/bin/rustup default 1.73.0
-
-# Add PostgreSQL's third party repository to get the latest versions
-RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+    && /root/.cargo/bin/rustup default ${RUST_VERSION}
 
 RUN apt-get update && apt-get install -y postgresql-server-dev-${PG_VERSION_MAJOR} \
     && rm -rf /var/lib/apt/lists/*
@@ -77,7 +77,7 @@ ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
 RUN cargo install cargo-get
-RUN cargo install --locked cargo-pgrx --version 0.11.2 && \
+RUN cargo install --locked cargo-pgrx --version ${PGRX_VERSION} && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,12 +113,18 @@ ENV PKGDIR=/tmp/pg_bm25/deb-pkg
 # Use the build argument to update the version in Cargo.toml
 RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config" --out-dir $PKGDIR
 
-RUN cd $PKGDIR && debmake \
-    -p $(cargo get package.name | sed 's/_/-/g') \
-    -u $(cargo get package.version) \
-    --native -x0 -i debuild
+WORKDIR $PKGDIR
 
-RUN cp $PKGDIR/../*.deb /tmp
+RUN mkdir -p DEBIAN \
+    && tee DEBIAN/control <<EOF
+Package: $(cargo get package.name | sed 's/_/-/g')
+Description: $(cargo get package.description)
+Maintainer: $DEBFULLNAME <$DEBEMAIL>
+Version: $(cargo get package.version)
+Architecture: $(dpkg --print-architecture)
+EOF
+
+RUN dpkg-deb --build $PKGDIR /tmp/pg-bm25.deb
 
 ######################
 # pg_analytics
@@ -139,12 +145,18 @@ RUN rustup update nightly && \
     cargo install --locked cargo-pgrx --version 0.11.2 --force && \
     cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config" --out-dir $PKGDIR
 
-RUN cd $PKGDIR && debmake \
-    -p $(cargo get package.name | sed 's/_/-/g') \
-    -u $(cargo get package.version) \
-    --native -x0 -i debuild
+WORKDIR $PKGDIR
 
-RUN cp $PKGDIR/../*.deb /tmp
+RUN mkdir -p DEBIAN \
+    && tee DEBIAN/control <<EOF
+Package: $(cargo get package.name | sed 's/_/-/g')
+Description: $(cargo get package.description)
+Maintainer: $DEBFULLNAME <$DEBEMAIL>
+Version: $(cargo get package.version)
+Architecture: $(dpkg --print-architecture)
+EOF
+
+RUN dpkg-deb --build $PKGDIR /tmp/pg-analytics.deb
 
 ######################
 # pg_sparse
@@ -161,12 +173,17 @@ RUN make clean && \
     make USE_PGXS=1 OPTFLAGS="" -j && \
     make USE_PGXS=1 DESTDIR="$PKGDIR" install -j
 
-RUN cd $PKGDIR && debmake \
-    -p pg-sparse \
-    -u $(awk -F "= '|\'" '/default_version/ {print $2}' ../svector.control) \
-    --native -x0 -i debuild
+WORKDIR $PKGDIR
 
-RUN cp $PKGDIR/../*.deb /tmp
+RUN mkdir -p DEBIAN \
+    && tee DEBIAN/control <<EOF
+Package: pg-sparse
+Maintainer: $DEBFULLNAME <$DEBEMAIL>
+Version: $(awk -F "= '|\'" '/default_version/ {print $2}' ../svector.control)
+Architecture: $(dpkg --print-architecture)
+EOF
+
+RUN dpkg-deb --build $PKGDIR /tmp/pg-sparse.deb
 
 ######################
 # additional extensions
@@ -190,10 +207,12 @@ LABEL org.opencontainers.image.created="$BUILD_DATE"
 LABEL org.opencontainers.image.description="PostgreSQL for search and analaytics"
 LABEL io.artifacthub.package.readme-url="https://github.com/paradedb/paradedb/blob/main/README.md"
 
+# Copy third party extensions
+COPY --from=builder-ext-misc /tmp/*.deb /tmp/extensions-deb/
+
 # Copy the ParadeDB extensions from their builder stages
 COPY --from=builder-pg_sparse /tmp/pg-sparse*.deb /tmp/extensions-deb/
 COPY --from=builder-pg_bm25 /tmp/pg-bm25*.deb /tmp/extensions-deb/
-COPY --from=builder-ext-misc /tmp/*.deb /tmp/extensions-deb/
 COPY --from=builder-pg_analytics /tmp/pg-analytics*.deb /tmp/extensions-deb/
 
 RUN dpkg -i /tmp/extensions-deb/*.deb \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgres
 RUN curl -o /usr/share/keyrings/apt-fast.asc -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xA2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B
 RUN echo "deb [signed-by=/usr/share/keyrings/apt-fast.asc] http://ppa.launchpad.net/apt-fast/stable/ubuntu jammy main" | tee /etc/apt/sources.list.d/apt-fast.list
 
-RUN apt-get update && apt-get install apt-fast -y
+RUN apt-get update \
+    && apt-get install --no-install-recommends apt-fast -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Rust (specific version) and other build dependencies
 RUN apt-fast update && apt-fast install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,16 +82,16 @@ RUN apt-fast update && apt-fast install -y --no-install-recommends \
     make
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && /root/.cargo/bin/rustup default ${RUST_VERSION}
+    && /root/.cargo/bin/rustup default "${RUST_VERSION}"
 
-RUN apt-get update && apt-get install -y postgresql-server-dev-${PG_VERSION_MAJOR} \
+RUN apt-get update && apt-get install --no-install-recommends -y "postgresql-server-dev-${PG_VERSION_MAJOR}" \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
 RUN cargo install cargo-get
-RUN cargo install --locked cargo-pgrx --version ${PGRX_VERSION} && \
+RUN cargo install --locked cargo-pgrx --version "${PGRX_VERSION}" && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 # debmake needs these to be set
@@ -115,8 +115,7 @@ RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERS
 
 WORKDIR $PKGDIR
 
-RUN mkdir -p DEBIAN \
-    && tee DEBIAN/control <<EOF
+RUN mkdir -p DEBIAN && tee DEBIAN/control <<EOF
 Package: $(cargo get package.name | sed 's/_/-/g')
 Description: $(cargo get package.description)
 Maintainer: $DEBFULLNAME <$DEBEMAIL>
@@ -147,8 +146,7 @@ RUN rustup update nightly && \
 
 WORKDIR $PKGDIR
 
-RUN mkdir -p DEBIAN \
-    && tee DEBIAN/control <<EOF
+RUN mkdir -p DEBIAN && tee DEBIAN/control <<EOF
 Package: $(cargo get package.name | sed 's/_/-/g')
 Description: $(cargo get package.description)
 Maintainer: $DEBFULLNAME <$DEBEMAIL>
@@ -175,8 +173,7 @@ RUN make clean && \
 
 WORKDIR $PKGDIR
 
-RUN mkdir -p DEBIAN \
-    && tee DEBIAN/control <<EOF
+RUN mkdir -p DEBIAN && tee DEBIAN/control <<EOF
 Package: pg-sparse
 Maintainer: $DEBFULLNAME <$DEBEMAIL>
 Version: $(awk -F "= '|\'" '/default_version/ {print $2}' ../svector.control)
@@ -192,7 +189,7 @@ RUN dpkg-deb --build $PKGDIR /tmp/pg-sparse.deb
 FROM builder as builder-ext-misc
 
 WORKDIR /tmp
-RUN apt-get update && apt-get download postgresql-${PG_VERSION_MAJOR}-pgvector
+RUN apt-get update && apt-get download "postgresql-${PG_VERSION_MAJOR}-pgvector"
 
 ###############################################
 # Third Stage: PostgreSQL

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,9 @@ ARG COMMIT_SHA
 ARG TELEMETRY
 ARG BUILD_DATE
 
+# This is used to checkout the correct branch on the pgvector repo
+ARG PGVECTOR_BRANCH=v0.5.1
+
 ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     POSTHOG_HOST=${POSTHOG_HOST} \
@@ -24,37 +27,18 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     DEBIAN_FRONTEND=noninteractive \
     TZ=UTC
 
+ENV PGVECTOR_BRANCH=${PGVECTOR_BRANCH}
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install common dependencies to builder and runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    wget \
-    sudo \
-    gnupg \
-    gcc \
-    make \
-    uuid-runtime \
     software-properties-common \
     ca-certificates \
+    uuid-runtime \
     libssl-dev \
-    libopenblas-dev \
-    python3-dev \
-    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install apt-fast
-RUN /bin/bash -c "$(curl -sL https://git.io/vokNn)"
-
-# Add PostgreSQL's third party repository to get the latest versions
-RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-
-# Install PostgreSQL development headers and pgvector
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
-    postgresql-server-dev-${PG_VERSION_MAJOR} \
-    "postgresql-${PG_VERSION_MAJOR}-pgvector" \
-    && rm -rf /var/lib/apt/lists/*
 
 ###############################################
 # Second Stage: Builder
@@ -65,21 +49,39 @@ FROM base as builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Rust (specific version) and other build dependencies
-RUN apt-fast update && apt-fast install -y --no-install-recommends \
+RUN apt update && apt install -y --no-install-recommends \
     build-essential \
+    checkinstall \
     clang \
     git \
     cmake \
     pkg-config \
     liblz4-dev \
     libcurl4-openssl-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    libopenblas-dev \
+    python3-dev \
+    python3-pip \
+    curl \
+    wget \
+    sudo \
+    gnupg \
+    gcc \
+    make
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && /root/.cargo/bin/rustup default 1.73.0
+
+# Add PostgreSQL's third party repository to get the latest versions
+RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+
+RUN apt update && apt install -y postgresql-server-dev-${PG_VERSION_MAJOR} \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
+RUN cargo install cargo-get
 RUN cargo install --locked cargo-pgrx --version 0.11.2 && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
@@ -89,12 +91,20 @@ RUN cargo install --locked cargo-pgrx --version 0.11.2 && \
 
 FROM builder as builder-pg_bm25
 
-WORKDIR /tmp/pg_bm25
-
 COPY pg_bm25/ /tmp/pg_bm25
 COPY shared/ /tmp/shared
 
+WORKDIR /tmp/pg_bm25
+
+# Use the build argument to update the version in Cargo.toml
 RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+
+RUN checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
+   --exclude=/root/.cargo \
+   --pkgname $(cargo get package.name) \
+   --pkgversion $(cargo get package.version) \
+   --maintainer "ParadeDB <support@paradedb.com>" \
+   -- cargo pgrx install --release --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 ######################
 # pg_analytics
@@ -112,7 +122,55 @@ COPY shared/ /tmp/shared
 RUN rustup update nightly && \
     rustup override set nightly && \
     cargo install --locked cargo-pgrx --version 0.11.2 --force && \
-    cargo pgrx package --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+    cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+
+# Use the build argument to update the version in Cargo.toml
+RUN cargo pgrx package --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+
+
+RUN checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
+    --exclude=/root/.cargo \
+    --pkgname $(cargo get package.name) \
+    --pkgversion $(cargo get package.version) \
+    --maintainer "ParadeDB <support@paradedb.com>" \
+    -- cargo pgrx install --release --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+
+######################
+# pg_sparse
+######################
+FROM builder as builder-pg_sparse
+
+WORKDIR /tmp/pg_sparse
+COPY pg_sparse/ /tmp/pg_sparse
+
+RUN make clean && \
+    make USE_PGXS=1 OPTFLAGS="" -j && \
+    checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
+    --pkgname pg-sparse \
+    --pkgversion $(awk -F "= '|\''" '/default_version/ {print $2}' svector.control) \
+    --maintainer "ParadeDB <support@paradedb.com>" \
+    -- make USE_PGXS=1 install -j
+
+######################
+# pgvector
+######################
+
+FROM builder as builder-pgvector
+
+RUN cd /tmp \
+ && git clone --branch ${PGVECTOR_BRANCH} https://github.com/pgvector/pgvector.git
+
+WORKDIR /tmp/pgvector
+ENV PG_CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare"
+
+RUN echo "trusted = true" >> vector.control && \
+    make clean -j && \
+    make USE_PGXS=1 OPTFLAGS="" -j && \
+    checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
+    --pkgname pgvector \
+    --pkgversion $(awk -F "= '|\''" '/default_version/ {print $2}' vector.control) \
+    --maintainer "Andrew Kane <andrew@ankane.org>" \
+    -- make USE_PGXS=1 install -j
 
 ###############################################
 # Third Stage: PostgreSQL
@@ -128,20 +186,13 @@ LABEL org.opencontainers.image.description="PostgreSQL for Search"
 LABEL io.artifacthub.package.readme-url="https://github.com/paradedb/paradedb/blob/main/README.md"
 
 # Copy the ParadeDB extensions from their builder stages
-COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
-COPY --from=builder-pg_bm25 /tmp/pg_bm25/target/release/pg_bm25-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
-COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
-COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
+COPY --from=builder-pg_sparse /tmp/pg-sparse*.deb /tmp/extensions-deb/
+COPY --from=builder-pg_bm25 /tmp/pg-bm25*.deb /tmp/extensions-deb/
+COPY --from=builder-pgvector /tmp/pgvector*.deb /tmp/extensions-deb/
+COPY --from=builder-pg_analytics /tmp/pg-analytics*.deb /tmp/extensions-deb/
 
-# Install the ParadeDB pg_sparse extension directly, since it's not as modular as pgrx extensions
-# We set OPTFLAGS="" to disable the -march=native flag, which isn't supported on macOS ARM
-WORKDIR /tmp/pg_sparse
-COPY pg_sparse/ /tmp/pg_sparse
-RUN make clean && \
-    make USE_PGXS=1 OPTFLAGS="" && \
-    make install && \
-    rm -rf /tmp/pg_sparse
-WORKDIR /
+RUN dpkg -i /tmp/extensions-deb/*.deb \
+    && rm -rf /tmp/extensions-deb
 
 # Copy entrypoint script, which will be handled by the official image initialization scipt
 COPY ./docker/entrypoint.sh /docker-entrypoint-initdb.d/10_paradedb.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     uuid-runtime \
     libssl-dev \
+    curl \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -47,8 +49,18 @@ FROM base as builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Add PostgreSQL's third party repository to get the latest versions
+RUN curl -o /usr/share/keyrings/postgresql.asc -s https://www.postgresql.org/media/keys/ACCC4CF8.asc
+RUN echo "deb [signed-by=/usr/share/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
+
+# Add apt-fast repo
+RUN curl -o /usr/share/keyrings/apt-fast.asc -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0xA2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B
+RUN echo "deb [signed-by=/usr/share/keyrings/apt-fast.asc] http://ppa.launchpad.net/apt-fast/stable/ubuntu jammy main" | tee /etc/apt/sources.list.d/apt-fast.list
+
+RUN apt-get update && apt-get install apt-fast -y
+
 # Install Rust (specific version) and other build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-fast update && apt-fast install -y --no-install-recommends \
     build-essential \
     checkinstall \
     clang \
@@ -62,9 +74,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     curl \
     wget \
-    sudo \
+    apt-fast \
     gnupg \
     gcc \
+    debmake \
+    debhelper \
     make
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
@@ -80,6 +94,10 @@ RUN cargo install cargo-get
 RUN cargo install --locked cargo-pgrx --version ${PGRX_VERSION} && \
     cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
+# debmake needs these to be set
+ENV DEBEMAIL="support@paradedb.com"
+ENV DEBFULLNAME="ParadeDB"
+
 ######################
 # pg_bm25
 ######################
@@ -90,16 +108,17 @@ COPY pg_bm25/ /tmp/pg_bm25
 COPY shared/ /tmp/shared
 
 WORKDIR /tmp/pg_bm25
+ENV PKGDIR=/tmp/pg_bm25/deb-pkg
 
 # Use the build argument to update the version in Cargo.toml
-RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config" --out-dir $PKGDIR
 
-RUN checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
-   --exclude=/root/.cargo \
-   --pkgname $(cargo get package.name) \
-   --pkgversion $(cargo get package.version) \
-   --maintainer "ParadeDB <support@paradedb.com>" \
-   -- cargo pgrx install --release --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cd $PKGDIR && debmake \
+    -p $(cargo get package.name | sed 's/_/-/g') \
+    -u $(cargo get package.version) \
+    --native -x0 -i debuild
+
+RUN cp $PKGDIR/../*.deb /tmp
 
 ######################
 # pg_analytics
@@ -108,27 +127,20 @@ RUN checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pa
 FROM builder as builder-pg_analytics
 
 WORKDIR /tmp/pg_analytics
+ENV PKGDIR=/tmp/pg_analytics/deb-pkg
 
 COPY pg_analytics/ /tmp/pg_analytics
 COPY shared/ /tmp/shared
 
 # Use the build argument to update the version in Cargo.toml
-# Note: We require Rust nightly to build pg_analytics with SIMD support
-RUN rustup update nightly && \
-    rustup override set nightly && \
-    cargo install --locked cargo-pgrx --version 0.11.2 --force && \
-    cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config" --out-dir $PKGDIR
 
-# Use the build argument to update the version in Cargo.toml
-RUN cargo pgrx package --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cd $PKGDIR && debmake \
+    -p $(cargo get package.name | sed 's/_/-/g') \
+    -u $(cargo get package.version) \
+    --native -x0 -i debuild
 
-
-RUN checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
-    --exclude=/root/.cargo \
-    --pkgname $(cargo get package.name) \
-    --pkgversion $(cargo get package.version) \
-    --maintainer "ParadeDB <support@paradedb.com>" \
-    -- cargo pgrx install --release --features simd --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cp $PKGDIR/../*.deb /tmp
 
 ######################
 # pg_sparse
@@ -138,22 +150,28 @@ FROM builder as builder-pg_sparse
 WORKDIR /tmp/pg_sparse
 COPY pg_sparse/ /tmp/pg_sparse
 
+ENV PKGDIR=/tmp/pg_sparse/deb-pkg
+ENV PKGNAME=pg-sparse
+
 RUN make clean && \
     make USE_PGXS=1 OPTFLAGS="" -j && \
-    checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
-    --pkgname pg-sparse \
-    --pkgversion $(awk -F "= '|\''" '/default_version/ {print $2}' svector.control) \
-    --maintainer "ParadeDB <support@paradedb.com>" \
-    -- make USE_PGXS=1 install -j
+    make USE_PGXS=1 DESTDIR="$PKGDIR" install -j
+
+RUN cd $PKGDIR && debmake \
+    -p pg-sparse \
+    -u $(awk -F "= '|\'" '/default_version/ {print $2}' ../svector.control) \
+    --native -x0 -i debuild
+
+RUN cp $PKGDIR/../*.deb /tmp
 
 ######################
-# pgvector
+# additional extensions
 ######################
 
-FROM builder as builder-pgvector
+FROM builder as builder-ext-misc
 
-WORKDIR /tmp/extensions-deb
-RUN apt-get download postgresql-${PG_VERSION_MAJOR}-pgvector
+WORKDIR /tmp
+RUN apt-get update && apt-get download postgresql-${PG_VERSION_MAJOR}-pgvector
 
 ###############################################
 # Third Stage: PostgreSQL
@@ -171,7 +189,7 @@ LABEL io.artifacthub.package.readme-url="https://github.com/paradedb/paradedb/bl
 # Copy the ParadeDB extensions from their builder stages
 COPY --from=builder-pg_sparse /tmp/pg-sparse*.deb /tmp/extensions-deb/
 COPY --from=builder-pg_bm25 /tmp/pg-bm25*.deb /tmp/extensions-deb/
-COPY --from=builder-pgvector /tmp/pgvector*.deb /tmp/extensions-deb/
+COPY --from=builder-ext-misc /tmp/*.deb /tmp/extensions-deb/
 COPY --from=builder-pg_analytics /tmp/pg-analytics*.deb /tmp/extensions-deb/
 
 RUN dpkg -i /tmp/extensions-deb/*.deb \
@@ -187,5 +205,3 @@ RUN usermod -u 26 postgres \
     && chmod -R 700 /var/lib/postgresql
 
 USER 26
-
-FROM builder-pgvector as bb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,6 @@ ARG COMMIT_SHA
 ARG TELEMETRY
 ARG BUILD_DATE
 
-# This is used to checkout the correct branch on the pgvector repo
-ARG PGVECTOR_BRANCH=v0.5.1
-
 ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     POSTHOG_HOST=${POSTHOG_HOST} \
@@ -26,8 +23,6 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR} \
     BUILD_DATE=${BUILD_DATE} \
     DEBIAN_FRONTEND=noninteractive \
     TZ=UTC
-
-ENV PGVECTOR_BRANCH=${PGVECTOR_BRANCH}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -49,7 +44,7 @@ FROM base as builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Rust (specific version) and other build dependencies
-RUN apt update && apt install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     checkinstall \
     clang \
@@ -75,7 +70,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
 RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
-RUN apt update && apt install -y postgresql-server-dev-${PG_VERSION_MAJOR} \
+RUN apt-get update && apt-get install -y postgresql-server-dev-${PG_VERSION_MAJOR} \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.cargo/bin:$PATH" \
@@ -157,20 +152,8 @@ RUN make clean && \
 
 FROM builder as builder-pgvector
 
-RUN cd /tmp \
- && git clone --branch ${PGVECTOR_BRANCH} https://github.com/pgvector/pgvector.git
-
-WORKDIR /tmp/pgvector
-ENV PG_CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-compare"
-
-RUN echo "trusted = true" >> vector.control && \
-    make clean -j && \
-    make USE_PGXS=1 OPTFLAGS="" -j && \
-    checkinstall --default -D --nodoc --install=no --fstrans=no --backup=no --pakdir=/tmp \
-    --pkgname pgvector \
-    --pkgversion $(awk -F "= '|\''" '/default_version/ {print $2}' vector.control) \
-    --maintainer "Andrew Kane <andrew@ankane.org>" \
-    -- make USE_PGXS=1 install -j
+WORKDIR /tmp/extensions-deb
+RUN apt-get download postgresql-${PG_VERSION_MAJOR}-pgvector
 
 ###############################################
 # Third Stage: PostgreSQL
@@ -204,3 +187,5 @@ RUN usermod -u 26 postgres \
     && chmod -R 700 /var/lib/postgresql
 
 USER 26
+
+FROM builder-pgvector as bb


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR has introduces changes to the Dockerfile which can reduce the final image size by ~\~70%~ ~60%.

## Why

The latest Docker image (v0.5.2) is about 1.73GB due to dev dependencies being included inside the final image. This PR reduces the image to ~725MB.

## How

A brief overview of changes:

- Moved most of the dev dependencies from the `base` image to the `builder` image.
- Compile & package `pg_bm25`, `pg_sparse`, `pg_vector` and `pg_analytics` in their respective build stages.
- Generate `.deb` files for each build stage `checkinstall` and install them in the final image.