### PR TITLE
feat: Make `paradedb.term` field optional to allow searching all fields

### DIFF
--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -239,7 +239,7 @@ SELECT * FROM search_idx.search(
 ```
 
 <ParamField body="field">
-  Specifies the field within the document to search for the term.
+  Specifies the field within the document to search for the term. If omitted, all indexed fields will be searched.
 </ParamField>
 <ParamField body="value">Value to search for in the document field.</ParamField>
 

--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -239,7 +239,8 @@ SELECT * FROM search_idx.search(
 ```
 
 <ParamField body="field">
-  Specifies the field within the document to search for the term. If omitted, all indexed fields will be searched.
+  Specifies the field within the document to search for the term. If omitted,
+  all indexed fields will be searched.
 </ParamField>
 <ParamField body="value">Value to search for in the document field.</ParamField>
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -331,7 +331,7 @@ macro_rules! term_fn {
             let convert = $conversion;
             if let Some(value) = value {
                 SearchQueryInput::Term {
-                    field: field,
+                    field,
                     value: convert(value),
                 }
             } else {
@@ -435,13 +435,7 @@ pub fn term_set(
     let terms: Vec<_> = terms
         .into_iter()
         .filter_map(|input| match input {
-            SearchQueryInput::Term { field, value, .. } => {
-                if let Some(field) = field {
-                    Some((field, value))
-                } else {
-                    None
-                }
-            }
+            SearchQueryInput::Term { field, value, .. } => field.map(|field| (field, value)),
             _ => panic!("only term queries can be passed to term_set"),
         })
         .collect();

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -417,6 +417,16 @@ fn default_as_freqs_and_positions() -> IndexRecordOption {
 }
 
 impl AsFieldType<String> for SearchIndexSchema {
+    fn fields(&self) -> Vec<(tantivy::schema::FieldType, Field)> {
+        self.fields
+            .iter()
+            .map(|search_field| {
+                let field = search_field.id.0;
+                let field_type = self.schema.get_field_entry(field).field_type().clone();
+                (field_type, field)
+            })
+            .collect()
+    }
     fn as_field_type(&self, from: &String) -> Option<(tantivy::schema::FieldType, Field)> {
         self.get_search_field(&SearchFieldName(from.into()))
             .map(|search_field| {

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -206,6 +206,16 @@ fn single_queries(mut conn: PgConnection) {
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 3);
 
+    // Term with no field (should search all columns)
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+    	query => paradedb.term(value => 'shoes'),
+	    stable_sort => true
+
+	)"#
+    .fetch_collect(&mut conn);
+    assert_eq!(columns.len(), 3);
+
     // TermSet with invalid term list
     match r#"
     SELECT * FROM bm25_search.search(


### PR DESCRIPTION
## What
A user on Slack mentioned that we no longer have a way to search across all fields, ever since we switched to the Tantivy "lenient" query parser and introduced advanced queries.

This PR adds a default behavior to `paradedb.term`, emulating the behavior of "lenient" queries that didn't specify a field. If you omit `field` in `paradedb.term`, it'll search across all indexed fields.

## Tests
Added a test for `term` without a `field` param.