### PR TITLE
fix: Replace `i8` with `c_char`

### DIFF
--- a/pg_analytics/src/storage/metadata.rs
+++ b/pg_analytics/src/storage/metadata.rs
@@ -158,7 +158,7 @@ impl PgMetadata for pg_sys::Relation {
                 smgr,
                 pg_sys::ForkNumber_MAIN_FORKNUM,
                 FIRST_BLOCK_NUMBER,
-                page as *mut i8,
+                page as *mut std::ffi::c_char,
                 true,
             );
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes build issue, see https://doc.rust-lang.org/std/ffi/type.c_char.html#:~:text=Type%20Alias%20std%3A%3Affi%3A%3Ac_char&text=C's%20char%20type%20is%20completely,memory%20with%208%2Dbit%20bytes.

## Why

## How

## Tests
