### PR TITLE
fix: Remove redundant DataFusion calls

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -45,7 +45,9 @@ jobs:
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-04-21
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -52,7 +52,9 @@ jobs:
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-04-21
 
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version
         run: |

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -64,6 +64,10 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: actions/checkout@v4
 
+      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+
       # This checks that the version in Cargo.toml is incremented to the next release. We only run it
       # on PRs to main, which are our release promotion PRs.
       - name: Check version in Cargo.toml

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -66,7 +66,9 @@ jobs:
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly-2024-04-21
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-04-21
 
       # This checks that the version in Cargo.toml is incremented to the next release. We only run it
       # on PRs to main, which are our release promotion PRs.

--- a/pg_lakehouse/src/fdw/base.rs
+++ b/pg_lakehouse/src/fdw/base.rs
@@ -3,7 +3,6 @@ use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::CatalogProvider;
 use datafusion::common::DataFusionError;
-use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
 use datafusion::sql::TableReference;
 use deltalake::DeltaTableError;
@@ -55,7 +54,6 @@ pub trait BaseFdw {
         limit: &Option<Limit>,
         options: HashMap<String, String>,
     ) -> Result<(), BaseFdwError> {
-        let start = std::time::Instant::now();
         self.set_target_columns(columns);
 
         let oid_u32: u32 = options
@@ -91,8 +89,7 @@ pub trait BaseFdw {
     }
 
     fn iter_scan_impl(&mut self, row: &mut Row) -> Result<Option<()>, BaseFdwError> {
-        info!("iter scan");
-        task::block_on(self.set_stream());
+        task::block_on(self.set_stream())?;
 
         if self.get_current_batch().is_none()
             || self.get_current_batch_index()

--- a/pg_lakehouse/src/fdw/gcs.rs
+++ b/pg_lakehouse/src/fdw/gcs.rs
@@ -1,8 +1,8 @@
 use async_std::stream::StreamExt;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
-use datafusion::prelude::DataFrame;
 use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::prelude::DataFrame;
 use object_store_opendal::OpendalStore;
 use opendal::services::Gcs;
 use opendal::Operator;

--- a/pg_lakehouse/src/fdw/gcs.rs
+++ b/pg_lakehouse/src/fdw/gcs.rs
@@ -1,5 +1,7 @@
 use async_std::stream::StreamExt;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DataFusionError;
+use datafusion::prelude::DataFrame;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use object_store_opendal::OpendalStore;
 use opendal::services::Gcs;
@@ -23,6 +25,7 @@ use super::base::*;
     error_type = "BaseFdwError"
 )]
 pub(crate) struct GcsFdw {
+    dataframe: Option<DataFrame>,
     stream: Option<SendableRecordBatchStream>,
     current_batch: Option<RecordBatch>,
     current_batch_index: usize,
@@ -179,8 +182,16 @@ impl BaseFdw for GcsFdw {
         self.current_batch_index = index;
     }
 
-    fn set_stream(&mut self, stream: Option<SendableRecordBatchStream>) {
-        self.stream = stream;
+    fn set_dataframe(&mut self, dataframe: DataFrame) {
+        self.dataframe = Some(dataframe);
+    }
+
+    async fn set_stream(&mut self) -> Result<(), DataFusionError> {
+        if self.stream.is_none() {
+            self.stream = Some(self.dataframe.clone().unwrap().execute_stream().await?);
+        }
+
+        Ok(())
     }
 
     fn set_target_columns(&mut self, columns: &[Column]) {
@@ -219,6 +230,7 @@ impl ForeignDataWrapper<BaseFdwError> for GcsFdw {
         )?;
 
         Ok(Self {
+            dataframe: None,
             current_batch: None,
             current_batch_index: 0,
             stream: None,

--- a/pg_lakehouse/src/fdw/local.rs
+++ b/pg_lakehouse/src/fdw/local.rs
@@ -1,6 +1,5 @@
 use async_std::stream::StreamExt;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::DataFusionError;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
 use object_store::local::LocalFileSystem;
@@ -77,12 +76,22 @@ impl BaseFdw for LocalFileFdw {
         self.dataframe = Some(dataframe);
     }
 
-    async fn set_stream(&mut self) -> Result<(), DataFusionError> {
+    async fn create_stream(&mut self) -> Result<(), BaseFdwError> {
         if self.stream.is_none() {
-            self.stream = Some(self.dataframe.clone().unwrap().execute_stream().await?);
+            self.stream = Some(
+                self.dataframe
+                    .clone()
+                    .ok_or(BaseFdwError::DataFrameNotFound)?
+                    .execute_stream()
+                    .await?,
+            );
         }
 
         Ok(())
+    }
+
+    fn clear_stream(&mut self) {
+        self.stream = None;
     }
 
     fn set_target_columns(&mut self, columns: &[Column]) {

--- a/pg_lakehouse/src/fdw/local.rs
+++ b/pg_lakehouse/src/fdw/local.rs
@@ -1,8 +1,8 @@
 use async_std::stream::StreamExt;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
-use datafusion::prelude::DataFrame;
 use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::prelude::DataFrame;
 use object_store::local::LocalFileSystem;
 use pgrx::*;
 use std::collections::HashMap;
@@ -110,16 +110,15 @@ impl ForeignDataWrapper<BaseFdwError> for LocalFileFdw {
         server_options: HashMap<String, String>,
         user_mapping_options: HashMap<String, String>,
     ) -> Result<Self, BaseFdwError> {
-        info!("new");
-        // let path = require_option(TableOption::Path.as_str(), &table_options)?;
-        // let format = require_option_or(TableOption::Format.as_str(), &table_options, "");
+        let path = require_option(TableOption::Path.as_str(), &table_options)?;
+        let format = require_option_or(TableOption::Format.as_str(), &table_options, "");
 
-        // LocalFileFdw::register_object_store(
-        //     &Url::parse(path)?,
-        //     TableFormat::from(format),
-        //     server_options,
-        //     user_mapping_options,
-        // )?;
+        LocalFileFdw::register_object_store(
+            &Url::parse(path)?,
+            TableFormat::from(format),
+            server_options,
+            user_mapping_options,
+        )?;
 
         Ok(Self {
             dataframe: None,

--- a/pg_lakehouse/src/fdw/s3.rs
+++ b/pg_lakehouse/src/fdw/s3.rs
@@ -1,6 +1,5 @@
 use async_std::stream::StreamExt;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::DataFusionError;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
 use object_store_opendal::OpendalStore;
@@ -179,12 +178,22 @@ impl BaseFdw for S3Fdw {
         self.dataframe = Some(dataframe);
     }
 
-    async fn set_stream(&mut self) -> Result<(), DataFusionError> {
+    async fn create_stream(&mut self) -> Result<(), BaseFdwError> {
         if self.stream.is_none() {
-            self.stream = Some(self.dataframe.clone().unwrap().execute_stream().await?);
+            self.stream = Some(
+                self.dataframe
+                    .clone()
+                    .ok_or(BaseFdwError::DataFrameNotFound)?
+                    .execute_stream()
+                    .await?,
+            );
         }
 
         Ok(())
+    }
+
+    fn clear_stream(&mut self) {
+        self.stream = None;
     }
 
     fn set_target_columns(&mut self, columns: &[Column]) {

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -1,12 +1,13 @@
-use crate::datafusion::context::ContextError;
-use crate::datafusion::plan::QueryString;
-use crate::datafusion::session::Session;
-use crate::schema::cell::*;
 use async_std::task;
 use datafusion::common::arrow::array::RecordBatch;
 use datafusion::logical_expr::LogicalPlan;
 use pgrx::*;
 use thiserror::Error;
+
+use crate::datafusion::context::ContextError;
+use crate::datafusion::plan::QueryString;
+use crate::datafusion::session::Session;
+use crate::schema::cell::*;
 
 use super::query::*;
 

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -1,12 +1,12 @@
+use crate::datafusion::context::ContextError;
+use crate::datafusion::plan::QueryString;
+use crate::datafusion::session::Session;
+use crate::schema::cell::*;
 use async_std::task;
 use datafusion::common::arrow::array::RecordBatch;
 use datafusion::logical_expr::LogicalPlan;
 use pgrx::*;
 use thiserror::Error;
-use crate::datafusion::context::ContextError;
-use crate::datafusion::plan::QueryString;
-use crate::datafusion::session::Session;
-use crate::schema::cell::*;
 
 use super::query::*;
 
@@ -50,60 +50,33 @@ pub unsafe fn executor_run(
         return Ok(());
     }
 
-    let ctx = datafusion::prelude::SessionContext::new();
-    let query = "SELECT COUNT(*) FROM hits WHERE \"AdvEngineID\" <> 0;";
-
-    const PARQUET_PATH: &str = "/Users/mingying/Downloads/hits.parquet";
-
-    task::block_on(ctx.register_parquet(
-        "hits",
-        PARQUET_PATH,
-        datafusion::datasource::file_format::options::ParquetReadOptions::default(),
-    )).unwrap();
-
-    let start = std::time::Instant::now();
-    let ast = datafusion::sql::parser::DFParser::parse_sql_with_dialect(
-        query,
-        &datafusion::sql::sqlparser::dialect::PostgreSqlDialect {},
-    )
-    .unwrap();
-    let statement = &ast[0];
-    let plan = task::block_on(ctx.state().statement_to_plan(statement.clone())).unwrap();
-    let dataframe = task::block_on(ctx.execute_logical_plan(plan)).unwrap();
-    let results = task::block_on(dataframe.collect()).unwrap();
-    info!("test query took {:?} ms", start.elapsed().as_millis());
-
     // Parse the query into a LogicalPlan
-    // match LogicalPlan::try_from(QueryString(&pg_query.text())) {
-    //     Ok(logical_plan) => {
-    //         // Don't intercept any DDL or DML statements
-    //         match logical_plan {
-    //             LogicalPlan::Ddl(_) | LogicalPlan::Dml(_) => {
-    //                 prev_hook(query_desc, direction, count, execute_once);
-    //                 return Ok(());
-    //             }
-    //             _ => {}
-    //         };
+    match LogicalPlan::try_from(QueryString(&pg_query.text())) {
+        Ok(logical_plan) => {
+            // Don't intercept any DDL or DML statements
+            match logical_plan {
+                LogicalPlan::Ddl(_) | LogicalPlan::Dml(_) => {
+                    prev_hook(query_desc, direction, count, execute_once);
+                    return Ok(());
+                }
+                _ => {}
+            };
 
-    //         // Execute SELECT
-    //         let start1 = std::time::Instant::now();
-    //         match task::block_on(get_datafusion_batches(logical_plan)) {
-    //             Ok(batches) => {
-    //                 info!("get_datafusion_batches took {:?} ms", start1.elapsed().as_millis());
-    //                 write_batches_to_slots(query_desc, batches)?
-    //             },
-    //             Err(err) => {
-    //                 fallback_warning!(err.to_string());
-    //                 prev_hook(query_desc, direction, count, execute_once);
-    //                 return Ok(());
-    //             }
-    //         };
-    //     }
-    //     Err(err) => {
-    //         fallback_warning!(err.to_string());
-    //         prev_hook(query_desc, direction, count, execute_once);
-    //     }
-    // };
+            // Execute SELECT
+            match task::block_on(get_datafusion_batches(logical_plan)) {
+                Ok(batches) => write_batches_to_slots(query_desc, batches)?,
+                Err(err) => {
+                    fallback_warning!(err.to_string());
+                    prev_hook(query_desc, direction, count, execute_once);
+                    return Ok(());
+                }
+            };
+        }
+        Err(err) => {
+            fallback_warning!(err.to_string());
+            prev_hook(query_desc, direction, count, execute_once);
+        }
+    };
 
     Ok(())
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
`begin_scan` was calling `execute_logical_plan`, which was adding 100-200ms latency to queries. This has been moved to `iter_scan`, so it only fires when we call back to the FDW and not on every query.

## Why
Performance - now we match DataFusion benchmarks exactly.

## How

## Tests
