### PR TITLE
feat: non-integer keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5507,7 +5507,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "ordered-float 4.2.0",
- "paste",
  "pgrx",
  "pgrx-tests",
  "pgvector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -5240,7 +5240,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -8730,7 +8730,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "wasite",
  "web-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,6 +5503,7 @@ dependencies = [
  "interprocess",
  "json5",
  "libc",
+ "log",
  "memoffset",
  "num_cpus",
  "once_cell",
@@ -5518,6 +5519,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "shared",
+ "simple-logging",
  "sqlx",
  "tantivy",
  "tantivy-common",
@@ -6172,6 +6174,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -7151,6 +7159,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-logging"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542"
+dependencies = [
+ "lazy_static",
+ "log",
+ "thread-id",
+]
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7995,6 +8014,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5141,6 +5141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,6 +5506,7 @@ dependencies = [
  "memoffset",
  "num_cpus",
  "once_cell",
+ "ordered-float 4.2.0",
  "pgrx",
  "pgrx-tests",
  "pgvector",
@@ -8005,7 +8015,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "windows-sys 0.52.0",
 ]
 
@@ -5240,7 +5240,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -5503,7 +5503,6 @@ dependencies = [
  "interprocess",
  "json5",
  "libc",
- "log",
  "memoffset",
  "num_cpus",
  "once_cell",
@@ -5519,7 +5518,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "shared",
- "simple-logging",
  "sqlx",
  "tantivy",
  "tantivy-common",
@@ -6174,12 +6172,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -7159,17 +7151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple-logging"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542"
-dependencies = [
- "lazy_static",
- "log",
- "thread-id",
-]
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8017,17 +7998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8760,7 +8730,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5507,6 +5507,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "ordered-float 4.2.0",
+ "paste",
  "pgrx",
  "pgrx-tests",
  "pgvector",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -52,7 +52,6 @@ num_cpus = "1.16.0"
 zstd-sys = "=2.0.9"
 chrono = "0.4.38"
 ordered-float = "4.2.0"
-paste = "1.0.15"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -52,6 +52,7 @@ num_cpus = "1.16.0"
 zstd-sys = "=2.0.9"
 chrono = "0.4.38"
 ordered-float = "4.2.0"
+paste = "1.0.15"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -52,6 +52,8 @@ num_cpus = "1.16.0"
 zstd-sys = "=2.0.9"
 chrono = "0.4.38"
 ordered-float = "4.2.0"
+simple-logging = "2.0.2"
+log = "0.4.21"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -52,8 +52,6 @@ num_cpus = "1.16.0"
 zstd-sys = "=2.0.9"
 chrono = "0.4.38"
 ordered-float = "4.2.0"
-simple-logging = "2.0.2"
-log = "0.4.21"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -51,6 +51,7 @@ walkdir = "2.5.0"
 num_cpus = "1.16.0"
 zstd-sys = "=2.0.9"
 chrono = "0.4.38"
+ordered-float = "4.2.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -400,13 +400,21 @@ pub fn range_timestamp(field: String, range: Range<pgrx::Timestamp>) -> SearchQu
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap()),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap()),
+                RangeBound::Inclusive(n) => {
+                    Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap())
+                }
+                RangeBound::Exclusive(n) => {
+                    Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap())
+                }
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap()),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap()),
+                RangeBound::Inclusive(n) => {
+                    Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap())
+                }
+                RangeBound::Exclusive(n) => {
+                    Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap())
+                }
             },
         },
     }
@@ -431,13 +439,21 @@ pub fn range_timestamptz(
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
+                RangeBound::Inclusive(n) => {
+                    Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap())
+                }
+                RangeBound::Exclusive(n) => {
+                    Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap())
+                }
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
+                RangeBound::Inclusive(n) => {
+                    Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap())
+                }
+                RangeBound::Exclusive(n) => {
+                    Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap())
+                }
             },
         },
     }

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -543,9 +543,7 @@ term_fn!(
     pgrx::Range<pgrx::TimestampWithTimeZone>,
     |_v| unimplemented!("timestamp ranges with time zone in term query not implemented")
 );
-term_fn!(uuid, pgrx::Uuid, |_v| unimplemented!(
-    "uuid in term query not implemented"
-));
+term_fn!(uuid, pgrx::Uuid, |v: pgrx::Uuid| tantivy::schema::Value::Str(v.to_string()));
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn term_set(

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -544,7 +544,7 @@ term_fn!(
     |_v| unimplemented!("timestamp ranges with time zone in term query not implemented")
 );
 term_fn!(uuid, pgrx::Uuid, |v: pgrx::Uuid| {
-    tantivy::schema::Value::Str(v.to_string())
+    tantivy::schema::OwnedValue::Str(v.to_string())
 });
 
 #[pg_extern(immutable, parallel_safe)]

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -372,13 +372,13 @@ pub fn range_date(field: String, range: Range<pgrx::Date>) -> SearchQueryInput {
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_date_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_date_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_date_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_date_to_tantivy_value(n).unwrap()),
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_date_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_date_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_date_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_date_to_tantivy_value(n).unwrap()),
             },
         },
     }
@@ -400,13 +400,13 @@ pub fn range_timestamp(field: String, range: Range<pgrx::Timestamp>) -> SearchQu
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap()),
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamp_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamp_to_tantivy_value(n).unwrap()),
             },
         },
     }
@@ -431,13 +431,13 @@ pub fn range_timestamptz(
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n)),
-                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n)),
+                RangeBound::Inclusive(n) => Bound::Included(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
+                RangeBound::Exclusive(n) => Bound::Excluded(pgrx_timestamptz_to_tantivy_value(n).unwrap()),
             },
         },
     }

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -514,7 +514,7 @@ term_fn_unsupported!(tsrange, pgrx::Range<pgrx::Timestamp>, "timestamp range");
 term_fn_unsupported!(
     tstzrange,
     pgrx::Range<pgrx::TimestampWithTimeZone>,
-    "timstamp ranges with time zone"
+    "timestamp ranges with time zone"
 );
 
 #[pg_extern(immutable, parallel_safe)]

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -468,6 +468,20 @@ macro_rules! term_fn {
     };
 }
 
+macro_rules! term_fn_unsupported {
+    ($func_name:ident, $value_type:ty, $term_type:literal) => {
+        #[pg_extern(name = "term", immutable, parallel_safe)]
+        pub fn $func_name(
+            field: default!(Option<String>, "NULL"),
+            value: default!(Option<$value_type>, "NULL"),
+        ) -> SearchQueryInput {
+            unimplemented!(
+                "{} in term query not implemented", $term_type
+            )
+        }
+    };
+}
+
 // Generate functions for each type
 term_fn!(term_bytes, Vec<u8>);
 term_fn!(term_str, String);
@@ -478,26 +492,26 @@ term_fn!(term_i64, i64);
 term_fn!(term_f32, f32);
 term_fn!(term_f64, f64);
 term_fn!(term_bool, bool);
-term_fn!(json, pgrx::Json);
-term_fn!(jsonb, pgrx::JsonB);
 term_fn!(date, pgrx::Date);
 term_fn!(time, pgrx::Time);
 term_fn!(timestamp, pgrx::Timestamp);
 term_fn!(time_with_time_zone, pgrx::TimeWithTimeZone);
 term_fn!(timestamp_with_time_zome, pgrx::TimestampWithTimeZone);
-term_fn!(anyarray, pgrx::AnyArray);
-term_fn!(pg_box, pgrx::pg_sys::BOX);
-term_fn!(point, pgrx::pg_sys::Point);
-term_fn!(tid, pgrx::pg_sys::ItemPointerData);
-term_fn!(inet, pgrx::Inet);
 term_fn!(numeric, pgrx::AnyNumeric);
-term_fn!(int4range, pgrx::Range<i32>);
-term_fn!(int8range, pgrx::Range<i64>);
-term_fn!(numrange, pgrx::Range<pgrx::AnyNumeric>);
-term_fn!(daterange, pgrx::Range<pgrx::Date>);
-term_fn!(tsrange, pgrx::Range<pgrx::Timestamp>);
-term_fn!(tstzrange, pgrx::Range<pgrx::TimestampWithTimeZone>);
 term_fn!(uuid, pgrx::Uuid);
+term_fn_unsupported!(json, pgrx::Json, "json");
+term_fn_unsupported!(jsonb, pgrx::JsonB, "jsonb");
+term_fn_unsupported!(anyarray, pgrx::AnyArray, "array");
+term_fn_unsupported!(pg_box, pgrx::pg_sys::BOX, "box");
+term_fn_unsupported!(point, pgrx::pg_sys::Point, "point");
+term_fn_unsupported!(tid, pgrx::pg_sys::ItemPointerData, "tid");
+term_fn_unsupported!(inet, pgrx::Inet, "inet");
+term_fn_unsupported!(int4range, pgrx::Range<i32>, "int4 range");
+term_fn_unsupported!(int8range, pgrx::Range<i64>, "int8 range");
+term_fn_unsupported!(numrange, pgrx::Range<pgrx::AnyNumeric>, "numeric range");
+term_fn_unsupported!(daterange, pgrx::Range<pgrx::Date>, "date range");
+term_fn_unsupported!(tsrange, pgrx::Range<pgrx::Timestamp>, "timestamp range");
+term_fn_unsupported!(tstzrange, pgrx::Range<pgrx::TimestampWithTimeZone>, "timstamp ranges with time zone");
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn term_set(

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -372,18 +372,14 @@ macro_rules! datetime_range_fn {
                     lower_bound: match lower {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
-                            TantivyValue::try_from(n)
-                                .unwrap()
-                                .tantivy_schema_value()
-                                .as_date()
+                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                                .as_datetime()
                                 .unwrap()
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
-                            TantivyValue::try_from(n)
-                                .unwrap()
-                                .tantivy_schema_value()
-                                .as_date()
+                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                                .as_datetime()
                                 .unwrap()
                                 .into(),
                         ),
@@ -391,18 +387,14 @@ macro_rules! datetime_range_fn {
                     upper_bound: match upper {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
-                            TantivyValue::try_from(n)
-                                .unwrap()
-                                .tantivy_schema_value()
-                                .as_date()
+                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                                .as_datetime()
                                 .unwrap()
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
-                            TantivyValue::try_from(n)
-                                .unwrap()
-                                .tantivy_schema_value()
-                                .as_date()
+                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                                .as_datetime()
                                 .unwrap()
                                 .into(),
                         ),

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -543,7 +543,9 @@ term_fn!(
     pgrx::Range<pgrx::TimestampWithTimeZone>,
     |_v| unimplemented!("timestamp ranges with time zone in term query not implemented")
 );
-term_fn!(uuid, pgrx::Uuid, |v: pgrx::Uuid| tantivy::schema::Value::Str(v.to_string()));
+term_fn!(uuid, pgrx::Uuid, |v: pgrx::Uuid| {
+    tantivy::schema::Value::Str(v.to_string())
+});
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn term_set(

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -464,74 +464,20 @@ pub fn regex(field: String, pattern: String) -> SearchQueryInput {
     SearchQueryInput::Regex { field, pattern }
 }
 
-macro_rules! term_fn {
-    ($func_name:ident, $value_type:ty) => {
-        #[pg_extern(name = "term", immutable, parallel_safe)]
-        pub fn $func_name(
-            field: default!(Option<String>, "NULL"),
-            value: default!(Option<$value_type>, "NULL"),
-        ) -> SearchQueryInput {
-            if let Some(value) = value {
-                SearchQueryInput::Term {
-                    field,
-                    value: TantivyValue::try_from(value)
-                        .unwrap()
-                        .tantivy_schema_value(),
-                }
-            } else {
-                panic!("no value provided to term query")
-            }
+#[pg_extern]
+pub fn term(field: default!(Option<String>, "NULL"),
+            value: default!(Option<AnyElement>, "NULL")) -> SearchQueryInput {
+    if let Some(value) = value {
+        SearchQueryInput::Term {
+            field,
+            value: unsafe { TantivyValue::try_from_anyelement(value) }
+                .unwrap()
+                .tantivy_schema_value(),
         }
-    };
+    } else {
+        panic!("no value provided to term query")
+    }
 }
-
-macro_rules! term_fn_unsupported {
-    ($func_name:ident, $value_type:ty, $term_type:literal) => {
-        #[pg_extern(name = "term", immutable, parallel_safe)]
-        #[allow(unused)]
-        pub fn $func_name(
-            field: default!(Option<String>, "NULL"),
-            value: default!(Option<$value_type>, "NULL"),
-        ) -> SearchQueryInput {
-            unimplemented!("{} in term query not implemented", $term_type)
-        }
-    };
-}
-
-// Generate functions for each type
-term_fn!(term_bytes, Vec<u8>);
-term_fn!(term_str, String);
-term_fn!(term_i8, i8);
-term_fn!(term_i16, i16);
-term_fn!(term_i32, i32);
-term_fn!(term_i64, i64);
-term_fn!(term_f32, f32);
-term_fn!(term_f64, f64);
-term_fn!(term_bool, bool);
-term_fn!(date, pgrx::Date);
-term_fn!(time, pgrx::Time);
-term_fn!(timestamp, pgrx::Timestamp);
-term_fn!(time_with_time_zone, pgrx::TimeWithTimeZone);
-term_fn!(timestamp_with_time_zome, pgrx::TimestampWithTimeZone);
-term_fn!(numeric, pgrx::AnyNumeric);
-term_fn!(uuid, pgrx::Uuid);
-term_fn_unsupported!(json, pgrx::Json, "json");
-term_fn_unsupported!(jsonb, pgrx::JsonB, "jsonb");
-term_fn_unsupported!(anyarray, pgrx::AnyArray, "array");
-term_fn_unsupported!(pg_box, pgrx::pg_sys::BOX, "box");
-term_fn_unsupported!(point, pgrx::pg_sys::Point, "point");
-term_fn_unsupported!(tid, pgrx::pg_sys::ItemPointerData, "tid");
-term_fn_unsupported!(inet, pgrx::Inet, "inet");
-term_fn_unsupported!(int4range, pgrx::Range<i32>, "int4 range");
-term_fn_unsupported!(int8range, pgrx::Range<i64>, "int8 range");
-term_fn_unsupported!(numrange, pgrx::Range<pgrx::AnyNumeric>, "numeric range");
-term_fn_unsupported!(daterange, pgrx::Range<pgrx::Date>, "date range");
-term_fn_unsupported!(tsrange, pgrx::Range<pgrx::Timestamp>, "timestamp range");
-term_fn_unsupported!(
-    tstzrange,
-    pgrx::Range<pgrx::TimestampWithTimeZone>,
-    "timestamp ranges with time zone"
-);
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn term_set(

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -17,6 +17,7 @@
 
 use crate::env::needs_commit;
 use crate::index::state::SearchStateManager;
+use crate::postgres::types::TantivyValue;
 use crate::schema::SearchConfig;
 use crate::{globals::WriterGlobal, postgres::utils::get_search_index};
 use pgrx::*;

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -54,9 +54,9 @@ fn search_tantivy(
     let hash_set = &cached.1;
     let key_field_name = &search_config.key_field;
 
-    let key_field_value = match unsafe { i64::from_datum(element.datum(), false) } {
-        None => panic!("no value present in key_field {key_field_name} in tuple"),
-        Some(value) => value,
+    let key_field_value = match unsafe { TantivyValue::try_from_datum(element.datum(), PgOid::from_untagged(element.oid())) } {
+        Err(err) => panic!("no value present in key_field {key_field_name} in tuple: {err}"),
+        Ok(value) => value,
     };
 
     hash_set.contains(&key_field_value)

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -55,7 +55,9 @@ fn search_tantivy(
     let hash_set = &cached.1;
     let key_field_name = &search_config.key_field;
 
-    let key_field_value = match unsafe { TantivyValue::try_from_datum(element.datum(), PgOid::from_untagged(element.oid())) } {
+    let key_field_value = match unsafe {
+        TantivyValue::try_from_datum(element.datum(), PgOid::from_untagged(element.oid()))
+    } {
         Err(err) => panic!("no value present in key_field {key_field_name} in tuple: {err}"),
         Ok(value) => value,
     };

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -26,14 +26,14 @@ const DEFAULT_SNIPPET_PREFIX: &str = "<b>";
 const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
 
 #[pg_extern]
-pub fn rank_bm25(key: i64, alias: default!(Option<String>, "NULL")) -> f32 {
+pub fn rank_bm25(key: String, alias: default!(Option<String>, "NULL")) -> f32 {
     SearchStateManager::get_score(key, alias.map(SearchAlias::from))
         .expect("could not lookup doc address for search query")
 }
 
 #[pg_extern]
 pub fn highlight(
-    key: i64,
+    key: String,
     field: &str,
     prefix: default!(Option<String>, "NULL"),
     postfix: default!(Option<String>, "NULL"),
@@ -66,7 +66,7 @@ pub fn highlight(
 #[pg_extern]
 pub fn minmax_bm25(
     config_json: JsonB,
-) -> TableIterator<'static, (name!(id, i64), name!(rank_bm25, f32))> {
+) -> TableIterator<'static, (name!(id, String), name!(rank_bm25, f32))> {
     let JsonB(search_config_json) = config_json;
     let search_config: SearchConfig =
         serde_json::from_value(search_config_json).expect("could not parse search config");

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -35,13 +35,11 @@ macro_rules! rank_bm25_fn {
     };
 }
 
-// #[pg_extern]
 pub fn rank_bm25_impl(key: TantivyValue, alias: default!(Option<String>, "NULL")) -> f32 {
     SearchStateManager::get_score(key, alias.map(SearchAlias::from))
         .expect("could not lookup doc address for search query")
 }
 
-// TODO: set a list of key supported pgrx key types and auto-generate all the sub-fns for it (repeat for highlight)
 rank_bm25_fn!(rank_bool, bool);
 rank_bm25_fn!(rank_i8, i8);
 rank_bm25_fn!(rank_i16, i16);
@@ -86,6 +84,7 @@ highlight_fn!(highlight_i16, i16);
 highlight_fn!(highlight_i32, i32);
 highlight_fn!(highlight_i64, i64);
 highlight_fn!(highlight_f32, f32);
+highlight_fn!(highlight_f64, f64);
 highlight_fn!(highlight_numeric, pgrx::AnyNumeric);
 highlight_fn!(highlight_string, String);
 highlight_fn!(highlight_uuid, pgrx::Uuid);
@@ -95,22 +94,14 @@ highlight_fn!(highlight_timestamp, pgrx::Timestamp);
 highlight_fn!(highlight_timetz, pgrx::TimeWithTimeZone);
 highlight_fn!(highlight_timestamptz, pgrx::TimestampWithTimeZone);
 
-// #[pg_extern]
 pub fn highlight_impl(
-    key: TantivyValue, // TODO: should be able to take in columns of other types and turn into string
-    // index_name: &str,
+    key: TantivyValue,
     field: &str,
     prefix: default!(Option<String>, "NULL"),
     postfix: default!(Option<String>, "NULL"),
     max_num_chars: default!(Option<i32>, "NULL"),
     alias: default!(Option<String>, "NULL"),
 ) -> String {
-    // let bm25_index_name = format!("{}_bm25_index", index_name);
-    // let search_index = get_search_index(&bm25_index_name);
-    // let schema = search_index.schema;
-
-    // let key_field_name = schema.fields[schema.key];
-
     let mut snippet = SearchStateManager::get_snippet(
         key,
         field,

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -42,6 +42,7 @@ pub fn rank_bm25_impl(key: TantivyValue, alias: default!(Option<String>, "NULL")
 }
 
 // TODO: set a list of key supported pgrx key types and auto-generate all the sub-fns for it (repeat for highlight)
+rank_bm25_fn!(rank_bool, bool);
 rank_bm25_fn!(rank_i8, i8);
 rank_bm25_fn!(rank_i16, i16);
 rank_bm25_fn!(rank_i32, i32);

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -124,7 +124,7 @@ key_arg_repeat_fn!(highlight_fn, highlight);
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 // #[pg_extern]
-pub fn minmax_bm25_impl<T: std::convert::TryFrom<TantivyValue>>(
+pub fn minmax_bm25_impl<T: pgrx::datum::IntoDatum + std::convert::TryFrom<TantivyValue> + 'static>(
     config_json: JsonB,
 ) -> TableIterator<'static, (name!(id, T), name!(rank_bm25, f32))> {
     let JsonB(search_config_json) = config_json;

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -48,6 +48,7 @@ rank_bm25_fn!(rank_i16, i16);
 rank_bm25_fn!(rank_i32, i32);
 rank_bm25_fn!(rank_i64, i64);
 rank_bm25_fn!(rank_f32, f32);
+rank_bm25_fn!(rank_f64, f64);
 rank_bm25_fn!(rank_numeric, pgrx::AnyNumeric);
 rank_bm25_fn!(rank_string, String);
 rank_bm25_fn!(rank_uuid, pgrx::Uuid);

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -22,9 +22,6 @@ use crate::schema::SearchConfig;
 use crate::writer::{WriterClient, WriterDirectory};
 use crate::{globals::WriterGlobal, index::SearchIndex, postgres::utils::get_search_index};
 use pgrx::{prelude::TableIterator, *};
-use thiserror::Error;
-
-use serde::{Deserialize, Deserializer, Serialize};
 
 const DEFAULT_SNIPPET_PREFIX: &str = "<b>";
 const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
@@ -32,12 +29,10 @@ const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
 macro_rules! rank_bm25_fn {
     ($func_name:ident, $key_type:ty) => {
         #[pg_extern(name = "rank_bm25")]
-        pub fn $func_name(
-            key: $key_type, alias: default!(Option<String>, "NULL")
-        ) -> f32 {
+        pub fn $func_name(key: $key_type, alias: default!(Option<String>, "NULL")) -> f32 {
             rank_bm25_impl(TantivyValue::try_from(key).unwrap(), alias)
         }
-    }
+    };
 }
 
 // #[pg_extern]
@@ -72,9 +67,16 @@ macro_rules! highlight_fn {
             max_num_chars: default!(Option<i32>, "NULL"),
             alias: default!(Option<String>, "NULL"),
         ) -> String {
-            highlight_impl(TantivyValue::try_from(key).unwrap(), field, prefix, postfix, max_num_chars, alias)
+            highlight_impl(
+                TantivyValue::try_from(key).unwrap(),
+                field,
+                prefix,
+                postfix,
+                max_num_chars,
+                alias,
+            )
         }
-    }
+    };
 }
 
 highlight_fn!(highlight_i8, i8);

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -29,7 +29,7 @@ const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
 #[pg_extern(name = "rank_bm25")]
 pub fn rank_bm25(key: AnyElement, alias: default!(Option<String>, "NULL")) -> f32 {
     let key = unsafe {
-        TantivyValue::try_from_datum(key.datum(), PgOid::from_untagged(key.oid())).unwrap()
+        TantivyValue::try_from_anyelement(key).unwrap()
     };
 
     SearchStateManager::get_score(key, alias.map(SearchAlias::from))
@@ -46,7 +46,7 @@ pub fn highlight(
     alias: default!(Option<String>, "NULL"),
 ) -> String {
     let key = unsafe {
-        TantivyValue::try_from_datum(key.datum(), PgOid::from_untagged(key.oid())).unwrap()
+        TantivyValue::try_from_anyelement(key).unwrap()
     };
 
     let mut snippet = SearchStateManager::get_snippet(

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -122,14 +122,14 @@ macro_rules! highlight_fn {
 }
 key_arg_repeat_fn!(highlight_fn, highlight);
 
-#[pg_extern(name = "minmax_bm25")]
+#[pg_extern]
 pub fn minmax_bm25(
     config_json: JsonB,
-    key_field: String,
-) -> TableIterator<'static, (name!(id, TantivyValue), name!(rank_bm25, f32))> {
+    key_type_dummy: AnyElement // this dummy is needed to allow a polymorphic return type of AnyElement
+) -> TableIterator<'static, (name!(id, AnyElement), name!(rank_bm25, f32))> {
     let JsonB(search_config_json) = config_json;
     let search_config: SearchConfig =
-        serde_json::from_value(search_config_json).expect("could not parse search config");
+        serde_json::from_value(search_config_json.clone()).expect("could not parse search config");
     let search_index = get_search_index(&search_config.index_name);
 
     let writer_client = WriterGlobal::client();
@@ -149,11 +149,12 @@ pub fn minmax_bm25(
         });
     let score_range = max_score - min_score;
 
+    let key_oid = PgOid::from_untagged(key_type_dummy.oid());
+
     // Now that we have min and max, iterate over the collected results
     let mut field_rows = Vec::new();
     for (score, doc_address) in top_docs {
-        // let key: T = TantivyValue::try_into(scan_state.key_value(doc_address)).unwrap_or_else(|_| panic!("key conversion failed!"));
-        let key = scan_state.key_value(doc_address);
+        let key = unsafe { datum::AnyElement::from_polymorphic_datum(scan_state.key_value(doc_address).try_into_datum(key_oid).unwrap(), false, key_oid.value()).unwrap() };
         let normalized_score = if score_range == 0.0 {
             1.0 // Avoid division by zero
         } else {
@@ -164,60 +165,6 @@ pub fn minmax_bm25(
     }
     TableIterator::new(field_rows)
 }
-
-// TODO: figure out how to get the right return type when the key is in the return
-
-// #[allow(clippy::not_unsafe_ptr_arg_deref)]
-// pub fn minmax_bm25_impl<T: pgrx::datum::IntoDatum + std::convert::TryFrom<TantivyValue> + 'static>(
-//     config_json: JsonB,
-// ) -> TableIterator<'static, (name!(id, T), name!(rank_bm25, f32))> {
-//     let JsonB(search_config_json) = config_json;
-//     let search_config: SearchConfig =
-//         serde_json::from_value(search_config_json).expect("could not parse search config");
-//     let search_index = get_search_index(&search_config.index_name);
-
-//     let writer_client = WriterGlobal::client();
-//     let mut scan_state = search_index
-//         .search_state(&writer_client, &search_config, needs_commit())
-//         .unwrap();
-
-//     // Collect into a Vec to allow multiple iterations
-//     let top_docs: Vec<_> = scan_state.search_dedup(search_index.executor).collect();
-
-//     // Calculate min and max scores
-//     let (min_score, max_score) = top_docs
-//         .iter()
-//         .map(|(score, _)| score)
-//         .fold((f32::MAX, f32::MIN), |(min, max), bm25| {
-//             (min.min(*bm25), max.max(*bm25))
-//         });
-//     let score_range = max_score - min_score;
-
-//     // Now that we have min and max, iterate over the collected results
-//     let mut field_rows = Vec::new();
-//     for (score, doc_address) in top_docs {
-//         let key: T = TantivyValue::try_into(scan_state.key_value(doc_address)).unwrap_or_else(|_| panic!("key conversion failed!"));
-//         let normalized_score = if score_range == 0.0 {
-//             1.0 // Avoid division by zero
-//         } else {
-//             (score - min_score) / score_range
-//         };
-
-//         field_rows.push((key, normalized_score));
-//     }
-//     TableIterator::new(field_rows)
-// }
-
-// macro_rules! minmax_bm25_fn {
-//     ($func_name:ident, $key_type:ty) => {
-//         pub fn $func_name(
-//             config_json: JsonB,
-//         ) -> TableIterator<'static, (name!(id, $key_type), name!(rank_bm25, f32))> {
-//             minmax_bm25_impl::<$key_type>(config_json).into()
-//         }
-//     };
-// }
-// key_arg_repeat_fn!(minmax_bm25_fn, minmax_bm25);
 
 #[pg_extern]
 fn drop_bm25_internal(index_name: &str) {

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -28,9 +28,7 @@ const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
 
 #[pg_extern(name = "rank_bm25")]
 pub fn rank_bm25(key: AnyElement, alias: default!(Option<String>, "NULL")) -> f32 {
-    let key = unsafe {
-        TantivyValue::try_from_anyelement(key).unwrap()
-    };
+    let key = unsafe { TantivyValue::try_from_anyelement(key).unwrap() };
 
     SearchStateManager::get_score(key, alias.map(SearchAlias::from))
         .expect("could not lookup doc address for search query")
@@ -45,9 +43,7 @@ pub fn highlight(
     max_num_chars: default!(Option<i32>, "NULL"),
     alias: default!(Option<String>, "NULL"),
 ) -> String {
-    let key = unsafe {
-        TantivyValue::try_from_anyelement(key).unwrap()
-    };
+    let key = unsafe { TantivyValue::try_from_anyelement(key).unwrap() };
 
     let mut snippet = SearchStateManager::get_snippet(
         key,

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -181,19 +181,17 @@ fn create_bm25(
     ))?;
 
     // Get the type and type oid of the key column
-    let (key_oid, key_type) = match Spi::get_two::<pg_sys::Oid, String>(
-        &format!(
-            "SELECT a.atttypid AS type_oid, CAST(t.typname AS TEXT) AS type_name
+    let (key_oid, key_type) = match Spi::get_two::<pg_sys::Oid, String>(&format!(
+        "SELECT a.atttypid AS type_oid, CAST(t.typname AS TEXT) AS type_name
             FROM pg_attribute a
             JOIN pg_type t ON a.atttypid = t.oid
             JOIN pg_class c ON a.attrelid = c.oid
             JOIN pg_namespace n ON c.relnamespace = n.oid
             WHERE c.relname = {} AND a.attname = {} AND n.nspname = {}",
-            spi::quote_literal(table_name),
-            spi::quote_literal(key_field),
-            spi::quote_literal(schema_name)
-        )
-    )? {
+        spi::quote_literal(table_name),
+        spi::quote_literal(key_field),
+        spi::quote_literal(schema_name)
+    ))? {
         (Some(key_oid), Some(key_type)) => (key_oid, key_type),
         _ => bail!("could not select key field type and type oid"),
     };
@@ -233,7 +231,7 @@ fn create_bm25(
             spi::quote_identifier(schema_name),
             spi::quote_identifier(table_name),
             key_type,
-            key_oid
+            key_oid.as_u32()
         ),
         &index_json
     ))?;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -181,6 +181,7 @@ fn create_bm25(
         &format!("RETURN QUERY SELECT * FROM paradedb.schema_bm25({})", spi::quote_literal(index_name))
     ))?;
 
+    // Get the type and type oid of the key column
     let (key_oid, key_type) = match Spi::get_two::<pg_sys::Oid, String>(
         &format!(
             "SELECT a.atttypid AS type_oid, t.typname AS type_name

--- a/pg_search/src/fixtures/mod.rs
+++ b/pg_search/src/fixtures/mod.rs
@@ -71,7 +71,11 @@ pub fn default_fields() -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldT
     let boolean: SearchFieldConfig = serde_json::from_value(json!({"Boolean": {}})).unwrap();
 
     vec![
-        ("id".into(), SearchFieldConfig::Key(numeric.clone().into()), SearchFieldType::I64),
+        (
+            "id".into(),
+            SearchFieldConfig::Key(numeric.clone().into()),
+            SearchFieldType::I64,
+        ),
         ("ctid".into(), SearchFieldConfig::Ctid, SearchFieldType::U64),
         ("description".into(), text.clone(), SearchFieldType::Text),
         ("rating".into(), numeric.clone(), SearchFieldType::I64),
@@ -90,7 +94,11 @@ pub fn chinese_fields() -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldT
     let json: SearchFieldConfig = serde_json::from_value(json!({"Json": {}})).unwrap();
 
     vec![
-        ("id".into(), SearchFieldConfig::Key(numeric.clone().into()), SearchFieldType::I64),
+        (
+            "id".into(),
+            SearchFieldConfig::Key(numeric.clone().into()),
+            SearchFieldType::I64,
+        ),
         ("ctid".into(), SearchFieldConfig::Ctid, SearchFieldType::U64),
         ("author".into(), text.clone(), SearchFieldType::Text),
         ("title".into(), text.clone(), SearchFieldType::Text),

--- a/pg_search/src/fixtures/mod.rs
+++ b/pg_search/src/fixtures/mod.rs
@@ -71,7 +71,7 @@ pub fn default_fields() -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldT
     let boolean: SearchFieldConfig = serde_json::from_value(json!({"Boolean": {}})).unwrap();
 
     vec![
-        ("id".into(), SearchFieldConfig::Key, SearchFieldType::I64),
+        ("id".into(), SearchFieldConfig::Key(numeric.clone().into()), SearchFieldType::I64),
         ("ctid".into(), SearchFieldConfig::Ctid, SearchFieldType::U64),
         ("description".into(), text.clone(), SearchFieldType::Text),
         ("rating".into(), numeric.clone(), SearchFieldType::I64),
@@ -90,7 +90,7 @@ pub fn chinese_fields() -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldT
     let json: SearchFieldConfig = serde_json::from_value(json!({"Json": {}})).unwrap();
 
     vec![
-        ("id".into(), SearchFieldConfig::Key, SearchFieldType::I64),
+        ("id".into(), SearchFieldConfig::Key(numeric.clone().into()), SearchFieldType::I64),
         ("ctid".into(), SearchFieldConfig::Ctid, SearchFieldType::U64),
         ("author".into(), text.clone(), SearchFieldType::Text),
         ("title".into(), text.clone(), SearchFieldType::Text),

--- a/pg_search/src/index/score.rs
+++ b/pg_search/src/index/score.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::postgres::types::TantivyValue;
 use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
@@ -24,7 +25,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchIndexScore {
     pub bm25: f32,
-    pub key: String,
+    pub key: TantivyValue,
 }
 
 // We do these custom trait impls, because we want these to be sortable so:

--- a/pg_search/src/index/score.rs
+++ b/pg_search/src/index/score.rs
@@ -21,10 +21,10 @@ use serde::{Deserialize, Serialize};
 
 /// A custom score struct for ordering Tantivy results.
 /// For use with the `stable` sorting feature.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchIndexScore {
     pub bm25: f32,
-    pub key: i64,
+    pub key: String,
 }
 
 // We do these custom trait impls, because we want these to be sortable so:

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -90,11 +90,9 @@ impl SearchIndex {
         // to be rebuilt and this method is called again.
         directory.remove().map_err(SearchIndexError::from)?;
 
-        pgrx::info!("creating schema from fields: {:?}", fields);
         let schema = SearchIndexSchema::new(fields)?;
 
         let tantivy_dir_path = directory.tantivy_dir_path(true)?;
-        pgrx::info!("schema key: {:?}", schema.key_field().name);
         let mut underlying_index = Index::builder()
             .schema(schema.schema.clone())
             .create_in_dir(tantivy_dir_path)

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -23,7 +23,6 @@ use pgrx::{
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
-use tantivy::schema::document::Value;
 use tantivy::{query::QueryParser, Executor, Index, Searcher};
 use tantivy::{IndexReader, IndexWriter, TantivyDocument, TantivyError};
 use thiserror::Error;

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -90,9 +90,11 @@ impl SearchIndex {
         // to be rebuilt and this method is called again.
         directory.remove().map_err(SearchIndexError::from)?;
 
+        pgrx::info!("creating schema from fields: {:?}", fields);
         let schema = SearchIndexSchema::new(fields)?;
 
         let tantivy_dir_path = directory.tantivy_dir_path(true)?;
+        pgrx::info!("schema key: {:?}", schema.key_field().name);
         let mut underlying_index = Index::builder()
             .schema(schema.schema.clone())
             .create_in_dir(tantivy_dir_path)

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError};
 use tantivy::{query::QueryParser, Executor, Index, Searcher};
-use tantivy::{IndexReader, IndexWriter, TantivyDocument, TantivyError};
+use tantivy::{schema::Value, IndexReader, IndexWriter, TantivyDocument, TantivyError};
 use thiserror::Error;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager};
 use tracing::{error, info};

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -399,7 +399,7 @@ impl SearchState {
                     // This iterator contains the results after limit + offset are applied.
                     let ctid = self.ctid_value(doc_address);
                     SearchStateManager::set_result(
-                        score.key,
+                        score.key.clone(),
                         score.bm25,
                         doc_address,
                         self.config.alias.clone(),
@@ -426,7 +426,7 @@ impl SearchState {
                     // This iterator contains the results after limit + offset are applied.
                     let (key, ctid) = self.key_and_ctid_value(doc_address);
                     SearchStateManager::set_result(
-                        key,
+                        key.clone(),
                         score,
                         doc_address,
                         self.config.alias.clone(),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -179,7 +179,8 @@ impl SearchStateManager {
         doc_address: DocAddress,
         alias: Option<SearchAlias>,
     ) -> Result<(), SearchStateError> {
-        pgrx::info!("set_result key {:?} score {:?}", key, score);
+        // THIS PRINT CAUSES TESTS TO CRASH
+        // pgrx::info!("set_result key {:?} score {:?}", key, score);
         let mut manager = SEARCH_STATE_MANAGER
             .lock()
             .map_err(SearchStateError::from)?;

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -87,9 +87,7 @@ impl SearchStateManager {
         let result_map = &manager.result_map;
         let (score, _) = result_map
             .get(&alias.unwrap_or_default())
-            .and_then(|inner_map| {
-                inner_map.get(&key)
-            })
+            .and_then(|inner_map| inner_map.get(&key))
             .ok_or(SearchStateError::DocLookup(key))?;
 
         Ok(*score)

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -17,6 +17,7 @@
 
 use super::score::SearchIndexScore;
 use super::SearchIndex;
+use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchConfig, SearchFieldName, SearchFieldType, SearchIndexSchema};
 use derive_more::{AsRef, Display, From};
 use once_cell::sync::Lazy;
@@ -447,16 +448,7 @@ impl SearchState {
             .get_first(self.schema.key_field().id.0)
             .unwrap();
 
-        match value {
-            tantivy::schema::OwnedValue::Str(string) => string.clone(),
-            tantivy::schema::OwnedValue::U64(u64) => format!("{:?}", u64),
-            tantivy::schema::OwnedValue::I64(i64) => format!("{:?}", i64),
-            tantivy::schema::OwnedValue::F64(f64) => format!("{:?}", f64),
-            tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
-            tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
-            tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
-            _ => panic!("NO"),
-        }
+        TantivyValue(value.clone()).to_string()
     }
 
     pub fn ctid_value(&self, doc_address: DocAddress) -> u64 {
@@ -482,16 +474,7 @@ impl SearchState {
             .get_first(self.schema.key_field().id.0)
             .unwrap();
 
-        let key = match value {
-            tantivy::schema::OwnedValue::Str(string) => string.clone(),
-            tantivy::schema::OwnedValue::U64(u64) => format!("{:?}", u64),
-            tantivy::schema::OwnedValue::I64(i64) => format!("{:?}", i64),
-            tantivy::schema::OwnedValue::F64(f64) => format!("{:?}", f64),
-            tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
-            tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
-            tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
-            _ => panic!("NO"),
-        };
+        let key = TantivyValue(value.clone()).to_string();
 
         let ctid = retrieved_doc
             .get_first(self.schema.ctid_field().id.0)

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -77,7 +77,10 @@ impl SearchStateManager {
             .ok_or(SearchStateError::AliasLookup(alias))
     }
 
-    pub fn get_score(key: TantivyValue, alias: Option<SearchAlias>) -> Result<Score, SearchStateError> {
+    pub fn get_score(
+        key: TantivyValue,
+        alias: Option<SearchAlias>,
+    ) -> Result<Score, SearchStateError> {
         let manager = SEARCH_STATE_MANAGER
             .lock()
             .map_err(SearchStateError::from)?;

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -291,7 +291,7 @@ impl SearchState {
             let key_field_name = self.config.key_field.clone();
             let schema = self.schema.clone();
             let collector = TopDocs::with_limit(limit).and_offset(offset).tweak_score(
-                move |segment_reader: &tantivy::SegmentReader| {
+                move |segment_reader: &tantivy::SegmentReader| -> Box<dyn FnMut(tantivy::DocId, Score) -> SearchIndexScore> {
                     let fast_fields = segment_reader
                         .fast_fields();
 
@@ -307,89 +307,83 @@ impl SearchState {
                                 .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", "id"))
                                 .first_or_default_col(0);
 
-                            move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
                                 SearchIndexScore {
                                     bm25: original_score,
                                     key: format!("{}", key_field_reader.get_val(doc)),
                                 }
-                            }
+                            })
                         }
-                        _ => panic!("test")
+                        SearchFieldType::U64 => {
+                            let key_field_reader = fast_fields
+                                .u64(&key_field_name)
+                                .unwrap_or_else(|err| panic!("key field {} is not a u64: {err:?}", "id"))
+                                .first_or_default_col(0); 
+
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                                SearchIndexScore {
+                                    bm25: original_score,
+                                    key: format!("{}", key_field_reader.get_val(doc)),
+                                }
+                            })
+                        }
+                        SearchFieldType::F64 => {
+                            let key_field_reader = fast_fields
+                                .f64(&key_field_name)
+                                .unwrap_or_else(|err| panic!("key field {} is not a f64: {err:?}", "id"))
+                                .first_or_default_col(0.0);
+
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                                SearchIndexScore {
+                                    bm25: original_score,
+                                    key: format!("{}", key_field_reader.get_val(doc)),
+                                }
+                            })
+                        }
+                        SearchFieldType::Text => {
+                            let key_field_reader = fast_fields
+                                .str(&key_field_name)
+                                .unwrap_or_else(|err| panic!("key field {} is not a string: {err:?}", "id"))
+                                .unwrap();
+
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                                let mut tok_str: String = Default::default();
+                                // TODO: not really sure what the first argument should be here
+                                key_field_reader.ord_to_str(doc.into(), &mut tok_str);
+                                SearchIndexScore {
+                                    bm25: original_score,
+                                    key: tok_str,
+                                }
+                            })
+                        }
+                        SearchFieldType::Bool => {
+                            let key_field_reader = fast_fields
+                                .bool(&key_field_name)
+                                .unwrap_or_else(|err| panic!("key field {} is not a bool: {err:?}", "id"))
+                                .first_or_default_col(false);
+
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                                SearchIndexScore {
+                                    bm25: original_score,
+                                    key: format!("{}", key_field_reader.get_val(doc)),
+                                }
+                            })
+                        }
+                        SearchFieldType::Date => {
+                            let key_field_reader = fast_fields
+                                .date(&key_field_name)
+                                .unwrap_or_else(|err| panic!("key field {} is not a date: {err:?}", "id"))
+                                .first_or_default_col(tantivy::DateTime::MIN);
+
+                            Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
+                                SearchIndexScore {
+                                    bm25: original_score,
+                                    key: format!("{}", key_field_reader.get_val(doc).into_primitive().to_string()),
+                                }
+                            })
+                        }
+                        _ => panic!("not a supported field type")
                     }
-
-                    // let i64_key_field_reader = fast_fields
-                    //     .i64(&key_field_name)
-                    //     .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", "id"))
-                    //     .first_or_default_col(0);
-                    // // let key = fast_fields
-                    // //     .i64(&key_field_name)
-                    // //     .map_or_else(|_| {
-                    // //         fast_fields.str(&key_field_name)
-                    // //         .map_or_else(|_| {
-                    // //             fast_fields.f64(&key_field_name)
-                    // //             .map_or_else(|_| {
-                    // //                 fast_fields.u64(&key_field_name)
-                    // //                 .map_or_else(|_| {
-                    // //                     fast_fields.date(&key_field_name)
-                    // //                     .map_or_else(|_| {
-                    // //                         panic!("key field not a fast field")
-                    // //                     }, |i| format!("{}", i.first_or_default_col(tantivy::DateTime::MIN).get_val(doc)))
-                    // //                 }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)))
-                    // //             }, |i| format!("{}", i.first_or_default_col(0.0).get_val(doc)))
-                    // //         }, |i| {
-                    // //             let mut ret_str: String;
-                    // //             i.ord_to_str(0, ret_str);
-                    // //             ret_str
-                    // //         })
-                    // //     }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)));
-                    // // TODO: get the value and turn into a string
-
-                    // // This function will be called on every document in the index that matches the
-                    // // query, before limit + offset are applied. It's important that it's efficient.
-                    // move |doc: tantivy::DocId, original_score: tantivy::Score| {
-                    //     // let value = doc
-                    //     //     .get_first(key_field_name)
-                    //     //     .unwrap();
-
-                    //     // let key = match value {
-                    //     //     tantivy::schema::OwnedValue::Str(string) => string.clone(),
-                    //     //     tantivy::schema::OwnedValue::U64(u64) => format!("{:?}", u64),
-                    //     //     tantivy::schema::OwnedValue::I64(i64) => format!("{:?}", i64),
-                    //     //     tantivy::schema::OwnedValue::F64(f64) => format!("{:?}", f64),
-                    //     //     tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
-                    //     //     tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
-                    //     //     tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
-                    //     //     _ => panic!("NO")
-                    //     // };
-
-                    //     // let key = fast_fields
-                    //     // .i64(&key_field_name)
-                    //     // .map_or_else(|_| {
-                    //     //     fast_fields.str(&key_field_name)
-                    //     //     .map_or_else(|_| {
-                    //     //         fast_fields.f64(&key_field_name)
-                    //     //         .map_or_else(|_| {
-                    //     //             fast_fields.u64(&key_field_name)
-                    //     //             .map_or_else(|_| {
-                    //     //                 fast_fields.date(&key_field_name)
-                    //     //                 .map_or_else(|_| {
-                    //     //                     panic!("key field not a fast field")
-                    //     //                 }, |i| format!("{}", i.first_or_default_col(tantivy::DateTime::MIN).get_val(doc).into_primitive().to_string()))
-                    //     //             }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)))
-                    //     //         }, |i| format!("{}", i.first_or_default_col(0.0).get_val(doc)))
-                    //     //     }, |i| {
-                    //     //         let mut ret_str: String;
-                    //     //         i.unwrap().ord_to_str(0, &mut ret_str);
-                    //     //         ret_str
-                    //     //     })
-                    //     // }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)));
-
-                    //     SearchIndexScore {
-                    //         bm25: original_score,
-                    //         key: format!("{}", key_field_reader.get_val(doc)),
-                    //         // key: key
-                    //     }
-                    // }
                 },
             );
             self.searcher

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -298,13 +298,31 @@ impl SearchState {
                         panic!("0!!!");
                     }
 
-                    // let key_field_reader = fast_fields
-                    //     .i64(&key_field_name)
-                    //     .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", "id"))
-                    //     .first_or_default_col(0);
-                    let key = fast_fields
+                    let key_field_reader = fast_fields
                         .i64(&key_field_name)
-                        .map()
+                        .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", "id"))
+                        .first_or_default_col(0);
+                    // let key = fast_fields
+                    //     .i64(&key_field_name)
+                    //     .map_or_else(|_| {
+                    //         fast_fields.str(&key_field_name)
+                    //         .map_or_else(|_| {
+                    //             fast_fields.f64(&key_field_name)
+                    //             .map_or_else(|_| {
+                    //                 fast_fields.u64(&key_field_name)
+                    //                 .map_or_else(|_| {
+                    //                     fast_fields.date(&key_field_name)
+                    //                     .map_or_else(|_| {
+                    //                         panic!("key field not a fast field")
+                    //                     }, |i| format!("{}", i.first_or_default_col(tantivy::DateTime::MIN).get_val(doc)))
+                    //                 }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)))
+                    //             }, |i| format!("{}", i.first_or_default_col(0.0).get_val(doc)))
+                    //         }, |i| {
+                    //             let mut ret_str: String;
+                    //             i.ord_to_str(0, ret_str);
+                    //             ret_str
+                    //         })
+                    //     }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)));
                     // TODO: get the value and turn into a string
 
                     // This function will be called on every document in the index that matches the
@@ -325,10 +343,32 @@ impl SearchState {
                         //     _ => panic!("NO")
                         // };
 
+                        // let key = fast_fields
+                        // .i64(&key_field_name)
+                        // .map_or_else(|_| {
+                        //     fast_fields.str(&key_field_name)
+                        //     .map_or_else(|_| {
+                        //         fast_fields.f64(&key_field_name)
+                        //         .map_or_else(|_| {
+                        //             fast_fields.u64(&key_field_name)
+                        //             .map_or_else(|_| {
+                        //                 fast_fields.date(&key_field_name)
+                        //                 .map_or_else(|_| {
+                        //                     panic!("key field not a fast field")
+                        //                 }, |i| format!("{}", i.first_or_default_col(tantivy::DateTime::MIN).get_val(doc).into_primitive().to_string()))
+                        //             }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)))
+                        //         }, |i| format!("{}", i.first_or_default_col(0.0).get_val(doc)))
+                        //     }, |i| {
+                        //         let mut ret_str: String;
+                        //         i.unwrap().ord_to_str(0, &mut ret_str);
+                        //         ret_str
+                        //     })
+                        // }, |i| format!("{}", i.first_or_default_col(0).get_val(doc)));
+
                         SearchIndexScore {
                             bm25: original_score,
-                            // key: key_field_reader.get_val(doc),
-                            key: key
+                            key: format!("{}", key_field_reader.get_val(doc)),
+                            // key: key
                         }
                     }
                 },
@@ -349,7 +389,7 @@ impl SearchState {
                     // This iterator contains the results after limit + offset are applied.
                     let ctid = self.ctid_value(doc_address);
                     SearchStateManager::set_result(
-                        score.key,
+                        score.key.clone(),
                         score.bm25,
                         doc_address,
                         self.config.alias.clone(),
@@ -376,7 +416,7 @@ impl SearchState {
                     // This iterator contains the results after limit + offset are applied.
                     let (key, ctid) = self.key_and_ctid_value(doc_address);
                     SearchStateManager::set_result(
-                        key,
+                        key.clone(),
                         score,
                         doc_address,
                         self.config.alias.clone(),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -295,16 +295,12 @@ impl SearchState {
                     let fast_fields = segment_reader
                         .fast_fields();
 
-                    if fast_fields.column_num_bytes(&key_field_name).unwrap() == 0 {
-                        panic!("0!!!");
-                    }
-
                     // Check the type of the field from the schema
                     match schema.get_search_field(&key_field_name.clone().into()).unwrap_or_else(|| panic!("key field {} not found", key_field_name)).type_ {
                         SearchFieldType::I64 => {
                             let key_field_reader = fast_fields
                                 .i64(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a i64: {err:?}", key_field_name))
                                 .first_or_default_col(0);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -317,7 +313,7 @@ impl SearchState {
                         SearchFieldType::U64 => {
                             let key_field_reader = fast_fields
                                 .u64(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a u64: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a u64: {err:?}", key_field_name))
                                 .first_or_default_col(0);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -330,7 +326,7 @@ impl SearchState {
                         SearchFieldType::F64 => {
                             let key_field_reader = fast_fields
                                 .f64(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a f64: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a f64: {err:?}", key_field_name))
                                 .first_or_default_col(0.0);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -343,7 +339,7 @@ impl SearchState {
                         SearchFieldType::Text => {
                             let key_field_reader = fast_fields
                                 .str(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a string: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a string: {err:?}", key_field_name))
                                 .unwrap();
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -359,7 +355,7 @@ impl SearchState {
                         SearchFieldType::Bool => {
                             let key_field_reader = fast_fields
                                 .bool(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a bool: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a bool: {err:?}", key_field_name))
                                 .first_or_default_col(false);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -372,7 +368,7 @@ impl SearchState {
                         SearchFieldType::Date => {
                             let key_field_reader = fast_fields
                                 .date(&key_field_name)
-                                .unwrap_or_else(|err| panic!("key field {} is not a date: {err:?}", "id"))
+                                .unwrap_or_else(|err| panic!("key field {} is not a date: {err:?}", key_field_name))
                                 .first_or_default_col(tantivy::DateTime::MIN);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
@@ -382,7 +378,7 @@ impl SearchState {
                                 }
                             })
                         }
-                        _ => panic!("not a supported field type")
+                        _ => panic!("key field {} is not a supported field type", key_field_name)
                     }
                 },
             );

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -349,8 +349,8 @@ impl SearchState {
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
                                 let mut tok_str: String = Default::default();
-                                let ord = key_field_reader.term_ords(doc.into()).nth(0).unwrap();
-                                key_field_reader.ord_to_str(ord.into(), &mut tok_str).expect("no string!!");
+                                let ord = key_field_reader.term_ords(doc).nth(0).unwrap();
+                                key_field_reader.ord_to_str(ord, &mut tok_str).expect("no string!!");
                                 SearchIndexScore {
                                     bm25: original_score,
                                     key: TantivyValue(tok_str.clone().into()),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -442,7 +442,7 @@ impl SearchState {
         }
     }
 
-    pub fn key_value(&self, doc_address: DocAddress) -> String {
+    pub fn key_value(&self, doc_address: DocAddress) -> TantivyValue {
         let retrieved_doc: TantivyDocument = self
             .searcher
             .doc(doc_address)
@@ -452,7 +452,7 @@ impl SearchState {
             .get_first(self.schema.key_field().id.0)
             .unwrap();
 
-        TantivyValue(value.clone()).to_string()
+        TantivyValue(value.clone())
     }
 
     pub fn ctid_value(&self, doc_address: DocAddress) -> u64 {

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -318,7 +318,7 @@ impl SearchState {
                             let key_field_reader = fast_fields
                                 .u64(&key_field_name)
                                 .unwrap_or_else(|err| panic!("key field {} is not a u64: {err:?}", "id"))
-                                .first_or_default_col(0); 
+                                .first_or_default_col(0);
 
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
                                 SearchIndexScore {
@@ -349,7 +349,7 @@ impl SearchState {
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
                                 let mut tok_str: String = Default::default();
                                 // TODO: not really sure what the first argument should be here
-                                key_field_reader.ord_to_str(doc.into(), &mut tok_str);
+                                key_field_reader.ord_to_str(doc.into(), &mut tok_str).expect("no string!!");
                                 SearchIndexScore {
                                     bm25: original_score,
                                     key: tok_str,
@@ -378,7 +378,7 @@ impl SearchState {
                             Box::new(move |doc: tantivy::DocId, original_score: tantivy::Score| {
                                 SearchIndexScore {
                                     bm25: original_score,
-                                    key: format!("{}", key_field_reader.get_val(doc).into_primitive().to_string()),
+                                    key: key_field_reader.get_val(doc).into_primitive().to_string(),
                                 }
                             })
                         }
@@ -459,7 +459,7 @@ impl SearchState {
             tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
             tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
             tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
-            _ => panic!("NO")
+            _ => panic!("NO"),
         }
     }
 
@@ -482,11 +482,6 @@ impl SearchState {
             .doc(doc_address)
             .expect("could not retrieve document by address");
 
-        // let key = retrieved_doc
-        //     .get_first(self.schema.key_field().id.0)
-        //     .unwrap()
-        //     .as_i64()
-        //     .expect("could not access key field on document");
         let value = retrieved_doc
             .get_first(self.schema.key_field().id.0)
             .unwrap();
@@ -499,7 +494,7 @@ impl SearchState {
             tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
             tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
             tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
-            _ => panic!("NO")
+            _ => panic!("NO"),
         };
 
         let ctid = retrieved_doc

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -51,6 +51,11 @@ pub unsafe extern "C" fn _PG_init() {
     postgres::options::init();
     GUCS.init("pg_search");
 
+    std::panic::set_hook(Box::new(|panic_info| {
+        let backtrace = std::backtrace::Backtrace::capture();
+        eprintln!("Panic info: {panic_info:?}, backtrace: {backtrace:#?}");
+    }));
+
     // Set up the writer bgworker shared state.
     pg_shmem_init!(WRITER_GLOBAL);
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -51,6 +51,8 @@ pub unsafe extern "C" fn _PG_init() {
     postgres::options::init();
     GUCS.init("pg_search");
 
+    simple_logging::log_to_file("/Users/Suriya/Documents/parade/test.log", log::LevelFilter::Debug);
+
     // Set up the writer bgworker shared state.
     pg_shmem_init!(WRITER_GLOBAL);
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -51,8 +51,6 @@ pub unsafe extern "C" fn _PG_init() {
     postgres::options::init();
     GUCS.init("pg_search");
 
-    simple_logging::log_to_file("/Users/Suriya/Documents/parade/test.log", log::LevelFilter::Debug);
-
     // Set up the writer bgworker shared state.
     pg_shmem_init!(WRITER_GLOBAL);
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -51,11 +51,6 @@ pub unsafe extern "C" fn _PG_init() {
     postgres::options::init();
     GUCS.init("pg_search");
 
-    std::panic::set_hook(Box::new(|panic_info| {
-        let backtrace = std::backtrace::Backtrace::capture();
-        eprintln!("Panic info: {panic_info:?}, backtrace: {backtrace:#?}");
-    }));
-
     // Set up the writer bgworker shared state.
     pg_shmem_init!(WRITER_GLOBAL);
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -133,11 +133,13 @@ pub extern "C" fn ambuild(
         None => panic!("key field does not exist"),
     };
     let key_config = match key_field_type {
-        SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => SearchFieldConfig::Numeric {
-            indexed: true, 
-            fast: true,
-            stored: true,
-        },
+        SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => {
+            SearchFieldConfig::Numeric {
+                indexed: true,
+                fast: true,
+                stored: true,
+            }
+        }
         SearchFieldType::Text => SearchFieldConfig::Text {
             indexed: true,
             fast: true,
@@ -145,7 +147,7 @@ pub extern "C" fn ambuild(
             fieldnorms: false,
             tokenizer: SearchTokenizer::Raw,
             record: IndexRecordOption::Basic,
-            normalizer: SearchNormalizer::Raw
+            normalizer: SearchNormalizer::Raw,
         },
         SearchFieldType::Json => SearchFieldConfig::Json {
             indexed: true,
@@ -154,7 +156,7 @@ pub extern "C" fn ambuild(
             expand_dots: false,
             tokenizer: SearchTokenizer::Raw,
             record: IndexRecordOption::Basic,
-            normalizer: SearchNormalizer::Raw
+            normalizer: SearchNormalizer::Raw,
         },
         SearchFieldType::Bool => SearchFieldConfig::Boolean {
             indexed: true,
@@ -165,7 +167,7 @@ pub extern "C" fn ambuild(
             indexed: true,
             fast: true,
             stored: true,
-        }
+        },
     };
 
     // Concatenate the separate lists of fields.

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -96,9 +96,9 @@ pub extern "C" fn ambuild(
         .get_numeric_fields()
         .into_iter()
         .map(|(name, config)| match name_type_map.get(&name) {
-            Some(field_type @ SearchFieldType::I64) | Some(field_type @ SearchFieldType::F64) => {
-                (name, config, *field_type)
-            }
+            Some(field_type @ SearchFieldType::U64)
+            | Some(field_type @ SearchFieldType::I64)
+            | Some(field_type @ SearchFieldType::F64) => (name, config, *field_type),
             _ => panic!("'{name}' cannot be indexed as a numeric field"),
         });
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -177,7 +177,7 @@ pub extern "C" fn ambuild(
         .chain(datetime_fields)
         .chain(std::iter::once((
             key_field,
-            key_config, // make this a type-based config instead
+            SearchFieldConfig::Key(key_config.into()), // make this a type-based config instead
             *key_field_type,
         )))
         // "ctid" is a reserved column name in Postgres, so we don't need to worry about

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -25,6 +25,8 @@ use crate::writer::WriterDirectory;
 use pgrx::*;
 use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
+use tantivy::schema::IndexRecordOption;
+use tokenizers::{SearchNormalizer, SearchTokenizer};
 
 // For now just pass the count on the build callback state
 struct BuildState {
@@ -66,6 +68,7 @@ pub extern "C" fn ambuild(
         .filter_map(|attribute| {
             let attname = attribute.name();
             let attribute_type_oid = attribute.type_oid();
+            pgrx::info!("name: {:?}, oid: {:?}", attname, attribute_type_oid);
             let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
             let base_oid = if array_type != pg_sys::InvalidOid {
                 PgOid::from(array_type)
@@ -126,11 +129,44 @@ pub extern "C" fn ambuild(
         });
 
     let key_field = rdopts.get_key_field().expect("must specify key field");
-
-    match name_type_map.get(&key_field) {
-        Some(SearchFieldType::I64) => {}
+    let key_field_type = match name_type_map.get(&key_field) {
+        Some(field_type) => field_type,
         None => panic!("key field does not exist"),
-        _ => panic!("key field must be an integer"),
+    };
+    let key_config = match key_field_type {
+        SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => SearchFieldConfig::Numeric {
+            indexed: true, 
+            fast: true,
+            stored: true,
+        },
+        SearchFieldType::Text => SearchFieldConfig::Text {
+            indexed: true,
+            fast: true,
+            stored: true,
+            fieldnorms: false,
+            tokenizer: SearchTokenizer::Raw,
+            record: IndexRecordOption::Basic,
+            normalizer: SearchNormalizer::Raw
+        },
+        SearchFieldType::Json => SearchFieldConfig::Json {
+            indexed: true,
+            fast: true,
+            stored: true,
+            expand_dots: false,
+            tokenizer: SearchTokenizer::Raw,
+            record: IndexRecordOption::Basic,
+            normalizer: SearchNormalizer::Raw
+        },
+        SearchFieldType::Bool => SearchFieldConfig::Boolean {
+            indexed: true,
+            fast: true,
+            stored: true,
+        },
+        SearchFieldType::Date => SearchFieldConfig::Date {
+            indexed: true,
+            fast: true,
+            stored: true,
+        }
     };
 
     // Concatenate the separate lists of fields.
@@ -141,8 +177,8 @@ pub extern "C" fn ambuild(
         .chain(datetime_fields)
         .chain(std::iter::once((
             key_field,
-            SearchFieldConfig::Key,
-            SearchFieldType::I64,
+            key_config, // make this a type-based config instead
+            *key_field_type,
         )))
         // "ctid" is a reserved column name in Postgres, so we don't need to worry about
         // creating a name conflict with a user-named column.

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -178,7 +178,7 @@ pub extern "C" fn ambuild(
         .chain(datetime_fields)
         .chain(std::iter::once((
             key_field,
-            SearchFieldConfig::Key(key_config.into()), // make this a type-based config instead
+            SearchFieldConfig::Key(key_config.into()),
             *key_field_type,
         )))
         // "ctid" is a reserved column name in Postgres, so we don't need to worry about

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -68,7 +68,6 @@ pub extern "C" fn ambuild(
         .filter_map(|attribute| {
             let attname = attribute.name();
             let attribute_type_oid = attribute.type_oid();
-            pgrx::info!("name: {:?}, oid: {:?}", attname, attribute_type_oid);
             let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
             let base_oid = if array_type != pg_sys::InvalidOid {
                 PgOid::from(array_type)

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -99,7 +99,7 @@ pub fn tantivy_value_to_pgrx_date(
 ) -> Result<pgrx::Date, DatetimeConversionError> {
     let prim_dt = value.into_primitive();
     pgrx::Date::new(prim_dt.year(), prim_dt.month().into(), prim_dt.day())
-    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+        .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
 }
 
 pub fn pgrx_timestamp_to_tantivy_value(

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -20,6 +20,8 @@ use thiserror::Error;
 
 static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
 
+// TODO: create a conversion trait
+
 fn datetime_components_to_tantivy_date(
     ymd: Option<(i32, u8, u8)>,
     hms_micro: (u8, u8, u8, u32),

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -16,16 +16,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use thiserror::Error;
+use pgrx::datum::datetime_support::DateTimeConversionError;
 
-static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
+pub static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
 
-// TODO: create a conversion trait
-
-fn datetime_components_to_tantivy_date(
+pub fn datetime_components_to_tantivy_date(
     ymd: Option<(i32, u8, u8)>,
     hms_micro: (u8, u8, u8, u32),
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
+) -> Result<tantivy::schema::OwnedValue, DateTimeConversionError> {
     let naive_dt = match ymd {
         Some(ymd) => NaiveDate::from_ymd_opt(ymd.0, ymd.1.into(), ymd.2.into()).unwrap(),
         None => NaiveDateTime::UNIX_EPOCH.date(),
@@ -36,130 +34,10 @@ fn datetime_components_to_tantivy_date(
         hms_micro.2.into(),
         hms_micro.3 % MICROSECONDS_IN_SECOND,
     )
-    .ok_or(DatetimeConversionError::FailedPostgresToTantivy)?
+    .ok_or(DateTimeConversionError::OutOfRange)?
     .and_utc();
 
     Ok(tantivy::schema::OwnedValue::Date(
         tantivy::DateTime::from_timestamp_micros(naive_dt.timestamp_micros()),
     ))
-}
-
-pub fn pgrx_time_to_tantivy_value(
-    value: pgrx::Time,
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
-    let (v_h, v_m, v_s, v_ms) = value.to_hms_micro();
-    datetime_components_to_tantivy_date(None, (v_h, v_m, v_s, v_ms))
-}
-
-pub fn tantivy_value_to_pgrx_time(
-    value: tantivy::DateTime,
-) -> Result<pgrx::Time, DatetimeConversionError> {
-    let prim_dt = value.into_primitive();
-    let (h, m, s, micro) = prim_dt.as_hms_micro();
-    pgrx::Time::new(
-        h,
-        m,
-        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
-    )
-    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
-}
-
-pub fn pgrx_timetz_to_tantivy_value(
-    value: pgrx::TimeWithTimeZone,
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
-    let (v_h, v_m, v_s, v_ms) = value.to_utc().to_hms_micro();
-    datetime_components_to_tantivy_date(None, (v_h, v_m, v_s, v_ms))
-}
-
-pub fn tantivy_value_to_pgrx_timetz(
-    value: tantivy::DateTime,
-) -> Result<pgrx::TimeWithTimeZone, DatetimeConversionError> {
-    let prim_dt = value.into_primitive();
-    let (h, m, s, micro) = prim_dt.as_hms_micro();
-    pgrx::TimeWithTimeZone::with_timezone(
-        h,
-        m,
-        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
-        "UTC",
-    )
-    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
-}
-
-pub fn pgrx_date_to_tantivy_value(
-    value: pgrx::Date,
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
-    datetime_components_to_tantivy_date(
-        Some((value.year(), value.month(), value.day())),
-        (0, 0, 0, 0),
-    )
-}
-
-pub fn tantivy_value_to_pgrx_date(
-    value: tantivy::DateTime,
-) -> Result<pgrx::Date, DatetimeConversionError> {
-    let prim_dt = value.into_primitive();
-    pgrx::Date::new(prim_dt.year(), prim_dt.month().into(), prim_dt.day())
-        .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
-}
-
-pub fn pgrx_timestamp_to_tantivy_value(
-    value: pgrx::Timestamp,
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
-    let (v_h, v_m, v_s, v_ms) = value.to_hms_micro();
-    datetime_components_to_tantivy_date(
-        Some((value.year(), value.month(), value.day())),
-        (v_h, v_m, v_s, v_ms),
-    )
-}
-
-pub fn tantivy_value_to_pgrx_timestamp(
-    value: tantivy::DateTime,
-) -> Result<pgrx::Timestamp, DatetimeConversionError> {
-    let prim_dt = value.into_primitive();
-    let (h, m, s, micro) = prim_dt.as_hms_micro();
-    pgrx::Timestamp::new(
-        prim_dt.year(),
-        prim_dt.month().into(),
-        prim_dt.day(),
-        h,
-        m,
-        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
-    )
-    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
-}
-
-pub fn pgrx_timestamptz_to_tantivy_value(
-    value: pgrx::TimestampWithTimeZone,
-) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
-    let (v_h, v_m, v_s, v_ms) = value.to_utc().to_hms_micro();
-    datetime_components_to_tantivy_date(
-        Some((value.year(), value.month(), value.day())),
-        (v_h, v_m, v_s, v_ms),
-    )
-}
-
-pub fn tantivy_value_to_pgrx_timestamptz(
-    value: tantivy::DateTime,
-) -> Result<pgrx::TimestampWithTimeZone, DatetimeConversionError> {
-    let prim_dt = value.into_primitive();
-    let (h, m, s, micro) = prim_dt.as_hms_micro();
-    pgrx::TimestampWithTimeZone::with_timezone(
-        prim_dt.year(),
-        prim_dt.month().into(),
-        prim_dt.day(),
-        h,
-        m,
-        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
-        "UTC",
-    )
-    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
-}
-
-#[derive(Error, Debug)]
-pub enum DatetimeConversionError {
-    #[error("Could not convert postgres datetime to TantivyValue")]
-    FailedPostgresToTantivy,
-
-    #[error("Could not convert TantivyValue datetime to postgres")]
-    FailedTantivyToPostgres,
 }

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -16,13 +16,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use chrono::{NaiveDate, NaiveDateTime};
+use thiserror::Error;
 
 static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
 
 fn datetime_components_to_tantivy_date(
     ymd: Option<(i32, u8, u8)>,
     hms_micro: (u8, u8, u8, u32),
-) -> tantivy::schema::OwnedValue {
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     let naive_dt = match ymd {
         Some(ymd) => NaiveDate::from_ymd_opt(ymd.0, ymd.1.into(), ymd.2.into()).unwrap(),
         None => NaiveDateTime::UNIX_EPOCH.date(),
@@ -33,32 +34,75 @@ fn datetime_components_to_tantivy_date(
         hms_micro.2.into(),
         hms_micro.3 % MICROSECONDS_IN_SECOND,
     )
-    .unwrap()
+    .ok_or(DatetimeConversionError::FailedPostgresToTantivy)?
     .and_utc();
 
-    tantivy::schema::OwnedValue::Date(tantivy::DateTime::from_timestamp_micros(
-        naive_dt.timestamp_micros(),
+    Ok(tantivy::schema::OwnedValue::Date(
+        tantivy::DateTime::from_timestamp_micros(naive_dt.timestamp_micros()),
     ))
 }
 
-pub fn pgrx_time_to_tantivy_value(value: pgrx::Time) -> tantivy::schema::OwnedValue {
+pub fn pgrx_time_to_tantivy_value(
+    value: pgrx::Time,
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     let (v_h, v_m, v_s, v_ms) = value.to_hms_micro();
     datetime_components_to_tantivy_date(None, (v_h, v_m, v_s, v_ms))
 }
 
-pub fn pgrx_timetz_to_tantivy_value(value: pgrx::TimeWithTimeZone) -> tantivy::schema::OwnedValue {
+pub fn tantivy_value_to_pgrx_time(
+    value: tantivy::DateTime,
+) -> Result<pgrx::Time, DatetimeConversionError> {
+    let prim_dt = value.into_primitive();
+    let (h, m, s, micro) = prim_dt.as_hms_micro();
+    pgrx::Time::new(
+        h,
+        m,
+        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
+    )
+    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+}
+
+pub fn pgrx_timetz_to_tantivy_value(
+    value: pgrx::TimeWithTimeZone,
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     let (v_h, v_m, v_s, v_ms) = value.to_utc().to_hms_micro();
     datetime_components_to_tantivy_date(None, (v_h, v_m, v_s, v_ms))
 }
 
-pub fn pgrx_date_to_tantivy_value(value: pgrx::Date) -> tantivy::schema::OwnedValue {
+pub fn tantivy_value_to_pgrx_timetz(
+    value: tantivy::DateTime,
+) -> Result<pgrx::TimeWithTimeZone, DatetimeConversionError> {
+    let prim_dt = value.into_primitive();
+    let (h, m, s, micro) = prim_dt.as_hms_micro();
+    pgrx::TimeWithTimeZone::with_timezone(
+        h,
+        m,
+        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
+        "UTC",
+    )
+    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+}
+
+pub fn pgrx_date_to_tantivy_value(
+    value: pgrx::Date,
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     datetime_components_to_tantivy_date(
         Some((value.year(), value.month(), value.day())),
         (0, 0, 0, 0),
     )
 }
 
-pub fn pgrx_timestamp_to_tantivy_value(value: pgrx::Timestamp) -> tantivy::schema::OwnedValue {
+pub fn tantivy_value_to_pgrx_date(
+    value: tantivy::DateTime,
+) -> Result<pgrx::Date, DatetimeConversionError> {
+    let prim_dt = value.into_primitive();
+    pgrx::Date::new(prim_dt.year(), prim_dt.month().into(), prim_dt.day())
+    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+}
+
+pub fn pgrx_timestamp_to_tantivy_value(
+    value: pgrx::Timestamp,
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     let (v_h, v_m, v_s, v_ms) = value.to_hms_micro();
     datetime_components_to_tantivy_date(
         Some((value.year(), value.month(), value.day())),
@@ -66,12 +110,54 @@ pub fn pgrx_timestamp_to_tantivy_value(value: pgrx::Timestamp) -> tantivy::schem
     )
 }
 
+pub fn tantivy_value_to_pgrx_timestamp(
+    value: tantivy::DateTime,
+) -> Result<pgrx::Timestamp, DatetimeConversionError> {
+    let prim_dt = value.into_primitive();
+    let (h, m, s, micro) = prim_dt.as_hms_micro();
+    pgrx::Timestamp::new(
+        prim_dt.year(),
+        prim_dt.month().into(),
+        prim_dt.day(),
+        h,
+        m,
+        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
+    )
+    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+}
+
 pub fn pgrx_timestamptz_to_tantivy_value(
     value: pgrx::TimestampWithTimeZone,
-) -> tantivy::schema::OwnedValue {
+) -> Result<tantivy::schema::OwnedValue, DatetimeConversionError> {
     let (v_h, v_m, v_s, v_ms) = value.to_utc().to_hms_micro();
     datetime_components_to_tantivy_date(
         Some((value.year(), value.month(), value.day())),
         (v_h, v_m, v_s, v_ms),
     )
+}
+
+pub fn tantivy_value_to_pgrx_timestamptz(
+    value: tantivy::DateTime,
+) -> Result<pgrx::TimestampWithTimeZone, DatetimeConversionError> {
+    let prim_dt = value.into_primitive();
+    let (h, m, s, micro) = prim_dt.as_hms_micro();
+    pgrx::TimestampWithTimeZone::with_timezone(
+        prim_dt.year(),
+        prim_dt.month().into(),
+        prim_dt.day(),
+        h,
+        m,
+        s as f64 + ((micro as f64) / (MICROSECONDS_IN_SECOND as f64)),
+        "UTC",
+    )
+    .map_err(|_| DatetimeConversionError::FailedTantivyToPostgres)
+}
+
+#[derive(Error, Debug)]
+pub enum DatetimeConversionError {
+    #[error("Could not convert postgres datetime to TantivyValue")]
+    FailedPostgresToTantivy,
+
+    #[error("Could not convert TantivyValue datetime to postgres")]
+    FailedTantivyToPostgres,
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -27,6 +27,7 @@ mod vacuum;
 mod validate;
 
 pub mod datetime;
+pub mod types;
 pub mod utils;
 
 #[pg_extern(sql = "

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -95,7 +95,7 @@ pub extern "C" fn amgettuple(
 ) -> bool {
     let mut scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
     let iter =
-        unsafe { (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, i64, u64)>).as_mut() }
+        unsafe { (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, String, u64)>).as_mut() }
             .expect("no scandesc state");
 
     scan.xs_recheck = false;

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -94,9 +94,10 @@ pub extern "C" fn amgettuple(
     _direction: pg_sys::ScanDirection,
 ) -> bool {
     let mut scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
-    let iter =
-        unsafe { (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, String, u64)>).as_mut() }
-            .expect("no scandesc state");
+    let iter = unsafe {
+        (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, String, u64)>).as_mut()
+    }
+    .expect("no scandesc state");
 
     scan.xs_recheck = false;
 

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -17,6 +17,7 @@
 
 use crate::env::needs_commit;
 use crate::index::state::SearchStateManager;
+use crate::postgres::types::TantivyValue;
 use crate::schema::SearchConfig;
 use crate::{globals::WriterGlobal, postgres::utils::get_search_index};
 use pgrx::*;
@@ -95,7 +96,7 @@ pub extern "C" fn amgettuple(
 ) -> bool {
     let mut scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
     let iter = unsafe {
-        (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, String, u64)>).as_mut()
+        (scan.opaque as *mut std::vec::IntoIter<(Score, DocAddress, TantivyValue, u64)>).as_mut()
     }
     .expect("no scandesc state");
 

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, PostgresType)]
 pub struct TantivyValue(pub tantivy::schema::OwnedValue);
 
 impl TantivyValue {

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -173,6 +173,10 @@ impl TantivyValue {
             _ => Err(TantivyValueError::InvalidOid),
         }
     }
+
+    pub unsafe fn try_from_anyelement(any_element: pgrx::AnyElement) -> Result<Self, TantivyValueError> {
+        Self::try_from_datum(any_element.datum(), PgOid::from_untagged(any_element.oid()))
+    }
 }
 
 impl fmt::Display for TantivyValue {

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -776,7 +776,7 @@ impl TryFrom<TantivyValue> for pgrx::Uuid {
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
         if let tantivy::schema::OwnedValue::Str(val) = value.0 {
             Ok(pgrx::Uuid::from_slice(val.as_bytes())
-                .map_err(|err| TantivyValueError::UuidConversionError(err))?)
+                .map_err(TantivyValueError::UuidConversionError)?)
         } else {
             Err(TantivyValueError::UnsupportedIntoConversion(
                 "uuid".to_string(),

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -900,7 +900,7 @@ pub enum TantivyValueError {
     #[error(transparent)]
     PgrxNumericError(#[from] pgrx::datum::numeric_support::error::Error),
 
-    #[error(transparent)]
+    #[error("Could not generate datetime datum")]
     DateTimeConversionError(#[from] DateTimeConversionError),
 
     #[error("Failed UUID conversion: {0}")]

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -1,0 +1,272 @@
+// Convert pgrx types into tantivy values
+use crate::postgres::datetime::{
+    pgrx_date_to_tantivy_value, pgrx_time_to_tantivy_value, pgrx_timestamp_to_tantivy_value,
+    pgrx_timestamptz_to_tantivy_value, pgrx_timetz_to_tantivy_value,
+};
+use thiserror::Error;
+
+pub struct TantivyValue(pub tantivy::schema::OwnedValue);
+
+impl TantivyValue {
+    pub fn tantivy_schema_value(&self) -> tantivy::schema::OwnedValue {
+        self.0.clone()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum TantivyValueError {
+    #[error("{0} term not supported")]
+    TermNotImplemented(String),
+
+    #[error(transparent)]
+    PgrxNumericError(#[from] pgrx::datum::numeric_support::error::Error),
+}
+
+impl ToString for TantivyValue {
+    fn to_string(&self) -> String {
+        match self.tantivy_schema_value() {
+            tantivy::schema::OwnedValue::Str(string) => string.clone(),
+            tantivy::schema::OwnedValue::U64(u64) => format!("{:?}", u64),
+            tantivy::schema::OwnedValue::I64(i64) => format!("{:?}", i64),
+            tantivy::schema::OwnedValue::F64(f64) => format!("{:?}", f64),
+            tantivy::schema::OwnedValue::Bool(bool) => format!("{:?}", bool),
+            tantivy::schema::OwnedValue::Date(datetime) => datetime.into_primitive().to_string(),
+            tantivy::schema::OwnedValue::Bytes(bytes) => String::from_utf8(bytes.clone()).unwrap(),
+            _ => panic!("tantivy owned value not supported"),
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::Bytes(val)))
+    }
+}
+
+impl TryFrom<String> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: String) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::Str(val)))
+    }
+}
+
+impl TryFrom<i8> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: i8) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::I64(val as i64)))
+    }
+}
+
+impl TryFrom<i16> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: i16) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::I64(val as i64)))
+    }
+}
+
+impl TryFrom<i32> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: i32) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::I64(val as i64)))
+    }
+}
+
+impl TryFrom<i64> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: i64) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::I64(val)))
+    }
+}
+
+impl TryFrom<f32> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: f32) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::F64(val as f64)))
+    }
+}
+
+impl TryFrom<f64> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: f64) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::F64(val)))
+    }
+}
+
+impl TryFrom<bool> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: bool) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::Bool(val)))
+    }
+}
+
+impl TryFrom<pgrx::Json> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Json) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("json".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::JsonB> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::JsonB) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("jsonb".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Date> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Date) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(pgrx_date_to_tantivy_value(val)))
+    }
+}
+
+impl TryFrom<pgrx::Time> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Time) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(pgrx_time_to_tantivy_value(val)))
+    }
+}
+
+impl TryFrom<pgrx::Timestamp> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Timestamp) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(pgrx_timestamp_to_tantivy_value(val)))
+    }
+}
+
+impl TryFrom<pgrx::TimeWithTimeZone> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::TimeWithTimeZone) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(pgrx_timetz_to_tantivy_value(val)))
+    }
+}
+
+impl TryFrom<pgrx::TimestampWithTimeZone> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::TimestampWithTimeZone) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(pgrx_timestamptz_to_tantivy_value(val)))
+    }
+}
+
+impl TryFrom<pgrx::AnyArray> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::AnyArray) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("array".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::pg_sys::BOX> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::pg_sys::BOX) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("box".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::pg_sys::Point> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::pg_sys::Point) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("point".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::pg_sys::ItemPointerData> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::pg_sys::ItemPointerData) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("tid".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Inet> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Inet) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("inet".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::AnyNumeric> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::AnyNumeric) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::F64(val.try_into()?)))
+    }
+}
+
+impl TryFrom<pgrx::Range<i32>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<i32>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("int4 range".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Range<i64>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<i64>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("int8 range".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Range<pgrx::AnyNumeric>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<pgrx::AnyNumeric>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("nuemric range".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Range<pgrx::Date>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<pgrx::Date>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("date range".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Range<pgrx::Timestamp>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<pgrx::Timestamp>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented("timestamp range".to_string()))
+    }
+}
+
+impl TryFrom<pgrx::Range<pgrx::TimestampWithTimeZone>> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Range<pgrx::TimestampWithTimeZone>) -> Result<Self, Self::Error> {
+        Err(TantivyValueError::TermNotImplemented(
+            "timestamp with time zone range".to_string(),
+        ))
+    }
+}
+
+impl TryFrom<pgrx::Uuid> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(val: pgrx::Uuid) -> Result<Self, Self::Error> {
+        Ok(TantivyValue(tantivy::schema::OwnedValue::Str(val.to_string())))
+    }
+}

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -174,7 +174,9 @@ impl TantivyValue {
         }
     }
 
-    pub unsafe fn try_from_anyelement(any_element: pgrx::AnyElement) -> Result<Self, TantivyValueError> {
+    pub unsafe fn try_from_anyelement(
+        any_element: pgrx::AnyElement,
+    ) -> Result<Self, TantivyValueError> {
         Self::try_from_datum(any_element.datum(), PgOid::from_untagged(any_element.oid()))
     }
 }

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -12,6 +12,8 @@ use serde_json::Map;
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::num::ParseFloatError;
+use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, PartialEq, PostgresType)]
@@ -420,22 +422,16 @@ impl TryFrom<TantivyValue> for i64 {
     }
 }
 
-const U32_HIGHEST_BIT: u32 = 1 << 31;
 impl TryFrom<f32> for TantivyValue {
     type Error = TantivyValueError;
 
     fn try_from(val: f32) -> Result<Self, Self::Error> {
         // Casting f32 to f64 causes some precision errors when Tantivy writes the document.
-        //     For now, we store the bit representation of the f32 as a u32 and cast to a u64.
-        let bits = val.to_bits();
-        let val_as_u32: u32 = if val.is_sign_positive() {
-            bits ^ U32_HIGHEST_BIT
-        } else {
-            !bits
-        };
-        Ok(TantivyValue(tantivy::schema::OwnedValue::U64(
-            val_as_u32 as u64,
-        )))
+        //     To avoid this, we string format the f32 and then read it as f64.
+        let f32_string = format!("{}", val);
+        let val_as_f64 = f64::from_str(&f32_string)?;
+
+        Ok(TantivyValue(tantivy::schema::OwnedValue::F64(val_as_f64)))
     }
 }
 
@@ -443,15 +439,12 @@ impl TryFrom<TantivyValue> for f32 {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::U64(val) = value.0 {
+        if let tantivy::schema::OwnedValue::F64(val) = value.0 {
             // Casting f32 to f64 causes some precision errors when Tantivy writes the document.
-            //     For now, we store the bit representation of the f32 as a u32 and cast to a u64.
-            let val = val as u32;
-            let val_as_f32 = f32::from_bits(if val & U32_HIGHEST_BIT != 0 {
-                val ^ U32_HIGHEST_BIT
-            } else {
-                !val
-            });
+            //     To avoid this, we string format the stored f64 and then read it as f32.
+            let f64_string = format!("{}", val);
+            let val_as_f32 = f32::from_str(&f64_string)?;
+
             Ok(val_as_f32)
         } else {
             Err(TantivyValueError::UnsupportedIntoConversion(
@@ -947,6 +940,9 @@ pub enum TantivyValueError {
 
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    ParseFloatError(#[from] ParseFloatError),
 
     #[error("Cannot convert oid of InvalidOid to TantivyValue")]
     InvalidOid,

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -66,5 +66,6 @@ pub unsafe fn row_to_search_document(
             );
         }
     }
+    pgrx::info!("document: {:?}", document);
     Ok(document)
 }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -66,6 +66,5 @@ pub unsafe fn row_to_search_document(
             );
         }
     }
-    pgrx::info!("document: {:?}", document);
     Ok(document)
 }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -155,6 +155,11 @@ pub unsafe fn row_to_search_document(
                         .ok_or(IndexError::DatumDeref)?;
                     document.insert(search_field.id, pgrx_timetz_to_tantivy_value(value));
                 }
+                PgBuiltInOids::UUIDOID => {
+                    let value = pgrx::datum::Uuid::from_datum(datum, false)
+                        .ok_or(IndexError::DatumDeref)?;
+                    document.insert(search_field.id, value.to_string().into());
+                }
                 unsupported => Err(IndexError::UnsupportedValue(
                     search_field.name.0.to_string(),
                     format!("{unsupported:?}"),

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -16,10 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::SearchIndex;
-use crate::postgres::datetime::{
-    pgrx_date_to_tantivy_value, pgrx_time_to_tantivy_value, pgrx_timestamp_to_tantivy_value,
-    pgrx_timestamptz_to_tantivy_value, pgrx_timetz_to_tantivy_value,
-};
 use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchDocument, SearchIndexSchema};
 use crate::writer::{IndexError, WriterDirectory};
@@ -64,118 +60,11 @@ pub unsafe fn row_to_search_document(
                 document.insert(search_field.id, value.tantivy_schema_value());
             }
         } else {
-            document.insert(search_field.id, TantivyValue::try_from_datum(datum, base_oid).unwrap().tantivy_schema_value());
+            document.insert(
+                search_field.id,
+                TantivyValue::try_from_datum(datum, base_oid)?.tantivy_schema_value(),
+            );
         }
-
-    //     match &base_oid {
-    //         PgOid::BuiltIn(builtin) => match builtin {
-    //             PgBuiltInOids::BOOLOID => {
-    //                 let value = bool::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, value.into());
-    //             }
-    //             PgBuiltInOids::INT2OID => {
-    //                 let value = i16::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, (value as i64).into());
-    //             }
-    //             PgBuiltInOids::INT4OID => {
-    //                 let value = i32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, (value as i64).into());
-    //             }
-    //             PgBuiltInOids::INT8OID => {
-    //                 let value = i64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, value.into());
-    //             }
-    //             PgBuiltInOids::OIDOID => {
-    //                 let value = u32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, (value as u64).into());
-    //             }
-    //             PgBuiltInOids::FLOAT4OID => {
-    //                 let value = f32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, (value as f64).into());
-    //             }
-    //             PgBuiltInOids::FLOAT8OID => {
-    //                 let value = f64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, value.into());
-    //             }
-    //             PgBuiltInOids::NUMERICOID => {
-    //                 let value =
-    //                     pgrx::AnyNumeric::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(
-    //                     search_field.id,
-    //                     TryInto::<f64>::try_into(value).unwrap().into(),
-    //                 );
-    //             }
-    //             PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
-    //                 if is_array {
-    //                     let array: Array<pg_sys::Datum> =
-    //                         Array::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                     for element_datum in array.iter().flatten() {
-    //                         let value = String::from_datum(element_datum, false)
-    //                             .ok_or(IndexError::DatumDeref)?;
-    //                         document.insert(search_field.id, value.into())
-    //                     }
-    //                 } else {
-    //                     let value =
-    //                         String::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                     document.insert(search_field.id, value.into())
-    //                 }
-    //             }
-    //             PgBuiltInOids::JSONOID => {
-    //                 let JsonString(value) =
-    //                     JsonString::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(
-    //                     search_field.id,
-    //                     serde_json::from_str::<Map<String, serde_json::Value>>(&value)?.into(),
-    //                 );
-    //             }
-    //             PgBuiltInOids::JSONBOID => {
-    //                 let JsonB(serde_value) =
-    //                     JsonB::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-    //                 let value = serde_json::to_vec(&serde_value)?;
-    //                 document.insert(
-    //                     search_field.id,
-    //                     serde_json::from_slice::<Map<String, serde_json::Value>>(&value)?.into(),
-    //                 );
-    //             }
-    //             PgBuiltInOids::DATEOID => {
-    //                 let value = pgrx::datum::Date::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, pgrx_date_to_tantivy_value(value));
-    //             }
-    //             PgBuiltInOids::TIMESTAMPOID => {
-    //                 let value = pgrx::datum::Timestamp::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-
-    //                 document.insert(search_field.id, pgrx_timestamp_to_tantivy_value(value));
-    //             }
-    //             PgBuiltInOids::TIMESTAMPTZOID => {
-    //                 let value = pgrx::datum::TimestampWithTimeZone::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-
-    //                 document.insert(search_field.id, pgrx_timestamptz_to_tantivy_value(value));
-    //             }
-    //             PgBuiltInOids::TIMEOID => {
-    //                 let value = pgrx::datum::Time::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, pgrx_time_to_tantivy_value(value));
-    //             }
-    //             PgBuiltInOids::TIMETZOID => {
-    //                 let value = pgrx::datum::TimeWithTimeZone::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, pgrx_timetz_to_tantivy_value(value));
-    //             }
-    //             PgBuiltInOids::UUIDOID => {
-    //                 let value = pgrx::datum::Uuid::from_datum(datum, false)
-    //                     .ok_or(IndexError::DatumDeref)?;
-    //                 document.insert(search_field.id, value.to_string().into());
-    //             }
-    //             unsupported => Err(IndexError::UnsupportedValue(
-    //                 search_field.name.0.to_string(),
-    //                 format!("{unsupported:?}"),
-    //             ))?,
-    //         },
-    //         _ => Err(IndexError::InvalidOid(search_field.name.0.to_string()))?,
-    //     }
     }
     Ok(document)
 }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -20,7 +20,6 @@ use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchDocument, SearchIndexSchema};
 use crate::writer::{IndexError, WriterDirectory};
 use pgrx::*;
-use serde_json::Map;
 
 pub fn get_search_index(index_name: &str) -> &'static mut SearchIndex {
     let directory = WriterDirectory::from_index_name(index_name);

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -20,6 +20,7 @@ use crate::postgres::datetime::{
     pgrx_date_to_tantivy_value, pgrx_time_to_tantivy_value, pgrx_timestamp_to_tantivy_value,
     pgrx_timestamptz_to_tantivy_value, pgrx_timetz_to_tantivy_value,
 };
+use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchDocument, SearchIndexSchema};
 use crate::writer::{IndexError, WriterDirectory};
 use pgrx::*;
@@ -58,115 +59,123 @@ pub unsafe fn row_to_search_document(
 
         let datum = *values.add(attno);
 
-        match &base_oid {
-            PgOid::BuiltIn(builtin) => match builtin {
-                PgBuiltInOids::BOOLOID => {
-                    let value = bool::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, value.into());
-                }
-                PgBuiltInOids::INT2OID => {
-                    let value = i16::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, (value as i64).into());
-                }
-                PgBuiltInOids::INT4OID => {
-                    let value = i32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, (value as i64).into());
-                }
-                PgBuiltInOids::INT8OID => {
-                    let value = i64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, value.into());
-                }
-                PgBuiltInOids::OIDOID => {
-                    let value = u32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, (value as u64).into());
-                }
-                PgBuiltInOids::FLOAT4OID => {
-                    let value = f32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, (value as f64).into());
-                }
-                PgBuiltInOids::FLOAT8OID => {
-                    let value = f64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, value.into());
-                }
-                PgBuiltInOids::NUMERICOID => {
-                    let value =
-                        pgrx::AnyNumeric::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(
-                        search_field.id,
-                        TryInto::<f64>::try_into(value).unwrap().into(),
-                    );
-                }
-                PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
-                    if is_array {
-                        let array: Array<pg_sys::Datum> =
-                            Array::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                        for element_datum in array.iter().flatten() {
-                            let value = String::from_datum(element_datum, false)
-                                .ok_or(IndexError::DatumDeref)?;
-                            document.insert(search_field.id, value.into())
-                        }
-                    } else {
-                        let value =
-                            String::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                        document.insert(search_field.id, value.into())
-                    }
-                }
-                PgBuiltInOids::JSONOID => {
-                    let JsonString(value) =
-                        JsonString::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    document.insert(
-                        search_field.id,
-                        serde_json::from_str::<Map<String, serde_json::Value>>(&value)?.into(),
-                    );
-                }
-                PgBuiltInOids::JSONBOID => {
-                    let JsonB(serde_value) =
-                        JsonB::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
-                    let value = serde_json::to_vec(&serde_value)?;
-                    document.insert(
-                        search_field.id,
-                        serde_json::from_slice::<Map<String, serde_json::Value>>(&value)?.into(),
-                    );
-                }
-                PgBuiltInOids::DATEOID => {
-                    let value = pgrx::datum::Date::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, pgrx_date_to_tantivy_value(value));
-                }
-                PgBuiltInOids::TIMESTAMPOID => {
-                    let value = pgrx::datum::Timestamp::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-
-                    document.insert(search_field.id, pgrx_timestamp_to_tantivy_value(value));
-                }
-                PgBuiltInOids::TIMESTAMPTZOID => {
-                    let value = pgrx::datum::TimestampWithTimeZone::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-
-                    document.insert(search_field.id, pgrx_timestamptz_to_tantivy_value(value));
-                }
-                PgBuiltInOids::TIMEOID => {
-                    let value = pgrx::datum::Time::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, pgrx_time_to_tantivy_value(value));
-                }
-                PgBuiltInOids::TIMETZOID => {
-                    let value = pgrx::datum::TimeWithTimeZone::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, pgrx_timetz_to_tantivy_value(value));
-                }
-                PgBuiltInOids::UUIDOID => {
-                    let value = pgrx::datum::Uuid::from_datum(datum, false)
-                        .ok_or(IndexError::DatumDeref)?;
-                    document.insert(search_field.id, value.to_string().into());
-                }
-                unsupported => Err(IndexError::UnsupportedValue(
-                    search_field.name.0.to_string(),
-                    format!("{unsupported:?}"),
-                ))?,
-            },
-            _ => Err(IndexError::InvalidOid(search_field.name.0.to_string()))?,
+        if is_array {
+            for value in TantivyValue::try_from_datum_array(datum, base_oid).unwrap() {
+                document.insert(search_field.id, value.tantivy_schema_value());
+            }
+        } else {
+            document.insert(search_field.id, TantivyValue::try_from_datum(datum, base_oid).unwrap().tantivy_schema_value());
         }
+
+    //     match &base_oid {
+    //         PgOid::BuiltIn(builtin) => match builtin {
+    //             PgBuiltInOids::BOOLOID => {
+    //                 let value = bool::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, value.into());
+    //             }
+    //             PgBuiltInOids::INT2OID => {
+    //                 let value = i16::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, (value as i64).into());
+    //             }
+    //             PgBuiltInOids::INT4OID => {
+    //                 let value = i32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, (value as i64).into());
+    //             }
+    //             PgBuiltInOids::INT8OID => {
+    //                 let value = i64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, value.into());
+    //             }
+    //             PgBuiltInOids::OIDOID => {
+    //                 let value = u32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, (value as u64).into());
+    //             }
+    //             PgBuiltInOids::FLOAT4OID => {
+    //                 let value = f32::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, (value as f64).into());
+    //             }
+    //             PgBuiltInOids::FLOAT8OID => {
+    //                 let value = f64::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, value.into());
+    //             }
+    //             PgBuiltInOids::NUMERICOID => {
+    //                 let value =
+    //                     pgrx::AnyNumeric::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(
+    //                     search_field.id,
+    //                     TryInto::<f64>::try_into(value).unwrap().into(),
+    //                 );
+    //             }
+    //             PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
+    //                 if is_array {
+    //                     let array: Array<pg_sys::Datum> =
+    //                         Array::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                     for element_datum in array.iter().flatten() {
+    //                         let value = String::from_datum(element_datum, false)
+    //                             .ok_or(IndexError::DatumDeref)?;
+    //                         document.insert(search_field.id, value.into())
+    //                     }
+    //                 } else {
+    //                     let value =
+    //                         String::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                     document.insert(search_field.id, value.into())
+    //                 }
+    //             }
+    //             PgBuiltInOids::JSONOID => {
+    //                 let JsonString(value) =
+    //                     JsonString::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(
+    //                     search_field.id,
+    //                     serde_json::from_str::<Map<String, serde_json::Value>>(&value)?.into(),
+    //                 );
+    //             }
+    //             PgBuiltInOids::JSONBOID => {
+    //                 let JsonB(serde_value) =
+    //                     JsonB::from_datum(datum, false).ok_or(IndexError::DatumDeref)?;
+    //                 let value = serde_json::to_vec(&serde_value)?;
+    //                 document.insert(
+    //                     search_field.id,
+    //                     serde_json::from_slice::<Map<String, serde_json::Value>>(&value)?.into(),
+    //                 );
+    //             }
+    //             PgBuiltInOids::DATEOID => {
+    //                 let value = pgrx::datum::Date::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, pgrx_date_to_tantivy_value(value));
+    //             }
+    //             PgBuiltInOids::TIMESTAMPOID => {
+    //                 let value = pgrx::datum::Timestamp::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+
+    //                 document.insert(search_field.id, pgrx_timestamp_to_tantivy_value(value));
+    //             }
+    //             PgBuiltInOids::TIMESTAMPTZOID => {
+    //                 let value = pgrx::datum::TimestampWithTimeZone::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+
+    //                 document.insert(search_field.id, pgrx_timestamptz_to_tantivy_value(value));
+    //             }
+    //             PgBuiltInOids::TIMEOID => {
+    //                 let value = pgrx::datum::Time::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, pgrx_time_to_tantivy_value(value));
+    //             }
+    //             PgBuiltInOids::TIMETZOID => {
+    //                 let value = pgrx::datum::TimeWithTimeZone::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, pgrx_timetz_to_tantivy_value(value));
+    //             }
+    //             PgBuiltInOids::UUIDOID => {
+    //                 let value = pgrx::datum::Uuid::from_datum(datum, false)
+    //                     .ok_or(IndexError::DatumDeref)?;
+    //                 document.insert(search_field.id, value.to_string().into());
+    //             }
+    //             unsupported => Err(IndexError::UnsupportedValue(
+    //                 search_field.name.0.to_string(),
+    //                 format!("{unsupported:?}"),
+    //             ))?,
+    //         },
+    //         _ => Err(IndexError::InvalidOid(search_field.name.0.to_string()))?,
+    //     }
     }
     Ok(document)
 }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -378,7 +378,12 @@ impl SearchIndexSchema {
             }
             .into();
 
-            search_fields.push(SearchField { id, name, config, type_: field_type });
+            search_fields.push(SearchField {
+                id,
+                name,
+                config,
+                type_: field_type,
+            });
         }
 
         let schema = builder.build();

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -64,7 +64,9 @@ impl TryFrom<&PgOid> for SearchFieldType {
     fn try_from(pg_oid: &PgOid) -> Result<Self, Self::Error> {
         match &pg_oid {
             PgOid::BuiltIn(builtin) => match builtin {
-                PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID | PgBuiltInOids::UUIDOID => Ok(SearchFieldType::Text),
+                PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID | PgBuiltInOids::UUIDOID => {
+                    Ok(SearchFieldType::Text)
+                }
                 PgBuiltInOids::INT2OID | PgBuiltInOids::INT4OID | PgBuiltInOids::INT8OID => {
                     Ok(SearchFieldType::I64)
                 }
@@ -353,13 +355,15 @@ impl SearchIndexSchema {
                 SearchFieldConfig::Key(key_config) => {
                     config = *key_config.clone();
                     key_index = index;
-                },
+                }
                 SearchFieldConfig::Ctid => ctid_index = index,
                 _ => {}
             }
 
             let id: SearchFieldId = match &config {
-                SearchFieldConfig::Ctid => builder.add_u64_field(name.as_ref(), INDEXED | STORED | FAST),
+                SearchFieldConfig::Ctid => {
+                    builder.add_u64_field(name.as_ref(), INDEXED | STORED | FAST)
+                }
                 _ => match field_type {
                     SearchFieldType::Text => builder.add_text_field(name.as_ref(), config.clone()),
                     SearchFieldType::I64 => builder.add_i64_field(name.as_ref(), config.clone()),
@@ -368,8 +372,9 @@ impl SearchIndexSchema {
                     SearchFieldType::Bool => builder.add_bool_field(name.as_ref(), config.clone()),
                     SearchFieldType::Json => builder.add_json_field(name.as_ref(), config.clone()),
                     SearchFieldType::Date => builder.add_date_field(name.as_ref(), config.clone()),
-                }
-            }.into();
+                },
+            }
+            .into();
 
             // let id: SearchFieldId = match &config {
             //     SearchFieldConfig::Text { .. } => {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -71,9 +71,9 @@ impl TryFrom<&PgOid> for SearchFieldType {
                     Ok(SearchFieldType::I64)
                 }
                 PgBuiltInOids::OIDOID | PgBuiltInOids::XIDOID => Ok(SearchFieldType::U64),
-                PgBuiltInOids::FLOAT4OID | PgBuiltInOids::FLOAT8OID | PgBuiltInOids::NUMERICOID => {
-                    Ok(SearchFieldType::F64)
-                }
+                // See types.rs to understand why f32 is represented as a u64 instead of f64
+                PgBuiltInOids::FLOAT4OID => Ok(SearchFieldType::U64),
+                PgBuiltInOids::FLOAT8OID | PgBuiltInOids::NUMERICOID => Ok(SearchFieldType::F64),
                 PgBuiltInOids::BOOLOID => Ok(SearchFieldType::Bool),
                 PgBuiltInOids::JSONOID | PgBuiltInOids::JSONBOID => Ok(SearchFieldType::Json),
                 PgBuiltInOids::DATEOID

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -317,6 +317,8 @@ pub struct SearchField {
     pub name: SearchFieldName,
     /// Configuration for the field passed at index build time.
     pub config: SearchFieldConfig,
+    /// Field type
+    pub type_: SearchFieldType,
 }
 
 impl From<&SearchField> for Field {
@@ -376,35 +378,7 @@ impl SearchIndexSchema {
             }
             .into();
 
-            // let id: SearchFieldId = match &config {
-            //     SearchFieldConfig::Text { .. } => {
-            //         builder.add_text_field(name.as_ref(), config.clone())
-            //     }
-            //     SearchFieldConfig::Numeric { .. } => match field_type {
-            //         SearchFieldType::I64 => builder.add_i64_field(name.as_ref(), config.clone()),
-            //         SearchFieldType::U64 => builder.add_u64_field(name.as_ref(), config.clone()),
-            //         SearchFieldType::F64 => builder.add_f64_field(name.as_ref(), config.clone()),
-            //         _ => return Err(SearchIndexSchemaError::InvalidNumericType(field_type)),
-            //     }
-            //     SearchFieldConfig::Boolean { .. } => {
-            //         builder.add_bool_field(name.as_ref(), config.clone())
-            //     }
-            //     SearchFieldConfig::Json { .. } => {
-            //         builder.add_json_field(name.as_ref(), config.clone())
-            //     }
-            //     SearchFieldConfig::Date { .. } => {
-            //         builder.add_date_field(name.as_ref(), config.clone())
-            //     }
-            //     SearchFieldConfig::Key { .. } => {
-            //         builder.add_i64_field(name.as_ref(), INDEXED | STORED | FAST)
-            //     }
-            //     SearchFieldConfig::Ctid { .. } => {
-            //         builder.add_u64_field(name.as_ref(), INDEXED | STORED | FAST)
-            //     }
-            // }
-            // .into();
-
-            search_fields.push(SearchField { id, name, config });
+            search_fields.push(SearchField { id, name, config, type_: field_type });
         }
 
         let schema = builder.build();

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -71,9 +71,9 @@ impl TryFrom<&PgOid> for SearchFieldType {
                     Ok(SearchFieldType::I64)
                 }
                 PgBuiltInOids::OIDOID | PgBuiltInOids::XIDOID => Ok(SearchFieldType::U64),
-                // See types.rs to understand why f32 is represented as a u64 instead of f64
-                PgBuiltInOids::FLOAT4OID => Ok(SearchFieldType::U64),
-                PgBuiltInOids::FLOAT8OID | PgBuiltInOids::NUMERICOID => Ok(SearchFieldType::F64),
+                PgBuiltInOids::FLOAT4OID | PgBuiltInOids::FLOAT8OID | PgBuiltInOids::NUMERICOID => {
+                    Ok(SearchFieldType::F64)
+                }
                 PgBuiltInOids::BOOLOID => Ok(SearchFieldType::Bool),
                 PgBuiltInOids::JSONOID | PgBuiltInOids::JSONBOID => Ok(SearchFieldType::Json),
                 PgBuiltInOids::DATEOID

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -146,7 +146,7 @@ pub enum SearchFieldConfig {
         #[serde(default = "default_as_true")]
         stored: bool,
     },
-    Key,
+    Key(Box<SearchFieldConfig>),
     Ctid,
 }
 
@@ -348,9 +348,12 @@ impl SearchIndexSchema {
 
         let mut key_index = 0;
         let mut ctid_index = 0;
-        for (index, (name, config, field_type)) in fields.into_iter().enumerate() {
+        for (index, (name, mut config, field_type)) in fields.into_iter().enumerate() {
             match &config {
-                SearchFieldConfig::Key => key_index = index,
+                SearchFieldConfig::Key(key_config) => {
+                    config = *key_config.clone();
+                    key_index = index;
+                },
                 SearchFieldConfig::Ctid => ctid_index = index,
                 _ => {}
             }

--- a/pg_search/src/writer/mod.rs
+++ b/pg_search/src/writer/mod.rs
@@ -21,6 +21,7 @@ mod index;
 mod server;
 mod transfer;
 
+use crate::postgres::types::TantivyValueError;
 use crate::schema::SearchDocument;
 pub use client::{Client, ClientError};
 pub use directory::*;
@@ -86,17 +87,8 @@ pub trait WriterClient<T: Serialize> {
 
 #[derive(Error, Debug)]
 pub enum IndexError {
-    #[error("unsupported value for attribute '{0}': {1}")]
-    UnsupportedValue(String, String),
-
-    #[error("could not dereference postgres datum")]
-    DatumDeref,
-
     #[error("couldn't get writer for {0:?}: {1}")]
     GetWriterFailed(WriterDirectory, String),
-
-    #[error("{0} has a type oid of InvalidOid")]
-    InvalidOid(String),
 
     #[error(transparent)]
     TantivyError(#[from] tantivy::TantivyError),
@@ -109,6 +101,9 @@ pub enum IndexError {
 
     #[error("couldn't remove index files on drop_index: {0}")]
     DeleteDirectory(#[from] SearchDirectoryError),
+
+    #[error(transparent)]
+    TantivyValueError(#[from] TantivyValueError),
 }
 
 #[cfg(test)]

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -249,9 +249,7 @@ fn uuid(mut conn: PgConnection) {
     )"#
     .execute(&mut conn);
 
-    let rows: Vec<(i32,)> =
-        r#"SELECT * FROM uuid_table.search('some_text:some')"#
-            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = r#"SELECT * FROM uuid_table.search('some_text:some')"#.fetch(&mut conn);
 
     assert_eq!(rows.len(), 10);
 }

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -240,21 +240,20 @@ fn uuid(mut conn: PgConnection) {
     CALL paradedb.drop_bm25('uuid_table');"#
         .execute(&mut conn);
 
-    match r#"
+    r#"
     CALL paradedb.create_bm25(
         index_name => 'uuid_table',
         table_name => 'uuid_table',
         key_field => 'id',
         text_fields => '{"some_text": {}, "random_uuid": {}}'
     )"#
-    .execute_result(&mut conn)
-    {
-        Err(err) => assert!(
-            err.to_string().contains("cannot be indexed"),
-            "received {err:?}"
-        ),
-        _ => panic!("uuid fields in bm25 index should not be supported"),
-    };
+    .execute(&mut conn);
+
+    let rows: Vec<(i32,)> =
+        r#"SELECT * FROM uuid_table.search('some_text:some')"#
+            .fetch(&mut conn);
+
+    assert_eq!(rows.len(), 10);
 }
 
 #[rstest]

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -5,6 +5,9 @@ use pretty_assertions::assert_eq;
 use rstest::*;
 use sqlx::PgConnection;
 
+// In addition to checking whether all the expected types work for keys, make sure to include tests for anything that
+//    is reliant on keys (e.g. stable_sort, alias)
+
 #[rstest]
 fn boolean_key(mut conn: PgConnection) {
     // Boolean keys are pretty useless, but they're supported!

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -42,7 +42,7 @@ fn boolean_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -121,7 +121,7 @@ fn uuid_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -182,7 +182,7 @@ fn i64_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -243,7 +243,7 @@ fn i32_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -304,7 +304,7 @@ fn i16_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -365,7 +365,7 @@ fn f32_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -426,7 +426,7 @@ fn f64_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -487,7 +487,7 @@ fn numeric_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -528,7 +528,7 @@ fn string_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -566,7 +566,7 @@ fn string_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -607,7 +607,7 @@ fn date_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -627,7 +627,7 @@ fn date_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -668,7 +668,7 @@ fn time_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -688,7 +688,7 @@ fn time_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -729,7 +729,7 @@ fn timestamp_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -749,7 +749,7 @@ fn timestamp_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -790,7 +790,7 @@ fn timestamptz_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -810,7 +810,7 @@ fn timestamptz_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
@@ -851,7 +851,7 @@ fn timetz_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
         stable_sort => true
     );
     "#
@@ -871,7 +871,7 @@ fn timetz_key(mut conn: PgConnection) {
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
     SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
+        query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -47,6 +47,17 @@ fn boolean_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 2);
+
+    // alias
+    let rows: Vec<(bool, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 3);
 }
 
 #[rstest]
@@ -126,6 +137,17 @@ fn uuid_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -187,6 +209,17 @@ fn i64_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(i64, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -248,6 +281,17 @@ fn i32_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(i32, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -309,6 +353,17 @@ fn i16_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(i16, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -370,6 +425,17 @@ fn f32_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(f32, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -431,6 +497,17 @@ fn f64_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(f64, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -492,6 +569,17 @@ fn numeric_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(f64, String)> = r#"
+    SELECT CAST(id AS FLOAT8), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS FLOAT8), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -528,7 +616,7 @@ fn string_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -571,6 +659,17 @@ fn string_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -607,7 +706,7 @@ fn date_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -632,6 +731,17 @@ fn date_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -668,7 +778,7 @@ fn time_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -693,6 +803,17 @@ fn time_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -729,7 +850,7 @@ fn timestamp_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -754,6 +875,17 @@ fn timestamp_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -790,7 +922,7 @@ fn timestamptz_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -815,6 +947,17 @@ fn timestamptz_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -851,7 +994,7 @@ fn timetz_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
+        query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
     "#
@@ -876,4 +1019,15 @@ fn timetz_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
+
+    // alias
+    let rows: Vec<(String, String)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
+    UNION
+    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
+    FROM test_index.search('value:tooth', alias => 'tooth')
+    ORDER BY id
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 8);
 }

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -29,6 +29,7 @@ fn boolean_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(bool, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -37,6 +38,15 @@ fn boolean_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows, vec![(false, 0.25759196), (true, 0.14109309)]);
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 2);
 }
 
 #[rstest]
@@ -70,6 +80,7 @@ fn uuid_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -106,6 +117,15 @@ fn uuid_key(mut conn: PgConnection) {
             ),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -139,6 +159,7 @@ fn i64_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(i64, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -157,6 +178,15 @@ fn i64_key(mut conn: PgConnection) {
             (4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -190,6 +220,7 @@ fn i32_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(i32, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -208,6 +239,15 @@ fn i32_key(mut conn: PgConnection) {
             (4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -241,6 +281,7 @@ fn i16_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(i16, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -259,6 +300,15 @@ fn i16_key(mut conn: PgConnection) {
             (4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -292,6 +342,7 @@ fn f32_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(f32, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -310,6 +361,15 @@ fn f32_key(mut conn: PgConnection) {
             (4.4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -343,6 +403,7 @@ fn f64_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(f64, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -361,6 +422,15 @@ fn f64_key(mut conn: PgConnection) {
             (4.4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -394,6 +464,7 @@ fn numeric_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(f64, f32)> = r#"
     SELECT CAST(id AS FLOAT8), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -412,6 +483,15 @@ fn numeric_key(mut conn: PgConnection) {
             (4.4, 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -445,6 +525,7 @@ fn string_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -481,6 +562,15 @@ fn string_key(mut conn: PgConnection) {
             ),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -514,6 +604,7 @@ fn date_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -532,6 +623,15 @@ fn date_key(mut conn: PgConnection) {
             ("2023-05-06".to_string(), 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -565,6 +665,7 @@ fn time_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -583,6 +684,15 @@ fn time_key(mut conn: PgConnection) {
             ("11:12:13".to_string(), 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -616,6 +726,7 @@ fn timestamp_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -634,6 +745,15 @@ fn timestamp_key(mut conn: PgConnection) {
             ("2023-05-06 11:12:13".to_string(), 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -667,6 +787,7 @@ fn timestamptz_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -685,6 +806,15 @@ fn timestamptz_key(mut conn: PgConnection) {
             ("2023-05-06 17:12:13+00".to_string(), 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]
@@ -718,6 +848,7 @@ fn timetz_key(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -736,4 +867,13 @@ fn timetz_key(mut conn: PgConnection) {
             ("11:12:13-06".to_string(), 0.44761515),
         ]
     );
+
+    // no stable_sort
+    let rows: Vec<(f32,)> = r#"
+    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows.len(), 6);
 }

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -1,0 +1,148 @@
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn boolean_key(mut conn: PgConnection) {
+    // Boolean keys are pretty useless, but they're supported!
+
+    r#"
+    CREATE TABLE test_table (
+        id BOOLEAN,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (true, 'bluetooth'), (false, 'blue');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(bool, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(rows, vec![(false, 0.25759196), (true, 0.14109309)]);
+}
+
+#[rstest]
+fn uuid_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id UUID,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('f159c89e-2162-48cd-85e3-e42b71d2ecd0', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('eb833eb6-c598-4042-b84a-0045828fceea', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('ea1181a0-5d3e-4f5f-a6ab-b1354ffc91ad', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('28b6374a-67d3-41c8-93af-490712f9923e', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('f6e85626-298e-4112-9abb-3856f8aa046a', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('88345d21-7b89-4fd6-87e4-83a4f68dbc3c', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('40bc9216-66d0-4ae8-87ee-ddb02e3e1b33', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('02f9789d-4963-47d5-a189-d9c114f5cba4', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "b5faacc0-9eba-441a-81f8-820b46a3b57e".to_string(),
+                0.61846066
+            ),
+            (
+                "38bf27a0-1aa8-42cd-9cb0-993025e0b8d0".to_string(),
+                0.57459813
+            ),
+            (
+                "f159c89e-2162-48cd-85e3-e42b71d2ecd0".to_string(),
+                0.53654534
+            ),
+            (
+                "40bc9216-66d0-4ae8-87ee-ddb02e3e1b33".to_string(),
+                0.50321954
+            ),
+            (
+                "ea1181a0-5d3e-4f5f-a6ab-b1354ffc91ad".to_string(),
+                0.47379148
+            ),
+            (
+                "eb833eb6-c598-4042-b84a-0045828fceea".to_string(),
+                0.44761515
+            ),
+        ]
+    );
+}
+
+#[rstest]
+fn i64_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id BIGINT,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1, 'text 1'), (2, 'text 2'), (3, 'text 3'), (3, 'text 4');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{"value": {}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(i64, String)> = r#"
+    SELECT * FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'text'),
+        stable_sort => true);
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (1, "text 1".to_string()),
+            (2, "text 2".to_string()),
+            (3, "text 4".to_string()),
+            (3, "text 3".to_string())
+        ]
+    );
+}

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -43,7 +43,7 @@ fn boolean_key(mut conn: PgConnection) {
 fn uuid_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (
-        id UUID,
+        id SERIAL,
         value TEXT
     );
 

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -43,7 +43,7 @@ fn boolean_key(mut conn: PgConnection) {
 fn uuid_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (
-        id SERIAL,
+        id UUID,
         value TEXT
     );
 
@@ -116,7 +116,16 @@ fn i64_key(mut conn: PgConnection) {
         value TEXT
     );
 
-    INSERT INTO test_table (id, value) VALUES (1, 'text 1'), (2, 'text 2'), (3, 'text 3'), (3, 'text 4');
+    INSERT INTO test_table (id, value) VALUES (1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10, 'rainbow');
     "#
     .execute(&mut conn);
 
@@ -125,24 +134,606 @@ fn i64_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{"value": {}}'
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
     );
     "#
     .execute(&mut conn);
 
-    let rows: Vec<(i64, String)> = r#"
-    SELECT * FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'text'),
-        stable_sort => true);
+    let rows: Vec<(i64, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(
         rows,
         vec![
-            (1, "text 1".to_string()),
-            (2, "text 2".to_string()),
-            (3, "text 4".to_string()),
-            (3, "text 3".to_string())
+            (3, 0.61846066),
+            (2, 0.57459813),
+            (1, 0.53654534),
+            (9, 0.50321954),
+            (5, 0.47379148),
+            (4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn i32_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id INT,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10, 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(i32, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (3, 0.61846066),
+            (2, 0.57459813),
+            (1, 0.53654534),
+            (9, 0.50321954),
+            (5, 0.47379148),
+            (4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn i16_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id SMALLINT,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10, 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(i16, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (3, 0.61846066),
+            (2, 0.57459813),
+            (1, 0.53654534),
+            (9, 0.50321954),
+            (5, 0.47379148),
+            (4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn f32_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id FLOAT4,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1.1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2.2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3.3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4.4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5.5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6.6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7.7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8.8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9.9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10.1, 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(f32, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (3.3, 0.61846066),
+            (2.2, 0.57459813),
+            (1.1, 0.53654534),
+            (9.9, 0.50321954),
+            (5.5, 0.47379148),
+            (4.4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn f64_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id FLOAT8,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1.1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2.2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3.3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4.4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5.5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6.6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7.7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8.8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9.9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10.1, 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(f64, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (3.3, 0.61846066),
+            (2.2, 0.57459813),
+            (1.1, 0.53654534),
+            (9.9, 0.50321954),
+            (5.5, 0.47379148),
+            (4.4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn numeric_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id NUMERIC,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES (1.1, 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES (2.2, 'bluebell');
+    INSERT INTO test_table (id, value) VALUES (3.3, 'jetblue');
+    INSERT INTO test_table (id, value) VALUES (4.4, 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES (5.5, 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES (6.6, 'redness');
+    INSERT INTO test_table (id, value) VALUES (7.7, 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES (8.8, 'great white');
+    INSERT INTO test_table (id, value) VALUES (9.9, 'blue skies');
+    INSERT INTO test_table (id, value) VALUES (10.1, 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(f64, f32)> = r#"
+    SELECT CAST(id AS FLOAT8), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (3.3, 0.61846066),
+            (2.2, 0.57459813),
+            (1.1, 0.53654534),
+            (9.9, 0.50321954),
+            (5.5, 0.47379148),
+            (4.4, 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn string_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id TEXT,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('f159c89e-2162-48cd-85e3-e42b71d2ecd0', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('eb833eb6-c598-4042-b84a-0045828fceea', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('ea1181a0-5d3e-4f5f-a6ab-b1354ffc91ad', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('28b6374a-67d3-41c8-93af-490712f9923e', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('f6e85626-298e-4112-9abb-3856f8aa046a', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('88345d21-7b89-4fd6-87e4-83a4f68dbc3c', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('40bc9216-66d0-4ae8-87ee-ddb02e3e1b33', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('02f9789d-4963-47d5-a189-d9c114f5cba4', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "b5faacc0-9eba-441a-81f8-820b46a3b57e".to_string(),
+                0.61846066
+            ),
+            (
+                "38bf27a0-1aa8-42cd-9cb0-993025e0b8d0".to_string(),
+                0.57459813
+            ),
+            (
+                "f159c89e-2162-48cd-85e3-e42b71d2ecd0".to_string(),
+                0.53654534
+            ),
+            (
+                "40bc9216-66d0-4ae8-87ee-ddb02e3e1b33".to_string(),
+                0.50321954
+            ),
+            (
+                "ea1181a0-5d3e-4f5f-a6ab-b1354ffc91ad".to_string(),
+                0.47379148
+            ),
+            (
+                "eb833eb6-c598-4042-b84a-0045828fceea".to_string(),
+                0.44761515
+            ),
+        ]
+    );
+}
+
+#[rstest]
+fn date_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id DATE,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('2023-05-03', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-04', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-05', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-06', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-07', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-08', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-09', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-10', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-11', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-12', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            ("2023-05-05".to_string(), 0.61846066),
+            ("2023-05-04".to_string(), 0.57459813),
+            ("2023-05-03".to_string(), 0.53654534),
+            ("2023-05-11".to_string(), 0.50321954),
+            ("2023-05-07".to_string(), 0.47379148),
+            ("2023-05-06".to_string(), 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn time_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id TIME,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('08:09:10', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('09:10:11', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('10:11:12', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('11:12:13', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('12:13:14', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('13:14:15', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('14:15:16', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('15:16:17', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('16:17:18', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('17:18:19', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            ("10:11:12".to_string(), 0.61846066),
+            ("09:10:11".to_string(), 0.57459813),
+            ("08:09:10".to_string(), 0.53654534),
+            ("16:17:18".to_string(), 0.50321954),
+            ("12:13:14".to_string(), 0.47379148),
+            ("11:12:13".to_string(), 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn timestamp_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id TIMESTAMP,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('2023-05-03 08:09:10', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-04 09:10:11', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-05 10:11:12', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-06 11:12:13', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-07 12:13:14', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-08 13:14:15', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-09 14:15:16', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-10 15:16:17', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-11 16:17:18', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-12 17:18:19', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            ("2023-05-05 10:11:12".to_string(), 0.61846066),
+            ("2023-05-04 09:10:11".to_string(), 0.57459813),
+            ("2023-05-03 08:09:10".to_string(), 0.53654534),
+            ("2023-05-11 16:17:18".to_string(), 0.50321954),
+            ("2023-05-07 12:13:14".to_string(), 0.47379148),
+            ("2023-05-06 11:12:13".to_string(), 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn timestamptz_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id TIMESTAMP WITH TIME ZONE,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('2023-05-03 08:09:10 EST', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-04 09:10:11 PST', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-05 10:11:12 MST', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-06 11:12:13 CST', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-07 12:13:14 EST', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-08 13:14:15 PST', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-09 14:15:16 MST', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-10 15:16:17 CST', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-11 16:17:18 EST', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('2023-05-12 17:18:19 PST', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            ("2023-05-05 17:11:12+00".to_string(), 0.61846066),
+            ("2023-05-04 17:10:11+00".to_string(), 0.57459813),
+            ("2023-05-03 13:09:10+00".to_string(), 0.53654534),
+            ("2023-05-11 21:17:18+00".to_string(), 0.50321954),
+            ("2023-05-07 17:13:14+00".to_string(), 0.47379148),
+            ("2023-05-06 17:12:13+00".to_string(), 0.44761515),
+        ]
+    );
+}
+
+#[rstest]
+fn timetz_key(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id TIME WITH TIME ZONE,
+        value TEXT
+    );
+
+    INSERT INTO test_table (id, value) VALUES ('08:09:10 EST', 'bluetooth');
+    INSERT INTO test_table (id, value) VALUES ('09:10:11 PST', 'bluebell');
+    INSERT INTO test_table (id, value) VALUES ('10:11:12 MST', 'jetblue');
+    INSERT INTO test_table (id, value) VALUES ('11:12:13 CST', 'blue''s clues');
+    INSERT INTO test_table (id, value) VALUES ('12:13:14 EST', 'blue bloods');
+    INSERT INTO test_table (id, value) VALUES ('13:14:15 PST', 'redness');
+    INSERT INTO test_table (id, value) VALUES ('14:15:16 MST', 'yellowtooth');
+    INSERT INTO test_table (id, value) VALUES ('15:16:17 CST', 'great white');
+    INSERT INTO test_table (id, value) VALUES ('16:17:18 EST', 'blue skies');
+    INSERT INTO test_table (id, value) VALUES ('17:18:19 PST', 'rainbow');
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+        table_name => 'test_table',
+        index_name => 'test_index',
+        key_field => 'id',
+        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, f32)> = r#"
+    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+        query => paradedb.term(field => 'value', value => 'blue'),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        rows,
+        vec![
+            ("10:11:12-07".to_string(), 0.61846066),
+            ("09:10:11-08".to_string(), 0.57459813),
+            ("08:09:10-05".to_string(), 0.53654534),
+            ("16:17:18-05".to_string(), 0.50321954),
+            ("12:13:14-05".to_string(), 0.47379148),
+            ("11:12:13-06".to_string(), 0.44761515),
         ]
     );
 }

--- a/pg_search/tests/quickstart.rs
+++ b/pg_search/tests/quickstart.rs
@@ -153,7 +153,7 @@ fn quickstart(mut conn: PgConnection) {
     assert_eq!(rows[1].3, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(rows[2].3, Vector::from(vec![1.0, 2.0, 3.0]));
 
-    let rows: Vec<(i64, f32)> = r#"
+    let rows: Vec<(i32, f32)> = r#"
     SELECT * FROM search_idx.rank_hybrid(
         bm25_query => 'description:keyboard OR category:electronics',
         similarity_query => '''[1,2,3]'' <-> embedding',


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1164

## What

Allow users to key on (almost) any type.

## Why

It is particularly important for types like UUID, but a user can also key on timestamp, float, etc (or boolean if they want to for some reason).

## How

Introduce a wrapper type to serialize and compare all key types.

## Tests
See tests/key.rs
