### PR TITLE
fix: Prod Promotion v0.6.0

### DIFF
--- a/pg_analytics/src/storage/metadata.rs
+++ b/pg_analytics/src/storage/metadata.rs
@@ -158,7 +158,7 @@ impl PgMetadata for pg_sys::Relation {
                 smgr,
                 pg_sys::ForkNumber_MAIN_FORKNUM,
                 FIRST_BLOCK_NUMBER,
-                page as *mut i8,
+                page as *mut std::ffi::c_char,
                 true,
             );
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
There was a slight bug in packaging `pg_analytics`, which this PR fixes. It will over-ride the `v0.6.0` release from last night, and be the proper `v0.6.0` release

## Why

## How

## Tests
