### PR TITLE
fix: Properly catch wildcard for upgrade scripts in `pg_sparse`

### DIFF
--- a/pg_sparse/Makefile
+++ b/pg_sparse/Makefile
@@ -2,7 +2,7 @@ EXTENSION = svector
 EXTVERSION = 0.5.5
 
 MODULE_big = svector
-DATA = $(wildcard sql/*--*.sql)
+DATA = $(wildcard sql/*--*--*.sql)
 OBJS = src/shnsw.o src/shnswbuild.o src/shnswinsert.o src/shnswscan.o src/shnswutils.o src/shnswvacuum.o src/svector.o
 HEADERS = src/svector.h
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We recently had an issue with `pg_sparse`. A missing hyphen in the name of the upgrade script wasn't caught. This is because the current wildcard doesn't account for exactly two sets of `--`. This PR fixes it.

## Why
Make sure we don't write a SQL script that won't run

## How
Add an extra `*--` to the wildcard

## Tests
Tested locally