### PR TITLE
fix: Add one more missing dependency to Debian deployments

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
       # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install Rust
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This was preventing the `upload_url` from being retrieved

## Why

## How

## Tests
