### PR TITLE
fix: Serialize/deserialize large sparse vectors

### DIFF
--- a/pg_sparse/src/svector.c
+++ b/pg_sparse/src/svector.c
@@ -420,13 +420,13 @@ svector_recv(PG_FUNCTION_ARGS)
 	StringInfo	buf = (StringInfo) PG_GETARG_POINTER(0);
 	int32		typmod = PG_GETARG_INT32(2);
 	Vector	   *result;
-	int16		n_elem;
-	int16		dim;
-	int16		unused;
+	int32		n_elem;
+	int32		dim;
+	int32		unused;
 
-	n_elem = pq_getmsgint(buf, sizeof(int16));
-	dim = pq_getmsgint(buf, sizeof(int16));
-	unused = pq_getmsgint(buf, sizeof(int16));
+	n_elem = pq_getmsgint(buf, sizeof(int32));
+	dim = pq_getmsgint(buf, sizeof(int32));
+	unused = pq_getmsgint(buf, sizeof(int32));
 
 	CheckDim(dim);
 	CheckNElem(n_elem);
@@ -459,9 +459,9 @@ svector_send(PG_FUNCTION_ARGS)
 	StringInfoData buf;
 
 	pq_begintypsend(&buf);
-	pq_sendint(&buf, vec->n_elem, sizeof(int16));
-	pq_sendint(&buf, vec->dim, sizeof(int16));
-	pq_sendint(&buf, vec->unused, sizeof(int16));
+	pq_sendint(&buf, vec->n_elem, sizeof(int32));
+	pq_sendint(&buf, vec->dim, sizeof(int32));
+	pq_sendint(&buf, vec->unused, sizeof(int32));
 	for (int i = 0; i < vec->n_elem; i++) {
 		pq_sendint(&buf, vec->x[i].index, sizeof(int32));
 		pq_sendfloat4(&buf, vec->x[i].value);

--- a/pg_sparse/test/expected/serialize.out
+++ b/pg_sparse/test/expected/serialize.out
@@ -1,0 +1,12 @@
+CREATE TABLE t (id SERIAL PRIMARY KEY, vec svector);
+INSERT INTO t (vec) VALUES ((ARRAY[1, 2] || ARRAY(SELECT 0 FROM generate_series(1, 131072)))::svector);
+CREATE TEMP TABLE temp_svector_test AS SELECT vec FROM t LIMIT 0;
+COPY (SELECT vec FROM t WHERE id = 1) TO '/tmp/svector_data.bin' WITH (FORMAT binary);
+COPY temp_svector_test FROM '/tmp/svector_data.bin' WITH (FORMAT binary);
+SELECT svector_dims(vec) AS svector_length FROM temp_svector_test;
+ svector_length 
+----------------
+         131074
+(1 row)
+
+DROP TABLE t;

--- a/pg_sparse/test/sql/serialize.sql
+++ b/pg_sparse/test/sql/serialize.sql
@@ -1,0 +1,7 @@
+CREATE TABLE t (id SERIAL PRIMARY KEY, vec svector);
+INSERT INTO t (vec) VALUES ((ARRAY[1, 2] || ARRAY(SELECT 0 FROM generate_series(1, 131072)))::svector);
+CREATE TEMP TABLE temp_svector_test AS SELECT vec FROM t LIMIT 0;
+COPY (SELECT vec FROM t WHERE id = 1) TO '/tmp/svector_data.bin' WITH (FORMAT binary);
+COPY temp_svector_test FROM '/tmp/svector_data.bin' WITH (FORMAT binary);
+SELECT svector_dims(vec) AS svector_length FROM temp_svector_test;
+DROP TABLE t;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #838 

## What
Fixes an issue where serializing/deserializing large vectors (len greater than `65536`) would result in dropped values.

## Why
User-reported issue.

## How
Converted underlying `n_elem`, `dim`, and `unused` to `int32`.

## Tests
Added a regression test.