### PR TITLE
chore: Update missing `pg_bm25` references to `pg_search`

### DIFF
--- a/docs/changelog/0.4.1.mdx
+++ b/docs/changelog/0.4.1.mdx
@@ -2,11 +2,11 @@
 title: 0.4.1
 ---
 
-## pg_bm25
+## pg_search
 
 ### Brand New API Interface
 
-`0.4.1` introduces a major API overhaul of `pg_bm25`. All queries have been rewritten
+`0.4.1` introduces a major API overhaul of `pg_search`. All queries have been rewritten
 to use a consistent dynamic function interface. For instance, the old way to create a BM25
 index was:
 
@@ -46,7 +46,7 @@ features and bug fixes (continue reading below).
 ### Searching Over JOINed Tables
 
 The new `create_bm25` function requires a `key_field` parameter, which is a unique integer column.
-This is necessary for unlocking search over JOINed tables. Previously, `pg_bm25` relied on the
+This is necessary for unlocking search over JOINed tables. Previously, `pg_search` relied on the
 Postgres-internal `ctid` column, which doesn't exist in a JOINed table.
 
 ### Multiple Concurrent Indexes

--- a/docs/changelog/0.4.1.mdx
+++ b/docs/changelog/0.4.1.mdx
@@ -4,7 +4,9 @@ title: 0.4.1
 
 ## pg_search
 
-### Brand New API Interface
+### Features
+
+#### Brand New API Interface
 
 `0.4.1` introduces a major API overhaul of `pg_search`. All queries have been rewritten
 to use a consistent dynamic function interface. For instance, the old way to create a BM25
@@ -43,26 +45,28 @@ SELECT * FROM <index_name>.search('<query>');
 Not only is this new API interface more pleasant to look at, it helps unlock several new
 features and bug fixes (continue reading below).
 
-### Searching Over JOINed Tables
+#### Searching Over JOINed Tables
 
 The new `create_bm25` function requires a `key_field` parameter, which is a unique integer column.
 This is necessary for unlocking search over JOINed tables. Previously, `pg_search` relied on the
 Postgres-internal `ctid` column, which doesn't exist in a JOINed table.
 
-### Multiple Concurrent Indexes
+#### Multiple Concurrent Indexes
 
 The new interface allows multiple indexes to exist over the same table. Previously, only one
 `BM25` index was allowed per table. This prevented use cases where users
 wanted to create multiple different tokenizers over the same column.
 
-### Sequential Scan Fix
+#### Sequential Scan Fix
 
 The sequential scan code path was completely broken, which led to queries
 unexpectedly failing. This issue has been addressed.
 
 ## pg_sparse
 
-`pg_sparse` has been introduced to the ParadeDB Docker Image and to ParadeDB Cloud.
+### Features
+
+- `pg_sparse` has been introduced to the ParadeDB Docker Image and to ParadeDB Cloud.
 
 ## Full Changelog
 

--- a/docs/changelog/0.4.2.mdx
+++ b/docs/changelog/0.4.2.mdx
@@ -4,9 +4,9 @@ title: 0.4.2
 
 ## pg_sparse
 
-### Docker Image Fix
+### Bug Fixes
 
-Fixed a bug where `pg_sparse` was broken in our Docker image due to an issue in our build.
+- Fixed a bug where `pg_sparse` was broken in our Docker image due to an issue in our build.
 
 ## Full Changelog
 

--- a/docs/changelog/0.4.3.mdx
+++ b/docs/changelog/0.4.3.mdx
@@ -2,7 +2,7 @@
 title: 0.4.3
 ---
 
-## pg_bm25
+## pg_search
 
 ### Query Performance Fix
 

--- a/docs/changelog/0.4.3.mdx
+++ b/docs/changelog/0.4.3.mdx
@@ -4,9 +4,9 @@ title: 0.4.3
 
 ## pg_search
 
-### Query Performance Fix
+### Bug Fixes
 
-Fixed a bug where query times were slowed due to index scans not being properly triggered.
+- Fixed a bug where query times were slowed due to index scans not being properly triggered.
 
 ## Full Changelog
 

--- a/docs/changelog/0.4.4.mdx
+++ b/docs/changelog/0.4.4.mdx
@@ -2,7 +2,7 @@
 title: 0.4.4
 ---
 
-## pg_bm25
+## pg_search
 
 ### Introduce global background writer
 
@@ -10,10 +10,10 @@ Overhauled the process in which data is written to the index, fixing several iss
 
 Fixes an issue with using the `prefix => ` parameter in fuzzy searches.
 
-Users must make the following change to their `postgresql.conf` configuration file when self-hosting. `pg_bm25` must be added to the list of `shared_preload_libraries` so the background process can be initialized:
+Users must make the following change to their `postgresql.conf` configuration file when self-hosting. `pg_search` must be added to the list of `shared_preload_libraries` so the background process can be initialized:
 
 ```c
-shared_preload_libraries = 'pg_bm25'
+shared_preload_libraries = 'pg_search'
 ```
 
 ## Full Changelog

--- a/docs/changelog/0.4.4.mdx
+++ b/docs/changelog/0.4.4.mdx
@@ -4,7 +4,9 @@ title: 0.4.4
 
 ## pg_search
 
-### Introduce global background writer
+### Features
+
+#### Introduce global background writer
 
 Overhauled the process in which data is written to the index, fixing several issues related to concurrency and insert performance.
 

--- a/docs/changelog/0.4.5.mdx
+++ b/docs/changelog/0.4.5.mdx
@@ -2,7 +2,7 @@
 title: 0.4.5
 ---
 
-## pg_bm25
+## pg_search
 
 ### ICU tokenizer
 

--- a/docs/changelog/0.4.5.mdx
+++ b/docs/changelog/0.4.5.mdx
@@ -4,9 +4,9 @@ title: 0.4.5
 
 ## pg_search
 
-### ICU tokenizer
+### Features
 
-Add support for the ICU tokenizer. This tokenizer tokenizes text into words on word boundaries, as defined in the Unicode Standard Annex #29 - Unicode Text Segmentation.
+- Add support for the ICU tokenizer. This tokenizer tokenizes text into words on word boundaries, as defined in the Unicode Standard Annex #29 - Unicode Text Segmentation.
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.1.mdx
+++ b/docs/changelog/0.5.1.mdx
@@ -8,13 +8,13 @@ title: 0.5.1
 
 `pg_analytics` is an extension that transforms Postgres into a very fast analytical database. Query speeds are comparable to those of dedicated OLAP databases like ClickHouse — without the need to leave Postgres.
 
-Users must make the following change to their `postgresql.conf` configuration file when self-hosting. `pg_analytics` must be added to the list of `shared_preload_libraries` alongside `pg_bm25`:
+Users must make the following change to their `postgresql.conf` configuration file when self-hosting. `pg_analytics` must be added to the list of `shared_preload_libraries` alongside `pg_search`:
 
 ```c
-shared_preload_libraries = 'pg_analytics, pg_bm25'
+shared_preload_libraries = 'pg_analytics, pg_search'
 ```
 
-The easiest way to get started with `pg_analytics` is via the ParadeDB Docker image, which also comes with `pg_bm25`.
+The easiest way to get started with `pg_analytics` is via the ParadeDB Docker image, which also comes with `pg_search`.
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.1.mdx
+++ b/docs/changelog/0.5.1.mdx
@@ -4,7 +4,9 @@ title: 0.5.1
 
 ## pg_analytics
 
-### Introduce pg_analytics
+### Features
+
+#### Introduce pg_analytics
 
 `pg_analytics` is an extension that transforms Postgres into a very fast analytical database. Query speeds are comparable to those of dedicated OLAP databases like ClickHouse — without the need to leave Postgres.
 

--- a/docs/changelog/0.5.11.mdx
+++ b/docs/changelog/0.5.11.mdx
@@ -2,7 +2,7 @@
 title: 0.5.11
 ---
 
-## pg_bm25
+## pg_search
 
 ### Bug Fixes
 

--- a/docs/changelog/0.5.2.mdx
+++ b/docs/changelog/0.5.2.mdx
@@ -2,21 +2,18 @@
 title: 0.5.2
 ---
 
-## ParadeDB
-
-### Upgrade to PostgreSQL 16
-
-The ParadeDB Docker image now ships with PostgreSQL 16.
-
-### Reduced image size
-
-We have removed third-party PostgreSQL extensions from the ParadeDB Docker image, reducing the image size significantly. If you would like a specific third-party PostgreSQL extension supported on ParadeDB, please contact us at [hello@paradedb.com](mailto:hello@paradedb.com).
-
 ## pg_analytics
 
-### Automatic initialization
+### Features
 
-Previously, users of `pg_analytics` needed to run `CALL paradedb.init();` on every new database connection. This is no longer necessary. `pg_analytics` now automatically initializes itself on the first query.
+- Previously, users of `pg_analytics` needed to run `CALL paradedb.init();` on every new database connection. This is no longer necessary. `pg_analytics` now automatically initializes itself on the first query.
+
+## ParadeDB
+
+### Features
+
+- The ParadeDB Docker image now ships with PostgreSQL 16.
+- We have removed third-party PostgreSQL extensions from the ParadeDB Docker image, reducing the image size significantly. If you would like a specific third-party PostgreSQL extension supported on ParadeDB, please contact us at [hello@paradedb.com](mailto:hello@paradedb.com).
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.3.mdx
+++ b/docs/changelog/0.5.3.mdx
@@ -2,17 +2,17 @@
 title: 0.5.3
 ---
 
-## pg_search
-
-### Logging
-
-We have clarified the error message when `pg_search` is not added to `shared_preload_libraries` in `postgresql.conf`.
-
 ## pg_analytics
 
-### Performance
+### Features
 
-We have upgraded to Apache DataFusion 35.0, which brings new performance improvements and fixes a bug related to nullability.
+- We have upgraded to Apache DataFusion 35.0, which brings new performance improvements and fixes a bug related to nullability.
+
+## pg_search
+
+### Features
+
+- We have clarified the error message when `pg_search` is not added to `shared_preload_libraries` in `postgresql.conf`.
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.3.mdx
+++ b/docs/changelog/0.5.3.mdx
@@ -2,11 +2,11 @@
 title: 0.5.3
 ---
 
-## pg_bm25
+## pg_search
 
 ### Logging
 
-We have clarified the error message when `pg_bm25` is not added to `shared_preload_libraries` in `postgresql.conf`.
+We have clarified the error message when `pg_search` is not added to `shared_preload_libraries` in `postgresql.conf`.
 
 ## pg_analytics
 

--- a/docs/changelog/0.5.4.mdx
+++ b/docs/changelog/0.5.4.mdx
@@ -2,13 +2,17 @@
 title: 0.5.4
 ---
 
-## Dockerfile
-
-Reduced the ParadeDB Docker image size by 60% removing unnecessary dev dependencies.
-
 ## pg_analytics
 
-`DELETE` clauses now work over `parquet` tables.
+### Features
+
+- `DELETE` clauses now work over `parquet` tables.
+
+## ParadeDB
+
+### Features
+
+- Reduced the ParadeDB Docker image size by 60% removing unnecessary dev dependencies.
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.5.mdx
+++ b/docs/changelog/0.5.5.mdx
@@ -4,6 +4,8 @@ title: 0.5.5
 
 ## pg_analytics
 
+### Features
+
 This update introduces several breaking changes to `pg_analytics`. Users will need to drop and recreate `pg_analytics` in order
 to upgrade. Note that this will delete all data that depends on `pg_analytics`.
 
@@ -12,20 +14,20 @@ DROP EXTENSION pg_analytics CASCADE;
 CREATE EXTENSION pg_analytics;
 ```
 
-### New Table Access Method Name
+#### New Table Access Method Name
 
 We've renamed `deltalake` tables to `parquet` tables. This was done to avoid confusion with how we are currently using `deltalake`
 -- as a library for managing local Parquet files, not as an external object store (this is coming in the future).
 
-### Multiple Database Compatibility
+#### Multiple Database Compatibility
 
 We fixed a bug where `VACUUM`ing would delete `parquet` tables in other databases.
 
-### Physical Backup Support
+#### Physical Backup Support
 
 Physical backups with `pg_dump` now work over `parquet` tables.
 
-### Utility Statements
+#### Utility Statements
 
 `COPY` and `ADD COLUMN` clauses now work over `parquet` tables.
 

--- a/docs/changelog/0.5.6.mdx
+++ b/docs/changelog/0.5.6.mdx
@@ -7,7 +7,7 @@ title: 0.5.6
 Fixed a bug where mutli-line query statements (i.e. SQL queries separated by semicolons) were being
 executed incorrectly.
 
-## pg_bm25
+## pg_search
 
 Fixed a bug where the presence of unsupported Postgres types like UUIDs was causing BM25 index creation
 to fail.

--- a/docs/changelog/0.5.6.mdx
+++ b/docs/changelog/0.5.6.mdx
@@ -4,13 +4,15 @@ title: 0.5.6
 
 ## pg_analytics
 
-Fixed a bug where mutli-line query statements (i.e. SQL queries separated by semicolons) were being
-executed incorrectly.
+### Bug Fixes
+
+- Fixed a bug where mutli-line query statements (i.e. SQL queries separated by semicolons) were being executed incorrectly.
 
 ## pg_search
 
-Fixed a bug where the presence of unsupported Postgres types like UUIDs was causing BM25 index creation
-to fail.
+### Bug Fixes
+
+- Fixed a bug where the presence of unsupported Postgres types like UUIDs was causing BM25 index creation to fail.
 
 ## Full Changelog
 

--- a/docs/changelog/0.5.7.mdx
+++ b/docs/changelog/0.5.7.mdx
@@ -9,7 +9,7 @@ title: 0.5.7
 - Fixed a bug where mutli-line utility statements were being parsed incorrectly.
 - Fixed a bug where changing the Postgres search path would break `SELECT` statements over `parquet` tables.
 
-## pg_bm25
+## pg_search
 
 ### Bug Fixes
 

--- a/docs/changelog/0.5.8.mdx
+++ b/docs/changelog/0.5.8.mdx
@@ -10,7 +10,7 @@ title: 0.5.8
 - Fixed a bug where rows were reversed in SELECT statements.
 - Significantly improved INSERT speeds.
 
-## pg_bm25
+## pg_search
 
 ### Bug Fixes
 

--- a/pg_search/sql/pg_search--0.0.0--0.3.3.sql
+++ b/pg_search/sql/pg_search--0.0.0--0.3.3.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.3'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.3'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.10--0.3.11.sql
+++ b/pg_search/sql/pg_search--0.3.10--0.3.11.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.11'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.11'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.11--0.3.12.sql
+++ b/pg_search/sql/pg_search--0.3.11--0.3.12.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.12'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.12'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.12--0.3.13.sql
+++ b/pg_search/sql/pg_search--0.3.12--0.3.13.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.13'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.13'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.13--0.4.1.sql
+++ b/pg_search/sql/pg_search--0.3.13--0.4.1.sql
@@ -1,4 +1,4 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.1'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.4.1'" to load this file. \quit
 
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table(table_name VARCHAR DEFAULT 'bm25_test_table', schema_name VARCHAR DEFAULT 'paradedb')
 LANGUAGE plpgsql

--- a/pg_search/sql/pg_search--0.3.3--0.3.4.sql
+++ b/pg_search/sql/pg_search--0.3.3--0.3.4.sql
@@ -1,4 +1,4 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.4'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.4'" to load this file. \quit
 
 DO $$
 BEGIN

--- a/pg_search/sql/pg_search--0.3.4--0.3.5.sql
+++ b/pg_search/sql/pg_search--0.3.4--0.3.5.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.5'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.5'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.5--0.3.6.sql
+++ b/pg_search/sql/pg_search--0.3.5--0.3.6.sql
@@ -1,4 +1,4 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.6'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.6'" to load this file. \quit
 
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table()
 LANGUAGE plpgsql

--- a/pg_search/sql/pg_search--0.3.6--0.3.7.sql
+++ b/pg_search/sql/pg_search--0.3.6--0.3.7.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.7'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.7'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.7--0.3.8.sql
+++ b/pg_search/sql/pg_search--0.3.7--0.3.8.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.8'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.8'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.8--0.3.9.sql
+++ b/pg_search/sql/pg_search--0.3.8--0.3.9.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.9'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.9'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.3.9--0.3.10.sql
+++ b/pg_search/sql/pg_search--0.3.9--0.3.10.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.3.10'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.3.10'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.4.1--0.4.2.sql
+++ b/pg_search/sql/pg_search--0.4.1--0.4.2.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.2'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.4.2'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.4.2--0.4.3.sql
+++ b/pg_search/sql/pg_search--0.4.2--0.4.3.sql
@@ -1,4 +1,4 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.3'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.4.3'" to load this file. \quit
 
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
     index_name text DEFAULT '',

--- a/pg_search/sql/pg_search--0.4.3--0.4.4.sql
+++ b/pg_search/sql/pg_search--0.4.3--0.4.4.sql
@@ -1,4 +1,4 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.4'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.4.4'" to load this file. \quit
 
 -- Use this create_bm25 function to dynamically create index and query functions.
 -- This call will create a new function called 'dynamicbm25', which can be used to query.

--- a/pg_search/sql/pg_search--0.4.4--0.4.5.sql
+++ b/pg_search/sql/pg_search--0.4.4--0.4.5.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.4.5'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.4.5'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.4.5--0.5.1.sql
+++ b/pg_search/sql/pg_search--0.4.5--0.5.1.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.1'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.1'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.1--0.5.2.sql
+++ b/pg_search/sql/pg_search--0.5.1--0.5.2.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.2'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.2'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.10--0.5.11.sql
+++ b/pg_search/sql/pg_search--0.5.10--0.5.11.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.11'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.11'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.2--0.5.3.sql
+++ b/pg_search/sql/pg_search--0.5.2--0.5.3.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.3'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.3'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.3--0.5.4.sql
+++ b/pg_search/sql/pg_search--0.5.3--0.5.4.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.4'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.4'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.4--0.5.5.sql
+++ b/pg_search/sql/pg_search--0.5.4--0.5.5.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.5'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.5'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.5--0.5.6.sql
+++ b/pg_search/sql/pg_search--0.5.5--0.5.6.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.6'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.6'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.6--0.5.7.sql
+++ b/pg_search/sql/pg_search--0.5.6--0.5.7.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.7'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.7'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.7--0.5.8.sql
+++ b/pg_search/sql/pg_search--0.5.7--0.5.8.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.8'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.8'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.8--0.5.9.sql
+++ b/pg_search/sql/pg_search--0.5.8--0.5.9.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.9'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.9'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.5.9--0.5.10.sql
+++ b/pg_search/sql/pg_search--0.5.9--0.5.10.sql
@@ -1,1 +1,1 @@
-\echo Use "ALTER EXTENSION pg_bm25 UPDATE TO '0.5.10'" to load this file. \quit
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.5.10'" to load this file. \quit


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We updated `pg_bm25` to `pg_search`, but missed a few places. This fixes it.

While I was at it, I noticed the Changelog isn't fully uniform, so I fixed that too.

## Why
^

## How
^

## Tests
^