### PR TITLE
fix: extension_path value in telemetry background worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,6 +5366,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "envy",
+ "humansize",
  "mockall",
  "once_cell",
  "os_info",

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -69,7 +69,7 @@ We provide pre-built binaries for Debian-based Linux for PostgreSQL 16. You can 
 
 Our pre-built binaries come with the ICU tokenizer enable, which requires the `libicu70` library. If you don't have it installed, you can do so with `sudo apt-get install libicu70 -y`, or compile the extension from source without `--features icu` to build without the ICU tokenizer.
 
-ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt-out of telemetry by setting `export PARADEDB_TELEMETRY=false` (or unsetting the variable) in your shell or in your `~/.bashrc` file before running the extension.
+ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt-out of telemetry by setting `export TELEMETRY=false` (or unsetting the variable) in your shell or in your `~/.bashrc` file before running the extension.
 
 #### macOS
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -37,6 +37,7 @@ derive_builder = "0.20.0"
 walkdir = "2.5.0"
 os_info = { version = "3", default-features = false }
 chrono = { version = "0.4.34", features = ["clock", "alloc"] }
+humansize = "2.1.3"
 
 [dev-dependencies]
 mockall = "0.12.1"

--- a/shared/src/telemetry/bgworker.rs
+++ b/shared/src/telemetry/bgworker.rs
@@ -84,17 +84,17 @@ pub fn setup_telemetry_background_worker(extension: ParadeExtension) {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn telemetry_worker(extension_name_datum: pg_sys::Datum) {
-    // If telemetry is not enabled at compile time, return early.
-    if option_env!("TELEMETRY") != Some("true") {
-        pgrx::log!("TELEMETRY var not set at compile time");
-        return;
-    }
-
     let extension_i32 = unsafe { i32::from_datum(extension_name_datum, false) }
         .expect("extension enum i32 not passed to bgworker");
     let extension = ParadeExtension::from_i32(extension_i32)
         .unwrap_or_else(|| panic!("unexpected extension i32 passed to bgworker {extension_i32}"));
     let extension_name = extension.name();
+
+    // If telemetry is not enabled at compile time, return early.
+    if option_env!("TELEMETRY") != Some("true") {
+        pgrx::log!("TELEMETRY var not set at compile time for {extension_name}");
+        return;
+    }
 
     pgrx::log!(
         "starting {extension_name} telemetry worker at PID {}",

--- a/shared/src/telemetry/controller.rs
+++ b/shared/src/telemetry/controller.rs
@@ -19,6 +19,7 @@ pub struct TelemetrySender {
 impl TelemetrySender {
     pub fn send(&self, uuid: &str, event: &TelemetryEvent) -> Result<(), TelemetryError> {
         let conn = self.telemetry_store.get_connection()?;
+
         if self.config_store.telemetry_enabled()? {
             conn.send(uuid, event)
         } else {
@@ -45,6 +46,7 @@ impl TelemetrySender {
             extension_path: path,
             os_type: os_info.os_type().to_string(),
             os_version: os_info.version().to_string(),
+            replication_mode: std::env::var("POSTGRESQL_REPLICATION_MODE").ok(),
             postgres_version: std::str::from_utf8(PG_VERSION)
                 .map_err(TelemetryError::VersionInfo)?
                 .trim_end_matches('\0')
@@ -65,6 +67,8 @@ impl TelemetrySender {
         let event = TelemetryEvent::DirectoryStatus {
             path,
             size,
+            humansize: humansize::format_size(size, humansize::DECIMAL),
+            replication_mode: std::env::var("POSTGRESQL_REPLICATION_MODE").ok(),
             extension_name: self.config_store.extension_name()?,
         };
 

--- a/shared/src/telemetry/event.rs
+++ b/shared/src/telemetry/event.rs
@@ -13,13 +13,16 @@ pub enum TelemetryEvent {
         extension_path: PathBuf,
         os_type: String,
         os_version: String,
+        replication_mode: Option<String>,
         postgres_version: String,
         postgres_version_details: String,
     },
     DirectoryStatus {
         extension_name: String,
+        replication_mode: Option<String>,
         path: PathBuf,
         size: u64,
+        humansize: String,
     },
 }
 

--- a/shared/src/telemetry/postgres.rs
+++ b/shared/src/telemetry/postgres.rs
@@ -13,7 +13,14 @@ impl DirectoryStore for PostgresDirectoryStore {
     }
 
     fn extension_path(&self) -> Result<PathBuf, TelemetryError> {
-        Ok(self.root_path()?.join(self.config_store.extension_name()?))
+        let root = self.root_path()?;
+        let name = self.config_store.extension_name()?;
+
+        Ok(match name.as_str() {
+            "pg_analytics" => root.join("deltalake"),
+            "pg_search" => root.join("paradedb").join("pg_search"),
+            _ => panic!("no extension_path for unrecognized extension: {name:?}"),
+        })
     }
 
     fn extension_uuid_path(&self) -> Result<PathBuf, TelemetryError> {

--- a/shared/src/telemetry/posthog.rs
+++ b/shared/src/telemetry/posthog.rs
@@ -49,6 +49,7 @@ impl TelemetryConnection for PosthogConnection {
                 "telemetry_data": serde_json::to_value(event).map_err(TelemetryError::ToJson)?,
             },
         });
+
         self.client
             .post(self.endpoint())
             .header("Content-Type", "application/json")


### PR DESCRIPTION
## What
We had the wrong `extension_path` for both `pg_analytics` and `pg_search` in telemetry.

While fixing this, I added some extra logging, a `humansize` field for more readable sizes, and started logging the `POSTGRESQL_REPLICATION_MODE` env var.

It's unclear if all env vars propagate to the background worker, so we'll see if any data shows up for that in Posthog.

## Tests
Confirmed events appear in Posthog.
