### PR TITLE
feat: Enable `ADD COLUMN`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,8 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.17.0"
-source = "git+https://github.com/paradedb/delta-rs.git?branch=main#71396f9c274eb982bedfc3889b5e963d68fe77b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b9304c1b0a1dcc3fb4391e7039fa8dea0cebccf0cfe690a081c5fcf7c83c9e"
 dependencies = [
  "deltalake-core",
 ]
@@ -1470,7 +1471,8 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.17.0"
-source = "git+https://github.com/paradedb/delta-rs.git?branch=main#71396f9c274eb982bedfc3889b5e963d68fe77b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa36b3134e005ea27b129d44416830edf4954beeecfc7933b6fc6e2efa5cc92"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -1499,6 +1501,7 @@ dependencies = [
  "fix-hidden-lifetime-bug",
  "futures",
  "hashbrown",
+ "indexmap",
  "itertools 0.12.0",
  "lazy_static",
  "libc",
@@ -2454,9 +2457,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -3629,6 +3632,7 @@ dependencies = [
  "chrono",
  "deltalake",
  "futures-util",
+ "indexmap",
  "lazy_static",
  "parking_lot",
  "pgrx",

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -27,9 +27,10 @@ lazy_static = "1.4.0"
 async-std = { version = "1.12.0", features = ["tokio1"] }
 parking_lot = "0.12.1"
 async-trait = "0.1.77"
-deltalake = { git = "https://github.com/paradedb/delta-rs.git", branch = "main", features = ["datafusion"] }
 chrono = "0.4.33"
 thiserror = "1.0.56"
+deltalake = { version = "0.17.0", features = ["datafusion"] }
+indexmap = "2.2.2"
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/pg_analytics/sample_db_backup.sql
+++ b/pg_analytics/sample_db_backup.sql
@@ -1,0 +1,424 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 16.1 (Debian 16.1-1.pgdg120+1)
+-- Dumped by pg_dump version 16.1 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: paradedb; Type: SCHEMA; Schema: -; Owner: myuser
+--
+
+CREATE SCHEMA paradedb;
+
+
+ALTER SCHEMA paradedb OWNER TO myuser;
+
+--
+-- Name: search_idx; Type: SCHEMA; Schema: -; Owner: myuser
+--
+
+CREATE SCHEMA search_idx;
+
+
+ALTER SCHEMA search_idx OWNER TO myuser;
+
+--
+-- Name: pg_analytics; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_analytics WITH SCHEMA paradedb;
+
+
+--
+-- Name: EXTENSION pg_analytics; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_analytics IS 'Real-time analytics for PostgreSQL using columnar storage and vectorized execution';
+
+
+--
+-- Name: pg_bm25; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_bm25 WITH SCHEMA paradedb;
+
+
+--
+-- Name: EXTENSION pg_bm25; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION pg_bm25 IS 'pg_bm25: Full text search for PostgreSQL using BM25';
+
+
+--
+-- Name: svector; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS svector WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION svector; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION svector IS 'pg_sparse: Sparse vector data type and sparse HNSW access methods';
+
+
+--
+-- Name: vector; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION vector; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access methods';
+
+
+--
+-- Name: highlight(text, integer, integer, text, integer, boolean, boolean, text, integer, text); Type: FUNCTION; Schema: search_idx; Owner: myuser
+--
+
+CREATE FUNCTION search_idx.highlight(query text, offset_rows integer DEFAULT NULL::integer, limit_rows integer DEFAULT NULL::integer, fuzzy_fields text DEFAULT NULL::text, distance integer DEFAULT NULL::integer, transpose_cost_one boolean DEFAULT NULL::boolean, prefix boolean DEFAULT NULL::boolean, regex_fields text DEFAULT NULL::text, max_num_chars integer DEFAULT NULL::integer, highlight_field text DEFAULT NULL::text) RETURNS TABLE(id bigint, highlight_bm25 text)
+    LANGUAGE plpgsql
+    AS $$
+        DECLARE
+            __paradedb_search_config__ JSONB;
+        BEGIN
+           -- Merge the outer 'index_json' object into the parameters passed to the dynamic function.
+           __paradedb_search_config__ := jsonb_strip_nulls(
+        		'{"key_field": "id", "index_name": "search_idx_bm25_index", "table_name": "mock_items", "schema_name": "public"}'::jsonb || jsonb_build_object(
+            		'query', query,
+                	'offset_rows', offset_rows,
+                	'limit_rows', limit_rows,
+                	'fuzzy_fields', fuzzy_fields,
+                	'distance', distance,
+                	'transpose_cost_one', transpose_cost_one,
+                	'prefix', prefix,
+                	'regex_fields', regex_fields,
+                	'max_num_chars', max_num_chars,
+                    'highlight_field', highlight_field
+            	)
+        	);
+            RETURN QUERY SELECT * FROM paradedb.highlight_bm25(__paradedb_search_config__);
+        END;
+        $$;
+
+
+ALTER FUNCTION search_idx.highlight(query text, offset_rows integer, limit_rows integer, fuzzy_fields text, distance integer, transpose_cost_one boolean, prefix boolean, regex_fields text, max_num_chars integer, highlight_field text) OWNER TO myuser;
+
+--
+-- Name: rank(text, integer, integer, text, integer, boolean, boolean, text, integer, text); Type: FUNCTION; Schema: search_idx; Owner: myuser
+--
+
+CREATE FUNCTION search_idx.rank(query text, offset_rows integer DEFAULT NULL::integer, limit_rows integer DEFAULT NULL::integer, fuzzy_fields text DEFAULT NULL::text, distance integer DEFAULT NULL::integer, transpose_cost_one boolean DEFAULT NULL::boolean, prefix boolean DEFAULT NULL::boolean, regex_fields text DEFAULT NULL::text, max_num_chars integer DEFAULT NULL::integer, highlight_field text DEFAULT NULL::text) RETURNS TABLE(id bigint, rank_bm25 real)
+    LANGUAGE plpgsql
+    AS $$
+        DECLARE
+            __paradedb_search_config__ JSONB;
+        BEGIN
+           -- Merge the outer 'index_json' object into the parameters passed to the dynamic function.
+           __paradedb_search_config__ := jsonb_strip_nulls(
+        		'{"key_field": "id", "index_name": "search_idx_bm25_index", "table_name": "mock_items", "schema_name": "public"}'::jsonb || jsonb_build_object(
+            		'query', query,
+                	'offset_rows', offset_rows,
+                	'limit_rows', limit_rows,
+                	'fuzzy_fields', fuzzy_fields,
+                	'distance', distance,
+                	'transpose_cost_one', transpose_cost_one,
+                	'prefix', prefix,
+                	'regex_fields', regex_fields,
+                	'max_num_chars', max_num_chars,
+                    'highlight_field', highlight_field
+            	)
+        	);
+            RETURN QUERY SELECT * FROM paradedb.rank_bm25(__paradedb_search_config__);
+        END;
+        $$;
+
+
+ALTER FUNCTION search_idx.rank(query text, offset_rows integer, limit_rows integer, fuzzy_fields text, distance integer, transpose_cost_one boolean, prefix boolean, regex_fields text, max_num_chars integer, highlight_field text) OWNER TO myuser;
+
+--
+-- Name: rank_hybrid(text, text, integer, integer, real, real); Type: FUNCTION; Schema: search_idx; Owner: myuser
+--
+
+CREATE FUNCTION search_idx.rank_hybrid(bm25_query text, similarity_query text, similarity_limit_n integer DEFAULT 100, bm25_limit_n integer DEFAULT 100, similarity_weight real DEFAULT 0.5, bm25_weight real DEFAULT 0.5) RETURNS TABLE(id bigint, rank_hybrid real)
+    LANGUAGE plpgsql
+    AS $_$
+            DECLARE
+                __paradedb_search_config__ JSONB;
+                query text;
+            BEGIN
+            -- Merge the outer 'index_json' object into the parameters passed to the dynamic function.
+                __paradedb_search_config__ := jsonb_strip_nulls(
+                    '{"key_field": "id", "index_name": "search_idx_bm25_index", "table_name": "mock_items", "schema_name": "public"}'::jsonb || jsonb_build_object(
+                        'query', bm25_query,
+                        'limit_rows', bm25_limit_n
+                    )
+                );
+
+                query := replace('
+            WITH similarity AS (
+                SELECT
+                    __key_field__ as key_field,
+                    1 - ((__similarity_query__) - MIN(__similarity_query__) OVER ()) / 
+                    (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ()) AS score
+                FROM mock_items
+                ORDER BY __similarity_query__
+                LIMIT $2
+            ),
+            bm25 AS (
+                SELECT 
+                    __key_field__ as key_field, 
+                    rank_bm25 as score 
+                FROM paradedb.minmax_bm25($1)
+            )
+            SELECT
+                COALESCE(similarity.key_field, bm25.key_field) AS __key_field__,
+                (COALESCE(similarity.score, 0.0) * $3 + COALESCE(bm25.score, 0.0) * $4)::real AS score_hybrid
+            FROM similarity
+            FULL OUTER JOIN bm25 ON similarity.key_field = bm25.key_field
+            ORDER BY score_hybrid DESC;
+        ', '__similarity_query__', similarity_query);
+                query := replace(query, '__key_field__', __paradedb_search_config__ ->>'key_field');
+
+                RETURN QUERY EXECUTE query
+                USING __paradedb_search_config__, similarity_limit_n, similarity_weight, bm25_weight;
+            END;
+            $_$;
+
+
+ALTER FUNCTION search_idx.rank_hybrid(bm25_query text, similarity_query text, similarity_limit_n integer, bm25_limit_n integer, similarity_weight real, bm25_weight real) OWNER TO myuser;
+
+--
+-- Name: schema(); Type: FUNCTION; Schema: search_idx; Owner: myuser
+--
+
+CREATE FUNCTION search_idx.schema() RETURNS TABLE(name text, field_type text, stored boolean, indexed boolean, fast boolean, fieldnorms boolean, expand_dots boolean, tokenizer text, record text, normalizer text)
+    LANGUAGE plpgsql
+    AS $$
+        BEGIN
+            RETURN QUERY SELECT * FROM paradedb.schema_bm25('search_idx');
+        END;
+        $$;
+
+
+ALTER FUNCTION search_idx.schema() OWNER TO myuser;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: mock_items; Type: TABLE; Schema: public; Owner: myuser
+--
+
+CREATE TABLE public.mock_items (
+    id integer NOT NULL,
+    description text,
+    rating integer,
+    category character varying(255),
+    in_stock boolean,
+    metadata jsonb,
+    CONSTRAINT mock_items_rating_check CHECK (((rating >= 1) AND (rating <= 5)))
+);
+
+
+ALTER TABLE public.mock_items OWNER TO myuser;
+
+--
+-- Name: search(text, integer, integer, text, integer, boolean, boolean, text, integer, text); Type: FUNCTION; Schema: search_idx; Owner: myuser
+--
+
+CREATE FUNCTION search_idx.search(query text, offset_rows integer DEFAULT NULL::integer, limit_rows integer DEFAULT NULL::integer, fuzzy_fields text DEFAULT NULL::text, distance integer DEFAULT NULL::integer, transpose_cost_one boolean DEFAULT NULL::boolean, prefix boolean DEFAULT NULL::boolean, regex_fields text DEFAULT NULL::text, max_num_chars integer DEFAULT NULL::integer, highlight_field text DEFAULT NULL::text) RETURNS SETOF public.mock_items
+    LANGUAGE plpgsql
+    AS $$
+        DECLARE
+            __paradedb_search_config__ JSONB;
+        BEGIN
+           -- Merge the outer 'index_json' object into the parameters passed to the dynamic function.
+           __paradedb_search_config__ := jsonb_strip_nulls(
+        		'{"key_field": "id", "index_name": "search_idx_bm25_index", "table_name": "mock_items", "schema_name": "public"}'::jsonb || jsonb_build_object(
+            		'query', query,
+                	'offset_rows', offset_rows,
+                	'limit_rows', limit_rows,
+                	'fuzzy_fields', fuzzy_fields,
+                	'distance', distance,
+                	'transpose_cost_one', transpose_cost_one,
+                	'prefix', prefix,
+                	'regex_fields', regex_fields,
+                	'max_num_chars', max_num_chars,
+                    'highlight_field', highlight_field
+            	)
+        	);
+            RETURN QUERY SELECT * FROM public.mock_items WHERE mock_items @@@ __paradedb_search_config__;
+        END;
+        $$;
+
+
+ALTER FUNCTION search_idx.search(query text, offset_rows integer, limit_rows integer, fuzzy_fields text, distance integer, transpose_cost_one boolean, prefix boolean, regex_fields text, max_num_chars integer, highlight_field text) OWNER TO myuser;
+
+--
+-- Name: mock_items_id_seq; Type: SEQUENCE; Schema: public; Owner: myuser
+--
+
+CREATE SEQUENCE public.mock_items_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.mock_items_id_seq OWNER TO myuser;
+
+--
+-- Name: mock_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: myuser
+--
+
+ALTER SEQUENCE public.mock_items_id_seq OWNED BY public.mock_items.id;
+
+
+SET default_table_access_method = deltalake;
+
+--
+-- Name: test_table; Type: TABLE; Schema: public; Owner: myuser
+--
+
+CREATE TABLE public.test_table (
+    id integer NOT NULL,
+    data text
+);
+
+
+ALTER TABLE public.test_table OWNER TO myuser;
+
+--
+-- Name: test_table_id_seq; Type: SEQUENCE; Schema: public; Owner: myuser
+--
+
+CREATE SEQUENCE public.test_table_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.test_table_id_seq OWNER TO myuser;
+
+--
+-- Name: test_table_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: myuser
+--
+
+ALTER SEQUENCE public.test_table_id_seq OWNED BY public.test_table.id;
+
+
+--
+-- Name: mock_items id; Type: DEFAULT; Schema: public; Owner: myuser
+--
+
+ALTER TABLE ONLY public.mock_items ALTER COLUMN id SET DEFAULT nextval('public.mock_items_id_seq'::regclass);
+
+
+--
+-- Data for Name: mock_items; Type: TABLE DATA; Schema: public; Owner: myuser
+--
+
+COPY public.mock_items (id, description, rating, category, in_stock, metadata) FROM stdin;
+1	Ergonomic metal keyboard	4	Electronics	t	{"color": "Silver", "location": "United States"}
+2	Plastic Keyboard	4	Electronics	f	{"color": "Black", "location": "Canada"}
+3	Sleek running shoes	5	Footwear	t	{"color": "Blue", "location": "China"}
+4	White jogging shoes	3	Footwear	f	{"color": "White", "location": "United States"}
+5	Generic shoes	4	Footwear	t	{"color": "Brown", "location": "Canada"}
+6	Compact digital camera	5	Photography	f	{"color": "Black", "location": "China"}
+7	Hardcover book on history	2	Books	t	{"color": "Brown", "location": "United States"}
+8	Organic green tea	3	Groceries	t	{"color": "Green", "location": "Canada"}
+9	Modern wall clock	4	Home Decor	f	{"color": "Silver", "location": "China"}
+10	Colorful kids toy	1	Toys	t	{"color": "Multicolor", "location": "United States"}
+11	Soft cotton shirt	5	Apparel	t	{"color": "Blue", "location": "Canada"}
+12	Innovative wireless earbuds	5	Electronics	t	{"color": "Black", "location": "China"}
+13	Sturdy hiking boots	4	Footwear	t	{"color": "Brown", "location": "United States"}
+14	Elegant glass table	3	Furniture	t	{"color": "Clear", "location": "Canada"}
+15	Refreshing face wash	2	Beauty	f	{"color": "White", "location": "China"}
+16	High-resolution DSLR	4	Photography	t	{"color": "Black", "location": "United States"}
+17	Paperback romantic novel	3	Books	t	{"color": "Multicolor", "location": "Canada"}
+18	Freshly ground coffee beans	5	Groceries	t	{"color": "Brown", "location": "China"}
+19	Artistic ceramic vase	4	Home Decor	f	{"color": "Multicolor", "location": "United States"}
+20	Interactive board game	3	Toys	t	{"color": "Multicolor", "location": "Canada"}
+21	Slim-fit denim jeans	5	Apparel	f	{"color": "Blue", "location": "China"}
+22	Fast charging power bank	4	Electronics	t	{"color": "Black", "location": "United States"}
+23	Comfortable slippers	3	Footwear	t	{"color": "Brown", "location": "Canada"}
+24	Classic leather sofa	5	Furniture	f	{"color": "Brown", "location": "China"}
+25	Anti-aging serum	4	Beauty	t	{"color": "White", "location": "United States"}
+26	Portable tripod stand	4	Photography	t	{"color": "Black", "location": "Canada"}
+27	Mystery detective novel	2	Books	f	{"color": "Multicolor", "location": "China"}
+28	Organic breakfast cereal	5	Groceries	t	{"color": "Brown", "location": "United States"}
+29	Designer wall paintings	5	Home Decor	t	{"color": "Multicolor", "location": "Canada"}
+30	Robot building kit	4	Toys	t	{"color": "Multicolor", "location": "China"}
+31	Sporty tank top	4	Apparel	t	{"color": "Blue", "location": "United States"}
+32	Bluetooth-enabled speaker	3	Electronics	t	{"color": "Black", "location": "Canada"}
+33	Winter woolen socks	5	Footwear	f	{"color": "Gray", "location": "China"}
+34	Rustic bookshelf	4	Furniture	t	{"color": "Brown", "location": "United States"}
+35	Moisturizing lip balm	4	Beauty	t	{"color": "Pink", "location": "Canada"}
+36	Lightweight camera bag	5	Photography	f	{"color": "Black", "location": "China"}
+37	Historical fiction book	3	Books	t	{"color": "Multicolor", "location": "United States"}
+38	Pure honey jar	4	Groceries	t	{"color": "Yellow", "location": "Canada"}
+39	Handcrafted wooden frame	5	Home Decor	f	{"color": "Brown", "location": "China"}
+40	Plush teddy bear	4	Toys	t	{"color": "Brown", "location": "United States"}
+41	Warm woolen sweater	3	Apparel	f	{"color": "Red", "location": "Canada"}
+\.
+
+
+--
+-- Data for Name: test_table; Type: TABLE DATA; Schema: public; Owner: myuser
+--
+
+COPY public.test_table (id, data) FROM stdin;
+\.
+
+
+--
+-- Name: mock_items_id_seq; Type: SEQUENCE SET; Schema: public; Owner: myuser
+--
+
+SELECT pg_catalog.setval('public.mock_items_id_seq', 41, true);
+
+
+--
+-- Name: test_table_id_seq; Type: SEQUENCE SET; Schema: public; Owner: myuser
+--
+
+SELECT pg_catalog.setval('public.test_table_id_seq', 2, true);
+
+
+--
+-- Name: mock_items mock_items_pkey; Type: CONSTRAINT; Schema: public; Owner: myuser
+--
+
+ALTER TABLE ONLY public.mock_items
+    ADD CONSTRAINT mock_items_pkey PRIMARY KEY (id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/pg_analytics/src/datafusion/datatype.rs
+++ b/pg_analytics/src/datafusion/datatype.rs
@@ -68,14 +68,25 @@ impl DatafusionTypeTranslator for DataType {
 
     fn from_sql_data_type(sql_data_type: SQLDataType) -> Result<DataType, ParadeError> {
         let result = match sql_data_type {
-            SQLDataType::Boolean => DataType::Boolean,
-            SQLDataType::Text => DataType::Utf8,
-            SQLDataType::Int2(_) => DataType::Int16,
-            SQLDataType::Int4(_) => DataType::Int32,
-            SQLDataType::Int8(_) => DataType::Int64,
-            SQLDataType::UnsignedInt4(_) => DataType::UInt32,
-            SQLDataType::Float4 => DataType::Float32,
-            SQLDataType::Float8 => DataType::Float64,
+            SQLDataType::Boolean | SQLDataType::Bool => DataType::Boolean,
+            SQLDataType::Text
+            | SQLDataType::Char(_)
+            | SQLDataType::Varchar(_)
+            | SQLDataType::String(_) => DataType::Utf8,
+            SQLDataType::TinyInt(_) => DataType::Int8,
+            SQLDataType::SmallInt(_) | SQLDataType::Int2(_) => DataType::Int16,
+            SQLDataType::Int(_) | SQLDataType::Integer(_) | SQLDataType::Int4(_) => DataType::Int32,
+            SQLDataType::BigInt(_) | SQLDataType::Int8(_) => DataType::Int64,
+            SQLDataType::UnsignedTinyInt(_) => DataType::UInt8,
+            SQLDataType::UnsignedSmallInt(_) | SQLDataType::UnsignedInt2(_) => DataType::UInt16,
+            SQLDataType::UnsignedInt(_)
+            | SQLDataType::UnsignedInteger(_)
+            | SQLDataType::UnsignedInt4(_) => DataType::UInt32,
+            SQLDataType::UnsignedBigInt(_) | SQLDataType::UnsignedInt8(_) => DataType::UInt64,
+            SQLDataType::Float4 | SQLDataType::Float(_) => DataType::Float32,
+            SQLDataType::Double | SQLDataType::DoublePrecision | SQLDataType::Float8 => {
+                DataType::Float64
+            }
             SQLDataType::Bytea => DataType::Binary,
             SQLDataType::Numeric(ExactNumberInfo::PrecisionAndScale(precision, scale)) => {
                 let casted_precision = precision as u8;

--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -81,8 +81,14 @@ pub enum NotSupported {
     #[error("Custom Postgres types are not supported")]
     CustomPostgresType,
 
-    #[error("ALTER TABLE is not yet supported. Please DROP and CREATE the table instead.")]
-    AlterTable,
+    #[error("DROP COLUMN is not yet supported. Please recreate the table instead.")]
+    DropColumn,
+
+    #[error("ALTER COLUMN is not yet supported. Please recreate the table instead.")]
+    AlterColumn,
+
+    #[error("RENAME COLUMN is not yet supported. Please recreate the table instead.")]
+    RenameColumn,
 
     #[error("UPDATE is not yet supported for deltalake tables")]
     Update,

--- a/pg_analytics/src/hooks/alter.rs
+++ b/pg_analytics/src/hooks/alter.rs
@@ -1,13 +1,22 @@
+use async_std::task;
+use deltalake::datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+use deltalake::datafusion::arrow::record_batch::RecordBatch;
 use deltalake::datafusion::error::DataFusionError;
-use deltalake::datafusion::sql::parser::DFParser;
-use deltalake::datafusion::sql::planner::SqlToRel;
+use deltalake::datafusion::sql::parser::{self, DFParser};
+use deltalake::datafusion::sql::sqlparser::ast::{AlterTableOperation::*, ColumnOption, Statement};
 use deltalake::datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use pgrx::*;
+use std::sync::Arc;
 
+use crate::datafusion::context::DatafusionContext;
+use crate::datafusion::datatype::DatafusionTypeTranslator;
 use crate::errors::{NotSupported, ParadeError};
 use crate::hooks::handler::DeltaHandler;
 
-pub unsafe fn alter(alter_stmt: *mut pg_sys::AlterTableStmt) -> Result<(), ParadeError> {
+pub unsafe fn alter(
+    alter_stmt: *mut pg_sys::AlterTableStmt,
+    query_string: &str,
+) -> Result<(), ParadeError> {
     let rangevar = (*alter_stmt).relation;
     let rangevar_oid = pg_sys::RangeVarGetRelidExtended(
         rangevar,
@@ -27,16 +36,48 @@ pub unsafe fn alter(alter_stmt: *mut pg_sys::AlterTableStmt) -> Result<(), Parad
         return Ok(());
     }
 
-    let pg_relation = PgRelation::from_pg(relation);
-    let tupdesc = pg_relation.tuple_desc();
-    for attribute in tupdesc.iter() {
-        if attribute.is_dropped() {
-            continue;
-        }
+    let pg_relation = unsafe { PgRelation::from_pg_owned(relation) };
+    let table_name = pg_relation.name();
+    let schema_name = pg_relation.namespace();
 
-        let attname = attribute.name();
-        info!("Attribute name: {}", attname);
+    let dialect = PostgreSqlDialect {};
+    let ast = DFParser::parse_sql_with_dialect(query_string, &dialect)
+        .map_err(|err| ParadeError::DataFusion(DataFusionError::SQL(err, None)))?;
+
+    if let parser::Statement::Statement(statement) = &ast[0] {
+        if let Statement::AlterTable { operations, .. } = statement.as_ref() {
+            for operation in operations {
+                match operation {
+                    AddColumn { column_def, .. } => {
+                        let options = &column_def.options;
+                        let nullability = options
+                            .iter()
+                            .any(|opt| matches!(opt.option, ColumnOption::Null));
+                        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+                            column_def.name.value.clone(),
+                            DataType::from_sql_data_type(column_def.data_type.clone())?,
+                            !nullability,
+                        )]));
+                        let batch = RecordBatch::new_empty(schema);
+
+                        DatafusionContext::with_schema_provider(schema_name, |provider| {
+                            task::block_on(provider.merge_schema(table_name, batch))
+                        })?;
+                    }
+                    DropColumn { .. } => {
+                        return Err(NotSupported::DropColumn.into());
+                    }
+                    AlterColumn { .. } | ChangeColumn { .. } => {
+                        return Err(NotSupported::AlterColumn.into());
+                    }
+                    RenameColumn { .. } => {
+                        return Err(NotSupported::RenameColumn.into());
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
 
-    Err(NotSupported::AlterTable.into())
+    Ok(())
 }

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -1,9 +1,7 @@
 use deltalake::datafusion::error::DataFusionError;
 use deltalake::datafusion::logical_expr::LogicalPlan;
-
 use deltalake::datafusion::sql::parser::DFParser;
 use deltalake::datafusion::sql::planner::SqlToRel;
-
 use deltalake::datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use pgrx::*;
 use std::ffi::CStr;

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -35,7 +35,7 @@ pub fn process_utility(
         let plan = pstmt.utilityStmt;
 
         match (*plan).type_ {
-            NodeTag::T_AlterTableStmt => {                
+            NodeTag::T_AlterTableStmt => {
                 alter(plan as *mut pg_sys::AlterTableStmt, query_string.to_str()?)?;
             }
             NodeTag::T_DropStmt => {

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -35,8 +35,8 @@ pub fn process_utility(
         let plan = pstmt.utilityStmt;
 
         match (*plan).type_ {
-            NodeTag::T_AlterTableStmt => {
-                alter(plan as *mut pg_sys::AlterTableStmt)?;
+            NodeTag::T_AlterTableStmt => {                
+                alter(plan as *mut pg_sys::AlterTableStmt, query_string.to_str()?)?;
             }
             NodeTag::T_DropStmt => {
                 drop(plan as *mut pg_sys::DropStmt)?;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Uses the new `delta-rs` schema evolution feature to enable users to `ADD COLUMN`.

Also fixes an issue where `ALTER TABLE` calls that did not affect the table schema were not being allowed to run.

Leaving this as a draft until tests are written.

## Why

## How

## Tests
