### PR TITLE
fix: New catalog for every database

### DIFF
--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -11,7 +11,9 @@ extension_sql!(
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn init() {
-    let _ = DatafusionContext::init(unsafe { pg_sys::MyDatabaseId }).unwrap_or_else(|err| {
-        panic!("{}", err);
-    });
+    let _ =
+        DatafusionContext::init(DatafusionContext::catalog_oid().expect("Catalog OID not found"))
+            .unwrap_or_else(|err| {
+                panic!("{}", err);
+            });
 }

--- a/pg_analytics/src/api/init.rs
+++ b/pg_analytics/src/api/init.rs
@@ -11,7 +11,7 @@ extension_sql!(
 #[pg_guard]
 #[no_mangle]
 pub extern "C" fn init() {
-    let _ = DatafusionContext::init().unwrap_or_else(|err| {
+    let _ = DatafusionContext::init(unsafe { pg_sys::MyDatabaseId }).unwrap_or_else(|err| {
         panic!("{}", err);
     });
 }

--- a/pg_analytics/src/datafusion/catalog.rs
+++ b/pg_analytics/src/datafusion/catalog.rs
@@ -5,6 +5,7 @@ use parking_lot::RwLock;
 use pgrx::*;
 use std::{any::type_name, any::Any, collections::HashMap, ffi::CStr, ffi::OsStr, sync::Arc};
 
+use crate::datafusion::context::DatafusionContext;
 use crate::datafusion::directory::ParadeDirectory;
 use crate::datafusion::schema::ParadeSchemaProvider;
 use crate::errors::{NotFound, ParadeError};
@@ -25,7 +26,7 @@ impl ParadeCatalog {
     }
 
     pub async fn init(&self) -> Result<(), ParadeError> {
-        let delta_dir = ParadeDirectory::catalog_path(unsafe { pg_sys::MyDatabaseId })?;
+        let delta_dir = ParadeDirectory::catalog_path(DatafusionContext::catalog_oid()?)?;
 
         for entry in std::fs::read_dir(delta_dir)? {
             let entry = entry?;
@@ -53,7 +54,7 @@ impl ParadeCatalog {
                 let schema_provider = Arc::new(
                     ParadeSchemaProvider::try_new(
                         schema_name.as_str(),
-                        ParadeDirectory::schema_path(unsafe { pg_sys::MyDatabaseId }, pg_oid)?,
+                        ParadeDirectory::schema_path(DatafusionContext::catalog_oid()?, pg_oid)?,
                     )
                     .await?,
                 );

--- a/pg_analytics/src/datafusion/catalog.rs
+++ b/pg_analytics/src/datafusion/catalog.rs
@@ -9,8 +9,6 @@ use crate::datafusion::directory::ParadeDirectory;
 use crate::datafusion::schema::ParadeSchemaProvider;
 use crate::errors::{NotFound, ParadeError};
 
-pub static PARADE_CATALOG: &str = "datafusion";
-
 pub struct ParadeCatalog {
     schemas: RwLock<HashMap<String, Arc<dyn SchemaProvider>>>,
 }
@@ -27,7 +25,7 @@ impl ParadeCatalog {
     }
 
     pub async fn init(&self) -> Result<(), ParadeError> {
-        let delta_dir = ParadeDirectory::delta_path()?;
+        let delta_dir = ParadeDirectory::catalog_path(unsafe { pg_sys::MyDatabaseId })?;
 
         for entry in std::fs::read_dir(delta_dir)? {
             let entry = entry?;
@@ -55,7 +53,7 @@ impl ParadeCatalog {
                 let schema_provider = Arc::new(
                     ParadeSchemaProvider::try_new(
                         schema_name.as_str(),
-                        ParadeDirectory::schema_path(pg_oid)?,
+                        ParadeDirectory::schema_path(unsafe { pg_sys::MyDatabaseId }, pg_oid)?,
                     )
                     .await?,
                 );

--- a/pg_analytics/src/datafusion/context.rs
+++ b/pg_analytics/src/datafusion/context.rs
@@ -37,7 +37,7 @@ impl<'a> DatafusionContext {
             Some(context) => context.clone(),
             None => {
                 drop(context_lock);
-                DatafusionContext::init(unsafe { pg_sys::MyDatabaseId })?
+                DatafusionContext::init(Self::catalog_oid()?)?
             }
         };
 
@@ -53,7 +53,7 @@ impl<'a> DatafusionContext {
             Some(context) => context.clone(),
             None => {
                 drop(context_lock);
-                DatafusionContext::init(unsafe { pg_sys::MyDatabaseId })?
+                DatafusionContext::init(Self::catalog_oid()?)?
             }
         };
 
@@ -82,7 +82,7 @@ impl<'a> DatafusionContext {
             Some(context) => context.clone(),
             None => {
                 drop(context_lock);
-                DatafusionContext::init(unsafe { pg_sys::MyDatabaseId })?
+                DatafusionContext::init(Self::catalog_oid()?)?
             }
         };
 
@@ -135,14 +135,16 @@ impl<'a> DatafusionContext {
     }
 
     pub fn catalog_name() -> Result<String, ParadeError> {
-        let database_name = unsafe { pg_sys::get_database_name(pg_sys::MyDatabaseId) };
+        let database_name = unsafe { pg_sys::get_database_name(Self::catalog_oid()?) };
         if database_name.is_null() {
-            return Err(
-                NotFound::Database(unsafe { pg_sys::MyDatabaseId }.as_u32().to_string()).into(),
-            );
+            return Err(NotFound::Database(Self::catalog_oid()?.as_u32().to_string()).into());
         }
 
         Ok(unsafe { CStr::from_ptr(database_name).to_str()?.to_owned() })
+    }
+
+    pub fn catalog_oid() -> Result<pg_sys::Oid, ParadeError> {
+        Ok(unsafe { pg_sys::MyDatabaseId })
     }
 }
 

--- a/pg_analytics/src/datafusion/directory.rs
+++ b/pg_analytics/src/datafusion/directory.rs
@@ -9,41 +9,48 @@ pub static PARADE_DIRECTORY: &str = "deltalake";
 pub struct ParadeDirectory;
 
 impl ParadeDirectory {
-    pub fn delta_path() -> Result<PathBuf, ParadeError> {
-        let data_dir = ParadeDirectory::root_path()?;
-        let delta_dir = data_dir.join(PARADE_DIRECTORY);
+    pub fn catalog_path(catalog_oid: pg_sys::Oid) -> Result<PathBuf, ParadeError> {
+        let delta_dir = Self::root_path()?;
+        let catalog_dir = delta_dir.join(catalog_oid.as_u32().to_string());
 
-        Ok(delta_dir)
+        Ok(catalog_dir)
     }
 
-    pub fn schema_path(schema_oid: pg_sys::Oid) -> Result<PathBuf, ParadeError> {
-        let delta_dir = Self::delta_path()?;
+    pub fn schema_path(
+        catalog_oid: pg_sys::Oid,
+        schema_oid: pg_sys::Oid,
+    ) -> Result<PathBuf, ParadeError> {
+        let delta_dir = Self::catalog_path(catalog_oid)?;
         let schema_dir = delta_dir.join(schema_oid.as_u32().to_string());
 
         Ok(schema_dir)
     }
 
     pub fn table_path(
+        catalog_oid: pg_sys::Oid,
         schema_oid: pg_sys::Oid,
         table_oid: pg_sys::Oid,
     ) -> Result<PathBuf, ParadeError> {
-        let schema_dir = ParadeDirectory::schema_path(schema_oid)?;
+        let schema_dir = ParadeDirectory::schema_path(catalog_oid, schema_oid)?;
         let table_dir = schema_dir.join(table_oid.as_u32().to_string());
 
         Ok(table_dir)
     }
 
-    pub fn create_delta_path() -> Result<(), ParadeError> {
-        let delta_dir = Self::delta_path()?;
-        if !delta_dir.exists() {
-            fs::create_dir_all(&delta_dir)?;
+    pub fn create_catalog_path(catalog_oid: pg_sys::Oid) -> Result<(), ParadeError> {
+        let catalog_dir = Self::catalog_path(catalog_oid)?;
+        if !catalog_dir.exists() {
+            fs::create_dir_all(&catalog_dir)?;
         }
 
         Ok(())
     }
 
-    pub fn create_schema_path(schema_oid: pg_sys::Oid) -> Result<(), ParadeError> {
-        let schema_dir = Self::schema_path(schema_oid)?;
+    pub fn create_schema_path(
+        catalog_oid: pg_sys::Oid,
+        schema_oid: pg_sys::Oid,
+    ) -> Result<(), ParadeError> {
+        let schema_dir = Self::schema_path(catalog_oid, schema_oid)?;
         if !schema_dir.exists() {
             fs::create_dir_all(&schema_dir)?;
         }
@@ -62,6 +69,6 @@ impl ParadeDirectory {
             .to_str()?
         };
 
-        Ok(PathBuf::from(data_dir_str))
+        Ok(PathBuf::from(data_dir_str).join(PARADE_DIRECTORY))
     }
 }

--- a/pg_analytics/src/datafusion/schema.rs
+++ b/pg_analytics/src/datafusion/schema.rs
@@ -27,6 +27,7 @@ use std::{
     path::PathBuf, sync::Arc,
 };
 
+use crate::datafusion::context::DatafusionContext;
 use crate::datafusion::directory::ParadeDirectory;
 use crate::datafusion::table::DeltaTableProvider;
 use crate::errors::{NotFound, ParadeError};
@@ -123,12 +124,12 @@ impl ParadeSchemaProvider {
 
         // Create a DeltaTable
 
-        ParadeDirectory::create_schema_path(unsafe { pg_sys::MyDatabaseId }, schema_oid)?;
+        ParadeDirectory::create_schema_path(DatafusionContext::catalog_oid()?, schema_oid)?;
 
         let mut delta_table = CreateBuilder::new()
             .with_location(
                 ParadeDirectory::table_path(
-                    unsafe { pg_sys::MyDatabaseId },
+                    DatafusionContext::catalog_oid()?,
                     schema_oid,
                     table_oid,
                 )?
@@ -394,7 +395,7 @@ impl ParadeSchemaProvider {
 
                 deltalake::open_table(
                     ParadeDirectory::table_path(
-                        unsafe { pg_sys::MyDatabaseId },
+                        DatafusionContext::catalog_oid()?,
                         schema_oid,
                         table_oid,
                     )?

--- a/pg_analytics/src/datafusion/table.rs
+++ b/pg_analytics/src/datafusion/table.rs
@@ -67,6 +67,7 @@ impl DeltaTableProvider for PgRelation {
     fn arrow_schema(&self) -> Result<Arc<ArrowSchema>, ParadeError> {
         let table_name = self.name();
         let schema_name = self.namespace();
+        let catalog_name = DatafusionContext::catalog_name()?;
 
         let provider = DatafusionContext::with_schema_provider(schema_name, |provider| {
             let delta_table = task::block_on(provider.get_delta_table(table_name))?;
@@ -77,7 +78,7 @@ impl DeltaTableProvider for PgRelation {
         })?;
 
         let source = provider_as_source(provider.ok_or(NotFound::Table(table_name.to_string()))?);
-        let reference = TableReference::partial(schema_name, table_name);
+        let reference = TableReference::full(catalog_name, schema_name, table_name);
         let df_schema = DFSchema::try_from_qualified_schema(reference, source.schema().as_ref())?;
 
         Ok(Arc::new(df_schema.into()))

--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -39,7 +39,7 @@ pub enum ParadeError {
 
 #[derive(Error, Debug)]
 pub enum NotFound {
-    #[error("Database {0} does not have a name")]
+    #[error("Database {0} not found")]
     Database(String),
 
     #[error("No catalog registered with name {0}")]

--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -39,6 +39,9 @@ pub enum ParadeError {
 
 #[derive(Error, Debug)]
 pub enum NotFound {
+    #[error("Database {0} does not have a name")]
+    Database(String),
+
     #[error("No catalog registered with name {0}")]
     Catalog(String),
 

--- a/pg_analytics/src/tableam/create.rs
+++ b/pg_analytics/src/tableam/create.rs
@@ -55,7 +55,10 @@ fn create_file_node(rel: pg_sys::Relation, persistence: c_char) -> Result<(), Pa
                 if catalog.schema(&schema_name).is_none() {
                     let schema_provider = Arc::new(task::block_on(ParadeSchemaProvider::try_new(
                         &schema_name,
-                        ParadeDirectory::schema_path(unsafe { pg_sys::MyDatabaseId }, schema_oid)?,
+                        ParadeDirectory::schema_path(
+                            DatafusionContext::catalog_oid()?,
+                            schema_oid,
+                        )?,
                     ))?);
 
                     catalog.register_schema(&schema_name, schema_provider)?;

--- a/pg_analytics/src/tableam/create.rs
+++ b/pg_analytics/src/tableam/create.rs
@@ -48,13 +48,14 @@ fn create_file_node(rel: pg_sys::Relation, persistence: c_char) -> Result<(), Pa
         _ => {
             let table_name = pg_relation.name().to_string();
             let schema_name = pg_relation.namespace().to_string();
+            let catalog_name = DatafusionContext::catalog_name()?;
             let schema_oid = pg_relation.namespace_oid();
 
             DatafusionContext::with_catalog(|catalog| {
                 if catalog.schema(&schema_name).is_none() {
                     let schema_provider = Arc::new(task::block_on(ParadeSchemaProvider::try_new(
                         &schema_name,
-                        ParadeDirectory::schema_path(schema_oid)?,
+                        ParadeDirectory::schema_path(unsafe { pg_sys::MyDatabaseId }, schema_oid)?,
                     ))?);
 
                     catalog.register_schema(&schema_name, schema_provider)?;
@@ -64,7 +65,7 @@ fn create_file_node(rel: pg_sys::Relation, persistence: c_char) -> Result<(), Pa
             })?;
 
             let table_exists = DatafusionContext::with_session_context(|context| {
-                let reference = TableReference::partial(schema_name.clone(), table_name);
+                let reference = TableReference::full(catalog_name, schema_name.clone(), table_name);
                 Ok(context.table_exist(reference)?)
             })?;
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes a bug where VACUUMs would physically delete delta tables in other databases.

## Why
This bug was caused by the fact that all Postgres databases were stored in the same Datafusion catalog. When you're in a new Postgres database, Postgres is unaware of tables in other databases, so VACUUMs would think that these other tables were stale and delete them.

## How
Created a new catalog per Postgres database.

## Tests
