### PR TITLE
fix: Support JSON top-level arrays in pg_search

### DIFF
--- a/docs/search/full-text/bm25.mdx
+++ b/docs/search/full-text/bm25.mdx
@@ -90,16 +90,36 @@ Filters can be applied over numeric fields, which improves query times compared 
 
 ### JSON Fields
 
-Use `.` to search over text values nested inside JSON. For instance, the following query would search
-over a field with values like `{"metadata": {"color": "white"}}`.
+Use `.` to search over text values nested inside JSON. For instance, the following query would search over a field with values like `{"metadata": {"color": "white"}}`.
+
+````sql
+'metadata.color:white'
+
+When dealing with JSON arrays, the array elements are “flattened” so that each element can be searched individually. This means that if a JSON array is encountered, each element in the array is treated as a separate value and indexed accordingly. For example, given the following JSON structure:
+
+```json
+{
+  "metadata": {
+    "colors": ["red", "green", "blue"]
+  }
+}
+````
+
+The JSON array in the colors field is flattened to emit separate terms for each color. This allows for individual search queries like:
 
 ```sql
-'metadata.color:white'
+'metadata.colors:red'
+'metadata.colors:green'
+'metadata.colors:blue'
 ```
 
+Each of these queries would correctly match the document containing the JSON array.
+
 <Note>
-  JSON search only works over `json` and `jsonb` Postgres columns that have been
-  indexed as [`json_fields`](/search/full-text/index#creating-a-bm25-index).
+  Searching for integers in a nested JSON structure is not supported. For example:
+  ```
+  SELECT * FROM <index_name>.search('metadata.attributes:4', stable_sort => true)
+  ```
 </Note>
 
 ### Boosting

--- a/pg_lakehouse/tests/fixtures/mod.rs
+++ b/pg_lakehouse/tests/fixtures/mod.rs
@@ -79,8 +79,8 @@ pub fn conn_with_pg_search(database: Db) -> PgConnection {
 /// and the S3 client. It's important that they be owned together, because
 /// testcontainers will stop the Docker container is stopped once the variable
 /// is dropped.
+#[allow(unused)]
 pub struct S3 {
-    #[allow(unused)]
     container: ContainerAsync<LocalStack>,
     pub client: aws_sdk_s3::Client,
     pub url: String,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1205

## What
When creating a BM25 index on a table with JSON fields containing arrays, the following error was encountered:
```rust
WriterIndexError(SerdeJsonError(Error("invalid type: sequence, expected a map", line: 1, column: 0)))
```

## Why
This issue arises during the serialization/deserialization process, preventing proper indexing of JSON arrays.

## How

The fix involves adjusting the serialization/deserialization logic to handle JSON arrays correctly. This change ensures that JSON arrays are flattened and each element is indexed as an individual value.

## Tests
Added tests to verify the correct behavior of JSON array flattening and indexing:
	•	`json_array_flattening`: Tests that individual elements in a JSON array can be searched.
	•	`json_array_multiple_documents`: Ensures that documents with JSON arrays are indexed correctly and can be retrieved based on individual elements.
	•	`json_array_mixed_data`: Verifies that mixed data types in JSON arrays are handled, except for numbers, which are not supported.
	•	`json_nested_arrays`: Checks that nested JSON arrays are correctly flattened and indexed.
