### PR TITLE
chore: Adjust CI instances size

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -13,7 +13,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
-      - staging
       - main
     paths:
       - "docker/Dockerfile"

--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   benchmark-pg_lakehouse:
     name: Benchmark pg_lakehouse on ${{ matrix.name }}
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -13,7 +13,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
-      - staging
       - main
     paths:
       - "docker/Dockerfile"

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-bash:
     name: Lint Bash Scripts
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-docker:
     name: Lint Dockerfiles
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint-format:
     name: Lint File Endings & Trailing Whitespaces
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint-markdown:
     name: Lint Markdown Files
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: Validate PR Title
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-rust:
     name: Lint Rust Files
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-yaml:
     name: Lint YAML Files
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - staging
       - dev
   workflow_dispatch:
 

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   publish-github-release:
     name: Publish ParadeDB GitHub Release
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   publish-paradedb-container-image:
     name: Publish ParadeDB Container Image for PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     strategy:
       matrix:
         pg_version: [16]
@@ -90,7 +90,7 @@ jobs:
 
   publish-paradedb-helm-chart:
     name: Publish ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     strategy:
       matrix:
         pg_version: [16]

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           # Ubuntu 22.04
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 14
             arch: amd64
@@ -38,7 +38,7 @@ jobs:
             image: ubuntu:22.04
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 15
             arch: amd64
@@ -46,7 +46,7 @@ jobs:
             image: ubuntu:22.04
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 16
             arch: amd64
@@ -55,7 +55,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 11
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 14
             arch: amd64
@@ -63,7 +63,7 @@ jobs:
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 15
             arch: amd64
@@ -71,7 +71,7 @@ jobs:
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 16
             arch: amd64
@@ -80,7 +80,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 12
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 14
             arch: amd64
@@ -88,7 +88,7 @@ jobs:
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 15
             arch: amd64
@@ -96,7 +96,7 @@ jobs:
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 16
             arch: amd64
@@ -105,7 +105,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Red Hat Enterprise Linux 9
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 14
             arch: amd64
@@ -113,7 +113,7 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 15
             arch: amd64
@@ -121,7 +121,7 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           # Ubuntu 22.04
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 14
             arch: amd64
@@ -38,7 +38,7 @@ jobs:
             image: ubuntu:22.04
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 15
             arch: amd64
@@ -46,7 +46,7 @@ jobs:
             image: ubuntu:22.04
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: ubuntu:22.04
             pg_version: 16
             arch: amd64
@@ -55,7 +55,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 11
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 14
             arch: amd64
@@ -63,7 +63,7 @@ jobs:
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 15
             arch: amd64
@@ -71,7 +71,7 @@ jobs:
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:11-slim
             pg_version: 16
             arch: amd64
@@ -80,7 +80,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Debian 12
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 14
             arch: amd64
@@ -88,7 +88,7 @@ jobs:
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 15
             arch: amd64
@@ -96,7 +96,7 @@ jobs:
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: debian:12-slim
             pg_version: 16
             arch: amd64
@@ -105,7 +105,7 @@ jobs:
             pg_version: 16
             arch: arm64
           # Red Hat Enterprise Linux 9
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 14
             arch: amd64
@@ -113,7 +113,7 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 15
             arch: amd64
@@ -121,7 +121,7 @@ jobs:
             image: redhat/ubi9:latest
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,7 +10,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
       - dev
     paths:
       - "docs/**"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   test-docs:
     name: Test Docs for Broken Links
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB on PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -10,7 +10,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
       - dev
     paths:
       - "docker/**"

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -10,7 +10,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
-      - staging
       - main
     paths:
       - "pg_lakehouse/**"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -10,7 +10,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
-      - staging
       - main
     paths:
       - "pg_search/**"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -40,19 +40,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             pg_version: 12
             arch: amd64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             pg_version: 13
             arch: amd64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-4
+          - runner: depot-ubuntu-22.04-8
             pg_version: 16
             arch: amd64
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,40 +227,19 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
 dependencies = [
- "arrow-arith 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-cast 51.0.0",
- "arrow-csv 51.0.0",
- "arrow-data 51.0.0",
- "arrow-ipc 51.0.0",
- "arrow-json 51.0.0",
- "arrow-ord 51.0.0",
- "arrow-row 51.0.0",
- "arrow-schema 51.0.0",
- "arrow-select 51.0.0",
- "arrow-string 51.0.0",
-]
-
-[[package]]
-name = "arrow"
-version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
-dependencies = [
- "arrow-arith 52.0.0",
- "arrow-array 52.0.0",
- "arrow-buffer 52.0.0",
- "arrow-cast 52.0.0",
- "arrow-csv 52.0.0",
- "arrow-data 52.0.0",
- "arrow-ipc 52.0.0",
- "arrow-json 52.0.0",
- "arrow-ord 52.0.0",
- "arrow-row 52.0.0",
- "arrow-schema 52.0.0",
- "arrow-select 52.0.0",
- "arrow-string 52.0.0",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -285,9 +264,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
 dependencies = [
  "ahash",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half 2.4.1",
@@ -312,11 +291,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
- "arrow-select 51.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -333,30 +312,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-cast 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
-dependencies = [
- "arrow-array 52.0.0",
- "arrow-buffer 52.0.0",
- "arrow-cast 52.0.0",
- "arrow-data 52.0.0",
- "arrow-schema 52.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -383,27 +343,13 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-cast 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
- "flatbuffers 23.5.26",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
  "lz4_flex",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
-dependencies = [
- "arrow-array 52.0.0",
- "arrow-buffer 52.0.0",
- "arrow-cast 52.0.0",
- "arrow-data 52.0.0",
- "arrow-schema 52.0.0",
- "flatbuffers 24.3.25",
 ]
 
 [[package]]
@@ -466,39 +412,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-schema"
-version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "arrow-select"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
 dependencies = [
  "ahash",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
-version = "52.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
-dependencies = [
- "ahash",
- "arrow-array 52.0.0",
- "arrow-buffer 52.0.0",
- "arrow-data 52.0.0",
- "arrow-schema 52.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
 ]
 
@@ -1458,18 +1381,7 @@ checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 2.5.1",
-]
-
-[[package]]
-name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 4.0.1",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -1655,18 +1567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.2.1",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build 0.3.0",
+ "chrono-tz-build",
  "phf",
 ]
 
@@ -1675,17 +1576,6 @@ name = "chrono-tz-build"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -2191,10 +2081,10 @@ checksum = "85069782056753459dc47e386219aa1fdac5b731f26c28abb8c0ffd4b7c5ab11"
 dependencies = [
  "ahash",
  "apache-avro",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-ipc 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2221,9 +2111,9 @@ dependencies = [
  "log",
  "num-traits",
  "num_cpus",
- "object_store 0.9.1",
+ "object_store",
  "parking_lot",
- "parquet 51.0.0",
+ "parquet",
  "pin-project-lite",
  "rand",
  "sqlparser 0.44.0",
@@ -2243,10 +2133,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-ipc 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2273,9 +2163,9 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "num_cpus",
- "object_store 0.9.1",
+ "object_store",
  "parking_lot",
- "parquet 51.0.0",
+ "parquet",
  "pin-project-lite",
  "rand",
  "sqlparser 0.45.0",
@@ -2296,17 +2186,17 @@ checksum = "309d9040751f6dc9e33c85dce6abb55a46ef7ea3644577dd014611c379447ef3"
 dependencies = [
  "ahash",
  "apache-avro",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "chrono",
  "half 2.4.1",
  "instant",
  "libc",
  "num_cpus",
- "object_store 0.9.1",
- "parquet 51.0.0",
+ "object_store",
+ "parquet",
  "sqlparser 0.44.0",
 ]
 
@@ -2317,17 +2207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "chrono",
  "half 2.4.1",
  "instant",
  "libc",
  "num_cpus",
- "object_store 0.9.1",
- "parquet 51.0.0",
+ "object_store",
+ "parquet",
  "sqlparser 0.45.0",
 ]
 
@@ -2355,7 +2245,7 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a3a29ae36bcde07d179cc33b45656a8e7e4d023623e320e48dcf1200eeee95"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "chrono",
  "dashmap",
  "datafusion-common 37.1.0",
@@ -2363,7 +2253,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store 0.9.1",
+ "object_store",
  "parking_lot",
  "rand",
  "tempfile",
@@ -2376,7 +2266,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "chrono",
  "dashmap",
  "datafusion-common 38.0.0",
@@ -2384,7 +2274,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store 0.9.1",
+ "object_store",
  "parking_lot",
  "rand",
  "tempfile",
@@ -2398,8 +2288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3542aa322029c2121a671ce08000d4b274171070df13f697b14169ccf4f628"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
+ "arrow",
+ "arrow-array",
  "chrono",
  "datafusion-common 37.1.0",
  "paste",
@@ -2415,8 +2305,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
+ "arrow",
+ "arrow-array",
  "chrono",
  "datafusion-common 38.0.0",
  "paste",
@@ -2484,7 +2374,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "datafusion-common 38.0.0",
  "datafusion-execution 38.0.0",
  "datafusion-expr 38.0.0",
@@ -2500,11 +2390,11 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e501801e84d9c6ef54caaebcda1b18a6196a24176c12fb70e969bc0572e03c55"
 dependencies = [
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-ord 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "datafusion-common 37.1.0",
  "datafusion-execution 37.1.0",
  "datafusion-expr 37.1.0",
@@ -2520,11 +2410,11 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
 dependencies = [
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-ord 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "datafusion-common 38.0.0",
  "datafusion-execution 38.0.0",
  "datafusion-expr 38.0.0",
@@ -2540,7 +2430,7 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bd7f5087817deb961764e8c973d243b54f8572db414a8f0a8f33a48f991e0a"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "async-trait",
  "chrono",
  "datafusion-common 37.1.0",
@@ -2558,7 +2448,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "async-trait",
  "chrono",
  "datafusion-common 38.0.0",
@@ -2643,7 +2533,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
 ]
@@ -2655,10 +2545,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c0523e9c8880f2492a88bbd857dde02bed1ed23f3e9211a89d3d7ec3b44af9"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common 37.1.0",
@@ -2686,11 +2576,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
 dependencies = [
  "ahash",
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-ord 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common 38.0.0",
@@ -2719,12 +2609,12 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db73393e42f35e165d31399192fbf41691967d428ebed47875ad34239fbcfc16"
 dependencies = [
- "arrow 51.0.0",
+ "arrow",
  "chrono",
  "datafusion 37.1.0",
  "datafusion-common 37.1.0",
  "datafusion-expr 37.1.0",
- "object_store 0.9.1",
+ "object_store",
  "prost",
 ]
 
@@ -2734,9 +2624,9 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49eb54b42227136f6287573f2434b1de249fe1b8e6cd6cc73a634e4a3ec29356"
 dependencies = [
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
  "datafusion-common 37.1.0",
  "datafusion-expr 37.1.0",
  "log",
@@ -2750,58 +2640,14 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
 dependencies = [
- "arrow 51.0.0",
- "arrow-array 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
  "log",
  "sqlparser 0.45.0",
  "strum 0.26.2",
-]
-
-[[package]]
-name = "delta_kernel"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ddfe35af3696786ab5f23cd995df33a66f6cff272ac1f85e09c1a6316acd4c"
-dependencies = [
- "arrow-arith 52.0.0",
- "arrow-array 52.0.0",
- "arrow-json 52.0.0",
- "arrow-ord 52.0.0",
- "arrow-schema 52.0.0",
- "arrow-select 52.0.0",
- "bytes",
- "chrono",
- "delta_kernel_derive",
- "either",
- "fix-hidden-lifetime-bug",
- "indexmap 2.2.6",
- "itertools 0.13.0",
- "lazy_static",
- "parquet 52.0.0",
- "roaring",
- "rustc_version 0.4.0",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "url",
- "uuid",
- "visibility",
- "z85",
-]
-
-[[package]]
-name = "delta_kernel_derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d2127a34b12919a6bce08225f0ca6fde8a19342a32675370edfc8795e7c38a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -2811,7 +2657,7 @@ source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd9846
 dependencies = [
  "deltalake-aws",
  "deltalake-azure",
- "deltalake-core 0.17.3",
+ "deltalake-core",
  "deltalake-gcp",
 ]
 
@@ -2828,11 +2674,11 @@ dependencies = [
  "aws-smithy-runtime-api",
  "backoff",
  "bytes",
- "deltalake-core 0.18.0",
+ "deltalake-core",
  "futures",
  "lazy_static",
  "maplit",
- "object_store 0.10.1",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -2848,10 +2694,10 @@ source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd9846
 dependencies = [
  "async-trait",
  "bytes",
- "deltalake-core 0.17.3",
+ "deltalake-core",
  "futures",
  "lazy_static",
- "object_store 0.9.1",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -2864,17 +2710,17 @@ name = "deltalake-core"
 version = "0.17.3"
 source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
 dependencies = [
- "arrow 51.0.0",
- "arrow-arith 51.0.0",
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-cast 51.0.0",
- "arrow-ipc 51.0.0",
- "arrow-json 51.0.0",
- "arrow-ord 51.0.0",
- "arrow-row 51.0.0",
- "arrow-schema 51.0.0",
- "arrow-select 51.0.0",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
  "async-trait",
  "bytes",
  "cfg-if",
@@ -2901,10 +2747,10 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
- "object_store 0.9.1",
+ "object_store",
  "once_cell",
  "parking_lot",
- "parquet 51.0.0",
+ "parquet",
  "percent-encoding",
  "pin-project-lite",
  "rand",
@@ -2922,71 +2768,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "deltalake-core"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d245c54723a39cf66af430e0b73552819dc0be8ec04667baf42c31cf960d5d1e"
-dependencies = [
- "arrow 52.0.0",
- "arrow-arith 52.0.0",
- "arrow-array 52.0.0",
- "arrow-buffer 52.0.0",
- "arrow-cast 52.0.0",
- "arrow-ipc 52.0.0",
- "arrow-json 52.0.0",
- "arrow-ord 52.0.0",
- "arrow-row 52.0.0",
- "arrow-schema 52.0.0",
- "arrow-select 52.0.0",
- "async-trait",
- "bytes",
- "cfg-if",
- "chrono",
- "dashmap",
- "delta_kernel",
- "either",
- "errno",
- "fix-hidden-lifetime-bug",
- "futures",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "itertools 0.13.0",
- "lazy_static",
- "libc",
- "maplit",
- "num-bigint",
- "num-traits",
- "num_cpus",
- "object_store 0.10.1",
- "once_cell",
- "parking_lot",
- "parquet 52.0.0",
- "percent-encoding",
- "pin-project-lite",
- "rand",
- "regex",
- "roaring",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "z85",
-]
-
-[[package]]
 name = "deltalake-gcp"
 version = "0.2.0"
 source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
 dependencies = [
  "async-trait",
  "bytes",
- "deltalake-core 0.17.3",
+ "deltalake-core",
  "futures",
  "lazy_static",
- "object_store 0.9.1",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -4422,15 +4213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5255,36 +5037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object_store"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "hyper 1.3.1",
- "itertools 0.12.1",
- "md-5",
- "parking_lot",
- "percent-encoding",
- "quick-xml",
- "rand",
- "reqwest 0.12.5",
- "ring",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
 name = "object_store_opendal"
 version = "0.43.1"
 source = "git+https://github.com/apache/opendal.git?rev=79ab57f#79ab57f49846f7267072ca7452be37f5582cde6e"
@@ -5293,7 +5045,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-util",
- "object_store 0.9.1",
+ "object_store",
  "opendal",
  "pin-project",
  "tokio",
@@ -5527,7 +5279,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store 0.9.1",
+ "object_store",
  "paste",
  "seq-macro",
  "snap",
@@ -5724,9 +5476,8 @@ dependencies = [
  "dashmap",
  "datafusion 37.1.0",
  "deltalake",
- "deltalake-aws",
  "futures",
- "object_store 0.9.1",
+ "object_store",
  "object_store_opendal",
  "opendal",
  "pgrx",
@@ -7184,10 +6935,10 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff56acef131ef74bacc5e86c5038b524d61dee59d65c9e3e5e0f35b9de98cf99"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "bytemuck",
  "chrono",
  "half 2.4.1",
@@ -8807,17 +8558,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "visibility"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,10 +248,10 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half 2.4.1",
  "num",
@@ -358,11 +358,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-cast 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half 2.4.1",
  "indexmap 2.2.6",
@@ -431,11 +431,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
 dependencies = [
- "arrow-array 51.0.0",
- "arrow-buffer 51.0.0",
- "arrow-data 51.0.0",
- "arrow-schema 51.0.0",
- "arrow-select 51.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "memchr",
  "num",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,19 +227,40 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-csv 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-json 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-row 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
+ "arrow-string 51.0.0",
+]
+
+[[package]]
+name = "arrow"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
+dependencies = [
+ "arrow-arith 52.0.0",
+ "arrow-array 52.0.0",
+ "arrow-buffer 52.0.0",
+ "arrow-cast 52.0.0",
+ "arrow-csv 52.0.0",
+ "arrow-data 52.0.0",
+ "arrow-ipc 52.0.0",
+ "arrow-json 52.0.0",
+ "arrow-ord 52.0.0",
+ "arrow-row 52.0.0",
+ "arrow-schema 52.0.0",
+ "arrow-select 52.0.0",
+ "arrow-string 52.0.0",
 ]
 
 [[package]]
@@ -248,10 +269,10 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
  "chrono",
  "half 2.4.1",
  "num",
@@ -264,9 +285,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
  "chrono",
  "chrono-tz",
  "half 2.4.1",
@@ -291,11 +312,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -312,11 +333,30 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
+dependencies = [
+ "arrow-array 52.0.0",
+ "arrow-buffer 52.0.0",
+ "arrow-cast 52.0.0",
+ "arrow-data 52.0.0",
+ "arrow-schema 52.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -343,13 +383,27 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "flatbuffers",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "flatbuffers 23.5.26",
  "lz4_flex",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
+dependencies = [
+ "arrow-array 52.0.0",
+ "arrow-buffer 52.0.0",
+ "arrow-cast 52.0.0",
+ "arrow-data 52.0.0",
+ "arrow-schema 52.0.0",
+ "flatbuffers 24.3.25",
 ]
 
 [[package]]
@@ -358,11 +412,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
  "chrono",
  "half 2.4.1",
  "indexmap 2.2.6",
@@ -412,16 +466,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-schema"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrow-select"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
+dependencies = [
+ "ahash",
+ "arrow-array 52.0.0",
+ "arrow-buffer 52.0.0",
+ "arrow-data 52.0.0",
+ "arrow-schema 52.0.0",
  "num",
 ]
 
@@ -431,11 +508,11 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
  "memchr",
  "num",
  "regex",
@@ -1381,7 +1458,18 @@ checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 2.5.1",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.1",
 ]
 
 [[package]]
@@ -1567,7 +1655,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
- "chrono-tz-build",
+ "chrono-tz-build 0.2.1",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build 0.3.0",
  "phf",
 ]
 
@@ -1576,6 +1675,17 @@ name = "chrono-tz-build"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -2081,10 +2191,10 @@ checksum = "85069782056753459dc47e386219aa1fdac5b731f26c28abb8c0ffd4b7c5ab11"
 dependencies = [
  "ahash",
  "apache-avro",
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-schema 51.0.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2113,7 +2223,7 @@ dependencies = [
  "num_cpus",
  "object_store 0.9.1",
  "parking_lot",
- "parquet",
+ "parquet 51.0.0",
  "pin-project-lite",
  "rand",
  "sqlparser 0.44.0",
@@ -2133,10 +2243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-schema 51.0.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2165,7 +2275,7 @@ dependencies = [
  "num_cpus",
  "object_store 0.9.1",
  "parking_lot",
- "parquet",
+ "parquet 51.0.0",
  "pin-project-lite",
  "rand",
  "sqlparser 0.45.0",
@@ -2186,17 +2296,17 @@ checksum = "309d9040751f6dc9e33c85dce6abb55a46ef7ea3644577dd014611c379447ef3"
 dependencies = [
  "ahash",
  "apache-avro",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-schema 51.0.0",
  "chrono",
  "half 2.4.1",
  "instant",
  "libc",
  "num_cpus",
  "object_store 0.9.1",
- "parquet",
+ "parquet 51.0.0",
  "sqlparser 0.44.0",
 ]
 
@@ -2207,17 +2317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-schema 51.0.0",
  "chrono",
  "half 2.4.1",
  "instant",
  "libc",
  "num_cpus",
  "object_store 0.9.1",
- "parquet",
+ "parquet 51.0.0",
  "sqlparser 0.45.0",
 ]
 
@@ -2245,7 +2355,7 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a3a29ae36bcde07d179cc33b45656a8e7e4d023623e320e48dcf1200eeee95"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "chrono",
  "dashmap",
  "datafusion-common 37.1.0",
@@ -2266,7 +2376,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "chrono",
  "dashmap",
  "datafusion-common 38.0.0",
@@ -2288,8 +2398,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3542aa322029c2121a671ce08000d4b274171070df13f697b14169ccf4f628"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
  "chrono",
  "datafusion-common 37.1.0",
  "paste",
@@ -2305,8 +2415,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
  "chrono",
  "datafusion-common 38.0.0",
  "paste",
@@ -2374,7 +2484,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "datafusion-common 38.0.0",
  "datafusion-execution 38.0.0",
  "datafusion-expr 38.0.0",
@@ -2390,11 +2500,11 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e501801e84d9c6ef54caaebcda1b18a6196a24176c12fb70e969bc0572e03c55"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-schema 51.0.0",
  "datafusion-common 37.1.0",
  "datafusion-execution 37.1.0",
  "datafusion-expr 37.1.0",
@@ -2410,11 +2520,11 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-schema 51.0.0",
  "datafusion-common 38.0.0",
  "datafusion-execution 38.0.0",
  "datafusion-expr 38.0.0",
@@ -2430,7 +2540,7 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bd7f5087817deb961764e8c973d243b54f8572db414a8f0a8f33a48f991e0a"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "async-trait",
  "chrono",
  "datafusion-common 37.1.0",
@@ -2448,7 +2558,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "async-trait",
  "chrono",
  "datafusion-common 38.0.0",
@@ -2533,7 +2643,7 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
 ]
@@ -2545,10 +2655,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c0523e9c8880f2492a88bbd857dde02bed1ed23f3e9211a89d3d7ec3b44af9"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-schema 51.0.0",
  "async-trait",
  "chrono",
  "datafusion-common 37.1.0",
@@ -2576,11 +2686,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-schema 51.0.0",
  "async-trait",
  "chrono",
  "datafusion-common 38.0.0",
@@ -2609,7 +2719,7 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db73393e42f35e165d31399192fbf41691967d428ebed47875ad34239fbcfc16"
 dependencies = [
- "arrow",
+ "arrow 51.0.0",
  "chrono",
  "datafusion 37.1.0",
  "datafusion-common 37.1.0",
@@ -2624,9 +2734,9 @@ version = "37.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49eb54b42227136f6287573f2434b1de249fe1b8e6cd6cc73a634e4a3ec29356"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-schema 51.0.0",
  "datafusion-common 37.1.0",
  "datafusion-expr 37.1.0",
  "log",
@@ -2640,14 +2750,58 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-schema 51.0.0",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
  "log",
  "sqlparser 0.45.0",
  "strum 0.26.2",
+]
+
+[[package]]
+name = "delta_kernel"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ddfe35af3696786ab5f23cd995df33a66f6cff272ac1f85e09c1a6316acd4c"
+dependencies = [
+ "arrow-arith 52.0.0",
+ "arrow-array 52.0.0",
+ "arrow-json 52.0.0",
+ "arrow-ord 52.0.0",
+ "arrow-schema 52.0.0",
+ "arrow-select 52.0.0",
+ "bytes",
+ "chrono",
+ "delta_kernel_derive",
+ "either",
+ "fix-hidden-lifetime-bug",
+ "indexmap 2.2.6",
+ "itertools 0.13.0",
+ "lazy_static",
+ "parquet 52.0.0",
+ "roaring",
+ "rustc_version 0.4.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+ "visibility",
+ "z85",
+]
+
+[[package]]
+name = "delta_kernel_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d2127a34b12919a6bce08225f0ca6fde8a19342a32675370edfc8795e7c38a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2657,7 +2811,7 @@ source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd9846
 dependencies = [
  "deltalake-aws",
  "deltalake-azure",
- "deltalake-core",
+ "deltalake-core 0.17.3",
  "deltalake-gcp",
 ]
 
@@ -2674,7 +2828,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "backoff",
  "bytes",
- "deltalake-core",
+ "deltalake-core 0.18.0",
  "futures",
  "lazy_static",
  "maplit",
@@ -2694,7 +2848,7 @@ source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd9846
 dependencies = [
  "async-trait",
  "bytes",
- "deltalake-core",
+ "deltalake-core 0.17.3",
  "futures",
  "lazy_static",
  "object_store 0.9.1",
@@ -2710,17 +2864,17 @@ name = "deltalake-core"
 version = "0.17.3"
 source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
 dependencies = [
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
+ "arrow 51.0.0",
+ "arrow-arith 51.0.0",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast 51.0.0",
+ "arrow-ipc 51.0.0",
+ "arrow-json 51.0.0",
+ "arrow-ord 51.0.0",
+ "arrow-row 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select 51.0.0",
  "async-trait",
  "bytes",
  "cfg-if",
@@ -2750,7 +2904,7 @@ dependencies = [
  "object_store 0.9.1",
  "once_cell",
  "parking_lot",
- "parquet",
+ "parquet 51.0.0",
  "percent-encoding",
  "pin-project-lite",
  "rand",
@@ -2768,13 +2922,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltalake-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d245c54723a39cf66af430e0b73552819dc0be8ec04667baf42c31cf960d5d1e"
+dependencies = [
+ "arrow 52.0.0",
+ "arrow-arith 52.0.0",
+ "arrow-array 52.0.0",
+ "arrow-buffer 52.0.0",
+ "arrow-cast 52.0.0",
+ "arrow-ipc 52.0.0",
+ "arrow-json 52.0.0",
+ "arrow-ord 52.0.0",
+ "arrow-row 52.0.0",
+ "arrow-schema 52.0.0",
+ "arrow-select 52.0.0",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "dashmap",
+ "delta_kernel",
+ "either",
+ "errno",
+ "fix-hidden-lifetime-bug",
+ "futures",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "itertools 0.13.0",
+ "lazy_static",
+ "libc",
+ "maplit",
+ "num-bigint",
+ "num-traits",
+ "num_cpus",
+ "object_store 0.10.1",
+ "once_cell",
+ "parking_lot",
+ "parquet 52.0.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "z85",
+]
+
+[[package]]
 name = "deltalake-gcp"
 version = "0.2.0"
 source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
 dependencies = [
  "async-trait",
  "bytes",
- "deltalake-core",
+ "deltalake-core 0.17.3",
  "futures",
  "lazy_static",
  "object_store 0.9.1",
@@ -4213,6 +4422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5043,7 +5261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
 dependencies = [
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
@@ -5055,7 +5273,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest 0.12.3",
+ "reqwest 0.12.5",
  "ring",
  "serde",
  "serde_json",
@@ -6966,10 +7184,10 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff56acef131ef74bacc5e86c5038b524d61dee59d65c9e3e5e0f35b9de98cf99"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
  "bytemuck",
  "chrono",
  "half 2.4.1",
@@ -8589,6 +8807,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
  "log",
  "num-traits",
  "num_cpus",
- "object_store",
+ "object_store 0.9.1",
  "parking_lot",
  "parquet",
  "pin-project-lite",
@@ -2163,7 +2163,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "num_cpus",
- "object_store",
+ "object_store 0.9.1",
  "parking_lot",
  "parquet",
  "pin-project-lite",
@@ -2195,7 +2195,7 @@ dependencies = [
  "instant",
  "libc",
  "num_cpus",
- "object_store",
+ "object_store 0.9.1",
  "parquet",
  "sqlparser 0.44.0",
 ]
@@ -2216,7 +2216,7 @@ dependencies = [
  "instant",
  "libc",
  "num_cpus",
- "object_store",
+ "object_store 0.9.1",
  "parquet",
  "sqlparser 0.45.0",
 ]
@@ -2253,7 +2253,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store",
+ "object_store 0.9.1",
  "parking_lot",
  "rand",
  "tempfile",
@@ -2274,7 +2274,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store",
+ "object_store 0.9.1",
  "parking_lot",
  "rand",
  "tempfile",
@@ -2614,7 +2614,7 @@ dependencies = [
  "datafusion 37.1.0",
  "datafusion-common 37.1.0",
  "datafusion-expr 37.1.0",
- "object_store",
+ "object_store 0.9.1",
  "prost",
 ]
 
@@ -2678,7 +2678,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "maplit",
- "object_store",
+ "object_store 0.10.1",
  "regex",
  "thiserror",
  "tokio",
@@ -2697,7 +2697,7 @@ dependencies = [
  "deltalake-core",
  "futures",
  "lazy_static",
- "object_store",
+ "object_store 0.9.1",
  "regex",
  "thiserror",
  "tokio",
@@ -2747,7 +2747,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
- "object_store",
+ "object_store 0.9.1",
  "once_cell",
  "parking_lot",
  "parquet",
@@ -2777,7 +2777,7 @@ dependencies = [
  "deltalake-core",
  "futures",
  "lazy_static",
- "object_store",
+ "object_store 0.9.1",
  "regex",
  "thiserror",
  "tokio",
@@ -5037,6 +5037,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper 1.3.1",
+ "itertools 0.12.1",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest 0.12.3",
+ "ring",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "object_store_opendal"
 version = "0.43.1"
 source = "git+https://github.com/apache/opendal.git?rev=79ab57f#79ab57f49846f7267072ca7452be37f5582cde6e"
@@ -5045,7 +5075,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-util",
- "object_store",
+ "object_store 0.9.1",
  "opendal",
  "pin-project",
  "tokio",
@@ -5279,7 +5309,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.9.1",
  "paste",
  "seq-macro",
  "snap",
@@ -5476,8 +5506,9 @@ dependencies = [
  "dashmap",
  "datafusion 37.1.0",
  "deltalake",
+ "deltalake-aws",
  "futures",
- "object_store",
+ "object_store 0.9.1",
  "object_store_opendal",
  "opendal",
  "pgrx",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We started having a few CI runs fail due to instances running out of memory. I've realized our listing workflows can probably run on 2 vCPUs instead of 4, to save cost. And our large test workflows should run on 8 vCPUs instead of 4. While this double cost per run, the runs also take half the time, so it all roughly evens out and we don't get any failures/faster results.

## Why
^

## How
^

## Tests
All CI should pass