### PR TITLE
chore: Remove pg_cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ ParadeDB is currently in Public Beta. Star and watch this repository to get noti
   - [x] Kubernetes Helm chart & [deployment instructions](https://docs.paradedb.com/deploy/helm)
 - [x] Specialized Workloads
   - [x] Support for geospatial data with [PostGIS](https://github.com/postgis/postgis)
-  - [x] Support for cron jobs with [pg_cron](https://github.com/citusdata/pg_cron)
 
 ## Get Started
 

--- a/docker/01_bootstrap.sh
+++ b/docker/01_bootstrap.sh
@@ -34,15 +34,6 @@ PGPASSWORD=$SUPERUSER_PASSWORD psql -U postgres -d "$POSTGRESQL_DATABASE" -c "GR
 
 echo "Installing PostgreSQL extensions..."
 
-# This setting is required by pg_cron to CREATE EXTENSION properly. It can only be installed in one database, so we install it in
-# the user database. Creating the `pg_cron` extension requires a restart of the PostgreSQL server, so we can't do it here. A restart
-# is already part of the launch process of the Bitnami PostgreSQL container post this point, so the extension can be created by the
-# user after the container has been launched.
-#
-# For simplicity, and because we don't expect most users to use pg_cron, we don't force a restart here and we don't pre-create the
-# extension, leaving it to the user to do it if they want to use it.
-echo "cron.database_name = '$POSTGRESQL_DATABASE'" >> "/opt/bitnami/postgresql/conf/postgresql.conf"
-
 # Pre-install all required PostgreSQL extensions to the user database via the `postgres` superuser
 PGPASSWORD=$SUPERUSER_PASSWORD psql -U postgres -d "$POSTGRESQL_DATABASE" -c "CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;"
 PGPASSWORD=$SUPERUSER_PASSWORD psql -U postgres -d "$POSTGRESQL_DATABASE" -c "CREATE EXTENSION IF NOT EXISTS pg_lakehouse CASCADE;"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -130,20 +130,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 ######################
-# pg_cron
-######################
-
-FROM builder as builder-pg_cron
-
-# Build the extension
-WORKDIR /tmp
-RUN git clone --branch v1.6.2 https://github.com/citusdata/pg_cron.git
-WORKDIR /tmp/pg_cron
-RUN echo "trusted = true" >> pg_cron.control && \
-    make clean -j && \
-    make USE_PGXS=1 -j
-
-######################
 # pg_ivm
 ######################
 
@@ -175,9 +161,6 @@ COPY --from=builder-pgvector /tmp/pgvector/*.control /opt/bitnami/postgresql/sha
 COPY --from=builder-pgvector /tmp/pgvector/sql/*.sql /opt/bitnami/postgresql/share/extension/
 COPY --from=builder-pgvectorscale /tmp/pgvectorscale/pgvectorscale/target/release/vectorscale-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /opt/bitnami/postgresql/lib/
 COPY --from=builder-pgvectorscale /tmp/pgvectorscale/pgvectorscale/target/release/vectorscale-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /opt/bitnami/postgresql/share/extension/
-COPY --from=builder-pg_cron /tmp/pg_cron/*.so /opt/bitnami/postgresql/lib/
-COPY --from=builder-pg_cron /tmp/pg_cron/*.control /opt/bitnami/postgresql/share/extension/
-COPY --from=builder-pg_cron /tmp/pg_cron/*.sql /opt/bitnami/postgresql/share/extension/
 COPY --from=builder-pg_ivm /tmp/pg_ivm/*.so /opt/bitnami/postgresql/lib/
 COPY --from=builder-pg_ivm /tmp/pg_ivm/*.control /opt/bitnami/postgresql/share/extension/
 COPY --from=builder-pg_ivm /tmp/pg_ivm/*.sql /opt/bitnami/postgresql/share/extension/
@@ -198,7 +181,7 @@ COPY ./docker/01_bootstrap.sh /docker-entrypoint-initdb.d/
 
 # Configure shared_preload_libraries
 # Note: pgaudit is needed here as it comes pre-packaged in the Bitnami image
-ENV POSTGRESQL_SHARED_PRELOAD_LIBRARIES="pgaudit,pg_cron,pg_search,pg_lakehouse"
+ENV POSTGRESQL_SHARED_PRELOAD_LIBRARIES="pgaudit,pg_lakehouse,pg_search"
 
 # We set a default password to enable users to get started quickly, as it is a required
 # environment variable for the Bitnami image.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #890 (as won't fix)

## What
Sister PR: https://github.com/paradedb/helm-charts/pull/97

We added `pg_cron` at a time when we expected people to do a lot of data transformation between row-oriented and column-oriented tables. We no longer plan to support this workload, and we haven't seen any demand for `pg_cron`, so I'm going to remove it in the meantime.

## Why
Remove bloat/room for problems.

## How
N/A

## Tests
N/A