### PR TITLE
fix: Fix issue w/ Ubuntu publishing

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -106,6 +106,8 @@ jobs:
             arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
+    env:
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository
@@ -208,5 +210,5 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
-          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -108,8 +108,6 @@ jobs:
           #   arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
-    env:
-      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository
@@ -146,7 +144,7 @@ jobs:
           # Install PostgreSQL
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   publish-pg_lakehouse:
-    name: Publish pg_lakehouse for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
+    name: Publish pg_lakehouse for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,6 +7,8 @@ name: Publish pg_lakehouse
 
 on:
   push:
+    branches:
+      - phil/cleanup
     tags:
       - "v*"
   workflow_dispatch:
@@ -205,10 +207,10 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_lakehouse .deb to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      # - name: Upload pg_lakehouse .deb to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -108,6 +108,8 @@ jobs:
           #   arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
+    env:
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository
@@ -115,7 +117,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq tzdata
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
       # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
@@ -141,13 +143,6 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          # Configure tzdata for non-interactive installation
-          sudo ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
-          echo 'Etc/UTC' | sudo tee /etc/timezone
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-          export DEBIAN_FRONTEND=noninteractive
-
           # Install PostgreSQL
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
+        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq tzdata
 
       # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
       # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -108,8 +108,6 @@ jobs:
             arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
-    env:
-      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository
@@ -143,6 +141,7 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
+          export DEBIAN_FRONTEND=noninteractive
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -57,7 +57,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # # Debian 11
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:11-slim
           #   pg_version: 14
           #   arch: amd64
@@ -65,7 +65,7 @@ jobs:
           #   image: debian:11-slim
           #   pg_version: 14
           #   arch: arm64
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:11-slim
           #   pg_version: 15
           #   arch: amd64
@@ -73,7 +73,7 @@ jobs:
           #   image: debian:11-slim
           #   pg_version: 15
           #   arch: arm64
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:11-slim
           #   pg_version: 16
           #   arch: amd64
@@ -82,7 +82,7 @@ jobs:
           #   pg_version: 16
           #   arch: arm64
           # # Debian 12
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:12-slim
           #   pg_version: 14
           #   arch: amd64
@@ -90,7 +90,7 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 14
           #   arch: arm64
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:12-slim
           #   pg_version: 15
           #   arch: amd64
@@ -98,7 +98,7 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 15
           #   arch: arm64
-          # - runner: depot-ubuntu-22.04-arm-4
+          # - runner: depot-ubuntu-22.04-4
           #   image: debian:12-slim
           #   pg_version: 16
           #   arch: amd64
@@ -172,7 +172,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_lakehouse*"` archive
-          package_dir=pg_lakehouse-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}
+          package_dir=pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -192,20 +192,21 @@ jobs:
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
           deb_version=${{ steps.version.outputs.version }}
-          CONTROL_FILE="${package_dir}/DEBIAN/control"
-          echo 'Package: pg-lakehouse' >> $CONTROL_FILE
-          echo 'Version:' ${deb_version} >> $CONTROL_FILE
-          echo 'Section: database' >> $CONTROL_FILE
-          echo 'Priority: optional' >> $CONTROL_FILE
-          echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
-          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
-          echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: An analytical query engine for Postgres' >> $CONTROL_FILE
+          cat <<EOL > $CONTROL_FILE
+          Package: pg-lakehouse
+          Version: ${deb_version}
+          Section: database
+          Priority: optional
+          Architecture: ${{ matrix.arch }}
+          Depends: postgresql-${{ matrix.pg_version }}
+          Maintainer: ParadeDB <support@paradedb.com>
+          Description: An analytical query engine for Postgres
+          EOL
 
           # Create .deb package
           # Note: We specify `xz` compression for compatibility with Debian 11
           sudo chown -R root:root ${package_dir}
-          sudo chmod -R 00755 ${package_dir}
+          sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       # We retrieve the GitHub release for the specific release version

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -56,56 +56,56 @@ jobs:
             image: ubuntu:22.04
             pg_version: 16
             arch: arm64
-          # Debian 11
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 14
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 14
-            arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 15
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 15
-            arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:11-slim
-            pg_version: 16
-            arch: arm64
-          # Debian 12
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 14
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 14
-            arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 15
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 15
-            arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: debian:12-slim
-            pg_version: 16
-            arch: arm64
+          # # Debian 11
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 15
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 16
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:11-slim
+          #   pg_version: 16
+          #   arch: arm64
+          # # Debian 12
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 15
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 16
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: debian:12-slim
+          #   pg_version: 16
+          #   arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
 
@@ -142,8 +142,11 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           # Configure tzdata for non-interactive installation
-          echo "tzdata tzdata/Areas select Etc" | sudo debconf-set-selections
-          echo "tzdata tzdata/Zones/Etc select UTC" | sudo debconf-set-selections
+          sudo ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
+          echo 'Etc/UTC' | sudo tee /etc/timezone
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+          export DEBIAN_FRONTEND=noninteractive
 
           # Install PostgreSQL
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -141,7 +141,11 @@ jobs:
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |
-          export DEBIAN_FRONTEND=noninteractive
+          # Configure tzdata for non-interactive installation
+          echo "tzdata tzdata/Areas select Etc" | sudo debconf-set-selections
+          echo "tzdata tzdata/Zones/Etc select UTC" | sudo debconf-set-selections
+
+          # Install PostgreSQL
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,8 +7,6 @@ name: Publish pg_lakehouse
 
 on:
   push:
-    branches:
-      - phil/cleanup
     tags:
       - "v*"
   workflow_dispatch:
@@ -56,56 +54,56 @@ jobs:
             image: ubuntu:22.04
             pg_version: 16
             arch: arm64
-          # # Debian 11
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 16
-          #   arch: arm64
-          # # Debian 12
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 16
-          #   arch: arm64
+          # Debian 11
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: arm64
+          # Debian 12
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
 
@@ -185,16 +183,15 @@ jobs:
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
           deb_version=${{ steps.version.outputs.version }}
-          cat <<EOL > $CONTROL_FILE
-          Package: pg-lakehouse
-          Version: ${deb_version}
-          Section: database
-          Priority: optional
-          Architecture: ${{ matrix.arch }}
-          Depends: postgresql-${{ matrix.pg_version }}
-          Maintainer: ParadeDB <support@paradedb.com>
-          Description: An analytical query engine for Postgres
-          EOL
+          CONTROL_FILE="${package_dir}/DEBIAN/control"
+          echo 'Package: pg-lakehouse' >> $CONTROL_FILE
+          echo 'Version:' ${deb_version} >> $CONTROL_FILE
+          echo 'Section: database' >> $CONTROL_FILE
+          echo 'Priority: optional' >> $CONTROL_FILE
+          echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
+          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
+          echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
+          echo 'Description: An analytical query engine for Postgres' >> $CONTROL_FILE
 
           # Create .deb package
           # Note: We specify `xz` compression for compatibility with Debian 11
@@ -207,10 +204,10 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # - name: Upload pg_lakehouse .deb to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-      #     asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      - name: Upload pg_lakehouse .deb to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -106,8 +106,6 @@ jobs:
             arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
-    env:
-      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
+    name: Publish pg_search for ${{ matrix.image }} on ${{ matrix.arch }} and PostgreSQL ${{ matrix.pg_version }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
@@ -106,6 +106,8 @@ jobs:
             arch: arm64
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
+    env:
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
       - name: Checkout Git Repository
@@ -204,5 +206,5 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
-          asset_name: pg_search-v${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}.deb
+          asset_path: ./pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: pg_search-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for ${{ matrix.image }} on ${{ matrix.arch }} and PostgreSQL ${{ matrix.pg_version }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -55,7 +55,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 11
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:11-slim
             pg_version: 14
             arch: amd64
@@ -63,7 +63,7 @@ jobs:
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:11-slim
             pg_version: 15
             arch: amd64
@@ -71,7 +71,7 @@ jobs:
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:11-slim
             pg_version: 16
             arch: amd64
@@ -80,7 +80,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 12
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:12-slim
             pg_version: 14
             arch: amd64
@@ -88,7 +88,7 @@ jobs:
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:12-slim
             pg_version: 15
             arch: amd64
@@ -96,7 +96,7 @@ jobs:
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-22.04-4
             image: debian:12-slim
             pg_version: 16
             arch: amd64
@@ -160,7 +160,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}-${{ steps.version.outputs.os_version }}
+          package_dir=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -188,12 +188,12 @@ jobs:
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Full text search for PostgreSQL using BM25' >> $CONTROL_FILE
+          echo 'Description: Full-text search for PostgreSQL using BM25' >> $CONTROL_FILE
 
           # Create .deb package
           # Note: We specify `xz` compression for compatibility with Debian 11
           sudo chown -R root:root ${package_dir}
-          sudo chmod -R 00755 ${package_dir}
+          sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       # We retrieve the GitHub release for the specific release version

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
-        run: apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install Rust
         if: ${{ matrix.image }} == 'debian:11-slim' || ${{ matrix.image }} == 'debian:12-slim'
@@ -138,7 +138,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We had some issue with building on the wrong architecture for our extensions, and Ubuntu images would get blocked at `tzdata` due to DEBIAN_FRONTEND not being set. For some reason, setting it via `export` does not work, it needs to be directly in the command.

## Why
^

## How
^

## Tests
Tested manually by adding a trigger to this branch