### PR TITLE
feat: Optional stable sorting and multithreaded search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "pg_analytics"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "pg_bm25"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "approx",
@@ -3698,6 +3698,7 @@ dependencies = [
  "json5",
  "libc",
  "memoffset",
+ "num_cpus",
  "once_cell",
  "pgrx",
  "pgrx-tests",

--- a/docs/search/full-text/bm25.mdx
+++ b/docs/search/full-text/bm25.mdx
@@ -157,6 +157,25 @@ FROM <index_name>.search(
 )
 ```
 
+## Stable Ordering
+
+Search results are always ordered based on their BM25 score, but we can use the `stable_sort`
+parameter for control over the order of equally-scored results.
+
+If `false`, equally-scored results will be ordered based on their insertion order into the index.
+This is the default, and allows for the fastest possible query times.
+
+If `true`, equally-scored results will be ordered based on their `key_field`, but query times will be slower.
+This is useful for testing or anytime where results need to be deterministic.
+
+```sql
+SELECT *
+FROM <index_name>.search(
+  '<query>',
+  stable_sort => true
+)
+```
+
 <ParamField body="index_name" required>
   The name of the index.
 </ParamField>
@@ -166,4 +185,8 @@ FROM <index_name>.search(
 <ParamField body="limit_rows">The maximum number of rows to return.</ParamField>
 <ParamField body="offset_rows">
   The number of rows to skip before starting to return rows.
+</ParamField>
+<ParamField body="stable_sort" default={false}>
+  A boolean specifying whether ParadeDB should stabilize the order of
+  equally-scored results, at the cost of performance.
 </ParamField>

--- a/pg_bm25/Cargo.toml
+++ b/pg_bm25/Cargo.toml
@@ -50,6 +50,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 utoipa = "4.2.0"
 walkdir = "2.5.0"
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_bm25/sql/_bootstrap.sql
+++ b/pg_bm25/sql/_bootstrap.sql
@@ -217,7 +217,8 @@ BEGIN
             query text, -- The search query
             offset_rows integer DEFAULT NULL, -- Offset for paginated results
             limit_rows integer DEFAULT NULL, -- Limit for paginated results
-            alias text DEFAULT NULL -- Alias for disambiguation
+            alias text DEFAULT NULL, -- Alias for disambiguation
+            stable_sort boolean DEFAULT NULL -- Stable sort order of results
         ) RETURNS %s AS $func$
         BEGIN
             -- Explicitly cast the 'query' text parameter to 'paradedb.searchqueryinput' type
@@ -225,7 +226,8 @@ BEGIN
                 query => paradedb.parse(query),
                 offset_rows => offset_rows,
                 limit_rows => limit_rows,
-                alias => alias
+                alias => alias,
+                stable_sort => stable_sort
             );
         END
         $func$ LANGUAGE plpgsql;
@@ -234,7 +236,8 @@ BEGIN
             query paradedb.searchqueryinput, -- The search query
             offset_rows integer DEFAULT NULL, -- Offset for paginated results
             limit_rows integer DEFAULT NULL, -- Limit for paginated results
-            alias text DEFAULT NULL -- Alias for disambiguation
+            alias text DEFAULT NULL, -- Alias for disambiguation
+            stable_sort boolean DEFAULT NULL -- Stable sort order of results
         ) RETURNS %s AS $func$
         DECLARE
             __paradedb_search_config__ JSONB;
@@ -244,7 +247,8 @@ BEGIN
                 'query', query::text::jsonb,
                 'offset_rows', offset_rows,
                 'limit_rows', limit_rows,
-                'alias', alias
+                'alias', alias,
+                'stable_sort', stable_sort
             );
             %s; -- Execute the function body with the constructed JSONB parameter
         END

--- a/pg_bm25/src/api/operator.rs
+++ b/pg_bm25/src/api/operator.rs
@@ -21,7 +21,7 @@ fn search_tantivy(
         let scan_state = search_index
             .search_state(&writer_client, &search_config, needs_commit())
             .unwrap();
-        let top_docs = scan_state.search();
+        let top_docs = scan_state.search(search_index.executor);
         let mut hs = FxHashSet::default();
 
         for (_score, _doc_address, key, _ctid) in top_docs {

--- a/pg_bm25/src/api/search.rs
+++ b/pg_bm25/src/api/search.rs
@@ -61,7 +61,7 @@ pub fn minmax_bm25(
         .unwrap();
 
     // Collect into a Vec to allow multiple iterations
-    let top_docs: Vec<_> = scan_state.search_dedup().collect();
+    let top_docs: Vec<_> = scan_state.search_dedup(search_index.executor).collect();
 
     // Calculate min and max scores
     let (min_score, max_score) = top_docs

--- a/pg_bm25/src/index/score.rs
+++ b/pg_bm25/src/index/score.rs
@@ -2,11 +2,12 @@ use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
 
+/// A custom score struct for ordering Tantivy results.
+/// For use with the `stable` sorting feature.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct SearchIndexScore {
     pub bm25: f32,
     pub key: i64,
-    pub ctid: u64,
 }
 
 // We do these custom trait impls, because we want these to be sortable so:

--- a/pg_bm25/src/postgres/scan.rs
+++ b/pg_bm25/src/postgres/scan.rs
@@ -56,7 +56,7 @@ pub extern "C" fn amrescan(
         .search_state(&writer_client, &search_config, needs_commit())
         .unwrap();
 
-    let top_docs = state.search();
+    let top_docs = state.search(search_index.executor);
     SearchStateManager::set_state(state.clone()).expect("could not store search state in manager");
 
     // Save the iterator onto the current memory context.

--- a/pg_bm25/src/schema/config.rs
+++ b/pg_bm25/src/schema/config.rs
@@ -14,6 +14,7 @@ pub struct SearchConfig {
     pub max_num_chars: Option<usize>,
     pub highlight_field: Option<String>,
     pub alias: Option<SearchAlias>,
+    pub stable_sort: Option<bool>,
 }
 
 impl SearchConfig {

--- a/pg_bm25/tests/icu.rs
+++ b/pg_bm25/tests/icu.rs
@@ -24,15 +24,18 @@ fn test_icu_arabic_tokenizer(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let columns: IcuArabicPostsTableVec =
-        r#"SELECT * FROM idx_arabic.search('author:"محمد"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_arabic.search('author:"محمد"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![2]);
 
     let columns: IcuArabicPostsTableVec =
-        r#"SELECT * FROM idx_arabic.search('title:"السوق"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_arabic.search('title:"السوق"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![2]);
 
     let columns: IcuArabicPostsTableVec =
-        r#"SELECT * FROM idx_arabic.search('message:"في"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_arabic.search('message:"في"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![2, 1, 3]);
 }
 
@@ -53,15 +56,18 @@ fn test_icu_amharic_tokenizer(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let columns: IcuAmharicPostsTableVec =
-        r#"SELECT * FROM idx_amharic.search('author:"አለም"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_amharic.search('author:"አለም"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![3]);
 
     let columns: IcuAmharicPostsTableVec =
-        r#"SELECT * FROM idx_amharic.search('title:"ለመማር"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_amharic.search('title:"ለመማር"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![3]);
 
     let columns: IcuAmharicPostsTableVec =
-        r#"SELECT * FROM idx_amharic.search('message:"ዝናብ"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_amharic.search('message:"ዝናብ"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![2, 1]);
 }
 
@@ -82,14 +88,17 @@ fn test_icu_greek_tokenizer(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let columns: IcuGreekPostsTableVec =
-        r#"SELECT * FROM idx_greek.search('author:"Σοφία"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_greek.search('author:"Σοφία"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![2]);
 
     let columns: IcuGreekPostsTableVec =
-        r#"SELECT * FROM idx_greek.search('title:"επιτυχία"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_greek.search('title:"επιτυχία"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![3]);
 
     let columns: IcuGreekPostsTableVec =
-        r#"SELECT * FROM idx_greek.search('message:"συμβουλές"')"#.fetch_collect(&mut conn);
+        r#"SELECT * FROM idx_greek.search('message:"συμβουλές"', stable_sort => true)"#
+            .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![3]);
 }

--- a/pg_bm25/tests/lindera.rs
+++ b/pg_bm25/tests/lindera.rs
@@ -33,13 +33,16 @@ async fn lindera_korean_tokenizer(mut conn: PgConnection) {
     )"#
     .execute(&mut conn);
 
-    let row: (i32,) = r#"SELECT id FROM korean.search('author:김민준')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM korean.search('author:김민준', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    let row: (i32,) = r#"SELECT id FROM korean.search('title:"경기"')"#.fetch_one(&mut conn);
+    let row: (i32,) =
+        r#"SELECT id FROM korean.search('title:"경기"', stable_sort => true)"#.fetch_one(&mut conn);
     assert_eq!(row.0, 2);
 
-    let row: (i32,) = r#"SELECT id FROM korean.search('message:"지역 축제"')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM korean.search('message:"지역 축제"', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 3);
 }
 
@@ -68,13 +71,16 @@ async fn lindera_chinese_tokenizer(mut conn: PgConnection) {
     )"#
     .execute(&mut conn);
 
-    let row: (i32,) = r#"SELECT id FROM chinese.search('author:华')"#.fetch_one(&mut conn);
+    let row: (i32,) =
+        r#"SELECT id FROM chinese.search('author:华', stable_sort => true)"#.fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    let row: (i32,) = r#"SELECT id FROM chinese.search('title:北京')"#.fetch_one(&mut conn);
+    let row: (i32,) =
+        r#"SELECT id FROM chinese.search('title:北京', stable_sort => true)"#.fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    let row: (i32,) = r#"SELECT id FROM chinese.search('message:文化节')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM chinese.search('message:文化节', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 3);
 }
 
@@ -104,12 +110,15 @@ async fn lindera_japenese_tokenizer(mut conn: PgConnection) {
     )"#
     .execute(&mut conn);
 
-    let row: (i32,) = r#"SELECT id FROM japanese.search('author:佐藤')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM japanese.search('author:佐藤', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 1);
 
-    let row: (i32,) = r#"SELECT id FROM japanese.search('title:サッカー')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM japanese.search('title:サッカー', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 2);
 
-    let row: (i32,) = r#"SELECT id FROM japanese.search('message:祭り')"#.fetch_one(&mut conn);
+    let row: (i32,) = r#"SELECT id FROM japanese.search('message:祭り', stable_sort => true)"#
+        .fetch_one(&mut conn);
     assert_eq!(row.0, 3);
 }

--- a/pg_bm25/tests/query.rs
+++ b/pg_bm25/tests/query.rs
@@ -19,7 +19,8 @@ fn boolean_tree(mut conn: PgConnection) {
 			    paradedb.term(field => 'description', value => 'speaker'),
 			    paradedb.fuzzy_term(field => 'description', value => 'wolo')
 		    ]
-	    )
+	    ),
+	    stable_sort => true
 	);
     "#
     .fetch_collect(&mut conn);
@@ -31,14 +32,16 @@ fn fuzzy_fields(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.fuzzy_term(field => 'category', value => 'elector')
+    	query => paradedb.fuzzy_term(field => 'category', value => 'elector'),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![1, 2, 12, 22, 32], "wrong results");
 
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.term(field => 'category', value => 'electornics')
+    	query => paradedb.term(field => 'category', value => 'electornics'),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert!(columns.is_empty(), "without fuzzy field should be empty");
@@ -50,7 +53,8 @@ fn fuzzy_fields(mut conn: PgConnection) {
     	    value => 'keybaord',
     	    tranposition_cost_one => false,
     	    distance => 1
-    	)
+    	),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert!(
@@ -65,7 +69,8 @@ fn fuzzy_fields(mut conn: PgConnection) {
     	    value => 'keybaord',
     	    tranposition_cost_one => true,
     	    distance => 1
-    	)
+    	),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(
@@ -82,7 +87,8 @@ fn single_queries(mut conn: PgConnection) {
     // All
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-	    query => paradedb.all()
+	    query => paradedb.all(),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
@@ -90,7 +96,8 @@ fn single_queries(mut conn: PgConnection) {
     // Boost
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-	    query => paradedb.boost(query => paradedb.all(), boost => 1.5)
+	    query => paradedb.boost(query => paradedb.all(), boost => 1.5),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
@@ -98,7 +105,8 @@ fn single_queries(mut conn: PgConnection) {
     // ConstScore
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-	    query => paradedb.const_score(query => paradedb.all(), score => 3.9)
+	    query => paradedb.const_score(query => paradedb.all(), score => 3.9),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
@@ -106,7 +114,8 @@ fn single_queries(mut conn: PgConnection) {
     // DisjunctionMax
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.disjunction_max(disjuncts => ARRAY[paradedb.parse('description:shoes')])
+    	query => paradedb.disjunction_max(disjuncts => ARRAY[paradedb.parse('description:shoes')]),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 3);
@@ -114,7 +123,8 @@ fn single_queries(mut conn: PgConnection) {
     // Empty
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.empty()
+    	query => paradedb.empty(),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 0);
@@ -122,7 +132,8 @@ fn single_queries(mut conn: PgConnection) {
     // FuzzyTerm
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.fuzzy_term(field => 'description', value => 'wolo')
+    	query => paradedb.fuzzy_term(field => 'description', value => 'wolo'),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 4);
@@ -130,7 +141,8 @@ fn single_queries(mut conn: PgConnection) {
     // Parse
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.parse('description:teddy')
+    	query => paradedb.parse('description:teddy'),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 1);
@@ -138,7 +150,8 @@ fn single_queries(mut conn: PgConnection) {
     // PhrasePrefix
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.phrase_prefix(field => 'description', phrases => ARRAY['har'])
+    	query => paradedb.phrase_prefix(field => 'description', phrases => ARRAY['har']),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 1);
@@ -146,7 +159,8 @@ fn single_queries(mut conn: PgConnection) {
     // Phrase with invalid term list
     match r#"
        SELECT * FROM bm25_search.search(
-       	query => paradedb.phrase(field => 'description', phrases => ARRAY['robot'])
+       	query => paradedb.phrase(field => 'description', phrases => ARRAY['robot']),
+	    stable_sort => true
     )"#
     .fetch_result::<SimpleProductsTable>(&mut conn)
     {
@@ -162,7 +176,8 @@ fn single_queries(mut conn: PgConnection) {
     	query => paradedb.phrase(
     		field => 'description',
     		phrases => ARRAY['robot', 'building', 'kit']
-    	)
+    	),
+	    stable_sort => true
 
 	)"#
     .fetch_collect(&mut conn);
@@ -174,7 +189,8 @@ fn single_queries(mut conn: PgConnection) {
     	query => paradedb.regex(
     		field => 'description',
     		pattern => '(hardcover|plush|leather|running|wireless)'
-    	)
+    	),
+	    stable_sort => true
 
 	)"#
     .fetch_collect(&mut conn);
@@ -183,7 +199,8 @@ fn single_queries(mut conn: PgConnection) {
     // Term
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-    	query => paradedb.term(field => 'description', value => 'shoes')
+    	query => paradedb.term(field => 'description', value => 'shoes'),
+	    stable_sort => true
 
 	)"#
     .fetch_collect(&mut conn);
@@ -196,7 +213,8 @@ fn single_queries(mut conn: PgConnection) {
     	    terms => ARRAY[
     	        paradedb.regex(field => 'description', pattern => '.+')
     	    ]
-    	)
+    	),
+	    stable_sort => true
 	)"#
     .fetch_result::<SimpleProductsTable>(&mut conn)
     {
@@ -214,7 +232,8 @@ fn single_queries(mut conn: PgConnection) {
     	        paradedb.term(field => 'description', value => 'shoes'),
     	        paradedb.term(field => 'description', value => 'novel')
     	    ]
-    	)
+    	),
+	    stable_sort => true
 	)"#
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 5);

--- a/pg_bm25/tests/quickstart.rs
+++ b/pg_bm25/tests/quickstart.rs
@@ -44,7 +44,7 @@ fn quickstart(mut conn: PgConnection) {
 
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
-    FROM search_idx.search('description:keyboard OR category:electronics')
+    FROM search_idx.search('description:keyboard OR category:electronics', stable_sort => true)
     LIMIT 5;
     "#
     .fetch(&mut conn);
@@ -57,7 +57,7 @@ fn quickstart(mut conn: PgConnection) {
 
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
-    FROM search_idx.search('description:"bluetooth speaker"~1')
+    FROM search_idx.search('description:"bluetooth speaker"~1', stable_sort => true)
     LIMIT 5;
     "#
     .fetch(&mut conn);
@@ -75,7 +75,7 @@ fn quickstart(mut conn: PgConnection) {
     "#.execute(&mut conn);
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
-    FROM ngrams_idx.search('description:blue');
+    FROM ngrams_idx.search('description:blue', stable_sort => true);
     "#
     .fetch(&mut conn);
     assert_eq!(rows.len(), 1);
@@ -83,7 +83,7 @@ fn quickstart(mut conn: PgConnection) {
 
     let rows: Vec<(String, String, f32)> = r#"
     SELECT description, paradedb.highlight(id, field => 'description'), paradedb.rank_bm25(id)
-    FROM ngrams_idx.search('description:blue')
+    FROM ngrams_idx.search('description:blue', stable_sort => true)
     "#
     .fetch(&mut conn);
     assert_eq!(rows.len(), 1);
@@ -209,16 +209,20 @@ fn identical_queries(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows1: SimpleProductsTableVec =
-        "SELECT * FROM search_idx.search('description:shoes')".fetch_collect(&mut conn);
-    let rows2: SimpleProductsTableVec =
-        "SELECT * FROM search_idx.search(query => paradedb.parse('description:shoes'))"
+        "SELECT * FROM search_idx.search('description:shoes', stable_sort => true)"
             .fetch_collect(&mut conn);
+    let rows2: SimpleProductsTableVec = "SELECT * FROM search_idx.search(
+            query => paradedb.parse('description:shoes'),
+            stable_sort => true
+        )"
+    .fetch_collect(&mut conn);
     let rows3: SimpleProductsTableVec = r#"
         SELECT * FROM search_idx.search(
 	        query => paradedb.term(
 	        	field => 'description',
 	        	value => 'shoes'
-	        )
+	        ),
+	        stable_sort => true
         )"#
     .fetch_collect(&mut conn);
 

--- a/pg_bm25/tests/search_config.rs
+++ b/pg_bm25/tests/search_config.rs
@@ -9,23 +9,26 @@ use sqlx::PgConnection;
 fn basic_search_query(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let rows: SimpleProductsTableVec =
-        "SELECT * FROM bm25_search.search('category:electronics')".fetch_collect(&mut conn);
+        "SELECT * FROM bm25_search.search('category:electronics', stable_sort => true)"
+            .fetch_collect(&mut conn);
 
     assert_eq!(rows.id, vec![1, 2, 12, 22, 32])
 }
 
-#[ignore = "will fail until stable sorting is implemented"]
 #[rstest]
 fn with_limit_and_offset(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
-    let rows: SimpleProductsTableVec =
-        "SELECT * FROM bm25_search.search('category:electronics', limit_rows => 2)"
-            .fetch_collect(&mut conn);
+    let rows: SimpleProductsTableVec = "SELECT * FROM bm25_search.search(
+            'category:electronics',
+            limit_rows => 2,
+            stable_sort => true
+    )"
+    .fetch_collect(&mut conn);
 
     assert_eq!(rows.id, vec![1, 2]);
 
     let rows: SimpleProductsTableVec =
-        "SELECT * FROM bm25_search.search('category:electronics', limit_rows => 2, offset_rows => 1)"
+        "SELECT * FROM bm25_search.search('category:electronics', limit_rows => 2, offset_rows => 1, stable_sort => true)"
             .fetch_collect(&mut conn);
 
     assert_eq!(rows.id, vec![2, 12]);
@@ -46,7 +49,8 @@ fn default_tokenizer_config(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<()> =
-        "SELECT * FROM tokenizer_config.search('description:earbud')".fetch(&mut conn);
+        "SELECT * FROM tokenizer_config.search('description:earbud', stable_sort => true)"
+            .fetch(&mut conn);
 
     assert!(rows.is_empty());
 }
@@ -66,7 +70,8 @@ fn en_stem_tokenizer_config(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(i32,)> =
-        "SELECT id FROM tokenizer_config.search('description:earbud')".fetch(&mut conn);
+        "SELECT id FROM tokenizer_config.search('description:earbud', stable_sort => true)"
+            .fetch(&mut conn);
 
     assert_eq!(rows[0], (12,));
 }
@@ -86,7 +91,8 @@ fn ngram_tokenizer_config(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(i32,)> =
-        "SELECT id FROM tokenizer_config.search('description:boa')".fetch(&mut conn);
+        "SELECT id FROM tokenizer_config.search('description:boa', stable_sort => true)"
+            .fetch(&mut conn);
 
     assert_eq!(rows[0], (2,));
     assert_eq!(rows[1], (20,));
@@ -110,7 +116,8 @@ fn chinese_compatible_tokenizer_config(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(i32,)> =
-        "SELECT id FROM tokenizer_config.search('description:电脑')".fetch(&mut conn);
+        "SELECT id FROM tokenizer_config.search('description:电脑', stable_sort => true)"
+            .fetch(&mut conn);
 
     assert_eq!(rows[0], (42,));
 }


### PR DESCRIPTION
## What
This is an important PR for `pg_bm25` performance. We now use Tantivy's multi-threaded searcher for 2x faster searches, and we add an option for stable ordering of results. By default, results are unstable for the fastest possible performance.

## Why
With testing `pg_search` on over a billion rows, I've been able to identify performance bottlenecks that we start to see at scale. Before this PR, searches over 1.18 billion rows took 30 to 40 seconds. These are now around 200ms for warm searches.

## How
Added a `stable_sort` parameter to search which controls whether we use deterministic ordering (based on key field) for search results.

For multithreading, each connection now stores a static `Executor` which is passed to searches. 

## Tests
All tests now use `stable_sort`.