### PR TITLE
chore: Remove outdated `pg_search` deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 
 [![Publish ParadeDB](https://github.com/paradedb/paradedb/actions/workflows/publish-paradedb.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/publish-paradedb.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/paradedb/paradedb)](https://hub.docker.com/r/paradedb/paradedb)
-[![pg_search Deployments](https://img.shields.io/badge/22k-green?label=pg_search%20deployments)](https://github.com/paradedb/paradedb/releases/latest)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/paradedb)](https://artifacthub.io/packages/search?repo=paradedb)
 
 [ParadeDB](https://paradedb.com) is an Elasticsearch alternative built on Postgres. We're modernizing the features of Elasticsearch's product suite, starting with real-time search and analytics.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We're now at aorund 26K, but we'll just track via Docker pulls instead for simplicity, since it updates automatically.

## Why
More accurate info. Docker pulls and self-hosted deploys are independent, but the idea here is not to provide all our user metrics but just give an estimate of usage, which the Docker Pulls does better.

## How
N/A

## Tests
N/A