### PR TITLE
fix: Switch memory context during index creation, and delete old folders

### DIFF
--- a/pg_bm25/src/postgres/build.rs
+++ b/pg_bm25/src/postgres/build.rs
@@ -225,7 +225,7 @@ unsafe fn build_callback_internal(
                     panic!("error inserting document during build callback: {err:?}")
                 });
 
-            register_commit_callback(&writer_client)
+            register_commit_callback(&writer_client, search_index.directory.clone())
                 .expect("could not register commit callbacks for build operation");
         });
         state.memctx.reset();

--- a/pg_bm25/src/postgres/build.rs
+++ b/pg_bm25/src/postgres/build.rs
@@ -12,11 +12,15 @@ use std::panic::{self, AssertUnwindSafe};
 // For now just pass the count on the build callback state
 struct BuildState {
     count: usize,
+    memctx: PgMemoryContexts,
 }
 
 impl BuildState {
     fn new() -> Self {
-        BuildState { count: 0 }
+        BuildState {
+            count: 0,
+            memctx: PgMemoryContexts::new("pg_search_index_build"),
+        }
     }
 }
 
@@ -185,27 +189,36 @@ unsafe extern "C" fn build_callback(
 unsafe fn build_callback_internal(
     ctid: pg_sys::ItemPointerData,
     values: *mut pg_sys::Datum,
-    _state: *mut std::os::raw::c_void,
+    state: *mut std::os::raw::c_void,
     index: pg_sys::Relation,
 ) {
     check_for_interrupts!();
 
-    let index_relation_ref: PgRelation = PgRelation::from_pg(index);
-    let tupdesc = lookup_index_tupdesc(&index_relation_ref);
-    let index_name = index_relation_ref.name();
-    let search_index = get_search_index(index_name);
-    let search_document = search_index
-        .row_to_search_document(ctid, &tupdesc, values)
-        .unwrap_or_else(|err| {
-            panic!("error creating index entries for index '{index_name}': {err:?}",)
+    let state = (state as *mut BuildState).as_mut().unwrap();
+    unsafe {
+        state.memctx.reset();
+        state.memctx.switch_to(|_| {
+            let index_relation_ref: PgRelation = PgRelation::from_pg(index);
+            let tupdesc = lookup_index_tupdesc(&index_relation_ref);
+            let index_name = index_relation_ref.name();
+            let search_index = get_search_index(index_name);
+            let search_document = search_index
+                .row_to_search_document(ctid, &tupdesc, values)
+                .unwrap_or_else(|err| {
+                    panic!("error creating index entries for index '{index_name}': {err:?}",)
+                });
+
+            let writer_client = WriterGlobal::client();
+
+            search_index
+                .insert(&writer_client, search_document)
+                .unwrap_or_else(|err| {
+                    panic!("error inserting document during build callback: {err:?}")
+                });
+
+            register_commit_callback(&writer_client)
+                .expect("could not register commit callbacks for build operation");
         });
-
-    let writer_client = WriterGlobal::client();
-
-    search_index
-        .insert(&writer_client, search_document)
-        .unwrap_or_else(|err| panic!("error inserting document during build callback: {err:?}"));
-
-    register_commit_callback(&writer_client)
-        .expect("could not register commit callbacks for build operation");
+        state.memctx.reset();
+    }
 }

--- a/pg_bm25/src/postgres/delete.rs
+++ b/pg_bm25/src/postgres/delete.rs
@@ -30,7 +30,7 @@ pub extern "C" fn ambulkdelete(
     }
 
     let writer_client = WriterGlobal::client();
-    register_commit_callback(&writer_client)
+    register_commit_callback(&writer_client, search_index.directory.clone())
         .expect("could not register commit callbacks for delete operation");
 
     if let Some(actual_callback) = callback {

--- a/pg_bm25/src/postgres/insert.rs
+++ b/pg_bm25/src/postgres/insert.rs
@@ -51,7 +51,7 @@ unsafe fn aminsert_internal(
         });
 
     let writer_client = WriterGlobal::client();
-    register_commit_callback(&writer_client)
+    register_commit_callback(&writer_client, search_index.directory.clone())
         .expect("could not register commit callbacks for insert operation");
 
     search_index

--- a/pg_bm25/src/postgres/utils.rs
+++ b/pg_bm25/src/postgres/utils.rs
@@ -2,8 +2,8 @@ use crate::index::SearchIndex;
 use crate::schema::{SearchDocument, SearchIndexSchema};
 use crate::writer::{IndexError, WriterDirectory};
 use pgrx::{
-    pg_sys, varsize, Array, FromDatum, JsonB, JsonString, PgBuiltInOids, PgMemoryContexts, PgOid,
-    PgRelation, PgTupleDesc,
+    pg_sys, varsize, Array, FromDatum, JsonB, JsonString, PgBuiltInOids, PgOid, PgRelation,
+    PgTupleDesc,
 };
 use serde_json::Map;
 use std::default::Default;
@@ -29,11 +29,7 @@ pub fn lookup_index_tupdesc(indexrel: &PgRelation) -> PgTupleDesc<'static> {
 
     // lookup the tuple descriptor for the rowtype we're *indexing*, rather than
     // using the tuple descriptor for the index definition itself
-    unsafe {
-        PgMemoryContexts::TopTransactionContext.switch_to(|_| {
-            PgTupleDesc::from_pg_is_copy(pg_sys::lookup_rowtype_tupdesc_copy(typid, typmod))
-        })
-    }
+    unsafe { PgTupleDesc::from_pg_is_copy(pg_sys::lookup_rowtype_tupdesc_copy(typid, typmod)) }
 }
 
 pub unsafe fn row_to_search_document(

--- a/pg_bm25/src/writer/client.rs
+++ b/pg_bm25/src/writer/client.rs
@@ -153,8 +153,8 @@ mod tests {
         directory: mock_dir().writer_dir,
         document: simple_doc(simple_schema(default_fields())),
     })]
-    #[case::commit_request(WriterRequest::Commit)]
-    #[case::abort_request(WriterRequest::Abort)]
+    #[case::commit_request(WriterRequest::Commit { directory: mock_dir().writer_dir })]
+    #[case::abort_request(WriterRequest::Abort {directory: mock_dir().writer_dir})]
     #[case::vacuum_request(WriterRequest::Vacuum { directory: mock_dir().writer_dir })]
     #[case::drop_index_request(WriterRequest::DropIndex { directory: mock_dir().writer_dir })]
     /// Test request serialization and transfer between client and server.

--- a/pg_bm25/src/writer/mod.rs
+++ b/pg_bm25/src/writer/mod.rs
@@ -30,8 +30,12 @@ pub enum WriterRequest {
     DropIndex {
         directory: WriterDirectory,
     },
-    Abort,
-    Commit,
+    Abort {
+        directory: WriterDirectory,
+    },
+    Commit {
+        directory: WriterDirectory,
+    },
     Vacuum {
         directory: WriterDirectory,
     },

--- a/pg_bm25/tests/cleanup.rs
+++ b/pg_bm25/tests/cleanup.rs
@@ -1,0 +1,13 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn vacuum_full(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    "DELETE FROM paradedb.bm25_search WHERE id IN (1, 2, 3, 4, 5)".execute(&mut conn);
+
+    "VACUUM FULL".execute(&mut conn);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #870
- Closes #702

## What
#870 describes ballooning memory usage when creating an index on large tables. This is because Postgres seems to want to wait until the end of the transaction to free the memory taken when we lookup `PgTupleDesc` for each row. By manually switching memory contexts and calling `reset()`, we force the memory to be freed. We've gone from a 2.5GB memory increase to no increase at all.

I've also changed the background writer to no longer keep writers in memory. There's an outstanding problem that we see when running the test suite around "too many open files". Dropping writers after commit/abort helps with this, and improves memory usage in the background process.

Previously, we also commit all the cached writers at the end of a transaction. This isn't correct with multiple DBs in play, as the background writer manages all the writers for all DBs. Some writers may be mid-transaction when commit is called on another DB. This PR corrects this, so a commit request to the background writer will specify an index.

An additional fix included for #702, now that we're aware that the index is recreated during VACUUM/TRUNCATE. The `SearchIndex` will automatically delete any name-collisioned folders during `new`. 

## Tests
A new test has been added for VACUUM FULL. I verified the memory usage improvement with `top`, testing on 5.3million rows.