### PR TITLE
fix: Use `xz` compression for Debian 11 compatibility

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -111,9 +111,10 @@ jobs:
           echo 'Description: An analytical query engine for Postgres' >> $CONTROL_FILE
 
           # Create .deb package
+          # Note: We specify `xz` compression for compatibility with Debian 11
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 00755 ${package_dir}
-          sudo dpkg-deb --build --root-owner-group ${package_dir}
+          sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -110,9 +110,10 @@ jobs:
           echo 'Description: Full text search for PostgreSQL using BM25' >> $CONTROL_FILE
 
           # Create .deb package
+          # Note: We specify `xz` compression for compatibility with Debian 11
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 00755 ${package_dir}
-          sudo dpkg-deb --build --root-owner-group ${package_dir}
+          sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #986 

## What
Finally getting around to this. Another user reported the same issue. By specifying `xz` compression, it should work across Debian 11 and 12.

## Why
^

## How
^

## Tests
Tested on EC2