### PR TITLE
fix: Create heap table from parquet table

### DIFF
--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -1,6 +1,5 @@
 use async_std::task;
 use deltalake::datafusion::logical_expr::{DdlStatement, LogicalPlan};
-
 use pgrx::*;
 use std::ffi::CStr;
 

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -59,8 +59,8 @@ pub fn executor_run(
             }
         };
 
-        // CREATE TABLE commands can reach the executor hookin the case of
-        // CREATE TABLE AS SELECT. We should let them go through to the table access method.
+        // CREATE TABLE queries can reach the executor for CREATE TABLE AS SELECT
+        // We should let these queries go through to the table access method
         if let LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(_)) = logical_plan {
             prev_hook(query_desc, direction, count, execute_once);
             return Ok(());

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -1,14 +1,10 @@
 use async_std::task;
-use deltalake::datafusion::error::DataFusionError;
-use deltalake::datafusion::logical_expr::LogicalPlan;
-use deltalake::datafusion::sql::parser::DFParser;
-use deltalake::datafusion::sql::planner::SqlToRel;
-use deltalake::datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+use deltalake::datafusion::sql::parser;
+use deltalake::datafusion::sql::sqlparser::ast::Statement;
 use pgrx::*;
 use std::ffi::CStr;
 
 use crate::datafusion::commit::{commit_writer, needs_commit};
-use crate::datafusion::context::QueryContext;
 use crate::errors::{NotSupported, ParadeError};
 use crate::hooks::delete::delete;
 use crate::hooks::handler::IsColumn;
@@ -35,9 +31,8 @@ pub fn executor_run(
     unsafe {
         let ps = query_desc.plannedstmt;
         let rtable = (*ps).rtable;
-        let query = query_desc
-            .plannedstmt
-            .current_query_string(CStr::from_ptr(query_desc.sourceText))?;
+        let pg_plan = query_desc.plannedstmt;
+        let query = pg_plan.get_query_string(CStr::from_ptr(query_desc.sourceText))?;
 
         if query_desc.operation == pg_sys::CmdType_CMD_INSERT {
             insert(rtable, query_desc.clone())?;
@@ -55,8 +50,20 @@ pub fn executor_run(
             return Ok(());
         }
 
+        // CREATE TABLE commands can reach the executor hook
+        // in the case of CREATE TABLE AS SELECT, and we should
+        // let them go through to the table access method
+        if let Ok(ast) = pg_plan.get_ast(&query) {
+            if let parser::Statement::Statement(inner_statement) = &ast[0] {
+                if let Statement::CreateTable { .. } = inner_statement.as_ref() {
+                    prev_hook(query_desc, direction, count, execute_once);
+                    return Ok(());
+                }
+            }
+        };
+
         // Parse the query into a LogicalPlan
-        let logical_plan = match create_logical_plan(&query) {
+        let logical_plan = match pg_plan.get_logical_plan(&query) {
             Ok(logical_plan) => logical_plan,
             // If DataFusion can't parse the query, let Postgres handle it
             Err(_) => {
@@ -76,18 +83,4 @@ pub fn executor_run(
             }
         }
     }
-}
-
-#[inline]
-fn create_logical_plan(query: &str) -> Result<LogicalPlan, ParadeError> {
-    let dialect = PostgreSqlDialect {};
-    let ast = DFParser::parse_sql_with_dialect(query, &dialect)
-        .map_err(|err| ParadeError::DataFusion(DataFusionError::SQL(err, None)))?;
-    let statement = &ast[0];
-
-    // Convert the AST into a logical plan
-    let context_provider = QueryContext::new()?;
-    let sql_to_rel = SqlToRel::new(&context_provider);
-
-    Ok(sql_to_rel.statement_to_plan(statement.clone())?)
 }

--- a/pg_analytics/src/hooks/query.rs
+++ b/pg_analytics/src/hooks/query.rs
@@ -1,17 +1,30 @@
+use deltalake::datafusion::error::DataFusionError;
+use deltalake::datafusion::logical_expr::LogicalPlan;
+use deltalake::datafusion::sql::parser::{self, DFParser};
+use deltalake::datafusion::sql::planner::SqlToRel;
+use deltalake::datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use pgrx::*;
+use std::collections::VecDeque;
 use std::ffi::CStr;
 
+use crate::datafusion::context::QueryContext;
 use crate::errors::ParadeError;
 
 pub trait Query {
     // Extracts the query string from a PlannedStmt,
     // accounting for multi-line queries where we only want a
     // specific line of the entire query.
-    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError>;
+    fn get_query_string(self, source_text: &CStr) -> Result<String, ParadeError>;
+
+    // Parses the query string into an AST
+    fn get_ast(self, query_string: &str) -> Result<VecDeque<parser::Statement>, ParadeError>;
+
+    // Parses the query string into a DataFusion LogicalPlan
+    fn get_logical_plan(self, query_string: &str) -> Result<LogicalPlan, ParadeError>;
 }
 
 impl Query for *mut pg_sys::PlannedStmt {
-    fn current_query_string(self, source_text: &CStr) -> Result<String, ParadeError> {
+    fn get_query_string(self, source_text: &CStr) -> Result<String, ParadeError> {
         let query_start_index = unsafe { (*self).stmt_location };
         let query_len = unsafe { (*self).stmt_len };
         let mut query = source_text.to_str()?;
@@ -26,5 +39,23 @@ impl Query for *mut pg_sys::PlannedStmt {
         }
 
         Ok(query.to_string())
+    }
+
+    fn get_ast(self, query: &str) -> Result<VecDeque<parser::Statement>, ParadeError> {
+        let dialect = PostgreSqlDialect {};
+        DFParser::parse_sql_with_dialect(query, &dialect)
+            .map_err(|err| ParadeError::DataFusion(DataFusionError::SQL(err, None)))
+    }
+
+    fn get_logical_plan(self, query: &str) -> Result<LogicalPlan, ParadeError> {
+        let dialect = PostgreSqlDialect {};
+        let ast = DFParser::parse_sql_with_dialect(query, &dialect)
+            .map_err(|err| ParadeError::DataFusion(DataFusionError::SQL(err, None)))?;
+        let statement = &ast[0];
+
+        let context_provider = QueryContext::new()?;
+        let sql_to_rel = SqlToRel::new(&context_provider);
+
+        Ok(sql_to_rel.statement_to_plan(statement.clone())?)
     }
 }

--- a/pg_analytics/tests/basic.rs
+++ b/pg_analytics/tests/basic.rs
@@ -804,14 +804,26 @@ fn copy_parquet_to_heap(mut conn: PgConnection) {
     UserSessionLogsTable::setup().execute(&mut conn);
     "CREATE TABLE heap AS SELECT * FROM user_session_logs".execute(&mut conn);
 
-    let columns: UserSessionLogsTableVec =
-        "SELECT * FROM heap ORDER BY id".fetch_collect(&mut conn);
-
     let ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(&columns.id[0..10], ids, "ids are in expected order");
     let event_names =
         "Login,Purchase,Logout,Signup,ViewProduct,AddToCart,RemoveFromCart,Checkout,Payment,Review";
 
+    let columns: UserSessionLogsTableVec =
+        "SELECT * FROM heap ORDER BY id".fetch_collect(&mut conn);
+
+    assert_eq!(&columns.id[0..10], ids, "ids are in expected order");
+    assert_eq!(
+        &columns.event_name[0..10],
+        event_names.split(',').collect::<Vec<_>>(),
+        "event names are in expected order"
+    );
+
+    "SELECT * INTO heap2 from user_session_logs".execute(&mut conn);
+
+    let columns: UserSessionLogsTableVec =
+        "SELECT * FROM heap2 ORDER BY id".fetch_collect(&mut conn);
+
+    assert_eq!(&columns.id[0..10], ids, "ids are in expected order");
     assert_eq!(
         &columns.event_name[0..10],
         event_names.split(',').collect::<Vec<_>>(),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #931 

## What
Fixes a bug where `CREATE TABLE heap AS SELECT * FROM parquet` was not working, where `heap` is a heap table and `parquet` is a parquet table.

## Why
User-reported bug

## How
We were intercepting this command with our hooks, this PR lets it pass through to the table access method.

## Tests
Added a test