### PR TITLE
fix: explicitly create postgres user and add to group in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -174,6 +174,12 @@ COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-p
 # Install runtime dependencies (requires switching to root temporarily)
 USER root
 RUN install_packages curl uuid-runtime libpq5
+
+# Explicitly create postgres user using default uid and gid.
+RUN groupadd -r postgres --gid=999; \
+	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	mkdir -p /var/lib/postgresql
+
 USER 1001
 
 # Copy ParadeDB bootstrap script to install extensions, configure postgresql.conf, etc.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR creates the `postgres` user which needs to exist so the operator in the helm charts can start the server. It is started with the default uid and gid so it has the correct permissions.
## Why
This is the bug in question: https://github.com/cloudnative-pg/cloudnative-pg/issues/3331
The operator needs the `postgres` user to exist or it will fail. As for the uid and gid, it doesn't care what they are, but this PR: https://github.com/paradedb/helm-charts/pull/83 sets them so they match the permissions in the bitnami (and paradedb) docker image.

## How

## Tests
