### PR TITLE
chore: Bump opendal to 0.47.1, object_store_opendal to 0.44.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
 dependencies = [
  "bytes",
  "half 2.4.1",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -404,18 +404,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1386,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85069782056753459dc47e386219aa1fdac5b731f26c28abb8c0ffd4b7c5ab11"
+checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
 dependencies = [
  "ahash",
  "apache-avro",
@@ -2091,16 +2091,18 @@ dependencies = [
  "bzip2",
  "chrono",
  "dashmap",
- "datafusion-common 37.1.0",
- "datafusion-common-runtime 37.1.0",
- "datafusion-execution 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-functions 37.1.0",
- "datafusion-functions-array 37.1.0",
- "datafusion-optimizer 37.1.0",
- "datafusion-physical-expr 37.1.0",
- "datafusion-physical-plan 37.1.0",
- "datafusion-sql 37.1.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-array",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-sql",
  "flate2",
  "futures",
  "glob",
@@ -2111,64 +2113,13 @@ dependencies = [
  "log",
  "num-traits",
  "num_cpus",
- "object_store",
+ "object_store 0.10.1",
  "parking_lot",
  "parquet",
+ "paste",
  "pin-project-lite",
  "rand",
- "sqlparser 0.44.0",
- "tempfile",
- "tokio",
- "tokio-util",
- "url",
- "uuid",
- "xz2",
- "zstd 0.13.0",
-]
-
-[[package]]
-name = "datafusion"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
- "async-compression",
- "async-trait",
- "bytes",
- "bzip2",
- "chrono",
- "dashmap",
- "datafusion-common 38.0.0",
- "datafusion-common-runtime 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
- "datafusion-functions 38.0.0",
- "datafusion-functions-aggregate",
- "datafusion-functions-array 38.0.0",
- "datafusion-optimizer 38.0.0",
- "datafusion-physical-expr 38.0.0",
- "datafusion-physical-plan 38.0.0",
- "datafusion-sql 38.0.0",
- "flate2",
- "futures",
- "glob",
- "half 2.4.1",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "itertools 0.12.1",
- "log",
- "num_cpus",
- "object_store",
- "parking_lot",
- "parquet",
- "pin-project-lite",
- "rand",
- "sqlparser 0.45.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2180,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309d9040751f6dc9e33c85dce6abb55a46ef7ea3644577dd014611c379447ef3"
+checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
 dependencies = [
  "ahash",
  "apache-avro",
@@ -2192,170 +2143,79 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.4.1",
+ "hashbrown 0.14.5",
  "instant",
  "libc",
  "num_cpus",
- "object_store",
+ "object_store 0.10.1",
  "parquet",
- "sqlparser 0.44.0",
+ "sqlparser",
 ]
 
 [[package]]
-name = "datafusion-common"
-version = "38.0.0"
+name = "datafusion-common-runtime"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
+checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
+dependencies = [
+ "arrow",
+ "chrono",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "hashbrown 0.14.5",
+ "log",
+ "object_store 0.10.1",
+ "parking_lot",
+ "rand",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-schema",
  "chrono",
- "half 2.4.1",
- "instant",
- "libc",
- "num_cpus",
- "object_store",
- "parquet",
- "sqlparser 0.45.0",
-]
-
-[[package]]
-name = "datafusion-common-runtime"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e4a44d8ef1b1e85d32234e6012364c411c3787859bb3bba893b0332cb03dfd"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "datafusion-common-runtime"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8ddfb8d8cb51646a30da0122ecfffb81ca16919ae9a3495a9e7468bdcd52b8"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "datafusion-execution"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3a29ae36bcde07d179cc33b45656a8e7e4d023623e320e48dcf1200eeee95"
-dependencies = [
- "arrow",
- "chrono",
- "dashmap",
- "datafusion-common 37.1.0",
- "datafusion-expr 37.1.0",
- "futures",
- "hashbrown 0.14.5",
- "log",
- "object_store",
- "parking_lot",
- "rand",
- "tempfile",
- "url",
-]
-
-[[package]]
-name = "datafusion-execution"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
-dependencies = [
- "arrow",
- "chrono",
- "dashmap",
- "datafusion-common 38.0.0",
- "datafusion-expr 38.0.0",
- "futures",
- "hashbrown 0.14.5",
- "log",
- "object_store",
- "parking_lot",
- "rand",
- "tempfile",
- "url",
-]
-
-[[package]]
-name = "datafusion-expr"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3542aa322029c2121a671ce08000d4b274171070df13f697b14169ccf4f628"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "chrono",
- "datafusion-common 37.1.0",
- "paste",
- "sqlparser 0.44.0",
- "strum 0.26.2",
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "datafusion-expr"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "chrono",
- "datafusion-common 38.0.0",
+ "datafusion-common",
  "paste",
  "serde_json",
- "sqlparser 0.45.0",
+ "sqlparser",
  "strum 0.26.2",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd221792c666eac174ecc09e606312844772acc12cbec61a420c2fca1ee70959"
+checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
 dependencies = [
  "arrow",
  "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common 37.1.0",
- "datafusion-execution 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-physical-expr 37.1.0",
- "hex",
- "itertools 0.12.1",
- "log",
- "md-5",
- "regex",
- "sha2",
- "unicode-segmentation",
- "uuid",
-]
-
-[[package]]
-name = "datafusion-functions"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4afd261cea6ac9c3ca1192fd5e9f940596d8e9208c5b1333f4961405db53185"
-dependencies = [
- "arrow",
- "base64 0.22.1",
- "blake2",
- "blake3",
- "chrono",
- "datafusion-common 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
- "datafusion-physical-expr 38.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -2370,55 +2230,37 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
+checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
 dependencies = [
+ "ahash",
  "arrow",
- "datafusion-common 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-physical-expr-common",
  "log",
  "paste",
- "sqlparser 0.45.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-functions-array"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e501801e84d9c6ef54caaebcda1b18a6196a24176c12fb70e969bc0572e03c55"
+checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
- "datafusion-common 37.1.0",
- "datafusion-execution 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-functions 37.1.0",
- "itertools 0.12.1",
- "log",
- "paste",
-]
-
-[[package]]
-name = "datafusion-functions-array"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
-dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "datafusion-common 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
- "datafusion-functions 38.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -2426,34 +2268,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bd7f5087817deb961764e8c973d243b54f8572db414a8f0a8f33a48f991e0a"
+checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
 dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "datafusion-common 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-physical-expr 37.1.0",
- "hashbrown 0.14.5",
- "itertools 0.12.1",
- "log",
- "regex-syntax 0.8.4",
-]
-
-[[package]]
-name = "datafusion-optimizer"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
-dependencies = [
- "arrow",
- "async-trait",
- "chrono",
- "datafusion-common 38.0.0",
- "datafusion-expr 38.0.0",
- "datafusion-physical-expr 38.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -2463,44 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cabc0d9aaa0f5eb1b472112f16223c9ffd2fb04e58cbf65c0a331ee6e993f96"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "arrow-string",
- "base64 0.22.1",
- "blake2",
- "blake3",
- "chrono",
- "datafusion-common 37.1.0",
- "datafusion-execution 37.1.0",
- "datafusion-expr 37.1.0",
- "half 2.4.1",
- "hashbrown 0.14.5",
- "hex",
- "indexmap 2.2.6",
- "itertools 0.12.1",
- "log",
- "md-5",
- "paste",
- "petgraph",
- "rand",
- "regex",
- "sha2",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "datafusion-physical-expr"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adf8eb12716f52ddf01e09eb6c94d3c9b291e062c05c91b839a448bddba2ff8"
+checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2511,9 +2300,9 @@ dependencies = [
  "arrow-string",
  "base64 0.22.1",
  "chrono",
- "datafusion-common 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-functions-aggregate",
  "datafusion-physical-expr-common",
  "half 2.4.1",
@@ -2529,51 +2318,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
+checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
 dependencies = [
  "arrow",
- "datafusion-common 38.0.0",
- "datafusion-expr 38.0.0",
-]
-
-[[package]]
-name = "datafusion-physical-plan"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c0523e9c8880f2492a88bbd857dde02bed1ed23f3e9211a89d3d7ec3b44af9"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
- "async-trait",
- "chrono",
- "datafusion-common 37.1.0",
- "datafusion-common-runtime 37.1.0",
- "datafusion-execution 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-physical-expr 37.1.0",
- "futures",
- "half 2.4.1",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "itertools 0.12.1",
- "log",
- "once_cell",
- "parking_lot",
- "pin-project-lite",
+ "datafusion-common",
+ "datafusion-expr",
  "rand",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
+checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
 dependencies = [
  "ahash",
  "arrow",
@@ -2583,12 +2342,12 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common 38.0.0",
- "datafusion-common-runtime 38.0.0",
- "datafusion-execution 38.0.0",
- "datafusion-expr 38.0.0",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-functions-aggregate",
- "datafusion-physical-expr 38.0.0",
+ "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half 2.4.1",
@@ -2605,55 +2364,98 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db73393e42f35e165d31399192fbf41691967d428ebed47875ad34239fbcfc16"
+checksum = "db8eb8d706c73f01c0e2630c64ffc61c33831b064a813ec08a3e094dc3190c0f"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion 37.1.0",
- "datafusion-common 37.1.0",
- "datafusion-expr 37.1.0",
- "object_store",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-proto-common",
+ "object_store 0.10.1",
+ "prost",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7115772d326eeb78a1c77c974e7753b1538e1747675cb6b428058b654b31c"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "object_store 0.9.1",
  "prost",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "37.1.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb54b42227136f6287573f2434b1de249fe1b8e6cd6cc73a634e4a3ec29356"
+checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
- "datafusion-common 37.1.0",
- "datafusion-expr 37.1.0",
+ "datafusion-common",
+ "datafusion-expr",
  "log",
- "sqlparser 0.44.0",
+ "regex",
+ "sqlparser",
  "strum 0.26.2",
 ]
 
 [[package]]
-name = "datafusion-sql"
-version = "38.0.0"
+name = "delta_kernel"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
+checksum = "b1ddfe35af3696786ab5f23cd995df33a66f6cff272ac1f85e09c1a6316acd4c"
 dependencies = [
- "arrow",
+ "arrow-arith",
  "arrow-array",
+ "arrow-json",
+ "arrow-ord",
  "arrow-schema",
- "datafusion-common 38.0.0",
- "datafusion-expr 38.0.0",
- "log",
- "sqlparser 0.45.0",
- "strum 0.26.2",
+ "arrow-select",
+ "bytes",
+ "chrono",
+ "delta_kernel_derive",
+ "either",
+ "fix-hidden-lifetime-bug",
+ "indexmap 2.2.6",
+ "itertools 0.13.0",
+ "lazy_static",
+ "parquet",
+ "roaring",
+ "rustc_version 0.4.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+ "visibility",
+ "z85",
+]
+
+[[package]]
+name = "delta_kernel_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d2127a34b12919a6bce08225f0ca6fde8a19342a32675370edfc8795e7c38a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "deltalake"
-version = "0.17.1"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
+version = "0.18.1"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=d17ed97#d17ed97b5bda0cadbc0df959f8fb38e275570c87"
 dependencies = [
  "deltalake-aws",
  "deltalake-azure",
@@ -2663,8 +2465,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-aws"
-version = "0.1.1"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
+version = "0.1.2"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=d17ed97#d17ed97b5bda0cadbc0df959f8fb38e275570c87"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2678,7 +2480,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "maplit",
- "object_store",
+ "object_store 0.10.1",
  "regex",
  "thiserror",
  "tokio",
@@ -2689,15 +2491,15 @@ dependencies = [
 
 [[package]]
 name = "deltalake-azure"
-version = "0.1.0"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
+version = "0.1.2"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=d17ed97#d17ed97b5bda0cadbc0df959f8fb38e275570c87"
 dependencies = [
  "async-trait",
  "bytes",
  "deltalake-core",
  "futures",
  "lazy_static",
- "object_store",
+ "object_store 0.10.1",
  "regex",
  "thiserror",
  "tokio",
@@ -2707,8 +2509,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-core"
-version = "0.17.3"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
+version = "0.18.1"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=d17ed97#d17ed97b5bda0cadbc0df959f8fb38e275570c87"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2726,28 +2528,29 @@ dependencies = [
  "cfg-if",
  "chrono",
  "dashmap",
- "datafusion 37.1.0",
- "datafusion-common 37.1.0",
- "datafusion-expr 37.1.0",
- "datafusion-functions 37.1.0",
- "datafusion-functions-array 37.1.0",
- "datafusion-physical-expr 37.1.0",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-array",
+ "datafusion-physical-expr",
  "datafusion-proto",
- "datafusion-sql 37.1.0",
+ "datafusion-sql",
+ "delta_kernel",
  "either",
  "errno",
  "fix-hidden-lifetime-bug",
  "futures",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy_static",
  "libc",
  "maplit",
  "num-bigint",
  "num-traits",
  "num_cpus",
- "object_store",
+ "object_store 0.10.1",
  "once_cell",
  "parking_lot",
  "parquet",
@@ -2758,7 +2561,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sqlparser 0.44.0",
+ "sqlparser",
  "thiserror",
  "tokio",
  "tracing",
@@ -2769,15 +2572,15 @@ dependencies = [
 
 [[package]]
 name = "deltalake-gcp"
-version = "0.2.0"
-source = "git+https://github.com/delta-io/delta-rs.git?rev=27c1e48#27c1e48cd98465f41fd718bbbe433ee1f40f394c"
+version = "0.2.1"
+source = "git+https://github.com/delta-io/delta-rs.git?rev=d17ed97#d17ed97b5bda0cadbc0df959f8fb38e275570c87"
 dependencies = [
  "async-trait",
  "bytes",
  "deltalake-core",
  "futures",
  "lazy_static",
- "object_store",
+ "object_store 0.10.1",
  "regex",
  "thiserror",
  "tokio",
@@ -3291,9 +3094,9 @@ checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version 0.4.0",
@@ -3959,6 +3762,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "rustls 0.23.10",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -4199,6 +4003,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4994,19 +4807,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper 0.14.29",
+ "itertools 0.12.1",
+ "parking_lot",
+ "percent-encoding",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "object_store"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper 1.3.1",
  "itertools 0.12.1",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "ring",
  "rustls-pemfile 2.1.2",
  "serde",
@@ -5020,14 +4854,15 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.43.1"
-source = "git+https://github.com/apache/opendal.git?rev=79ab57f#79ab57f49846f7267072ca7452be37f5582cde6e"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b95ffc753c0da86e6ab4e7633348e0f31288c5d83eb7ef4f35cbf028238b5d7"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
  "futures-util",
- "object_store",
+ "object_store 0.10.1",
  "opendal",
  "pin-project",
  "tokio",
@@ -5053,8 +4888,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
-source = "git+https://github.com/apache/opendal.git?rev=79ab57f#79ab57f49846f7267072ca7452be37f5582cde6e"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876c6655dd5b410c83e0c9edf38be60fed540a1cc1c2f3a2ac31830eb8a8ff45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5238,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096795d4f47f65fd3ee1ec5a98b77ab26d602f2cc785b0e4be5443add17ecc32"
+checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -5261,7 +5097,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.10.1",
  "paste",
  "seq-macro",
  "snap",
@@ -5269,6 +5105,7 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd 0.13.0",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -5456,10 +5293,10 @@ dependencies = [
  "aws-sdk-s3",
  "chrono",
  "dashmap",
- "datafusion 37.1.0",
+ "datafusion",
  "deltalake",
  "futures",
- "object_store",
+ "object_store 0.10.1",
  "object_store_opendal",
  "opendal",
  "pgrx",
@@ -6293,7 +6130,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.29",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -6303,8 +6139,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -6313,13 +6147,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "winreg 0.50.0",
 ]
@@ -6354,6 +6185,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.10",
+ "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -7081,7 +6913,7 @@ dependencies = [
  "bigdecimal",
  "bytes",
  "chrono",
- "datafusion 38.0.0",
+ "datafusion",
  "derive_builder",
  "envy",
  "humansize",
@@ -7313,19 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.44.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf9c7ff146298ffda83a200f8d5084f08dcee1edfc135fcc1d646a45d50ffd6"
-dependencies = [
- "log",
- "sqlparser_derive",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8551,6 +8373,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "vsimd"

--- a/pg_lakehouse/Cargo.toml
+++ b/pg_lakehouse/Cargo.toml
@@ -22,21 +22,21 @@ anyhow = "1.0.83"
 async-std = { version = "1.12.0", features = ["tokio1", "attributes"] }
 chrono = "0.4.34"
 dashmap = "5.5.3"
-datafusion = { version = "37.1.0", features = ["avro"] }
+datafusion = { version = "39", features = ["avro"] }
 deltalake = { git = "https://github.com/delta-io/delta-rs.git", features = [
   "datafusion",
   "s3",
   "gcs",
   "azure",
-], rev = "27c1e48" }
-object_store = { version = "0.9.1", features = ["aws", "http"] }
-object_store_opendal = { git = "https://github.com/apache/opendal.git", rev = "79ab57f" }
-opendal = { git = "https://github.com/apache/opendal.git", features = [
+], rev = "d17ed97" }
+object_store = { version = "0.10.1", features = ["aws", "http"] }
+object_store_opendal = "0.44.1"
+opendal = { version ="0.47.1", features = [
   "services-azblob",
   "services-azdls",
   "services-gcs",
   "services-s3",
-], rev = "79ab57f" }
+]}
 pgrx = "0.11.3"
 serde = "1.0.201"
 shared = { path = "../shared" }
@@ -50,7 +50,7 @@ aws-sdk-s3 = "1.34.0"
 futures = "0.3.30"
 pgrx-tests = "0.11.3"
 rstest = "0.19.0"
-serde_arrow = { version = "0.11.3", features = ["arrow-51"] }
+serde_arrow = { version = "0.11.3", features = ["arrow-52"] }
 shared = { path = "../shared", features = ["fixtures"] }
 sqlx = { version = "0.7.4", features = [
   "postgres",

--- a/pg_lakehouse/src/datafusion/context.rs
+++ b/pg_lakehouse/src/datafusion/context.rs
@@ -82,21 +82,21 @@ impl ContextProvider for QueryContext {
         &self.options
     }
 
-    fn udfs_names(&self) -> Vec<String> {
+    fn udf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udafs_names(&self) -> Vec<String> {
+    fn udaf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udwfs_names(&self) -> Vec<String> {
+    fn udwf_names(&self) -> Vec<String> {
         Vec::new()
     }
 }
 
 pub async fn get_table_source(
-    reference: TableReference<'_>,
+    reference: TableReference,
 ) -> Result<Arc<dyn TableSource>, ContextError> {
     let catalog_name = Session::catalog_name()?;
     let schema_name = reference.schema();

--- a/pg_lakehouse/tests/scan.rs
+++ b/pg_lakehouse/tests/scan.rs
@@ -158,7 +158,7 @@ async fn test_arrow_types_s3_delta(
     let delta_schema = deltalake::kernel::Schema::try_from(batch.schema().as_ref())?;
     let mut table = CreateBuilder::new()
         .with_location(temp_path.to_string_lossy())
-        .with_columns(delta_schema.fields().to_vec())
+        .with_columns(delta_schema.fields().cloned())
         .await?;
     let mut writer = RecordBatchWriter::for_table(&table)?;
     writer.write(batch.clone()).await?;
@@ -201,7 +201,7 @@ async fn test_s3_delta_connect_success(
     let delta_schema = deltalake::kernel::Schema::try_from(batch.schema().as_ref())?;
     let mut table = CreateBuilder::new()
         .with_location(temp_path.to_string_lossy())
-        .with_columns(delta_schema.fields().to_vec())
+        .with_columns(delta_schema.fields().cloned())
         .await?;
     let mut writer = RecordBatchWriter::for_table(&table)?;
     writer.write(batch.clone()).await?;
@@ -260,7 +260,7 @@ async fn test_arrow_types_local_file_delta(mut conn: PgConnection, tempdir: Temp
     let delta_schema = deltalake::kernel::Schema::try_from(batch.schema().as_ref())?;
     let mut table = CreateBuilder::new()
         .with_location(temp_path.to_string_lossy().as_ref())
-        .with_columns(delta_schema.fields().to_vec())
+        .with_columns(delta_schema.fields().cloned())
         .await?;
     let mut writer = RecordBatchWriter::for_table(&table)?;
     writer.write(batch.clone()).await?;
@@ -297,7 +297,7 @@ async fn test_local_file_delta_connect_success(
     let delta_schema = deltalake::kernel::Schema::try_from(batch.schema().as_ref())?;
     let mut table = CreateBuilder::new()
         .with_location(temp_path.to_string_lossy().as_ref())
-        .with_columns(delta_schema.fields().to_vec())
+        .with_columns(delta_schema.fields().cloned())
         .await?;
     let mut writer = RecordBatchWriter::for_table(&table)?;
     writer.write(batch.clone()).await?;
@@ -326,7 +326,7 @@ async fn test_local_file_delta_connect_failure(
     let delta_schema = deltalake::kernel::Schema::try_from(batch.schema().as_ref())?;
     let mut table = CreateBuilder::new()
         .with_location(temp_path.to_string_lossy().as_ref())
-        .with_columns(delta_schema.fields().to_vec())
+        .with_columns(delta_schema.fields().cloned())
         .await?;
     let mut writer = RecordBatchWriter::for_table(&table)?;
     writer.write(batch.clone()).await?;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -39,7 +39,7 @@ os_info = { version = "3", default-features = false }
 chrono = { version = "0.4.34", features = ["clock", "alloc"] }
 humansize = "2.1.3"
 anyhow = "1.0.83"
-datafusion = "38.0.0"
+datafusion = "39.0.0"
 tempfile = "3.10.1"
 
 [dev-dependencies]


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Bump opendal to 0.47.1, object_store_opendal to 0.44.1

## Why

Pin opendal and object_store_opendal with released version so that we can receive upstream patches without effort.

This PR also helps removing duplicated datafusion (v37 and v38) usage.

## How

`object_store_opendal` integrate with `object_store 0.10`. So I also helped bumping `datafusion`, `delta_lake`, `object_store` to latest version.

## Tests

Build passed.