### PR TITLE
fix: Only ping Slack for failed runs on non-PR branches

### DIFF
--- a/.github/workflows/benchmark-pg_analytics.yml
+++ b/.github/workflows/benchmark-pg_analytics.yml
@@ -39,6 +39,6 @@ jobs:
         run: ./benchmark.sh -t local
 
       - name: Notify Slack on Failure
-        if: failure()
+        if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"Benchmark pg_analytics Workflow failed on ${{ steps.system.outputs.system_to_benchmark }} -- investigate immediately!"}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -58,6 +58,6 @@ jobs:
         run: cat benchmark_${{ steps.system.outputs.system_to_benchmark }}.csv
 
       - name: Notify Slack on Failure
-        if: failure()
+        if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"Benchmark pg_search Workflow failed on ${{ steps.system.outputs.system_to_benchmark }} -- investigate immediately!"}' ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We were getting a bunch of pings as part of development. This should fix it.

## Why
Avoid noise

## How
Check the branch

## Tests
Check CI