### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/analytics/object_stores/local.mdx
+++ b/docs/analytics/object_stores/local.mdx
@@ -9,11 +9,11 @@ for files on the same machine as the Postgres instance.
 
 ```sql
 CREATE FOREIGN DATA WRAPPER <wrapper_name>
-HANDLER s3_fdw_handler
-VALIDATOR s3_fdw_validator;
+HANDLER local_file_fdw_handler
+VALIDATOR local_file_fdw_validator;
 
 CREATE SERVER <server_name>
-FOREIGN DATA WRAPPER <wrapper_name> ;
+FOREIGN DATA WRAPPER <wrapper_name>;
 
 -- Replace the dummy schema with the actual schema
 CREATE FOREIGN TABLE <table_name> ("x" INT)
@@ -34,7 +34,7 @@ OPTIONS (path '<path>', extension '<extension>');
 ### Options for `CREATE FOREIGN TABLE`
 
 <ParamField body="path" required>
-  Must start with `s3://` and point to the location of your file. The path
+  Must start with `file:///` and point to the location of your file. The path
   should end in a `/` if it points to a directory of partitioned Parquet files.
 </ParamField>
 <ParamField body="extension" required>


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
There were some copy paste typos for the `pg_lakehouse` docs.

## Why

## How

## Tests
