### PR TITLE
feat(docs): better index pages

### DIFF
--- a/docs/search/indexing/hnsw.mdx
+++ b/docs/search/indexing/hnsw.mdx
@@ -72,3 +72,11 @@ DROP INDEX <index_name>;
 
 Like a BM25 index, an HNSW index only needs to be recreated if the name of the indexed column changes.
 To recreate the index, simply delete and create it using the SQL commands above.
+
+## Limitations
+
+Stemming from [pgvector](https://github.com/pgvector/pgvector#hnsw),
+HNSW indexing supports vectors with a maximum dimensionality of 2,000.
+Larger vectors are typically needed only for sparse data scenarios.
+Addressing this, ParadeDB introduces [`pg_sparse`](https://github.com/paradedb/paradedb/tree/dev/pg_sparse)
+to facilitate efficient [sparse vector indexing](/search/indexing/sparse).

--- a/docs/search/indexing/sparse.mdx
+++ b/docs/search/indexing/sparse.mdx
@@ -11,6 +11,19 @@ SPLADE outputs sparse vectors with over 30,000 entries.
 
 A sparse HNSW index is a specialized HNSW index designed to handle sparse vectors.
 
+## Using `pg_sparse`
+
+Paradedb introduces `pg_sparse`, a fork of `pgvector`, for sparse vectors. To get started,
+ensure the extension is installed by following the [installation guide](https://github.com/paradedb/paradedb/blob/dev/pg_sparse/README.md#installation).
+
+The following adds a sparse vector column using `svector`:
+
+```sql
+ALTER TABLE mock_items ADD COLUMN sparse_embedding svector(30522);
+```
+
+For additional details, please refer to the [Github README](https://github.com/paradedb/paradedb/blob/dev/pg_sparse/README.md).
+
 ## Creating a Sparse HNSW Index
 
 The following command creates a sparse HNSW index over a column:


### PR DESCRIPTION


# Ticket(s) Closed

- Closes #892 

## What

Update the HNSW indexing pages. 
For dense, the page now mentions the max vector size, as a limitation. It also points to the sparse index page. 
The Sparse HNSW page now introduces pg_sparse, and the bare info needed to get it running.

## Why

To make it easier for people to understand everything they need, for using the system.

## Tests
Local dev

## Extra notes:

pg_sparse is only available through a GitHub README link. This is potentially fragile. To be fair, it is equally fragile as any other link in these docs. However, a local link can be validated through mintlify, making a dead link harder to leave in. This is something to keep in mind, but no action is required. 
Potentially, it might make sense to put `pg_sparse` somewhere on the docs site. Or, it might be easier / better to abstract `pg_sparse` out of Paradedb, and make it its own repo. That might require too much extra overhead. But at least something to consider

Another thing I would love to one day see, is recipes. This does not have to sit on the docs site, and can solely exist on GitHub. But examples of more advanced uses, are always nice. Perhaps it makes sense to wait for more library stability before introducing more things to maintain, but eventually, a place with a few recipes would be nice. 

