### PR TITLE
ci: Add test for whether the Dockerfile starts properly

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -38,9 +38,12 @@ jobs:
         working-directory: docker/
         run: docker buildx create --use && docker compose -f docker-compose.dev.yml build
 
+      # Sleep 10 seconds to give time for Postgres to start inside the container
       - name: Start the ParadeDB Docker Image
         working-directory: docker/
-        run: docker compose -f docker-compose.dev.yml up -d
+        run: |
+          docker compose -f docker-compose.dev.yml up -d
+          sleep 10
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
       - name: Check for Errors in the ParadeDB Docker Image

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker buildx create --use && docker compose -f docker-compose.dev.yml build
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
-      - name: Test Running ParadeDB Docker Image
+      - name: Test Running the ParadeDB Docker Image
         working-directory: docker/
         run: |
           docker compose -f docker-compose.dev.yml up -d

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -46,4 +46,4 @@ jobs:
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
       - name: Check for Errors in the ParadeDB Docker Image
         working-directory: docker/
-        run: docker logs $(docker ps -q --filter "name=paradedb-dev") | grep ERROR
+        run: docker logs $(docker ps -q --filter "name=paradedb-dev") | grep -q ERROR || exit 0

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -34,6 +34,13 @@ jobs:
         uses: actions/checkout@v4
 
       # By using the docker-compose.dev.yml file, we also test that the build arguments are correct
-      - name: Test Building ParadeDB Docker Image
+      - name: Test Building the ParadeDB Docker Image
         working-directory: docker/
         run: docker buildx create --use && docker compose -f docker-compose.dev.yml build
+
+      # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
+      - name: Test Running ParadeDB Docker Image
+        working-directory: docker/
+        run: |
+          docker compose -f docker-compose.dev.yml up -d
+          docker logs $(docker ps -q --filter "paradedb-dev") | grep ERROR

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -34,13 +34,15 @@ jobs:
         uses: actions/checkout@v4
 
       # By using the docker-compose.dev.yml file, we also test that the build arguments are correct
-      - name: Test Building the ParadeDB Docker Image
+      - name: Build the ParadeDB Docker Image
         working-directory: docker/
         run: docker buildx create --use && docker compose -f docker-compose.dev.yml build
 
-      # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
-      - name: Test Running the ParadeDB Docker Image
+      - name: Start the ParadeDB Docker Image
         working-directory: docker/
-        run: |
-          docker compose -f docker-compose.dev.yml up -d
-          docker logs $(docker ps -q --filter "paradedb-dev") | grep ERROR
+        run: docker compose -f docker-compose.dev.yml up -d
+
+      # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
+      - name: Check for Errors in the ParadeDB Docker Image
+        working-directory: docker/
+        run: docker logs $(docker ps -q --filter "name=paradedb-dev") | grep ERROR

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -41,9 +41,7 @@ jobs:
       # Sleep 10 seconds to give time for Postgres to start inside the container
       - name: Start the ParadeDB Docker Image
         working-directory: docker/
-        run: |
-          docker compose -f docker-compose.dev.yml up -d
-          sleep 10
+        run: docker compose -f docker-compose.dev.yml up -d && sleep 10
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
       - name: Check for Errors in the ParadeDB Docker Image

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 /docs/search/full-text/autocomplete.mdx
 /docs/search/full-text/fuzzy.mdx
 /docs/upgrading.mdx
+/pg_analytics/benchmarks/*.tsv
 /pg_search/benchmarks/out/
 /pg_search/benchmarks/*_ts.json
 /pg_search/benchmarks/wiki-articles.json

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -17,6 +17,7 @@ services:
         - type=local,src=./.docker_cache_dev
       cache_to:
         - type=local,dest=./.docker_cache_dev
+    container_name: paradedb-dev
     environment:
       POSTGRESQL_USERNAME: myuser
       POSTGRESQL_PASSWORD: mypassword


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Two weeks ago, we accidentally pushed a broken Dockerfile to prod. I realized we weren't testing for whether the image starts properly in CI, and took a note to add a test for it. This does that.

## Why
Make sure we don't push broken Dockerfiles

## How
Grep the logs for ERROR

## Tests
See CI