### PR TITLE
fix: `EXPLAIN` and `EXPLAIN ANALYZE`

### DIFF
--- a/pg_lakehouse/README.md
+++ b/pg_lakehouse/README.md
@@ -91,9 +91,9 @@ Note: If `path` points to a directory of partitioned files, it should end in a `
 
 Note: Column names must be wrapped in double quotes to preserve uppercase letters. This is because DataFusion is case-sensitive and Postgres' foreign table column names must match the foreign table's column names exactly.
 
-## Query Acceleration
+## Shared Preload Libraries
 
-This extension uses Postgres hooks to intercept and push queries down to DataFusion. In order to enable these hooks, the extension must be added to `shared_preload_libraries` inside `postgresql.conf`.
+Because this extension uses Postgres hooks to intercept and push queries down to DataFusion, it is **very important** that it is added to `shared_preload_libraries` inside `postgresql.conf`.
 
 ```bash
 # Inside postgresql.conf

--- a/pg_lakehouse/src/datafusion/catalog.rs
+++ b/pg_lakehouse/src/datafusion/catalog.rs
@@ -10,7 +10,9 @@ use thiserror::Error;
 
 use crate::schema::attribute::SchemaError;
 
+use super::context::ContextError;
 use super::provider::TableProviderError;
+use super::session::SessionError;
 
 #[derive(Clone)]
 pub struct LakehouseCatalog {
@@ -96,6 +98,9 @@ impl CatalogProviderList for LakehouseCatalogList {
 #[derive(Error, Debug)]
 pub enum CatalogError {
     #[error(transparent)]
+    ContextError(#[from] ContextError),
+
+    #[error(transparent)]
     DataFusionError(#[from] DataFusionError),
 
     #[error(transparent)]
@@ -120,7 +125,13 @@ pub enum CatalogError {
     SchemaError(#[from] SchemaError),
 
     #[error(transparent)]
+    SessionError(#[from] SessionError),
+
+    #[error(transparent)]
     TableProviderError(#[from] TableProviderError),
+
+    #[error(transparent)]
+    UrlParseError(#[from] url::ParseError),
 
     #[error(transparent)]
     Utf8Error(#[from] std::str::Utf8Error),

--- a/pg_lakehouse/src/datafusion/provider.rs
+++ b/pg_lakehouse/src/datafusion/provider.rs
@@ -15,7 +15,7 @@ use crate::schema::attribute::*;
 use super::format::*;
 use super::session::*;
 
-struct ObjectStoreUrl(pub Url);
+pub struct ObjectStoreUrl(pub Url);
 
 impl AsRef<Url> for ObjectStoreUrl {
     fn as_ref(&self) -> &Url {

--- a/pg_lakehouse/src/fdw/handler.rs
+++ b/pg_lakehouse/src/fdw/handler.rs
@@ -56,6 +56,13 @@ impl From<*mut pg_sys::ForeignServer> for FdwHandler {
     }
 }
 
+impl From<*mut pg_sys::ForeignTable> for FdwHandler {
+    fn from(table: *mut pg_sys::ForeignTable) -> Self {
+        let server = unsafe { pg_sys::GetForeignServer((*table).serverid) };
+        FdwHandler::from(server)
+    }
+}
+
 pub fn register_object_store(
     handler: FdwHandler,
     url: &Url,

--- a/pg_lakehouse/src/fdw/options.rs
+++ b/pg_lakehouse/src/fdw/options.rs
@@ -67,8 +67,8 @@ impl ServerOptions {
 
 pub trait ForeignOptions {
     fn table_options(&self) -> Result<HashMap<String, String>, OptionsError>;
-    #[allow(dead_code)]
     fn server_options(&self) -> Result<HashMap<String, String>, OptionsError>;
+    fn user_mapping_options(&self) -> Result<HashMap<String, String>, OptionsError>;
 }
 
 impl ForeignOptions for PgRelation {
@@ -93,6 +93,18 @@ impl ForeignOptions for PgRelation {
         let server_options = unsafe { options_to_hashmap((*foreign_server).options)? };
 
         Ok(server_options)
+    }
+
+    fn user_mapping_options(&self) -> Result<HashMap<String, String>, OptionsError> {
+        if !self.is_foreign_table() {
+            return Ok(HashMap::new());
+        }
+
+        let foreign_table = unsafe { pg_sys::GetForeignTable(self.oid()) };
+        let foreign_server = unsafe { pg_sys::GetForeignServer((*foreign_table).serverid) };
+        let user_mapping_options = unsafe { user_mapping_options(foreign_server) };
+
+        Ok(user_mapping_options)
     }
 }
 

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -2,6 +2,7 @@ use async_std::task;
 use datafusion::common::arrow::array::RecordBatch;
 use datafusion::logical_expr::LogicalPlan;
 use pgrx::*;
+use std::ffi::CStr;
 use thiserror::Error;
 
 use crate::datafusion::context::ContextError;
@@ -31,22 +32,21 @@ pub fn executor_run(
 ) -> Result<(), ExecutorHookError> {
     let ps = query_desc.plannedstmt;
     let rtable = unsafe { (*ps).rtable };
-    let pg_query = PgQuery::try_from(query_desc.clone())?;
+    let query = get_current_query(ps, unsafe { CStr::from_ptr(query_desc.sourceText) })?;
+    let query_type = get_query_type(ps);
 
-    // Only use this hook for deltalake tables
-    // Allow INSERTs to go through
     if rtable.is_null()
         || query_desc.operation != pg_sys::CmdType_CMD_SELECT
-        || pg_query.query_type() != QueryType::DataFusion
+        || query_type != QueryType::DataFusion
         // Tech Debt: Find a less hacky way to let COPY go through
-        || pg_query.text().to_lowercase().starts_with("copy")
+        || query.to_lowercase().starts_with("copy")
     {
         prev_hook(query_desc, direction, count, execute_once);
         return Ok(());
     }
 
     // Parse the query into a LogicalPlan
-    match LogicalPlan::try_from(QueryString(&pg_query.text())) {
+    match LogicalPlan::try_from(QueryString(&query)) {
         Ok(logical_plan) => {
             // Don't intercept any DDL or DML statements
             match logical_plan {
@@ -83,7 +83,6 @@ pub fn executor_run(
 async fn get_datafusion_batches(
     logical_plan: LogicalPlan,
 ) -> Result<Vec<RecordBatch>, ContextError> {
-    info!("Executing DataFusion query: {:?}", logical_plan);
     // Execute the logical plan and collect the resulting batches
     let context = Session::session_context()?;
     let dataframe = context.execute_logical_plan(logical_plan).await?;

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -50,7 +50,10 @@ pub fn executor_run(
         Ok(logical_plan) => {
             // Don't intercept any DDL or DML statements
             match logical_plan {
-                LogicalPlan::Ddl(_) | LogicalPlan::Dml(_) => {
+                LogicalPlan::Ddl(_)
+                | LogicalPlan::Dml(_)
+                | LogicalPlan::Explain(_)
+                | LogicalPlan::Analyze(_) => {
                     prev_hook(query_desc, direction, count, execute_once);
                     return Ok(());
                 }
@@ -80,6 +83,7 @@ pub fn executor_run(
 async fn get_datafusion_batches(
     logical_plan: LogicalPlan,
 ) -> Result<Vec<RecordBatch>, ContextError> {
+    info!("Executing DataFusion query: {:?}", logical_plan);
     // Execute the logical plan and collect the resulting batches
     let context = Session::session_context()?;
     let dataframe = context.execute_logical_plan(logical_plan).await?;

--- a/pg_lakehouse/src/hooks/explain.rs
+++ b/pg_lakehouse/src/hooks/explain.rs
@@ -1,0 +1,83 @@
+use datafusion::arrow::array::StringArray;
+use datafusion::arrow::error::ArrowError;
+use datafusion::common::{downcast_value, DataFusionError};
+use datafusion::logical_expr::LogicalPlan;
+use pgrx::pg_sys::AsPgCStr;
+use pgrx::*;
+use std::ffi::CStr;
+use thiserror::Error;
+
+use super::query::*;
+use crate::datafusion::plan::QueryString;
+use crate::datafusion::session::*;
+
+pub async unsafe fn explain(
+    plan: *mut pg_sys::PlannedStmt,
+    query: &CStr,
+    dest: &PgBox<pg_sys::DestReceiver>,
+) -> Result<bool, ExplainHookError> {
+    let query = get_current_query(plan, query)?;
+
+    match LogicalPlan::try_from(QueryString(&query)) {
+        Ok(logical_plan) => {
+            let explain_state = pg_sys::NewExplainState();
+
+            match logical_plan {
+                LogicalPlan::Explain(explain) => {
+                    pg_sys::appendStringInfoString(
+                        (*explain_state).str_,
+                        format!("{} \n {:?}", "DataFusionScan: LogicalPlan", explain.plan)
+                            .as_pg_cstr(),
+                    );
+                }
+                LogicalPlan::Analyze(_) => {
+                    let context = Session::session_context()?;
+                    let dataframe = context.execute_logical_plan(logical_plan).await?;
+                    let batches = dataframe.collect().await?;
+
+                    if let Some(array) = batches[0].column_by_name("plan") {
+                        let string_array = downcast_value!(array, StringArray);
+                        let plan = string_array.value(0);
+                        pg_sys::appendStringInfoString((*explain_state).str_, plan.as_pg_cstr());
+                    } else {
+                        return Ok(false);
+                    }
+                }
+                _ => return Ok(false),
+            };
+
+            let tupdesc = pg_sys::CreateTemplateTupleDesc(1);
+            pg_sys::TupleDescInitEntry(
+                tupdesc,
+                1,
+                "QUERY PLAN".as_pg_cstr(),
+                pg_sys::TEXTOID,
+                -1,
+                0,
+            );
+            let tstate =
+                pg_sys::begin_tup_output_tupdesc(dest.as_ptr(), tupdesc, &pg_sys::TTSOpsVirtual);
+            pg_sys::do_text_output_multiline(tstate, (*(*explain_state).str_).data);
+            pg_sys::end_tup_output(tstate);
+            pg_sys::pfree((*(*explain_state).str_).data as *mut std::ffi::c_void);
+
+            Ok(true)
+        }
+        Err(_) => Ok(false),
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ExplainHookError {
+    #[error(transparent)]
+    ArrowError(#[from] ArrowError),
+
+    #[error(transparent)]
+    DataFusion(#[from] DataFusionError),
+
+    #[error(transparent)]
+    SessionError(#[from] SessionError),
+
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+}

--- a/pg_lakehouse/src/hooks/process.rs
+++ b/pg_lakehouse/src/hooks/process.rs
@@ -1,0 +1,57 @@
+use async_std::task;
+use pgrx::*;
+use std::ffi::CStr;
+use thiserror::Error;
+
+use super::explain::*;
+
+#[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
+pub fn process_utility(
+    pstmt: PgBox<pg_sys::PlannedStmt>,
+    query_string: &CStr,
+    read_only_tree: Option<bool>,
+    context: pg_sys::ProcessUtilityContext,
+    params: PgBox<pg_sys::ParamListInfoData>,
+    query_env: PgBox<pg_sys::QueryEnvironment>,
+    dest: PgBox<pg_sys::DestReceiver>,
+    completion_tag: *mut pg_sys::QueryCompletion,
+    prev_hook: fn(
+        pstmt: PgBox<pg_sys::PlannedStmt>,
+        query_string: &CStr,
+        read_only_tree: Option<bool>,
+        context: pg_sys::ProcessUtilityContext,
+        params: PgBox<pg_sys::ParamListInfoData>,
+        query_env: PgBox<pg_sys::QueryEnvironment>,
+        dest: PgBox<pg_sys::DestReceiver>,
+        completion_tag: *mut pg_sys::QueryCompletion,
+    ) -> HookResult<()>,
+) -> Result<(), ProcessHookError> {
+    let plan = pstmt.utilityStmt;
+    let pg_plan = pstmt.clone().into_pg();
+
+    if pg_sys::NodeTag::T_ExplainStmt == unsafe { (*plan).type_ } {
+        if let Ok(true) = unsafe { task::block_on(explain(pg_plan, query_string, &dest)) } {
+            return Ok(());
+        }
+    }
+
+    prev_hook(
+        pstmt,
+        query_string,
+        read_only_tree,
+        context,
+        params,
+        query_env,
+        dest,
+        completion_tag,
+    );
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub enum ProcessHookError {
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+}

--- a/pg_lakehouse/src/hooks/query.rs
+++ b/pg_lakehouse/src/hooks/query.rs
@@ -12,93 +12,74 @@ pub enum QueryType {
     Postgres,
 }
 
-pub struct PgQuery {
-    text: String,
-    query_type: QueryType,
-}
+pub fn get_current_query(
+    planned_stmt: *mut pg_sys::PlannedStmt,
+    query_string: &CStr,
+) -> Result<String, Utf8Error> {
+    let query_start_index = unsafe { (*planned_stmt).stmt_location };
+    let query_len = unsafe { (*planned_stmt).stmt_len };
+    let full_query = query_string.to_str()?;
 
-impl PgQuery {
-    pub fn new(text: String, query_type: QueryType) -> Self {
-        Self { text, query_type }
-    }
-
-    pub fn text(&self) -> String {
-        self.text.clone()
-    }
-
-    pub fn query_type(&self) -> QueryType {
-        self.query_type.clone()
-    }
-}
-
-impl TryFrom<PgBox<pg_sys::QueryDesc>> for PgQuery {
-    type Error = Utf8Error;
-
-    fn try_from(query_desc: PgBox<pg_sys::QueryDesc>) -> Result<Self, Self::Error> {
-        let planned_stmt = query_desc.plannedstmt;
-        let query_start_index = unsafe { (*planned_stmt).stmt_location };
-        let query_len = unsafe { (*planned_stmt).stmt_len };
-        let query = unsafe { CStr::from_ptr(query_desc.sourceText) }.to_str()?;
-
-        let raw_text = if query_start_index != -1 {
-            if query_len == 0 {
-                query[(query_start_index as usize)..query.len()].to_string()
-            } else {
-                query[(query_start_index as usize)..((query_start_index + query_len) as usize)]
-                    .to_string()
-            }
+    let current_query = if query_start_index != -1 {
+        if query_len == 0 {
+            full_query[(query_start_index as usize)..full_query.len()].to_string()
         } else {
-            query.to_string()
-        };
+            full_query[(query_start_index as usize)..((query_start_index + query_len) as usize)]
+                .to_string()
+        }
+    } else {
+        full_query.to_string()
+    };
 
-        let mut row_tables: Vec<PgRelation> = vec![];
-        let mut col_tables: Vec<PgRelation> = vec![];
+    Ok(current_query)
+}
 
-        unsafe {
-            let rtable = (*planned_stmt).rtable;
+pub fn get_query_type(planned_stmt: *mut pg_sys::PlannedStmt) -> QueryType {
+    let mut row_tables: Vec<PgRelation> = vec![];
+    let mut col_tables: Vec<PgRelation> = vec![];
+
+    unsafe {
+        let rtable = (*planned_stmt).rtable;
+        #[cfg(feature = "pg12")]
+        let mut current_cell = (*rtable).head;
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        let elements = (*rtable).elements;
+
+        for i in 0..(*rtable).length {
+            let rte: *mut pg_sys::RangeTblEntry;
             #[cfg(feature = "pg12")]
-            let mut current_cell = (*rtable).head;
+            {
+                rte = (*current_cell).data.ptr_value as *mut pg_sys::RangeTblEntry;
+                current_cell = (*current_cell).next;
+            }
             #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
-            let elements = (*rtable).elements;
+            {
+                rte = (*elements.offset(i as isize)).ptr_value as *mut pg_sys::RangeTblEntry;
+            }
 
-            for i in 0..(*rtable).length {
-                let rte: *mut pg_sys::RangeTblEntry;
-                #[cfg(feature = "pg12")]
-                {
-                    rte = (*current_cell).data.ptr_value as *mut pg_sys::RangeTblEntry;
-                    current_cell = (*current_cell).next;
-                }
-                #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
-                {
-                    rte = (*elements.offset(i as isize)).ptr_value as *mut pg_sys::RangeTblEntry;
-                }
+            if (*rte).rtekind != pg_sys::RTEKind_RTE_RELATION {
+                continue;
+            }
+            let relation = pg_sys::RelationIdGetRelation((*rte).relid);
+            let pg_relation = PgRelation::from_pg_owned(relation);
 
-                if (*rte).rtekind != pg_sys::RTEKind_RTE_RELATION {
-                    continue;
+            if pg_relation.is_foreign_table() {
+                let foreign_table = pg_sys::GetForeignTable(pg_relation.oid());
+                let foreign_server = pg_sys::GetForeignServer((*foreign_table).serverid);
+                let fdw_handler = FdwHandler::from(foreign_server);
+                if fdw_handler != FdwHandler::Other {
+                    col_tables.push(pg_relation)
                 }
-                let relation = pg_sys::RelationIdGetRelation((*rte).relid);
-                let pg_relation = PgRelation::from_pg_owned(relation);
-
-                if pg_relation.is_foreign_table() {
-                    let foreign_table = pg_sys::GetForeignTable(pg_relation.oid());
-                    let foreign_server = pg_sys::GetForeignServer((*foreign_table).serverid);
-                    let fdw_handler = FdwHandler::from(foreign_server);
-                    if fdw_handler != FdwHandler::Other {
-                        col_tables.push(pg_relation)
-                    }
-                } else {
-                    row_tables.push(pg_relation)
-                }
+            } else {
+                row_tables.push(pg_relation)
             }
         }
+    }
 
-        let query_type = match (row_tables.is_empty(), col_tables.is_empty()) {
-            (true, true) => QueryType::Postgres,
-            (false, true) => QueryType::Postgres,
-            (true, false) => QueryType::DataFusion,
-            (false, false) => QueryType::Postgres,
-        };
-
-        Ok(PgQuery::new(raw_text, query_type))
+    match (row_tables.is_empty(), col_tables.is_empty()) {
+        (true, true) => QueryType::Postgres,
+        (false, true) => QueryType::Postgres,
+        (true, false) => QueryType::DataFusion,
+        (false, false) => QueryType::Postgres,
     }
 }

--- a/pg_lakehouse/tests/explain.rs
+++ b/pg_lakehouse/tests/explain.rs
@@ -74,3 +74,76 @@ async fn test_explain_federated(#[future(awt)] s3: S3, mut conn: PgConnection) -
 
     Ok(())
 }
+
+#[rstest]
+async fn test_explain_analyze_fdw(#[future(awt)] s3: S3, mut conn: PgConnection) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+    let rows: Vec<NycTripsTable> = "SELECT * FROM nyc_trips".fetch(&mut conn);
+    s3.client.create_bucket().bucket(S3_BUCKET).send().await?;
+    s3.create_bucket(S3_BUCKET).await?;
+    s3.put_rows(S3_BUCKET, S3_KEY, &rows).await?;
+
+    NycTripsTable::setup_s3_listing_fdw(&s3.url.clone(), &format!("s3://{S3_BUCKET}/{S3_KEY}"))
+        .execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN ANALYZE SELECT COUNT(*) FROM trips WHERE tip_amount <> 0".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("AggregateExec"));
+    assert!(explain[1].0.contains("CoalescePartitionsExec"));
+    assert!(explain[2].0.contains("AggregateExec"));
+    assert!(explain[3].0.contains("RepartitionExec"));
+    assert!(explain[4].0.contains("ProjectionExec"));
+    assert!(explain[5].0.contains("CoalesceBatchesExec"));
+    assert!(explain[6].0.contains("FilterExec"));
+    assert!(explain[7].0.contains("ParquetExec"));
+
+    Ok(())
+}
+
+#[rstest]
+async fn test_explain_analyze_heap(mut conn: PgConnection) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN ANALYZE SELECT COUNT(*) FROM nyc_trips WHERE tip_amount <> 0".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("Aggregate"));
+    assert!(explain[1].0.contains("Seq Scan on nyc_trips"));
+    assert!(explain[2].0.contains("Filter"));
+    assert!(explain[3].0.contains("Rows Removed by Filter"));
+    assert!(explain[4].0.contains("Planning Time"));
+    assert!(explain[5].0.contains("Execution Time"));
+
+    Ok(())
+}
+
+#[rstest]
+async fn test_explain_analyze_federated(
+    #[future(awt)] s3: S3,
+    mut conn: PgConnection,
+) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+    let rows: Vec<NycTripsTable> = "SELECT * FROM nyc_trips".fetch(&mut conn);
+    s3.client.create_bucket().bucket(S3_BUCKET).send().await?;
+    s3.create_bucket(S3_BUCKET).await?;
+    s3.put_rows(S3_BUCKET, S3_KEY, &rows).await?;
+
+    NycTripsTable::setup_s3_listing_fdw(&s3.url.clone(), &format!("s3://{S3_BUCKET}/{S3_KEY}"))
+        .execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN ANALYZE SELECT COUNT(*) FROM trips LEFT JOIN nyc_trips ON trips.\"VendorID\" = nyc_trips.\"VendorID\"".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("Aggregate"));
+    assert!(explain[1].0.contains("Hash Right Join"));
+    assert!(explain[2]
+        .0
+        .contains("Hash Cond: (nyc_trips.\"VendorID\" = trips.\"VendorID\")"));
+    assert!(explain[3].0.contains("Seq Scan on nyc_trips"));
+    assert!(explain[4].0.contains("Hash"));
+    assert!(explain[5].0.contains("Buckets"));
+    assert!(explain[6].0.contains("Foreign Scan on trips"));
+
+    Ok(())
+}

--- a/pg_lakehouse/tests/explain.rs
+++ b/pg_lakehouse/tests/explain.rs
@@ -1,0 +1,76 @@
+mod fixtures;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+const S3_BUCKET: &str = "test-trip-setup";
+const S3_KEY: &str = "test_trip_setup.parquet";
+
+#[rstest]
+async fn test_explain_fdw(#[future(awt)] s3: S3, mut conn: PgConnection) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+    let rows: Vec<NycTripsTable> = "SELECT * FROM nyc_trips".fetch(&mut conn);
+    s3.client.create_bucket().bucket(S3_BUCKET).send().await?;
+    s3.create_bucket(S3_BUCKET).await?;
+    s3.put_rows(S3_BUCKET, S3_KEY, &rows).await?;
+
+    NycTripsTable::setup_s3_listing_fdw(&s3.url.clone(), &format!("s3://{S3_BUCKET}/{S3_KEY}"))
+        .execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN SELECT COUNT(*) FROM trips WHERE tip_amount <> 0".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("DataFusionScan: LogicalPlan"));
+    assert!(explain[1].0.contains("Projection: COUNT(*)"));
+    assert!(explain[2]
+        .0
+        .contains("Aggregate: groupBy=[[]], aggr=[[COUNT(*)]]"));
+    assert!(explain[3]
+        .0
+        .contains("Filter: trips.tip_amount != Int64(0)"));
+    assert!(explain[4].0.contains("TableScan: trips"));
+
+    Ok(())
+}
+
+#[rstest]
+async fn test_explain_heap(mut conn: PgConnection) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN SELECT COUNT(*) FROM nyc_trips WHERE tip_amount <> 0".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("Aggregate"));
+    assert!(explain[1].0.contains("Seq Scan on nyc_trips"));
+    assert!(explain[2].0.contains("Filter"));
+
+    Ok(())
+}
+
+#[rstest]
+async fn test_explain_federated(#[future(awt)] s3: S3, mut conn: PgConnection) -> Result<()> {
+    NycTripsTable::setup().execute(&mut conn);
+    let rows: Vec<NycTripsTable> = "SELECT * FROM nyc_trips".fetch(&mut conn);
+    s3.client.create_bucket().bucket(S3_BUCKET).send().await?;
+    s3.create_bucket(S3_BUCKET).await?;
+    s3.put_rows(S3_BUCKET, S3_KEY, &rows).await?;
+
+    NycTripsTable::setup_s3_listing_fdw(&s3.url.clone(), &format!("s3://{S3_BUCKET}/{S3_KEY}"))
+        .execute(&mut conn);
+
+    let explain: Vec<(String,)> =
+        "EXPLAIN SELECT COUNT(*) FROM trips LEFT JOIN nyc_trips ON trips.\"VendorID\" = nyc_trips.\"VendorID\"".fetch(&mut conn);
+
+    assert!(explain[0].0.contains("Aggregate"));
+    assert!(explain[1].0.contains("Hash Right Join"));
+    assert!(explain[2]
+        .0
+        .contains("Hash Cond: (nyc_trips.\"VendorID\" = trips.\"VendorID\")"));
+    assert!(explain[3].0.contains("Seq Scan on nyc_trips"));
+    assert!(explain[4].0.contains("Hash"));
+    assert!(explain[5].0.contains("Foreign Scan on trips"));
+
+    Ok(())
+}

--- a/pg_lakehouse/tests/fixtures/mod.rs
+++ b/pg_lakehouse/tests/fixtures/mod.rs
@@ -124,6 +124,7 @@ impl S3 {
         self.put_batch(bucket, key, &batch).await
     }
 
+    #[allow(dead_code)]
     pub async fn put_directory(&self, bucket: &str, path: &str, dir: &Path) -> Result<()> {
         fn upload_files(
             client: aws_sdk_s3::Client,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Returns the correct DataFusion plan on `EXPLAIN` and `EXPLAIN ANALYZE`.

## Why

## How
I ended up re-using the process utility hook from `pg_analytics`. While the FDW API does have an `explain` hook, this hook is meant to return the query plan if it were executed by the FDW. Since the executor hook intercepts the query before it reaches the FDW, using the process utility hook ensures that the correct plan is shown.

## Tests
See tests.