### PR TITLE
fix: re-enable telemetry with correct postgres data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ You can then connect to the database using `psql`:
 docker exec -it paradedb psql -U <user> -d <dbname> -p 5432 -W
 ```
 
-ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt out of telemetry by setting `PARADEDB_TELEMETRY` to `false` or by unsetting the variable.
+ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt out of telemetry using configuration variables within Postgres:
+
+```sql
+ALTER SYSTEM SET paradedb.pg_search_telemetry TO 'off';
+ALTER SYSTEM SET paradedb.pg_analytics_telemetry TO 'off';
+```
 
 ### Helm Chart
 

--- a/pg_analytics/src/lib.rs
+++ b/pg_analytics/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 use crate::hooks::ParadeHook;
 use guc::PostgresPgAnalyticsGucSettings;
 use pgrx::*;
-// use shared::telemetry::{setup_telemetry_background_worker, ParadeExtension};
+use shared::telemetry::{setup_telemetry_background_worker, ParadeExtension};
 
 pgrx::pg_module_magic!();
 extension_sql_file!("../sql/_bootstrap.sql");
@@ -30,8 +30,7 @@ pub extern "C" fn _PG_init() {
         register_hook(&mut PARADE_HOOK)
     };
 
-    // TODO: Uncomment this once we fix the telemetry PGDATA error
-    // setup_telemetry_background_worker(ParadeExtension::PgAnalytics);
+    setup_telemetry_background_worker(ParadeExtension::PgAnalytics);
 }
 
 #[cfg(test)]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -14,7 +14,7 @@ use crate::globals::WRITER_GLOBAL;
 use pgrx::bgworkers::{BackgroundWorker, BackgroundWorkerBuilder, SignalWakeFlags};
 use pgrx::*;
 use shared::gucs::PostgresGlobalGucSettings;
-// use shared::telemetry::setup_telemetry_background_worker;
+use shared::telemetry::setup_telemetry_background_worker;
 use std::process;
 use std::time::Duration;
 
@@ -40,8 +40,7 @@ pub unsafe extern "C" fn _PG_init() {
     // can be used in test suites.
     setup_background_workers();
 
-    // TODO: Uncomment this once we fix the telemetry PGDATA error
-    // setup_telemetry_background_worker(shared::telemetry::ParadeExtension::PgSearch);
+    setup_telemetry_background_worker(shared::telemetry::ParadeExtension::PgSearch);
 }
 
 #[pg_guard]

--- a/shared/src/telemetry/bgworker.rs
+++ b/shared/src/telemetry/bgworker.rs
@@ -148,7 +148,7 @@ impl BgWorkerTelemetryConfig {
                 .map(|s| s.to_string())
                 .ok_or(TelemetryError::PosthogApiKey)?,
             posthog_host_url: option_env!("POSTHOG_HOST")
-                .map(|s| s.to_string())
+                .map(|s| format!("https://{s}"))
                 .ok_or(TelemetryError::PosthogHost)?,
             extension_name: extension_name.to_string(),
             root_data_directory: unsafe {

--- a/shared/src/telemetry/mod.rs
+++ b/shared/src/telemetry/mod.rs
@@ -56,7 +56,7 @@ pub enum TelemetryError {
     ParseUuid(#[source] uuid::Error),
     #[error("missing posthog api key")]
     PosthogApiKey,
-    #[error("missing posthog api key")]
+    #[error("missing posthog host")]
     PosthogHost,
     #[error("unknown extension name: {0}")]
     UnknownExtension(String),

--- a/shared/src/telemetry/mod.rs
+++ b/shared/src/telemetry/mod.rs
@@ -7,7 +7,7 @@ mod posthog;
 use self::event::TelemetryEvent;
 pub use bgworker::{setup_telemetry_background_worker, ParadeExtension};
 use pgrx::spi::SpiError;
-use std::{env::VarError, path::PathBuf, str::Utf8Error};
+use std::{path::PathBuf, str::Utf8Error};
 use thiserror::Error;
 
 pub trait TelemetryStore {
@@ -44,8 +44,6 @@ pub enum TelemetryError {
     DetoastExtensionName(#[source] Utf8Error),
     #[error("could not check telemetry file for handled status: {0}")]
     HandledCheck(#[source] std::io::Error),
-    #[error("could not read PGDATA variable for telemetry director: {0}")]
-    NoPgData(#[source] VarError),
     #[error("could not read telemetry config: {0}")]
     ConfigEnv(#[source] envy::Error),
     #[error("could not send telemetry request: {0}")]


### PR DESCRIPTION
## What
We had to comment out telemetry in #1049, as we weren't picking up the DATA_DIR env variable correctly. 

I also fixed the documentation for how to disable telemetry, and added some extra logging for when it is disabled.

## How
Here, I'm just using `pgrx::pg_sys::DataDir` instead.

## Tests
I've done a test publish to Docker Hub to confirm this works in a deployed docker image.
