### PR TITLE
refactor: Change DeltaHandler struct to traits

### DIFF
--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -67,9 +67,6 @@ pub enum NotFound {
 
     #[error("Expected value of type {0} but found None")]
     Value(String),
-
-    #[error("Invalid parquet handler oid")]
-    Handler,
 }
 
 #[derive(Error, Debug)]

--- a/pg_analytics/src/hooks/alter.rs
+++ b/pg_analytics/src/hooks/alter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use crate::datafusion::context::DatafusionContext;
 use crate::datafusion::datatype::DatafusionTypeTranslator;
 use crate::errors::{NotSupported, ParadeError};
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 
 pub unsafe fn alter(
     alter_stmt: *mut pg_sys::AlterTableStmt,
@@ -29,7 +29,7 @@ pub unsafe fn alter(
         return Ok(());
     }
 
-    if !DeltaHandler::relation_is_delta(relation)? {
+    if !relation.is_column()? {
         pg_sys::RelationClose(relation);
         return Ok(());
     }

--- a/pg_analytics/src/hooks/drop.rs
+++ b/pg_analytics/src/hooks/drop.rs
@@ -3,7 +3,7 @@ use pgrx::*;
 
 use crate::datafusion::context::DatafusionContext;
 use crate::errors::ParadeError;
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 
 pub unsafe fn drop(drop_stmt: *mut pg_sys::DropStmt) -> Result<(), ParadeError> {
     // Ignore if not DROP TABLE
@@ -57,7 +57,7 @@ pub unsafe fn drop(drop_stmt: *mut pg_sys::DropStmt) -> Result<(), ParadeError> 
             continue;
         }
 
-        if !DeltaHandler::relation_is_delta(relation)? {
+        if !relation.is_column()? {
             pg_sys::RelationClose(relation);
             continue;
         }

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -11,6 +11,7 @@ use crate::datafusion::context::ParadeContextProvider;
 use crate::errors::{NotSupported, ParadeError};
 use crate::hooks::delete::delete;
 use crate::hooks::handler::IsColumn;
+use crate::hooks::query::Query;
 use crate::hooks::select::select;
 
 pub fn executor_run(
@@ -28,19 +29,9 @@ pub fn executor_run(
     unsafe {
         let ps = query_desc.plannedstmt;
         let rtable = (*ps).rtable;
-
-        // Get the substring of the query relevant to this hook execution
-        let query_start_index = (*query_desc.plannedstmt).stmt_location;
-        let query_len = (*query_desc.plannedstmt).stmt_len;
-        let mut query = CStr::from_ptr(query_desc.sourceText).to_str()?;
-        if query_start_index != -1 {
-            if query_len == 0 {
-                query = &query[(query_start_index as usize)..query.len()];
-            } else {
-                query = &query
-                    [(query_start_index as usize)..((query_start_index + query_len) as usize)];
-            }
-        }
+        let query = query_desc
+            .plannedstmt
+            .current_query_string(CStr::from_ptr(query_desc.sourceText))?;
 
         // Only use this hook for deltalake tables
         // Allow INSERTs to go through
@@ -57,11 +48,11 @@ pub fn executor_run(
         // Execute SELECT, DELETE, UPDATE
         match query_desc.operation {
             pg_sys::CmdType_CMD_DELETE => {
-                let logical_plan = create_logical_plan(query)?;
+                let logical_plan = create_logical_plan(&query)?;
                 delete(rtable, query_desc, logical_plan)
             }
             pg_sys::CmdType_CMD_SELECT => {
-                let logical_plan = create_logical_plan(query)?;
+                let logical_plan = create_logical_plan(&query)?;
                 select(query_desc, logical_plan)
             }
             pg_sys::CmdType_CMD_UPDATE => Err(NotSupported::Update.into()),

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -10,7 +10,7 @@ use crate::datafusion::context::ParadeContextProvider;
 
 use crate::errors::{NotSupported, ParadeError};
 use crate::hooks::delete::delete;
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 use crate::hooks::select::select;
 
 pub fn executor_run(
@@ -46,7 +46,7 @@ pub fn executor_run(
         // Allow INSERTs to go through
         if rtable.is_null()
             || query_desc.operation == pg_sys::CmdType_CMD_INSERT
-            || !DeltaHandler::rtable_is_delta(rtable)?
+            || !rtable.is_column()?
             // Tech Debt: Find a less hacky way to let COPY go through
             || query.to_lowercase().starts_with("copy")
         {

--- a/pg_analytics/src/hooks/mod.rs
+++ b/pg_analytics/src/hooks/mod.rs
@@ -4,6 +4,7 @@ mod drop;
 mod executor;
 mod handler;
 mod process;
+mod query;
 mod rename;
 mod select;
 mod truncate;

--- a/pg_analytics/src/hooks/query.rs
+++ b/pg_analytics/src/hooks/query.rs
@@ -1,0 +1,30 @@
+use pgrx::*;
+use std::ffi::CStr;
+
+use crate::errors::ParadeError;
+
+pub trait Query {
+    // Extracts the query string from a PlannedStmt,
+    // accounting for multi-line queries where we only want a
+    // specific line of the entire query.
+    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError>;
+}
+
+impl Query for *mut pg_sys::PlannedStmt {
+    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError> {
+        let query_start_index = unsafe { (*self).stmt_location };
+        let query_len = unsafe { (*self).stmt_len };
+        let mut query = source_text.to_str()?;
+
+        if query_start_index != -1 {
+            if query_len == 0 {
+                query = &query[(query_start_index as usize)..query.len()];
+            } else {
+                query = &query
+                    [(query_start_index as usize)..((query_start_index + query_len) as usize)];
+            }
+        }
+
+        Ok(query.to_string())
+    }
+}

--- a/pg_analytics/src/hooks/rename.rs
+++ b/pg_analytics/src/hooks/rename.rs
@@ -6,7 +6,7 @@ use std::ffi::CStr;
 
 use crate::datafusion::context::DatafusionContext;
 use crate::errors::{NotSupported, ParadeError};
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 
 pub unsafe fn rename(
     rename_stmt: *mut pg_sys::RenameStmt,
@@ -27,7 +27,7 @@ pub unsafe fn rename(
         return Ok(());
     }
 
-    if !DeltaHandler::relation_is_delta(relation)? {
+    if !relation.is_column()? {
         pg_sys::RelationClose(relation);
         return Ok(());
     }

--- a/pg_analytics/src/hooks/truncate.rs
+++ b/pg_analytics/src/hooks/truncate.rs
@@ -3,7 +3,7 @@ use pgrx::*;
 
 use crate::datafusion::context::DatafusionContext;
 use crate::errors::ParadeError;
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 
 pub unsafe fn truncate(truncate_stmt: *mut pg_sys::TruncateStmt) -> Result<(), ParadeError> {
     let rels = (*truncate_stmt).relations;
@@ -41,7 +41,7 @@ pub unsafe fn truncate(truncate_stmt: *mut pg_sys::TruncateStmt) -> Result<(), P
             continue;
         }
 
-        if !DeltaHandler::relation_is_delta(relation)? {
+        if !relation.is_column()? {
             pg_sys::RelationClose(relation);
             continue;
         }

--- a/pg_analytics/src/hooks/vacuum.rs
+++ b/pg_analytics/src/hooks/vacuum.rs
@@ -6,7 +6,7 @@ use crate::datafusion::context::DatafusionContext;
 use deltalake::datafusion::catalog::CatalogProvider;
 
 use crate::errors::ParadeError;
-use crate::hooks::handler::DeltaHandler;
+use crate::hooks::handler::IsColumn;
 
 #[derive(Debug)]
 struct VacuumOptions {
@@ -127,7 +127,7 @@ pub unsafe fn vacuum(vacuum_stmt: *mut pg_sys::VacuumStmt) -> Result<(), ParadeE
                     continue;
                 }
 
-                if !DeltaHandler::relation_is_delta(relation)? {
+                if !relation.is_column()? {
                     pg_sys::RelationClose(relation);
                     continue;
                 }

--- a/pg_analytics/tests/basic.rs
+++ b/pg_analytics/tests/basic.rs
@@ -481,6 +481,43 @@ fn multiline_query(mut conn: PgConnection) {
     };
     let select_count: (i64,) = "SELECT COUNT(*) FROM employees".fetch_one(&mut conn);
     assert_eq!(select_count, (2,));
+
+    "CREATE TABLE test_table (id smallint) USING parquet; ALTER TABLE test_table ADD COLUMN name text; ALTER TABLE test_table ADD COLUMN age smallint;"
+        .execute(&mut conn);
+    let rows: Vec<(String,)> =
+        "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table'"
+            .fetch(&mut conn);
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    assert_eq!(
+        column_names.sort(),
+        ["id".to_string(), "age".to_string(), "name".to_string()].sort()
+    );
+
+    "CREATE TABLE test_table2 (id smallint) USING parquet; INSERT INTO test_table2 VALUES (1), (2), (3); ALTER TABLE test_table2 ADD COLUMN name text;"
+        .execute(&mut conn);
+    let count: (i64,) = "SELECT COUNT(*) FROM test_table2".fetch_one(&mut conn);
+    assert_eq!(count, (3,));
+    let rows: Vec<(String,)> =
+        "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table2'"
+            .fetch(&mut conn);
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    assert_eq!(
+        column_names.sort(),
+        ["id".to_string(), "name".to_string()].sort()
+    );
+
+    "CREATE TABLE test_table3 (id smallint) USING parquet; ALTER TABLE test_table3 ADD COLUMN name text; TRUNCATE TABLE test_table3;"
+        .execute(&mut conn);
+    let count: (i64,) = "SELECT COUNT(*) FROM test_table3".fetch_one(&mut conn);
+    assert_eq!(count, (0,));
+    let rows: Vec<(String,)> =
+        "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table3'"
+            .fetch(&mut conn);
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    assert_eq!(
+        column_names.sort(),
+        ["id".to_string(), "name".to_string()].sort()
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Introduces a trait that adds the `is_column` method to `RelationData` and `List`, which removes the need to maintain a separate struct for this purpose.

This is just code cleanup and doesn't introduce any new functionality.

## Why

## How

## Tests
