### PR TITLE
fix: `cast_mut_ptr` expects different types on arm/intel

### DIFF
--- a/pg_analytics/src/datafusion/context.rs
+++ b/pg_analytics/src/datafusion/context.rs
@@ -14,7 +14,7 @@ use lazy_static::lazy_static;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use pgrx::*;
 use std::any::type_name;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 use std::sync::Arc;
 
 use crate::datafusion::catalog::{ParadeCatalog, ParadeCatalogList};
@@ -201,7 +201,7 @@ impl ParadeContextProvider {
             if let Some(current_schemas) = current_schemas {
                 for datum in current_schemas.iter().flatten() {
                     let schema_name =
-                        unsafe { CStr::from_ptr(datum.cast_mut_ptr::<i8>()).to_str()? };
+                        unsafe { CStr::from_ptr(datum.cast_mut_ptr::<c_char>()).to_str()? };
                     let schema_registered = DatafusionContext::with_catalog(|catalog| {
                         Ok(catalog.schema(schema_name).is_some())
                     })?;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Uses `c_char` instead of `i8` for `cast_mut_ptr`. `c_char` can be either `i8` or `u8` depending on the target platform: https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/os/raw/type.c_char.html

## Why

## How

## Tests
