### PR TITLE
fix: Don't double set the root path

### DIFF
--- a/pg_lakehouse/src/fdw/gcs.rs
+++ b/pg_lakehouse/src/fdw/gcs.rs
@@ -89,10 +89,6 @@ impl TryFrom<ServerOptions> for Gcs {
 
         let mut builder = Gcs::default();
 
-        if let Root(Some(root)) = Root::from(url.clone()) {
-            builder.root(&root);
-        }
-
         if let Some(bucket) = url.host_str() {
             builder.bucket(bucket);
         }

--- a/pg_lakehouse/src/fdw/options.rs
+++ b/pg_lakehouse/src/fdw/options.rs
@@ -1,35 +1,8 @@
 use crate::fdw::base::BaseFdwError;
 use pgrx::*;
 use std::collections::HashMap;
-use std::path::Path;
 use supabase_wrappers::prelude::*;
 use url::Url;
-
-pub struct Root(pub Option<String>);
-
-impl From<Url> for Root {
-    fn from(url: Url) -> Self {
-        let path = url.path();
-
-        let is_file = Path::new(path).extension().is_some();
-
-        let extracted_path = if is_file {
-            let mut segments = match url.path_segments() {
-                Some(segments) => segments.collect::<Vec<&str>>(),
-                None => {
-                    return Root(None);
-                }
-            };
-
-            segments.pop();
-            segments.join("/")
-        } else {
-            path.to_string()
-        };
-
-        Root(Some(extracted_path))
-    }
-}
 
 pub enum TableOption {
     Path,

--- a/pg_lakehouse/src/fdw/s3.rs
+++ b/pg_lakehouse/src/fdw/s3.rs
@@ -84,10 +84,6 @@ impl TryFrom<ServerOptions> for S3 {
         builder.disable_config_load();
         builder.disable_ec2_metadata();
 
-        if let Root(Some(root)) = Root::from(url.clone()) {
-            builder.root(&root);
-        }
-
         if let Some(bucket) = url.host_str() {
             builder.bucket(bucket);
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We don't need to set `root` in the builder. If we do, the `root` will be repeated in the full path.

## Why

## How

## Tests
I tested putting a parquet file in nested folders in S3/Azure and noticed that setting `root` caused queries to fail.