### PR TITLE
fix: Dedup search, add schema to hybrid func, fix delete error

### DIFF
--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Install pgvector
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
+          export PG_CONFIG=`which pg_config`
           git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git
           cd pgvector/
           make -j

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -113,6 +113,15 @@ jobs:
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/extension/ /usr/lib/postgresql/${{ matrix.pg_version }}/lib/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
+      # Needed for hybrid search unit tests
+      - name: Install pgvector
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: |
+          git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git
+          cd pgvector/
+          make -j
+          make install -j
+
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -120,7 +120,7 @@ jobs:
           git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git
           cd pgvector/
           make -j
-          make install -j
+          sudo make install -j
 
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -117,11 +117,10 @@ jobs:
       - name: Install pgvector
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
-          export PG_CONFIG=`which pg_config`
           git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git
           cd pgvector/
-          make -j
-          sudo make install -j
+          sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
+          sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
 
       - name: Install pgrx, grcov & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/pg_bm25/sql/_bootstrap.sql
+++ b/pg_bm25/sql/_bootstrap.sql
@@ -192,7 +192,7 @@ BEGIN
                     __key_field__ as key_field,
                     1 - ((__similarity_query__) - MIN(__similarity_query__) OVER ()) / 
                     (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ()) AS score
-                FROM %I
+                FROM %I.%I
                 ORDER BY __similarity_query__
                 LIMIT $2
             ),
@@ -276,11 +276,14 @@ CREATE OR REPLACE FUNCTION paradedb.format_hybrid_function(
 BEGIN
     DECLARE
         __table_name__ text;
+        __schema_name__ text;
         __function_body__ text;
     BEGIN
         __table_name__ := index_json->>'table_name';
+        __schema_name__ := index_json->>'schema_name';
         __function_body__ := format(
             function_body,
+            __schema_name__,
             __table_name__
         );
 

--- a/pg_bm25/src/index/score.rs
+++ b/pg_bm25/src/index/score.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct SearchIndexScore {
     pub bm25: f32,
     pub key: i64,

--- a/pg_bm25/src/writer/index.rs
+++ b/pg_bm25/src/writer/index.rs
@@ -62,9 +62,8 @@ impl Writer {
     fn commit(&mut self, directory: WriterDirectory) -> Result<(), IndexError> {
         if directory.exists()? {
             let writer = self
-                .tantivy_writers
-                .get_mut(&directory)
-                .expect("writer exists");
+                .get_writer(directory.clone())
+                .expect("cannot lookup writer");
             writer.prepare_commit()?;
             writer.commit()?;
         } else {

--- a/pg_bm25/tests/bm25_search.rs
+++ b/pg_bm25/tests/bm25_search.rs
@@ -227,10 +227,8 @@ fn hybrid(mut conn: PgConnection) {
     ((m.id + 3) % 10 + 1)::integer || ']')::vector;
 
     CREATE INDEX on paradedb.bm25_search
-    USING hnsw (embedding vector_l2_ops);
-
-    "#
-    .execute(&mut conn);
+    USING hnsw (embedding vector_l2_ops)"#
+        .execute(&mut conn);
 
     let columns: SimpleProductsTableVec = r#"
     SELECT m.*, s.rank_hybrid
@@ -243,9 +241,8 @@ fn hybrid(mut conn: PgConnection) {
             similarity_weight => 0.1
         )
     ) s ON m.id = s.id
-    LIMIT 5;
-    "#
-    .fetch_collect(&mut conn);
+    LIMIT 5"#
+        .fetch_collect(&mut conn);
 
     assert_eq!(columns.id, vec![2, 1, 29, 39, 9]);
 }

--- a/pg_bm25/tests/bm25_search.rs
+++ b/pg_bm25/tests/bm25_search.rs
@@ -1,4 +1,3 @@
-#![allow(unused_variables)]
 mod fixtures;
 
 use fixtures::*;
@@ -61,6 +60,8 @@ fn with_bm25_scoring(mut conn: PgConnection) {
 
     let ranks: Vec<_> = rows.iter().map(|r| r.1).collect();
     let expected = [5.3764954, 4.931014, 2.1096356, 2.1096356, 2.1096356];
+
+    assert_eq!(ranks, expected);
 }
 
 #[rstest]
@@ -231,8 +232,6 @@ fn hybrid(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    "VACUUM".execute(&mut conn);
-
     let columns: SimpleProductsTableVec = r#"
     SELECT m.*, s.rank_hybrid
     FROM paradedb.bm25_search m
@@ -248,5 +247,5 @@ fn hybrid(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
 
-    assert_eq!(columns.id, vec![2, 1, 39, 29, 19]);
+    assert_eq!(columns.id, vec![2, 1, 29, 39, 9]);
 }


### PR DESCRIPTION
## What

Fixing a few small issues with `rank_hybrid`, as well as handling a unusual deletion case we're seeing in CI.

- `rank_hybrid` was not previously working with schemas not on the `search_path`.
- `rank_hybrid` was returning stale rows when used outside of Postgres index scan, because we couldn't rely on Postgres filtering.
- Deleting Tantivy files occasionally fails, because we try to delete a file that doesn't exist. We now just check for a `NotFound` error, and ignore it if we see it.

## Tests
New test to confirm `rank_hybrid` results.
