### PR TITLE
fix: shutdown telemetry worker early if TELEMETRY=false at compile time

### DIFF
--- a/shared/src/telemetry/bgworker.rs
+++ b/shared/src/telemetry/bgworker.rs
@@ -84,6 +84,12 @@ pub fn setup_telemetry_background_worker(extension: ParadeExtension) {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn telemetry_worker(extension_name_datum: pg_sys::Datum) {
+    // If telemetry is not enabled at compile time, return early..
+    if option_env!("TELEMETRY") != Some("true") {
+        pgrx::log!("TELEMETRY var not set at compile time");
+        return;
+    }
+
     let extension_i32 = unsafe { i32::from_datum(extension_name_datum, false) }
         .expect("extension enum i32 not passed to bgworker");
     let extension = ParadeExtension::from_i32(extension_i32)
@@ -177,12 +183,6 @@ impl BgWorkerTelemetryConfig {
             // `connect_worker_to_spi`. If it is called again, the worker will segfault.
             BackgroundWorker::connect_worker_to_spi(Some("template1"), None);
             *has_connected_to_spi = true
-        }
-
-        // If telemetry is not enabled at compile time, we will never enable.
-        if option_env!("TELEMETRY") != Some("true") {
-            pgrx::log!("TELEMETRY var not set at compile time");
-            return Ok(false);
         }
 
         let guc_setting_query = format!("SHOW paradedb.{}_telemetry", self.extension_name);

--- a/shared/src/telemetry/bgworker.rs
+++ b/shared/src/telemetry/bgworker.rs
@@ -84,7 +84,7 @@ pub fn setup_telemetry_background_worker(extension: ParadeExtension) {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn telemetry_worker(extension_name_datum: pg_sys::Datum) {
-    // If telemetry is not enabled at compile time, return early..
+    // If telemetry is not enabled at compile time, return early.
     if option_env!("TELEMETRY") != Some("true") {
         pgrx::log!("TELEMETRY var not set at compile time");
         return;


### PR DESCRIPTION
## What
Just moving a shutdown check to the beginning of the background worker.

## Why
While the GUC setting for telemetry (`paradedb.pg_analytics_telemetry` / `paradedb.pg_search_telemetry`) is a runtime-check, we also have the compile time `TELEMETRY` env var that controls whether telemetry ever happens. If the compile-time `TELEMETRY` is false, then telemetry should never work at runtime, so we might as well just shutdown the worker early.

## Tests
Confirmed telemetry behavior with both `TELEMETRY=true/false`.
