### PR TITLE
fix: throw exception for duplicate index instead of drop_bm25

### DIFF
--- a/pg_search/sql/_bootstrap.sql
+++ b/pg_search/sql/_bootstrap.sql
@@ -121,6 +121,11 @@ BEGIN
         RAISE EXCEPTION 'no index_name parameter given for bm25 index';
     END IF;
 
+    -- Disallow creation of an index with existing name
+    IF EXISTS(SELECT i.schema_name FROM information_schema.schemata i WHERE i.schema_name = index_name) THEN
+        RAISE EXCEPTION 'relation "%" already exists', index_name;
+    END IF;
+
     IF table_name IS NULL OR table_name = '' THEN
         RAISE EXCEPTION 'no table_name parameter given for bm25 index "%"', index_name;
     END IF;
@@ -139,9 +144,6 @@ BEGIN
         'key_field', key_field,
         'schema_name', schema_name
     );
-
-    -- Drop any existing index and function with the same name to avoid conflicts.
-    CALL paradedb.drop_bm25(index_name, schema_name => schema_name);
 
     -- Create the new, empty schema.
     EXECUTE format('CREATE SCHEMA %s', index_name);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #912

## What
Throw exception for duplicate index instead of dropping.

## Why
Shouldn’t automatically drop indices.

## How
Check if index schema exists and abort if it does.

## Tests
Check that trying to create a duplicate index errors out.
