### PR TITLE
fix: Properly set `generic` CPU for `arm` architecture during deployments

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,16 +4,6 @@
 [build]
 rustflags = ["-Ctarget-cpu=native"]
 
-# On arm CPUs, we add the option to use generic CPU optimizations when
-# building for distribution. This is to avoid illegal instructions on
-# machines with older CPUs. If you are looking for maximum performance
-# and can compile on the target machine, don't set this option.
-[target.'cfg(target_arch = "arm")']
-rustflags = [
-  { env = "USE_GENERIC_CPU", value = "-Ctarget-cpu=generic" },
-  { env_not = "USE_GENERIC_CPU", value = "-Ctarget-cpu=native" },
-]
-
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -159,7 +159,9 @@ jobs:
       # their target machine, or use our Docker image.
       - name: Package pg_lakehouse Extension with pgrx
         working-directory: pg_lakehouse/
-        run: USE_GENERIC_CPU=1 cargo pgrx package --features telemetry
+        run: |
+          sed -i '/\[target\.\x27cfg(target_arch = "arm")\x27\]/a rustflags = ["-Ctarget-cpu=generic"]' ../.cargo/config.toml || echo -e '[target.\x27cfg(target_arch = "arm")\x27]\nrustflags = ["-Ctarget-cpu=generic"]' >> ../.cargo/config.toml
+          cargo pgrx package --features telemetry
 
       - name: Create .deb Package
         run: |

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -154,7 +154,9 @@ jobs:
       # their target machine, or use our Docker image.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        run: USE_GENERIC_CPU=1 cargo pgrx package --features "icu telemetry"
+        run: |
+          sed -i '/\[target\.\x27cfg(target_arch = "arm")\x27\]/a rustflags = ["-Ctarget-cpu=generic"]' ../.cargo/config.toml || echo -e '[target.\x27cfg(target_arch = "arm")\x27]\nrustflags = ["-Ctarget-cpu=generic"]' >> ../.cargo/config.toml
+          cargo pgrx package --features "icu telemetry"
 
       - name: Create .deb Package
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
