### PR TITLE
fix: Run cargo clean before packaging, to avoid running out of space on device

### DIFF
--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -161,4 +161,4 @@ jobs:
       - name: Test Packaging pg_analytics
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && github.base_ref == 'main'
         working-directory: pg_analytics/
-        run: cargo pgrx package --features telemetry
+        run: cargo clean && cargo pgrx package --features telemetry

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -166,4 +166,4 @@ jobs:
       - name: Test Packaging pg_bm25
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && github.base_ref == 'main'
         working-directory: pg_bm25/
-        run: cargo pgrx package --features "icu telemetry"
+        run: cargo clean && cargo pgrx package --features "icu telemetry"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes this: https://github.com/paradedb/paradedb/actions/runs/8146266846/job/22264945717?pr=938

## Why

## How

## Tests
