### PR TITLE
fix: bm25 index breaks VACUUM FULL

### DIFF
--- a/pg_bm25/src/index/search.rs
+++ b/pg_bm25/src/index/search.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use shared::telemetry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
+use tantivy::directory::MmapDirectory;
 use tantivy::{query::QueryParser, schema::*, Document, Index, IndexSettings, Searcher};
 use tantivy::{IndexReader, IndexSortByField, IndexWriter, Order, TantivyError};
 use thiserror::Error;
@@ -77,7 +78,7 @@ impl SearchIndex {
         let mut underlying_index = Index::builder()
             .schema(schema.schema.clone())
             .settings(settings.clone())
-            .create_in_dir(tantivy_dir_path)
+            .open_or_create(MmapDirectory::open(tantivy_dir_path).unwrap())
             .expect("failed to create index");
 
         Self::setup_tokenizers(&mut underlying_index, &schema);


### PR DESCRIPTION
for the reason that `vacuum full` follow the steps: Lock on the relation -> Create an empty storage file  -> Copy live tuples from current storage to new storage  -> Then free up the original storage -> Free up the lock -> for that when the process to `copy` it will re_index and run the but the index in tantivy side will run again, so this commit fix it by use `open_or_create` method instead

# Ticket(s) Closed

- Closes #816

more info 

## backtrace

```cli
#0  tantivy::core::index::IndexBuilder::create_in_dir<std::path::PathBuf> (self=..., 
    directory_path=...)
    at /home/hyi/.cargo/git/checkouts/tantivy-c35452d6cd96d777/e678820/src/core/index.rs:171
#1  0x0000ffff969496f0 in pg_bm25::index::search::SearchIndex::new (directory=..., fields=...)
    at pg_bm25/src/index/search.rs:77
#2  0x0000ffff96990c54 in pg_bm25::postgres::build::ambuild::ambuild_inner (
    heaprel=0xffff9c9f5fb8, indexrel=0xffff9c9f0a88, index_info=0x37c401f0)
    at pg_bm25/src/postgres/build.rs:124
#3  0x0000ffff9695bfa4 in pg_bm25::postgres::build::ambuild::{closure#0} ()
    at pg_bm25/src/postgres/build.rs:23
#4  0x0000ffff96947640 in std::panicking::try::do_call<pg_bm25::postgres::build::ambuild::{closure_env#0}, *mut pgrx_pg_sys::include::pg16::IndexBuildResult> (data=0xfffffc830440)
    at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:552
#5  0x0000ffff96948f90 in __rust_try ()
   from /home/hyi/.pgrx/16.2/pgrx-install/lib/postgresql/pg_bm25.so
#6  0x0000ffff96945bc0 in std::panicking::try<*mut pgrx_pg_sys::include::pg16::IndexBuildResult, pg_bm25::postgres::build::ambuild::{closure_env#0}> (f=...)
    at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panicking.rs:516
#7  0x0000ffff9695b358 in std::panic::catch_unwind<pg_bm25::postgres::build::ambuild::{closure_env#0}, *mut pgrx_pg_sys::include::pg16::IndexBuildResult> (f=...)
    at /rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/panic.rs:142
#8  0x0000ffff96a0e044 in pgrx_pg_sys::submodules::panic::run_guarded<pg_bm25::postgres::build::ambuild::{closure_env#0}, *mut pgrx_pg_sys::include::pg16::IndexBuildResult> (f=...)
    at /home/hyi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pgrx-pg-sys-0.11.2/src/submodules/panic.rs:408
#9  0x0000ffff96a0fed4 in pgrx_pg_sys::submodules::panic::pgrx_extern_c_guard<pg_bm25::postgres::build::ambuild::{closure_env#0}, *mut pgrx_pg_sys::include::pg16::IndexBuildResult> (f=...)
    at /home/hyi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pgrx-pg-sys-0.11.2/src/submodules/panic.rs:385
#10 0x0000ffff96990474 in pg_bm25::postgres::build::ambuild (heaprel=0xffff9c9f5fb8, 
    indexrel=0xffff9c9f0a88, index_info=0x37c401f0) at pg_bm25/src/postgres/build.rs:25
#11 0x0000000000576638 in index_build (heapRelation=heapRelation@entry=0xffff9c9f5fb8, 
    indexRelation=indexRelation@entry=0xffff9c9f0a88, indexInfo=indexInfo@entry=0x37c401f0, 
    isreindex=isreindex@entry=true, parallel=parallel@entry=true) at index.c:3042
#12 0x0000000000579084 in reindex_index (indexId=indexId@entry=16432, 
    skip_constraint_checks=skip_constraint_checks@entry=true, 
    persistence=persistence@entry=112 'p', params=params@entry=0xfffffc830d88) at index.c:3760
#13 0x00000000005796c8 in reindex_relation (relid=relid@entry=16386, flags=flags@entry=18, 
    params=params@entry=0xfffffc830d88) at index.c:3989
#14 0x00000000005efa84 in finish_heap_swap (OIDOldHeap=OIDOldHeap@entry=16386, 
    OIDNewHeap=OIDNewHeap@entry=16516, is_system_catalog=is_system_catalog@entry=false, 
    swap_toast_by_content=true, check_constraints=check_constraints@entry=false, 
    is_internal=is_internal@entry=true, frozenXid=761, cutoffMulti=1, 
--Type <RET> for more, q to quit, c to continue without paging--
    newrelpersistence=newrelpersistence@entry=112 'p') at cluster.c:1521
#15 0x00000000005efe1c in rebuild_relation (verbose=false, indexOid=0, OldHeap=<optimized out>)
    at cluster.c:670
#16 cluster_rel (tableOid=tableOid@entry=16386, indexOid=indexOid@entry=0, 
    params=params@entry=0xfffffc830ee8) at cluster.c:477
#17 0x000000000066d0d4 in vacuum_rel (relid=16386, relation=<optimized out>, 
    params=params@entry=0xfffffc831198, bstrategy=bstrategy@entry=0x0) at vacuum.c:2214
#18 0x000000000066e510 in vacuum (relations=0x37c5cbb8, params=params@entry=0xfffffc831198, 
    bstrategy=0x0, vac_context=vac_context@entry=0x37c5ca20, isTopLevel=isTopLevel@entry=true)
    at vacuum.c:622
#19 0x000000000066ed38 in ExecVacuum (pstate=pstate@entry=0x37bc9478, 
    vacstmt=vacstmt@entry=0x379d2e68, isTopLevel=isTopLevel@entry=true) at vacuum.c:449
#20 0x000000000084ad94 in standard_ProcessUtility (pstmt=0x379d2fb8, 
    queryString=0x379d23c8 "VACUUM FULL t;", readOnlyTree=<optimized out>, 
    context=PROCESS_UTILITY_TOPLEVEL, params=0x0, queryEnv=0x0, dest=0x379d3278, 
    qc=0xfffffc831590) at utility.c:866
#21 0x00000000008491ac in PortalRunUtility (portal=portal@entry=0x37a522e8, 
    pstmt=pstmt@entry=0x379d2fb8, isTopLevel=isTopLevel@entry=true, 
    setHoldSnapshot=setHoldSnapshot@entry=false, dest=dest@entry=0x379d3278, 
    qc=qc@entry=0xfffffc831590) at pquery.c:1158
#22 0x000000000084933c in PortalRunMulti (portal=portal@entry=0x37a522e8, 
    isTopLevel=isTopLevel@entry=true, setHoldSnapshot=setHoldSnapshot@entry=false, 
    dest=dest@entry=0x379d3278, altdest=altdest@entry=0x379d3278, qc=qc@entry=0xfffffc831590)
    at pquery.c:1315
#23 0x00000000008498a0 in PortalRun (portal=portal@entry=0x37a522e8, 
    count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=true, 
    run_once=run_once@entry=true, dest=dest@entry=0x379d3278, altdest=altdest@entry=0x379d3278, 
    qc=qc@entry=0xfffffc831590) at pquery.c:791
#24 0x00000000008454f8 in exec_simple_query (
    query_string=query_string@entry=0x379d23c8 "VACUUM FULL t;") at postgres.c:1274
#25 0x00000000008462e0 in PostgresMain (dbname=<optimized out>, username=<optimized out>)
    at postgres.c:4637
#26 0x00000000007aabf0 in BackendRun (port=0x379fe440, port=0x379fe440) at postmaster.c:4464
#27 BackendStartup (port=0x379fe440) at postmaster.c:4192
#28 ServerLoop () at postmaster.c:1782
#29 0x00000000007abc04 in PostmasterMain (argc=argc@entry=8, argv=argv@entry=0x379cae30)
    at postmaster.c:1466
#30 0x00000000004918c0 in main (argc=8, argv=0x379cae30) at main.c:198
(gdb) 
```
VACUUM FULL link:
- https://severalnines.com/blog/overview-vacuum-processing-postgresql/
- https://www.postgresql.org/docs/current/routine-vacuuming.html
- https://cloud.google.com/blog/products/databases/deep-dive-into-postgresql-vacuum-garbage-collector
