### PR TITLE
fix: Disable speculative insert

### DIFF
--- a/pg_analytics/src/errors.rs
+++ b/pg_analytics/src/errors.rs
@@ -89,6 +89,9 @@ pub enum NotSupported {
 
     #[error("Heap and parquet tables in the same query is not yet supported")]
     MixedTables,
+
+    #[error("Inserts with ON CONFLICT are not yet supported")]
+    SpeculativeInsert,
 }
 
 impl From<&str> for ParadeError {

--- a/pg_analytics/src/tableam/insert.rs
+++ b/pg_analytics/src/tableam/insert.rs
@@ -7,7 +7,7 @@ use pgrx::*;
 use crate::datafusion::commit::commit_writer;
 use crate::datafusion::table::DatafusionTable;
 use crate::datafusion::writer::Writer;
-use crate::errors::ParadeError;
+use crate::errors::{NotSupported, ParadeError};
 use crate::types::array::IntoArrowArray;
 use crate::types::datatype::PgTypeMod;
 
@@ -62,6 +62,7 @@ pub extern "C" fn deltalake_tuple_insert_speculative(
     _bistate: *mut pg_sys::BulkInsertStateData,
     _specToken: pg_sys::uint32,
 ) {
+    panic!("{}", NotSupported::SpeculativeInsert.to_string());
 }
 
 #[inline]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #973 

## What
Shows users an error if they try to `INSERT ... ON CONFLICT`.

## Why

`INSERT ... ON CONFLICT` is not implemented. This PR makes it so that users see an error instead of an incorrect INSERT.

## How

## Tests
