### PR TITLE
fix: Enable copying into deltalake tables

### DIFF
--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -26,6 +26,22 @@ DROP TABLE movies;
 
 That's it! `deltalake` tables accept standard Postgres queries, so there's nothing new to learn.
 
+## Copying into a Deltalake Table
+
+This example demonstrates how to copy data from an existing heap table into a `deltalake` table.
+
+```sql
+-- Create heap table
+CREATE TABLE heap (a int, b int);
+INSERT INTO heap VALUES (1, 2);
+
+-- Create deltalake table with the same schema
+CREATE TABLE delta (a int, b int) USING deltalake;
+
+-- Copy data into deltalake table
+INSERT INTO delta SELECT * FROM heap;
+```
+
 ## Use Cases
 
 `deltalake` tables have two primary advantages over regular tables:

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -32,7 +32,11 @@ pub fn executor_run(
         let rtable = (*ps).rtable;
 
         // Only use this hook for deltalake tables
-        if rtable.is_null() || !DeltaHandler::rtable_is_delta(rtable)? {
+        // Allow INSERTs to go through
+        if rtable.is_null()
+            || query_desc.operation == pg_sys::CmdType_CMD_INSERT
+            || !DeltaHandler::rtable_is_delta(rtable)?
+        {
             prev_hook(query_desc, direction, count, execute_once);
             return Ok(());
         }

--- a/pg_analytics/test/expected/insert.out
+++ b/pg_analytics/test/expected/insert.out
@@ -1,0 +1,11 @@
+CREATE TABLE t (a int, b int);
+INSERT INTO t VALUES (1, 2);
+CREATE TABLE s (a int, b int) USING deltalake;
+INSERT INTO s SELECT * FROM t;
+SELECT * FROM s;
+ a | b 
+---+---
+ 1 | 2
+(1 row)
+
+DROP TABLE s, t;

--- a/pg_analytics/test/sql/insert.sql
+++ b/pg_analytics/test/sql/insert.sql
@@ -1,0 +1,6 @@
+CREATE TABLE t (a int, b int);
+INSERT INTO t VALUES (1, 2);
+CREATE TABLE s (a int, b int) USING deltalake;
+INSERT INTO s SELECT * FROM t;
+SELECT * FROM s;
+DROP TABLE s, t;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Enables `INSERT`s into a deltalake table that reference a heap table.

## Why
This gives users a way to copy heap tables into deltalake tables.

## How
Modified the executor hook to call the standard Postgres hook on all `INSERT` statements. Added documentation as well.

## Tests
See new regression test.