### PR TITLE
fix: Multi-line utility queries

### DIFF
--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -11,6 +11,7 @@ use crate::datafusion::context::ParadeContextProvider;
 use crate::errors::{NotSupported, ParadeError};
 use crate::hooks::delete::delete;
 use crate::hooks::handler::IsColumn;
+use crate::hooks::query::Query;
 use crate::hooks::select::select;
 
 pub fn executor_run(
@@ -28,19 +29,9 @@ pub fn executor_run(
     unsafe {
         let ps = query_desc.plannedstmt;
         let rtable = (*ps).rtable;
-
-        // Get the substring of the query relevant to this hook execution
-        let query_start_index = (*query_desc.plannedstmt).stmt_location;
-        let query_len = (*query_desc.plannedstmt).stmt_len;
-        let mut query = CStr::from_ptr(query_desc.sourceText).to_str()?;
-        if query_start_index != -1 {
-            if query_len == 0 {
-                query = &query[(query_start_index as usize)..query.len()];
-            } else {
-                query = &query
-                    [(query_start_index as usize)..((query_start_index + query_len) as usize)];
-            }
-        }
+        let query = query_desc
+            .plannedstmt
+            .current_query(CStr::from_ptr(query_desc.sourceText))?;
 
         // Only use this hook for deltalake tables
         // Allow INSERTs to go through
@@ -57,11 +48,11 @@ pub fn executor_run(
         // Execute SELECT, DELETE, UPDATE
         match query_desc.operation {
             pg_sys::CmdType_CMD_DELETE => {
-                let logical_plan = create_logical_plan(query)?;
+                let logical_plan = create_logical_plan(&query)?;
                 delete(rtable, query_desc, logical_plan)
             }
             pg_sys::CmdType_CMD_SELECT => {
-                let logical_plan = create_logical_plan(query)?;
+                let logical_plan = create_logical_plan(&query)?;
                 select(query_desc, logical_plan)
             }
             pg_sys::CmdType_CMD_UPDATE => Err(NotSupported::Update.into()),

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -31,7 +31,7 @@ pub fn executor_run(
         let rtable = (*ps).rtable;
         let query = query_desc
             .plannedstmt
-            .current_query(CStr::from_ptr(query_desc.sourceText))?;
+            .current_query_string(CStr::from_ptr(query_desc.sourceText))?;
 
         // Only use this hook for deltalake tables
         // Allow INSERTs to go through

--- a/pg_analytics/src/hooks/mod.rs
+++ b/pg_analytics/src/hooks/mod.rs
@@ -4,6 +4,7 @@ mod drop;
 mod executor;
 mod handler;
 mod process;
+mod query;
 mod rename;
 mod select;
 mod truncate;

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -10,6 +10,7 @@ use std::ffi::CStr;
 use crate::errors::ParadeError;
 use crate::hooks::alter::alter;
 use crate::hooks::drop::drop;
+use crate::hooks::query::Query;
 use crate::hooks::rename::rename;
 use crate::hooks::truncate::truncate;
 use crate::hooks::vacuum::vacuum;
@@ -38,22 +39,17 @@ pub fn process_utility(
 ) -> Result<(), ParadeError> {
     unsafe {
         let plan = pstmt.utilityStmt;
+        let query = pstmt.clone().into_pg().current_query(query_string)?;
 
         match (*plan).type_ {
             NodeTag::T_AlterTableStmt => {
-                alter(
-                    plan as *mut pg_sys::AlterTableStmt,
-                    &create_ast(query_string.to_str()?)?[0],
-                )?;
+                alter(plan as *mut pg_sys::AlterTableStmt, &create_ast(&query)?[0])?;
             }
             NodeTag::T_DropStmt => {
                 drop(plan as *mut pg_sys::DropStmt)?;
             }
             NodeTag::T_RenameStmt => {
-                rename(
-                    plan as *mut pg_sys::RenameStmt,
-                    &create_ast(query_string.to_str()?)?[0],
-                )?;
+                rename(plan as *mut pg_sys::RenameStmt, &create_ast(&query)?[0])?;
             }
             NodeTag::T_TruncateStmt => {
                 truncate(plan as *mut pg_sys::TruncateStmt)?;

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -39,7 +39,7 @@ pub fn process_utility(
 ) -> Result<(), ParadeError> {
     unsafe {
         let plan = pstmt.utilityStmt;
-        let query = pstmt.clone().into_pg().current_query(query_string)?;
+        let query = pstmt.clone().into_pg().current_query_string(query_string)?;
 
         match (*plan).type_ {
             NodeTag::T_AlterTableStmt => {

--- a/pg_analytics/src/hooks/query.rs
+++ b/pg_analytics/src/hooks/query.rs
@@ -1,0 +1,30 @@
+use pgrx::*;
+use std::ffi::CStr;
+
+use crate::errors::ParadeError;
+
+pub trait Query {
+    // Extracts the query string from a PlannedStmt,
+    // accounting for multi-line queries where we only want a
+    // specific line of the entire query.
+    fn current_query(self, source_text: &CStr) -> Result<String, ParadeError>;
+}
+
+impl Query for *mut pg_sys::PlannedStmt {
+    fn current_query(self, source_text: &CStr) -> Result<String, ParadeError> {
+        let query_start_index = unsafe { (*self).stmt_location };
+        let query_len = unsafe { (*self).stmt_len };
+        let mut query = source_text.to_str()?;
+
+        if query_start_index != -1 {
+            if query_len == 0 {
+                query = &query[(query_start_index as usize)..query.len()];
+            } else {
+                query = &query
+                    [(query_start_index as usize)..((query_start_index + query_len) as usize)];
+            }
+        }
+
+        Ok(query.to_string())
+    }
+}

--- a/pg_analytics/src/hooks/query.rs
+++ b/pg_analytics/src/hooks/query.rs
@@ -7,11 +7,11 @@ pub trait Query {
     // Extracts the query string from a PlannedStmt,
     // accounting for multi-line queries where we only want a
     // specific line of the entire query.
-    fn current_query(self, source_text: &CStr) -> Result<String, ParadeError>;
+    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError>;
 }
 
 impl Query for *mut pg_sys::PlannedStmt {
-    fn current_query(self, source_text: &CStr) -> Result<String, ParadeError> {
+    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError> {
         let query_start_index = unsafe { (*self).stmt_location };
         let query_len = unsafe { (*self).stmt_len };
         let mut query = source_text.to_str()?;

--- a/pg_analytics/tests/basic.rs
+++ b/pg_analytics/tests/basic.rs
@@ -487,10 +487,10 @@ fn multiline_query(mut conn: PgConnection) {
     let rows: Vec<(String,)> =
         "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table'"
             .fetch(&mut conn);
-    let column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
     assert_eq!(
-        column_names,
-        vec!["id".to_string(), "age".to_string(), "name".to_string()]
+        column_names.sort(),
+        vec!["id".to_string(), "age".to_string(), "name".to_string()].sort()
     );
 
     "CREATE TABLE test_table2 (id smallint) USING parquet; INSERT INTO test_table2 VALUES (1), (2), (3); ALTER TABLE test_table2 ADD COLUMN name text;"
@@ -500,8 +500,11 @@ fn multiline_query(mut conn: PgConnection) {
     let rows: Vec<(String,)> =
         "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table2'"
             .fetch(&mut conn);
-    let column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
-    assert_eq!(column_names, vec!["id".to_string(), "name".to_string()]);
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    assert_eq!(
+        column_names.sort(),
+        vec!["id".to_string(), "name".to_string()].sort()
+    );
 
     "CREATE TABLE test_table3 (id smallint) USING parquet; ALTER TABLE test_table3 ADD COLUMN name text; TRUNCATE TABLE test_table3;"
         .execute(&mut conn);
@@ -510,8 +513,11 @@ fn multiline_query(mut conn: PgConnection) {
     let rows: Vec<(String,)> =
         "SELECT column_name FROM information_schema.columns WHERE table_name = 'test_table3'"
             .fetch(&mut conn);
-    let column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
-    assert_eq!(column_names, vec!["id".to_string(), "name".to_string()]);
+    let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
+    assert_eq!(
+        column_names.sort(),
+        vec!["id".to_string(), "name".to_string()].sort()
+    );
 }
 
 #[rstest]

--- a/pg_analytics/tests/basic.rs
+++ b/pg_analytics/tests/basic.rs
@@ -490,7 +490,7 @@ fn multiline_query(mut conn: PgConnection) {
     let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
     assert_eq!(
         column_names.sort(),
-        vec!["id".to_string(), "age".to_string(), "name".to_string()].sort()
+        ["id".to_string(), "age".to_string(), "name".to_string()].sort()
     );
 
     "CREATE TABLE test_table2 (id smallint) USING parquet; INSERT INTO test_table2 VALUES (1), (2), (3); ALTER TABLE test_table2 ADD COLUMN name text;"
@@ -503,7 +503,7 @@ fn multiline_query(mut conn: PgConnection) {
     let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
     assert_eq!(
         column_names.sort(),
-        vec!["id".to_string(), "name".to_string()].sort()
+        ["id".to_string(), "name".to_string()].sort()
     );
 
     "CREATE TABLE test_table3 (id smallint) USING parquet; ALTER TABLE test_table3 ADD COLUMN name text; TRUNCATE TABLE test_table3;"
@@ -516,7 +516,7 @@ fn multiline_query(mut conn: PgConnection) {
     let mut column_names: Vec<_> = rows.into_iter().map(|r| r.0).collect();
     assert_eq!(
         column_names.sort(),
-        vec!["id".to_string(), "name".to_string()].sort()
+        ["id".to_string(), "name".to_string()].sort()
     );
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
#829 added support for multi-line queries but only for ones that hit the executor hook. We needed to apply the same fix to the process utility hook.

## Why

## How
Introduced a new `current_query_string` function to `pg_sys::PlannedStmt`.

## Tests
Added more tests involving multi line queries that hit both the executor and process utility hooks.