### PR TITLE
chore: Add `tsvector` to `cargo-paradedb`

### DIFF
--- a/cargo-paradedb/src/benchmark.rs
+++ b/cargo-paradedb/src/benchmark.rs
@@ -26,6 +26,10 @@ impl Benchmark {
 
         Ok(())
     }
+    pub async fn query(&self, conn: &mut PgConnection) -> Result<()> {
+        conn.execute(self.query.as_ref()).await?;
+        Ok(())
+    }
     pub async fn run_pg(&self) -> Result<()> {
         // One-time setup code goes here.
         debug!(DATABASE_URL = self.database_url);
@@ -75,9 +79,7 @@ impl Benchmark {
 
         // Run actual query to be benchmarked.
         let start_time = SystemTime::now();
-        block_on(async {
-            sqlx::query(&self.query).execute(&mut conn).await.unwrap();
-        });
+        self.query(conn.as_mut()).await.unwrap();
         let end_time = SystemTime::now();
 
         Self::print_results(start_time, end_time);

--- a/cargo-paradedb/src/cli.rs
+++ b/cargo-paradedb/src/cli.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 const DEFAULT_BENCH_ESLOGS_TABLE: &str = "benchmark_eslogs";
 const DEFAULT_BENCH_ESLOGS_INDEX_NAME: &str = "benchmark_eslogs_pg_search";
+const DEFAULT_BENCH_GIN_INDEX_NAME: &str = "benchmark_eslogs_gin";
 
 /// A wrapper struct for subcommands.
 #[derive(Parser)]
@@ -131,6 +132,31 @@ pub enum EsLogsCommand {
         /// Should contain the index name as a path subcomponent.
         #[arg(short, long)]
         elastic_url: String,
+    },
+    BuildGinIndex {
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]
+        table: String,
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_GIN_INDEX_NAME)]
+        index: String,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
+    },
+    QueryGinIndex {
+        /// Postgres index name to query.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]
+        table: String,
+        /// Query to run.
+        #[arg(short, long, default_value = "flame")]
+        query: String,
+        /// Limit results to return.
+        #[arg(short, long, default_value_t = 1)]
+        limit: u64,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
     },
 }
 /// The command to run on the hits corpus.

--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -65,6 +65,17 @@ fn main() -> Result<()> {
                     field,
                     term,
                 )),
+                EsLogsCommand::BuildGinIndex { table, index, url } => {
+                    block_on(subcommand::bench_eslogs_build_gin_index(table, index, url))
+                }
+                EsLogsCommand::QueryGinIndex {
+                    table,
+                    query,
+                    limit,
+                    url,
+                } => block_on(subcommand::bench_eslogs_query_gin_index(
+                    table, query, limit, url,
+                )),
             },
             Corpus::Hits(hits) => match hits.command {
                 HitsCommand::Run {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Introduces benchmarks for tsvector.

Build tsvector:

```bash
cargo paradedb bench eslogs build-gin-index --url postgres://localhost:28816/postgres
```

Query tsvector:
```bash
cargo paradedb bench eslogs query-gin-index --url postgres://localhost:28816/postgres
```

## Why

## How

## Tests
