### PR TITLE
feat: Upgrade to Debian 12

### DIFF
--- a/cargo-paradedb/src/bench_hits.rs
+++ b/cargo-paradedb/src/bench_hits.rs
@@ -35,7 +35,7 @@ pub async fn bench_hits(url: &str, workload: &str, full: bool) -> Result<()> {
     println!("*********************************************************************************\n");
 
     let root_file_path = PathBuf::from_str("/tmp")?;
-    let single_file_path = root_file_path.join("/hits.parquet").display().to_string();
+    let single_file_path = root_file_path.join("hits.parquet").display().to_string();
     let partitioned_dir_path = root_file_path.join("partitioned/").display().to_string();
 
     let single_url = if full {

--- a/cargo-paradedb/src/bench_hits.rs
+++ b/cargo-paradedb/src/bench_hits.rs
@@ -35,7 +35,7 @@ pub async fn bench_hits(url: &str, workload: &str, full: bool) -> Result<()> {
     println!("*********************************************************************************\n");
 
     let root_file_path = PathBuf::from_str("/tmp")?;
-    let single_file_path = root_file_path.join("hits.parquet").display().to_string();
+    let single_file_path = root_file_path.join("/hits.parquet").display().to_string();
     let partitioned_dir_path = root_file_path.join("partitioned/").display().to_string();
 
     let single_url = if full {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,8 +8,9 @@ ARG PG_VERSION_MAJOR=16
 ###############################################
 
 # We build the extensions on the official PostgreSQL image, since the Bitnami
-# image does not have root access and necessary build tools
-FROM postgres:${PG_VERSION_MAJOR}-bullseye as builder
+# image locks root and has few pre-installed packages
+# Note: Debian Bookworm = Debian 12# 
+FROM postgres:${PG_VERSION_MAJOR}-bookworm as builder
 
 ARG PG_VERSION_MAJOR=16
 ARG RUST_VERSION=1.78.0
@@ -142,7 +143,8 @@ RUN echo "trusted = true" >> pg_ivm.control && \
 # Second Stage: PostgreSQL
 ###############################################
 
-FROM bitnami/postgresql:${PG_VERSION_MAJOR}-debian-11 as paradedb
+# Note: Debian Bookworm = Debian 12# 
+FROM bitnami/postgresql:${PG_VERSION_MAJOR}-debian-12 as paradedb
 
 ARG PG_VERSION_MAJOR=16
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG PG_VERSION_MAJOR=16
 
 # We build the extensions on the official PostgreSQL image, since the Bitnami
 # image locks root and has few pre-installed packages
-# Note: Debian Bookworm = Debian 12# 
+# Note: Debian Bookworm = Debian 12
 FROM postgres:${PG_VERSION_MAJOR}-bookworm as builder
 
 ARG PG_VERSION_MAJOR=16
@@ -143,7 +143,7 @@ RUN echo "trusted = true" >> pg_ivm.control && \
 # Second Stage: PostgreSQL
 ###############################################
 
-# Note: Debian Bookworm = Debian 12# 
+# Note: Debian Bookworm = Debian 12
 FROM bitnami/postgresql:${PG_VERSION_MAJOR}-debian-12 as paradedb
 
 ARG PG_VERSION_MAJOR=16


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #895 

## What
It's been released for a while, so we should probably upgrade. I also make the benchmarks run on every change to the extension to properly catch issues moving forward.

## Why
Stay current

## How
Use `bookworm` and debian-12` for the Postgres and Bitnami Postgres containers respectively

## Tests
Tested locally that it still builds, runs, and the extensions work properly