### PR TITLE
fix: Correctly `SELECT` NULL values 

### DIFF
--- a/pg_analytics/src/hooks/select.rs
+++ b/pg_analytics/src/hooks/select.rs
@@ -58,11 +58,20 @@ pub fn select(
                     let column = recordbatch.column(col_index);
                     let dt = column.data_type();
                     let tts_value = (*tuple_table_slot).tts_values.add(col_index);
-                    *tts_value = DatafusionMapProducer::index_datum(
+                    let tts_isnull = (*tuple_table_slot).tts_isnull.add(col_index);
+
+                    match DatafusionMapProducer::index_datum(
                         dt.to_sql_data_type()?,
                         column,
                         row_index,
-                    )?
+                    )? {
+                        Some(datum) => {
+                            *tts_value = datum;
+                        }
+                        None => {
+                            *tts_isnull = true;
+                        }
+                    };
                 }
 
                 receive(tuple_table_slot, dest);

--- a/pg_analytics/test/expected/insert.out
+++ b/pg_analytics/test/expected/insert.out
@@ -9,3 +9,22 @@ SELECT * FROM s;
 (1 row)
 
 DROP TABLE s, t;
+CREATE TABLE t (
+    id SERIAL PRIMARY KEY,
+    event_date DATE,
+    user_id INT,
+    event_name VARCHAR(50),
+    session_duration INT,
+    page_views INT,
+    revenue DECIMAL(10, 2)
+) USING deltalake;
+INSERT INTO t (event_date, user_id, event_name, session_duration, page_views, revenue)
+VALUES
+(NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT * FROM t;
+ id | event_date | user_id | event_name | session_duration | page_views | revenue 
+----+------------+---------+------------+------------------+------------+---------
+  1 |            |         |            |                  |            |        
+(1 row)
+
+DROP TABLE t;

--- a/pg_analytics/test/sql/insert.sql
+++ b/pg_analytics/test/sql/insert.sql
@@ -4,3 +4,18 @@ CREATE TABLE s (a int, b int) USING deltalake;
 INSERT INTO s SELECT * FROM t;
 SELECT * FROM s;
 DROP TABLE s, t;
+
+CREATE TABLE t (
+    id SERIAL PRIMARY KEY,
+    event_date DATE,
+    user_id INT,
+    event_name VARCHAR(50),
+    session_duration INT,
+    page_views INT,
+    revenue DECIMAL(10, 2)
+) USING deltalake;
+INSERT INTO t (event_date, user_id, event_name, session_duration, page_views, revenue)
+VALUES
+(NULL, NULL, NULL, NULL, NULL, NULL);
+SELECT * FROM t;
+DROP TABLE t;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #821 

## What
Fixes an issue where values that were supposed to be NULL were returning as `0`. This was because we were not setting `tts_is_null` in the returned `TupleTableSlot`.

## Why

## How

## Tests
