### PR TITLE
feat: Hybrid queries (DRAFT)

### DIFF
--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -32,7 +32,7 @@ pub fn executor_run(
         let rtable = (*ps).rtable;
 
         // Only use this hook for deltalake tables
-        if rtable.is_null() {
+        if rtable.is_null() || !DeltaHandler::rtable_is_delta(rtable)? {
             prev_hook(query_desc, direction, count, execute_once);
             return Ok(());
         }

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -32,7 +32,7 @@ pub fn executor_run(
         let rtable = (*ps).rtable;
 
         // Only use this hook for deltalake tables
-        if rtable.is_null() || !DeltaHandler::rtable_is_delta(rtable)? {
+        if rtable.is_null() {
             prev_hook(query_desc, direction, count, execute_once);
             return Ok(());
         }

--- a/pg_analytics/src/hooks/handler.rs
+++ b/pg_analytics/src/hooks/handler.rs
@@ -19,7 +19,6 @@ impl DeltaHandler {
         #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         let elements = (*rtable).elements;
 
-        let mut using_noncol: bool = false;
         let mut using_col: bool = false;
 
         for i in 0..(*rtable).length {
@@ -45,22 +44,9 @@ impl DeltaHandler {
 
             let relation_handler_oid = (*relation).rd_amhandler;
 
-            // If any table uses the Table AM handler, then return true.
-            // TODO: If we support more operations, this will be more complex.
-            //       for example, if to support joins, some of the nodes will use
-            //       table AM for the nodes while others won't. In this case,
-            //       we'll have to process in postgres plan for part of it and
-            //       datafusion for the other part. For now, we'll simply
-            //       fail if we encounter an unsupported node, so this won't happen.
             if relation_handler_oid == oid {
                 using_col = true;
-            } else {
-                using_noncol = true;
             }
-        }
-
-        if using_col && using_noncol {
-            return Err(NotSupported::MixedTables.into());
         }
 
         Ok(using_col)

--- a/pg_analytics/src/indexam/build.rs
+++ b/pg_analytics/src/indexam/build.rs
@@ -26,7 +26,7 @@ pub extern "C" fn ambuild(
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
     let schema_name = pg_relation.namespace();
 
-    DatafusionContext::with_schema_provider(schema_name, |provider| {
+    let _ = DatafusionContext::with_schema_provider(schema_name, |provider| {
         task::block_on(provider.create_table(&pg_relation))
     });
 
@@ -90,8 +90,8 @@ unsafe extern "C" fn build_callback(
 
 #[inline(always)]
 unsafe fn build_callback_internal(
-    ctid: pg_sys::ItemPointerData,
-    values: *mut pg_sys::Datum,
+    _ctid: pg_sys::ItemPointerData,
+    _values: *mut pg_sys::Datum,
     _state: *mut std::os::raw::c_void,
     index: pg_sys::Relation,
 ) {

--- a/pg_analytics/src/indexam/build.rs
+++ b/pg_analytics/src/indexam/build.rs
@@ -1,0 +1,137 @@
+use async_std::task;
+use deltalake::datafusion::common::arrow::array::ArrayRef;
+use pgrx::*;
+use std::panic;
+
+use crate::datafusion::context::DatafusionContext;
+use crate::datafusion::datatype::{DatafusionMapProducer, PostgresTypeTranslator};
+
+struct BuildState {
+    count: usize,
+}
+
+impl BuildState {
+    fn new() -> Self {
+        BuildState { count: 0 }
+    }
+}
+
+#[pg_guard]
+pub extern "C" fn ambuild(
+    heaprel: pg_sys::Relation,
+    indexrel: pg_sys::Relation,
+    index_info: *mut pg_sys::IndexInfo,
+) -> *mut pg_sys::IndexBuildResult {
+    let pg_relation = unsafe { PgRelation::from_pg(heaprel) };
+    let index_relation = unsafe { PgRelation::from_pg(indexrel) };
+    let schema_name = pg_relation.namespace();
+
+    DatafusionContext::with_schema_provider(schema_name, |provider| {
+        task::block_on(provider.create_table(&pg_relation))
+    });
+
+    let state = do_heap_scan(index_info, &pg_relation, &index_relation);
+
+    let mut result = unsafe { PgBox::<pg_sys::IndexBuildResult>::alloc0() };
+    result.heap_tuples = state.count as f64;
+    result.index_tuples = state.count as f64;
+
+    result.into_pg()
+}
+
+#[pg_guard]
+pub extern "C" fn ambuildempty(_index_relation: pg_sys::Relation) {}
+
+fn do_heap_scan<'a>(
+    index_info: *mut pg_sys::IndexInfo,
+    heap_relation: &'a PgRelation,
+    index_relation: &'a PgRelation,
+) -> BuildState {
+    let mut state = BuildState::new();
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| unsafe {
+        pg_sys::IndexBuildHeapScan(
+            heap_relation.as_ptr(),
+            index_relation.as_ptr(),
+            index_info,
+            Some(build_callback),
+            &mut state,
+        );
+    }));
+    state
+}
+
+#[cfg(feature = "pg12")]
+#[pg_guard]
+unsafe extern "C" fn build_callback(
+    index: pg_sys::Relation,
+    htup: pg_sys::HeapTuple,
+    values: *mut pg_sys::Datum,
+    _isnull: *mut bool,
+    _tuple_is_alive: bool,
+    state: *mut std::os::raw::c_void,
+) {
+    let htup = htup.as_ref().unwrap();
+
+    build_callback_internal(htup.t_self, values, state, index);
+}
+
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[pg_guard]
+unsafe extern "C" fn build_callback(
+    index: pg_sys::Relation,
+    ctid: pg_sys::ItemPointer,
+    values: *mut pg_sys::Datum,
+    _isnull: *mut bool,
+    _tuple_is_alive: bool,
+    state: *mut std::os::raw::c_void,
+) {
+    build_callback_internal(*ctid, values, state, index);
+}
+
+#[inline(always)]
+unsafe fn build_callback_internal(
+    ctid: pg_sys::ItemPointerData,
+    values: *mut pg_sys::Datum,
+    _state: *mut std::os::raw::c_void,
+    index: pg_sys::Relation,
+) {
+    check_for_interrupts!();
+
+    let index_relation = PgRelation::from_pg(index);
+
+    let typid = index_relation
+        .tuple_desc()
+        .get(0)
+        .expect("no attribute #0 on tupledesc")
+        .type_oid()
+        .value();
+    let typmod = index_relation
+        .tuple_desc()
+        .get(0)
+        .expect("no attribute #0 on tupledesc")
+        .type_mod();
+
+    // lookup the tuple descriptor for the rowtype we're *indexing*, rather than
+    // using the tuple descriptor for the index definition itself
+    let tuple_desc = PgMemoryContexts::TopTransactionContext.switch_to(|_| {
+        PgTupleDesc::from_pg_is_copy(pg_sys::lookup_rowtype_tupdesc_copy(typid, typmod))
+    });
+
+    let mut tuple_table_slot =
+        pg_sys::MakeTupleTableSlot(tuple_desc.clone().into_pg(), &pg_sys::TTSOpsVirtual);
+    let mut values: Vec<ArrayRef> = vec![];
+
+    for (col_idx, attr) in tuple_desc.iter().enumerate() {
+        values.push(
+            DatafusionMapProducer::array(
+                attr.type_oid().to_sql_data_type(attr.type_mod()).unwrap(),
+                &mut tuple_table_slot,
+                1,
+                col_idx,
+            )
+            .unwrap(),
+        );
+    }
+
+    info!("values: {:?}", values);
+}

--- a/pg_analytics/src/indexam/cost.rs
+++ b/pg_analytics/src/indexam/cost.rs
@@ -1,0 +1,15 @@
+use pgrx::*;
+
+#[allow(clippy::too_many_arguments)]
+#[pg_guard(immutable, parallel_safe)]
+pub unsafe extern "C" fn amcostestimate(
+    _root: *mut pg_sys::PlannerInfo,
+    path: *mut pg_sys::IndexPath,
+    _loop_count: f64,
+    index_startup_cost: *mut pg_sys::Cost,
+    index_total_cost: *mut pg_sys::Cost,
+    index_selectivity: *mut pg_sys::Selectivity,
+    index_correlation: *mut f64,
+    index_pages: *mut f64,
+) {
+}

--- a/pg_analytics/src/indexam/cost.rs
+++ b/pg_analytics/src/indexam/cost.rs
@@ -4,12 +4,12 @@ use pgrx::*;
 #[pg_guard(immutable, parallel_safe)]
 pub unsafe extern "C" fn amcostestimate(
     _root: *mut pg_sys::PlannerInfo,
-    path: *mut pg_sys::IndexPath,
+    _path: *mut pg_sys::IndexPath,
     _loop_count: f64,
-    index_startup_cost: *mut pg_sys::Cost,
-    index_total_cost: *mut pg_sys::Cost,
-    index_selectivity: *mut pg_sys::Selectivity,
-    index_correlation: *mut f64,
-    index_pages: *mut f64,
+    _index_startup_cost: *mut pg_sys::Cost,
+    _index_total_cost: *mut pg_sys::Cost,
+    _index_selectivity: *mut pg_sys::Selectivity,
+    _index_correlation: *mut f64,
+    _index_pages: *mut f64,
 ) {
 }

--- a/pg_analytics/src/indexam/delete.rs
+++ b/pg_analytics/src/indexam/delete.rs
@@ -1,0 +1,20 @@
+use pgrx::*;
+
+#[pg_guard]
+pub extern "C" fn ambulkdelete(
+    info: *mut pg_sys::IndexVacuumInfo,
+    stats: *mut pg_sys::IndexBulkDeleteResult,
+    callback: pg_sys::IndexBulkDeleteCallback,
+    callback_state: *mut ::std::os::raw::c_void,
+) -> *mut pg_sys::IndexBulkDeleteResult {
+    let mut stats = unsafe { PgBox::from_pg(stats) };
+    if stats.is_null() {
+        stats = unsafe {
+            PgBox::from_pg(
+                pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast(),
+            )
+        };
+    }
+
+    stats.into_pg()
+}

--- a/pg_analytics/src/indexam/delete.rs
+++ b/pg_analytics/src/indexam/delete.rs
@@ -2,10 +2,10 @@ use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn ambulkdelete(
-    info: *mut pg_sys::IndexVacuumInfo,
+    _info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
-    callback: pg_sys::IndexBulkDeleteCallback,
-    callback_state: *mut ::std::os::raw::c_void,
+    _callback: pg_sys::IndexBulkDeleteCallback,
+    _callback_state: *mut ::std::os::raw::c_void,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
     let mut stats = unsafe { PgBox::from_pg(stats) };
     if stats.is_null() {

--- a/pg_analytics/src/indexam/insert.rs
+++ b/pg_analytics/src/indexam/insert.rs
@@ -4,10 +4,10 @@ use pgrx::*;
 #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
-    index_relation: pg_sys::Relation,
-    values: *mut pg_sys::Datum,
+    _index_relation: pg_sys::Relation,
+    _values: *mut pg_sys::Datum,
     _isnull: *mut bool,
-    heap_tid: pg_sys::ItemPointer,
+    _heap_tid: pg_sys::ItemPointer,
     _heap_relation: pg_sys::Relation,
     _check_unique: pg_sys::IndexUniqueCheck,
     _index_unchanged: bool,

--- a/pg_analytics/src/indexam/insert.rs
+++ b/pg_analytics/src/indexam/insert.rs
@@ -1,0 +1,31 @@
+use pgrx::*;
+
+#[allow(clippy::too_many_arguments)]
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[pg_guard]
+pub unsafe extern "C" fn aminsert(
+    index_relation: pg_sys::Relation,
+    values: *mut pg_sys::Datum,
+    _isnull: *mut bool,
+    heap_tid: pg_sys::ItemPointer,
+    _heap_relation: pg_sys::Relation,
+    _check_unique: pg_sys::IndexUniqueCheck,
+    _index_unchanged: bool,
+    _index_info: *mut pg_sys::IndexInfo,
+) -> bool {
+    true
+}
+
+#[cfg(any(feature = "pg12", feature = "pg13"))]
+#[pg_guard]
+pub unsafe extern "C" fn aminsert(
+    index_relation: pg_sys::Relation,
+    values: *mut pg_sys::Datum,
+    _isnull: *mut bool,
+    heap_tid: pg_sys::ItemPointer,
+    _heap_relation: pg_sys::Relation,
+    _check_unique: pg_sys::IndexUniqueCheck,
+    _index_info: *mut pg_sys::IndexInfo,
+) -> bool {
+    true
+}

--- a/pg_analytics/src/indexam/mod.rs
+++ b/pg_analytics/src/indexam/mod.rs
@@ -1,0 +1,46 @@
+use pgrx::*;
+
+mod build;
+mod cost;
+mod delete;
+mod insert;
+mod options;
+mod scan;
+mod vacuum;
+mod validate;
+
+#[pg_extern(sql = "
+    CREATE FUNCTION deltalake_indexam_handler(internal) RETURNS index_am_handler PARALLEL SAFE IMMUTABLE STRICT COST 0.0001 LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+    CREATE ACCESS METHOD deltalakeindex TYPE INDEX HANDLER deltalake_indexam_handler;
+    COMMENT ON ACCESS METHOD deltalakeindex IS 'deltalake index access method';
+
+    CREATE OPERATOR CLASS deltalakeindex_ops DEFAULT FOR TYPE anyelement USING deltalakeindex AS
+        STORAGE anyelement;
+")]
+fn deltalake_indexam_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutine> {
+    let mut amroutine =
+        unsafe { PgBox::<pg_sys::IndexAmRoutine>::alloc_node(pg_sys::NodeTag::T_IndexAmRoutine) };
+
+    amroutine.amstrategies = 4;
+    amroutine.amsupport = 0;
+    amroutine.amcanmulticol = true;
+    amroutine.amsearcharray = true;
+
+    amroutine.amkeytype = pg_sys::InvalidOid;
+
+    amroutine.amvalidate = Some(validate::amvalidate);
+    amroutine.ambuild = Some(build::ambuild);
+    amroutine.ambuildempty = Some(build::ambuildempty);
+    amroutine.aminsert = Some(insert::aminsert);
+    amroutine.ambulkdelete = Some(delete::ambulkdelete);
+    amroutine.amvacuumcleanup = Some(vacuum::amvacuumcleanup);
+    amroutine.amcostestimate = Some(cost::amcostestimate);
+    amroutine.amoptions = Some(options::amoptions);
+    amroutine.ambeginscan = Some(scan::ambeginscan);
+    amroutine.amrescan = Some(scan::amrescan);
+    amroutine.amgettuple = Some(scan::amgettuple);
+    amroutine.amgetbitmap = None;
+    amroutine.amendscan = Some(scan::amendscan);
+
+    amroutine.into_pg_boxed()
+}

--- a/pg_analytics/src/indexam/options.rs
+++ b/pg_analytics/src/indexam/options.rs
@@ -1,0 +1,75 @@
+use pgrx::*;
+
+const NUM_REL_OPTS: usize = 0;
+static mut RELOPT_KIND_DELTALAKE: pg_sys::relopt_kind = 0;
+
+// Postgres handles string options by placing each option offset bytes from the start of rdopts and
+// plops the offset in the struct
+#[repr(C)]
+pub struct SearchIndexCreateOptions {
+    // varlena header (needed bc postgres treats this as bytea)
+    vl_len_: i32,
+}
+
+#[pg_guard]
+pub unsafe extern "C" fn amoptions(
+    reloptions: pg_sys::Datum,
+    validate: bool,
+) -> *mut pg_sys::bytea {
+    let options: [pg_sys::relopt_parse_elt; NUM_REL_OPTS] = [];
+    build_relopts(reloptions, validate, options)
+}
+
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+unsafe fn build_relopts(
+    reloptions: pg_sys::Datum,
+    validate: bool,
+    options: [pg_sys::relopt_parse_elt; NUM_REL_OPTS],
+) -> *mut pg_sys::bytea {
+    let rdopts = pg_sys::build_reloptions(
+        reloptions,
+        validate,
+        RELOPT_KIND_DELTALAKE,
+        std::mem::size_of::<SearchIndexCreateOptions>(),
+        options.as_ptr(),
+        NUM_REL_OPTS as i32,
+    );
+
+    rdopts as *mut pg_sys::bytea
+}
+
+#[cfg(feature = "pg12")]
+unsafe fn build_relopts(
+    reloptions: pg_sys::Datum,
+    validate: bool,
+    options: [pg_sys::relopt_parse_elt; NUM_REL_OPTS],
+) -> *mut pg_sys::bytea {
+    let mut n_options = 0;
+    let p_options =
+        pg_sys::parseRelOptions(reloptions, validate, RELOPT_KIND_DELTALAKE, &mut n_options);
+    if n_options == 0 {
+        return std::ptr::null_mut();
+    }
+
+    for relopt in std::slice::from_raw_parts_mut(p_options, n_options as usize) {
+        relopt.gen.as_mut().unwrap().lockmode = pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE;
+    }
+
+    let rdopts = pg_sys::allocateReloptStruct(
+        std::mem::size_of::<SearchIndexCreateOptions>(),
+        p_options,
+        n_options,
+    );
+    pg_sys::fillRelOptions(
+        rdopts,
+        std::mem::size_of::<SearchIndexCreateOptions>(),
+        p_options,
+        n_options,
+        validate,
+        options.as_ptr(),
+        options.len() as i32,
+    );
+    pg_sys::pfree(p_options as void_mut_ptr);
+
+    rdopts as *mut pg_sys::bytea
+}

--- a/pg_analytics/src/indexam/scan.rs
+++ b/pg_analytics/src/indexam/scan.rs
@@ -15,9 +15,9 @@ pub extern "C" fn ambeginscan(
 // An annotation to guard the function for PostgreSQL's threading model.
 #[pg_guard]
 pub extern "C" fn amrescan(
-    scan: pg_sys::IndexScanDesc,
-    keys: pg_sys::ScanKey,
-    nkeys: ::std::os::raw::c_int,
+    _scan: pg_sys::IndexScanDesc,
+    _keys: pg_sys::ScanKey,
+    _nkeys: ::std::os::raw::c_int,
     _orderbys: pg_sys::ScanKey,
     _norderbys: ::std::os::raw::c_int,
 ) {
@@ -28,7 +28,7 @@ pub extern "C" fn amendscan(_scan: pg_sys::IndexScanDesc) {}
 
 #[pg_guard]
 pub extern "C" fn amgettuple(
-    scan: pg_sys::IndexScanDesc,
+    _scan: pg_sys::IndexScanDesc,
     _direction: pg_sys::ScanDirection,
 ) -> bool {
     false

--- a/pg_analytics/src/indexam/scan.rs
+++ b/pg_analytics/src/indexam/scan.rs
@@ -1,0 +1,35 @@
+use pgrx::*;
+
+#[pg_guard]
+pub extern "C" fn ambeginscan(
+    indexrel: pg_sys::Relation,
+    nkeys: ::std::os::raw::c_int,
+    norderbys: ::std::os::raw::c_int,
+) -> pg_sys::IndexScanDesc {
+    let scandesc: PgBox<pg_sys::IndexScanDescData> =
+        unsafe { PgBox::from_pg(pg_sys::RelationGetIndexScan(indexrel, nkeys, norderbys)) };
+
+    scandesc.into_pg()
+}
+
+// An annotation to guard the function for PostgreSQL's threading model.
+#[pg_guard]
+pub extern "C" fn amrescan(
+    scan: pg_sys::IndexScanDesc,
+    keys: pg_sys::ScanKey,
+    nkeys: ::std::os::raw::c_int,
+    _orderbys: pg_sys::ScanKey,
+    _norderbys: ::std::os::raw::c_int,
+) {
+}
+
+#[pg_guard]
+pub extern "C" fn amendscan(_scan: pg_sys::IndexScanDesc) {}
+
+#[pg_guard]
+pub extern "C" fn amgettuple(
+    scan: pg_sys::IndexScanDesc,
+    _direction: pg_sys::ScanDirection,
+) -> bool {
+    false
+}

--- a/pg_analytics/src/indexam/scan.rs
+++ b/pg_analytics/src/indexam/scan.rs
@@ -12,7 +12,6 @@ pub extern "C" fn ambeginscan(
     scandesc.into_pg()
 }
 
-// An annotation to guard the function for PostgreSQL's threading model.
 #[pg_guard]
 pub extern "C" fn amrescan(
     _scan: pg_sys::IndexScanDesc,

--- a/pg_analytics/src/indexam/vacuum.rs
+++ b/pg_analytics/src/indexam/vacuum.rs
@@ -1,0 +1,9 @@
+use pgrx::*;
+
+#[pg_guard]
+pub extern "C" fn amvacuumcleanup(
+    info: *mut pg_sys::IndexVacuumInfo,
+    stats: *mut pg_sys::IndexBulkDeleteResult,
+) -> *mut pg_sys::IndexBulkDeleteResult {
+    stats
+}

--- a/pg_analytics/src/indexam/vacuum.rs
+++ b/pg_analytics/src/indexam/vacuum.rs
@@ -2,7 +2,7 @@ use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
-    info: *mut pg_sys::IndexVacuumInfo,
+    _info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
     stats

--- a/pg_analytics/src/indexam/validate.rs
+++ b/pg_analytics/src/indexam/validate.rs
@@ -1,0 +1,6 @@
+use pgrx::*;
+
+#[pg_guard]
+pub extern "C" fn amvalidate(_opclassoid: pg_sys::Oid) -> bool {
+    true
+}

--- a/pg_analytics/src/lib.rs
+++ b/pg_analytics/src/lib.rs
@@ -5,6 +5,7 @@ mod datafusion;
 mod errors;
 mod guc;
 mod hooks;
+mod indexam;
 mod tableam;
 
 use pgrx::*;

--- a/pg_bm25/src/postgres/build.rs
+++ b/pg_bm25/src/postgres/build.rs
@@ -21,7 +21,6 @@ impl BuildState {
 }
 
 #[pg_guard]
-// TODO: remove the unsafe
 pub extern "C" fn ambuild(
     heaprel: pg_sys::Relation,
     indexrel: pg_sys::Relation,
@@ -30,13 +29,6 @@ pub extern "C" fn ambuild(
     let heap_relation = unsafe { PgRelation::from_pg(heaprel) };
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
     let index_name = index_relation.name().to_string();
-
-    let rdopts: PgBox<SearchIndexCreateOptions> = if !index_relation.rd_options.is_null() {
-        unsafe { PgBox::from_pg(index_relation.rd_options as *mut SearchIndexCreateOptions) }
-    } else {
-        let ops = unsafe { PgBox::<SearchIndexCreateOptions>::alloc0() };
-        ops.into_pg_boxed()
-    };
 
     // Create a map from column name to column type. We'll use this to verify that index
     // configurations passed by the user reference the correct types for each column.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
A working MVP of JOINs between row and column oriented tables. The purpose of this PR is to demonstrate this kind of design for enabling row/column queries.

Please follow this example exactly when testing, as index inserts/deletes are not implemented (only builds).

```sql
-- Column oriented table 
CREATE TABLE u (
    id INT PRIMARY KEY,
    name VARCHAR(50),
    department_id INT
) USING deltalake;

-- Row oriented table
CREATE TABLE v (
    id INT PRIMARY KEY,
    department_name VARCHAR(50)
);

INSERT INTO u (id, name, department_id) VALUES
(1, 'Alice', 101),
(2, 'Bob', 102),
(3, 'Charlie', 103),
(4, 'David', 101);

INSERT INTO v (id, department_name) VALUES
(101, 'Human Resources'),
(102, 'Finance'),
(103, 'IT');

-- No index created, this will error
SELECT COUNT(*)
FROM u
JOIN v ON u.department_id = v.id;

-- Now create an index and try again!
create index on v using deltalakeindex ((v.*));

SELECT COUNT(*)
FROM u
JOIN v ON u.department_id = v.id;
```

## Why

## How
We create an index access method whose sole purpose is to sync heap tables with an underlying delta table. It should handle table creation, insert, delete, and vacuum, but not scans.

## Tests
