### PR TITLE
feat: Expose more like this function

### DIFF
--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -201,6 +201,73 @@ SELECT * FROM search_idx.search(
   entire string in the calculation.
 </ParamField>
 
+### More Like This
+
+Finds documents similar to a given document or set of field values. This is useful for recommendation engines or finding related content based on textual similarities.
+
+```sql
+-- with_document_id
+SELECT * FROM search_idx.search(
+    query => paradedb.more_like_this(
+        with_document_id => 2,
+        with_min_word_length => 2,
+        with_max_word_length => 5,
+        with_boost_factor => 1.0,
+        with_stop_words => ARRAY['and', 'the', 'for']
+    )
+);
+
+-- with_document_fields
+SELECT * FROM search_idx.search(
+    query => paradedb.more_like_this(
+        with_document_fields => '{"flavour": "banana"}',
+        with_min_doc_frequency => 0,
+        with_max_doc_frequency => 100,
+        with_min_term_frequency => 1,
+    )
+);
+```
+
+<Note>
+You must pass either:
+- `with_document_id`, which takes a "key field" value to match against the corresponding document.
+- `with_document_fields`, which takes a JSON object string to match against.
+
+All other parameters are compatible with both `with_document_id` and `with_document_fields`.
+
+</Note>
+
+<ParamField body="with_document_id">
+  The ID of the document to find similar documents to.
+</ParamField>
+<ParamField body="with_document_fields">
+  A JSON object representing the field values to use for similarity matching.
+</ParamField>
+<ParamField body="with_min_doc_frequency">
+  Minimum document frequency of terms to be considered.
+</ParamField>
+<ParamField body="with_max_doc_frequency">
+  Maximum document frequency of terms to be considered.
+</ParamField>
+<ParamField body="with_min_term_frequency">
+  Minimum term frequency of terms to be considered.
+</ParamField>
+<ParamField body="with_max_query_terms">
+  Maximum number of query terms to be used.
+</ParamField>
+<ParamField body="with_min_word_length">
+  Minimum word length of terms to be considered.
+</ParamField>
+<ParamField body="with_max_word_length">
+  Maximum word length of terms to be considered.
+</ParamField>
+<ParamField body="with_boost_factor">
+  Boost factor to amplify the impact of matching terms.
+</ParamField>
+<ParamField body="with_stop_words">
+  A JSON array of stop words to be ignored in the query.
+</ParamField>
+
 ### Phrase
 
 Searches for documents containing an exact sequence of words, with `slop` allowing for some flexibility in term proximity. This query type also requires position indexing.

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -262,7 +262,6 @@ Finally, to enable the ICU tokenizer in development, pass `--features icu` to th
 First, start pgrx:
 
 ```bash
-# Note: If not using pg16, specify with (i.e. -- pg15, -- pg14, etc.)
 cargo pgrx run
 ```
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -262,6 +262,7 @@ Finally, to enable the ICU tokenizer in development, pass `--features icu` to th
 First, start pgrx:
 
 ```bash
+# Note: If not using pg16, specify with (i.e. -- pg15, -- pg14, etc.)
 cargo pgrx run
 ```
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -254,7 +254,7 @@ pub fn more_like_this(
 
     if !(with_document_id.is_none() ^ (document_fields.len() == 0)) {
         panic!(
-            "more_like_this must be called with either with_docuemnt_id or with_document_fields"
+            "more_like_this must be called with either with_document_id or with_document_fields"
         );
     }
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -258,7 +258,9 @@ pub fn more_like_this(
     });
 
     if !(with_document_id.is_none() ^ (fields.len() == 0)) {
-        panic!("more_like_this must be called with either with_docuemnt_id or with_document_fields");
+        panic!(
+            "more_like_this must be called with either with_docuemnt_id or with_document_fields"
+        );
     }
 
     SearchQueryInput::MoreLikeThis {

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -252,7 +252,7 @@ pub fn more_like_this(
         serde_json::from_str(&with_document_fields.unwrap())
             .expect("could not parse with_document_fields");
 
-    if !(with_document_id.is_none() ^ (document_fields.len() == 0)) {
+    if !(with_document_id.is_none() ^ document_fields.is_empty()) {
         panic!(
             "more_like_this must be called with either with_document_id or with_document_fields"
         );

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -242,14 +242,14 @@ pub fn fuzzy_term(
 #[allow(clippy::too_many_arguments)]
 #[pg_extern(name = "more_like_this_raw", immutable, parallel_safe)]
 pub fn more_like_this(
-    min_doc_frequency: default!(Option<i32>, "NULL"),
-    max_doc_frequency: default!(Option<i32>, "NULL"),
-    min_term_frequency: default!(Option<i32>, "NULL"),
-    max_query_terms: default!(Option<i32>, "NULL"),
-    min_word_length: default!(Option<i32>, "NULL"),
-    max_word_length: default!(Option<i32>, "NULL"),
-    boost_factor: default!(Option<f32>, "NULL"),
-    stop_words: default!(Option<Vec<String>>, "NULL"),
+    with_min_doc_frequency: default!(Option<i32>, "NULL"),
+    with_max_doc_frequency: default!(Option<i32>, "NULL"),
+    with_min_term_frequency: default!(Option<i32>, "NULL"),
+    with_max_query_terms: default!(Option<i32>, "NULL"),
+    with_min_word_length: default!(Option<i32>, "NULL"),
+    with_max_word_length: default!(Option<i32>, "NULL"),
+    with_boost_factor: default!(Option<f32>, "NULL"),
+    with_stop_words: default!(Option<Vec<String>>, "NULL"),
     with_document_fields: default!(Option<String>, "'{}'"),
     with_document_id: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
@@ -264,16 +264,16 @@ pub fn more_like_this(
     }
 
     SearchQueryInput::MoreLikeThis {
-        min_doc_frequency: min_doc_frequency.map(|n| n as u64),
-        max_doc_frequency: max_doc_frequency.map(|n| n as u64),
-        min_term_frequency: min_term_frequency.map(|n| n as usize),
-        max_query_terms: max_query_terms.map(|n| n as usize),
-        min_word_length: min_word_length.map(|n| n as usize),
-        max_word_length: max_word_length.map(|n| n as usize),
-        boost_factor,
-        stop_words,
-        fields: document_fields.into_iter().collect(),
-        with_document_id,
+        min_doc_frequency: with_min_doc_frequency.map(|n| n as u64),
+        max_doc_frequency: with_max_doc_frequency.map(|n| n as u64),
+        min_term_frequency: with_min_term_frequency.map(|n| n as usize),
+        max_query_terms: with_max_query_terms.map(|n| n as usize),
+        min_word_length: with_min_word_length.map(|n| n as usize),
+        max_word_length: with_max_word_length.map(|n| n as usize),
+        boost_factor: with_boost_factor,
+        stop_words: with_stop_words,
+        document_fields: document_fields.into_iter().collect(),
+        document_id: with_document_id,
     }
 }
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -234,13 +234,8 @@ pub fn fuzzy_term(
     }
 }
 
-// We expose as more_like_this_raw so we can gather feedback on how the API is used.
-// Lucene and Elasticsearch seem to have different interfaces for this query,
-// and Tantivy doesn't have any examples of its use, so its unclear what the best
-// way to use it is with pg_search.
-// Once we gathered feedback, we can expose a more user-friendly interface.
 #[allow(clippy::too_many_arguments)]
-#[pg_extern(name = "more_like_this_raw", immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe)]
 pub fn more_like_this(
     with_min_doc_frequency: default!(Option<i32>, "NULL"),
     with_max_doc_frequency: default!(Option<i32>, "NULL"),

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -250,11 +250,17 @@ pub fn more_like_this(
     boost_factor: default!(Option<f32>, "NULL"),
     stop_words: default!(Option<Vec<String>>, "NULL"),
     fields: default!(Array<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
+    with_document_id: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
     let fields = fields.iter_deny_null().map(|input| match input {
         SearchQueryInput::Term { field, value, .. } => (field.unwrap_or("".into()), value),
         _ => panic!("only term queries can be passed to more_like_this"),
     });
+
+    if !(with_document_id.is_none() ^ (fields.len() == 0)) {
+        panic!("more_like_this must be called with either with_docuemnt_id or with_document_fields");
+    }
+
     SearchQueryInput::MoreLikeThis {
         min_doc_frequency: min_doc_frequency.map(|n| n as u64),
         max_doc_frequency: max_doc_frequency.map(|n| n as u64),
@@ -265,6 +271,7 @@ pub fn more_like_this(
         boost_factor,
         stop_words,
         fields: fields.collect(),
+        with_document_id,
     }
 }
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -233,12 +233,13 @@ pub fn fuzzy_term(
     }
 }
 
-// Avoid exposing more_like_this for now until we can decide on the exact API.
+// We expose as more_like_this_raw so we can gather feedback on how the API is used.
 // Lucene and Elasticsearch seem to have different interfaces for this query,
 // and Tantivy doesn't have any examples of its use, so its unclear what the best
 // way to use it is with pg_search.
-#[allow(unused)]
+// Once we gathered feedback, we can expose a more user-friendly interface.
 #[allow(clippy::too_many_arguments)]
+#[pg_extern(name = "more_like_this_raw", immutable, parallel_safe)]
 pub fn more_like_this(
     min_doc_frequency: default!(Option<i32>, "NULL"),
     max_doc_frequency: default!(Option<i32>, "NULL"),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -241,7 +241,7 @@ impl SearchState {
         let query = config
             .query
             .clone()
-            .into_tantivy_query(&schema, &mut parser, &searcher, &config)
+            .into_tantivy_query(&schema, &mut parser, &searcher, config)
             .expect("could not parse query");
         SearchState {
             query: Arc::new(query),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -241,7 +241,7 @@ impl SearchState {
         let query = config
             .query
             .clone()
-            .into_tantivy_query(&schema, &mut parser, &searcher)
+            .into_tantivy_query(&schema, &mut parser, &searcher, &config)
             .expect("could not parse query");
         SearchState {
             query: Arc::new(query),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -237,15 +237,16 @@ impl SearchState {
     pub fn new(search_index: &SearchIndex, config: &SearchConfig) -> Self {
         let schema = search_index.schema.clone();
         let mut parser = search_index.query_parser();
+        let searcher = search_index.searcher();
         let query = config
             .query
             .clone()
-            .into_tantivy_query(&schema, &mut parser)
+            .into_tantivy_query(&schema, &mut parser, &searcher)
             .expect("could not parse query");
         SearchState {
             query: Arc::new(query),
             config: config.clone(),
-            searcher: search_index.searcher(),
+            searcher,
             schema: schema.clone(),
         }
     }

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -30,7 +30,7 @@ use tantivy::{
     },
     query_grammar::Occur,
     schema::{Field, FieldType, IndexRecordOption, OwnedValue},
-    Term,
+    DocAddress, Term,
 };
 use thiserror::Error;
 
@@ -311,8 +311,6 @@ impl SearchQueryInput {
                 fields,
                 with_document_id,
             } => {
-                with_document_id;
-
                 let mut builder = MoreLikeThisQuery::builder();
 
                 if let Some(min_doc_frequency) = min_doc_frequency {
@@ -338,6 +336,13 @@ impl SearchQueryInput {
                 }
                 if let Some(stop_words) = stop_words {
                     builder = builder.with_stop_words(stop_words);
+                }
+
+                if let Some(document_id) = with_document_id {
+                    return Ok(Box::new(
+                        // TODO: We need to get the segment ord from somewhere
+                        builder.with_document(DocAddress::new(0, document_id as u32)),
+                    ));
                 }
 
                 let mut fields_map = HashMap::new();

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -308,8 +308,8 @@ impl SearchQueryInput {
                 max_word_length,
                 boost_factor,
                 stop_words,
-                fields,
-                with_document_id,
+                document_fields,
+                document_id,
             } => {
                 let mut builder = MoreLikeThisQuery::builder();
 
@@ -338,7 +338,7 @@ impl SearchQueryInput {
                     builder = builder.with_stop_words(stop_words);
                 }
 
-                if let Some(document_id) = with_document_id {
+                if let Some(document_id) = document_id {
                     return Ok(Box::new(
                         // TODO: We need to get the segment ord from somewhere
                         builder.with_document(DocAddress::new(0, document_id as u32)),
@@ -346,7 +346,7 @@ impl SearchQueryInput {
                 }
 
                 let mut fields_map = HashMap::new();
-                for (field_name, value) in fields {
+                for (field_name, value) in document_fields {
                     if !field_lookup.is_field_type(&field_name, &value) {
                         return Err(Box::new(QueryError::WrongFieldType(field_name)));
                     }

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -81,6 +81,7 @@ pub enum SearchQueryInput {
         boost_factor: Option<f32>,
         stop_words: Option<Vec<String>>,
         fields: Vec<(String, tantivy::schema::OwnedValue)>,
+        with_document_id: Option<i64>,
     },
     Parse {
         query_string: String,
@@ -308,7 +309,10 @@ impl SearchQueryInput {
                 boost_factor,
                 stop_words,
                 fields,
+                with_document_id,
             } => {
+                with_document_id;
+
                 let mut builder = MoreLikeThisQuery::builder();
 
                 if let Some(min_doc_frequency) = min_doc_frequency {

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -370,9 +370,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
         query => paradedb.more_like_this_raw(
             min_doc_frequency => 0,
             min_term_frequency => 0,
-            fields => ARRAY[
-                paradedb.term(field => 'flavour', value => 'banana')
-            ]
+            with_document_fields => '{"flavour": "banana"}'
         ),
         stable_sort => true
     );

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -346,7 +346,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
         table_name => 'test_more_like_this_table',
         index_name => 'test_more_like_this_index',
         key_field => 'id',
-        text_fields => '{"flavour": {tokenizer: {type: "en_stem"}}}'
+        text_fields => '{"flavour": {}}'    
     );
     "#
     .execute(&mut conn);
@@ -354,8 +354,10 @@ fn more_like_this_raw(mut conn: PgConnection) {
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
         query => paradedb.more_like_this_raw(
+            min_doc_frequency => 0,
+            min_term_frequency => 0,
             fields => ARRAY[
-                paradedb.term(field => 'flavour', value => 'anana')
+                paradedb.term(field => 'flavour', value => 'banana')
             ]
         ),
         stable_sort => true

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -360,10 +360,12 @@ fn more_like_this_raw(mut conn: PgConnection) {
     "#
     .fetch_result::<()>(&mut conn)
     {
-        Err(err) => assert!(err.to_string().contains(
-            "more_like_this must be called with either with_docuemnt_id or with_document_fields"
-        )),
-        _ => panic!("with_docuemnt_id or with_document_fields validation failed"),
+        Err(err) => {
+            assert_eq!(err
+            .to_string()
+            , "more_like_this must be called with either with_document_id or with_document_fields")
+        }
+        _ => panic!("with_document_id or with_document_fields validation failed"),
     }
 
     let rows: Vec<(i32, String)> = r#"

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -359,9 +359,9 @@ fn more_like_this_raw(mut conn: PgConnection) {
     "#
     .fetch_result::<()>(&mut conn)
     {
-        Err(err) => assert!(err
-            .to_string()
-            .contains("more_like_this must be called with either with_docuemnt_id or with_document_fields")),
+        Err(err) => assert!(err.to_string().contains(
+            "more_like_this must be called with either with_docuemnt_id or with_document_fields"
+        )),
         _ => panic!("with_docuemnt_id or with_document_fields validation failed"),
     }
 
@@ -379,4 +379,18 @@ fn more_like_this_raw(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 2);
+
+    let rows: Vec<(i32, String)> = r#"
+    SELECT id, flavour FROM test_more_like_this_index.search(
+        query => paradedb.more_like_this_raw(
+            min_doc_frequency => 0,
+            min_term_frequency => 0,
+            with_document_id => 0
+        ),
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    // TODO once the segment ord is set, assert_eq!(rows.len(), 2);
+    assert!(rows.len() > 0);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -368,8 +368,8 @@ fn more_like_this_raw(mut conn: PgConnection) {
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
         query => paradedb.more_like_this_raw(
-            min_doc_frequency => 0,
-            min_term_frequency => 0,
+            with_min_doc_frequency => 0,
+            with_min_term_frequency => 0,
             with_document_fields => '{"flavour": "banana"}'
         ),
         stable_sort => true
@@ -381,8 +381,8 @@ fn more_like_this_raw(mut conn: PgConnection) {
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
         query => paradedb.more_like_this_raw(
-            min_doc_frequency => 0,
-            min_term_frequency => 0,
+            with_min_doc_frequency => 0,
+            with_min_term_frequency => 0,
             with_document_id => 0
         ),
         stable_sort => true

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -351,6 +351,20 @@ fn more_like_this_raw(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    match r#"
+    SELECT id, flavour FROM test_more_like_this_index.search(
+        query => paradedb.more_like_this_raw(),
+        stable_sort => true
+    );
+    "#
+    .fetch_result::<()>(&mut conn)
+    {
+        Err(err) => assert!(err
+            .to_string()
+            .contains("more_like_this must be called with either with_docuemnt_id or with_document_fields")),
+        _ => panic!("with_docuemnt_id or with_document_fields validation failed"),
+    }
+
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
         query => paradedb.more_like_this_raw(

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -363,7 +363,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
         Err(err) => {
             assert_eq!(err
             .to_string()
-            , "more_like_this must be called with either with_document_id or with_document_fields")
+            , "error returned from database: more_like_this must be called with either with_document_id or with_document_fields")
         }
         _ => panic!("with_document_id or with_document_fields validation failed"),
     }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -386,12 +386,11 @@ fn more_like_this_raw(mut conn: PgConnection) {
         query => paradedb.more_like_this(
             with_min_doc_frequency => 0,
             with_min_term_frequency => 0,
-            with_document_id => 0
+            with_document_id => 2
         ),
         stable_sort => true
     );
     "#
     .fetch_collect(&mut conn);
-    // TODO once the segment ord is set, assert_eq!(rows.len(), 2);
-    assert!(rows.len() > 0);
+    assert_eq!(rows.len(), 2);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -326,6 +326,7 @@ fn exists_query(mut conn: PgConnection) {
     assert_eq!(columns.len(), 3);
 }
 
+#[rstest]
 fn more_like_this_raw(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -353,7 +354,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     match r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
-        query => paradedb.more_like_this_raw(),
+        query => paradedb.more_like_this(),
         stable_sort => true
     );
     "#
@@ -367,7 +368,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
-        query => paradedb.more_like_this_raw(
+        query => paradedb.more_like_this(
             with_min_doc_frequency => 0,
             with_min_term_frequency => 0,
             with_document_fields => '{"flavour": "banana"}'
@@ -380,7 +381,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_index.search(
-        query => paradedb.more_like_this_raw(
+        query => paradedb.more_like_this(
             with_min_doc_frequency => 0,
             with_min_term_frequency => 0,
             with_document_id => 0


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1172 

## What
`MoreLikeThis` is a useful, missing query from Tantviy's library. It's a little more involved to implement, because a version of it requires looking up document by id to match against.

This PR implements and exposes `more_like_this` along with the other advanced queries.

## Tests

Added test variants for each kind of `key_field`, as they all can be accepted on the `with_document_id` parameter.

- [x] prefix fields with a with_ prefix to mimic tantivy arguments
- [x] pass fields as a JSON instead of Array of terms
- [x] add a with_document option
- [x] add a validation to check the either with_fields or with_document is specified
- [x] add documentation
- [x] add proper default values, if not it does not work ie: min_doc_frequency: 0, min_term_frequency: 0
