### PR TITLE
feat: Publish ParadeDB extensions for RHEL 9

### DIFF
--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -284,6 +284,9 @@ jobs:
           fi
           sudo dnf clean all
 
+          # We first disable the existing Postgres module to avoid conflicts with the PostgreSQL version we want to install
+          sudo dnf -qy module disable postgresql
+
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -254,7 +254,7 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/>
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install & Configure Supported PostgreSQL Version on RHEL

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -131,7 +131,12 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
+              echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            else
+              # If there is no tag and no provided version, it's a test run and we set a dummy version
+              echo "version=0.0.0" >> $GITHUB_OUTPUT
+            fi
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -245,3 +245,4 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_lakehouse-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: pg_lakehouse-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          overwrite: true

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -289,7 +289,7 @@ jobs:
           sudo dnf -qy module disable llvm-toolset
           # sudo dnf -qy module reset llvm
           # sudo dnf -qy module enable llvm:${RHEL_VERSION}
-          sudo dnf -y install llvm-devel
+          sudo dnf -y install llvm-devel --setopt=module_platform_id=platform:el8
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -287,8 +287,9 @@ jobs:
           # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
           sudo dnf -qy module disable llvm-toolset
-          sudo dnf -qy module reset llvm
-          sudo dnf -qy module enable llvm:${RHEL_VERSION}
+          # sudo dnf -qy module reset llvm
+          # sudo dnf -qy module enable llvm:${RHEL_VERSION}
+          sudo dnf -y install llvm-devel
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -287,6 +287,8 @@ jobs:
           # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
           sudo dnf -qy module disable llvm-toolset
+          sudo dnf -qy module reset llvm
+          sudo dnf -qy module enable llvm:${RHEL_VERSION}
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -104,31 +104,6 @@ jobs:
             image: debian:12-slim
             pg_version: 16
             arch: arm64
-          # Red Hat Enterprise Linux 8
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 14
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 14
-            arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 15
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 15
-            arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 16
-            arch: arm64
           # Red Hat Enterprise Linux 9
           - runner: depot-ubuntu-22.04-4
             image: redhat/ubi9:latest
@@ -154,6 +129,7 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 16
             arch: arm64
+          # TODO: Add support for RHEL 8
 
     steps:
       - name: Checkout Git Repository
@@ -283,13 +259,6 @@ jobs:
             sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL
           fi
           sudo dnf clean all
-
-          # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
-          sudo dnf -qy module disable postgresql
-          sudo dnf -qy module disable llvm-toolset
-          # sudo dnf -qy module reset llvm
-          # sudo dnf -qy module enable llvm:${RHEL_VERSION}
-          sudo dnf -y install llvm-devel --setopt=module_platform_id=platform:el8
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -104,8 +104,56 @@ jobs:
             image: debian:12-slim
             pg_version: 16
             arch: arm64
-          # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
-          # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
+          # Red Hat Enterprise Linux 8
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi8:latest
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi8:latest
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi8:latest
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 16
+            arch: arm64
+          # Red Hat Enterprise Linux 9
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 16
+            arch: arm64
 
     steps:
       - name: Checkout Git Repository
@@ -117,7 +165,41 @@ jobs:
 
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
-        run: dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl-IPC-Run
+        run: |
+          # Install dependencies
+          dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq rpm-build
+
+          # Add Oracle Linux 9 repositories to enable epel-release
+          sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF
+          [ol9_baseos_latest]
+          name=Oracle Linux 9 BaseOS Latest (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+
+          [ol9_appstream]
+          name=Oracle Linux 9 Application Stream (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+
+          [ol9_codeready_builder]
+          name=Oracle Linux 9 CodeReady Builder (\$basearch) - Unsupported
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+          EOF
+
+          # Install epel-release, which is required by PostgreSQL via Perl-IPC-Run
+          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          sudo dnf install -y epel-release
+
+          # This package requires epel-release, which is why we install it last. It is required to
+          # configure the build environment for creating the RPM package via rpmbuild
+          sudo dnf install -y rpmdevtools
 
       # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
       # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
@@ -129,7 +211,6 @@ jobs:
       - name: Retrieve OS & GitHub Tag Versions
         id: version
         run: |
-          # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
@@ -148,10 +229,24 @@ jobs:
             RELEASE=$(lsb_release -rs)
           else
             DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
-            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"')
+            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
           fi
           echo "OS Version: $DISTRO-$RELEASE"
           echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
+
+          # RHEL uses different architecture and OS naming conventions when packaging via rpmbuid. We need to
+          # retrieve those as well to programmatically retrieve and upload the correct RPM package
+          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
+            if [ "${{ matrix.arch }}" == "amd64" ]; then
+              ARCH=x86_64
+            else
+              ARCH=aarch64
+            fi
+            echo "RPM Arch: $ARCH"
+            echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
+            echo "RPM OS: el$RELEASE"
+            echo "rpm_os=el$RELEASE" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install & Configure Supported PostgreSQL Version on Debian
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04'}}
@@ -163,15 +258,23 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install & Configure Supported PostgreSQL Version on RHEL
-        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-          sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+          else
+            REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
+          fi
+          sudo dnf -y install $REPO_URL
+
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
+          else
+            sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL
+          fi
           sudo dnf clean all
+
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
-          sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb
-          sudo systemctl enable postgresql-${{ matrix.pg_version }}
-          sudo systemctl start postgresql-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
@@ -180,9 +283,14 @@ jobs:
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_lakehouse/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+        run: |
+          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
+            PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
+          else
+            PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+          fi
+          cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
-      # TODO: Add telemetry to pg_lakehouse
       # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
       # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should
       # build the extension directly on their target machine, or use our Docker image.
@@ -233,16 +341,74 @@ jobs:
           sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
-      # We retrieve the GitHub release for the specific release version
+      - name: Create .rpm Package
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
+        run: |
+          echo "Configuring RPM build environment..."
+          rpmdev-setuptree
+
+          echo "Creating RPM SPEC file..."
+          spec_file=~/rpmbuild/SPECS/pg_lakehouse.spec
+          cat <<EOF > $spec_file
+          Name:           pg_lakehouse
+          Version:        ${{ steps.version.outputs.tag_version }}
+          Release:        1%{?dist}
+          Summary:        An analytical query engine for Postgres
+          License:        GNU Affero General Public License v3.0
+          URL:            https://github.com/paradedb/paradedb
+
+          BuildRequires:  postgresql${{ matrix.pg_version }}-devel
+          Requires:       postgresql${{ matrix.pg_version }}-server
+
+          %description
+          pg_lakehouse is a Postgres extension that enables fast analytics over
+          data lakes from Postgres. It is built on top of DataFusion, the Rust-based
+          analytics query engine, using pgrx.
+
+          %install
+          %{__rm} -rf %{buildroot}
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 755 %{_sourcedir}/pg_lakehouse_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/lib/pg_lakehouse.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
+          install -m 644 %{_sourcedir}/pg_lakehouse_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_lakehouse*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 644 %{_sourcedir}/pg_lakehouse_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_lakehouse.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+
+          %files
+          /usr/pgsql-${{ matrix.pg_version }}/lib/pg_lakehouse.so
+          /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_lakehouse.control
+          /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_lakehouse*sql
+
+          %changelog
+          * Thu Jun 6 2024 ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
+          - Initial RPM Release
+          EOF
+
+          echo "Copying pg_lakehouse binaries to RPM build directory..."
+          cp -r target/release/pg_lakehouse-pg${{ matrix.pg_version }}/ ~/rpmbuild/SOURCES/pg_lakehouse_${{ matrix.pg_version }}
+
+          echo "Building RPM package..."
+          rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_lakehouse.spec
+
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_lakehouse .deb to GitHub Release
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_lakehouse-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: pg_lakehouse-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          overwrite: true
+
+      - name: Upload pg_lakehouse .rpm to GitHub Release
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_lakehouse-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.rpm_os }}.${{ steps.version.outputs.rpm_arch }}.rpm
+          asset_name: pg_lakehouse-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
           overwrite: true

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -132,14 +132,16 @@ jobs:
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
-              echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+              VERSION=${GITHUB_REF#refs/tags/v}
             else
               # If there is no tag and no provided version, it's a test run and we set a dummy version
-              echo "version=0.0.0" >> $GITHUB_OUTPUT
+              VERSION="0.0.0"
             fi
           else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            VERSION=${{ github.event.inputs.version }}
           fi
+          echo "GitHub Tag Version: $VERSION"
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           if [ -x "$(command -v lsb_release)" ]; then
             DISTRO=$(echo "$(lsb_release -is)" | tr '[:upper:]' '[:lower:]')
@@ -195,7 +197,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_lakehouse*"` archive
-          package_dir=pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+          package_dir=pg_lakehouse-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -214,7 +216,7 @@ jobs:
           # Create control file (package name cannot have underscore)
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
-          deb_version=${{ steps.version.outputs.version }}
+          deb_version=${{ steps.version.outputs.tag_version }}
           CONTROL_FILE="${package_dir}/DEBIAN/control"
           echo 'Package: pg-lakehouse' >> $CONTROL_FILE
           echo 'Version:' ${deb_version} >> $CONTROL_FILE
@@ -234,12 +236,12 @@ jobs:
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_lakehouse .deb to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_lakehouse-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: pg_lakehouse-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_path: ./pg_lakehouse-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: pg_lakehouse-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -131,10 +131,10 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
+            if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
             else
-              # If there is no tag and no provided version, it's a test run and we set a dummy version
+              # If there is no tag and no provided version, it's a test run and we set a default version
               VERSION="0.0.0"
             fi
           else

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -284,8 +284,9 @@ jobs:
           fi
           sudo dnf clean all
 
-          # We first disable the existing Postgres module to avoid conflicts with the PostgreSQL version we want to install
+          # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
+          sudo dnf -qy module disable llvm-toolset
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -166,35 +166,45 @@ jobs:
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          # Determine RHEL version to retrieve the correct repositories
+          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
+            RHEL_VERSION=8
+          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
+            RHEL_VERSION=9
+          else
+            echo "Unsupported RHEL version"
+            exit 1
+          fi
+
           # Install dependencies
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq rpm-build
 
-          # Add Oracle Linux 9 repositories to enable epel-release
-          sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF
-          [ol9_baseos_latest]
-          name=Oracle Linux 9 BaseOS Latest (\$basearch)
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/\$basearch/
+          # Add Oracle Linux ${RHEL_VERSION} repositories to enable epel-release
+          sudo tee /etc/yum.repos.d/oracle-linux-ol${RHEL_VERSION}.repo > /dev/null <<EOF
+          [ol${RHEL_VERSION}_baseos_latest]
+          name=Oracle Linux ${RHEL_VERSION} BaseOS Latest (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/baseos/latest/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
 
-          [ol9_appstream]
-          name=Oracle Linux 9 Application Stream (\$basearch)
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/\$basearch/
+          [ol${RHEL_VERSION}_appstream]
+          name=Oracle Linux ${RHEL_VERSION} Application Stream (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/appstream/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
 
-          [ol9_codeready_builder]
-          name=Oracle Linux 9 CodeReady Builder (\$basearch) - Unsupported
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/\$basearch/
+          [ol${RHEL_VERSION}_codeready_builder]
+          name=Oracle Linux ${RHEL_VERSION} CodeReady Builder (\$basearch) - Unsupported
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/codeready/builder/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
           EOF
 
           # Install epel-release, which is required by PostgreSQL via Perl-IPC-Run
-          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol${RHEL_VERSION} -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           sudo dnf install -y epel-release
 
           # This package requires epel-release, which is why we install it last. It is required to

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -1,7 +1,7 @@
 # workflows/publish-pg_lakehouse.yml
 #
 # Publish pg_lakehouse
-# Build and publish the pg_lakehouse extension as a .deb to GitHub Releases.
+# Build and publish the pg_lakehouse extension as .deb and .rpm to GitHub Releases.
 
 name: Publish pg_lakehouse
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -268,6 +268,16 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          # Determine RHEL version to retrieve the correct repositories
+          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
+            RHEL_VERSION=8
+          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
+            RHEL_VERSION=9
+          else
+            echo "Unsupported RHEL version"
+            exit 1
+          fi
+
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
           else
@@ -282,19 +292,18 @@ jobs:
           fi
           sudo dnf clean all
 
-          # Enable required modules
-          echo "test1"
-          # Enable the llvm-toolset module
-          sudo dnf -qy module enable llvm-toolset
 
-          # Install LLVM and related packages
+
+          # Enable the llvm-toolset module for rhel8
+          sudo dnf module -y enable llvm-toolset:rhel${RHEL_VERSION}
           sudo dnf -y install llvm-toolset
 
-          sudo dnf -qy module enable postgresql:${{ matrix.pg_version }}
-
+          # sudo dnf -qy module enable postgresql:${{ matrix.pg_version }}
           # # Install LLVM and PostgreSQL
           # echo "test2"
           # sudo dnf -y install llvm-devel
+
+
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -312,9 +312,9 @@ jobs:
           %{__rm} -rf %{buildroot}
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
-          install -m 755 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
-          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
-          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 755 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
+          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
 
           %files
           /usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -130,24 +130,13 @@ jobs:
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+          else
+            subscription-manager repos --enable codeready-builder-for-rhel-9-aarch64-rpms
+          fi
+
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
-
-      - name: Install extra RHEL Dependencies
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
-        run: |
-          # Download and install EPEL release package
-          wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-          sudo dnf install -y ./epel-release-latest-9.noarch.rpm
-          sudo dnf update -y
-
-          # Install necessary build tools and Perl CPAN
-          sudo dnf install -y perl-CPAN perl-App-cpanminus gcc make
-
-          # Install IPC::Run Perl module via CPAN
-          sudo cpanm --force IPC::Run
-
-          # # Install PostgreSQL development package
-          # sudo dnf install -y postgresql16-devel
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -184,9 +173,15 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+          else
+            REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
+          fi
+          sudo dnf -y install $REPO_URL
           sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           sudo dnf clean all
+
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb
           sudo systemctl enable postgresql-${{ matrix.pg_version }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -313,7 +313,7 @@ jobs:
           Version:        ${rpm_version}
           Release:        1%{?dist}
           Summary:        Full-text search for PostgreSQL using BM25
-          License:        
+          License:        GNU Affero General Public License v3.0
           URL:            https://example.com
           Source0:        %{name}-%{version}.tar.gz
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -331,9 +331,7 @@ jobs:
           cp `find target/release -type f -name "pg_search*"` archive/SOURCES/pg_search_${{ matrix.pg_version }}
 
           echo "Building RPM package..."
-          cd archive/SPECS/
-          make pg_search
-          rpmbuild --without debuginfo -ba pg_search.spec
+          rpmbuild --without debuginfo -ba archive/SPECS/pg_search.spec
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+
+          subscription-manager repos --enable=rhel-7-server-optional-rpms
+
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
 
       - name: Install extra RHEL Dependencies

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -136,9 +136,9 @@ jobs:
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-          sudo dnf install ./epel-release-latest-9.noarch.rpm
-          sudo dnf update
-          sudo dnf install perl-IPC-Run
+          sudo dnf install -y ./epel-release-latest-9.noarch.rpm
+          sudo dnf update -y
+          sudo dnf install -y perl-IPC-Run
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -213,17 +213,23 @@ jobs:
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           else
-            if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
-              sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
-            fi
+            sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-AARCH64-RHEL9
 
-            # Convert the GPG key to ASCII armored format if needed and import it
-            if gpg --list-keys --with-colons | grep "PGDG RPM Signing Key"; then
-              gpg --export --armor "PGDG RPM Signing Key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
-              sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
-            else
-              sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
-            fi
+            # RPM-GPG-KEY-PGDG-AARCH64-RHEL7                     04-Jan-2024 14:24                1768
+            # RPM-GPG-KEY-PGDG-AARCH64-RHEL8                     04-Jan-2024 14:24                3183
+            # RPM-GPG-KEY-PGDG-AARCH64-RHEL9 
+
+            # if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
+            #   sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
+            # fi
+
+            # # Convert the GPG key to ASCII armored format if needed and import it
+            # if gpg --list-keys --with-colons | grep "PGDG RPM Signing Key"; then
+            #   gpg --export --armor "PGDG RPM Signing Key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
+            #   sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
+            # else
+            #   sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+            # fi
           fi
           sudo dnf clean all
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -201,10 +201,8 @@ jobs:
             fi
             echo "RPM Arch: $ARCH"
             echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
-
-            OS=$(echo $DISTRO-$RELEASE | cut -d '-' -f 2-)
-            echo "RPM OS: $OS"
-            echo "rpm_os=$OS" >> $GITHUB_OUTPUT
+            echo "RPM OS: el$RELEASE"
+            echo "rpm_os=el$RELEASE" >> $GITHUB_OUTPUT
           fi
 
       - name: Install & Configure Supported PostgreSQL Version on Debian

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           # Install dependencies
-          dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
+          dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq rpm-build
 
           # Add Oracle Linux 9 repositories to enable epel-release
           sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -126,8 +126,10 @@ jobs:
       - name: Install extra RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          dnf install epel-release
-          dnf update
+          wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+          sudo dnf install ./epel-release-latest-9.noarch.rpm
+          sudo dnf update
+          sudo dnf install perl-IPC-Run
 
       - name: Install Debian Dependencies
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -161,13 +161,16 @@ jobs:
           wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           sudo dnf install -y epel-release
 
+          # This package requires epel-release, which is why we install it last. It is required to
+          # configure the build environment for creating the RPM package via rpmbuild
+          sudo dnf install -y rpmdevtools
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version
         run: |
-          # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
@@ -237,7 +240,7 @@ jobs:
         working-directory: pg_search/
         run: |
           sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
-          cargo pgrx package --features icu
+          cargo pgrx package --features "icu telemetry"
 
       - name: Create .deb Package
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
@@ -284,13 +287,11 @@ jobs:
       - name: Create .rpm Package
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          mkdir archive
-          mkdir -p archive/SOURCES
-          mkdir -p archive/SOURCES/pg_search_${{ matrix.pg_version }}
-          mkdir -p archive/SPECS
+          echo "Configuring RPM build environment..."
+          rpmdev-setuptree
 
           echo "Creating RPM SPEC file..."
-          spec_file=archive/SPECS/pg_search.spec
+          spec_file=~/rpmbuild/SPECS/pg_search.spec
           cat <<EOF > $spec_file
           Name:           pg_search
           Version:        ${{ steps.version.outputs.tag_version }}
@@ -298,7 +299,6 @@ jobs:
           Summary:        Full-text search for PostgreSQL using BM25
           License:        GNU Affero General Public License v3.0
           URL:            https://github.com/paradedb/paradedb
-          Source0:        %{name}-%{version}.tar.gz
 
           BuildRequires:  postgresql${{ matrix.pg_version }}-devel
           Requires:       postgresql${{ matrix.pg_version }}-server
@@ -327,10 +327,10 @@ jobs:
           EOF
 
           echo "Copying pg_search binaries to RPM build directory..."
-          cp -r target/release/pg_search-pg${{ matrix.pg_version }}/ archive/SOURCES/pg_search_${{ matrix.pg_version }}/
+          cp -r target/release/pg_search-pg${{ matrix.pg_version }}/ ~/rpmbuild/SOURCES/pg_search_${{ matrix.pg_version }}
 
           echo "Building RPM package..."
-          rpmbuild --without debuginfo -ba archive/SPECS/pg_search.spec
+          rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -165,38 +165,49 @@ jobs:
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
+      # TODO: I probably need to do some conditional logic here for EL8 vs EL9
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          # Determine RHEL version to retrieve the correct repositories
+          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
+            RHEL_VERSION=8
+          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
+            RHEL_VERSION=9
+          else
+            echo "Unsupported RHEL version"
+            exit 1
+          fi
+
           # Install dependencies
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq rpm-build
 
-          # Add Oracle Linux 9 repositories to enable epel-release
-          sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF
-          [ol9_baseos_latest]
-          name=Oracle Linux 9 BaseOS Latest (\$basearch)
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/\$basearch/
+          # Add Oracle Linux ${RHEL_VERSION} repositories to enable epel-release
+          sudo tee /etc/yum.repos.d/oracle-linux-ol${RHEL_VERSION}.repo > /dev/null <<EOF
+          [ol${RHEL_VERSION}_baseos_latest]
+          name=Oracle Linux ${RHEL_VERSION} BaseOS Latest (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/baseos/latest/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
 
-          [ol9_appstream]
-          name=Oracle Linux 9 Application Stream (\$basearch)
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/\$basearch/
+          [ol${RHEL_VERSION}_appstream]
+          name=Oracle Linux ${RHEL_VERSION} Application Stream (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/appstream/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
 
-          [ol9_codeready_builder]
-          name=Oracle Linux 9 CodeReady Builder (\$basearch) - Unsupported
-          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/\$basearch/
+          [ol${RHEL_VERSION}_codeready_builder]
+          name=Oracle Linux ${RHEL_VERSION} CodeReady Builder (\$basearch) - Unsupported
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL${RHEL_VERSION}/codeready/builder/\$basearch/
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           gpgcheck=1
           enabled=1
           EOF
 
           # Install epel-release, which is required by PostgreSQL via Perl-IPC-Run
-          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol${RHEL_VERSION} -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           sudo dnf install -y epel-release
 
           # This package requires epel-release, which is why we install it last. It is required to
@@ -252,7 +263,7 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/>
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install & Configure Supported PostgreSQL Version on RHEL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -191,6 +191,17 @@ jobs:
           echo "OS Version: $DISTRO-$RELEASE"
           echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
 
+          # RHEL uses a different architecture naming convention
+          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
+            if [ "${{ matrix.arch }}" == "amd64" ]; then
+              ARCH=x86_64
+            else
+              ARCH=aarch64
+            fi
+            echo "Arch: $ARCH"
+            echo "arch=$ARCH" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install & Configure Supported PostgreSQL Version on Debian
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: |
@@ -346,13 +357,15 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          overwrite: true
 
-      # Need to fix OS ad arch here
+      # Need to fix OS
       - name: Upload pg_search .rpm to GitHub Release
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ~/rpmbuild/RPMS/x86_64/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.x86_64.rpm
+          asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.arch }}/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.${{ steps.version.outputs.arch }}.rpm
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          overwrite: true

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -214,7 +214,13 @@ jobs:
 
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
-        run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+        run: |
+          if [[ "${{ matrix.image }}" == "redhat/ubi8" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
+            PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
+          else
+            PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+          fi
+          cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
       # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
       # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -207,8 +207,6 @@ jobs:
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb
-          sudo systemctl enable postgresql-${{ matrix.pg_version }}
-          sudo systemctl start postgresql-${{ matrix.pg_version }}
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -285,8 +285,9 @@ jobs:
           # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
           sudo dnf -qy module disable llvm-toolset
-          sudo dnf -qy module reset llvm
-          sudo dnf -qy module enable llvm:${RHEL_VERSION}
+          # sudo dnf -qy module reset llvm
+          # sudo dnf -qy module enable llvm:${RHEL_VERSION}
+          sudo dnf -y install llvm-devel
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -211,7 +211,7 @@ jobs:
           sudo dnf -y install $REPO_URL
 
           if [ ! -f /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL ]; then
-            sudo curl -o /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+            sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
           fi
           sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           sudo dnf clean all

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -104,10 +104,6 @@ jobs:
             image: debian:12-slim
             pg_version: 16
             arch: arm64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 16
-            arch: arm64
           # Red Hat Enterprise Linux 9
           - runner: depot-ubuntu-22.04-4
             image: redhat/ubi9:latest

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -189,7 +189,7 @@ jobs:
             RELEASE=$(lsb_release -rs)
           else
             DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
-            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"')
+            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
           fi
           echo "OS Version: $DISTRO-$RELEASE"
           echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
@@ -346,11 +346,12 @@ jobs:
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
 
+      # Need to fix OS ad arch here
       - name: Upload pg_search .rpm to GitHub Release
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          asset_path: ~/rpmbuild/RPMS/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.x86_64.rpm
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -282,12 +282,16 @@ jobs:
           fi
           sudo dnf clean all
 
-          # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
-          sudo dnf -qy module disable postgresql
-          sudo dnf -qy module disable llvm-toolset
-          # sudo dnf -qy module reset llvm
-          # sudo dnf -qy module enable llvm:${RHEL_VERSION}
-          sudo dnf -y install llvm-devel --setopt=module_platform_id=platform:el8
+          # List available modules
+          sudo dnf module list llvm
+          sudo dnf module list postgresql
+
+          # Enable required modules
+          sudo dnf -qy module enable llvm:13
+          sudo dnf -qy module enable postgresql:14
+
+          # Install LLVM and PostgreSQL
+          sudo dnf -y install llvm-devel
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -213,23 +213,7 @@ jobs:
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           else
-            sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-AARCH64-RHEL9
-
-            # RPM-GPG-KEY-PGDG-AARCH64-RHEL7                     04-Jan-2024 14:24                1768
-            # RPM-GPG-KEY-PGDG-AARCH64-RHEL8                     04-Jan-2024 14:24                3183
-            # RPM-GPG-KEY-PGDG-AARCH64-RHEL9 
-
-            # if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
-            #   sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
-            # fi
-
-            # # Convert the GPG key to ASCII armored format if needed and import it
-            # if gpg --list-keys --with-colons | grep "PGDG RPM Signing Key"; then
-            #   gpg --export --armor "PGDG RPM Signing Key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
-            #   sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
-            # else
-            #   sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
-            # fi
+            sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL
           fi
           sudo dnf clean all
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -165,7 +165,6 @@ jobs:
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
-      # TODO: I probably need to do some conditional logic here for EL8 vs EL9
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -298,13 +298,12 @@ jobs:
           sudo dnf module -y enable llvm-toolset:rhel${RHEL_VERSION}
           sudo dnf -y install llvm-toolset
 
-          # sudo dnf -qy module enable postgresql:${{ matrix.pg_version }}
           # # Install LLVM and PostgreSQL
           # echo "test2"
           # sudo dnf -y install llvm-devel
 
 
-
+          sudo dnf module -y enable postgresql:${{ matrix.pg_version }}
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -202,7 +202,7 @@ jobs:
             echo "RPM Arch: $ARCH"
             echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
 
-            OS=$($DISTRO-$RELEASE | cut -d '-' -f 2-)
+            OS=$(echo $DISTRO-$RELEASE | cut -d '-' -f 2-)
             echo "RPM OS: $OS"
             echo "rpm_os=$OS" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -170,14 +170,16 @@ jobs:
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
-              echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+              VERSION=${GITHUB_REF#refs/tags/v}
             else
               # If there is no tag and no provided version, it's a test run and we set a dummy version
-              echo "version=0.0.0" >> $GITHUB_OUTPUT
+              VERSION="0.0.0"
             fi
           else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            VERSION=${{ github.event.inputs.version }}
           fi
+          echo "GitHub Tag Version: $VERSION"
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           if [ -x "$(command -v lsb_release)" ]; then
             DISTRO=$(echo "$(lsb_release -is)" | tr '[:upper:]' '[:lower:]')
@@ -243,7 +245,7 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+          package_dir=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -262,7 +264,7 @@ jobs:
           # Create control file (package name cannot have underscore)
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
-          deb_version=${{ steps.version.outputs.version }}
+          deb_version=${{ steps.version.outputs.tag_version }}
           CONTROL_FILE="${package_dir}/DEBIAN/control"
           echo 'Package: pg-search' >> $CONTROL_FILE
           echo 'Version:' ${deb_version} >> $CONTROL_FILE
@@ -285,8 +287,8 @@ jobs:
           # Create installable package
           mkdir archive
           cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
-          rpm_package_name=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          package_dir=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+          rpm_package_name=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
             
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib64/pgsql
@@ -305,7 +307,7 @@ jobs:
           # Create SPEC file
           mkdir -p ${package_dir}/SPECS
           spec_file=${package_dir}/SPECS/pg_search.spec
-          rpm_version=${{ steps.version.outputs.version }}
+          rpm_version=${{ steps.version.outputs.tag_version }}
           cat <<EOF > $spec_file
           Name:           pg_search
           Version:        ${deb_version}
@@ -359,7 +361,7 @@ jobs:
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
-        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_search .deb to GitHub Release
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
@@ -367,8 +369,8 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: pg_search-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
 
       - name: Upload pg_search .rpm to GitHub Release
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
@@ -376,5 +378,5 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
-          asset_name: pg_search-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -283,14 +283,17 @@ jobs:
           sudo dnf clean all
 
           # List available modules
+          echo "test0"
           sudo dnf module list llvm
           sudo dnf module list postgresql
 
           # Enable required modules
+          echo "test1"
           sudo dnf -qy module enable llvm:13
-          sudo dnf -qy module enable postgresql:14
+          sudo dnf -qy module enable postgresql:${{ matrix.pg_version }}
 
           # Install LLVM and PostgreSQL
+          echo "test2"
           sudo dnf -y install llvm-devel
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -282,6 +282,9 @@ jobs:
           fi
           sudo dnf clean all
 
+          # We first disable the existing Postgres module to avoid conflicts with the PostgreSQL version we want to install
+          sudo dnf -qy module disable postgresql
+
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -124,16 +124,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Debian Dependencies
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
-        run: dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
-
-      - name: Install additional RHEL deps
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          # Install dependencies
+          dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
+
+          # Add Oracle Linux 9 repositories to enable epel-release
           sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF
           [ol9_baseos_latest]
           name=Oracle Linux 9 BaseOS Latest (\$basearch)
@@ -157,6 +157,7 @@ jobs:
           enabled=1
           EOF
 
+          # Install epel-release, which is required by PostgreSQL via Perl-IPC-Run
           wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
           sudo dnf install -y epel-release
 
@@ -232,6 +233,7 @@ jobs:
           cargo pgrx package --features icu
 
       - name: Create .deb Package
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: |
           # Create installable package
           mkdir archive
@@ -271,6 +273,84 @@ jobs:
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
+
+      - name: Create .rpm Package
+        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        run: |
+          # Create installable package
+          mkdir archive
+          cp `find target/release -type f -name "pg_search*"` archive
+          package_dir=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+          rpm_package_name=pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+            
+          # Copy files into directory structure
+          mkdir -p ${package_dir}/usr/lib64/pgsql
+          mkdir -p ${package_dir}/var/lib/pgsql
+          cp archive/*.so ${package_dir}/usr/lib64/pgsql
+          cp archive/*.control ${package_dir}/var/lib/pgsql
+          cp archive/*.sql ${package_dir}/var/lib/pgsql
+
+          # Symlinks to copy files into directory structure
+          mkdir -p ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib
+          mkdir -p ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+          cp archive/*.so ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib
+          cp archive/*.control ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+          cp archive/*.sql ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+
+
+            # Create SPEC file
+            mkdir -p ${package_dir}/SPECS
+            spec_file=${package_dir}/SPECS/pg_search.spec
+            rpm_version=${{ steps.version.outputs.version }}
+            cat <<EOF > $spec_file
+            Name:           pg_search
+            Version:        ${deb_version}
+            Release:        1%{?dist}
+            Summary:        Full-text search for PostgreSQL using BM25
+            License:        
+            URL:            https://example.com
+            Source0:        %{name}-%{version}.tar.gz
+            
+            Requires:       postgresql${{ matrix.pg_version }}
+
+            %description
+            Full-text search for PostgreSQL using BM25.
+
+            %prep
+
+            %build
+
+            %install
+            install -d %{buildroot}/usr/lib64/pgsql
+            install -d %{buildroot}/var/lib/pgsql
+            install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
+            install -d %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+            install -m 755 ${package_dir}/usr/lib64/pgsql/* %{buildroot}/usr/lib64/pgsql
+            install -m 644 ${package_dir}/var/lib/pgsql/* %{buildroot}/var/lib/pgsql
+            install -m 755 ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib/* %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
+            install -m 644 ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension/* %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+
+            %files
+            /usr/lib64/pgsql/*
+            /var/lib/pgsql/*
+            /usr/pgsql-${{ matrix.pg_version }}/lib/*
+            /usr/share/pgsql/${{ matrix.pg_version }}/extension/*
+
+            %changelog
+            * Fri May 31 2024 ParadeDB <support@paradedb.com> - ${deb_version}-1
+            - Initial package
+            EOF
+
+            # Create tarball
+            tar -czvf ${package_dir}.tar.gz -C ${package_dir} .
+
+            # Build .rpm package
+            rpmbuild -ba $spec_file --define "_sourcedir ${package_dir}" --define "_rpmdir ${package_dir}" --define "_builddir ${package_dir}" --define "_srcrpmdir ${package_dir}" --define "_specdir ${package_dir}"
+
+            # Move .rpm package to a specific directory
+            mv ${package_dir}/x86_64/${rpm_package_name} ${package_dir}/
+
+            echo "RPM package created: ${package_dir}/${rpm_package_name}"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -111,10 +111,10 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi9:latest
-            pg_version: 16
-            arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 16
+          #   arch: arm64
 
           # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
           # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
@@ -202,13 +202,8 @@ jobs:
           fi
           sudo dnf -y install $REPO_URL
 
-          echo "Download GPG key"
-          sudo wget -O /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          echo "test1"
           sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
-          echo "test2"
           sudo dnf clean all
-          echo "test3"
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -320,7 +320,6 @@ jobs:
           /usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
-          %exclude /usr/lib/.build-id
 
           %changelog
           * Thu Jun 6 2024 ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -169,10 +169,10 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
+            if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
             else
-              # If there is no tag and no provided version, it's a test run and we set a dummy version
+              # If there is no tag and no provided version, it's a test run and we set a default version
               VERSION="0.0.0"
             fi
           else

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -130,18 +130,24 @@ jobs:
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-
-          subscription-manager repos --enable=rhel-7-server-optional-rpms
-
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
 
       - name: Install extra RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
+          # Download and install EPEL release package
           wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
           sudo dnf install -y ./epel-release-latest-9.noarch.rpm
           sudo dnf update -y
-          sudo dnf install -y perl-IPC-Run
+
+          # Install necessary build tools and Perl CPAN
+          sudo dnf install -y perl-CPAN perl-App-cpanminus gcc make
+
+          # Install IPC::Run Perl module via CPAN
+          sudo cpanm --force IPC::Run
+
+          # # Install PostgreSQL development package
+          # sudo dnf install -y postgresql16-devel
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -300,7 +300,7 @@ jobs:
           URL:            https://github.com/paradedb/paradedb
           Source0:        %{name}-%{version}.tar.gz
 
-          BuildRequires:	postgresql${{ matrix.pg_version }}-devel
+          BuildRequires:  postgresql${{ matrix.pg_version }}-devel
           Requires:       postgresql${{ matrix.pg_version }}-server
 
           %description
@@ -323,12 +323,12 @@ jobs:
           %exclude /usr/lib/.build-id
 
           %changelog
-          * Tue June 4 2024 ParadeDB <support@paradedb.com> - ${rpm_version}
+          * Thu Jun 6 2024 ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
           - Initial RPM Release
           EOF
 
           echo "Copying pg_search binaries to RPM build directory..."
-          cp `find target/release -type f -name "pg_search*"` archive/SOURCES/pg_search_${{ matrix.pg_version }}
+          cp -r target/release/pg_search-pg${{ matrix.pg_version }}/ archive/SOURCES/pg_search_${{ matrix.pg_version }}/
 
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba archive/SPECS/pg_search.spec

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -328,7 +328,7 @@ jobs:
           EOF
 
           echo "Copying pg_search binaries to RPM build directory..."
-          cp `find target/release/pg_search-${{ matrix.pg_version }} -type f -name "pg_search*"` archive/SOURCES/pg_search_${{ matrix.pg_version }}
+          cp `find target/release -type f -name "pg_search*"` archive/SOURCES/pg_search_${{ matrix.pg_version }}
 
           echo "Building RPM package..."
           cd archive/SPECS/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -310,7 +310,7 @@ jobs:
           rpm_version=${{ steps.version.outputs.tag_version }}
           cat <<EOF > $spec_file
           Name:           pg_search
-          Version:        ${deb_version}
+          Version:        ${rpm_version}
           Release:        1%{?dist}
           Summary:        Full-text search for PostgreSQL using BM25
           License:        

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -123,14 +123,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Install extra RHEL Dependencies
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
-        run: |
-          wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-          sudo dnf install ./epel-release-latest-9.noarch.rpm
-          sudo dnf update
-          sudo dnf install perl-IPC-Run
-
       - name: Install Debian Dependencies
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
@@ -139,6 +131,14 @@ jobs:
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
+
+      - name: Install extra RHEL Dependencies
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
+        run: |
+          wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+          sudo dnf install ./epel-release-latest-9.noarch.rpm
+          sudo dnf update
+          sudo dnf install perl-IPC-Run
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -206,7 +206,6 @@ jobs:
           sudo dnf clean all
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
-          sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -192,7 +192,7 @@ jobs:
           echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version on Debian
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04'}}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -210,6 +210,9 @@ jobs:
           fi
           sudo dnf -y install $REPO_URL
 
+          if [ ! -f /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL ]; then
+            sudo curl -o /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+          fi
           sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           sudo dnf clean all
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -353,5 +353,5 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ~/rpmbuild/RPMS/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.x86_64.rpm
+          asset_path: ~/rpmbuild/RPMS/x86_64/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.x86_64.rpm
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -191,15 +191,20 @@ jobs:
           echo "OS Version: $DISTRO-$RELEASE"
           echo "os_version=$DISTRO-$RELEASE" >> $GITHUB_OUTPUT
 
-          # RHEL uses a different architecture naming convention
-          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
+          # RHEL uses different architecture and OS naming conventions when packaging via rpmbuid. We need to
+          # retrieve those as well to programmatically retrieve and upload the correct RPM package
+          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
             if [ "${{ matrix.arch }}" == "amd64" ]; then
               ARCH=x86_64
             else
               ARCH=aarch64
             fi
-            echo "Arch: $ARCH"
-            echo "arch=$ARCH" >> $GITHUB_OUTPUT
+            echo "RPM Arch: $ARCH"
+            echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
+
+            OS=$($DISTRO-$RELEASE | cut -d '-' -f 2-)
+            echo "RPM OS: $OS"
+            echo "rpm_os=$OS" >> $GITHUB_OUTPUT
           fi
 
       - name: Install & Configure Supported PostgreSQL Version on Debian
@@ -212,7 +217,7 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install & Configure Supported PostgreSQL Version on RHEL
-        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
@@ -238,7 +243,7 @@ jobs:
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
         run: |
-          if [[ "${{ matrix.image }}" == "redhat/ubi8" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
+          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
             PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
           else
             PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
@@ -297,7 +302,7 @@ jobs:
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       - name: Create .rpm Package
-        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           echo "Configuring RPM build environment..."
           rpmdev-setuptree
@@ -359,13 +364,12 @@ jobs:
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           overwrite: true
 
-      # Need to fix OS
       - name: Upload pg_search .rpm to GitHub Release
-        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.arch }}/pg_search-${{ steps.version.outputs.tag_version }}-1.el9.${{ steps.version.outputs.arch }}.rpm
+          asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.rpm_os }}.${{ steps.version.outputs.rpm_arch }}.rpm
           asset_name: pg_search-v${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
           overwrite: true

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -1,14 +1,12 @@
 # workflows/publish-pg_search.yml
 #
 # Publish pg_search
-# Build and publish the pg_search extension as a .deb to GitHub Releases.
+# Build and publish the pg_search extension as .deb and .rpm to GitHub Releases.
 
 name: Publish pg_search
 
 on:
   push:
-    branches:
-      - phil/rhel
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -210,10 +210,10 @@ jobs:
           fi
           sudo dnf -y install $REPO_URL
 
-          if [ ! -f /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL ]; then
+          if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
             sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
           fi
-          sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
+          sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
           sudo dnf clean all
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -106,31 +106,31 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 16
           #   arch: arm64
-          # Red Hat Enterprise Linux 8
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 14
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 14
-            arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 15
-            arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 15
-            arch: arm64
+          # # Red Hat Enterprise Linux 8
+          # - runner: depot-ubuntu-22.04-4
+          #   image: redhat/ubi8:latest
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi8:latest
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   image: redhat/ubi8:latest
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi8:latest
+          #   pg_version: 15
+          #   arch: arm64
           - runner: depot-ubuntu-22.04-4
             image: redhat/ubi8:latest
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi8:latest
-            pg_version: 16
-            arch: arm64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi8:latest
+          #   pg_version: 16
+          #   arch: arm64
           # # Red Hat Enterprise Linux 9
           # - runner: depot-ubuntu-22.04-4
           #   image: redhat/ubi9:latest
@@ -281,11 +281,6 @@ jobs:
             sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-AARCH64-RHEL
           fi
           sudo dnf clean all
-
-          # List available modules
-          echo "test0"
-          sudo dnf module list llvm
-          sudo dnf module list postgresql
 
           # Enable required modules
           echo "test1"

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -169,7 +169,12 @@ jobs:
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            if [ -n "${GITHUB_REF#refs/tags/v}" ]; then
+              echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            else
+              # If there is no tag and no provided version, it's a test run and we set a dummy version
+              echo "version=0.0.0" >> $GITHUB_OUTPUT
+            fi
           else
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -297,60 +297,59 @@ jobs:
           cp archive/*.control ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
           cp archive/*.sql ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
 
+          # Create SPEC file
+          mkdir -p ${package_dir}/SPECS
+          spec_file=${package_dir}/SPECS/pg_search.spec
+          rpm_version=${{ steps.version.outputs.version }}
+          cat <<EOF > $spec_file
+          Name:           pg_search
+          Version:        ${deb_version}
+          Release:        1%{?dist}
+          Summary:        Full-text search for PostgreSQL using BM25
+          License:        
+          URL:            https://example.com
+          Source0:        %{name}-%{version}.tar.gz
 
-            # Create SPEC file
-            mkdir -p ${package_dir}/SPECS
-            spec_file=${package_dir}/SPECS/pg_search.spec
-            rpm_version=${{ steps.version.outputs.version }}
-            cat <<EOF > $spec_file
-            Name:           pg_search
-            Version:        ${deb_version}
-            Release:        1%{?dist}
-            Summary:        Full-text search for PostgreSQL using BM25
-            License:        
-            URL:            https://example.com
-            Source0:        %{name}-%{version}.tar.gz
-            
-            Requires:       postgresql${{ matrix.pg_version }}
+          Requires:       postgresql${{ matrix.pg_version }}
 
-            %description
-            Full-text search for PostgreSQL using BM25.
+          %description
+          Full-text search for PostgreSQL using BM25.
 
-            %prep
+          %prep
 
-            %build
+          %build
 
-            %install
-            install -d %{buildroot}/usr/lib64/pgsql
-            install -d %{buildroot}/var/lib/pgsql
-            install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
-            install -d %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
-            install -m 755 ${package_dir}/usr/lib64/pgsql/* %{buildroot}/usr/lib64/pgsql
-            install -m 644 ${package_dir}/var/lib/pgsql/* %{buildroot}/var/lib/pgsql
-            install -m 755 ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib/* %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
-            install -m 644 ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension/* %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+          %install
+          install -d %{buildroot}/usr/lib64/pgsql
+          install -d %{buildroot}/var/lib/pgsql
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
+          install -d %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+          install -m 755 ${package_dir}/usr/lib64/pgsql/* %{buildroot}/usr/lib64/pgsql
+          install -m 644 ${package_dir}/var/lib/pgsql/* %{buildroot}/var/lib/pgsql
+          install -m 755 ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib/* %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
+          install -m 644 ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension/* %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
 
-            %files
-            /usr/lib64/pgsql/*
-            /var/lib/pgsql/*
-            /usr/pgsql-${{ matrix.pg_version }}/lib/*
-            /usr/share/pgsql/${{ matrix.pg_version }}/extension/*
+          %files
+          /usr/lib64/pgsql/*
+          /var/lib/pgsql/*
+          /usr/pgsql-${{ matrix.pg_version }}/lib/*
+          /usr/share/pgsql/${{ matrix.pg_version }}/extension/*
 
-            %changelog
-            * Fri May 31 2024 ParadeDB <support@paradedb.com> - ${deb_version}-1
-            - Initial package
-            EOF
+          %changelog
+          * Fri May 31 2024 ParadeDB <support@paradedb.com> - ${rpm_version}-1
+          - Initial package
+          EOF
 
-            # Create tarball
-            tar -czvf ${package_dir}.tar.gz -C ${package_dir} .
+          # Create tarball
+          tar -czvf ${package_dir}.tar.gz -C ${package_dir} .
 
-            # Build .rpm package
-            rpmbuild -ba $spec_file --define "_sourcedir ${package_dir}" --define "_rpmdir ${package_dir}" --define "_builddir ${package_dir}" --define "_srcrpmdir ${package_dir}" --define "_specdir ${package_dir}"
+          # Build .rpm package
+          rpmbuild -ba $spec_file --define "_sourcedir ${package_dir}" --define "_rpmdir ${package_dir}" --define "_builddir ${package_dir}" --define "_srcrpmdir ${package_dir}" --define "_specdir ${package_dir}"
 
-            # Move .rpm package to a specific directory
-            mv ${package_dir}/x86_64/${rpm_package_name} ${package_dir}/
+          # Move .rpm package to a specific directory
+          mv ${package_dir}/x86_64/${rpm_package_name} ${package_dir}/
 
-            echo "RPM package created: ${package_dir}/${rpm_package_name}"
+          echo "RPM package created: ${package_dir}/${rpm_package_name}"
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
@@ -358,9 +357,19 @@ jobs:
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_search .deb to GitHub Release
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: pg_search-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+
+      - name: Upload pg_search .rpm to GitHub Release
+        if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
+          asset_name: pg_search-v${{ steps.version.outputs.version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -106,27 +106,6 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 16
           #   arch: arm64
-          # # Red Hat Enterprise Linux 8
-          # - runner: depot-ubuntu-22.04-4
-          #   image: redhat/ubi8:latest
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi8:latest
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: redhat/ubi8:latest
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi8:latest
-          #   pg_version: 15
-          #   arch: arm64
-          - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi8:latest
-            pg_version: 16
-            arch: amd64
           # - runner: depot-ubuntu-22.04-arm-4
           #   image: redhat/ubi8:latest
           #   pg_version: 16
@@ -156,6 +135,7 @@ jobs:
           #   image: redhat/ubi9:latest
           #   pg_version: 16
           #   arch: arm64
+          # TODO: Add support for RHEL 8
 
     steps:
       - name: Checkout Git Repository
@@ -268,16 +248,6 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          # Determine RHEL version to retrieve the correct repositories
-          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
-            RHEL_VERSION=8
-          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
-            RHEL_VERSION=9
-          else
-            echo "Unsupported RHEL version"
-            exit 1
-          fi
-
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
           else
@@ -292,10 +262,7 @@ jobs:
           fi
           sudo dnf clean all
 
-          echo "5"
-          sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel
-
-          echo "6"
+          sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -210,10 +210,14 @@ jobs:
           fi
           sudo dnf -y install $REPO_URL
 
-          if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
-            sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
+          if [ "${{ matrix.arch }}" == "amd64" ]; then
+            sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
+          else
+            # if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
+            #   sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
+            # fi
+            sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
           fi
-          sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
           sudo dnf clean all
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -292,26 +292,8 @@ jobs:
           fi
           sudo dnf clean all
 
-          echo "1"
-          # Reset all previously enabled PostgreSQL modules
-          sudo dnf module reset -y postgresql
-
-          echo "2"
-          # Enable the llvm-toolset module for rhel8
-          sudo dnf module -y enable llvm-toolset:rhel${RHEL_VERSION}
-          sudo dnf -y install llvm-toolset
-
-          echo "3"
-          # # Install LLVM and PostgreSQL
-          # echo "test2"
-          # sudo dnf -y install llvm-devel
-
-          echo "4"
-
-          sudo dnf module -y enable postgresql:${{ matrix.pg_version }}
-
           echo "5"
-          sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
+          sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel
 
           echo "6"
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -292,19 +292,28 @@ jobs:
           fi
           sudo dnf clean all
 
+          echo "1"
+          # Reset all previously enabled PostgreSQL modules
+          sudo dnf module reset -y postgresql
 
-
+          echo "2"
           # Enable the llvm-toolset module for rhel8
           sudo dnf module -y enable llvm-toolset:rhel${RHEL_VERSION}
           sudo dnf -y install llvm-toolset
 
+          echo "3"
           # # Install LLVM and PostgreSQL
           # echo "test2"
           # sudo dnf -y install llvm-devel
 
+          echo "4"
 
           sudo dnf module -y enable postgresql:${{ matrix.pg_version }}
+
+          echo "5"
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
+
+          echo "6"
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/
           echo "/usr/pgsql-${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -106,18 +106,15 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 16
           #   arch: arm64
-
           - runner: depot-ubuntu-22.04-4
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 16
-          #   arch: arm64
-
-          # TODO: Add Ubuntu 20.04, RedHat UBI 8, and RedHat UBI 9
-          # TODO: Maybe consider removing debian-slim for regular debian, and removing manual apt downloads
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 16
+            arch: arm64
+          # TODO: RedHat UBI 8, and finish adding RedHat UBI 9
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -284,12 +284,17 @@ jobs:
 
           # Enable required modules
           echo "test1"
-          sudo dnf -qy module enable llvm:13
+          # Enable the llvm-toolset module
+          sudo dnf -qy module enable llvm-toolset
+
+          # Install LLVM and related packages
+          sudo dnf -y install llvm-toolset
+
           sudo dnf -qy module enable postgresql:${{ matrix.pg_version }}
 
-          # Install LLVM and PostgreSQL
-          echo "test2"
-          sudo dnf -y install llvm-devel
+          # # Install LLVM and PostgreSQL
+          # echo "test2"
+          # sudo dnf -y install llvm-devel
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -240,7 +240,7 @@ jobs:
         working-directory: pg_search/
         run: |
           sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
-          cargo pgrx package --features "icu telemetry"
+          cargo pgrx package --features icu
 
       - name: Create .deb Package
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -285,6 +285,8 @@ jobs:
           # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
           sudo dnf -qy module disable llvm-toolset
+          sudo dnf -qy module reset llvm
+          sudo dnf -qy module enable llvm:${RHEL_VERSION}
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -284,79 +284,56 @@ jobs:
       - name: Create .rpm Package
         if: ${{ matrix.image == 'redhat/ubi8' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          # Create installable package
           mkdir archive
-          cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
-          rpm_package_name=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.rpm
-            
-          # Copy files into directory structure
-          mkdir -p ${package_dir}/usr/lib64/pgsql
-          mkdir -p ${package_dir}/var/lib/pgsql
-          cp archive/*.so ${package_dir}/usr/lib64/pgsql
-          cp archive/*.control ${package_dir}/var/lib/pgsql
-          cp archive/*.sql ${package_dir}/var/lib/pgsql
+          mkdir -p archive/SOURCES
+          mkdir -p archive/SOURCES/pg_search_${{ matrix.pg_version }}
+          mkdir -p archive/SPECS
 
-          # Symlinks to copy files into directory structure
-          mkdir -p ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib
-          mkdir -p ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
-          cp archive/*.so ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib
-          cp archive/*.control ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
-          cp archive/*.sql ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension
-
-          # Create SPEC file
-          mkdir -p ${package_dir}/SPECS
-          spec_file=${package_dir}/SPECS/pg_search.spec
-          rpm_version=${{ steps.version.outputs.tag_version }}
+          echo "Creating RPM SPEC file..."
+          spec_file=archive/SPECS/pg_search.spec
           cat <<EOF > $spec_file
           Name:           pg_search
-          Version:        ${rpm_version}
+          Version:        ${{ steps.version.outputs.tag_version }}
           Release:        1%{?dist}
           Summary:        Full-text search for PostgreSQL using BM25
           License:        GNU Affero General Public License v3.0
-          URL:            https://example.com
+          URL:            https://github.com/paradedb/paradedb
           Source0:        %{name}-%{version}.tar.gz
 
-          Requires:       postgresql${{ matrix.pg_version }}
+          BuildRequires:	postgresql${{ matrix.pg_version }}-devel
+          Requires:       postgresql${{ matrix.pg_version }}-server
 
           %description
-          Full-text search for PostgreSQL using BM25.
-
-          %prep
-
-          %build
+          pg_search is a Postgres extension that enables full-text search over
+          PostgreSQL tables using the BM25 algorithm. It is built on top of Tantivy,
+          the Rust-based alternative to Apache Lucene, using pgrx.
 
           %install
-          install -d %{buildroot}/usr/lib64/pgsql
-          install -d %{buildroot}/var/lib/pgsql
-          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
-          install -d %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
-          install -m 755 ${package_dir}/usr/lib64/pgsql/* %{buildroot}/usr/lib64/pgsql
-          install -m 644 ${package_dir}/var/lib/pgsql/* %{buildroot}/var/lib/pgsql
-          install -m 755 ${package_dir}/usr/pgsql-${{ matrix.pg_version }}/lib/* %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib
-          install -m 644 ${package_dir}/usr/share/pgsql/${{ matrix.pg_version }}/extension/* %{buildroot}/usr/share/pgsql/${{ matrix.pg_version }}/extension
+          %{__rm} -rf %{buildroot}
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 755 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
+          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
 
           %files
-          /usr/lib64/pgsql/*
-          /var/lib/pgsql/*
-          /usr/pgsql-${{ matrix.pg_version }}/lib/*
-          /usr/share/pgsql/${{ matrix.pg_version }}/extension/*
+          /usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so
+          /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control
+          /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
+          %exclude /usr/lib/.build-id
 
           %changelog
-          * Fri May 31 2024 ParadeDB <support@paradedb.com> - ${rpm_version}-1
-          - Initial package
+          * Tue June 4 2024 ParadeDB <support@paradedb.com> - ${rpm_version}
+          - Initial RPM Release
           EOF
 
-          # Create tarball
-          tar -czvf ${package_dir}.tar.gz -C ${package_dir} .
+          echo "Copying pg_search binaries to RPM build directory..."
+          cp `find target/release/pg_search-${{ matrix.pg_version }} -type f -name "pg_search*"` archive/SOURCES/pg_search_${{ matrix.pg_version }}
 
-          # Build .rpm package
-          rpmbuild -ba $spec_file --define "_sourcedir ${package_dir}" --define "_rpmdir ${package_dir}" --define "_builddir ${package_dir}" --define "_srcrpmdir ${package_dir}" --define "_specdir ${package_dir}"
-
-          # Move .rpm package to a specific directory
-          mv ${package_dir}/x86_64/${rpm_package_name} ${package_dir}/
-
-          echo "RPM package created: ${package_dir}/${rpm_package_name}"
+          echo "Building RPM package..."
+          cd archive/SPECS/
+          make pg_search
+          rpmbuild --without debuginfo -ba pg_search.spec
 
       # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -216,7 +216,14 @@ jobs:
             if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
               sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
             fi
-            sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+
+            # Convert the GPG key to ASCII armored format if needed and import it
+            if gpg --list-keys --with-colons | grep "PGDG RPM Signing Key"; then
+              gpg --export --armor "PGDG RPM Signing Key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
+              sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-ASCII
+            else
+              sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+            fi
           fi
           sudo dnf clean all
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -123,6 +123,12 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
+      - name: Install extra RHEL Dependencies
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
+        run: |
+          dnf install epel-release
+          dnf update
+
       - name: Install Debian Dependencies
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -106,15 +106,56 @@ jobs:
           #   image: debian:12-slim
           #   pg_version: 16
           #   arch: arm64
+          # Red Hat Enterprise Linux 8
           - runner: depot-ubuntu-22.04-4
-            image: redhat/ubi9:latest
+            image: redhat/ubi8:latest
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi8:latest
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi8:latest
             pg_version: 16
             arch: amd64
           - runner: depot-ubuntu-22.04-arm-4
-            image: redhat/ubi9:latest
+            image: redhat/ubi8:latest
             pg_version: 16
             arch: arm64
-          # TODO: RedHat UBI 8, and finish adding RedHat UBI 9
+          # # Red Hat Enterprise Linux 9
+          # - runner: depot-ubuntu-22.04-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 14
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 14
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 15
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 15
+          #   arch: arm64
+          # - runner: depot-ubuntu-22.04-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 16
+          #   arch: amd64
+          # - runner: depot-ubuntu-22.04-arm-4
+          #   image: redhat/ubi9:latest
+          #   pg_version: 16
+          #   arch: arm64
 
     steps:
       - name: Checkout Git Repository
@@ -347,7 +388,6 @@ jobs:
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec
 
-      # We retrieve the GitHub release for the specific release version
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -201,8 +201,14 @@ jobs:
             REPO_URL="https://download.postgresql.org/pub/repos/yum/reporpms/EL-$(rpm -E %{rhel})-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
           fi
           sudo dnf -y install $REPO_URL
+
+          echo "Download GPG key"
+          sudo wget -O /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
+          echo "test1"
           sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
+          echo "test2"
           sudo dnf clean all
+          echo "test3"
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo /usr/pgsql-${{ matrix.pg_version }}/bin/postgresql-${{ matrix.pg_version }}-setup initdb

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -130,11 +130,7 @@ jobs:
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
-          if [ "${{ matrix.arch }}" == "amd64" ]; then
-            subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
-          else
-            subscription-manager repos --enable codeready-builder-for-rhel-9-aarch64-rpms
-          fi
+          dnf --enablerepo=codeready-builder-for-rhel-8-rhui-rpms install perl-IPC-Run -y
 
           dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
 

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -287,7 +287,7 @@ jobs:
           sudo dnf -qy module disable llvm-toolset
           # sudo dnf -qy module reset llvm
           # sudo dnf -qy module enable llvm:${RHEL_VERSION}
-          sudo dnf -y install llvm-devel
+          sudo dnf -y install llvm-devel --setopt=module_platform_id=platform:el8
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -213,9 +213,9 @@ jobs:
           if [ "${{ matrix.arch }}" == "amd64" ]; then
             sudo rpm --import /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL
           else
-            # if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
-            #   sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
-            # fi
+            if [ ! -f /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG ]; then
+              sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG          
+            fi
             sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
           fi
           sudo dnf clean all

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -282,8 +282,9 @@ jobs:
           fi
           sudo dnf clean all
 
-          # We first disable the existing Postgres module to avoid conflicts with the PostgreSQL version we want to install
+          # We first disable the existing Postgres module and dependencies to avoid conflicts with the PostgreSQL version we want to install
           sudo dnf -qy module disable postgresql
+          sudo dnf -qy module disable llvm-toolset
 
           sudo dnf -y install postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel --disablerepo='pgdg-common'
           sudo chown -R $(whoami) /usr/pgsql-${{ matrix.pg_version }}/ /var/lib/pgsql/${{ matrix.pg_version }}/data/

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -129,10 +129,36 @@ jobs:
 
       - name: Install RHEL Dependencies
         if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
-        run: |
-          dnf --enablerepo=codeready-builder-for-rhel-8-rhui-rpms install perl-IPC-Run -y
+        run: dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
 
-          dnf install -y sudo wget pkgconf-pkg-config openssl-devel jq perl
+      - name: Install additional RHEL deps
+        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
+        run: |
+          sudo tee /etc/yum.repos.d/oracle-linux-ol9.repo > /dev/null <<EOF
+          [ol9_baseos_latest]
+          name=Oracle Linux 9 BaseOS Latest (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+
+          [ol9_appstream]
+          name=Oracle Linux 9 Application Stream (\$basearch)
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+
+          [ol9_codeready_builder]
+          name=Oracle Linux 9 CodeReady Builder (\$basearch) - Unsupported
+          baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/\$basearch/
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          gpgcheck=1
+          enabled=1
+          EOF
+
+          wget https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+          sudo dnf install -y epel-release
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -29,110 +29,110 @@ jobs:
     strategy:
       matrix:
         include:
-          # # Ubuntu 22.04
-          # - runner: depot-ubuntu-22.04-4
-          #   image: ubuntu:22.04
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: ubuntu:22.04
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: ubuntu:22.04
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: ubuntu:22.04
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: ubuntu:22.04
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: ubuntu:22.04
-          #   pg_version: 16
-          #   arch: arm64
-          # # Debian 11
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:11-slim
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:11-slim
-          #   pg_version: 16
-          #   arch: arm64
-          # # Debian 12
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: debian:12-slim
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: debian:12-slim
-          #   pg_version: 16
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi8:latest
-          #   pg_version: 16
-          #   arch: arm64
-          # # Red Hat Enterprise Linux 9
-          # - runner: depot-ubuntu-22.04-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 14
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 14
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 15
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 15
-          #   arch: arm64
-          # - runner: depot-ubuntu-22.04-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 16
-          #   arch: amd64
-          # - runner: depot-ubuntu-22.04-arm-4
-          #   image: redhat/ubi9:latest
-          #   pg_version: 16
-          #   arch: arm64
+          # Ubuntu 22.04
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: arm64
+          # Debian 11
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:11-slim
+            pg_version: 16
+            arch: arm64
+          # Debian 12
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: debian:12-slim
+            pg_version: 16
+            arch: arm64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 16
+            arch: arm64
+          # Red Hat Enterprise Linux 9
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-22.04-4
+            image: redhat/ubi9:latest
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-22.04-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 16
+            arch: arm64
           # TODO: Add support for RHEL 8
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-paradedb"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "pg_lakehouse"
-version = "0.7.3"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "approx",
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ParadeDB and its extensions are available as commercial software for installatio
 
 ### Extensions
 
-You can find prebuilt binaries for all ParadeDB extensions on Debian 11, 12 and Ubuntu 22.04 for Postgres 14, 15 and 16 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). We officially support Postgres 12 and above, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
+You can find prebuilt binaries for all ParadeDB extensions on Debian 11, Debian 12, Ubuntu 22.04, and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). We officially support Postgres 12 and above, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
 
 For official support on non-Debian-based systems, please [contact us by email](mailto:sales@paradedb.com).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,5 @@
 ARG PG_VERSION_MAJOR=16
 
-# Note: As of writing, Debian 11/Bullseye is the latest stable Debian distro
-# and if equivalent to Ubuntu 22.04, which we use for testing.
-
 ###############################################
 # First Stage: Builder
 ###############################################

--- a/docs/deploy/pg_lakehouse.mdx
+++ b/docs/deploy/pg_lakehouse.mdx
@@ -12,7 +12,7 @@ Ensure that you have superuser access to the Postgres database.
 
 # Install `pg_lakehouse`
 
-ParadeDB provides prebuilt binaries for the `pg_lakehouse` extension on Debian 11, 12 and Ubuntu 22.04 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_lakehouse` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries

--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -18,7 +18,7 @@ sudo apt-get install -y libicu70
 
 # Install `pg_search`
 
-ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 11, 12 and Ubuntu 22.04 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries


### PR DESCRIPTION
# Ticket(s) Closed

- Closes (partial) #1116

## What
We've got a few requests for publishing `.rpm` packages, so this does it for RHEL 9, which is the latest version of Red Hat Enterprise Linux. It's very close to working with RHEL 8, but I decided to stop there and we can bring it later as I've got some other priorities. I've done this at lost hours.

As part of this, I've also improved our test deployment workflow so we can be sure ahead of time that deployments will run properly.

## Why
Make it easier for our users to deploy!

## How
Followed the instructions kindly provided by @Vonng from PigSTY!

## Tests
See here for a test release I've created: https://github.com/paradedb/paradedb/releases/tag/v0.0.0