### PR TITLE
chore: add os + version details to telemetry calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,6 +4881,7 @@ dependencies = [
  "async-std",
  "bigdecimal",
  "bytes",
+ "chrono",
  "derive_builder",
  "envy",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3554,6 +3554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.1.0"
+version = "0.5.11"
 dependencies = [
  "async-std",
  "bigdecimal",
@@ -4875,6 +4885,7 @@ dependencies = [
  "envy",
  "mockall",
  "once_cell",
+ "os_info",
  "pgrx",
  "pgrx-tests",
  "reqwest",

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -22,7 +22,7 @@ telemetry = ["shared/telemetry"]
 pgrx = "=0.11.2"
 serde = "1.0.193"
 serde_json = "1.0.107"
-shared = { version = "0.1.0", path = "../shared" }
+shared = { path = "../shared" }
 async-std = { version = "1.12.0", features = ["tokio1"] }
 async-trait = "0.1.77"
 chrono = "0.4.34"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -41,7 +41,7 @@ rustc-hash = "1.1.0"
 serde = "1.0.188"
 serde_json = "1.0.105"
 serde_path_to_error = "0.1.14"
-shared = { version = "0.1.0", path = "../shared" }
+shared = { path = "../shared" }
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e678820" }
 tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e678820" }
 thiserror = "1.0.56"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared"
 description = "Shared code for ParadeDB crates"
-version = "0.1.0"
+version = "0.5.11"
 edition = "2021"
 license = "AGPL-3.0"
 
@@ -35,6 +35,7 @@ once_cell = "1.19.0"
 url = "2.5.0"
 derive_builder = "0.20.0"
 walkdir = "2.5.0"
+os_info = { version = "3", default-features = false }
 
 [dev-dependencies]
 mockall = "0.12.1"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -36,6 +36,7 @@ url = "2.5.0"
 derive_builder = "0.20.0"
 walkdir = "2.5.0"
 os_info = { version = "3", default-features = false }
+chrono = { version = "0.4.34", features = ["clock", "alloc"] }
 
 [dev-dependencies]
 mockall = "0.12.1"

--- a/shared/src/telemetry/bgworker.rs
+++ b/shared/src/telemetry/bgworker.rs
@@ -180,7 +180,7 @@ impl BgWorkerTelemetryConfig {
         }
 
         // Check the GUC setting for telemetry.
-        let enabled = BackgroundWorker::transaction(|| {
+        BackgroundWorker::transaction(|| {
             match pgrx::Spi::get_one::<&str>(&format!(
                 "SHOW paradedb.{}_telemetry",
                 self.extension_name
@@ -190,9 +190,7 @@ impl BgWorkerTelemetryConfig {
                 Err(err) => Err(TelemetryError::EnabledCheck(err)),
                 _ => Ok(false),
             }
-        });
-        pgrx::log!("TELEMETRY ENABLED?: {enabled:?}");
-        enabled
+        })
     }
 }
 

--- a/shared/src/telemetry/event.rs
+++ b/shared/src/telemetry/event.rs
@@ -1,18 +1,20 @@
-use std::{path::PathBuf, time::SystemTime};
+use std::path::PathBuf;
 
 use serde::Serialize;
 
-#[derive(Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum TelemetryEvent {
     Deployment {
-        timestamp: SystemTime,
+        timestamp: String,
         arch: String,
         extension_name: String,
         extension_version: String,
+        extension_path: PathBuf,
         os_type: String,
         os_version: String,
         postgres_version: String,
+        postgres_version_details: String,
     },
     DirectoryStatus {
         extension_name: String,

--- a/shared/src/telemetry/event.rs
+++ b/shared/src/telemetry/event.rs
@@ -1,14 +1,21 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::SystemTime};
 
-use serde_json::json;
+use serde::Serialize;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
+#[serde(untagged)]
 pub enum TelemetryEvent {
     Deployment {
-        extension: String,
+        timestamp: SystemTime,
+        arch: String,
+        extension_name: String,
+        extension_version: String,
+        os_type: String,
+        os_version: String,
+        postgres_version: String,
     },
     DirectoryStatus {
-        extension: String,
+        extension_name: String,
         path: PathBuf,
         size: u64,
     },
@@ -17,18 +24,10 @@ pub enum TelemetryEvent {
 impl TelemetryEvent {
     pub fn name(&self) -> String {
         match self {
-            Self::Deployment { extension } => format!("{extension} Deployment"),
-            Self::DirectoryStatus { extension, .. } => format!("{extension} Directory Status"),
-        }
-    }
-
-    pub fn to_json(&self) -> serde_json::Value {
-        match self {
-            Self::Deployment { .. } => json!(serde_json::Value::Null),
-            Self::DirectoryStatus { path, size, .. } => json!({
-                "path": path.to_str(),
-                "size": size
-            }),
+            Self::Deployment { extension_name, .. } => format!("{extension_name} Deployment"),
+            Self::DirectoryStatus { extension_name, .. } => {
+                format!("{extension_name} Directory Status")
+            }
         }
     }
 

--- a/shared/src/telemetry/mod.rs
+++ b/shared/src/telemetry/mod.rs
@@ -11,27 +11,19 @@ use std::{env::VarError, path::PathBuf, str::Utf8Error};
 use thiserror::Error;
 
 pub trait TelemetryStore {
-    type Error;
-
-    fn get_connection(
-        &self,
-    ) -> Result<Box<dyn TelemetryConnection<Error = Self::Error>>, Self::Error>;
+    fn get_connection(&self) -> Result<Box<dyn TelemetryConnection>, TelemetryError>;
 }
 
 pub trait TelemetryConnection {
-    type Error;
-
-    fn send(&self, uuid: &str, event: &TelemetryEvent) -> Result<(), Self::Error>;
+    fn send(&self, uuid: &str, event: &TelemetryEvent) -> Result<(), TelemetryError>;
 }
 
 pub trait DirectoryStore {
-    type Error;
-
-    fn root_path(&self) -> Result<PathBuf, Self::Error>;
-    fn extension_path(&self) -> Result<PathBuf, Self::Error>;
-    fn extension_size(&self) -> Result<u64, Self::Error>;
-    fn extension_uuid(&self) -> Result<String, Self::Error>;
-    fn extension_uuid_path(&self) -> Result<PathBuf, Self::Error>;
+    fn root_path(&self) -> Result<PathBuf, TelemetryError>;
+    fn extension_path(&self) -> Result<PathBuf, TelemetryError>;
+    fn extension_size(&self) -> Result<u64, TelemetryError>;
+    fn extension_uuid(&self) -> Result<String, TelemetryError>;
+    fn extension_uuid_path(&self) -> Result<PathBuf, TelemetryError>;
 }
 
 pub trait TermPoll {
@@ -74,4 +66,6 @@ pub enum TelemetryError {
     EnabledCheck(#[source] SpiError),
     #[error("could not lock spi connection in telemetry config")]
     SpiConnectLock(String),
+    #[error("could not serialize telemetry data to JSON: {0}")]
+    ToJson(#[source] serde_json::Error),
 }

--- a/shared/src/telemetry/mod.rs
+++ b/shared/src/telemetry/mod.rs
@@ -68,4 +68,6 @@ pub enum TelemetryError {
     SpiConnectLock(String),
     #[error("could not serialize telemetry data to JSON: {0}")]
     ToJson(#[source] serde_json::Error),
+    #[error("could not parse postgres version information: {0}")]
+    VersionInfo(#[source] Utf8Error),
 }

--- a/shared/src/telemetry/postgres.rs
+++ b/shared/src/telemetry/postgres.rs
@@ -8,23 +8,21 @@ pub struct PostgresDirectoryStore {
 }
 
 impl DirectoryStore for PostgresDirectoryStore {
-    type Error = TelemetryError;
-
-    fn root_path(&self) -> Result<PathBuf, Self::Error> {
+    fn root_path(&self) -> Result<PathBuf, TelemetryError> {
         self.config_store.root_data_directory()
     }
 
-    fn extension_path(&self) -> Result<PathBuf, Self::Error> {
+    fn extension_path(&self) -> Result<PathBuf, TelemetryError> {
         Ok(self.root_path()?.join(self.config_store.extension_name()?))
     }
 
-    fn extension_uuid_path(&self) -> Result<PathBuf, Self::Error> {
+    fn extension_uuid_path(&self) -> Result<PathBuf, TelemetryError> {
         Ok(self
             .extension_path()?
             .join(format!("{}_uuid", self.config_store.extension_name()?)))
     }
 
-    fn extension_uuid(&self) -> Result<String, Self::Error> {
+    fn extension_uuid(&self) -> Result<String, TelemetryError> {
         let uuid_file = self.extension_uuid_path()?;
         match fs::read_to_string(&uuid_file)
             .map_err(TelemetryError::ReadUuid)
@@ -42,7 +40,7 @@ impl DirectoryStore for PostgresDirectoryStore {
         }
     }
 
-    fn extension_size(&self) -> Result<u64, Self::Error> {
+    fn extension_size(&self) -> Result<u64, TelemetryError> {
         Ok(WalkDir::new(self.extension_path()?)
             .into_iter()
             .filter_map(|entry| entry.ok())

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -46,7 +46,7 @@ impl TelemetryConnection for PosthogConnection {
             "distinct_id": uuid,
             "properties": {
                 "commit_sha": event.commit_sha(),
-                "telemetry_data": serde_json::to_value(event).map_err(|err| TelemetryError::ToJson(err))?,
+                "telemetry_data": serde_json::to_value(event).map_err(TelemetryError::ToJson)?,
             },
         });
         self.client


### PR DESCRIPTION
## What

Using the `os_info` crate to gather some information about operating system + processor during the deployment call. The data looks like this:

```json
{
  "arch": "arm64",
  "extension_name": "pg_search",
  "extension_version": "0.5.11",
  "os_type": "Mac OS",
  "os_version": "13.5.0",
  "postgres_version": "16.2",
  "timestamp": {
    "nanos_since_epoch": 721633000,
    "secs_since_epoch": 1711410121
  }
}
```

I've derived `Serialize` for `TelemetryEvent` to simplify the implementation. I also removed the associated `Error` type from many of the Telemetry traits, and just baked in the `TelemetryError`. The abstraction was unnecessary.