### PR TITLE
chore: Don't fail on Codecov error

### DIFF
--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -161,4 +161,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/
           files: lcov
-          fail_ci_if_error: true
+          fail_ci_if_error: false # Don't fail on error, it's usually due to a Codecov network issue

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -160,4 +160,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/
           files: lcov
-          fail_ci_if_error: true
+          fail_ci_if_error: false # Don't fail on error, it's usually due to a Codecov network issue


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Things like this happen: https://github.com/paradedb/paradedb/actions/runs/7732130732/job/21081359494

And it's because Codecov has network issues. Let's not fail our own CI for that.

## Why

## How

## Tests
