### PR TITLE
fix: Index on null values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-paradedb"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5454,7 +5454,7 @@ dependencies = [
 
 [[package]]
 name = "pg_lakehouse"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.7.6"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -314,9 +314,11 @@ impl SearchIndex {
         ctid: ItemPointerData,
         tupdesc: &PgTupleDesc,
         values: *mut Datum,
+        isnull: *mut bool,
     ) -> Result<SearchDocument, SearchIndexError> {
         // Create a vector of index entries from the postgres row.
-        let mut search_document = unsafe { row_to_search_document(tupdesc, values, &self.schema) }?;
+        let mut search_document =
+            unsafe { row_to_search_document(tupdesc, values, isnull, &self.schema) }?;
 
         // Insert the ctid value into the entries.
         let ctid_index_value = pgrx::item_pointer_to_u64(ctid);

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -285,7 +285,7 @@ unsafe fn build_callback_internal(
             let search_document = search_index
                 .row_to_search_document(ctid, &tupdesc, values, isnull)
                 .unwrap_or_else(|err| {
-                    panic!("error creating index entries for index '{index_name}': {err:?}",)
+                    panic!("error creating index entries for index '{index_name}': {err}",)
                 });
 
             let writer_client = WriterGlobal::client();

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -25,14 +25,14 @@ use pgrx::*;
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,
     values: *mut pg_sys::Datum,
-    _isnull: *mut bool,
+    isnull: *mut bool,
     heap_tid: pg_sys::ItemPointer,
     _heap_relation: pg_sys::Relation,
     _check_unique: pg_sys::IndexUniqueCheck,
     _index_unchanged: bool,
     _index_info: *mut pg_sys::IndexInfo,
 ) -> bool {
-    aminsert_internal(index_relation, values, heap_tid)
+    aminsert_internal(index_relation, values, isnull, heap_tid)
 }
 
 #[cfg(any(feature = "pg12", feature = "pg13"))]
@@ -40,19 +40,20 @@ pub unsafe extern "C" fn aminsert(
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,
     values: *mut pg_sys::Datum,
-    _isnull: *mut bool,
+    isnull: *mut bool,
     heap_tid: pg_sys::ItemPointer,
     _heap_relation: pg_sys::Relation,
     _check_unique: pg_sys::IndexUniqueCheck,
     _index_info: *mut pg_sys::IndexInfo,
 ) -> bool {
-    aminsert_internal(index_relation, values, heap_tid)
+    aminsert_internal(index_relation, values, isnull, heap_tid)
 }
 
 #[inline(always)]
 unsafe fn aminsert_internal(
     index_relation: pg_sys::Relation,
     values: *mut pg_sys::Datum,
+    isnull: *mut bool,
     ctid: pg_sys::ItemPointer,
 ) -> bool {
     let index_relation_ref: PgRelation = PgRelation::from_pg(index_relation);
@@ -60,7 +61,7 @@ unsafe fn aminsert_internal(
     let index_name = index_relation_ref.name();
     let search_index = get_search_index(index_name);
     let search_document = search_index
-        .row_to_search_document(*ctid, &tupdesc, values)
+        .row_to_search_document(*ctid, &tupdesc, values, isnull)
         .unwrap_or_else(|err| {
             panic!("error creating index entries for index '{index_name}': {err:?}",)
         });

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -63,7 +63,7 @@ unsafe fn aminsert_internal(
     let search_document = search_index
         .row_to_search_document(*ctid, &tupdesc, values, isnull)
         .unwrap_or_else(|err| {
-            panic!("error creating index entries for index '{index_name}': {err:?}",)
+            panic!("error creating index entries for index '{index_name}': {err}",)
         });
 
     let writer_client = WriterGlobal::client();

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -31,6 +31,7 @@ pub fn get_search_index(index_name: &str) -> &'static mut SearchIndex {
 pub unsafe fn row_to_search_document(
     tupdesc: &PgTupleDesc,
     values: *mut pg_sys::Datum,
+    isnull: *mut bool,
     schema: &SearchIndexSchema,
 ) -> Result<SearchDocument, IndexError> {
     let mut document = schema.new_document();
@@ -59,6 +60,11 @@ pub unsafe fn row_to_search_document(
         );
 
         let datum = *values.add(attno);
+        let isnull = *isnull.add(attno);
+
+        if isnull {
+            continue;
+        }
 
         if is_array || is_json {
             for value in TantivyValue::try_from_datum_array(datum, base_oid).unwrap() {

--- a/pg_search/src/writer/mod.rs
+++ b/pg_search/src/writer/mod.rs
@@ -99,11 +99,14 @@ pub enum IndexError {
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
 
+    #[error(transparent)]
+    TantivyValueError(#[from] TantivyValueError),
+
     #[error("couldn't remove index files on drop_index: {0}")]
     DeleteDirectory(#[from] SearchDirectoryError),
 
-    #[error(transparent)]
-    TantivyValueError(#[from] TantivyValueError),
+    #[error("key_field column '{0}' cannot be NULL")]
+    KeyIdNull(String),
 }
 
 #[cfg(test)]

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -431,3 +431,39 @@ fn multiple_fields(mut conn: PgConnection) {
     assert_eq!(rows[5], ("metadata".into(), "JsonObject".into()));
     assert_eq!(rows[6], ("rating".into(), "I64".into()));
 }
+
+#[rstest]
+fn null_values(mut conn: PgConnection) {
+    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+        .execute(&mut conn);
+
+    "INSERT INTO paradedb.index_config (description, category, rating) VALUES ('Null Item 1', NULL, NULL), ('Null Item 2', NULL, 2)"
+        .execute(&mut conn);
+
+    "CALL paradedb.create_bm25( 
+        index_name => 'index_config',
+	    table_name => 'index_config',
+	    schema_name => 'paradedb',
+	    key_field => 'id',
+	    text_fields => '{description: {}, category: {}}',
+	    numeric_fields => '{rating: {}}',
+	    boolean_fields => '{in_stock: {}}',
+	    json_fields => '{metadata: {}}'
+    )"
+    .execute(&mut conn);
+
+    let rows: Vec<(String, Option<String>, Option<i32>)> =
+        "SELECT description, category, rating FROM index_config.search('description:\"Null Item\"', stable_sort => true)"
+            .fetch(&mut conn);
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], ("Null Item 1".into(), None, None));
+    assert_eq!(rows[1], ("Null Item 2".into(), None, Some(2)));
+
+    // If incorrectly handled, false booleans can be mistaken as NULL values and ignored during indexing
+    // This tests that false booleans are correctly indexed as such
+    let rows: Vec<(bool,)> =
+        "SELECT in_stock FROM index_config.search('in_stock:false')".fetch(&mut conn);
+
+    assert_eq!(rows.len(), 13);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1307 

## What
Fixes a crash that occurred when BM25 indexes were created over NULL values.

## Why
User reported bug.

## How
In order to handle null values on index build/insert, you need to make use of the `isnull: *mut bool` argument provided by the index access method.

When a null value is encountered, we simply skip it (i.e don't add it to the Tantivy document).

## Tests
See the `null_values` test.