### PR TITLE
fix: Speed up scans by not using `into_iter` when reading batches

### DIFF
--- a/cargo-paradedb/src/tables/mod.rs
+++ b/cargo-paradedb/src/tables/mod.rs
@@ -41,6 +41,7 @@ pub trait PathReader: DeserializeOwned + 'static {
         source: S,
     ) -> Result<Box<dyn Iterator<Item = Result<Self, Self::Error>>>, Self::Error>;
 
+    #[allow(dead_code)]
     fn read_ok<S: PathSource>(
         source: S,
         offset: usize,
@@ -54,6 +55,7 @@ pub trait PathReader: DeserializeOwned + 'static {
         ))
     }
 
+    #[allow(dead_code)]
     fn read_all_ok<S: PathSource>(
         source: S,
     ) -> Result<Box<dyn Iterator<Item = Self>>, Self::Error> {

--- a/pg_analytics/src/types/datatype.rs
+++ b/pg_analytics/src/types/datatype.rs
@@ -1,6 +1,7 @@
 use deltalake::arrow::error::ArrowError;
 use deltalake::datafusion::arrow::datatypes::DataType::*;
 use deltalake::datafusion::arrow::datatypes::*;
+use deltalake::datafusion::common::DataFusionError;
 use pgrx::pg_sys::BuiltinOid::*;
 use pgrx::*;
 use thiserror::Error;
@@ -109,6 +110,9 @@ impl TryFrom<ArrowDataType> for PgAttribute {
 pub enum DataTypeError {
     #[error(transparent)]
     Arrow(#[from] ArrowError),
+
+    #[error(transparent)]
+    DataFusion(#[from] DataFusionError),
 
     #[error(transparent)]
     Date(#[from] DateError),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #994 

## What
Speeds up any operations that use the table AM scans, including view creation, index creation, and moving data between tables. In my testing scans are 2-3x faster.

## Why
I noticed that table AM scans were slow. While reading the documentation, it recommends against using `ArrayIter` for performance reasons.

## How
Use the `is_null` and `value` functions instead of `into_iter`.

## Tests
All existing tests pass, no new tests needed.