### PR TITLE
fix: Only index on fields passed into options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-paradedb"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "pg_lakehouse"
-version = "0.7.3"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "approx",
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-std",

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -88,7 +88,6 @@ fn create_bm25(
     ))?;
 
     let mut column_names = HashSet::new();
-    column_names.insert(key_field.to_string());
     for fields in [
         text_fields,
         numeric_fields,

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -147,11 +147,7 @@ fn create_bm25(
 
     Spi::run(&format_bm25_function(
         &spi::quote_qualified_identifier(index_name, "explain"),
-        &format!(
-            "SETOF {}.{}",
-            spi::quote_identifier(schema_name),
-            spi::quote_identifier(table_name)
-        ),
+        "TABLE(plan text)",
         &format!(
             "RETURN QUERY EXPLAIN SELECT * FROM {}.{} WHERE {} @@@ __paradedb_search_config__",
             spi::quote_identifier(schema_name),

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -147,7 +147,7 @@ fn create_bm25(
 
     Spi::run(&format_bm25_function(
         &spi::quote_qualified_identifier(index_name, "explain"),
-        "TABLE(plan text)",
+        "TABLE(\"QUERY PLAN\" text)",
         &format!(
             "RETURN QUERY EXPLAIN SELECT * FROM {}.{} WHERE {} @@@ __paradedb_search_config__",
             spi::quote_identifier(schema_name),

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -115,8 +115,6 @@ fn create_bm25(
         .collect::<Vec<String>>()
         .join(", ");
 
-    info!("Creating bm25 index for columns: {}", column_names_csv);
-
     Spi::run(&format!(
         "CREATE INDEX {} ON {}.{} USING bm25 ({}) WITH (key_field={}, text_fields={}, numeric_fields={}, boolean_fields={}, json_fields={}, datetime_fields={});",
         spi::quote_identifier(format!("{}_bm25_index", index_name)),

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -116,10 +116,11 @@ fn create_bm25(
         .join(", ");
 
     Spi::run(&format!(
-        "CREATE INDEX {} ON {}.{} USING bm25 ({}) WITH (key_field={}, text_fields={}, numeric_fields={}, boolean_fields={}, json_fields={}, datetime_fields={});",
+        "CREATE INDEX {} ON {}.{} USING bm25 ({}, {}) WITH (key_field={}, text_fields={}, numeric_fields={}, boolean_fields={}, json_fields={}, datetime_fields={});",
         spi::quote_identifier(format!("{}_bm25_index", index_name)),
         spi::quote_identifier(schema_name),
         spi::quote_identifier(table_name),
+        spi::quote_identifier(key_field),
         column_names_csv,
         spi::quote_literal(key_field),
         spi::quote_literal(text_fields),

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -1,7 +1,5 @@
 use super::utils::get_search_index;
-use crate::{
-    env::register_commit_callback, globals::WriterGlobal, postgres::utils::lookup_index_tupdesc,
-};
+use crate::{env::register_commit_callback, globals::WriterGlobal};
 use pgrx::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -41,7 +39,7 @@ unsafe fn aminsert_internal(
     ctid: pg_sys::ItemPointer,
 ) -> bool {
     let index_relation_ref: PgRelation = PgRelation::from_pg(index_relation);
-    let tupdesc = lookup_index_tupdesc(&index_relation_ref);
+    let tupdesc = index_relation_ref.tuple_desc();
     let index_name = index_relation_ref.name();
     let search_index = get_search_index(index_name);
     let search_document = search_index

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -117,7 +117,7 @@ fn sequential_scan_syntax(mut conn: PgConnection) {
 
     let columns: SimpleProductsTableVec = "SELECT * FROM paradedb.bm25_search
         WHERE paradedb.search_tantivy(
-            paradedb.bm25_search.*,
+            id,
             jsonb_build_object(
                 'index_name', 'bm25_search_bm25_index',
                 'table_name', 'bm25_test_table',

--- a/pg_search/tests/quickstart.rs
+++ b/pg_search/tests/quickstart.rs
@@ -151,7 +151,7 @@ fn quickstart(mut conn: PgConnection) {
     assert_eq!(rows[3].0, 39);
     assert_eq!(rows[4].0, 9);
     assert_relative_eq!(rows[0].1, 0.95714283, epsilon = 1e-6); // Adjust epsilon as needed
-    assert_relative_eq!(rows[1].1, 0.8487012, epsilon = 1e-6);
+    assert_relative_eq!(rows[1].1, 0.8490507, epsilon = 1e-6);
     assert_relative_eq!(rows[2].1, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].1, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[4].1, 0.1, epsilon = 1e-6);
@@ -183,7 +183,7 @@ fn quickstart(mut conn: PgConnection) {
     assert_eq!(rows[3].2, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(rows[4].2, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_relative_eq!(rows[0].3, 0.95714283, epsilon = 1e-6);
-    assert_relative_eq!(rows[1].3, 0.8487012, epsilon = 1e-6);
+    assert_relative_eq!(rows[1].3, 0.8490507, epsilon = 1e-6);
     assert_relative_eq!(rows[2].3, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].3, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[4].3, 0.1, epsilon = 1e-6);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1256 

## What
The index access method only inserts/commits when columns that have been indexed are modified. In my testing, this means that UPDATEs of non-indexed columns are over 100X faster!

```sql
\timing

CALL paradedb.create_bm25(
        index_name => 'search_idx',
        schema_name => 'public',
        table_name => 'mock_items',
        key_field => 'id',
        text_fields => '{description: {tokenizer: {type: "en_stem"}}}'
);

-- BEFORE
pg_search=# update mock_items set category = 'Electronics 2' where description = 'Plastic Keyboard';
UPDATE 1
Time: 165.444 ms

-- AFTER
pg_search=# update mock_items set category = 'Electronics 2' where description = 'Plastic Keyboard';
UPDATE 1
Time: 1.463 ms
```

## Why
See Github issue.

## How
1. Instead of passing in the wildcard `table_name.*` to the BM25 index, we pass in the names of the columns that we want to index separated by columns. This is standard for Postgres multi-column indexes.
2. Modify the LHS of the `@@@` operator to take in the key field instead of the table. This was necessary for the planner to trigger an index scan.
3. Now that we pass in the columns directly, we can remove a lot of hacky code that was used to extract a `TupleDesc` from the table and just use `index.tuple_desc()` directly.
4. Introduced an `explain` function that is helpful in testing whether an index scan is being triggered.

## Tests
See tests