### PR TITLE
fix: hardcoded column name in pg_search minmax function

### DIFF
--- a/pg_search/sql/_bootstrap.sql
+++ b/pg_search/sql/_bootstrap.sql
@@ -184,7 +184,7 @@ BEGIN
             ),
             bm25 AS (
                 SELECT 
-                    __key_field__ as key_field, 
+                    id as key_field, 
                     rank_bm25 as score 
                 FROM paradedb.minmax_bm25($1)
             )

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -305,6 +305,50 @@ fn highlight(mut conn: PgConnection) {
 }
 
 #[rstest]
+fn hybrid_with_complex_key_field_name(mut conn: PgConnection) {
+    // Create a test table.
+    "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
+        .execute(&mut conn);
+
+    // Add the custom key field column.
+    "ALTER TABLE paradedb.bm25_search ADD COLUMN custom_key_field SERIAL".execute(&mut conn);
+
+    // The test table will normally be created here, but it'll be skipped because we did it above.
+    SimpleProductsTable::setup_with_key_field("custom_key_field").execute(&mut conn);
+
+    r#"
+    CREATE EXTENSION vector;
+    ALTER TABLE paradedb.bm25_search ADD COLUMN embedding vector(3);
+
+    UPDATE paradedb.bm25_search m
+    SET embedding = ('[' ||
+    ((m.id + 1) % 10 + 1)::integer || ',' ||
+    ((m.id + 2) % 10 + 1)::integer || ',' ||
+    ((m.id + 3) % 10 + 1)::integer || ']')::vector;
+
+    CREATE INDEX on paradedb.bm25_search
+    USING hnsw (embedding vector_l2_ops)"#
+        .execute(&mut conn);
+
+    // Test with query object.
+    let columns: SimpleProductsTableVec = r#"
+    SELECT m.*, s.rank_hybrid
+    FROM paradedb.bm25_search m
+    LEFT JOIN (
+        SELECT * FROM bm25_search.rank_hybrid(
+            bm25_query => paradedb.parse('description:keyboard OR category:electronics'),
+            similarity_query => '''[1,2,3]'' <-> embedding',
+            bm25_weight => 0.9,
+            similarity_weight => 0.1
+        )
+    ) s ON m.custom_key_field = s.custom_key_field
+    LIMIT 5"#
+        .fetch_collect(&mut conn);
+
+    assert_eq!(columns.id, vec![2, 1, 29, 39, 9]);
+}
+
+#[rstest]
 fn alias(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/shared/src/fixtures/tables/simple_products.rs
+++ b/shared/src/fixtures/tables/simple_products.rs
@@ -12,8 +12,12 @@ pub struct SimpleProductsTable {
 }
 
 impl SimpleProductsTable {
-    pub fn setup() -> &'static str {
-        SIMPLE_PRODUCTS_TABLE_SETUP
+    pub fn setup() -> String {
+        SIMPLE_PRODUCTS_TABLE_SETUP.replace("%s", "id")
+    }
+
+    pub fn setup_with_key_field(key_field: &str) -> String {
+        SIMPLE_PRODUCTS_TABLE_SETUP.replace("%s", key_field)
     }
 }
 
@@ -25,7 +29,7 @@ BEGIN;
     	index_name => 'bm25_search',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
-        key_field => 'id',
+        key_field => '%s',
         text_fields => '{"description": {}, "category": {}}',
     	numeric_fields => '{"rating": {}}',
     	boolean_fields => '{"in_stock": {}}',


### PR DESCRIPTION
## What
Users reported issues using custom key field names with `rank_hybrid`.

## Why
In `minmax`, we return a `TableIterator`, which requires you to statically define the column names and types that you return. We have `"id"` there, and there's not much we can do about that, since we have to have something chosen at compile time.

## How
Fortunately, because of all the funky "SQL-macro" stuff going on in `_bootstrap`, we can just alias the column there to whatever the user passed as `key_field`, so they won't feel any pain from `minmax`'s hard-coded columns.

## Tests
Added a test for `key_field => 'custom_key_field'`.