### PR TITLE
feat: support bitmap scans in pg_search

### DIFF
--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -46,7 +46,7 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     // 2. Supporting bitmap scans would require transformation of queries into actual bitmaps, which introduces complexity
     //    without significant performance gain. This complexity is unnecessary as our operator does not require bitmap scans
     //    for optimal functioning.
-    amroutine.amgetbitmap = None;
+    amroutine.amgetbitmap = Some(scan::amgetbitmap);
     amroutine.amendscan = Some(scan::amendscan);
 
     amroutine.into_pg_boxed()


### PR DESCRIPTION
## What
Bitmap / combined index support for pg_search.

## Why
Supporting bitmap scans will allow us to combine multiple indexes during a search.
https://www.postgresql.org/docs/current/indexes-bitmap-scans.html

## How
Implement approrpriate access method, similarly to `amrescan`. We are well setup for this, because the nature of how our search works already aggregates all the Tantivy results at once.

## Tests
incoming