### PR TITLE
feat: explain

### DIFF
--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -1,5 +1,4 @@
 use async_std::task;
-use deltalake::datafusion::arrow::record_batch::RecordBatch;
 use deltalake::datafusion::logical_expr::{DdlStatement, LogicalPlan};
 use pgrx::*;
 use std::ffi::CStr;
@@ -21,7 +20,7 @@ macro_rules! fallback_warning {
     };
 }
 
-pub fn execute_datafusion(query: &str, query_desc: PgBox<pg_sys::QueryDesc>) -> Result<Option<LogicalPlanDetails>, ExecutorHookError> {
+pub fn get_logical_plan_details(query: &str, query_desc: PgBox<pg_sys::QueryDesc>) -> Result<Option<LogicalPlanDetails>, ExecutorHookError> {
     // Parse the query into a LogicalPlan
     match LogicalPlanDetails::try_from(QueryString(&query)) {
         Ok(logical_plan_details) => {
@@ -36,8 +35,6 @@ pub fn execute_datafusion(query: &str, query_desc: PgBox<pg_sys::QueryDesc>) -> 
                 }
                 _ => {}
             };
-
-            info!("op: {:?}", query_desc.operation);
 
             // Execute SELECT, DELETE, UPDATE
             match query_desc.operation {

--- a/pg_analytics/src/hooks/executor.rs
+++ b/pg_analytics/src/hooks/executor.rs
@@ -1,4 +1,6 @@
 use async_std::task;
+use deltalake::datafusion::common::DataFusionError;
+use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::logical_expr::{DdlStatement, LogicalPlan};
 use pgrx::*;
 use std::ffi::CStr;
@@ -6,13 +8,13 @@ use thiserror::Error;
 
 use crate::datafusion::catalog::CatalogError;
 use crate::datafusion::plan::LogicalPlanDetails;
-use crate::datafusion::query::QueryString;
-use crate::federation::handler::{get_federated_batches, FederatedHandlerError};
+use crate::datafusion::query::{QueryParserError, QueryString};
+use crate::federation::handler::{get_federated_dataframe, FederatedHandlerError};
 use crate::federation::{COLUMN_FEDERATION_KEY, ROW_FEDERATION_KEY};
 
 use super::handler::{HandlerError, TableClassifier};
 use super::query::{Query, QueryStringError};
-use super::select::{get_datafusion_batches, write_batches_to_slots, SelectHookError};
+use super::select::{get_datafusion_dataframe, write_batches_to_slots, SelectHookError};
 
 macro_rules! fallback_warning {
     ($msg:expr) => {
@@ -20,22 +22,50 @@ macro_rules! fallback_warning {
     };
 }
 
-// Use QueryDesc details to determine whether this plan should even be executed by Datafusion
-pub trait ExecutableDatafusion {
-    fn try_get_logical_plan_details(
-        &self,
-        query: &str,
-    ) -> Result<Option<LogicalPlanDetails>, ExecutorHookError>;
+pub trait ExecutableDataFrame {
+    fn try_get_dataframe(&self) -> Result<Option<DataFrame>, ExecutorHookError>;
 }
 
-impl ExecutableDatafusion for PgBox<pg_sys::QueryDesc> {
-    fn try_get_logical_plan_details(
-        &self,
-        query: &str,
-    ) -> Result<Option<LogicalPlanDetails>, ExecutorHookError> {
-        // Parse the query into a LogicalPlan
-        match LogicalPlanDetails::try_from(QueryString(query)) {
-            Ok(logical_plan_details) => {
+impl ExecutableDataFrame for PgBox<pg_sys::QueryDesc> {
+    fn try_get_dataframe(&self) -> Result<Option<DataFrame>, ExecutorHookError> {
+        unsafe {
+            let ps = self.plannedstmt;
+            let rtable = (*ps).rtable;
+            let pg_plan = self.plannedstmt;
+            let query = pg_plan.get_query_string(CStr::from_ptr(self.sourceText))?;
+
+            let classified_tables = rtable.table_lists()?;
+            let col_tables = classified_tables
+                .get(COLUMN_FEDERATION_KEY)
+                .ok_or(ExecutorHookError::ColumnListNotFound)?;
+            let row_tables = classified_tables
+                .get(ROW_FEDERATION_KEY)
+                .ok_or(ExecutorHookError::RowListNotFound)?;
+
+            // Only use this hook for deltalake tables
+            // Allow INSERTs to go through
+            if rtable.is_null()
+                || self.operation == pg_sys::CmdType_CMD_INSERT
+                || col_tables.is_empty()
+                // Tech Debt: Find a less hacky way to let COPY go through
+                || query.to_lowercase().starts_with("copy")
+            {
+                return Ok(None);
+            }
+
+            // If tables of different types are both present in the query, federate the query.
+            if !row_tables.is_empty() && !col_tables.is_empty() {
+                Ok(if self.operation != pg_sys::CmdType_CMD_SELECT {
+                    None
+                } else {
+                    Some(task::block_on(get_federated_dataframe(
+                        query,
+                        classified_tables,
+                    ))?)
+                })
+            } else {
+                // Parse the query into a LogicalPlan
+                let logical_plan_details = LogicalPlanDetails::try_from(QueryString(&query))?;
                 let logical_plan = logical_plan_details.logical_plan();
 
                 // CREATE TABLE queries can reach the executor for CREATE TABLE AS SELECT
@@ -50,12 +80,14 @@ impl ExecutableDatafusion for PgBox<pg_sys::QueryDesc> {
 
                 // Execute SELECT, DELETE, UPDATE
                 match self.operation {
-                    pg_sys::CmdType_CMD_SELECT => Ok(Some(logical_plan_details)),
+                    pg_sys::CmdType_CMD_SELECT => {
+                        let single_thread = logical_plan_details.includes_udf();
+                        Ok(Some(get_datafusion_dataframe(logical_plan, single_thread)?))
+                    }
                     pg_sys::CmdType_CMD_UPDATE => Err(ExecutorHookError::UpdateNotSupported),
                     _ => Ok(None),
                 }
             }
-            Err(_) => Ok(None),
         }
     }
 }
@@ -72,75 +104,29 @@ pub fn executor_run(
         execute_once: bool,
     ) -> HookResult<()>,
 ) -> Result<(), ExecutorHookError> {
-    unsafe {
-        let ps = query_desc.plannedstmt;
-        let rtable = (*ps).rtable;
-        let pg_plan = query_desc.plannedstmt;
-        let query = pg_plan.get_query_string(CStr::from_ptr(query_desc.sourceText))?;
-
-        let classified_tables = rtable.table_lists()?;
-        let col_tables = classified_tables
-            .get(COLUMN_FEDERATION_KEY)
-            .ok_or(ExecutorHookError::ColumnListNotFound)?;
-        let row_tables = classified_tables
-            .get(ROW_FEDERATION_KEY)
-            .ok_or(ExecutorHookError::ColumnListNotFound)?;
-
-        // Only use this hook for deltalake tables
-        // Allow INSERTs to go through
-        if rtable.is_null()
-            || query_desc.operation == pg_sys::CmdType_CMD_INSERT
-            || col_tables.is_empty()
-            // Tech Debt: Find a less hacky way to let COPY go through
-            || query.to_lowercase().starts_with("copy")
-        {
-            prev_hook(query_desc, direction, count, execute_once);
-            return Ok(());
+    match query_desc.try_get_dataframe() {
+        Ok(Some(df)) => {
+            let batches = task::block_on(df.collect())?;
+            write_batches_to_slots(query_desc, batches)?;
         }
-
-        // If tables of different types are both present in the query, federate the query.
-        if !row_tables.is_empty() && !col_tables.is_empty() {
-            if query_desc.operation != pg_sys::CmdType_CMD_SELECT {
-                prev_hook(query_desc, direction, count, execute_once);
-                return Ok(());
+        other => {
+            if let Err(err) = other {
+                fallback_warning!(err.to_string());
             }
-
-            match task::block_on(get_federated_batches(query, classified_tables)) {
-                Ok(batches) => write_batches_to_slots(query_desc, batches)?,
-                Err(err) => {
-                    fallback_warning!(err.to_string());
-                    prev_hook(query_desc, direction, count, execute_once);
-                    return Ok(());
-                }
-            };
-        } else {
-            // Parse the query into a LogicalPlan
-            match query_desc.try_get_logical_plan_details(&query)? {
-                Some(logical_plan_details) => {
-                    let single_thread = logical_plan_details.includes_udf();
-                    match get_datafusion_batches(logical_plan_details.logical_plan(), single_thread)
-                    {
-                        Ok(batches) => write_batches_to_slots(query_desc, batches)?,
-                        Err(err) => {
-                            fallback_warning!(err.to_string());
-                            prev_hook(query_desc, direction, count, execute_once);
-                        }
-                    }
-                }
-                None => {
-                    prev_hook(query_desc, direction, count, execute_once);
-                }
-            };
+            prev_hook(query_desc, direction, count, execute_once);
         }
-
-        Ok(())
     }
+
+    Ok(())
 }
 
 #[derive(Error, Debug)]
 pub enum ExecutorHookError {
     #[error(transparent)]
     CatalogError(#[from] CatalogError),
+
+    #[error(transparent)]
+    DataFusionError(#[from] DataFusionError),
 
     #[error(transparent)]
     FederatedHandlerError(#[from] FederatedHandlerError),
@@ -152,10 +138,16 @@ pub enum ExecutorHookError {
     SelectHookError(#[from] SelectHookError),
 
     #[error(transparent)]
+    QueryParserError(#[from] QueryParserError),
+
+    #[error(transparent)]
     QueryStringError(#[from] QueryStringError),
 
     #[error("Table classifier did not return a column list")]
     ColumnListNotFound,
+
+    #[error("Table classifier did not return a row list")]
+    RowListNotFound,
 
     #[error("UPDATE is not currently supported because Parquet tables are append only.")]
     UpdateNotSupported,

--- a/pg_analytics/src/hooks/explain.rs
+++ b/pg_analytics/src/hooks/explain.rs
@@ -1,0 +1,87 @@
+use deltalake::datafusion::sql::parser::Statement;
+use pgrx::pg_sys::AsPgCStr;
+use pgrx::*;
+use std::num::TryFromIntError;
+use thiserror::Error;
+
+use crate::hooks::executor::ExecutableDataFrame;
+
+pub unsafe fn explain(
+    explain_stmt: *mut pg_sys::ExplainStmt,
+    statement: &Statement,
+    query: &str,
+    params: &PgBox<pg_sys::ParamListInfoData>,
+    query_env: &PgBox<pg_sys::QueryEnvironment>,
+    dest: &PgBox<pg_sys::DestReceiver>,
+) -> Result<bool, ExplainHookError> {
+    if let Statement::Explain(estmt) = statement {
+        let inner_query_string = estmt.statement.to_string();
+
+        // Get the query desc for the explained query
+        let explained_query_tree = (*explain_stmt).query as *mut pg_sys::Query;
+        let es = pg_sys::NewExplainState();
+        (*es).format = pg_sys::ExplainFormat_EXPLAIN_FORMAT_TEXT;
+        let internal_pstmt: *mut pg_sys::PlannedStmt;
+
+        #[cfg(feature = "pg12")]
+        {
+            internal_pstmt = pg_sys::pg_plan_query(
+                explained_query_tree,
+                pg_sys::CURSOR_OPT_PARALLEL_OK.try_into()?,
+                params.as_ptr(),
+            );
+        }
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        {
+            internal_pstmt = pg_sys::pg_plan_query(
+                explained_query_tree,
+                query.as_pg_cstr(),
+                pg_sys::CURSOR_OPT_PARALLEL_OK.try_into()?,
+                params.as_ptr(),
+            );
+        }
+
+        let query_desc = pg_sys::CreateQueryDesc(
+            internal_pstmt,
+            inner_query_string.clone().as_pg_cstr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            dest.as_ptr(),
+            params.as_ptr(),
+            query_env.as_ptr(),
+            0,
+        );
+
+        // If successfully get logical plan details, then that means we use the datafusion plan
+        if let Ok(Some(df)) = pgbox::PgBox::from_pg(query_desc).try_get_dataframe() {
+            let logical_plan = df.logical_plan();
+            let es = pg_sys::NewExplainState();
+            pg_sys::appendStringInfoString((*es).str_, format!("{:?}", logical_plan).as_pg_cstr());
+            let tupdesc = pg_sys::CreateTemplateTupleDesc(1);
+            pg_sys::TupleDescInitEntry(
+                tupdesc,
+                1,
+                "QUERY PLAN".as_pg_cstr(),
+                pg_sys::TEXTOID,
+                -1,
+                0,
+            );
+            let tstate =
+                pg_sys::begin_tup_output_tupdesc(dest.as_ptr(), tupdesc, &pg_sys::TTSOpsVirtual);
+            pg_sys::do_text_output_multiline(tstate, (*(*es).str_).data);
+            pg_sys::end_tup_output(tstate);
+            pg_sys::pfree((*(*es).str_).data as *mut std::ffi::c_void);
+
+            // Explained datafusion logical plan
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+#[derive(Error, Debug)]
+pub enum ExplainHookError {
+    #[error(transparent)]
+    TryFromIntError(#[from] TryFromIntError),
+}

--- a/pg_analytics/src/hooks/mod.rs
+++ b/pg_analytics/src/hooks/mod.rs
@@ -1,6 +1,7 @@
 mod alter;
 mod drop;
 mod executor;
+mod explain;
 mod handler;
 mod process;
 mod query;

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -1,14 +1,14 @@
 use crate::datafusion::query::{ASTVec, QueryString};
 use async_std::task;
-use deltalake::datafusion::sql::parser::Statement;
-use pgrx::pg_sys::{AsPgCStr, NodeTag};
+use pgrx::pg_sys::NodeTag;
 use pgrx::*;
 use std::ffi::CStr;
 use thiserror::Error;
 
 use super::alter::{alter, AlterHookError};
 use super::drop::{drop, DropHookError};
-use super::executor::{ExecutableDatafusion, ExecutorHookError};
+use super::executor::ExecutorHookError;
+use super::explain::{explain, ExplainHookError};
 use super::query::{Query, QueryStringError};
 use super::rename::{rename, RenameHookError};
 use super::truncate::{truncate, TruncateHookError};
@@ -68,78 +68,16 @@ pub fn process_utility(
             }
             NodeTag::T_ExplainStmt => {
                 if let Ok(ASTVec(ast)) = ast {
-                    if let Statement::Explain(estmt) = &ast[0] {
-                        let inner_query_string = estmt.statement.to_string();
-
-                        // Get the query desc for the explained query
-                        let stmt = plan as *mut pg_sys::ExplainStmt;
-                        let explained_query_tree = (*stmt).query as *mut pg_sys::Query;
-                        let es = pg_sys::NewExplainState();
-                        (*es).format = pg_sys::ExplainFormat_EXPLAIN_FORMAT_TEXT;
-                        let internal_pstmt: *mut pg_sys::PlannedStmt;
-                        #[cfg(feature = "pg12")]
-                        {
-                            internal_pstmt = pg_sys::pg_plan_query(
-                                explained_query_tree,
-                                pg_sys::CURSOR_OPT_PARALLEL_OK.try_into().unwrap(),
-                                params.as_ptr(),
-                            );
-                        }
-                        #[cfg(any(
-                            feature = "pg13",
-                            feature = "pg14",
-                            feature = "pg15",
-                            feature = "pg16"
-                        ))]
-                        {
-                            internal_pstmt = pg_sys::pg_plan_query(
-                                explained_query_tree,
-                                query.clone().as_pg_cstr(),
-                                pg_sys::CURSOR_OPT_PARALLEL_OK.try_into().unwrap(),
-                                params.as_ptr(),
-                            );
-                        }
-                        let query_desc = pg_sys::CreateQueryDesc(
-                            internal_pstmt,
-                            query.clone().as_pg_cstr(),
-                            std::ptr::null_mut(),
-                            std::ptr::null_mut(),
-                            dest.as_ptr(),
-                            params.as_ptr(),
-                            query_env.as_ptr(),
-                            0,
-                        );
-
-                        // If successfully get logical plan details, then that means we use the datafusion plan
-                        if let Some(logical_plan_details) = pgbox::PgBox::from_pg(query_desc)
-                            .try_get_logical_plan_details(&inner_query_string)?
-                        {
-                            let es = pg_sys::NewExplainState();
-                            pg_sys::appendStringInfoString(
-                                (*es).str_,
-                                format!("{:?}", logical_plan_details.logical_plan()).as_pg_cstr(),
-                            );
-                            let tupdesc = pg_sys::CreateTemplateTupleDesc(1);
-                            pg_sys::TupleDescInitEntry(
-                                tupdesc,
-                                1,
-                                "QUERY PLAN".as_pg_cstr(),
-                                pg_sys::TEXTOID,
-                                -1,
-                                0,
-                            );
-                            let tstate = pg_sys::begin_tup_output_tupdesc(
-                                dest.as_ptr(),
-                                tupdesc,
-                                &pg_sys::TTSOpsVirtual,
-                            );
-                            pg_sys::do_text_output_multiline(tstate, (*(*es).str_).data);
-                            pg_sys::end_tup_output(tstate);
-                            pg_sys::pfree((*(*es).str_).data as *mut std::ffi::c_void);
-
-                            // Don't execute prev_hook for EXPLAIN
-                            return Ok(());
-                        }
+                    if explain(
+                        plan as *mut pg_sys::ExplainStmt,
+                        &ast[0],
+                        &query,
+                        &params,
+                        &query_env,
+                        &dest,
+                    )? {
+                        // If explain returns true for a successful Datafusion explain, then we don't run prev_hook
+                        return Ok(());
                     }
                 }
             }
@@ -174,6 +112,9 @@ pub enum ProcessHookError {
 
     #[error(transparent)]
     ExecutorHook(#[from] ExecutorHookError),
+
+    #[error(transparent)]
+    ExplainHook(#[from] ExplainHookError),
 
     #[error(transparent)]
     QueryString(#[from] QueryStringError),

--- a/pg_analytics/src/hooks/process.rs
+++ b/pg_analytics/src/hooks/process.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use super::alter::{alter, AlterHookError};
 use super::drop::{drop, DropHookError};
-use super::executor::{get_df_exec_logical_plan_details, ExecutorHookError};
+use super::executor::{ExecutableDatafusion, ExecutorHookError};
 use super::query::{Query, QueryStringError};
 use super::rename::{rename, RenameHookError};
 use super::truncate::{truncate, TruncateHookError};
@@ -94,11 +94,9 @@ pub fn process_utility(
                         );
 
                         // If successfully get logical plan details, then that means we use the datafusion plan
-                        let logical_plan_details_opt = get_df_exec_logical_plan_details(
-                            &inner_query_string,
-                            pgbox::PgBox::from_pg(query_desc),
-                        )?;
-                        if let Some(logical_plan_details) = logical_plan_details_opt {
+                        if let Some(logical_plan_details) = pgbox::PgBox::from_pg(query_desc)
+                            .try_get_logical_plan_details(&inner_query_string)?
+                        {
                             let es = pg_sys::NewExplainState();
                             pg_sys::appendStringInfoString(
                                 (*es).str_,

--- a/pg_analytics/src/hooks/select.rs
+++ b/pg_analytics/src/hooks/select.rs
@@ -1,5 +1,6 @@
 use deltalake::datafusion::arrow::record_batch::RecordBatch;
 use deltalake::datafusion::common::arrow::error::ArrowError;
+use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::logical_expr::LogicalPlan;
 use deltalake::datafusion::prelude::SessionContext;
 use pgrx::*;
@@ -68,10 +69,10 @@ pub fn write_batches_to_slots(
     Ok(())
 }
 
-pub fn get_datafusion_batches(
+pub fn get_datafusion_dataframe(
     logical_plan: LogicalPlan,
     single_thread: bool,
-) -> Result<Vec<RecordBatch>, SelectHookError> {
+) -> Result<DataFrame, SelectHookError> {
     // Execute the logical plan and collect the resulting batches
     Ok(Session::with_session_context(|context| {
         Box::pin(async move {
@@ -83,7 +84,7 @@ pub fn get_datafusion_batches(
             } else {
                 context.execute_logical_plan(logical_plan).await?
             };
-            Ok(dataframe.collect().await?)
+            Ok(dataframe)
         })
     })?)
 }

--- a/pg_analytics/src/tableam/update.rs
+++ b/pg_analytics/src/tableam/update.rs
@@ -15,7 +15,7 @@ pub extern "C" fn deltalake_tuple_update(
     _lockmode: *mut pg_sys::LockTupleMode,
     _update_indexes: *mut bool,
 ) -> pg_sys::TM_Result {
-    panic!("{}", UpdateError::UpdateNotsupported.to_string());
+    panic!("{}", UpdateError::UpdateNotSupported.to_string());
 }
 
 #[pg_guard]
@@ -32,11 +32,11 @@ pub extern "C" fn deltalake_tuple_update(
     _lockmode: *mut pg_sys::LockTupleMode,
     _update_indexes: *mut pg_sys::TU_UpdateIndexes,
 ) -> pg_sys::TM_Result {
-    panic!("{}", UpdateError::UpdateNotsupported.to_string());
+    panic!("{}", UpdateError::UpdateNotSupported.to_string());
 }
 
 #[derive(Error, Debug)]
 pub enum UpdateError {
-    #[error("UPDATE is not supported because Parquet tables are append only.")]
-    UpdateNotsupported,
+    #[error("UPDATE is not currently supported because Parquet tables are append only.")]
+    UpdateNotSupported,
 }

--- a/pg_analytics/tests/explain.rs
+++ b/pg_analytics/tests/explain.rs
@@ -1,0 +1,37 @@
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn explain_df_query(mut conn: PgConnection) {
+    "CREATE TABLE t ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT ) USING parquet"
+        .execute(&mut conn);
+
+    let res = "EXPLAIN SELECT * FROM t LIMIT 5;".fetch_scalar::<String>(&mut conn);
+
+    assert_eq!(res.get(0).unwrap(), "Limit: skip=0, fetch=5");
+    assert_eq!(
+        res.get(1).unwrap(),
+        "  Projection: t.id, t.name, t.department_id, t.parade_ctid, t.parade_xmin, t.parade_xmax"
+    );
+    assert_eq!(res.get(2).unwrap(), "    TableScan: t");
+}
+
+#[rstest]
+fn explain_heap_query(mut conn: PgConnection) {
+    "CREATE TABLE t ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT )".execute(&mut conn);
+
+    let res = "EXPLAIN SELECT * FROM t LIMIT 5;".fetch_scalar::<String>(&mut conn);
+
+    assert_eq!(
+        res.get(0).unwrap(),
+        "Limit  (cost=0.00..0.14 rows=5 width=126)"
+    );
+    assert_eq!(
+        res.get(1).unwrap(),
+        "  ->  Seq Scan on t  (cost=0.00..15.30 rows=530 width=126)"
+    );
+}

--- a/pg_analytics/tests/explain.rs
+++ b/pg_analytics/tests/explain.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::get_first)]
+#![allow(clippy::get_first)]
 mod fixtures;
 
 use fixtures::*;

--- a/pg_analytics/tests/explain.rs
+++ b/pg_analytics/tests/explain.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::get_first)]
 mod fixtures;
 
 use fixtures::*;
@@ -34,4 +35,21 @@ fn explain_heap_query(mut conn: PgConnection) {
         res.get(1).unwrap(),
         "  ->  Seq Scan on t  (cost=0.00..15.30 rows=530 width=126)"
     );
+}
+
+#[rstest]
+fn explain_federated_query(mut conn: PgConnection) {
+    "CREATE TABLE t ( id INT PRIMARY KEY, name VARCHAR(50), department_id INT )".execute(&mut conn);
+    "CREATE TABLE u ( id INT PRIMARY KEY, t_id INT ) USING parquet".execute(&mut conn);
+
+    let res =
+        "EXPLAIN SELECT * FROM t INNER JOIN u ON t.id = u.t_id;".fetch_scalar::<String>(&mut conn);
+
+    assert_eq!(
+        res.get(0).unwrap(),
+        "Projection: t.id, t.name, t.department_id, u.id, u.t_id"
+    );
+    assert_eq!(res.get(1).unwrap(), "  Inner Join:  Filter: t.id = u.t_id");
+    assert_eq!(res.get(2).unwrap(), "    TableScan: t");
+    assert_eq!(res.get(3).unwrap(), "    TableScan: u");
 }

--- a/shared/src/fixtures/db.rs
+++ b/shared/src/fixtures/db.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use sqlx::{
     postgres::PgRow,
     testing::{TestArgs, TestContext, TestSupport},
-    ConnectOptions, Executor, FromRow, PgConnection, Postgres,
+    ConnectOptions, Decode, Executor, FromRow, PgConnection, Postgres, Type,
 };
 
 pub struct Db {
@@ -79,6 +79,18 @@ where
     fn fetch_dynamic(self, connection: &mut PgConnection) -> Vec<PgRow> {
         block_on(async {
             sqlx::query(self.as_ref())
+                .fetch_all(connection)
+                .await
+                .unwrap()
+        })
+    }
+
+    fn fetch_scalar<T>(self, connection: &mut PgConnection) -> Vec<T>
+    where
+        T: Type<Postgres> + for<'a> Decode<'a, sqlx::Postgres> + Send + Unpin,
+    {
+        block_on(async {
+            sqlx::query_scalar(self.as_ref())
                 .fetch_all(connection)
                 .await
                 .unwrap()


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1034

## What

Implement `EXPLAIN` for Datafusion plans.

## Why

Postgres' built-in implementation of `EXPLAIN` doesn't really make sense for queries that are executed in Datafusion, so we show the Datafusion plan instead for these queries.

## How

Intercept the `ExplainStmt` in the utility process handler and check if it is going to be executed by Datafusion, then proceed to explain the statement.

## Tests

Check the outputs of `EXPLAIN` on parquet, heap, and federated queries.