### PR TITLE
ci: Only run benchmarks on 5M rows

### DIFF
--- a/pg_search/benchmarks/benchmark-pg_search.sh
+++ b/pg_search/benchmarks/benchmark-pg_search.sh
@@ -116,8 +116,9 @@ echo "Done!"
 # Output file for recording times
 echo "Table Size,Index Time,Search Time" > "$OUTPUT_CSV"
 
-# Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset
-TABLE_SIZES=(10000 50000 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 1500000 2000000 2500000 3000000 3500000 4000000 4500000 5000000)
+# Table sizes to be processed (in number of rows). The maximum is 5M rows with the Wikipedia dataset. To test
+# on multiple sizes, add more row values to the array.
+TABLE_SIZES=(5000000)
 
 for SIZE in "${TABLE_SIZES[@]}"; do
   echo ""


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The `pg_search` benchmarks were quite slow. This fixes that. The product is much more stable now, and there's no point in doing really small row counts.

## Why

## How

## Tests
