### PR TITLE
fix: Fix illegal instructions issue on `arm64` extensions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,16 +1,19 @@
 # Global settings - optimize for the native CPU for all targets. This
 # is required by the 'datafusion` crate for maximum performance, and
-# applies in addition to the target-specific settings below
+# applies in addition to the target-specific settings below.
 [build]
 rustflags = ["-Ctarget-cpu=native"]
 
-# On ARM, we override the target CPU to be generic to avoid issues
-# of illegal instructions on machines with older CPUs. If you are
-# looking for maximum performance on ARM, you can compile locally
-# and override this setting.
+# On arm CPUs, we add the option to use generic CPU optimizations when
+# building for distribution. This is to avoid illegal instructions on
+# machines with older CPUs. If you are looking for maximum performance
+# and can compile on the target machine, don't set this option.
 [target.'cfg(target_arch = "arm")']
-rustflags = ["-Ctarget-cpu=generic"]
+rustflags = [
+  { env = "USE_GENERIC_CPU", value = "-Ctarget-cpu=generic" },
+  { env_not = "USE_GENERIC_CPU", value = "-Ctarget-cpu=native" },
+]
 
-# PostgreSQL symbols won't be available until runtime
+# on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,13 @@
 [build]
 rustflags = ["-Ctarget-cpu=native"]
 
+# On ARM, we override the target CPU to be generic to avoid issues
+# of illegal instructions on machines with older CPUs. If you are
+# looking for maximum performance on ARM, you can compile locally
+# and override this setting.
+[target.'cfg(target_arch = "arm")']
+rustflags = ["-Ctarget-cpu=generic"]
+
 # PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -154,9 +154,12 @@ jobs:
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       # TODO: Add telemetry to pg_lakehouse
+      # We set USE_GENERIC_CPU to build universal binaries for arm CPUs. This reduces performance, but is necessary as we don't know
+      # what CPU architecture the user will be running on. For the most optimized build, users should build the extension directly on
+      # their target machine, or use our Docker image.
       - name: Package pg_lakehouse Extension with pgrx
         working-directory: pg_lakehouse/
-        run: cargo pgrx package --features telemetry
+        run: USE_GENERIC_CPU=1 cargo pgrx package --features telemetry
 
       - name: Create .deb Package
         run: |

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -149,9 +149,12 @@ jobs:
         working-directory: pg_search/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
+      # We set USE_GENERIC_CPU to build universal binaries for arm CPUs. This reduces performance, but is necessary as we don't know
+      # what CPU architecture the user will be running on. For the most optimized build, users should build the extension directly on
+      # their target machine, or use our Docker image.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        run: cargo pgrx package --features "icu telemetry"
+        run: USE_GENERIC_CPU=1 cargo pgrx package --features "icu telemetry"
 
       - name: Create .deb Package
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Fix an issue where it would crash on `arm64` older CPUs. This happened since we switched to Depot, which uses a newer CPU.

## Why
Make sure it's compatible with all versions for our users.

## How
Use `target-cpu=generic`

## Tests
Needs testing