### PR TITLE
fix: don't panic in Box::pin

### DIFF
--- a/pg_lakehouse/src/datafusion/schema.rs
+++ b/pg_lakehouse/src/datafusion/schema.rs
@@ -122,11 +122,9 @@ impl SchemaProvider for LakehouseSchemaProvider {
         'life1: 'async_trait,
     {
         Box::pin(async move {
-            let table = self
-                .table_impl(table_name)
-                .unwrap_or_else(|err| panic!("{}", err));
-
-            Ok(Some(table))
+            self.table_impl(table_name)
+                .map(Some)
+                .map_err(|err| DataFusionError::Execution(err.to_string()))
         })
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1136

## What
This PR addresses an issue where a panic inside a `Box::pin`-wrapped future would cause the `async_std` global executor to crash permanently.

## Why
`Box::pin` is a utility that allows for the creation of a pinned heap allocation. In Rust, pinning is used to prevent data from being moved, which is crucial for certain types of asynchronous programming where references must remain stable across await points.

When you create a future with `Box::pin`, it ensures that the future will stay at a fixed memory location. This is particularly important for self-referential structures or for async tasks that rely on consistent memory addresses.

`async_std` provides a global executor we use to run asynchronous tasks with `block_on`. If this executor crashes, there's no way to restart it, which was causing #1136.

Apparently, the global executor crashes because its the only safe thing to do when the stack unwinding from a `panic!` risks interfering with the fixed memory layout of a pinned `Box`. So we need to make sure not to `panic!` in these contexts.

Really, should should try and avoid panicking altogether, and bubble up our errors with `thiserror` or `anyhow`.

## How
Replaced the `panic!` with` map(Some).map_err` to avoid panicking inside the `Box::pin`-wrapped future.
