### PR TITLE
docs: fix document link typo

### DIFF
--- a/pg_bm25/README.md
+++ b/pg_bm25/README.md
@@ -136,7 +136,7 @@ This will return:
 (5 rows)
 ```
 
-Advanced features like BM25 scoring, highlighting, custom tokenizers, fuzzy search, and more are supported. Please refer to the [documentation](http://localhost:3000/latest/search/bm25) and [quickstart](http://localhost:3000/latest/quickstart) for a more thorough overview of `pg_bm25`'s query support.
+Advanced features like BM25 scoring, highlighting, custom tokenizers, fuzzy search, and more are supported. Please refer to the [documentation](https://docs.paradedb.com) and [quickstart](https://docs.paradedb.com/search/quickstart) for a more thorough overview of `pg_bm25`'s query support.
 
 ## Development
 


### PR DESCRIPTION
# Ticket(s) Closed

None.

## What
There is a hyperlink error in the [pg_bm25](https://github.com/paradedb/paradedb/blob/dev/pg_bm25/README.md) `README.md`, it points to the document of `localhost:3000`.

## Why

## How
I fixed it to point to the correct page. Let me know if the link still wrong.

## Tests
