### PR TITLE
fix: Display error messages correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -3860,7 +3860,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5429,6 +5429,7 @@ version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-std",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "chrono",
@@ -5980,7 +5981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.55",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5429,7 +5429,6 @@ version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-std",
- "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "chrono",

--- a/pg_lakehouse/Cargo.toml
+++ b/pg_lakehouse/Cargo.toml
@@ -21,6 +21,7 @@ telemetry = ["shared/telemetry"]
 [dependencies]
 anyhow = "1.0.83"
 async-std = { version = "1.12.0", features = ["tokio1", "attributes"] }
+async-trait = "0.1.80"
 chrono = "0.4.34"
 datafusion = "37.1.0"
 deltalake = { version = "0.17.3", features = [

--- a/pg_lakehouse/Cargo.toml
+++ b/pg_lakehouse/Cargo.toml
@@ -21,7 +21,6 @@ telemetry = ["shared/telemetry"]
 [dependencies]
 anyhow = "1.0.83"
 async-std = { version = "1.12.0", features = ["tokio1", "attributes"] }
-async-trait = "0.1.80"
 chrono = "0.4.34"
 datafusion = "37.1.0"
 deltalake = { version = "0.17.3", features = [

--- a/pg_lakehouse/src/api/mod.rs
+++ b/pg_lakehouse/src/api/mod.rs
@@ -19,7 +19,7 @@ pub fn arrow_schema(
     format: default!(Option<String>, "NULL"),
 ) -> iter::TableIterator<'static, (name!(field, String), name!(datatype, String))> {
     task::block_on(arrow_schema_impl(server, path, extension, format)).unwrap_or_else(|err| {
-        panic!("{:?}", err);
+        panic!("{}", err);
     })
 }
 

--- a/pg_lakehouse/src/datafusion/context.rs
+++ b/pg_lakehouse/src/datafusion/context.rs
@@ -43,7 +43,7 @@ impl ContextProvider for QueryContext {
 
     fn get_function_meta(&self, name: &str) -> Option<Arc<ScalarUDF>> {
         let context = Session::session_context().unwrap_or_else(|err| {
-            panic!("{:?}", err);
+            panic!("{}", err);
         });
 
         context.udf(name).ok()

--- a/pg_lakehouse/src/datafusion/schema.rs
+++ b/pg_lakehouse/src/datafusion/schema.rs
@@ -39,7 +39,7 @@ impl LakehouseSchemaProvider {
     fn table_impl(&self, table_name: &str) -> Result<Arc<dyn TableProvider>, CatalogError> {
         let pg_relation = unsafe {
             PgRelation::open_with_name(table_name).unwrap_or_else(|err| {
-                panic!("{:?}", err);
+                panic!("{}", err);
             })
         };
 
@@ -124,7 +124,7 @@ impl SchemaProvider for LakehouseSchemaProvider {
         Box::pin(async move {
             let table = self
                 .table_impl(table_name)
-                .unwrap_or_else(|err| panic!("{:?}", err));
+                .unwrap_or_else(|err| panic!("{}", err));
 
             Ok(Some(table))
         })

--- a/pg_lakehouse/src/datafusion/session.rs
+++ b/pg_lakehouse/src/datafusion/session.rs
@@ -124,7 +124,7 @@ impl Session {
         let session_timezone = unsafe {
             CStr::from_ptr(pg_sys::pg_get_timezone_name(pg_sys::session_timezone))
                 .to_str()
-                .unwrap_or_else(|err| panic!("{:?}", err))
+                .unwrap_or_else(|err| panic!("{}", err))
         };
         session_config.options_mut().execution.time_zone = Some(session_timezone.to_string());
 

--- a/pg_lakehouse/src/fdw/azblob.rs
+++ b/pg_lakehouse/src/fdw/azblob.rs
@@ -1,4 +1,5 @@
 use async_std::stream::StreamExt;
+use async_std::task;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
@@ -309,11 +310,11 @@ impl ForeignDataWrapper<BaseFdwError> for AzblobFdw {
         limit: &Option<Limit>,
         options: HashMap<String, String>,
     ) -> Result<(), BaseFdwError> {
-        self.begin_scan_impl(_quals, columns, _sorts, limit, options)
+        task::block_on(self.begin_scan_impl(_quals, columns, _sorts, limit, options))
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BaseFdwError> {
-        self.iter_scan_impl(row)
+        task::block_on(self.iter_scan_impl(row))
     }
 
     fn end_scan(&mut self) -> Result<(), BaseFdwError> {

--- a/pg_lakehouse/src/fdw/azdls.rs
+++ b/pg_lakehouse/src/fdw/azdls.rs
@@ -1,4 +1,5 @@
 use async_std::stream::StreamExt;
+use async_std::task;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
@@ -260,11 +261,11 @@ impl ForeignDataWrapper<BaseFdwError> for AzdlsFdw {
         limit: &Option<Limit>,
         options: HashMap<String, String>,
     ) -> Result<(), BaseFdwError> {
-        self.begin_scan_impl(_quals, columns, _sorts, limit, options)
+        task::block_on(self.begin_scan_impl(_quals, columns, _sorts, limit, options))
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BaseFdwError> {
-        self.iter_scan_impl(row)
+        task::block_on(self.iter_scan_impl(row))
     }
 
     fn end_scan(&mut self) -> Result<(), BaseFdwError> {

--- a/pg_lakehouse/src/fdw/gcs.rs
+++ b/pg_lakehouse/src/fdw/gcs.rs
@@ -1,4 +1,5 @@
 use async_std::stream::StreamExt;
+use async_std::task;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
@@ -295,11 +296,11 @@ impl ForeignDataWrapper<BaseFdwError> for GcsFdw {
         limit: &Option<Limit>,
         options: HashMap<String, String>,
     ) -> Result<(), BaseFdwError> {
-        self.begin_scan_impl(_quals, columns, _sorts, limit, options)
+        task::block_on(self.begin_scan_impl(_quals, columns, _sorts, limit, options))
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BaseFdwError> {
-        self.iter_scan_impl(row)
+        task::block_on(self.iter_scan_impl(row))
     }
 
     fn end_scan(&mut self) -> Result<(), BaseFdwError> {

--- a/pg_lakehouse/src/fdw/local.rs
+++ b/pg_lakehouse/src/fdw/local.rs
@@ -1,4 +1,5 @@
 use async_std::stream::StreamExt;
+use async_std::task;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::DataFrame;
@@ -176,11 +177,11 @@ impl ForeignDataWrapper<BaseFdwError> for LocalFileFdw {
         limit: &Option<Limit>,
         options: HashMap<String, String>,
     ) -> Result<(), BaseFdwError> {
-        self.begin_scan_impl(_quals, columns, _sorts, limit, options)
+        task::block_on(self.begin_scan_impl(_quals, columns, _sorts, limit, options))
     }
 
     fn iter_scan(&mut self, row: &mut Row) -> Result<Option<()>, BaseFdwError> {
-        self.iter_scan_impl(row)
+        task::block_on(self.iter_scan_impl(row))
     }
 
     fn end_scan(&mut self) -> Result<(), BaseFdwError> {

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -13,17 +13,11 @@ use super::query::*;
 
 macro_rules! fallback_warning {
     ($msg:expr) => {
-        warning!(
-            r#"
-                This query was not fully pushed down to DataFusion because DataFusion returned an error: {}. 
-                Query times may be impacted.
-                Please submit a request at https://github.com/paradedb/paradedb/issues if you would like to see this query pushed down.
-            "#
-        , $msg);
+        warning!("This query was not fully pushed down to DataFusion because DataFusion returned an error: {}. Query times may be impacted. Please submit a request at https://github.com/paradedb/paradedb/issues if you would like to see this query pushed down.", $msg);
     };
 }
 
-pub unsafe fn executor_run(
+pub fn executor_run(
     query_desc: PgBox<pg_sys::QueryDesc>,
     direction: pg_sys::ScanDirection,
     count: u64,
@@ -36,7 +30,7 @@ pub unsafe fn executor_run(
     ) -> HookResult<()>,
 ) -> Result<(), ExecutorHookError> {
     let ps = query_desc.plannedstmt;
-    let rtable = (*ps).rtable;
+    let rtable = unsafe { (*ps).rtable };
     let pg_query = PgQuery::try_from(query_desc.clone())?;
 
     // Only use this hook for deltalake tables

--- a/pg_lakehouse/src/hooks/mod.rs
+++ b/pg_lakehouse/src/hooks/mod.rs
@@ -19,12 +19,10 @@ impl hooks::PgHooks for LakehouseHook {
             execute_once: bool,
         ) -> HookResult<()>,
     ) -> HookResult<()> {
-        unsafe {
-            executor::executor_run(query_desc, direction, count, execute_once, prev_hook)
-                .unwrap_or_else(|err| {
-                    panic!("{:?}", err);
-                });
-        }
+        executor::executor_run(query_desc, direction, count, execute_once, prev_hook)
+            .unwrap_or_else(|err| {
+                panic!("{}", err);
+            });
 
         HookResult::new(())
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We were using `panic!({:?})` instead of `panic!({})`, which means we were showing `Debug` instead of `Display` for error messages.

## Why
Show better error messages.

## How
I also made `BaseFdw` functions async to bubble up the `task::block_on` calls.

## Tests
