### PR TITLE
ci: Set Rust version in CI to stable, not hardcoded

### DIFF
--- a/.github/workflows/publish-pg_bm25.yml
+++ b/.github/workflows/publish-pg_bm25.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.73.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version

--- a/.github/workflows/test-pg_bm25.yml
+++ b/.github/workflows/test-pg_bm25.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install Rust
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        uses: dtolnay/rust-toolchain@1.73.0
+        uses: dtolnay/rust-toolchain@stable
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This happened after Ming's recent PR: https://github.com/paradedb/paradedb/actions/runs/8237670576/job/22526929890

It turns out that in two places in our CI we still had `v1.73.0` hardcoded for Rust, which we had initially hardcoded due to being based on an outdated version of Tantivy. This is no longer the case, and we can specify `stable` instead, which will keep us up-to-date and avoid version issues like this one.

## Why

## How

## Tests
