### PR TITLE
fix: Make Dockerfile also use Rust nightly

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
+      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
+      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -66,7 +66,8 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: actions/checkout@v4
 
-      # Fix Rust nightly because 1.80.0 is causing compilation issues with some dependencies
+      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
+      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
-# fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies    
+# fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${RUST_VERSION}" -y
 
 ENV PATH="/root/.cargo/bin:$PATH" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ARG PG_VERSION_MAJOR=16
 FROM postgres:${PG_VERSION_MAJOR}-bookworm as builder
 
 ARG PG_VERSION_MAJOR=16
-ARG RUST_VERSION=1.78.0
+ARG RUST_VERSION=nightly-2024-04-21
 ARG PGRX_VERSION=0.11.3
 
 # Declare buildtime environment variables
@@ -38,8 +38,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-server-dev-all \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && /root/.cargo/bin/rustup default "${RUST_VERSION}"
+# Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
+# fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies    
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${RUST_VERSION}" -y
 
 ENV PATH="/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This enables maximum performance for `pg_lakehouse` inside the Dockerfile. We were already doing this when deploying individual extensions in CI.

## Why
^

## How
^

## Tests
^