### PR TITLE
fix: Comment out retention as it causes crash

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.8"
 
 services:
   paradedb:
-    image: paradedb/paradedb:16-v0.5.11
+    image: paradedb/paradedb:latest
     environment:
       POSTGRESQL_USERNAME: myuser
       POSTGRESQL_PASSWORD: mypassword

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.8"
 
 services:
   paradedb:
-    image: paradedb/paradedb:latest
+    image: paradedb/paradedb:16-v0.5.11
     environment:
       POSTGRESQL_USERNAME: myuser
       POSTGRESQL_PASSWORD: mypassword

--- a/pg_analytics/src/lib.rs
+++ b/pg_analytics/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 use crate::hooks::ParadeHook;
 use guc::PostgresPgAnalyticsGucSettings;
 use pgrx::*;
-use shared::telemetry::{setup_telemetry_background_worker, ParadeExtension};
+// use shared::telemetry::{setup_telemetry_background_worker, ParadeExtension};
 
 pgrx::pg_module_magic!();
 extension_sql_file!("../sql/_bootstrap.sql");

--- a/pg_analytics/src/lib.rs
+++ b/pg_analytics/src/lib.rs
@@ -30,7 +30,8 @@ pub extern "C" fn _PG_init() {
         register_hook(&mut PARADE_HOOK)
     };
 
-    setup_telemetry_background_worker(ParadeExtension::PgAnalytics);
+    // TODO: Uncomment this once we fix the telemetry PGDATA error
+    // setup_telemetry_background_worker(ParadeExtension::PgAnalytics);
 }
 
 #[cfg(test)]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -14,7 +14,7 @@ use crate::globals::WRITER_GLOBAL;
 use pgrx::bgworkers::{BackgroundWorker, BackgroundWorkerBuilder, SignalWakeFlags};
 use pgrx::*;
 use shared::gucs::PostgresGlobalGucSettings;
-use shared::telemetry::setup_telemetry_background_worker;
+// use shared::telemetry::setup_telemetry_background_worker;
 use std::process;
 use std::time::Duration;
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -39,7 +39,9 @@ pub unsafe extern "C" fn _PG_init() {
     // We call this in a helper function to the bgworker initialization
     // can be used in test suites.
     setup_background_workers();
-    setup_telemetry_background_worker(shared::telemetry::ParadeExtension::PgSearch);
+
+    // TODO: Uncomment this once we fix the telemetry PGDATA error
+    // setup_telemetry_background_worker(shared::telemetry::ParadeExtension::PgSearch);
 }
 
 #[pg_guard]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The retention PR caused a crash in the start of the Dockerfile. Reverting here, and once we bring it back let's add a test to make sure this does not happen again.

## Why

## How

## Tests
