### PR TITLE
chore: Confirm strong consistency

### DIFF
--- a/docs/search/indexing/overview.mdx
+++ b/docs/search/indexing/overview.mdx
@@ -16,6 +16,4 @@ the HNSW index for dense vector search, and the sparse HNSW index for sparse vec
 
 Once an index is created, it will automatically stay in sync with the underlying table data, and
 does not need to be re-created unless the table schema changes (for instance, if a column is renamed or deleted).
-To not slow down transactions while indexing, indexes follow _weak consistency_, meaning that they are updated
-automatically in the background after a transaction commits, and become consistent soon after (although your
-mileage may vary depending on the size of your transaction(s)).
+ParadeDB is ACID-compliant, meaning the search indexes follow _strong consistency_.

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -104,7 +104,7 @@ To develop the extension, first install Rust v1.73.0 using `rustup`. We will soo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup install 1.73.0
 
-# We recommend setting the default version for consistency
+# We recommend setting the default version to 1.73.0 for consistency across your system
 rustup default 1.73.0
 ```
 

--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -148,7 +148,7 @@ To develop the extension, first install Rust v1.73.0 using `rustup`. We will soo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup install 1.73.0
 
-# We recommend setting the default version for consistency
+# We recommend setting the default version to 1.73.0 for consistency across your system
 rustup default 1.73.0
 ```
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #390

## What
We used to be weakly consistent, because we did not want to slow down transactions. This was when we thought customers would primarily run `pg_bm25` in their own database. Now that we expect ParadeDB to be a separate search node to production database(s), we've updated our work thanks to @neilyio to be strongly consistent. This was a lingering issue which I am now closing by fixing the documentation.

We no longer plan to give users the ability to choose the consistency mode, since we don't recommend runnings your search node directly within your primary Postgres.

## Why
^

## How
^

## Tests
^