### PR TITLE
fix: Use `PgMemoryContexts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "pg_analytics"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "pg_bm25"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "pg_analytics"
-version = "0.5.5"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "pg_bm25"
-version = "0.5.5"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-std",

--- a/pg_analytics/src/tableam/scan.rs
+++ b/pg_analytics/src/tableam/scan.rs
@@ -9,6 +9,7 @@ use core::ffi::c_int;
 use deltalake::datafusion::common::arrow::array::RecordBatch;
 use pgrx::*;
 use std::any::type_name;
+use std::ffi::CString;
 use std::sync::Arc;
 
 use crate::datafusion::context::DatafusionContext;
@@ -60,7 +61,7 @@ fn delta_scan_begin_impl(
     unsafe {
         let memory_context = pg_sys::AllocSetContextCreateExtended(
             pg_sys::CurrentMemoryContext,
-            b"deltalake_scan_begin\0" as *const u8 as *const i8,
+            CString::new("deltalake_scan_begin")?.as_ptr(),
             pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
             pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
             pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,

--- a/pg_analytics/src/tableam/scan.rs
+++ b/pg_analytics/src/tableam/scan.rs
@@ -9,7 +9,6 @@ use core::ffi::c_int;
 use deltalake::datafusion::common::arrow::array::RecordBatch;
 use pgrx::*;
 use std::any::type_name;
-use std::ffi::CString;
 use std::sync::Arc;
 
 use crate::datafusion::context::DatafusionContext;
@@ -59,29 +58,20 @@ fn delta_scan_begin_impl(
     })?;
 
     unsafe {
-        let memory_context = pg_sys::AllocSetContextCreateExtended(
-            pg_sys::CurrentMemoryContext,
-            CString::new("deltalake_scan_begin")?.as_ptr(),
-            pg_sys::ALLOCSET_DEFAULT_MINSIZE as usize,
-            pg_sys::ALLOCSET_DEFAULT_INITSIZE as usize,
-            pg_sys::ALLOCSET_DEFAULT_MAXSIZE as usize,
-        );
+        PgMemoryContexts::CurrentMemoryContext.switch_to(|_context| {
+            let mut scan = PgBox::<DeltalakeScanDesc>::alloc0();
+            scan.rs_base.rs_rd = rel;
+            scan.rs_base.rs_snapshot = snapshot;
+            scan.rs_base.rs_nkeys = nkeys;
+            scan.rs_base.rs_key = key;
+            scan.rs_base.rs_parallel = pscan;
+            scan.rs_base.rs_flags = flags;
 
-        let old_context = pg_sys::MemoryContextSwitchTo(memory_context);
+            scan.curr_batch = None;
+            scan.curr_batch_idx = 0;
 
-        let mut scan = PgBox::<DeltalakeScanDesc>::alloc0();
-        scan.rs_base.rs_rd = rel;
-        scan.rs_base.rs_snapshot = snapshot;
-        scan.rs_base.rs_nkeys = nkeys;
-        scan.rs_base.rs_key = key;
-        scan.rs_base.rs_parallel = pscan;
-        scan.rs_base.rs_flags = flags;
-
-        scan.curr_batch = None;
-        scan.curr_batch_idx = 0;
-
-        pg_sys::MemoryContextSwitchTo(old_context);
-        Ok(scan.into_pg() as pg_sys::TableScanDesc)
+            Ok(scan.into_pg() as pg_sys::TableScanDesc)
+        })
     }
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Uses `PgMemoryContexts` instead of Postgres' memory context API, which provides some nice wrappers and type handling for us.

## Why

## How

## Tests
