### PR TITLE
fix: reset memory contexts during pg_analytics tuple_insert

### DIFF
--- a/pg_analytics/src/tableam/insert.rs
+++ b/pg_analytics/src/tableam/insert.rs
@@ -82,10 +82,10 @@ async unsafe fn insert_tuples(
     slots: *mut *mut pg_sys::TupleTableSlot,
     nslots: usize,
 ) -> Result<(), ParadeError> {
-    // In the block below, we switch to the memory context we've defined on our build
-    // state, resetting it before and after. We do this because we're looking up a
-    // PgTupleDesc... which is supposed to free the corresponding Postgres memory when it
-    // is dropped. However, in practice, we're not seeing the memory get freed, which is
+    // In the block below, we switch to the memory context we've defined as a static
+    // variable, resetting it before and after we access the column values. We do this
+    // because PgTupleDesc "supposed" to free the corresponding Postgres memory when it
+    // is dropped... however, in practice, we're not seeing the memory get freed, which is
     // causing huge memory usage when building large indexes.
     //
     // By running in our own memory context, we can force the memory to be freed with

--- a/pg_search/benchmarks/README.md
+++ b/pg_search/benchmarks/README.md
@@ -60,7 +60,7 @@ The versions of the systems used for benchmarking are:
 - PostgreSQL: 15.4
 - Elasticsearch: 8.9.2
 
-For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack]().
+For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ).
 
 ### pg_search
 

--- a/pg_search/benchmarks/README.md
+++ b/pg_search/benchmarks/README.md
@@ -60,7 +60,7 @@ The versions of the systems used for benchmarking are:
 - PostgreSQL: 15.4
 - Elasticsearch: 8.9.2
 
-For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-217mordsh-ielS6BiZf7VW3rqKBFgAlQ).
+For any questions, clarifications, or suggestions regarding our benchmarking experimental setup, please open a GitHub issue or come chat with us in the [ParadeDB Community Slack]().
 
 ### pg_search
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1000 

## What
We are seeing very high memory usage when inserting large numbers of rows.

## How
This ended up being similar to the memory issues we had `pg_search`. The culprit is `PgRelation::tuple_desc()`, which allocates memory that is not correctly freed when dropped. To circumvent, we have to do a bit of a hack with memory context switching.

The implementation in this PR is structured carefully. The can be no references to a `PgRelation` instances outside of the `switch_to` call, and you need to make sure to `reset` before and after.
