### PR TITLE
docs: Update instructions for `libicu74` for Ubuntu 24.04

### DIFF
--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -13,7 +13,11 @@ First, ensure that you have superuser access to the Postgres database.
 Next, install `libicu`.
 
 ```bash
+# Ubuntu 20.04 or 22.04
 sudo apt-get install -y libicu70
+
+# Ubuntu 24.04
+sudo apt-get install -y libicu74
 ```
 
 # Install `pg_search`

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -63,7 +63,17 @@ This enables the extension to spawn a background worker process that performs wr
 
 We provide prebuilt binaries for Debian-based Linux for Postgres 16, 15 and 14. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
-Our prebuilt binaries come with the ICU tokenizer enabled, which requires the `libicu70` library. If you don't have it installed, you can do so with `sudo apt-get install libicu70 -y`, or compile the extension from source without `--features icu` to build without the ICU tokenizer.
+Our prebuilt binaries come with the ICU tokenizer enabled, which requires the `libicu` library. If you don't have it installed, you can do so with:
+
+```bash
+# Ubuntu 20.04 or 22.04
+sudo apt-get install -y libicu70
+
+# Ubuntu 24.04
+sudo apt-get install -y libicu74
+```
+
+Or, you can compile the extension from source without `--features icu` to build without the ICU tokenizer.
 
 ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt out of telemetry by setting `export PARADEDB_TELEMETRY=false` (or unsetting the variable) in your shell or in your `~/.bashrc` file before running the extension.
 
@@ -200,14 +210,17 @@ Note: While it is possible to develop using pgrx's own Postgres installation(s),
 
 `pg_search` comes with multiple tokenizers for different languages. The ICU tokenizer, which enables tokenization for Arabic, Amharic, and Greek, is not enabled by default in development due to the additional dependencies it requires. To develop with the ICU tokenizer enabled, first:
 
-Ensure that the `icu4c` library is installed. It should come preinstalled on most distros, but you can install it with your system package manager if it isn't:
+Ensure that the `libicu` library is installed. It should come preinstalled on most distros, but you can install it with your system package manager if it isn't:
 
 ```bash
 # macOS
 brew install icu4c
 
-# Ubuntu
-sudo apt-get install libicu70 -y
+# Ubuntu 20.04 or 22.04
+sudo apt-get install -y libicu70
+
+# Ubuntu 24.04
+sudo apt-get install -y libicu74
 ```
 
 Additionally, on macOS you'll need to add the `icu-config` binary to your path before continuing:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1270

## What
Ubuntu 24.04 requires a different version of `libicu`, which our documentation did not specify. This fixes it.

We won't release pre-built binaries for Ubuntu 24.04 yet, so I've just updated the docs.

## Why
Avoid users getting confusing errors.

## How
Just updated the docs.

## Tests
No test needed.