### PR TITLE
docs: Fix broken download link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ All development of ParadeDB is done via Docker and Compose. Our Docker setup is 
 
 ### Pull Request Worfklow
 
-All changes to ParadeDB happen through Github Pull Requests. Here is the recommended
+All changes to ParadeDB happen through GitHub Pull Requests. Here is the recommended
 flow for making a change:
 
 1. Before working on a change, please check to see if there is already a GitHub

--- a/docs/analytics/acceleration.mdx
+++ b/docs/analytics/acceleration.mdx
@@ -56,7 +56,7 @@ EXPLAIN SELECT add_one("VendorID") FROM trips LIMIT 1;
 (6 rows)
 ```
 
-Opening a [Github issue](https://github.com/paradedb/paradedb/issues) is the best way to request full DataFusion pushdown for these
+Opening a [GitHub issue](https://github.com/paradedb/paradedb/issues) is the best way to request full DataFusion pushdown for these
 queries.
 
 ## First Queries

--- a/docs/analytics/object_stores/unsupported.mdx
+++ b/docs/analytics/object_stores/unsupported.mdx
@@ -6,4 +6,4 @@ ParadeDB uses [Apache OpenDAL](https://github.com/apache/opendal) to integrate w
 straightforward to add support for many other object stores.
 
 Supporting all of OpenDAL's object stores is on the roadmap. To request prioritization for a specific object
-store, please open a [Github issue](https://github.com/paradedb/paradedb/issues).
+store, please open a [GitHub issue](https://github.com/paradedb/paradedb/issues).

--- a/docs/analytics/quickstart.mdx
+++ b/docs/analytics/quickstart.mdx
@@ -85,7 +85,7 @@ That's it! To query your own object store, please refer to the [object stores](/
 
 ## For Further Assistance
 
-The `paradedb.help` function opens a Github Discussion that the ParadeDB team will respond to.
+The `paradedb.help` function opens a GitHub Discussion that the ParadeDB team will respond to.
 
 ```sql
 SELECT paradedb.help(

--- a/docs/analytics_deprecated/quickstart.mdx
+++ b/docs/analytics_deprecated/quickstart.mdx
@@ -51,7 +51,7 @@ CREATE TABLE copy USING parquet AS SELECT * FROM heap;
 
 ## For Further Assistance
 
-The `paradedb.help` function opens a Github Discussion that the ParadeDB team will respond to.
+The `paradedb.help` function opens a GitHub Discussion that the ParadeDB team will respond to.
 
 ```sql
 SELECT paradedb.help(

--- a/docs/deploy/pg_analytics.mdx
+++ b/docs/deploy/pg_analytics.mdx
@@ -18,15 +18,15 @@ are using a different version of Postgres or a different operating system, you w
 ## Using Prebuilt Binaries
 
 ```bash
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.7.5/pg_analytics-v0.7.5-pg16-arm64-ubuntu2204.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.6.1/pg_analytics-v0.6.1-pg16-arm64-ubuntu2204.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
-Note: You can replace `v0.7.5` with the `pg_analytics` version you wish to install, and `pg16` with the version of Postgres you are using.
+Note: You can replace `v0.6.1` with the `pg_analytics` version you wish to install, and `pg16` with the version of Postgres you are using.
 
 ## Building from Source
 
-Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.7.5/pg_analytics#installation).
+Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.6.1/pg_analytics#installation).
 
 # Update `postgresql.conf`
 

--- a/docs/deploy/pg_lakehouse.mdx
+++ b/docs/deploy/pg_lakehouse.mdx
@@ -12,13 +12,14 @@ Ensure that you have superuser access to the Postgres database.
 
 # Install `pg_lakehouse`
 
-ParadeDB provides prebuilt binaries for the `pg_lakehouse` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_lakehouse` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries
 
 ```bash
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.7.5/pg_lakehouse-v0.7.5-pg16-arm64-ubuntu2204.deb" -o /tmp/pg_lakehouse.deb
+# Example for Ubuntu 22.04, don't forget replace the OS, arch and Postgres for your system
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.7.5/pg_lakehouse-v0.7.5-ubuntu-22.04-amd64-pg16.deb" -o /tmp/pg_lakehouse.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 

--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -18,13 +18,14 @@ sudo apt-get install -y libicu70
 
 # Install `pg_search`
 
-ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 11, Debian 12, Ubuntu 22.04 and Red Hat Enterprise Linux 9 for Postgres 14, 15 and 16 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries
 
 ```bash
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.7.5/pg_search-v0.7.5-pg16-arm64-ubuntu2204.deb" -o /tmp/pg_search.deb
+# Example for Ubuntu 22.04, don't forget replace the OS, arch and Postgres for your system
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.7.5/pg_search-v0.7.5-ubuntu-22.04-amd64-pg16.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 

--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -90,7 +90,7 @@ from an external object store or table format into ParadeDB.
 
 ## For Further Assistance
 
-The `paradedb.help` function opens a Github Discussion that the ParadeDB team will respond to.
+The `paradedb.help` function opens a GitHub Discussion that the ParadeDB team will respond to.
 
 ```sql
 SELECT paradedb.help(

--- a/docs/search/quickstart.mdx
+++ b/docs/search/quickstart.mdx
@@ -292,7 +292,7 @@ As we can see, results with the word `keyboard` scored higher than results with 
 
 ## For Further Assistance
 
-The `paradedb.help` function opens a Github Discussion that the ParadeDB team will respond to.
+The `paradedb.help` function opens a GitHub Discussion that the ParadeDB team will respond to.
 
 ```sql
 SELECT paradedb.help(

--- a/shared/src/github.rs
+++ b/shared/src/github.rs
@@ -24,7 +24,7 @@ const BASE_GITHUB_URL: &str = "https://github.com";
     END $$;
 "#)]
 pub fn help(subject: &str, body: &str) -> String {
-    let mut url = Url::parse(BASE_GITHUB_URL).expect("Failed to parse Github URL");
+    let mut url = Url::parse(BASE_GITHUB_URL).expect("Failed to parse GitHub URL");
     url.set_path("/orgs/paradedb/discussions/new");
 
     let query = form_urlencoded::Serializer::new(String::new())


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
The download link for `pg_analytics` was broken, since we stopped shipping post v0.6.1. The download link for `pg_search` and `pg_lakehouse` was also broken, since we changed the URL format. I've also added some clarifications.

## Why
No broken links!

## How
N/A

## Tests
N/A