### PR TITLE
chore: Rename deltalake table access method to parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ ParadeDB is currently in Public Beta. Star and watch this repository to get noti
   - [x] Dense vector search with [pgvector](https://github.com/pgvector/pgvector#pgvector)
   - [x] Hybrid search
 - [ ] Analytics
-  - [x] Real-time analytical queries and Delta Lake storage with [pg_analytics](https://github.com/paradedb/paradedb/tree/dev/pg_analytics#overview)
-  - [ ] High volume log ingest
-  - [ ] Kafka ingest
-  - [ ] Apache Iceberg storage
+  - [x] Acclerated analytical queries and column-oriented storage with [pg_analytics](https://github.com/paradedb/paradedb/tree/dev/pg_analytics#overview)
+  - [ ] External object store integrations (S3/Azure/GCS/HDFS)
+  - [ ] Apache Iceberg and Delta Lake support
+  - [ ] High volume data/Kafka ingest
+  - [ ] Non-Parquet file formats (Avro/ORC)
 - [x] Self-hosted ParadeDB
   - [x] Docker image & [deployment instructions](https://docs.paradedb.com/deploy/aws)
   - [x] Kubernetes Helm chart & [deployment instructions](https://docs.paradedb.com/deploy/helm)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ParadeDB is currently in Public Beta. Star and watch this repository to get noti
 - [ ] Analytics
   - [x] Acclerated analytical queries and column-oriented storage with [pg_analytics](https://github.com/paradedb/paradedb/tree/dev/pg_analytics#overview)
   - [ ] External object store integrations (S3/Azure/GCS/HDFS)
-  - [ ] Apache Iceberg and Delta Lake support
+  - [ ] External Apache Iceberg and Delta Lake support
   - [ ] High volume data/Kafka ingest
   - [ ] Non-Parquet file formats (Avro/ORC)
 - [x] Self-hosted ParadeDB

--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -12,7 +12,7 @@ ParadeDB introduces special tables called `parquet` tables. These tables behave 
 use a column-oriented layout via Apache Arrow and Parquet and leverage Apache DataFusion, a query engine
 optimized for column-oriented data.
 
-## USING Parquet Tables
+## Using Parquet Tables
 
 ```sql
 -- USING parquet must be provided
@@ -26,7 +26,7 @@ DROP TABLE movies;
 
 That's it! `parquet` tables accept standard Postgres queries, so there's nothing new to learn.
 
-## Copying into a Deltalake Table
+## Copying into a Parquet Table
 
 This example demonstrates how to copy data from an existing heap table into a `parquet` table.
 
@@ -36,10 +36,10 @@ CREATE TABLE heap (a int, b int);
 INSERT INTO heap VALUES (1, 2);
 
 -- Create parquet table with the same schema
-CREATE TABLE delta (a int, b int) USING parquet;
+CREATE TABLE events (a int, b int) USING parquet;
 
 -- Copy data into parquet table
-INSERT INTO delta SELECT * FROM heap;
+INSERT INTO events SELECT * FROM heap;
 ```
 
 ## Use Cases

--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -12,7 +12,7 @@ ParadeDB introduces special tables called `parquet` tables. These tables behave 
 use a column-oriented layout via Apache Arrow and Parquet and leverage Apache DataFusion, a query engine
 optimized for column-oriented data.
 
-## USING parquet Tables
+## USING Parquet Tables
 
 ```sql
 -- USING parquet must be provided

--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -8,15 +8,15 @@ Regular Postgres tables, known as heap tables, organize data by row. While this 
 it is inefficient for analytical queries, which often scan a large amount of data from a subset of the columns
 in a table.
 
-ParadeDB introduces special tables called `deltalake` tables. These tables behave like regular Postgres tables but
+ParadeDB introduces special tables called `parquet` tables. These tables behave like regular Postgres tables but
 use a column-oriented layout via Apache Arrow and Parquet and leverage Apache DataFusion, a query engine
 optimized for column-oriented data.
 
-## Using Deltalake Tables
+## USING parquet Tables
 
 ```sql
--- USING deltalake must be provided
-CREATE TABLE movies (name text, rating int) USING deltalake;
+-- USING parquet must be provided
+CREATE TABLE movies (name text, rating int) USING parquet;
 
 INSERT INTO movies VALUES ('Star Wars', 9), ('Indiana Jones', 8);
 SELECT AVG(rating) FROM movies;
@@ -24,27 +24,27 @@ SELECT AVG(rating) FROM movies;
 DROP TABLE movies;
 ```
 
-That's it! `deltalake` tables accept standard Postgres queries, so there's nothing new to learn.
+That's it! `parquet` tables accept standard Postgres queries, so there's nothing new to learn.
 
 ## Copying into a Deltalake Table
 
-This example demonstrates how to copy data from an existing heap table into a `deltalake` table.
+This example demonstrates how to copy data from an existing heap table into a `parquet` table.
 
 ```sql
 -- Create heap table
 CREATE TABLE heap (a int, b int);
 INSERT INTO heap VALUES (1, 2);
 
--- Create deltalake table with the same schema
-CREATE TABLE delta (a int, b int) USING deltalake;
+-- Create parquet table with the same schema
+CREATE TABLE delta (a int, b int) USING parquet;
 
--- Copy data into deltalake table
+-- Copy data into parquet table
 INSERT INTO delta SELECT * FROM heap;
 ```
 
 ## Use Cases
 
-`deltalake` tables have two primary advantages over regular tables:
+`parquet` tables have two primary advantages over regular tables:
 
 1. Significantly faster aggregate queries
 2. Lower disk space, since data is stored as highly-compressed Parquet files
@@ -58,18 +58,18 @@ or deletes.
 
 ## Known Limitations
 
-`deltalake` tables are currently in beta. The following is a list of known limitations. Many of these
-will become resolved as `deltalake` tables become production-ready.
+`parquet` tables are currently in beta. The following is a list of known limitations. Many of these
+will become resolved as `parquet` tables become production-ready.
 
 - [ ] `UPDATE` statements
 - [ ] Nested `DELETE` statements
 - [ ] Partitioning tables by column
 - [ ] Some Postgres types like JSON, time, and timestamp with time zone
 - [ ] User-defined functions, aggregations, or types
-- [ ] Referencing `deltalake` and regular Postgres `heap` tables in the same query
+- [ ] Referencing `parquet` and regular Postgres `heap` tables in the same query
 - [ ] Write-ahead-log (WAL) support and `ROLLBACK`
 - [ ] Foreign keys
 - [ ] Index scans
 - [ ] Collations
 - [ ] Using an external data lake as a table storage provider
-- [ ] Full text search over `deltalake` tables with `pg_bm25`
+- [ ] Full text search over `parquet` tables with `pg_bm25`

--- a/docs/analytics/storage.mdx
+++ b/docs/analytics/storage.mdx
@@ -2,7 +2,7 @@
 title: Storage Optimization
 ---
 
-When `deltalake` tables are dropped, they remain on disk until `VACUUM` is run. This operation physically
+When `parquet` tables are dropped, they remain on disk until `VACUUM` is run. This operation physically
 deletes the Parquet files of dropped tables.
 
 The `VACUUM FULL <table_name>` command is used to optimize a table's storage by bin-packing small Parquet

--- a/docs/changelog/0.5.4.mdx
+++ b/docs/changelog/0.5.4.mdx
@@ -8,4 +8,4 @@ Reduced the ParadeDB Docker image size by 60% removing unnecessary dev dependenc
 
 ## pg_analytics
 
-`DELETE` clauses now work over `deltalake` tables.
+`DELETE` clauses now work over `parquet` tables.

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -49,7 +49,7 @@ You can interact with `parquet` tables the same way as with normal Postgres tabl
 
 ### Storage Optimization
 
-When `parquet` files are dropped, they remain on disk until `VACUUM` is run. This operation physically
+When Parquet files are dropped, they remain on disk until `VACUUM` is run. This operation physically
 deletes the Parquet files of dropped tables.
 
 The `VACUUM FULL <table_name>` command is used to optimize a table's storage by bin-packing small Parquet

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -53,8 +53,8 @@ When Parquet files are dropped, they remain on disk until `VACUUM` is run. This 
 deletes the Parquet files of dropped tables.
 
 The `VACUUM FULL <table_name>` command is used to optimize a table's storage by bin-packing small Parquet
-files into larger files, which can significantly improve query time and compression. It also deletes
-Parquet files belonging to dropped data.
+files into larger files, which can significantly improve query time and compression. It also deletes dropped Parquet
+files.
 
 ## Roadmap
 

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -81,7 +81,8 @@ As `pg_analytics` becomes production-ready, many of these will be resolved.
 - [ ] Foreign keys
 - [ ] Index scans
 - [ ] Collations
-- [ ] Using an external data lake as a table storage provider
+- [ ] External object store integrations (S3/Azure/GCS/HDFS)
+- [ ] External Apache Iceberg and Delta Lake support
 - [ ] Full text search over `parquet` tables with `pg_bm25`
 
 ## Development

--- a/pg_analytics/README.md
+++ b/pg_analytics/README.md
@@ -35,21 +35,21 @@ This toy example demonstrates how to get started.
 
 ```sql
 CREATE EXTENSION pg_analytics;
--- Create a deltalake table
-CREATE TABLE t (a int) USING deltalake;
+-- Create a parquet table
+CREATE TABLE t (a int) USING parquet;
 -- pg_analytics supercharges the performance of any
--- Postgres query run on a deltalake table
+-- Postgres query run on a parquet table
 INSERT INTO t VALUES (1), (2), (3);
 SELECT COUNT(*) FROM t;
 ```
 
 ## Deltalake Tables
 
-You can interact with `deltalake` tables the same way as with normal Postgres tables. However, there are a few operations specific to `deltalake` tables.
+You can interact with `parquet` tables the same way as with normal Postgres tables. However, there are a few operations specific to `parquet` tables.
 
 ### Storage Optimization
 
-When `deltalake` tables are dropped, they remain on disk until `VACUUM` is run. This operation physically
+When `parquet` files are dropped, they remain on disk until `VACUUM` is run. This operation physically
 deletes the Parquet files of dropped tables.
 
 The `VACUUM FULL <table_name>` command is used to optimize a table's storage by bin-packing small Parquet
@@ -62,7 +62,7 @@ Parquet files belonging to dropped data.
 
 ### Features Supported
 
-- [x] `deltalake` tables behave like regular Postgres tables and support most Postgres queries (JOINs, CTEs, window functions, etc.)
+- [x] `parquet` tables behave like regular Postgres tables and support most Postgres queries (JOINs, CTEs, window functions, etc.)
 - [x] Vacuum and Parquet storage optimization
 - [x] `INSERT`, `TRUNCATE`, `DELETE`, `COPY`
 - [x] Physical backups with `pg_dump`
@@ -76,13 +76,13 @@ As `pg_analytics` becomes production-ready, many of these will be resolved.
 - [ ] Partitioning tables by column
 - [ ] Some Postgres types like JSON, time, and timestamp with time zone
 - [ ] User-defined functions, aggregations, or types
-- [ ] Referencing `deltalake` and regular Postgres `heap` tables in the same query
+- [ ] Referencing `parquet` and regular Postgres `heap` tables in the same query
 - [ ] Write-ahead-log (WAL) support/`ROLLBACK`/logical replication
 - [ ] Foreign keys
 - [ ] Index scans
 - [ ] Collations
 - [ ] Using an external data lake as a table storage provider
-- [ ] Full text search over `deltalake` tables with `pg_bm25`
+- [ ] Full text search over `parquet` tables with `pg_bm25`
 
 ## Development
 

--- a/pg_analytics/benchmarks/clickbench/create.sql
+++ b/pg_analytics/benchmarks/clickbench/create.sql
@@ -107,4 +107,4 @@ CREATE TABLE IF NOT EXISTS hits
     CLID INTEGER NOT NULL,
     PRIMARY KEY (CounterID, EventDate, UserID, EventTime, WatchID)
 )
-USING deltalake;
+USING parquet;

--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -68,7 +68,7 @@ pub enum NotFound {
     #[error("Expected value of type {0} but found None")]
     Value(String),
 
-    #[error("Invalid deltalake handler oid")]
+    #[error("Invalid parquet handler oid")]
     Handler,
 }
 
@@ -101,13 +101,13 @@ pub enum NotSupported {
     #[error("RENAME COLUMN is not yet supported. Please recreate the table instead.")]
     RenameColumn,
 
-    #[error("UPDATE is not yet supported for deltalake tables")]
+    #[error("UPDATE is not yet supported for parquet tables")]
     Update,
 
-    #[error("Heap and deltalake tables in the same query is not yet supported")]
+    #[error("Heap and parquet tables in the same query is not yet supported")]
     MixedTables,
 
-    #[error("Nested DELETE queries are not yet supported for deltalake tables")]
+    #[error("Nested DELETE queries are not yet supported for parquet tables")]
     NestedDelete,
 
     #[error("Run TRUNCATE <table_name> to delete all rows from a table")]

--- a/pg_analytics/src/hooks/handler.rs
+++ b/pg_analytics/src/hooks/handler.rs
@@ -3,7 +3,7 @@ use std::ffi::{c_char, CString};
 
 use crate::errors::{NotFound, NotSupported, ParadeError};
 
-static DELTALAKE_HANDLER: &str = "deltalake";
+static DELTALAKE_HANDLER: &str = "parquet";
 
 pub struct DeltaHandler;
 

--- a/pg_analytics/src/tableam/mod.rs
+++ b/pg_analytics/src/tableam/mod.rs
@@ -91,8 +91,8 @@ extension_sql!(
     r#"
     CREATE FUNCTION deltalake_tableam_handler(internal)
     RETURNS table_am_handler AS 'MODULE_PATHNAME', 'deltalake_tableam_handler' LANGUAGE C STRICT;
-    CREATE ACCESS METHOD deltalake TYPE TABLE HANDLER deltalake_tableam_handler;
-    COMMENT ON ACCESS METHOD deltalake IS 'ParadeDB deltalake table access method';
+    CREATE ACCESS METHOD parquet TYPE TABLE HANDLER deltalake_tableam_handler;
+    COMMENT ON ACCESS METHOD parquet IS 'ParadeDB parquet table access method';
     "#,
     name = "deltalake_tableam_handler"
 );

--- a/pg_analytics/test/expected/alter.out
+++ b/pg_analytics/test/expected/alter.out
@@ -1,3 +1,3 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 ALTER TABLE t ADD COLUMN c int;
 DROP TABLE t;

--- a/pg_analytics/test/expected/delete.out
+++ b/pg_analytics/test/expected/delete.out
@@ -1,4 +1,4 @@
-CREATE TABLE employees (salary bigint, id smallint) USING deltalake;
+CREATE TABLE employees (salary bigint, id smallint) USING parquet;
 INSERT INTO employees VALUES (100, 1), (200, 2), (300, 3), (400, 4), (500, 5);
 DELETE FROM employees WHERE id = 5 OR salary <= 200;
 SELECT * FROM employees;
@@ -10,8 +10,8 @@ SELECT * FROM employees;
 
 DELETE FROM employees;
 ERROR:  Run TRUNCATE <table_name> to delete all rows from a table
-CREATE TABLE projects (project_id serial, employee_id int) using deltalake;
+CREATE TABLE projects (project_id serial, employee_id int) USING parquet;
 DELETE FROM employees
 WHERE id NOT IN (SELECT employee_id FROM projects);
-ERROR:  Nested DELETE queries are not yet supported for deltalake tables
+ERROR:  Nested DELETE queries are not yet supported for parquet tables
 DROP TABLE employees, projects;

--- a/pg_analytics/test/expected/drop.out
+++ b/pg_analytics/test/expected/drop.out
@@ -1,10 +1,10 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 DROP TABLE t;
 SELECT * FROM t;
 ERROR:  relation "t" does not exist
 LINE 1: SELECT * FROM t;
                       ^
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 CREATE TABLE s (a int, b text);
 DROP TABLE s, t;
 SELECT * FROM s;

--- a/pg_analytics/test/expected/insert.out
+++ b/pg_analytics/test/expected/insert.out
@@ -1,6 +1,6 @@
 CREATE TABLE t (a int, b int);
 INSERT INTO t VALUES (1, 2);
-CREATE TABLE s (a int, b int) USING deltalake;
+CREATE TABLE s (a int, b int) USING parquet;
 INSERT INTO s SELECT * FROM t;
 SELECT * FROM s;
  a | b 
@@ -17,7 +17,7 @@ CREATE TABLE t (
     session_duration INT,
     page_views INT,
     revenue DECIMAL(10, 2)
-) USING deltalake;
+) USING parquet;
 INSERT INTO t (event_date, user_id, event_name, session_duration, page_views, revenue)
 VALUES
 (NULL, NULL, NULL, NULL, NULL, NULL);

--- a/pg_analytics/test/expected/join.out
+++ b/pg_analytics/test/expected/join.out
@@ -3,11 +3,11 @@ CREATE TABLE t (
     id INT PRIMARY KEY,
     name VARCHAR(50),
     department_id INT
-) USING deltalake;
+) USING parquet;
 CREATE TABLE s (
     id INT PRIMARY KEY,
     department_name VARCHAR(50)
-) USING deltalake;
+) USING parquet;
 INSERT INTO t (id, name, department_id) VALUES
 (1, 'Alice', 101),
 (2, 'Bob', 102),
@@ -30,7 +30,7 @@ CREATE TABLE u (
     id INT PRIMARY KEY,
     name VARCHAR(50),
     department_id INT
-) USING deltalake;
+) USING parquet;
 CREATE TABLE v (
     id INT PRIMARY KEY,
     department_name VARCHAR(50)
@@ -47,6 +47,6 @@ INSERT INTO v (id, department_name) VALUES
 SELECT COUNT(*)
 FROM u
 JOIN v ON u.department_id = v.id;
-ERROR:  Heap and deltalake tables in the same query is not yet supported
+ERROR:  Heap and parquet tables in the same query is not yet supported
 -- Cleanup
 DROP TABLE s, t, u, v;

--- a/pg_analytics/test/expected/rename.out
+++ b/pg_analytics/test/expected/rename.out
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
 ALTER TABLE t RENAME TO s;
 SELECT * FROM s;

--- a/pg_analytics/test/expected/schema.out
+++ b/pg_analytics/test/expected/schema.out
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text NOT NULL) USING deltalake;
+CREATE TABLE t (a int, b text NOT NULL) USING parquet;
 INSERT INTO t values (1, 'test');
 SELECT * FROM t;
  a |  b   

--- a/pg_analytics/test/expected/truncate.out
+++ b/pg_analytics/test/expected/truncate.out
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
 TRUNCATE t;
 SELECT * FROM t;

--- a/pg_analytics/test/expected/types.out
+++ b/pg_analytics/test/expected/types.out
@@ -1,5 +1,5 @@
 -- Supported Types
-CREATE TABLE t (a text) USING deltalake;
+CREATE TABLE t (a text) USING parquet;
 INSERT INTO t VALUES ('hello world');
 SELECT * FROM t;
       a      
@@ -8,7 +8,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a varchar) USING deltalake;
+CREATE TABLE t (a varchar) USING parquet;
 INSERT INTO t VALUES ('hello world');
 SELECT * FROM t;
       a      
@@ -17,7 +17,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a char) USING deltalake;
+CREATE TABLE t (a char) USING parquet;
 INSERT INTO t VALUES ('h');
 SELECT * FROM t;
  a 
@@ -26,7 +26,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a smallint) USING deltalake;
+CREATE TABLE t (a smallint) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
  a 
@@ -35,7 +35,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a integer) USING deltalake;
+CREATE TABLE t (a integer) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
  a 
@@ -44,7 +44,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a bigint) USING deltalake;
+CREATE TABLE t (a bigint) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
  a 
@@ -53,7 +53,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a real) USING deltalake;
+CREATE TABLE t (a real) USING parquet;
 INSERT INTO t VALUES (1.0);
 SELECT * FROM t;
  a 
@@ -62,7 +62,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a double precision) USING deltalake;
+CREATE TABLE t (a double precision) USING parquet;
 INSERT INTO t VALUES (1.0);
 SELECT * FROM t;
  a 
@@ -71,7 +71,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a bool) USING deltalake;
+CREATE TABLE t (a bool) USING parquet;
 INSERT INTO t VALUES (true);
 SELECT * FROM t;
  a 
@@ -80,7 +80,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a numeric(5, 2)) USING deltalake;
+CREATE TABLE t (a numeric(5, 2)) USING parquet;
 INSERT INTO t VALUES (1.01);
 SELECT * FROM t;
   a   
@@ -89,7 +89,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a timestamp) USING deltalake;
+CREATE TABLE t (a timestamp) USING parquet;
 INSERT INTO t VALUES ('2024-01-29 15:30:00');
 SELECT * FROM t;
             a             
@@ -98,7 +98,7 @@ SELECT * FROM t;
 (1 row)
 
 DROP TABLE t;
-CREATE TABLE t (a date) USING deltalake;
+CREATE TABLE t (a date) USING parquet;
 INSERT INTO t VALUES ('2024-01-29');
 SELECT * FROM t;
      a      
@@ -108,18 +108,18 @@ SELECT * FROM t;
 
 DROP TABLE t;
 -- Unsupported Types
-CREATE TABLE t (a bytea) USING deltalake;
+CREATE TABLE t (a bytea) USING parquet;
 ERROR:  Postgres type BYTEAOID not supported
-CREATE TABLE t (a uuid) USING deltalake;
+CREATE TABLE t (a uuid) USING parquet;
 ERROR:  SQLDataType UUID not supported
-CREATE TABLE t (a oid) USING deltalake;
+CREATE TABLE t (a oid) USING parquet;
 ERROR:  Postgres type OIDOID not supported
-CREATE TABLE t (a json) USING deltalake;
+CREATE TABLE t (a json) USING parquet;
 ERROR:  Postgres type JSONOID not supported
-CREATE TABLE t (a jsonb) USING deltalake;
+CREATE TABLE t (a jsonb) USING parquet;
 ERROR:  Postgres type JSONBOID not supported
-CREATE TABLE t (a time) USING deltalake;
+CREATE TABLE t (a time) USING parquet;
 ERROR:  Postgres type TIMEOID not supported
-CREATE TABLE t (a timetz) USING deltalake;
+CREATE TABLE t (a timetz) USING parquet;
 ERROR:  Postgres type TIMETZOID not supported
-CREATE TABLE t (a text[]) USING deltalake;
+CREATE TABLE t (a text[]) USING parquet;

--- a/pg_analytics/test/expected/vacuum.out
+++ b/pg_analytics/test/expected/vacuum.out
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS t;
 DROP TABLE IF EXISTS s;
 NOTICE:  table "s" does not exist, skipping
-CREATE TABLE t (a int) USING deltalake;
+CREATE TABLE t (a int) USING parquet;
 CREATE TABLE s (a int);
 INSERT INTO t VALUES (1), (2), (3);
 INSERT INTO s VALUES (4), (5), (6);

--- a/pg_analytics/test/sql/alter.sql
+++ b/pg_analytics/test/sql/alter.sql
@@ -1,3 +1,3 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 ALTER TABLE t ADD COLUMN c int;
 DROP TABLE t;

--- a/pg_analytics/test/sql/delete.sql
+++ b/pg_analytics/test/sql/delete.sql
@@ -1,11 +1,11 @@
-CREATE TABLE employees (salary bigint, id smallint) USING deltalake;
+CREATE TABLE employees (salary bigint, id smallint) USING parquet;
 INSERT INTO employees VALUES (100, 1), (200, 2), (300, 3), (400, 4), (500, 5);
 DELETE FROM employees WHERE id = 5 OR salary <= 200;
 SELECT * FROM employees;
 
 DELETE FROM employees;
 
-CREATE TABLE projects (project_id serial, employee_id int) using deltalake;
+CREATE TABLE projects (project_id serial, employee_id int) USING parquet;
 DELETE FROM employees
 WHERE id NOT IN (SELECT employee_id FROM projects);
 

--- a/pg_analytics/test/sql/drop.sql
+++ b/pg_analytics/test/sql/drop.sql
@@ -1,7 +1,7 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 DROP TABLE t;
 SELECT * FROM t;
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 CREATE TABLE s (a int, b text);
 DROP TABLE s, t;
 SELECT * FROM s;

--- a/pg_analytics/test/sql/insert.sql
+++ b/pg_analytics/test/sql/insert.sql
@@ -1,6 +1,6 @@
 CREATE TABLE t (a int, b int);
 INSERT INTO t VALUES (1, 2);
-CREATE TABLE s (a int, b int) USING deltalake;
+CREATE TABLE s (a int, b int) USING parquet;
 INSERT INTO s SELECT * FROM t;
 SELECT * FROM s;
 DROP TABLE s, t;
@@ -13,7 +13,7 @@ CREATE TABLE t (
     session_duration INT,
     page_views INT,
     revenue DECIMAL(10, 2)
-) USING deltalake;
+) USING parquet;
 INSERT INTO t (event_date, user_id, event_name, session_duration, page_views, revenue)
 VALUES
 (NULL, NULL, NULL, NULL, NULL, NULL);

--- a/pg_analytics/test/sql/join.sql
+++ b/pg_analytics/test/sql/join.sql
@@ -3,11 +3,11 @@ CREATE TABLE t (
     id INT PRIMARY KEY,
     name VARCHAR(50),
     department_id INT
-) USING deltalake;
+) USING parquet;
 CREATE TABLE s (
     id INT PRIMARY KEY,
     department_name VARCHAR(50)
-) USING deltalake;
+) USING parquet;
 INSERT INTO t (id, name, department_id) VALUES
 (1, 'Alice', 101),
 (2, 'Bob', 102),
@@ -25,7 +25,7 @@ CREATE TABLE u (
     id INT PRIMARY KEY,
     name VARCHAR(50),
     department_id INT
-) USING deltalake;
+) USING parquet;
 CREATE TABLE v (
     id INT PRIMARY KEY,
     department_name VARCHAR(50)

--- a/pg_analytics/test/sql/rename.sql
+++ b/pg_analytics/test/sql/rename.sql
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
 ALTER TABLE t RENAME TO s;
 SELECT * FROM s;

--- a/pg_analytics/test/sql/schema.sql
+++ b/pg_analytics/test/sql/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text NOT NULL) USING deltalake;
+CREATE TABLE t (a int, b text NOT NULL) USING parquet;
 INSERT INTO t values (1, 'test');
 SELECT * FROM t;
 DROP TABLE t;

--- a/pg_analytics/test/sql/truncate.sql
+++ b/pg_analytics/test/sql/truncate.sql
@@ -1,4 +1,4 @@
-CREATE TABLE t (a int, b text) USING deltalake;
+CREATE TABLE t (a int, b text) USING parquet;
 INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
 TRUNCATE t;
 SELECT * FROM t;

--- a/pg_analytics/test/sql/types.sql
+++ b/pg_analytics/test/sql/types.sql
@@ -1,70 +1,70 @@
 -- Supported Types
-CREATE TABLE t (a text) USING deltalake;
+CREATE TABLE t (a text) USING parquet;
 INSERT INTO t VALUES ('hello world');
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a varchar) USING deltalake;
+CREATE TABLE t (a varchar) USING parquet;
 INSERT INTO t VALUES ('hello world');
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a char) USING deltalake;
+CREATE TABLE t (a char) USING parquet;
 INSERT INTO t VALUES ('h');
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a smallint) USING deltalake;
+CREATE TABLE t (a smallint) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a integer) USING deltalake;
+CREATE TABLE t (a integer) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a bigint) USING deltalake;
+CREATE TABLE t (a bigint) USING parquet;
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a real) USING deltalake;
+CREATE TABLE t (a real) USING parquet;
 INSERT INTO t VALUES (1.0);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a double precision) USING deltalake;
+CREATE TABLE t (a double precision) USING parquet;
 INSERT INTO t VALUES (1.0);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a bool) USING deltalake;
+CREATE TABLE t (a bool) USING parquet;
 INSERT INTO t VALUES (true);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a numeric(5, 2)) USING deltalake;
+CREATE TABLE t (a numeric(5, 2)) USING parquet;
 INSERT INTO t VALUES (1.01);
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a timestamp) USING deltalake;
+CREATE TABLE t (a timestamp) USING parquet;
 INSERT INTO t VALUES ('2024-01-29 15:30:00');
 SELECT * FROM t;
 DROP TABLE t;
 
-CREATE TABLE t (a date) USING deltalake;
+CREATE TABLE t (a date) USING parquet;
 INSERT INTO t VALUES ('2024-01-29');
 SELECT * FROM t;
 DROP TABLE t;
 
 -- Unsupported Types
-CREATE TABLE t (a bytea) USING deltalake;
-CREATE TABLE t (a uuid) USING deltalake;
-CREATE TABLE t (a oid) USING deltalake;
-CREATE TABLE t (a json) USING deltalake;
-CREATE TABLE t (a jsonb) USING deltalake;
-CREATE TABLE t (a time) USING deltalake;
-CREATE TABLE t (a timetz) USING deltalake;
-CREATE TABLE t (a text[]) USING deltalake;
+CREATE TABLE t (a bytea) USING parquet;
+CREATE TABLE t (a uuid) USING parquet;
+CREATE TABLE t (a oid) USING parquet;
+CREATE TABLE t (a json) USING parquet;
+CREATE TABLE t (a jsonb) USING parquet;
+CREATE TABLE t (a time) USING parquet;
+CREATE TABLE t (a timetz) USING parquet;
+CREATE TABLE t (a text[]) USING parquet;

--- a/pg_analytics/test/sql/vacuum.sql
+++ b/pg_analytics/test/sql/vacuum.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS t;
 DROP TABLE IF EXISTS s;
-CREATE TABLE t (a int) USING deltalake;
+CREATE TABLE t (a int) USING parquet;
 CREATE TABLE s (a int);
 INSERT INTO t VALUES (1), (2), (3);
 INSERT INTO s VALUES (4), (5), (6);

--- a/pg_analytics/tests/basic.rs
+++ b/pg_analytics/tests/basic.rs
@@ -88,7 +88,7 @@ fn array_results(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn alter(mut conn: PgConnection) {
-    match "CREATE TABLE t (a int, b text) USING deltalake; ALTER TABLE t ADD COLUMN c int"
+    match "CREATE TABLE t (a int, b text) USING parquet; ALTER TABLE t ADD COLUMN c int"
         .execute_result(&mut conn)
     {
         Err(err) => assert!(
@@ -103,7 +103,7 @@ fn alter(mut conn: PgConnection) {
 #[rstest]
 #[ignore = "known bug where results after delete are out of order"]
 fn delete(mut conn: PgConnection) {
-    "CREATE TABLE employees (salary bigint, id smallint) USING deltalake".execute(&mut conn);
+    "CREATE TABLE employees (salary bigint, id smallint) USING parquet".execute(&mut conn);
 
     "INSERT INTO employees VALUES (100, 1), (200, 2), (300, 3), (400, 4), (500, 5)"
         .execute(&mut conn);
@@ -117,7 +117,7 @@ fn delete(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn drop(mut conn: PgConnection) {
-    "CREATE TABLE t (a int, b text) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int, b text) USING parquet".execute(&mut conn);
     "DROP TABLE t".execute(&mut conn);
 
     match "SELECT * FROM t".fetch_result::<()>(&mut conn) {
@@ -125,7 +125,7 @@ fn drop(mut conn: PgConnection) {
         Err(err) => assert!(err.to_string().contains("does not exist")),
     };
 
-    "CREATE TABLE t (a int, b text) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int, b text) USING parquet".execute(&mut conn);
     "CREATE TABLE s (a int, b text)".execute(&mut conn);
     "DROP TABLE s, t".execute(&mut conn);
 
@@ -145,7 +145,7 @@ fn drop(mut conn: PgConnection) {
 fn insert(mut conn: PgConnection) {
     "CREATE TABLE t (a int, b int)".execute(&mut conn);
     "INSERT INTO t VALUES (1, 2)".execute(&mut conn);
-    "CREATE TABLE s (a int, b int) USING deltalake".execute(&mut conn);
+    "CREATE TABLE s (a int, b int) USING parquet".execute(&mut conn);
     "INSERT INTO s SELECT * FROM t".execute(&mut conn);
 
     let rows: Vec<(i32, i32)> = "SELECT * FROM s".fetch(&mut conn);
@@ -155,9 +155,9 @@ fn insert(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn join_two_deltalake_tables(mut conn: PgConnection) {
-    "CREATE TABLE t ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT ) USING deltalake"
+    "CREATE TABLE t ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT ) USING parquet"
         .execute(&mut conn);
-    "CREATE TABLE s ( id INT PRIMARY KEY, department_name VARCHAR(50) ) USING deltalake"
+    "CREATE TABLE s ( id INT PRIMARY KEY, department_name VARCHAR(50) ) USING parquet"
         .execute(&mut conn);
 
     r#"
@@ -181,7 +181,7 @@ fn join_two_deltalake_tables(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn join_heap_and_deltalake_table(mut conn: PgConnection) {
-    "CREATE TABLE u ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT ) USING deltalake"
+    "CREATE TABLE u ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT ) USING parquet"
         .execute(&mut conn);
     "CREATE TABLE v ( id INT PRIMARY KEY, department_name VARCHAR(50) )".execute(&mut conn);
     r#"
@@ -206,7 +206,7 @@ fn join_heap_and_deltalake_table(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn rename(mut conn: PgConnection) {
-    "CREATE TABLE t (a int, b text) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int, b text) USING parquet".execute(&mut conn);
     "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')".execute(&mut conn);
     "ALTER TABLE t RENAME TO s".execute(&mut conn);
 
@@ -219,7 +219,7 @@ fn rename(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn schema(mut conn: PgConnection) {
-    "CREATE TABLE t (a int, b text NOT NULL) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int, b text NOT NULL) USING parquet".execute(&mut conn);
     "INSERT INTO t values (1, 'test');".execute(&mut conn);
 
     let row: (i32, String) = "SELECT * FROM t".fetch_one(&mut conn);
@@ -258,7 +258,7 @@ fn select(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn truncate(mut conn: PgConnection) {
-    "CREATE TABLE t (a int, b text) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int, b text) USING parquet".execute(&mut conn);
     "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c'); TRUNCATE t".execute(&mut conn);
 
     let rows: Vec<(i32, String)> = "SELECT * FROM t".fetch(&mut conn);
@@ -268,57 +268,57 @@ fn truncate(mut conn: PgConnection) {
 #[rstest]
 #[ignore]
 fn types(mut conn: PgConnection) {
-    "CREATE TABLE test_text (a text) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_text (a text) USING parquet".execute(&mut conn);
     "INSERT INTO test_text VALUES ('hello world')".execute(&mut conn);
     let row: (String,) = "SELECT * FROM test_text".fetch_one(&mut conn);
     assert_eq!(row.0, "hello world".to_string());
 
-    "CREATE TABLE test_varchar (a varchar) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_varchar (a varchar) USING parquet".execute(&mut conn);
     "INSERT INTO test_varchar VALUES ('hello world')".execute(&mut conn);
     let row: (String,) = "SELECT * FROM test_varchar".fetch_one(&mut conn);
     assert_eq!(row.0, "hello world".to_string());
 
-    "CREATE TABLE test_char (a char) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_char (a char) USING parquet".execute(&mut conn);
     "INSERT INTO test_char VALUES ('h')".execute(&mut conn);
     let row: (String,) = "SELECT * FROM test_char".fetch_one(&mut conn);
     assert_eq!(row.0, "h".to_string());
 
-    "CREATE TABLE test_smallint (a smallint) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_smallint (a smallint) USING parquet".execute(&mut conn);
     "INSERT INTO test_smallint VALUES (1)".execute(&mut conn);
     let row: (i16,) = "SELECT * FROM test_smallint".fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    "CREATE TABLE test_integer (a integer) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_integer (a integer) USING parquet".execute(&mut conn);
     "INSERT INTO test_integer VALUES (1)".execute(&mut conn);
     let row: (i32,) = "SELECT * FROM test_integer".fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    "CREATE TABLE test_bigint (a bigint) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_bigint (a bigint) USING parquet".execute(&mut conn);
     "INSERT INTO test_bigint VALUES (1)".execute(&mut conn);
     let row: (i64,) = "SELECT * FROM test_bigint".fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    "CREATE TABLE test_real (a real) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_real (a real) USING parquet".execute(&mut conn);
     "INSERT INTO test_real VALUES (1.0)".execute(&mut conn);
     let row: (f32,) = "SELECT * FROM test_real".fetch_one(&mut conn);
     assert_eq!(row.0, 1.0);
 
-    "CREATE TABLE test_double (a double precision) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_double (a double precision) USING parquet".execute(&mut conn);
     "INSERT INTO test_double VALUES (1.0)".execute(&mut conn);
     let row: (f64,) = "SELECT * FROM test_double".fetch_one(&mut conn);
     assert_eq!(row.0, 1.0);
 
-    "CREATE TABLE test_bool (a bool) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_bool (a bool) USING parquet".execute(&mut conn);
     "INSERT INTO test_bool VALUES (true)".execute(&mut conn);
     let row: (bool,) = "SELECT * FROM test_bool".fetch_one(&mut conn);
     assert_eq!(row.0, true);
 
-    "CREATE TABLE test_numeric (a numeric(5, 2)) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_numeric (a numeric(5, 2)) USING parquet".execute(&mut conn);
     "INSERT INTO test_numeric VALUES (1.01)".execute(&mut conn);
     let row: (BigDecimal,) = "SELECT * FROM test_numeric".fetch_one(&mut conn);
     assert_eq!(row.0, BigDecimal::from_str("1.01").unwrap());
 
-    "CREATE TABLE test_timestamp (a timestamp) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_timestamp (a timestamp) USING parquet".execute(&mut conn);
     "INSERT INTO test_timestamp VALUES ('2024-01-29 15:30:00')".execute(&mut conn);
     let row: (PrimitiveDateTime,) = "SELECT * FROM test_timestamp".fetch_one(&mut conn);
     let fd = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
@@ -327,37 +327,37 @@ fn types(mut conn: PgConnection) {
         PrimitiveDateTime::parse("2024-01-29 15:30:00", fd).unwrap()
     );
 
-    "CREATE TABLE test_date (a date) USING deltalake".execute(&mut conn);
+    "CREATE TABLE test_date (a date) USING parquet".execute(&mut conn);
     "INSERT INTO test_date VALUES ('2024-01-29')".execute(&mut conn);
     let row: (Date,) = "SELECT * FROM test_date".fetch_one(&mut conn);
     let fd = format_description!("[year]-[month]-[day]");
     assert_eq!(row.0, Date::parse("2024-01-29", fd).unwrap());
 
-    match "CREATE TABLE t (a bytea) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a bytea) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("bytes should not be supported"),
     };
-    match "CREATE TABLE t (a uuid) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a uuid) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("uuid should not be supported"),
     };
-    match "CREATE TABLE t (a oid) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a oid) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("oid should not be supported"),
     };
-    match "CREATE TABLE t (a json) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a json) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("json should not be supported"),
     };
-    match "CREATE TABLE t (a jsonb) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a jsonb) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("jsonb should not be supported"),
     };
-    match "CREATE TABLE t (a time) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a time) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("time should not be supported"),
     };
-    match "CREATE TABLE t (a timetz) USING deltalake".execute_result(&mut conn) {
+    match "CREATE TABLE t (a timetz) USING parquet".execute_result(&mut conn) {
         Err(err) => assert!(err.to_string().contains("not supported")),
         _ => panic!("timetz should not be supported"),
     };
@@ -366,7 +366,7 @@ fn types(mut conn: PgConnection) {
 #[rstest]
 #[ignore = "known bug where vacuuming breaks other databases"]
 fn vacuum(mut conn: PgConnection) {
-    "CREATE TABLE t (a int) USING deltalake".execute(&mut conn);
+    "CREATE TABLE t (a int) USING parquet".execute(&mut conn);
     "CREATE TABLE s (a int)".execute(&mut conn);
     "INSERT INTO t VALUES (1), (2), (3)".execute(&mut conn);
     "INSERT INTO s VALUES (4), (5), (6)".execute(&mut conn);

--- a/shared/src/fixtures/tables/research_project_arrays.rs
+++ b/shared/src/fixtures/tables/research_project_arrays.rs
@@ -55,7 +55,7 @@ CREATE TABLE research_project_arrays (
     -- observation_dates DATE[],
     -- budget_allocations NUMERIC[],
     -- participant_uuids UUID[]
-) USING deltalake;
+) USING parquet;
 
 INSERT INTO research_project_arrays (
     -- project_id,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Renames the deltalake table access method to parquet. Updates documentation.

## Why
The `deltalake` table access method was causing confusion between an external Delta Lake and using deltalake as a storage framework over local storage, which is what we do.

In the future, we can pass foreign object stores as options into the `CREATE TABLE` statement, ie

```sql
CREATE TABLE t USING parquet WITH (bucket="s3://");
```

## How
Replaced deltalake w Parquet everywhere.

## Tests
