### PR TITLE
feat: Also deploy ParadeDB extensions on Debian 11 and 12

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -123,17 +123,10 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
           # Retrieve the OS Distributor ID (-is) and Release (-rs) Versions
-          DISTRO=$(lsb_release -is)
+          DISTRO=$(echo "$(lsb_release -is)" | tr '[:upper:]' '[:lower:]')
           RELEASE=$(lsb_release -rs)
-
-          echo "$DISTRO"
-          echo "$RELEASE"
-
-          DISTRO_LOWERCASE="${DISTRO,,}"
-          echo "$DISTRO_LOWERCASE"
-
-          echo "OS Version: $DISTRO_LOWERCASE-$RELEASE"
-          echo "os_version=$DISTRO_LOWERCASE-$RELEASE" >> $GITHUB_OUTPUTxw
+          echo "OS Version: $DISTRO-$RELEASE"
+          echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Debian Dependencies
-        if: matrix.runner.image == 'debian:11-slim'
+        if: ${{ matrix.runner.image }} == 'debian:11-slim'
         run: apt-get install -y sudo wget curl
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.runner.image }} == 'debian:11-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust
@@ -113,7 +113,7 @@ jobs:
         with:
           toolchain: nightly-2024-04-21
 
-      - name: Retrieve Ubuntu & GitHub Tag Versions
+      - name: Retrieve OS & GitHub Tag Versions
         id: version
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
@@ -122,7 +122,11 @@ jobs:
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
-          echo "ubuntu_version=$(lsb_release -rs | sed 's/\.//')" >> $GITHUB_OUTPUT
+          # Retrieve the OS Distributor ID (-is) and Release (-rs) Versions
+          distro=$(lsb_release -is)
+          release=$(lsb_release -rs)
+          echo "os_version=${distro,,}-${release}" >> $GITHUB_OUTPUT
+          echo "OS Version: ${distro,,}-${release}"
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
@@ -149,7 +153,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_lakehouse*"` archive
-          package_dir=pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}
+          package_dir=pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -196,5 +200,5 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
       #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
-      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
+      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -123,10 +123,17 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
           # Retrieve the OS Distributor ID (-is) and Release (-rs) Versions
-          distro=$(lsb_release -is)
-          release=$(lsb_release -rs)
-          echo "os_version=${distro,,}-${release}" >> $GITHUB_OUTPUT
-          echo "OS Version: ${distro,,}-${release}"
+          DISTRO=$(lsb_release -is)
+          RELEASE=$(lsb_release -rs)
+
+          echo "$DISTRO"
+          echo "$RELEASE"
+
+          DISTRO_LOWERCASE="${DISTRO,,}"
+          echo "$DISTRO_LOWERCASE"
+
+          echo "OS Version: $DISTRO_LOWERCASE-$RELEASE"
+          echo "os_version=$DISTRO_LOWERCASE-$RELEASE" >> $GITHUB_OUTPUTxw
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -109,6 +109,10 @@ jobs:
         with:
           toolchain: nightly-2024-04-21
 
+      - name: Install Debian Dependencies
+        if: matrix.runner.image == 'debian:11-slim'
+        run: apt-get install -y sudo wget
+
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version
         run: |

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -103,15 +103,15 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      - name: Install Debian Dependencies
+        if: matrix.runner.image == 'debian:11-slim'
+        run: apt-get install -y sudo wget curl
+
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2024-04-21
-
-      - name: Install Debian Dependencies
-        if: matrix.runner.image == 'debian:11-slim'
-        run: apt-get install -y sudo wget
 
       - name: Retrieve Ubuntu & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
-        debian:11
     strategy:
       matrix:
         include:
@@ -53,11 +52,40 @@ jobs:
           #   arch: arm64
           # - runner: ubuntu-latest
           #   image: debian:11
+          # - runner: ubuntu-latest
+          #   image: debian:11-slim
+          #   pg_version: 14
+          #   arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: arm64
+
+          # - runner: ubuntu-latest
+          #   image: debian:12-slim
           #   pg_version: 14
           #   arch: amd64
           # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
           #   pg_version: 14
           #   arch: arm64
+          # - runner: ubuntu-latest
+          #   image: redhat/ubi8-minimal:latest
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi8-minimal:latest
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: ubuntu-latest
+          #   image: redhat/ubi9-minimal:latest
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi9-minimal:latest
+          #   pg_version: 14
+          #   arch: arm64
+
           # - runner: ubuntu-latest
           #   pg_version: 15
           #   arch: amd64

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.runner.image }} == 'debian:11-slim'
-        run: apt-get install -y sudo wget curl
+        run: apt-get update && apt-get install -y sudo wget curl
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -32,79 +32,90 @@ jobs:
     strategy:
       matrix:
         include:
-          # - runner: depot-ubuntu-22.04-4
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   pg_version: 16
-          #   arch: arm64
-          # - runner: ubuntu-latest
-          #   image: debian:11
-          # - runner: ubuntu-latest
-          #   image: debian:11-slim
-          #   pg_version: 14
-          #   arch: amd64
+          # Ubuntu 22.04
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: arm64
+          # Debian 11
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: amd64
           - runner: depot-ubuntu-22.04-arm-4
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-
-          # - runner: ubuntu-latest
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: ubuntu-latest
-          #   image: redhat/ubi8-minimal:latest
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi8-minimal:latest
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: ubuntu-latest
-          #   image: redhat/ubi9-minimal:latest
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi9-minimal:latest
-          #   pg_version: 14
-          #   arch: arm64
-
-          # - runner: ubuntu-latest
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: ubuntu-latest
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   pg_version: 16
-          #   arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: arm64
+          # Debian 12
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: arm64
+          # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
+          # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
       - name: Install Debian Dependencies
-        if: ${{ matrix.runner.image }} == 'debian:11-slim'
+        if: ${{ matrix.image }} == 'debian:11-slim'
         run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,9 +7,6 @@ name: Publish pg_lakehouse
 
 on:
   push:
-    # TODO: remove when done testing
-    branches:
-      - phil/builders
     tags:
       - "v*"
   workflow_dispatch:
@@ -205,11 +202,10 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # TODO: Uncomment when done testing
-      # - name: Upload pg_lakehouse .deb to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
-      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+      - name: Upload pg_lakehouse .deb to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.runner.image }} == 'debian:11-slim'
-        run: apt-get update && apt-get install -y sudo wget curl
+        run: apt-get update && apt-get install -y sudo wget curl gnupg
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,6 +7,9 @@ name: Publish pg_lakehouse
 
 on:
   push:
+    # TODO: remove when done testing
+    branches:
+      - phil/builders
     tags:
       - "v*"
   workflow_dispatch:
@@ -24,27 +27,49 @@ jobs:
   publish-pg_lakehouse:
     name: Publish pg_lakehouse for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+        debian:11
     strategy:
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-4
-            pg_version: 14
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            pg_version: 14
-            arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            pg_version: 15
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            pg_version: 15
-            arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            pg_version: 16
-            arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 15
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   pg_version: 16
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 16
+          #   arch: arm64
+          # - runner: ubuntu-latest
+          #   image: debian:11
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: ubuntu-latest
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 15
+          #   arch: arm64
+          # - runner: ubuntu-latest
+          #   pg_version: 16
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   pg_version: 16
+          #   arch: arm64
 
     steps:
       - name: Checkout Git Repository
@@ -133,10 +158,11 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_lakehouse .deb to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
-          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
+      # TODO: Uncomment when done testing
+      # - name: Upload pg_lakehouse .deb to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
+      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.runner.image }} == 'debian:11-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev
 
       # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
       - name: Install Rust

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -24,33 +24,98 @@ jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
     strategy:
       matrix:
         include:
+          # Ubuntu 22.04
           - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
             pg_version: 14
             arch: amd64
           - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
             pg_version: 14
             arch: arm64
           - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
             pg_version: 15
             arch: amd64
           - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
             pg_version: 15
             arch: arm64
           - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
             pg_version: 16
             arch: amd64
           - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
             pg_version: 16
             arch: arm64
+          # Debian 11
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: arm64
+          # Debian 12
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: arm64
+          # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
+          # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
 
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Retrieve Ubuntu & GitHub Tag Versions
+      - name: Install Debian Dependencies
+        if: ${{ matrix.image }} == 'debian:11-slim'
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev
+
+      - name: Retrieve OS & GitHub Tag Versions
         id: version
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
@@ -59,7 +124,11 @@ jobs:
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
-          echo "ubuntu_version=$(lsb_release -rs | sed 's/\.//')" >> $GITHUB_OUTPUT
+          # Retrieve the OS Distributor ID (-is) and Release (-rs) Versions
+          DISTRO=$(echo "$(lsb_release -is)" | tr '[:upper:]' '[:lower:]')
+          RELEASE=$(lsb_release -rs)
+          echo "OS Version: $DISTRO-$RELEASE"
+          echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
@@ -85,7 +154,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}
+          package_dir=pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -131,5 +200,5 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
-          asset_name: pg_search-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-ubuntu${{ steps.version.outputs.ubuntu_version }}.deb
+          asset_path: ./pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+          asset_name: pg_search-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A (partial #1116)

## What
An increasing number of our users have been requesting prebuilt binaries for their operating system. Notably, we weren't sharing prebuilt binaries for Debian 11, which is what most upstream `postgres` Docker images, like the PostGIS ones, are based on. That's a pretty big limitation for adoption. This PR adds support for building in containers on GHA runners, and adds support for Debian 11 and Debian 12 in addition to Ubuntu 22.04. Debian 12 is the base for Ubuntu 22.04, but we've seen some issues with using the Ubuntu version, so I figured we'd just publish everything separately for maximum compatibility.

In a subsequent PR, I'll add support for Red Hat UBI 8 & 9, which should unblock a lot more users, and clean things up a bit further in our CI.

## Why
Expand access to more users!

## How
Build in containers in GHA

## Tests
Tested manually in my own branch, but did not push. We'll need to promote to `main` for that.