### PR TITLE
fix: Only generate profraw in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,10 +8,6 @@ rustflags = ["-Ctarget-cpu=native"]
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 
-# Enable code coverage on Linux only, for CI builds
-[target.'cfg(target_os="linux")']
-rustflags = ["-Cinstrument-coverage"]
-
 # Enable Cargo-based benchmarks
 [alias]
 clickbench = "run --bin clickbench --"

--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -145,8 +145,11 @@ jobs:
         env:
           LLVM_PROFILE_FILE: target/coverage/pg_analytics-%p-%m.profraw
           RUST_BACKTRACE: full
-          RUSTFLAGS: "-Clink-arg=-Wl,-undefined,dynamic_lookup -Ctarget-cpu=native -Cinstrument-coverage" # Enable code coverage
         run: |
+          # Add the code coverage flags to the config.toml file
+          echo -e "\n# Enable code coverage on Linux only, for CI builds\n[target.'cfg(target_os=\"linux\")']\nrustflags = [\"-Cinstrument-coverage\"]" >> ../.cargo/config.toml
+
+          # Run tests with coverage
           mkdir -p ../target/coverage ../target/coverage-report
           cargo pgrx test --profile dev pg${{ matrix.pg_version }}
 

--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -145,6 +145,7 @@ jobs:
         env:
           LLVM_PROFILE_FILE: target/coverage/pg_analytics-%p-%m.profraw
           RUST_BACKTRACE: full
+          RUSTFLAGS: "-Clink-arg=-Wl,-undefined,dynamic_lookup -Ctarget-cpu=native -Cinstrument-coverage" # Enable code coverage
         run: |
           mkdir -p ../target/coverage ../target/coverage-report
           cargo pgrx test --profile dev pg${{ matrix.pg_version }}
@@ -156,7 +157,7 @@ jobs:
 
       - name: Upload Coverage Reports to Codecov
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == env.default_pg_version
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -144,8 +144,11 @@ jobs:
         env:
           LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
           RUST_BACKTRACE: full
-          RUSTFLAGS: "-Clink-arg=-Wl,-undefined,dynamic_lookup -Ctarget-cpu=native -Cinstrument-coverage" # Enable code coverage
         run: |
+          # Add the code coverage flags to the config.toml file
+          echo -e "\n# Enable code coverage on Linux only, for CI builds\n[target.'cfg(target_os=\"linux\")']\nrustflags = [\"-Cinstrument-coverage\"]" >> ../.cargo/config.toml
+
+          # Run tests with coverage
           mkdir -p ../target/coverage ../target/coverage-report
           cargo pgrx test --features icu pg${{ matrix.pg_version }} --profile dev
 

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -144,6 +144,7 @@ jobs:
         env:
           LLVM_PROFILE_FILE: target/coverage/pg_bm25-%p-%m.profraw
           RUST_BACKTRACE: full
+          RUSTFLAGS: "-Clink-arg=-Wl,-undefined,dynamic_lookup -Ctarget-cpu=native -Cinstrument-coverage" # Enable code coverage
         run: |
           mkdir -p ../target/coverage ../target/coverage-report
           cargo pgrx test --features icu pg${{ matrix.pg_version }} --profile dev
@@ -155,7 +156,7 @@ jobs:
 
       - name: Upload Coverage Reports to Codecov
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version == env.default_pg_version
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./target/coverage-report/


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #809

## What
Only generate code coverage in CI, to avoid it clogging the local folders/builds

## Why
^

## How
Moved the `Cinstrument-coverage` to the CI, instead of the `.cargo/config.toml` file

## Tests
Need to check that it still properly generates the code coverage