### PR TITLE
fix: vacuums work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "time",
+ "walkdir",
  "zstd-sys",
 ]
 

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -35,6 +35,7 @@ datafusion-federation-sql = { git = "https://github.com/paradedb/datafusion-fede
 futures = "0.3.30"
 memoffset = "0.9.0"
 zstd-sys = "=2.0.9"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -46,34 +46,21 @@ pub fn process_utility(
         let pg_plan = pstmt.clone().into_pg();
         let query = pg_plan.get_query_string(query_string)?;
 
-        let ast = match ASTVec::try_from(QueryString(&query)) {
-            Ok(ASTVec(ast)) => ast,
-            // If DataFusion can't parse the query, let Postgres handle it
-            Err(_) => {
-                let _ = prev_hook(
-                    pstmt,
-                    query_string,
-                    read_only_tree,
-                    context,
-                    params,
-                    query_env,
-                    dest,
-                    completion_tag,
-                );
-
-                return Ok(());
-            }
-        };
+        let ast = ASTVec::try_from(QueryString(&query));
 
         match (*plan).type_ {
             NodeTag::T_AlterTableStmt => {
-                task::block_on(alter(plan as *mut pg_sys::AlterTableStmt, &ast[0]))?;
+                if let Ok(ASTVec(ast)) = ast {
+                    task::block_on(alter(plan as *mut pg_sys::AlterTableStmt, &ast[0]))?;
+                }
             }
             NodeTag::T_DropStmt => {
                 drop(plan as *mut pg_sys::DropStmt)?;
             }
             NodeTag::T_RenameStmt => {
-                rename(plan as *mut pg_sys::RenameStmt, &ast[0])?;
+                if let Ok(ASTVec(ast)) = ast {
+                    rename(plan as *mut pg_sys::RenameStmt, &ast[0])?;
+                }
             }
             NodeTag::T_TruncateStmt => {
                 truncate(plan as *mut pg_sys::TruncateStmt)?;

--- a/pg_analytics/tests/vacuum.rs
+++ b/pg_analytics/tests/vacuum.rs
@@ -3,10 +3,32 @@ mod fixtures;
 use fixtures::*;
 use rstest::*;
 use sqlx::PgConnection;
+use std::path::Path;
 use walkdir::WalkDir;
+
+fn path_is_parquet_file(path: &Path) -> bool {
+    match path.extension() {
+        Some(ext) => ext == "parquet",
+        None => false,
+    }
+}
 
 #[rstest]
 fn vacuum(mut conn: PgConnection) {
+    "CREATE TABLE t (a int) USING parquet".execute(&mut conn);
+    "CREATE TABLE s (a int)".execute(&mut conn);
+    "INSERT INTO t VALUES (1), (2), (3)".execute(&mut conn);
+    "INSERT INTO s VALUES (4), (5), (6)".execute(&mut conn);
+    "VACUUM".execute(&mut conn);
+    "VACUUM FULL".execute(&mut conn);
+    "VACUUM t".execute(&mut conn);
+    "VACUUM FULL t".execute(&mut conn);
+    "DROP TABLE t, s".execute(&mut conn);
+    "VACUUM".execute(&mut conn);
+}
+
+#[rstest]
+fn vacuum_check_files(mut conn: PgConnection) {
     "CREATE TABLE t (a int) USING parquet".execute(&mut conn);
     "CREATE TABLE s (a int)".execute(&mut conn);
     "INSERT INTO t VALUES (1), (2), (3)".execute(&mut conn);
@@ -18,20 +40,45 @@ fn vacuum(mut conn: PgConnection) {
         "deltalake"
     );
     let total_pre_vacuum_files = WalkDir::new(data_path.clone())
+        .contents_first(true)
         .into_iter()
-        .filter_entry(|e| !e.path().to_str().unwrap().contains("_delta_log"))
+        .filter(|e| path_is_parquet_file(e.as_ref().unwrap().path()))
         .count();
 
-    "VACUUM".execute(&mut conn);
-    "VACUUM FULL".execute(&mut conn);
-    "VACUUM t".execute(&mut conn);
-    "VACUUM FULL t".execute(&mut conn);
     "DROP TABLE t, s".execute(&mut conn);
     "VACUUM".execute(&mut conn);
 
     let total_post_vacuum_files = WalkDir::new(data_path.clone())
+        .contents_first(true)
         .into_iter()
-        .filter_entry(|e| !e.path().to_str().unwrap().contains("_delta_log"))
+        .filter(|e| path_is_parquet_file(e.as_ref().unwrap().path()))
+        .count();
+
+    assert!(total_pre_vacuum_files > total_post_vacuum_files);
+}
+
+#[rstest]
+fn vacuum_full_check_files(mut conn: PgConnection) {
+    "CREATE TABLE t (a int) USING parquet".execute(&mut conn);
+    "INSERT INTO t VALUES (1), (2), (3)".execute(&mut conn);
+    "INSERT INTO t VALUES (4), (5), (6)".execute(&mut conn);
+
+    let data_path = format!(
+        "{}/{}",
+        "SHOW data_directory".fetch_one::<(String,)>(&mut conn).0,
+        "deltalake"
+    );
+    let total_pre_vacuum_files = WalkDir::new(data_path.clone())
+        .into_iter()
+        .filter(|e| path_is_parquet_file(e.as_ref().unwrap().path()))
+        .count();
+
+    "VACUUM FULL".execute(&mut conn);
+
+    let total_post_vacuum_files = WalkDir::new(data_path.clone())
+        .contents_first(true)
+        .into_iter()
+        .filter(|e| path_is_parquet_file(e.as_ref().unwrap().path()))
         .count();
 
     assert!(total_pre_vacuum_files > total_post_vacuum_files);

--- a/pg_analytics/tests/vacuum.rs
+++ b/pg_analytics/tests/vacuum.rs
@@ -3,6 +3,7 @@ mod fixtures;
 use fixtures::*;
 use rstest::*;
 use sqlx::PgConnection;
+use walkdir::WalkDir;
 
 #[rstest]
 fn vacuum(mut conn: PgConnection) {
@@ -10,10 +11,28 @@ fn vacuum(mut conn: PgConnection) {
     "CREATE TABLE s (a int)".execute(&mut conn);
     "INSERT INTO t VALUES (1), (2), (3)".execute(&mut conn);
     "INSERT INTO s VALUES (4), (5), (6)".execute(&mut conn);
+
+    let data_path = format!(
+        "{}/{}",
+        "SHOW data_directory".fetch_one::<(String,)>(&mut conn).0,
+        "deltalake"
+    );
+    let total_pre_vacuum_files = WalkDir::new(data_path.clone())
+        .into_iter()
+        .filter_entry(|e| !e.path().to_str().unwrap().contains("_delta_log"))
+        .count();
+
     "VACUUM".execute(&mut conn);
     "VACUUM FULL".execute(&mut conn);
     "VACUUM t".execute(&mut conn);
     "VACUUM FULL t".execute(&mut conn);
     "DROP TABLE t, s".execute(&mut conn);
     "VACUUM".execute(&mut conn);
+
+    let total_post_vacuum_files = WalkDir::new(data_path.clone())
+        .into_iter()
+        .filter_entry(|e| !e.path().to_str().unwrap().contains("_delta_log"))
+        .count();
+
+    assert!(total_pre_vacuum_files > total_post_vacuum_files);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #793
- Closes #964

## What
Vacuums regressed, and now they’re back.

## Why
^^

## How
We were using whether the AST could be parsed to decide whether to use our custom processing hooks, but sqlparser doesn’t support VACUUM. Now, the AST parse-ability only matters for the hooks that depend on the AST, and then we continue on to the `prev_hook` anyway.

## Tests
