### PR TITLE
docs: Clarify branding for third-party tools, add link to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/paradedb/paradedb)](https://hub.docker.com/r/paradedb/paradedb)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/paradedb)](https://artifacthub.io/packages/search?repo=paradedb)
 
-[ParadeDB](https://paradedb.com) is an ElasticSearch alternative built on Postgres. We're building the features of ElasticSearch's product suite, starting with real-time search and analytics.
+[ParadeDB](https://paradedb.com) is an Elasticsearch alternative built on Postgres. We're building the features of Elasticsearch's product suite, starting with real-time search and analytics.
 
 ## Status
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,7 @@ This folder contains the results and scripts for benchmarking ParadeDB against o
 
 - [x] ParadeDB
 - [x] PostgreSQL tsquery/tsvector
-- [x] ElasticSearch
+- [x] Elasticsearch
 
 If you'd like to see benchmarks against another system, please open an issue or a pull request.
 
@@ -58,7 +58,7 @@ The versions of the systems used for benchmarking are:
 
 - ParadeDB: 0.2.18
 - PostgreSQL: 15.4
-- ElasticSearch: 8.9.2
+- Elasticsearch: 8.9.2
 
 For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ).
 

--- a/benchmarks/benchmark-elasticsearch.sh
+++ b/benchmarks/benchmark-elasticsearch.sh
@@ -32,12 +32,12 @@ trap cleanup EXIT
 
 echo ""
 echo "*******************************************************"
-echo "* Benchmarking ElasticSearch version: $ES_VERSION"
+echo "* Benchmarking Elasticsearch version: $ES_VERSION"
 echo "*******************************************************"
 echo ""
 
-# Download and run docker container for ElasticSearch
-echo "Creating ElasticSearch $ES_VERSION node..."
+# Download and run docker container for Elasticsearch
+echo "Creating Elasticsearch $ES_VERSION node..."
 docker network create elastic
 docker run \
   -d \
@@ -61,7 +61,7 @@ echo "Done!"
 
 # Produce and save password
 echo ""
-echo "Producing and saving new ElasticSearch password..."
+echo "Producing and saving new Elasticsearch password..."
 ELASTIC_PASSWORD=$(docker exec es01 /usr/share/elasticsearch/bin/elasticsearch-reset-password --batch -u elastic | grep "New value:" | awk '{print $3}')
 docker cp es01:/usr/share/elasticsearch/config/certs/http_ca.crt .
 echo "Done!"
@@ -76,8 +76,8 @@ for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""
   echo "Running benchmarking suite on index with $SIZE documents..."
 
-  # Convert data to be consumed by ElasticSearch
-  echo "-- Converting data to bulk format consumable by ElasticSearch..."
+  # Convert data to be consumed by Elasticsearch
+  echo "-- Converting data to bulk format consumable by Elasticsearch..."
   python3 helpers/elastify_data.py $WIKI_ARTICLES_FILE $ELASTIC_BULK_FOLDER "$SIZE"
 
   # Time indexing

--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -9,7 +9,7 @@ it is inefficient for analytical queries, which often scan a large amount of dat
 in a table.
 
 ParadeDB introduces special tables called `deltalake` tables. These tables behave like regular Postgres tables but
-use a column-oriented layout via Apache Arrow and Parquet and leverage Apache Datafusion, a query engine
+use a column-oriented layout via Apache Arrow and Parquet and leverage Apache DataFusion, a query engine
 optimized for column-oriented data.
 
 ## Using Deltalake Tables

--- a/docs/blog/introducing_analytics.mdx
+++ b/docs/blog/introducing_analytics.mdx
@@ -75,7 +75,7 @@ At the time of writing, `pg_analytics` is open source and in an MVP state. Almos
 basic operations like inserts and vacuums are supported. Our roadmap can be found in the project
 [README](https://github.com/paradedb/paradedb/tree/dev/pg_analytics).
 
-The easiest way to try `pg_analytics` is by running the ParadeDB Docker image. Once connected, you can follow
+The easiest way to try `pg_analytics` is by [running the ParadeDB Docker image](https://docs.paradedb.com/introduction#get-started). Once connected, you can follow
 this toy example.
 
 ```sql

--- a/docs/blog/introducing_analytics.mdx
+++ b/docs/blog/introducing_analytics.mdx
@@ -32,7 +32,7 @@ built and why now is an unprecedented time for building a Postgres-based analyti
 Regular Postgres tables, known as heap tables, organize data by row. While this makes sense for operational
 data, it is inefficient for analytical queries, which often scan a large amount of data from a subset of the
 columns in a table. `pg_analytics` solves this by integrating Apache Arrow, a column-oriented data format,
-and Apache Datafusion, an embeddable query engine for Arrow, within Postgres.
+and Apache DataFusion, an embeddable query engine for Arrow, within Postgres.
 
 The extension uses two features of the Postgres API — executor hooks and the table access method. The table
 access method is responsible for creating a new kind of table that can emit Arrow data batches and receive
@@ -51,7 +51,7 @@ The final dependency is `delta-rs`, a Rust-based implementation of Delta Lake. T
 transactions, updates and deletes, and file compaction to Parquet storage. It also supports querying over data
 lakes like S3, which introduces the future possibility connecting Postgres tables to cloud data lakes.
 
-## Why Datafusion
+## Why DataFusion
 
 The history of analytical databases in Postgres extends back to 2005 with a project called Greenplum. Since
 then, several companies like Citus and Timescale have released similar products.
@@ -60,8 +60,8 @@ Twenty years later, the performance gap between these databases and their non-Po
 is wide. This is one reason that systems like Elasticsearch are popular even among companies that prefer
 Postgres.
 
-Recently, embeddable query engines like Datafusion have changed the game by surpassing the
-query speed of many OLAP databases. Datafusion teases the idea of excellent analytical
+Recently, embeddable query engines like DataFusion have changed the game by surpassing the
+query speed of many OLAP databases. DataFusion teases the idea of excellent analytical
 performance from _any_ database — including Postgres.
 
 Andy Pavlo, professor of databases at Carnegie Mellon, [was right](https://youtu.be/Zx4caucPF7s?feature=shared&t=3006).
@@ -100,7 +100,7 @@ Finally, please don’t hesitate to show your support by [giving us a star](htt
 
 2. We also evaluated DuckDB, Polars, and Velox as candidates for an embedded query engine. DuckDB is a popular in-process
    OLAP database, Polars is a dataframe processing library built on Arrow, and Velox is a query execution
-   library built by Meta. Datafusion was chosen for three reasons. First, it interoperates with a storage framework
+   library built by Meta. DataFusion was chosen for three reasons. First, it interoperates with a storage framework
    like Delta Lake, which provides essential properties like ACID transactions. Secondly, its API was intended to
    be embedded inside another database, unlike standalone databases like Polars and DuckDB. Finally,
    it’s written in Rust and comes with a query parser and optimizer, unlike Velox.

--- a/docs/blog/introducing_bm25.mdx
+++ b/docs/blog/introducing_bm25.mdx
@@ -15,8 +15,8 @@ Today, Postgres' native full text search, which uses the `tsvector` type, has tw
 2. **Functionality**: Postgres has no support for operations like fuzzy search, relevance tuning, or
    BM25 relevance scoring, which are the bread and butter of modern search engines.
 
-`pg_bm25` aims to bridge the gap between the native capabilities of Postgres’ full text search and those of a specialized search engine like ElasticSearch.
-The goal is to eliminate the need to bring a cumbersome service like ElasticSearch into the data stack.
+`pg_bm25` aims to bridge the gap between the native capabilities of Postgres’ full text search and those of a specialized search engine like Elasticsearch.
+The goal is to eliminate the need to bring a cumbersome service like Elasticsearch into the data stack.
 
 Some features of `pg_bm25` include:
 
@@ -24,7 +24,7 @@ Some features of `pg_bm25` include:
 - Built on top of Tantivy, a Rust-based alternative to the Apache Lucene search library
 - Query times over 1M rows are 20x faster compared to `tsquery` and `ts_rank`, Postgres' built-in full text search and sort functions
 - Support for fuzzy search, aggregations, highlighting, and relevance tuning
-- Relevance scoring uses BM25, the same algorithm used by ElasticSearch
+- Relevance scoring uses BM25, the same algorithm used by Elasticsearch
 - Real-time search — new data is immediately searchable without manual reindexing
 
 `pg_bm25` stands on the shoulders of several open-source giants. The goal of this blog post is to recognize these projects
@@ -33,12 +33,12 @@ and to share how `pg_bm25` was built.
 ## The Shoulders of Giants
 
 Putting a search engine inside of Postgres is hard. A few projects have attempted it, but with one caveat: every
-single one has relied on an external ElasticSearch instance. This means introducing a
+single one has relied on an external Elasticsearch instance. This means introducing a
 complex and expensive piece of infrastructure into the data stack. Perhaps the best-known example of this kind of design
 is a Postgres extension called [ZomboDB](https://github.com/zombodb/zombodb).
 
 In 2016, an open source search library called [Tantivy](https://github.com/quickwit-oss/tantivy) emerged. Tantivy
-was designed as a Rust-based alternative to Apache Lucene, the search library that powers ElasticSearch.
+was designed as a Rust-based alternative to Apache Lucene, the search library that powers Elasticsearch.
 Three years later, a library called [pgrx](https://github.com/pgcentralfoundation/pgrx) — built by the same
 author of ZomboDB — made it possible to build Postgres extensions in Rust.
 Combined, these projects laid the groundwork for a Postgres extension that could create Elastic-quality
@@ -46,7 +46,7 @@ search experiences within Postgres.
 
 ## Creating the Inverted Index
 
-Like ElasticSearch, the backbone of Tantivy's search engine is a data structure called the inverted index,
+Like Elasticsearch, the backbone of Tantivy's search engine is a data structure called the inverted index,
 which stores a mapping from words to their locations in a set of documents. An inverted index
 is like the table of contents of a book — without it, you might have to examine every page to find
 a specific chapter.
@@ -86,8 +86,8 @@ WHERE my_table @@@ 'description:keyboard^2 OR electronics:::fuzzy_fields=descrip
 ## Performance Benchmarks
 
 On a table with one million rows, `pg_bm25` indexes 50 seconds faster than `tsvector` and ranks results
-20x faster. Indexing and search times are nearly identical to those of a dedicated ElasticSearch instance.
-With further optimizations, we're aiming to reduce the query times compared to ElasticSearch
+20x faster. Indexing and search times are nearly identical to those of a dedicated Elasticsearch instance.
+With further optimizations, we're aiming to reduce the query times compared to Elasticsearch
 by an additional 2x.
 
 More detailed benchmark results can be found in the [README](https://github.com/paradedb/paradedb/blob/dev/benchmarks/README.md).

--- a/docs/blog/introducing_paradedb.mdx
+++ b/docs/blog/introducing_paradedb.mdx
@@ -5,12 +5,12 @@ title: Introducing ParadeDB
 <img height="300" src="/blog/images/paradedb.png" noZoom />
 
 We’re excited to announce ParadeDB: a PostgreSQL database optimized for search.
-ParadeDB is the first Postgres database built to be an ElasticSearch alternative, engineered for lightning-fast full
+ParadeDB is the first Postgres database built to be an Elasticsearch alternative, engineered for lightning-fast full
 text, semantic, and hybrid search over Postgres tables.
 
 ## Why We Built ParadeDB
 
-For many organizations, search remains an unsolved problem. Despite the existence of giants like ElasticSearch, most developers who have worked with ElasticSearch know how incredibly painful it is to run, tune, and manage. While alternative search engines exist, gluing these external services on top of an existing database introduces the headache and costs of reindexing and duplicating data.
+For many organizations, search remains an unsolved problem. Despite the existence of giants like Elasticsearch, most developers who have worked with Elasticsearch know how incredibly painful it is to run, tune, and manage. While alternative search engines exist, gluing these external services on top of an existing database introduces the headache and costs of reindexing and duplicating data.
 
 Many developers seeking a unified source of truth and search engine turn towards Postgres, which offers basic full text search via `tsvector` and semantic search via `pgvector`. These tools may work for simple use cases and medium-sized datasets, but break down when tables get large or queries become complex:
 
@@ -20,14 +20,14 @@ Many developers seeking a unified source of truth and search engine turn towards
 4. No real-time search — data must manually be re-indexed or re-embedded
 5. Limited support for complex queries like faceting or relevance tuning
 
-By now, we’ve witnessed dozens of engineering teams who have begrudgingly stitched ElasticSearch on top of Postgres,
+By now, we’ve witnessed dozens of engineering teams who have begrudgingly stitched Elasticsearch on top of Postgres,
 only to ditch it later because it was too bloated, expensive, or convoluted. We asked ourselves: what if Postgres
 itself was built for Elastic-quality search? What if developers didn’t need to choose between one unified Postgres database
 with limited search capabilities or two separate services, one as the source of truth and one as the search engine?
 
 ## Who ParadeDB is For
 
-ElasticSearch has many use cases, and we aren’t trying to tackle all of them — at least not yet. Instead, we’re focused
+Elasticsearch has many use cases, and we aren’t trying to tackle all of them — at least not yet. Instead, we’re focused
 on nailing a core set of use cases for Postgres users that want to search over their database. ParadeDB is a good fit
 for you if:
 

--- a/docs/blog/introducing_paradedb_cloud.mdx
+++ b/docs/blog/introducing_paradedb_cloud.mdx
@@ -17,7 +17,7 @@ Some features of ParadeDB we’re particularly excited about include:
 
 - 100% Postgres-native, with zero dependencies on an external search engine
 - Query times over 1M rows are 20x faster compared to `tsquery` and `ts_rank`, Postgres’ built-in full text search and sort functions
-- Relevance scoring uses BM25, the same algorithm used by ElasticSearch
+- Relevance scoring uses BM25, the same algorithm used by Elasticsearch
 - Support for custom tokenizers, relevance tuning, and fuzzy search
 
 ParadeDB Cloud offers all the capabilities of ParadeDB, plus

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -13,11 +13,11 @@ ships with Postgres 16.
 ## Why ParadeDB
 
 Today, developers implementing search and analytics over Postgres face one of two options: adopt an external
-service like ElasticSearch, which is powerful but painful to run, tune, and sync, or use Postgres’ native
+service like Elasticsearch, which is powerful but painful to run, tune, and sync, or use Postgres’ native
 search and aggregations, which lack functionality and perform poorly over large datasets.
 
 ParadeDB aims to be the best of both worlds, providing developers with the familiarity of Postgres and the
-performance of ElasticSearch. It's a drop-in solution for fast search and analytics without the need to
+performance of Elasticsearch. It's a drop-in solution for fast search and analytics without the need to
 extract, transform, and load (ETL) data to a non-Postgres system.
 
 ParadeDB is a good fit for:

--- a/docs/search/indexing/bm25.mdx
+++ b/docs/search/indexing/bm25.mdx
@@ -4,7 +4,7 @@ title: BM25 Index
 
 ## What is BM25?
 
-BM25, which stands for Best Matching 25, is the go-to choice for many modern search engines like ElasticSearch.
+BM25, which stands for Best Matching 25, is the go-to choice for many modern search engines like Elasticsearch.
 It ranks documents by considering how often a term appears and how unique that term is across all
 documents. BM25 is especially useful when you need to find exact keywords or phrases within documents.
 

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -10,14 +10,14 @@
 The primary dependencies are:
 
 - [x] [Apache Arrow](https://github.com/apache/arrow) for column-oriented memory format
-- [x] [Apache Datafusion](https://github.com/apache/arrow-datafusion) for vectorized query execution with SIMD
+- [x] [Apache DataFusion](https://github.com/apache/arrow-datafusion) for vectorized query execution with SIMD
 - [x] [Apache Parquet](https://github.com/apache/parquet-mr/) for persistence
 - [x] [Delta Lake](https://github.com/delta-io/delta-rs) as a storage framework with ACID properties
 - [x] [pgrx](https://github.com/pgcentralfoundation/pgrx), the framework for creating Postgres extensions in Rust
 
 ## Benchmarks
 
-With `pg_analytics` installed, ParadeDB is the fastest Postgres-based analytical database and outperforms many specialized OLAP systems. On Clickbench, ParadeDB is 94x faster than regular Postgres, 8x faster than ElasticSearch, and almost ties Clickhouse.
+With `pg_analytics` installed, ParadeDB is the fastest Postgres-based analytical database and outperforms many specialized OLAP systems. On Clickbench, ParadeDB is 94x faster than regular Postgres, 8x faster than Elasticsearch, and almost ties Clickhouse.
 
 <img src="../docs/images/clickbench_results.png" alt="Clickbench Results" width="1000px">
 
@@ -80,7 +80,7 @@ As `pg_analytics` becomes production-ready, many of these will be resolved.
 
 ## How It Works
 
-`pg_analytics` introduces column-oriented storage and vectorized query execution to Postgres via Apache Parquet, Arrow, and Datafusion. These libraries are the building blocks of many modern analytical databases.
+`pg_analytics` introduces column-oriented storage and vectorized query execution to Postgres via Apache Parquet, Arrow, and DataFusion. These libraries are the building blocks of many modern analytical databases.
 
 ### Column-Oriented Storage
 
@@ -92,7 +92,7 @@ Vectorized query execution is a technique that takes advantage of modern CPUs to
 
 ### Postgres Integration
 
-`pg_analytics` embeds Arrow, Parquet, and Datafusion inside Postgres via executor hooks and the table access method API. Executor hooks intercept queries to these tables and reroute them to Datafusion, which generates an optimized query plan, executes the query, and sends the results back to Postgres. The table access method persists Postgres tables as Parquet files and registers them with Postgres' system catalogs. The Parquet files are managed by Delta Lake, which provides ACID transactions.
+`pg_analytics` embeds Arrow, Parquet, and DataFusion inside Postgres via executor hooks and the table access method API. Executor hooks intercept queries to these tables and reroute them to DataFusion, which generates an optimized query plan, executes the query, and sends the results back to Postgres. The table access method persists Postgres tables as Parquet files and registers them with Postgres' system catalogs. The Parquet files are managed by Delta Lake, which provides ACID transactions.
 
 ## Development
 

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -113,7 +113,7 @@ unsafe fn send_tuples_if_necessary(
     let receive = (*dest).receiveSlot.ok_or_else(|| ParadeError::NotFound)?;
 
     for (row_number, recordbatch) in batches.iter().enumerate() {
-        // Convert the tuple_desc target types to the ones corresponding to the Datafusion column types
+        // Convert the tuple_desc target types to the ones corresponding to the DataFusion column types
         let tuple_attrs = (*(*query_desc).tupDesc).attrs.as_mut_ptr();
         for (col_index, _attr) in tuple_desc.iter().enumerate() {
             let dt = recordbatch.column(col_index).data_type();

--- a/pg_analytics/src/tableam/insert.rs
+++ b/pg_analytics/src/tableam/insert.rs
@@ -81,7 +81,7 @@ fn insert_tuples(
     let tuple_desc = pg_relation.tuple_desc();
     let mut values: Vec<ArrayRef> = vec![];
 
-    // Convert the TupleTableSlots into Datafusion arrays
+    // Convert the TupleTableSlots into DataFusion arrays
     for (col_idx, attr) in tuple_desc.iter().enumerate() {
         values.push(DatafusionMapProducer::array(
             attr.type_oid().to_sql_data_type(attr.type_mod())?,

--- a/pg_analytics/src/tableam/plan.rs
+++ b/pg_analytics/src/tableam/plan.rs
@@ -1,5 +1,5 @@
 /*
-    Storage and plan cost estimates are handled by Datafusion.
+    Storage and plan cost estimates are handled by DataFusion.
     These functions should never be called.
 */
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Chris Riccomini suggested we link to the Quickstart for our blog post, so I did.

I also fixed ElasticSearch to Elasticsearch, which is how Elastic itself calls their product, and Datafusion to DataFusion, which is how DataFusion calls their product.

## Why

## How

## Tests
