### PR TITLE
chore: Upgrade to delta-rs 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,8 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "0.17.0"
-source = "git+https://github.com/paradedb/delta-rs.git?branch=main#71396f9c274eb982bedfc3889b5e963d68fe77b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b9304c1b0a1dcc3fb4391e7039fa8dea0cebccf0cfe690a081c5fcf7c83c9e"
 dependencies = [
  "deltalake-core",
 ]
@@ -1470,7 +1471,8 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "0.17.0"
-source = "git+https://github.com/paradedb/delta-rs.git?branch=main#71396f9c274eb982bedfc3889b5e963d68fe77b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa36b3134e005ea27b129d44416830edf4954beeecfc7933b6fc6e2efa5cc92"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -1499,6 +1501,7 @@ dependencies = [
  "fix-hidden-lifetime-bug",
  "futures",
  "hashbrown",
+ "indexmap",
  "itertools 0.12.0",
  "lazy_static",
  "libc",
@@ -2454,9 +2457,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -3629,6 +3632,7 @@ dependencies = [
  "chrono",
  "deltalake",
  "futures-util",
+ "indexmap",
  "lazy_static",
  "parking_lot",
  "pgrx",

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -27,9 +27,10 @@ lazy_static = "1.4.0"
 async-std = { version = "1.12.0", features = ["tokio1"] }
 parking_lot = "0.12.1"
 async-trait = "0.1.77"
-deltalake = { git = "https://github.com/paradedb/delta-rs.git", branch = "main", features = ["datafusion"] }
 chrono = "0.4.33"
+deltalake = { version = "0.17.0", features = ["datafusion"]}
 thiserror = "1.0.56"
+indexmap = "2.2.2"
 
 [dev-dependencies]
 anyhow = "1.0.79"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Now that delta-rs 0.17.0 is released, we don't need to rely on our fork anymore.

Added the `indexmap` dependency because `pg_bm25` uses an older version of `indexmap` that isn't compatible with the latest `delta-rs`.

## Why

## How

## Tests
