### PR TITLE
ci: Only upgrade pg_search from 0.6.0 onwards

### DIFF
--- a/pg_analytics/runtests.sh
+++ b/pg_analytics/runtests.sh
@@ -135,12 +135,12 @@ function run_tests() {
   echo "Initializing pgrx environment..."
   cargo pgrx init "--pg$PG_VERSION=$PG_BIN_PATH/pg_config"
 
-  # This block runs a test whether our extension can upgrade to the current version, and then runs our integration tests
-  if [ -n "$FLAG_UPGRADE_VER" ]; then
-    echo "Running extension upgrade test..."
+  # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
+  BASE_RELEASE="0.5.2"
 
-    # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
-    BASE_RELEASE="0.5.2"
+  # This block runs a test whether our extension can upgrade to the current version
+  if [ -n "$FLAG_UPGRADE_VER" && ("$FLAG_UPGRADE_VER" != "$BASE_RELEASE") ]; then
+    echo "Running extension upgrade test..."
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL"
     sudo dpkg -i "pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"

--- a/pg_analytics/runtests.sh
+++ b/pg_analytics/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
   BASE_RELEASE="0.5.2"
 
   # This block runs a test whether our extension can upgrade to the current version
-  if [ -n "$FLAG_UPGRADE_VER" && ("$FLAG_UPGRADE_VER" != "$BASE_RELEASE") ]; then
+  if [ -n "$FLAG_UPGRADE_VER" ] && [ "$FLAG_UPGRADE_VER" != "$BASE_RELEASE" ]; then
     echo "Running extension upgrade test..."
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_analytics-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL"

--- a/pg_search/runtests.sh
+++ b/pg_search/runtests.sh
@@ -135,19 +135,19 @@ function run_tests() {
   echo "Initializing pgrx environment..."
   cargo pgrx init "--pg$PG_VERSION=$PG_BIN_PATH/pg_config"
 
-  # This block runs a test whether our extension can upgrade to the current version, and then runs our integration tests
-  if [ -n "$FLAG_UPGRADE_VER" ]; then
-    echo "Running extension upgrade test..."
+  # First release at which we started supporting upgrades for pg_search after the extension rename
+  BASE_RELEASE="0.6.0"
 
-    # First, download & install the first release at which we started supporting upgrades for Postgres 16 (v0.5.2)
-    BASE_RELEASE="0.5.2"
-    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"
+  # This block runs a test whether our extension can upgrade to the current version
+  if [ -n "$FLAG_UPGRADE_VER" && ("$FLAG_UPGRADE_VER" != "$BASE_RELEASE") ]; then
+    echo "Running extension upgrade test..."
+    DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null
-    sudo dpkg -i "pg_bm25-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb" > /dev/null
+    sudo dpkg -i "pg_search-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb" > /dev/null
 
     # Second, load the extension into the test database
     echo "Loading pg_search extension version v$BASE_RELEASE into the test database..."
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_bm25 VERSION '$BASE_RELEASE';" -d test_db
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pg_search VERSION '$BASE_RELEASE';" -d test_db
 
     # Third, build & install the current version of the extension
     echo "Building & installing the current version of the pg_search extension..."
@@ -155,7 +155,7 @@ function run_tests() {
     cargo pgrx install --features icu --pg-config="$PG_BIN_PATH/pg_config" --release
 
     # Fourth, upgrade the extension installed on the test database to the current version
-    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_bm25 UPDATE TO '$FLAG_UPGRADE_VER';" -d test_db
+    "$PG_BIN_PATH/psql" -v ON_ERROR_STOP=1 -c "ALTER EXTENSION pg_search UPDATE TO '$FLAG_UPGRADE_VER';" -d test_db
   else
     # Use cargo-pgrx to install the extension for the specified version
     echo "Installing pg_search extension onto the test database..."

--- a/pg_search/runtests.sh
+++ b/pg_search/runtests.sh
@@ -139,7 +139,7 @@ function run_tests() {
   BASE_RELEASE="0.6.0"
 
   # This block runs a test whether our extension can upgrade to the current version
-  if [ -n "$FLAG_UPGRADE_VER" && ("$FLAG_UPGRADE_VER" != "$BASE_RELEASE") ]; then
+  if [ -n "$FLAG_UPGRADE_VER" ] && [ "$FLAG_UPGRADE_VER" != "$BASE_RELEASE" ]; then
     echo "Running extension upgrade test..."
     DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v$BASE_RELEASE/pg_search-v$BASE_RELEASE-pg$PG_VERSION-$FLAG_ARCH-ubuntu2204.deb"
     curl -LOJ "$DOWNLOAD_URL" > /dev/null


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Now that we renamed, we need to adjust our extension upgrade test for `pg_search`.

## Why

## How

## Tests
