### PR TITLE
fix: `fuzzy_term` defaults

### DIFF
--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -150,7 +150,7 @@ SELECT * FROM search_idx.search(
   single edit in the Levenshtein distance calculation, while `false` considers
   it two separate edits (a deletion and an insertion).
 </ParamField>
-<ParamField body="prefix" default={true}>
+<ParamField body="prefix" default={false}>
   When set to `true`, the initial substring (prefix) of the query term is
   exempted from the fuzzy edit distance calculation, while false includes the
   entire string in the calculation.

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -204,14 +204,14 @@ pub fn fuzzy_term(
     field: String,
     value: String,
     distance: default!(Option<i32>, "NULL"),
-    tranposition_cost_one: default!(Option<bool>, "NULL"),
+    transposition_cost_one: default!(Option<bool>, "NULL"),
     prefix: default!(Option<bool>, "NULL"),
 ) -> SearchQueryInput {
     SearchQueryInput::FuzzyTerm {
         field,
         value,
         distance: distance.map(|n| n as u8),
-        tranposition_cost_one,
+        transposition_cost_one,
         prefix,
     }
 }

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -65,7 +65,7 @@ pub enum SearchQueryInput {
         field: String,
         value: String,
         distance: Option<u8>,
-        tranposition_cost_one: Option<bool>,
+        transposition_cost_one: Option<bool>,
         prefix: Option<bool>,
     },
     MoreLikeThis {
@@ -270,7 +270,7 @@ impl SearchQueryInput {
                 field,
                 value,
                 distance,
-                tranposition_cost_one,
+                transposition_cost_one,
                 prefix,
             } => {
                 let field = field_lookup
@@ -279,18 +279,18 @@ impl SearchQueryInput {
 
                 let term = Term::from_field_text(field, &value);
                 let distance = distance.unwrap_or(2);
-                let tranposition_cost_one = tranposition_cost_one.unwrap_or(true);
+                let transposition_cost_one = transposition_cost_one.unwrap_or(true);
                 if prefix.unwrap_or(false) {
                     Ok(Box::new(FuzzyTermQuery::new(
                         term,
                         distance,
-                        tranposition_cost_one,
+                        transposition_cost_one,
                     )))
                 } else {
                     Ok(Box::new(FuzzyTermQuery::new_prefix(
                         term,
                         distance,
-                        tranposition_cost_one,
+                        transposition_cost_one,
                     )))
                 }
             }

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -278,8 +278,8 @@ impl SearchQueryInput {
                     .ok_or_else(|| QueryError::WrongFieldType(field.clone()))?;
 
                 let term = Term::from_field_text(field, &value);
-                let distance = distance.unwrap_or(1);
-                let tranposition_cost_one = tranposition_cost_one.unwrap_or(false);
+                let distance = distance.unwrap_or(2);
+                let tranposition_cost_one = tranposition_cost_one.unwrap_or(true);
                 if prefix.unwrap_or(false) {
                     Ok(Box::new(FuzzyTermQuery::new(
                         term,

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -319,7 +319,7 @@ fn multi_tree(mut conn: PgConnection) {
 			    paradedb.parse('description:shoes'),
 			    paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
 			    paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo')
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1)
 		    ]
 	    ),
 	    stable_sort => true

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -34,7 +34,7 @@ fn boolean_tree(mut conn: PgConnection) {
                 paradedb.parse('description:shoes'),
                 paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
                 paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo')
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1)
             ]
         ),
         stable_sort => true
@@ -160,7 +160,7 @@ fn single_queries(mut conn: PgConnection) {
     // FuzzyTerm
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.fuzzy_term(field => 'description', value => 'wolo'),
+		paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1),
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -95,6 +95,17 @@ fn fuzzy_fields(mut conn: PgConnection) {
         vec![1, 2],
         "incorrect tranposition_cost_one true"
     );
+
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.fuzzy_term(
+            field => 'description',
+            value => 'keybaord'
+        ),
+        stable_sort => true
+    )"#
+    .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2], "incorrect defaults");
 }
 
 #[rstest]

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -34,7 +34,7 @@ fn boolean_tree(mut conn: PgConnection) {
                 paradedb.parse('description:shoes'),
                 paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
                 paradedb.term(field => 'description', value => 'speaker'),
-                paradedb.fuzzy_term(field => 'description', value => 'wolo')
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo')
             ]
         ),
         stable_sort => true
@@ -68,7 +68,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
         query => paradedb.fuzzy_term(
             field => 'description',
             value => 'keybaord',
-            tranposition_cost_one => false,
+            transposition_cost_one => false,
             distance => 1
         ),
         stable_sort => true
@@ -76,7 +76,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
     .fetch_collect(&mut conn);
     assert!(
         columns.is_empty(),
-        "tranposition_cost_one false should be empty"
+        "transposition_cost_one false should be empty"
     );
 
     let columns: SimpleProductsTableVec = r#"
@@ -84,7 +84,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
         query => paradedb.fuzzy_term(
             field => 'description',
             value => 'keybaord',
-            tranposition_cost_one => true,
+            transposition_cost_one => true,
             distance => 1
         ),
         stable_sort => true
@@ -93,7 +93,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
     assert_eq!(
         columns.id,
         vec![1, 2],
-        "incorrect tranposition_cost_one true"
+        "incorrect transposition_cost_one true"
     );
 
     let columns: SimpleProductsTableVec = r#"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The docs say that the defaults for `fuzzy_term` are `transpose_cost_one = true`, `distance = 2`, and `prefix = true`. But our actual defaults were `transpose_cost_one = false`, `distance = 1`, and `prefix = false`. This was causing confusion.

## Why

## How

## Tests
