### PR TITLE
fix: `paradedb.help` already installed won't cause extension install to fail

### DIFF
--- a/shared/src/github.rs
+++ b/shared/src/github.rs
@@ -3,7 +3,19 @@ use url::{form_urlencoded, Url};
 
 const BASE_GITHUB_URL: &str = "https://github.com";
 
-#[pg_extern]
+#[pg_extern(sql = r#"
+    DO $$
+    BEGIN
+    IF NOT EXISTS (SELECT FROM pg_proc p
+        JOIN pg_namespace n ON p.pronamespace = n.oid
+        WHERE n.nspname = 'paradedb' AND p.proname = 'help') THEN
+            CREATE OR REPLACE FUNCTION paradedb.help(subject TEXT, body TEXT) RETURNS TEXT
+            STRICT
+            LANGUAGE c 
+            AS '@MODULE_PATHNAME@', '@FUNCTION_NAME@';
+        END IF;
+    END $$;
+"#)]
 pub fn help(subject: &str, body: &str) -> String {
     let mut url = Url::parse(BASE_GITHUB_URL).expect("Failed to parse Github URL");
     url.set_path("/orgs/paradedb/discussions/new");


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The shared `paradedb.help` function only creates if it doesn't exist, so `pg_search` and `pg_analytics` don't conflict.

## Why

## How

## Tests
