### PR TITLE
fix: check for division by zero in rank_hybrid

### DIFF
--- a/pg_search/sql/_bootstrap.sql
+++ b/pg_search/sql/_bootstrap.sql
@@ -176,8 +176,13 @@ BEGIN
             WITH similarity AS (
                 SELECT
                     __key_field__ as key_field,
-                    1 - ((__similarity_query__) - MIN(__similarity_query__) OVER ()) / 
-                    (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ()) AS score
+                  CASE
+                    WHEN (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ()) = 0 THEN
+                      0
+                    ELSE
+                      1 - ((__similarity_query__) - MIN(__similarity_query__) OVER ()) / 
+                      (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ())
+                    END AS score
                 FROM %I.%I
                 ORDER BY __similarity_query__
                 LIMIT $2

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -349,6 +349,48 @@ fn hybrid_with_complex_key_field_name(mut conn: PgConnection) {
 }
 
 #[rstest]
+fn hybrid_with_single_result(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Here, we'll delete all rows in the table but the first.
+    // This previsouly triggered a "division by zero" error when there was
+    // only one result in the similarity query. This test ensures that we
+    // check for that condition.
+    "DELETE FROM paradedb.bm25_search WHERE id != 1".execute(&mut conn);
+
+    r#"
+    CREATE EXTENSION vector;
+    ALTER TABLE paradedb.bm25_search ADD COLUMN embedding vector(3);
+
+    UPDATE paradedb.bm25_search m
+    SET embedding = ('[' ||
+    ((m.id + 1) % 10 + 1)::integer || ',' ||
+    ((m.id + 2) % 10 + 1)::integer || ',' ||
+    ((m.id + 3) % 10 + 1)::integer || ']')::vector;
+
+    CREATE INDEX on paradedb.bm25_search
+    USING hnsw (embedding vector_l2_ops)"#
+        .execute(&mut conn);
+
+    // Test with query object.
+    let columns: SimpleProductsTableVec = r#"
+    SELECT m.*, s.rank_hybrid
+    FROM paradedb.bm25_search m
+    LEFT JOIN (
+        SELECT * FROM bm25_search.rank_hybrid(
+            bm25_query => paradedb.parse('description:keyboard OR category:electronics'),
+            similarity_query => '''[1,2,3]'' <-> embedding',
+            bm25_weight => 0.9,
+            similarity_weight => 0.1
+        )
+    ) s ON m.id = s.id
+    LIMIT 5"#
+        .fetch_collect(&mut conn);
+
+    assert_eq!(columns.id, vec![1]);
+}
+
+#[rstest]
 fn alias(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1080 

## What
A user pointed out that with a single result in the `rank_hybrid` similarity query, we were open to a division by zero error.

## How
Add a check in `_bootstrap.sql` for division by zero, and just return 0 if that's the case.

## Tests
Added a test for `rank_hybrid` on a one-row table that previously triggered the error.
