### PR TITLE
ci: Print docker logs when running benchmarks

### DIFF
--- a/pg_analytics/benchmarks/clickbench/benchmark.sh
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sh
@@ -58,6 +58,14 @@ cd "$BASEDIR/"
 
 # Cleanup function to reset the environment
 cleanup() {
+  # If the container successfully started, print the logs. This is
+  # helpful to debug scenarios where the container starts but the
+  # Postgres server crashes.
+  if docker ps -q --filter "name=paradedb" | grep -q .; then
+    echo ""
+    echo "Printing Docker logs..."
+    docker logs paradedb
+  fi
   echo ""
   echo "Cleaning up benchmark environment..."
   if [ "$FLAG_TAG" == "pgrx" ]; then

--- a/pg_analytics/benchmarks/clickbench/benchmark.sh
+++ b/pg_analytics/benchmarks/clickbench/benchmark.sh
@@ -61,11 +61,9 @@ cleanup() {
   # If the container successfully started, print the logs. This is
   # helpful to debug scenarios where the container starts but the
   # Postgres server crashes.
-  if docker ps -q --filter "name=paradedb" | grep -q .; then
-    echo ""
-    echo "Printing Docker logs..."
-    docker logs paradedb
-  fi
+  echo ""
+  echo "Printing Docker logs..."
+  docker logs paradedb
   echo ""
   echo "Cleaning up benchmark environment..."
   if [ "$FLAG_TAG" == "pgrx" ]; then

--- a/pg_search/benchmarks/benchmark-pg_search.sh
+++ b/pg_search/benchmarks/benchmark-pg_search.sh
@@ -48,11 +48,9 @@ cleanup() {
   # If the container successfully started, print the logs. This is
   # helpful to debug scenarios where the container starts but the
   # Postgres server crashes.
-  if docker ps -q --filter "name=paradedb" | grep -q .; then
-    echo ""
-    echo "Printing Docker logs..."
-    docker logs paradedb
-  fi
+  echo ""
+  echo "Printing Docker logs..."
+  docker logs paradedb
   if [ -s query_error.log ]; then
     echo "!!! Benchmark cleanup triggered !!!"
     cat query_error.log

--- a/pg_search/benchmarks/benchmark-pg_search.sh
+++ b/pg_search/benchmarks/benchmark-pg_search.sh
@@ -45,6 +45,14 @@ source "helpers/get_data.sh"
 
 # Cleanup function to stop and remove the Docker container
 cleanup() {
+  # If the container successfully started, print the logs. This is
+  # helpful to debug scenarios where the container starts but the
+  # Postgres server crashes.
+  if docker ps -q --filter "name=paradedb" | grep -q .; then
+    echo ""
+    echo "Printing Docker logs..."
+    docker logs paradedb
+  fi
   if [ -s query_error.log ]; then
     echo "!!! Benchmark cleanup triggered !!!"
     cat query_error.log


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Since a recent PR, I suspect the one adding `paradedb.help`, our benchmarks started failing. This PR does two things:
- [x] Improve our logging in our benchmarks, to help catch the error more easily in the future
- [x] Fix the error causing the benchmarks to crash. Edit: Ming fixed this in a separate PR which got merged

Example of a failed run: https://github.com/paradedb/paradedb/actions/runs/8364062048/job/22898484924

## Why
^

## How
^

## Tests
^