### PR TITLE
feat: Support UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "thiserror",
  "time",
  "url",
+ "uuid",
  "walkdir",
  "zstd-sys",
 ]

--- a/docs/analytics/limitations.mdx
+++ b/docs/analytics/limitations.mdx
@@ -31,6 +31,7 @@ supported.
 | `time`             | ✅             | 🚫              | Only `time` and `time(6)` supported                                    |
 | `timestamp`        | ✅             | 🚫              | Only `timestamp` and `timestamp(6)` supported                          |
 | `timestamptz`      | 🚫             | 🚫              |                                                                        |
+| `uuid`             | ✅             | 🚫              |                                                                        |
 | `json`             | 🚫             | 🚫              |                                                                        |
 | `jsonb`            | 🚫             | 🚫              |                                                                        |
 | `int4range`        | 🚫             | 🚫              |                                                                        |
@@ -39,7 +40,6 @@ supported.
 | `daterange`        | 🚫             | 🚫              |                                                                        |
 | `tsrange`          | 🚫             | 🚫              |                                                                        |
 | `tstzrange`        | 🚫             | 🚫              |                                                                        |
-| `uuid`             | 🚫             | 🚫              |                                                                        |
 | `oid`              | 🚫             | 🚫              |                                                                        |
 | `bytea`            | 🚫             | 🚫              |                                                                        |
 

--- a/pg_analytics/Cargo.toml
+++ b/pg_analytics/Cargo.toml
@@ -43,6 +43,7 @@ zstd-sys = "=2.0.9"
 walkdir = "2.5.0"
 url = "2.5.0"
 lazy_static = "1.4.0"
+uuid = "1.8.0"
 
 [dev-dependencies]
 anyhow = "1.0.79"

--- a/pg_analytics/src/datafusion/table.rs
+++ b/pg_analytics/src/datafusion/table.rs
@@ -285,7 +285,9 @@ impl PgTableProvider {
         table_name: &str,
     ) -> Result<Self, CatalogError> {
         let table_path = ParadeDirectory::table_path_from_name(schema_name, table_name)?;
-        let listing_table_url = ListingTableUrl::parse(table_path.to_str().unwrap())?;
+        let listing_table_url = ListingTableUrl::parse(table_path.to_str().ok_or(
+            DataFusionTableError::ListingTableUrlParseError(table_path.clone()),
+        )?)?;
         let file_format = ParquetFormat::new();
         let listing_options =
             ListingOptions::new(Arc::new(file_format)).with_file_extension(".parquet");
@@ -407,6 +409,9 @@ pub enum DataFusionTableError {
 
     #[error("Delta table state not found")]
     DeltaTableStateNotFound,
+
+    #[error("Could not convert {0:?} to ListingTableUrl")]
+    ListingTableUrlParseError(PathBuf),
 
     #[error("Column name {0} is reserved by pg_analytics")]
     ReservedFieldName(String),

--- a/pg_analytics/src/datafusion/udf.rs
+++ b/pg_analytics/src/datafusion/udf.rs
@@ -126,12 +126,13 @@ unsafe fn udf_datafusion(args: &[ColumnarValue]) -> Result<ColumnarValue, UDFErr
             (*fcinfo).nargs = num_args as i16 - 1;
 
             // Call function on each set of arguments and push to result vector
+            // TODO: Fill in PgOid
             let mut result_vec = vec![];
             for row_index in 0..num_rows {
                 for arg_index in 1..num_args {
                     let fcinfo_arg = (*fcinfo).args.as_mut_ptr().add(arg_index - 1);
                     (*fcinfo_arg).value = arg_arrays[arg_index - 1]
-                        .get_datum(row_index)?
+                        .get_datum(row_index, PgOid::Invalid)?
                         .ok_or(UDFError::DatumNotFound)?;
                     (*fcinfo_arg).isnull = false;
                 }

--- a/pg_analytics/src/datafusion/udf.rs
+++ b/pg_analytics/src/datafusion/udf.rs
@@ -12,7 +12,9 @@ use thiserror::Error;
 use super::catalog::CatalogError;
 use super::session::Session;
 use crate::types::array::IntoArrowArray;
-use crate::types::datatype::{ArrowDataType, DataTypeError, PgAttribute, PgTypeMod};
+use crate::types::datatype::{
+    ArrowDataType, DataTypeError, PgAttribute, PgTypeMod, DEFAULT_TYPE_MOD,
+};
 use crate::types::datum::GetDatum;
 
 // NOTE: because we don't use argtypes yet (see TODO below), using this function on overloaded functions WILL
@@ -126,13 +128,16 @@ unsafe fn udf_datafusion(args: &[ColumnarValue]) -> Result<ColumnarValue, UDFErr
             (*fcinfo).nargs = num_args as i16 - 1;
 
             // Call function on each set of arguments and push to result vector
-            // TODO: Fill in PgOid
             let mut result_vec = vec![];
             for row_index in 0..num_rows {
                 for arg_index in 1..num_args {
                     let fcinfo_arg = (*fcinfo).args.as_mut_ptr().add(arg_index - 1);
                     (*fcinfo_arg).value = arg_arrays[arg_index - 1]
-                        .get_datum(row_index, PgOid::from_untagged(*arg_oids.add(row_index)))?
+                        .get_datum(
+                            row_index,
+                            PgOid::from_untagged(*arg_oids.add(row_index)),
+                            DEFAULT_TYPE_MOD,
+                        )?
                         .ok_or(UDFError::DatumNotFound)?;
                     (*fcinfo_arg).isnull = false;
                 }
@@ -150,7 +155,7 @@ unsafe fn udf_datafusion(args: &[ColumnarValue]) -> Result<ColumnarValue, UDFErr
             Ok(ColumnarValue::Array(
                 result_vec
                     .into_iter()
-                    .into_arrow_array(rettype.into(), PgTypeMod(-1))?,
+                    .into_arrow_array(rettype.into(), PgTypeMod(DEFAULT_TYPE_MOD))?,
             ))
         } else {
             Err(UDFError::FunctionNameNotFound)

--- a/pg_analytics/src/datafusion/udf.rs
+++ b/pg_analytics/src/datafusion/udf.rs
@@ -132,7 +132,7 @@ unsafe fn udf_datafusion(args: &[ColumnarValue]) -> Result<ColumnarValue, UDFErr
                 for arg_index in 1..num_args {
                     let fcinfo_arg = (*fcinfo).args.as_mut_ptr().add(arg_index - 1);
                     (*fcinfo_arg).value = arg_arrays[arg_index - 1]
-                        .get_datum(row_index, PgOid::Invalid)?
+                        .get_datum(row_index, PgOid::from_untagged(*arg_oids.add(row_index)))?
                         .ok_or(UDFError::DatumNotFound)?;
                     (*fcinfo_arg).isnull = false;
                 }

--- a/pg_analytics/src/hooks/select.rs
+++ b/pg_analytics/src/hooks/select.rs
@@ -36,7 +36,9 @@ pub fn write_batches_to_slots(
                 pg_sys::ExecStoreVirtualTuple(tuple_table_slot);
 
                 for (col_index, _) in tuple_desc.iter().enumerate() {
-                    let attribute = tuple_desc.get(col_index).unwrap();
+                    let attribute = tuple_desc
+                        .get(col_index)
+                        .ok_or(SelectHookError::AttributeNotFound(col_index))?;
                     let column = batch.column(col_index);
                     let tts_value = (*tuple_table_slot).tts_values.add(col_index);
                     let tts_isnull = (*tuple_table_slot).tts_isnull.add(col_index);
@@ -99,6 +101,9 @@ pub enum SelectHookError {
 
     #[error(transparent)]
     DataTypeError(#[from] DataTypeError),
+
+    #[error("Could not find attribute {0} in tuple descriptor")]
+    AttributeNotFound(usize),
 
     #[error("Unexpected error: rShutdown not found")]
     RShutdownNotFound,

--- a/pg_analytics/src/hooks/select.rs
+++ b/pg_analytics/src/hooks/select.rs
@@ -7,40 +7,28 @@ use thiserror::Error;
 
 use crate::datafusion::catalog::CatalogError;
 use crate::datafusion::session::Session;
-use crate::types::datatype::{ArrowDataType, DataTypeError, PgAttribute, PgTypeMod};
+use crate::types::datatype::DataTypeError;
 use crate::types::datum::GetDatum;
 
 pub fn write_batches_to_slots(
-    mut query_desc: PgBox<pg_sys::QueryDesc>,
+    query_desc: PgBox<pg_sys::QueryDesc>,
     mut batches: Vec<RecordBatch>,
 ) -> Result<(), SelectHookError> {
     // Convert the DataFusion batches to Postgres tuples and send them to the destination
     unsafe {
+        let tuple_desc = PgTupleDesc::from_pg(query_desc.tupDesc);
         let estate = query_desc.estate;
         (*estate).es_processed = 0;
 
         let dest = query_desc.dest;
         let startup = (*dest).rStartup.ok_or(SelectHookError::RStartupNotFound)?;
-
         startup(dest, query_desc.operation as i32, query_desc.tupDesc);
 
-        let tuple_desc = PgTupleDesc::from_pg_unchecked(query_desc.tupDesc);
         let receive = (*dest)
             .receiveSlot
             .ok_or(SelectHookError::ReceiveSlotNotFound)?;
 
         for batch in batches.iter_mut() {
-            // Convert the tuple_desc target types to the ones corresponding to the DataFusion column types
-            let tuple_attrs = (*query_desc.tupDesc).attrs.as_mut_ptr();
-            for (col_index, _) in tuple_desc.iter().enumerate() {
-                let PgAttribute(typid, PgTypeMod(typmod)) =
-                    ArrowDataType(batch.column(col_index).data_type().clone()).try_into()?;
-
-                let tuple_attr = tuple_attrs.add(col_index);
-                (*tuple_attr).atttypid = typid.value();
-                (*tuple_attr).atttypmod = typmod;
-            }
-
             for row_index in 0..batch.num_rows() {
                 let tuple_table_slot =
                     pg_sys::MakeTupleTableSlot(query_desc.tupDesc, &pg_sys::TTSOpsVirtual);
@@ -48,11 +36,13 @@ pub fn write_batches_to_slots(
                 pg_sys::ExecStoreVirtualTuple(tuple_table_slot);
 
                 for (col_index, _) in tuple_desc.iter().enumerate() {
+                    let attribute = tuple_desc.get(col_index).unwrap();
+                    let typid = attribute.type_oid();
                     let column = batch.column(col_index);
                     let tts_value = (*tuple_table_slot).tts_values.add(col_index);
                     let tts_isnull = (*tuple_table_slot).tts_isnull.add(col_index);
 
-                    match column.get_datum(row_index)? {
+                    match column.get_datum(row_index, typid)? {
                         Some(datum) => {
                             *tts_value = datum;
                         }

--- a/pg_analytics/src/hooks/select.rs
+++ b/pg_analytics/src/hooks/select.rs
@@ -37,12 +37,11 @@ pub fn write_batches_to_slots(
 
                 for (col_index, _) in tuple_desc.iter().enumerate() {
                     let attribute = tuple_desc.get(col_index).unwrap();
-                    let typid = attribute.type_oid();
                     let column = batch.column(col_index);
                     let tts_value = (*tuple_table_slot).tts_values.add(col_index);
                     let tts_isnull = (*tuple_table_slot).tts_isnull.add(col_index);
 
-                    match column.get_datum(row_index, typid)? {
+                    match column.get_datum(row_index, attribute.type_oid(), attribute.type_mod())? {
                         Some(datum) => {
                             *tts_value = datum;
                         }

--- a/pg_analytics/src/tableam/index.rs
+++ b/pg_analytics/src/tableam/index.rs
@@ -82,7 +82,9 @@ pub async unsafe fn index_fetch_tuple(
             batch.remove_xmax_column()?;
 
             for col_index in 0..batch.num_columns() {
-                let attribute = tuple_desc.get(col_index).unwrap();
+                let attribute = tuple_desc
+                    .get(col_index)
+                    .ok_or(IndexScanError::AttributeNotFound(col_index))?;
                 let column = batch.column(col_index);
                 let tts_value = (*slot).tts_values.add(col_index);
                 let tts_isnull = (*slot).tts_isnull.add(col_index);
@@ -361,6 +363,9 @@ pub enum IndexScanError {
 
     #[error(transparent)]
     TIDError(#[from] TIDError),
+
+    #[error("Could not find attribute {0} in tuple descriptor")]
+    AttributeNotFound(usize),
 
     #[error("Unexpected index scan error: {0} rows with row number {1} was found")]
     DuplicateRowNumber(usize, i64),

--- a/pg_analytics/src/tableam/index.rs
+++ b/pg_analytics/src/tableam/index.rs
@@ -45,6 +45,7 @@ pub async unsafe fn index_fetch_tuple(
     }
 
     let pg_relation = PgRelation::from_pg(rel);
+    let tuple_desc = pg_relation.tuple_desc();
     let oid = pg_relation.oid();
     let table_name = pg_relation.name().to_string();
     let schema_name = pg_relation.namespace().to_string();
@@ -81,11 +82,13 @@ pub async unsafe fn index_fetch_tuple(
             batch.remove_xmax_column()?;
 
             for col_index in 0..batch.num_columns() {
+                let attribute = tuple_desc.get(col_index).unwrap();
+                let typid = attribute.type_oid();
                 let column = batch.column(col_index);
                 let tts_value = (*slot).tts_values.add(col_index);
                 let tts_isnull = (*slot).tts_isnull.add(col_index);
 
-                if let Some(datum) = column.get_datum(0)? {
+                if let Some(datum) = column.get_datum(0, typid)? {
                     *tts_value = datum;
                 } else {
                     *tts_isnull = true;

--- a/pg_analytics/src/tableam/index.rs
+++ b/pg_analytics/src/tableam/index.rs
@@ -83,12 +83,13 @@ pub async unsafe fn index_fetch_tuple(
 
             for col_index in 0..batch.num_columns() {
                 let attribute = tuple_desc.get(col_index).unwrap();
-                let typid = attribute.type_oid();
                 let column = batch.column(col_index);
                 let tts_value = (*slot).tts_values.add(col_index);
                 let tts_isnull = (*slot).tts_isnull.add(col_index);
 
-                if let Some(datum) = column.get_datum(0, typid)? {
+                if let Some(datum) =
+                    column.get_datum(0, attribute.type_oid(), attribute.type_mod())?
+                {
                     *tts_value = datum;
                 } else {
                     *tts_isnull = true;

--- a/pg_analytics/src/tableam/scan.rs
+++ b/pg_analytics/src/tableam/scan.rs
@@ -122,7 +122,9 @@ pub async unsafe fn scan_getnextslot(
         let column = current_batch.column(col_index);
 
         unsafe {
-            let attribute = tuple_desc.get(col_index).unwrap();
+            let attribute = tuple_desc
+                .get(col_index)
+                .ok_or(TableScanError::AttributeNotFound(col_index))?;
             let tts_value = (*slot).tts_values.add(col_index);
             let tts_isnull = (*slot).tts_isnull.add(col_index);
 
@@ -379,6 +381,9 @@ pub enum TableScanError {
 
     #[error(transparent)]
     TIDError(#[from] TIDError),
+
+    #[error("Could not find attribute {0} in tuple descriptor")]
+    AttributeNotFound(usize),
 
     #[error("Parallel scans are not implemented")]
     ParallelScanNotSupported,

--- a/pg_analytics/src/tableam/scan.rs
+++ b/pg_analytics/src/tableam/scan.rs
@@ -72,6 +72,7 @@ pub async unsafe fn scan_getnextslot(
 
     let dscan = scan as *mut DeltalakeScanDesc;
     let pg_relation = unsafe { PgRelation::from_pg((*dscan).rs_base.rs_rd) };
+    let tuple_desc = pg_relation.tuple_desc();
     let table_name = pg_relation.name();
     let schema_name = pg_relation.namespace();
     let table_path = pg_relation.table_path()?;
@@ -121,10 +122,12 @@ pub async unsafe fn scan_getnextslot(
         let column = current_batch.column(col_index);
 
         unsafe {
+            let attribute = tuple_desc.get(col_index).unwrap();
+            let typid = attribute.type_oid();
             let tts_value = (*slot).tts_values.add(col_index);
             let tts_isnull = (*slot).tts_isnull.add(col_index);
 
-            if let Some(datum) = column.get_datum((*dscan).curr_batch_idx)? {
+            if let Some(datum) = column.get_datum((*dscan).curr_batch_idx, typid)? {
                 *tts_value = datum;
             } else {
                 *tts_isnull = true;

--- a/pg_analytics/src/tableam/scan.rs
+++ b/pg_analytics/src/tableam/scan.rs
@@ -123,11 +123,14 @@ pub async unsafe fn scan_getnextslot(
 
         unsafe {
             let attribute = tuple_desc.get(col_index).unwrap();
-            let typid = attribute.type_oid();
             let tts_value = (*slot).tts_values.add(col_index);
             let tts_isnull = (*slot).tts_isnull.add(col_index);
 
-            if let Some(datum) = column.get_datum((*dscan).curr_batch_idx, typid)? {
+            if let Some(datum) = column.get_datum(
+                (*dscan).curr_batch_idx,
+                attribute.type_oid(),
+                attribute.type_mod(),
+            )? {
                 *tts_value = datum;
             } else {
                 *tts_isnull = true;

--- a/pg_analytics/src/types/datatype.rs
+++ b/pg_analytics/src/types/datatype.rs
@@ -12,7 +12,7 @@ use super::time::{TimeError, TimePrecision};
 use super::timestamp::{TimestampError, TimestampPrecision};
 
 // By default, unspecified type mods in Postgres are -1
-const DEFAULT_TYPE_MOD: i32 = -1;
+pub static DEFAULT_TYPE_MOD: i32 = -1;
 
 #[derive(Copy, Clone, Debug)]
 pub struct PgTypeMod(pub i32);

--- a/pg_analytics/src/types/datatype.rs
+++ b/pg_analytics/src/types/datatype.rs
@@ -48,6 +48,7 @@ impl TryFrom<PgAttribute> for ArrowDataType {
                         typemod.try_into()?;
                     Decimal128(precision, scale)
                 }
+                UUIDOID => Utf8,
                 unsupported => return Err(DataTypeError::UnsupportedPostgresType(unsupported)),
             },
             PgOid::Invalid => return Err(DataTypeError::InvalidPostgresOid),

--- a/pg_analytics/src/types/datum.rs
+++ b/pg_analytics/src/types/datum.rs
@@ -244,6 +244,7 @@ where
         oid: PgOid,
         typemod: i32,
     ) -> Result<Option<pg_sys::Datum>, DataTypeError> {
+        info!("{:?} {}", oid, index);
         let result = match oid {
             PgOid::BuiltIn(builtin) => match builtin {
                 BOOLOID => self.get_generic_datum::<BooleanArray>(index)?,
@@ -266,24 +267,36 @@ where
                     }
                 },
                 NUMERICOID => match self.data_type() {
-                    Decimal128(p, s) => self.get_numeric_datum_from_decimal(index, p, s)?,
-                    Float32 => self.get_numeric_datum::<Float32Type>(
-                        index,
-                        typemod,
-                        pg_sys::float4_numeric,
-                    )?,
-                    Float64 => self.get_numeric_datum::<Float64Type>(
-                        index,
-                        typemod,
-                        pg_sys::float8_numeric,
-                    )?,
+                    Decimal128(p, s) => {
+                        info!("decimal");
+                        self.get_numeric_datum_from_decimal(index, p, s)?
+                    },
+                    Float32 => {
+                        info!("f32");
+                        self.get_numeric_datum::<Float32Type>(
+                            index,
+                            typemod,
+                            pg_sys::float4_numeric,
+                        )?
+                    },
+                    Float64 => {
+                        info!("f64");
+                        self.get_numeric_datum::<Float64Type>(
+                            index,
+                            typemod,
+                            pg_sys::float8_numeric,
+                        )?
+                    },
                     Int16 => {
+                        info!("i16");
                         self.get_numeric_datum::<Int16Type>(index, typemod, pg_sys::int2_numeric)?
                     }
                     Int32 => {
+                        info!("i32");
                         self.get_numeric_datum::<Int32Type>(index, typemod, pg_sys::int4_numeric)?
                     }
                     Int64 => {
+                        info!("i64");
                         self.get_numeric_datum::<Int64Type>(index, typemod, pg_sys::int8_numeric)?
                     }
                     unsupported => return Err(DatumError::NumericError(unsupported.clone()).into()),

--- a/pg_analytics/src/types/datum.rs
+++ b/pg_analytics/src/types/datum.rs
@@ -230,14 +230,12 @@ where
                     Timestamp(TimeUnit::Millisecond, None) => self.get_ts_milli_datum(index)?,
                     Timestamp(TimeUnit::Second, None) => self.get_ts_datum(index)?,
                     unsupported => {
-                        return Err(DatumError::UnsupportedArrowType(unsupported.clone()).into())
+                        return Err(DatumError::TimestampError(unsupported.clone()).into())
                     }
                 },
                 NUMERICOID => match self.data_type() {
                     Decimal128(p, s) => self.get_numeric_datum(index, p, s)?,
-                    unsupported => {
-                        return Err(DatumError::UnsupportedArrowType(unsupported.clone()).into())
-                    }
+                    unsupported => return Err(DatumError::NumericError(unsupported.clone()).into()),
                 },
                 UUIDOID => self.get_uuid_datum(index)?,
                 BOOLARRAYOID => self.get_primitive_list_datum::<BooleanArray>(index)?,
@@ -280,6 +278,9 @@ pub enum DatumError {
     #[error("Could not downcast arrow array {0}")]
     DowncastGenericArray(String),
 
-    #[error("Could not convert arrow type {0:?} to Postgres type")]
-    UnsupportedArrowType(DataType),
+    #[error("Error converting {0:?} into NUMERIC")]
+    NumericError(DataType),
+
+    #[error("Error converting {0:?} into TIMESTAMP")]
+    TimestampError(DataType),
 }

--- a/pg_analytics/src/types/datum.rs
+++ b/pg_analytics/src/types/datum.rs
@@ -235,8 +235,14 @@ where
                 },
                 NUMERICOID => match self.data_type() {
                     Decimal128(p, s) => self.get_numeric_datum(index, p, s)?,
-                    Float32 => self.get_primitive_datum::<Float32Type>(index)?,
-                    Float64 => self.get_primitive_datum::<Float64Type>(index)?,
+                    Float32 => match self.as_primitive::<Float32Type>().iter().nth(index) {
+                        Some(Some(value)) => AnyNumeric::from(value as i128).into_datum(),
+                        _ => None,
+                    },
+                    Float64 => match self.as_primitive::<Float64Type>().iter().nth(index) {
+                        Some(Some(value)) => AnyNumeric::from(value as i128).into_datum(),
+                        _ => None,
+                    },
                     unsupported => return Err(DatumError::NumericError(unsupported.clone()).into()),
                 },
                 UUIDOID => self.get_uuid_datum(index)?,

--- a/pg_analytics/src/types/datum.rs
+++ b/pg_analytics/src/types/datum.rs
@@ -188,10 +188,10 @@ where
         A: ArrowPrimitiveType,
         A::Native: IntoDatum,
     {
-        match self.as_primitive::<Float64Type>().iter().nth(index) {
+        match self.as_primitive::<A>().iter().nth(index) {
             Some(Some(value)) => {
-                let numeric: AnyNumeric = unsafe {
-                    direct_function_call(func, &[value.into_datum(), typemod.into_datum()]).unwrap()
+                let numeric: Option<AnyNumeric> = unsafe {
+                    direct_function_call(func, &[value.into_datum(), typemod.into_datum()])
                 };
                 Ok(numeric.into_datum())
             }

--- a/pg_analytics/src/types/datum.rs
+++ b/pg_analytics/src/types/datum.rs
@@ -235,6 +235,8 @@ where
                 },
                 NUMERICOID => match self.data_type() {
                     Decimal128(p, s) => self.get_numeric_datum(index, p, s)?,
+                    Float32 => self.get_primitive_datum::<Float32Type>(index)?,
+                    Float64 => self.get_primitive_datum::<Float64Type>(index)?,
                     unsupported => return Err(DatumError::NumericError(unsupported.clone()).into()),
                 },
                 UUIDOID => self.get_uuid_datum(index)?,

--- a/pg_analytics/src/types/numeric.rs
+++ b/pg_analytics/src/types/numeric.rs
@@ -36,7 +36,7 @@ impl TryFrom<PgTypeMod> for PgNumericTypeMod {
         let PgTypeMod(typemod) = typemod;
 
         match typemod {
-            -1 => Err(NumericError::UnboundedNumeric()),
+            -1 => Err(NumericError::UnboundedNumeric),
             _ => {
                 let precision = ((typemod - pg_sys::VARHDRSZ as i32) >> 16) & 0xffff;
                 let scale = (((typemod - pg_sys::VARHDRSZ as i32) & 0x7ff) ^ 1024) - 1024;
@@ -127,5 +127,5 @@ pub enum NumericError {
     UnsupportedScale(i32),
 
     #[error("Unbounded numeric types are not yet supported. A precision and scale must be provided, i.e. numeric(precision, scale).")]
-    UnboundedNumeric(),
+    UnboundedNumeric,
 }

--- a/pg_analytics/src/types/time.rs
+++ b/pg_analytics/src/types/time.rs
@@ -88,7 +88,8 @@ impl TryFrom<NanosecondDay> for datum::Time {
         let NanosecondDay(nanos) = nanos;
 
         let time_delta = TimeDelta::nanoseconds(nanos);
-        let time = NaiveTime::from_hms_nano_opt(0, 0, 0, 0).unwrap() + time_delta;
+        let time = NaiveTime::from_hms_nano_opt(0, 0, 0, 0).ok_or(TimeError::MidnightNotFound)?
+            + time_delta;
         let total_seconds =
             time.second() as f64 + time.nanosecond() as f64 / NANOSECONDS_IN_SECOND as f64;
 
@@ -104,6 +105,9 @@ impl TryFrom<NanosecondDay> for datum::Time {
 pub enum TimeError {
     #[error(transparent)]
     DateTimeConversion(#[from] datum::datetime_support::DateTimeConversionError),
+
+    #[error("Could not convert midnight to NaiveTime")]
+    MidnightNotFound,
 
     #[error("Only time and time(6), not time({0}), are supported")]
     UnsupportedTypeMod(i32),

--- a/pg_analytics/tests/primitives.rs
+++ b/pg_analytics/tests/primitives.rs
@@ -3,7 +3,7 @@ mod fixtures;
 use fixtures::*;
 use pretty_assertions::assert_eq;
 use rstest::*;
-use sqlx::{types::BigDecimal, PgConnection};
+use sqlx::{types::BigDecimal, types::Uuid, PgConnection};
 use std::str::FromStr;
 use time::{macros::format_description, Date, PrimitiveDateTime, Time};
 
@@ -199,10 +199,14 @@ fn byte_type(mut conn: PgConnection) {
 
 #[rstest]
 fn uuid_type(mut conn: PgConnection) {
-    match "CREATE TABLE t (a uuid) USING parquet".execute_result(&mut conn) {
-        Err(err) => assert!(err.to_string().contains("not yet supported")),
-        _ => panic!("uuid should not be supported"),
-    };
+    "CREATE TABLE t (a uuid) USING parquet".execute(&mut conn);
+    "INSERT INTO t VALUES ('1bc6e67b-17f6-4bcc-a492-f0afb5212f38')".execute(&mut conn);
+    let row: (Uuid,) = "SELECT * FROM t".fetch_one(&mut conn);
+
+    assert_eq!(
+        row.0,
+        Uuid::try_parse("1bc6e67b-17f6-4bcc-a492-f0afb5212f38").unwrap()
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1055 

## What
Adds support for the `uuid` type

## Why

## How

- We store the `uuid` type as a `String` in Datafusion. To convert back to Postgres, we first convert it into bytes and then to the `datum::Uuid` type
- Caught and fixed a bug with lossy data types in `SELECT`s where we were overriding the data types provided by `PgTupleDesc` with our own lossy converted types

## Tests
Added test for UUID