### PR TITLE
feat: Throw error if pg_analytics not in shared_preload_libraries

### DIFF
--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -33,6 +33,11 @@ pub enum ParadeError {
     #[error("Could not downcast generic arrow array: {0}")]
     DowncastGenericArray(DataType),
 
+    #[error(
+        "pg_analytics not found in shared_preload_libraries. Check your postgresql.conf file."
+    )]
+    SharedPreload,
+
     #[error("{0}")]
     Generic(String),
 }

--- a/pg_analytics/test/runtests.sh
+++ b/pg_analytics/test/runtests.sh
@@ -220,6 +220,22 @@ function run_tests() {
     cargo pgrx install --pg-config="$PG_BIN_PATH/pg_config" --profile dev
   fi
 
+  # Configure shared_preload_libraries to include pg_analytics
+  echo "Setting test database shared_preload_libraries..."
+  case "$OS_NAME" in
+    Darwin)
+      sed -i '' "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_analytics'  # (change requires restart)/" "$PGDATA/postgresql.conf"
+      ;;
+    Linux)
+      sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_analytics'  # (change requires restart)/" "$PGDATA/postgresql.conf"
+      ;;
+  esac
+  # cat "$PGDATA/postgresql.conf"
+
+  # Reload PostgreSQL configuration
+  echo "Reloading PostgreSQL configuration..."
+  "$PG_BIN_PATH/pg_ctl" restart
+
   # Get a list of all tests
   while IFS= read -r line; do
     TESTS+=("$line")


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #831 

## What
Throws an error if `pg_analytics` is not in `shared_preload_libraries`

```sql
pg_analytics=# select * from t;
ERROR:  Execution error: pg_analytics not found in shared_preload_libraries. Check your postgresql.conf file.
```

## Why
Should hopefully reduce user error.

## How
Reads the `shared_preload_libraries` setting inside `init` and checks if `pg_analytics` is in there.

## Tests
