### PR TITLE
fix: Query tables with case-sensitive names

### DIFF
--- a/pg_lakehouse/src/datafusion/schema.rs
+++ b/pg_lakehouse/src/datafusion/schema.rs
@@ -40,7 +40,10 @@ impl LakehouseSchemaProvider {
 
     fn table_impl(&self, table_name: &str) -> Result<Arc<dyn TableProvider>, CatalogError> {
         let pg_relation = unsafe {
-            PgRelation::open_with_name(table_name).unwrap_or_else(|err| {
+            PgRelation::open_with_name(
+                format!("\"{}\".\"{}\"", self.schema_name, table_name).as_str(),
+            )
+            .unwrap_or_else(|err| {
                 panic!("{}", err);
             })
         };
@@ -149,7 +152,9 @@ impl SchemaProvider for LakehouseSchemaProvider {
 
     fn table_exist(&self, table_name: &str) -> bool {
         let pg_relation = match unsafe {
-            PgRelation::open_with_name(format!("{}.{}", self.schema_name, table_name).as_str())
+            PgRelation::open_with_name(
+                format!("\"{}\".\"{}\"", self.schema_name, table_name).as_str(),
+            )
         } {
             Ok(relation) => relation,
             Err(_) => return false,

--- a/pg_lakehouse/tests/fixtures/mod.rs
+++ b/pg_lakehouse/tests/fixtures/mod.rs
@@ -96,11 +96,13 @@ impl S3 {
         }
     }
 
+    #[allow(unused)]
     pub async fn create_bucket(&self, bucket: &str) -> Result<()> {
         self.client.create_bucket().bucket(bucket).send().await?;
         Ok(())
     }
 
+    #[allow(unused)]
     pub async fn put_batch(&self, bucket: &str, key: &str, batch: &RecordBatch) -> Result<()> {
         let mut buf = vec![];
         let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None)?;
@@ -117,6 +119,7 @@ impl S3 {
         Ok(())
     }
 
+    #[allow(unused)]
     pub async fn put_rows<T: Serialize>(&self, bucket: &str, key: &str, rows: &[T]) -> Result<()> {
         let fields = Vec::<FieldRef>::from_type::<NycTripsTable>(TracingOptions::default())?;
         let batch = serde_arrow::to_record_batch(&fields, &rows)?;

--- a/pg_lakehouse/tests/scan.rs
+++ b/pg_lakehouse/tests/scan.rs
@@ -107,7 +107,8 @@ async fn test_arrow_types_s3_listing(#[future(awt)] s3: S3, mut conn: PgConnecti
     s3.create_bucket(s3_bucket).await?;
     s3.put_batch(s3_bucket, s3_key, &stored_batch).await?;
 
-    primitive_setup_fdw_s3_listing(&s3_endpoint, &s3_object_path, "parquet").execute(&mut conn);
+    primitive_setup_fdw_s3_listing(&s3_endpoint, &s3_object_path, "parquet", "primitive")
+        .execute(&mut conn);
 
     let retrieved_batch =
         "SELECT * FROM primitive".fetch_recordbatch(&mut conn, &stored_batch.schema());
@@ -149,7 +150,8 @@ async fn test_arrow_types_s3_delta(
     s3.create_bucket(s3_bucket).await?;
     s3.put_directory(s3_bucket, s3_path, temp_path).await?;
 
-    primitive_setup_fdw_s3_delta(&s3_endpoint, &s3_object_path, "parquet").execute(&mut conn);
+    primitive_setup_fdw_s3_delta(&s3_endpoint, &s3_object_path, "parquet", "delta_primitive")
+        .execute(&mut conn);
 
     let retrieved_batch =
         "SELECT * FROM delta_primitive".fetch_recordbatch(&mut conn, &batch.schema());
@@ -191,7 +193,8 @@ async fn test_s3_delta_connect_success(
     s3.create_bucket(s3_bucket).await?;
     s3.put_directory(s3_bucket, s3_path, temp_path).await?;
 
-    primitive_setup_fdw_s3_delta(&s3_endpoint, &s3_object_path, "parquet").execute(&mut conn);
+    primitive_setup_fdw_s3_delta(&s3_endpoint, &s3_object_path, "parquet", "delta_primitive")
+        .execute(&mut conn);
 
     "CALL connect_table('delta_primitive')".execute_result(&mut conn)?;
     "CALL connect_table('public.delta_primitive')".execute_result(&mut conn)?;
@@ -212,8 +215,12 @@ async fn test_arrow_types_local_file_listing(
     writer.write(&stored_batch)?;
     writer.close()?;
 
-    primitive_setup_fdw_local_file_listing(parquet_path.as_path().to_str().unwrap(), "parquet")
-        .execute(&mut conn);
+    primitive_setup_fdw_local_file_listing(
+        parquet_path.as_path().to_str().unwrap(),
+        "parquet",
+        "primitive",
+    )
+    .execute(&mut conn);
 
     let retrieved_batch =
         "SELECT * FROM primitive".fetch_recordbatch(&mut conn, &stored_batch.schema());
@@ -242,8 +249,12 @@ async fn test_arrow_types_local_file_delta(mut conn: PgConnection, tempdir: Temp
     writer.write(batch.clone()).await?;
     writer.flush_and_commit(&mut table).await?;
 
-    primitive_setup_fdw_local_file_delta(&temp_path.to_string_lossy(), "parquet")
-        .execute(&mut conn);
+    primitive_setup_fdw_local_file_delta(
+        &temp_path.to_string_lossy(),
+        "parquet",
+        "delta_primitive",
+    )
+    .execute(&mut conn);
 
     let retrieved_batch =
         "SELECT * FROM delta_primitive".fetch_recordbatch(&mut conn, &batch.schema());
@@ -275,8 +286,12 @@ async fn test_local_file_delta_connect_success(
     writer.write(batch.clone()).await?;
     writer.flush_and_commit(&mut table).await?;
 
-    primitive_setup_fdw_local_file_delta(&temp_path.to_string_lossy(), "parquet")
-        .execute(&mut conn);
+    primitive_setup_fdw_local_file_delta(
+        &temp_path.to_string_lossy(),
+        "parquet",
+        "delta_primitive",
+    )
+    .execute(&mut conn);
 
     "CALL connect_table('delta_primitive')".execute_result(&mut conn)?;
     "CALL connect_table('public.delta_primitive')".execute_result(&mut conn)?;
@@ -300,7 +315,8 @@ async fn test_local_file_delta_connect_failure(
     writer.write(batch.clone()).await?;
     writer.flush_and_commit(&mut table).await?;
 
-    primitive_setup_fdw_local_file_delta("/var/folders/invalid", "parquet").execute(&mut conn);
+    primitive_setup_fdw_local_file_delta("/var/folders/invalid", "parquet", "delta_primitive")
+        .execute(&mut conn);
 
     match "CALL connect_table('delta_primitive')".execute_result(&mut conn) {
         Ok(_) => panic!("connect_table should have errored on an invalid path"),

--- a/pg_lakehouse/tests/table_names.rs
+++ b/pg_lakehouse/tests/table_names.rs
@@ -1,0 +1,45 @@
+mod fixtures;
+
+use anyhow::Result;
+use datafusion::parquet::arrow::ArrowWriter;
+use fixtures::*;
+use rstest::*;
+use shared::fixtures::arrow::{primitive_record_batch, primitive_setup_fdw_local_file_listing};
+use shared::fixtures::tempfile::TempDir;
+use sqlx::PgConnection;
+use std::fs::File;
+
+#[rstest]
+async fn test_table_case_sensitivity(mut conn: PgConnection, tempdir: TempDir) -> Result<()> {
+    let stored_batch = primitive_record_batch()?;
+    let parquet_path = tempdir.path().join("test_arrow_types.parquet");
+    let parquet_file = File::create(&parquet_path)?;
+
+    let mut writer = ArrowWriter::try_new(parquet_file, stored_batch.schema(), None).unwrap();
+    writer.write(&stored_batch)?;
+    writer.close()?;
+
+    primitive_setup_fdw_local_file_listing(
+        parquet_path.as_path().to_str().unwrap(),
+        "parquet",
+        "\"PrimitiveTable\"",
+    )
+    .execute(&mut conn);
+
+    let retrieved_batch =
+        "SELECT * FROM \"PrimitiveTable\"".fetch_recordbatch(&mut conn, &stored_batch.schema());
+
+    assert_eq!(stored_batch.num_columns(), retrieved_batch.num_columns());
+
+    let retrieved_batch = "SELECT * FROM public.\"PrimitiveTable\""
+        .fetch_recordbatch(&mut conn, &stored_batch.schema());
+
+    assert_eq!(stored_batch.num_columns(), retrieved_batch.num_columns());
+
+    let retrieved_batch = "SELECT * FROM \"public\".\"PrimitiveTable\""
+        .fetch_recordbatch(&mut conn, &stored_batch.schema());
+
+    assert_eq!(stored_batch.num_columns(), retrieved_batch.num_columns());
+
+    Ok(())
+}

--- a/shared/src/fixtures/arrow.rs
+++ b/shared/src/fixtures/arrow.rs
@@ -204,9 +204,9 @@ pub fn primitive_create_server(server: &str, wrapper: &str) -> String {
     format!("CREATE SERVER {server} FOREIGN DATA WRAPPER {wrapper}")
 }
 
-pub fn primitive_create_table(server: &str) -> String {
+pub fn primitive_create_table(server: &str, table: &str) -> String {
     format!(
-        "CREATE FOREIGN TABLE primitive (
+        "CREATE FOREIGN TABLE {table} (
             boolean_col       boolean,
             int8_col          smallint,
             int16_col         smallint,
@@ -236,9 +236,9 @@ pub fn primitive_create_table(server: &str) -> String {
     )
 }
 
-pub fn primitive_create_delta_table(server: &str) -> String {
+pub fn primitive_create_delta_table(server: &str, table: &str) -> String {
     format!(
-        "CREATE FOREIGN TABLE delta_primitive (
+        "CREATE FOREIGN TABLE {table} (
             boolean_col       boolean,
             int8_col          smallint,
             int16_col         smallint,
@@ -258,11 +258,12 @@ pub fn primitive_setup_fdw_s3_listing(
     s3_endpoint: &str,
     s3_object_path: &str,
     extension: &str,
+    table: &str,
 ) -> String {
     let create_foreign_data_wrapper =
         primitive_create_foreign_data_wrapper("s3_wrapper", "s3_fdw_handler", "s3_fdw_validator");
     let create_server = primitive_create_server("s3_server", "s3_wrapper");
-    let create_table = primitive_create_table("s3_server");
+    let create_table = primitive_create_table("s3_server", table);
 
     format!(
         r#"
@@ -277,11 +278,12 @@ pub fn primitive_setup_fdw_s3_delta(
     s3_endpoint: &str,
     s3_object_path: &str,
     extension: &str,
+    table: &str,
 ) -> String {
     let create_foreign_data_wrapper =
         primitive_create_foreign_data_wrapper("s3_wrapper", "s3_fdw_handler", "s3_fdw_validator");
     let create_server = primitive_create_server("s3_server", "s3_wrapper");
-    let create_table = primitive_create_delta_table("s3_server");
+    let create_table = primitive_create_delta_table("s3_server", table);
 
     format!(
         r#"
@@ -292,14 +294,18 @@ pub fn primitive_setup_fdw_s3_delta(
     )
 }
 
-pub fn primitive_setup_fdw_local_file_listing(local_file_path: &str, extension: &str) -> String {
+pub fn primitive_setup_fdw_local_file_listing(
+    local_file_path: &str,
+    extension: &str,
+    table: &str,
+) -> String {
     let create_foreign_data_wrapper = primitive_create_foreign_data_wrapper(
         "local_file_wrapper",
         "local_file_fdw_handler",
         "local_file_fdw_validator",
     );
     let create_server = primitive_create_server("local_file_server", "local_file_wrapper");
-    let create_table = primitive_create_table("local_file_server");
+    let create_table = primitive_create_table("local_file_server", table);
 
     format!(
         r#"
@@ -310,14 +316,18 @@ pub fn primitive_setup_fdw_local_file_listing(local_file_path: &str, extension: 
     )
 }
 
-pub fn primitive_setup_fdw_local_file_delta(local_file_path: &str, extension: &str) -> String {
+pub fn primitive_setup_fdw_local_file_delta(
+    local_file_path: &str,
+    extension: &str,
+    table: &str,
+) -> String {
     let create_foreign_data_wrapper = primitive_create_foreign_data_wrapper(
         "local_file_wrapper",
         "local_file_fdw_handler",
         "local_file_fdw_validator",
     );
     let create_server = primitive_create_server("local_file_server", "local_file_wrapper");
-    let create_table = primitive_create_delta_table("local_file_server");
+    let create_table = primitive_create_delta_table("local_file_server", table);
 
     format!(
         r#"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1250 

## What
Fixes a bug where tables with names wrapped in quotes could not be queried.

## Why
Bug reported by user.

## How
The error was coming from `PgRelation::open_with_name`. We just needed to wrap the table/schema names in quotes.

## Tests
See tests