### PR TITLE
fix: Connect to tables in Azure

### DIFF
--- a/pg_lakehouse/src/datafusion/format.rs
+++ b/pg_lakehouse/src/datafusion/format.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[derive(Clone, Debug)]
 pub struct FileExtension(pub String);
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum TableFormat {
     None,
     Delta,

--- a/pg_lakehouse/src/fdw/azblob.rs
+++ b/pg_lakehouse/src/fdw/azblob.rs
@@ -81,15 +81,20 @@ impl AzblobUserMappingOption {
     }
 }
 
-impl TryFrom<ServerOptions> for Azblob {
+impl TryFrom<ObjectStoreConfig> for Azblob {
     type Error = ContextError;
 
-    fn try_from(options: ServerOptions) -> Result<Self, Self::Error> {
+    fn try_from(options: ObjectStoreConfig) -> Result<Self, Self::Error> {
         let server_options = options.server_options();
         let url = options.url();
+        let format = options.format().clone();
         let user_mapping_options = options.user_mapping_options();
 
         let mut builder = Azblob::default();
+
+        if format == TableFormat::Delta {
+            builder.root(url.path());
+        }
 
         if let Some(connection_string) =
             user_mapping_options.get(AzblobUserMappingOption::ConnectionString.as_str())
@@ -154,14 +159,15 @@ impl TryFrom<ServerOptions> for Azblob {
 impl BaseFdw for AzblobFdw {
     fn register_object_store(
         url: &Url,
-        _format: TableFormat,
+        format: TableFormat,
         server_options: HashMap<String, String>,
         user_mapping_options: HashMap<String, String>,
     ) -> Result<(), ContextError> {
         let context = Session::session_context()?;
 
-        let builder = Azblob::try_from(ServerOptions::new(
+        let builder = Azblob::try_from(ObjectStoreConfig::new(
             url,
+            format,
             server_options.clone(),
             user_mapping_options.clone(),
         ))?;

--- a/pg_lakehouse/src/fdw/azblob.rs
+++ b/pg_lakehouse/src/fdw/azblob.rs
@@ -48,7 +48,7 @@ impl AzblobServerOption {
     pub fn is_required(&self) -> bool {
         match self {
             Self::EncryptionAlgorithm => false,
-            Self::Endpoint => false,
+            Self::Endpoint => true,
         }
     }
 

--- a/pg_lakehouse/src/fdw/azdls.rs
+++ b/pg_lakehouse/src/fdw/azdls.rs
@@ -45,7 +45,7 @@ impl AzdlsServerOption {
 
     pub fn is_required(&self) -> bool {
         match self {
-            Self::Endpoint => false,
+            Self::Endpoint => true,
         }
     }
 

--- a/pg_lakehouse/src/fdw/gcs.rs
+++ b/pg_lakehouse/src/fdw/gcs.rs
@@ -83,10 +83,10 @@ impl GcsUserMappingOption {
     }
 }
 
-impl TryFrom<ServerOptions> for Gcs {
+impl TryFrom<ObjectStoreConfig> for Gcs {
     type Error = ContextError;
 
-    fn try_from(options: ServerOptions) -> Result<Self, Self::Error> {
+    fn try_from(options: ObjectStoreConfig) -> Result<Self, Self::Error> {
         let server_options = options.server_options();
         let url = options.url();
         let user_mapping_options = options.user_mapping_options();
@@ -140,14 +140,15 @@ impl TryFrom<ServerOptions> for Gcs {
 impl BaseFdw for GcsFdw {
     fn register_object_store(
         url: &Url,
-        _format: TableFormat,
+        format: TableFormat,
         server_options: HashMap<String, String>,
         user_mapping_options: HashMap<String, String>,
     ) -> Result<(), ContextError> {
         let context = Session::session_context()?;
 
-        let builder = Gcs::try_from(ServerOptions::new(
+        let builder = Gcs::try_from(ObjectStoreConfig::new(
             url,
+            format,
             server_options.clone(),
             user_mapping_options.clone(),
         ))?;

--- a/pg_lakehouse/src/fdw/options.rs
+++ b/pg_lakehouse/src/fdw/options.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use supabase_wrappers::prelude::*;
 use url::Url;
 
+use crate::datafusion::format::TableFormat;
+
 pub enum TableOption {
     Path,
     Extension,
@@ -33,23 +35,30 @@ impl TableOption {
 }
 
 #[derive(Clone, Debug)]
-pub struct ServerOptions {
+pub struct ObjectStoreConfig {
     url: Url,
+    format: TableFormat,
     server_options: HashMap<String, String>,
     user_mapping_options: HashMap<String, String>,
 }
 
-impl ServerOptions {
+impl ObjectStoreConfig {
     pub fn new(
         url: &Url,
+        format: TableFormat,
         server_options: HashMap<String, String>,
         user_mapping_options: HashMap<String, String>,
     ) -> Self {
         Self {
             url: url.clone(),
+            format,
             server_options,
             user_mapping_options,
         }
+    }
+
+    pub fn format(&self) -> &TableFormat {
+        &self.format
     }
 
     pub fn server_options(&self) -> &HashMap<String, String> {

--- a/pg_lakehouse/src/fdw/s3.rs
+++ b/pg_lakehouse/src/fdw/s3.rs
@@ -76,10 +76,10 @@ impl AmazonUserMappingOption {
     }
 }
 
-impl TryFrom<ServerOptions> for S3 {
+impl TryFrom<ObjectStoreConfig> for S3 {
     type Error = ContextError;
 
-    fn try_from(options: ServerOptions) -> Result<Self, Self::Error> {
+    fn try_from(options: ObjectStoreConfig) -> Result<Self, Self::Error> {
         let url = options.url();
         let server_options = options.server_options();
         let user_mapping_options = options.user_mapping_options();
@@ -133,14 +133,15 @@ impl TryFrom<ServerOptions> for S3 {
 impl BaseFdw for S3Fdw {
     fn register_object_store(
         url: &Url,
-        _format: TableFormat,
+        format: TableFormat,
         server_options: HashMap<String, String>,
         user_mapping_options: HashMap<String, String>,
     ) -> Result<(), ContextError> {
         let context = Session::session_context()?;
 
-        let builder = S3::try_from(ServerOptions::new(
+        let builder = S3::try_from(ObjectStoreConfig::new(
             url,
+            format,
             server_options.clone(),
             user_mapping_options.clone(),
         ))?;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Two fixes for the Azure blob and ADLS Gen2 object stores:

- The `endpoint` server option for Azure should be required.
- We need to pass in `root` for the Azure builder, but only if it's a delta table.

## Why
Bug reported by user.

## How

## Tests
Haven't written a test due to our lack of Azure test fixture, but I uploaded a delta table to our Azure account and tested against it.