### PR TITLE
chore: Remove Rust Nightly

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -44,13 +44,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
-      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-04-21
-
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -187,13 +187,6 @@ jobs:
           # configure the build environment for creating the RPM package via rpmbuild
           sudo dnf install -y rpmdevtools
 
-      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
-      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-04-21
-
       # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -65,13 +65,6 @@ jobs:
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: actions/checkout@v4
 
-      # Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
-      # fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-04-21
-
       # This checks that the version in Cargo.toml is incremented to the next release. We only run it
       # on PRs to main, which are our release promotion PRs.
       - name: Check version in Cargo.toml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG PG_VERSION_MAJOR=16
 FROM postgres:${PG_VERSION_MAJOR}-bookworm as builder
 
 ARG PG_VERSION_MAJOR=16
-ARG RUST_VERSION=nightly-2024-04-21
+ARG RUST_VERSION=1.79.0
 ARG PGRX_VERSION=0.11.3
 
 # Declare buildtime environment variables
@@ -36,8 +36,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-server-dev-all \
     && rm -rf /var/lib/apt/lists/*
 
-# Note: DataFusion requires Rust nightly to enable packed_simd for SIMD optimizations. We
-# fix Rust nightly because current latest (1.80.0) is causing compilation issues with some dependencies
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${RUST_VERSION}" -y
 
 ENV PATH="/root/.cargo/bin:$PATH" \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This is no longer needed now that we've moved from DataFusion to DuckDB

## Why
Cleaner

## How
N/A

## Tests
N/A