### PR TITLE
ci: Update the version checking step

### DIFF
--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -79,10 +79,9 @@ jobs:
         working-directory: pg_analytics/
         run: |
           CARGO_VERSION=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
-          NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
-          NEW_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}"
-          if [ "$CARGO_VERSION" != "$NEW_VERSION" ]; then
-            echo "Version in Cargo.toml ($CARGO_VERSION) does not match upcoming release version ($NEW_VERSION), did you forget to increment it?"
+          RELEASE_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+          if [ "$CARGO_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Version in Cargo.toml ($CARGO_VERSION) does not match upcoming release version ($RELEASE_VERSION), did you forget to increment it?"
             exit 1
           fi
           echo "Version check passed!"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -80,10 +80,9 @@ jobs:
         working-directory: pg_search/
         run: |
           CARGO_VERSION=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
-          NEW_PATCH=$(( ${{ vars.VERSION_PATCH }} + 1 ))
-          NEW_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${NEW_PATCH}"
-          if [ "$CARGO_VERSION" != "$NEW_VERSION" ]; then
-            echo "Version in Cargo.toml ($CARGO_VERSION) does not match upcoming release version ($NEW_VERSION), did you forget to increment it?"
+          RELEASE_VERSION="${{ vars.VERSION_MAJOR }}.${{ vars.VERSION_MINOR }}.${{ vars.VERSION_PATCH }}"
+          if [ "$CARGO_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Version in Cargo.toml ($CARGO_VERSION) does not match upcoming release version ($RELEASE_VERSION), did you forget to increment it?"
             exit 1
           fi
           echo "Version check passed!"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We updated our deployment flow so that the version stored in GitHub Actions Variables is the upcoming release version, not the last release version, but I had forgotten to update the way we check for version equality in CI. This should fix it.

## Why
N/A

## How
N/A

## Tests
N/A