### PR TITLE
fix: Remove cpu=native on all OSes in CI

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -154,13 +154,13 @@ jobs:
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
       # TODO: Add telemetry to pg_lakehouse
-      # We set USE_GENERIC_CPU to build universal binaries for arm CPUs. This reduces performance, but is necessary as we don't know
-      # what CPU architecture the user will be running on. For the most optimized build, users should build the extension directly on
-      # their target machine, or use our Docker image.
+      # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
+      # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should
+      # build the extension directly on their target machine, or use our Docker image.
       - name: Package pg_lakehouse Extension with pgrx
         working-directory: pg_lakehouse/
         run: |
-          sed -i '/\[target\.\x27cfg(target_arch = "arm")\x27\]/a rustflags = ["-Ctarget-cpu=generic"]' ../.cargo/config.toml || echo -e '[target.\x27cfg(target_arch = "arm")\x27]\nrustflags = ["-Ctarget-cpu=generic"]' >> ../.cargo/config.toml
+          sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
           cargo pgrx package --features telemetry
 
       - name: Create .deb Package

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -149,13 +149,13 @@ jobs:
         working-directory: pg_search/
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
 
-      # We set USE_GENERIC_CPU to build universal binaries for arm CPUs. This reduces performance, but is necessary as we don't know
-      # what CPU architecture the user will be running on. For the most optimized build, users should build the extension directly on
-      # their target machine, or use our Docker image.
+      # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
+      # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should
+      # build the extension directly on their target machine, or use our Docker image.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
         run: |
-          sed -i '/\[target\.\x27cfg(target_arch = "arm")\x27\]/a rustflags = ["-Ctarget-cpu=generic"]' ../.cargo/config.toml || echo -e '[target.\x27cfg(target_arch = "arm")\x27]\nrustflags = ["-Ctarget-cpu=generic"]' >> ../.cargo/config.toml
+          sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
           cargo pgrx package --features "icu telemetry"
 
       - name: Create .deb Package

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docker/.docker_cache_dev/
 
 # SSH
 *.pem
+*.json
 
 # Code coverage
 *.profraw


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
There's been issues when users try to run the `amd64` binary on macOS ARM via Docker on an amd64 image

## Why

## How

## Tests
