### PR TITLE
fix: Re-enable extension upgrade test, this time for PG16 onwards

### DIFF
--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -123,8 +123,7 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_analytics/test/
         run: |
-          # TODO: Replace dev by main once done testing
-          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -123,9 +123,8 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_analytics/test/
         run: |
-          # TODO: Reenable the extension upgrade test once we fix for PG16
-          # if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "false" ]]; then
+          # TODO: Replace dev by main once done testing
+          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -122,9 +122,8 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_bm25/test/
         run: |
-          # TODO: Reenable the extension upgrade test once we fix for PG16
-          # if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
-          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "false" ]]; then
+          # TODO: Replace dev by main once done testing
+          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -122,8 +122,7 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_bm25/test/
         run: |
-          # TODO: Replace dev by main once done testing
-          if [[ "${{ github.base_ref }}" == "dev" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" && "${{ matrix.pg_version }}" == "${{ env.default_pg_version }}" ]]; then
             # Retrieve the version to test upgrading to
             if [[ "${{ github.event.inputs.test_upgrade_version }}" == "" ]]; then
               echo "New version not provided, assuming the next release is incrementing patch..."

--- a/pg_analytics/test/runtests.sh
+++ b/pg_analytics/test/runtests.sh
@@ -196,8 +196,8 @@ function run_tests() {
     # Don't send telemetry when running tests
     export TELEMETRY=false
 
-    # First, download & install the first release at which we started supporting upgrades (v0.5.0)
-    BASE_RELEASE="0.3.3"
+    # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
+    BASE_RELEASE="0.5.2"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL"
     sudo dpkg -i "pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"

--- a/pg_analytics/test/runtests.sh
+++ b/pg_analytics/test/runtests.sh
@@ -198,7 +198,7 @@ function run_tests() {
 
     # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
     BASE_RELEASE="0.5.2"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-ubuntu2204.deb"
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"    
     curl -LOJ "$DOWNLOAD_URL"
     sudo dpkg -i "pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"
 

--- a/pg_analytics/test/runtests.sh
+++ b/pg_analytics/test/runtests.sh
@@ -198,7 +198,7 @@ function run_tests() {
 
     # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
     BASE_RELEASE="0.5.2"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"    
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL"
     sudo dpkg -i "pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"
 

--- a/pg_bm25/test/runtests.sh
+++ b/pg_bm25/test/runtests.sh
@@ -174,8 +174,8 @@ function run_tests() {
     # Don't send telemetry when running tests
     export TELEMETRY=false
 
-    # First, download & install the first release at which we started supporting upgrades (v0.3.3)
-    BASE_RELEASE="0.3.3"
+    # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
+    BASE_RELEASE="0.5.2"
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
     sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-amd64-ubuntu2204.deb" > /dev/null


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I had disabled it since it was broken due to the switch to PG16. The reason is: Our test pulls a previous version of the extension pre-compiled from a past GitHub Release, installs it, then upgrades to the current branch. Since we had just pushed our first PG16 extension, and you can't upgrade from PG15 to PG16 without directly installing a brand new version of the extension compiled for PG16, I had nothing to test installing it against. Now that we've had a few releases, we can do it.

## Why
^

## How
^

## Tests
^