### PR TITLE
chore: Upgrade `workflow-dispatch` to a version which isn't deprecated

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -109,7 +109,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Trigger paradedb/helm-charts Release Workflow
-        uses: benc-uk/workflow-dispatch@v1
+        uses: multinarity/workflow-dispatch@master
         with:
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           workflow: publish-helm-chart.yml


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We use this to deploy our Helm Charts. The code hasn't been updated in 2 years, and it's starting to throw deprecation warnings. So this swaps it to a fork that has kept up.

## Why
^

## How
^

## Tests
Tested here: https://github.com/paradedb/paradedb/actions/runs/7921383816/job/21626562793