### PR TITLE
feat: support partial index for bm25

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -154,6 +154,12 @@ fn create_bm25(
         spi::quote_literal(datetime_fields),
         predicate))?;
 
+    let predicate = if !predicates.is_empty() {
+        format!("{} AND ", predicates)
+    } else {
+        "".to_string()
+    };
+
     Spi::run(&format_bm25_function(
         &spi::quote_qualified_identifier(index_name, "search"),
         &format!(
@@ -162,9 +168,10 @@ fn create_bm25(
             spi::quote_identifier(table_name)
         ),
         &format!(
-            "RETURN QUERY SELECT * FROM {}.{} WHERE {} @@@ __paradedb_search_config__",
+            "RETURN QUERY SELECT * FROM {}.{} WHERE {} {} @@@ __paradedb_search_config__",
             spi::quote_identifier(schema_name),
             spi::quote_identifier(table_name),
+            predicate,
             spi::quote_identifier(key_field)
         ),
         &index_json,
@@ -174,9 +181,10 @@ fn create_bm25(
         &spi::quote_qualified_identifier(index_name, "explain"),
         "TABLE(\"QUERY PLAN\" text)",
         &format!(
-            "RETURN QUERY EXPLAIN SELECT * FROM {}.{} WHERE {} @@@ __paradedb_search_config__",
+            "RETURN QUERY EXPLAIN SELECT * FROM {}.{} WHERE {} {} @@@ __paradedb_search_config__",
             spi::quote_identifier(schema_name),
             spi::quote_identifier(table_name),
+            predicate,
             spi::quote_identifier(key_field)
         ),
         &index_json,

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -703,3 +703,99 @@ async fn json_nested_arrays(mut conn: PgConnection) {
             .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![42]);
 }
+
+#[rstest]
+fn bm25_partial_index_search(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_index', schema_name => 'paradedb');".execute(&mut conn);
+
+    // Ensure report error when predicate is invalid
+    // unknown column
+    let ret = "CALL paradedb.create_bm25(
+        index_name => 'partial_idx',
+        schema_name => 'paradedb',
+        table_name => 'test_partial_index',
+        key_field => 'id',
+        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
+        numeric_fields => '{rating: {}}',
+        predicates => 'city = ''Electronics'''
+    );"
+    .execute_result(&mut conn);
+    assert_eq!(ret.is_err(), true);
+
+    // mismatch type
+    let ret = "CALL paradedb.create_bm25(
+        index_name => 'partial_idx',
+        schema_name => 'paradedb',
+        table_name => 'test_partial_index',
+        key_field => 'id',
+        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
+        numeric_fields => '{rating: {}}',
+        predicates => 'category = ''123''::INTEGER'
+    );"
+    .execute_result(&mut conn);
+    assert_eq!(ret.is_err(), true);
+
+    let ret = "CALL paradedb.create_bm25(
+        index_name => 'partial_idx',
+        schema_name => 'paradedb',
+        table_name => 'test_partial_index',
+        key_field => 'id',
+        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
+        numeric_fields => '{rating: {}}',
+        predicates => 'category = ''Electronics'''
+    );"
+    .execute_result(&mut conn);
+    assert_eq!(ret.is_ok(), true);
+
+    // Ensure returned rows match the predicate
+    let columns: SimpleProductsTableVec = "SELECT description, rating, category FROM partial_idx.search( 'rating:>3', limit_rows => 20) ORDER BY rating".fetch_collect(&mut conn);
+    assert_eq!(columns.category.len(), 4);
+    assert_eq!(
+        columns.category,
+        "Electronics,Electronics,Electronics,Electronics"
+            .split(',')
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(columns.rating, vec![4, 4, 4, 5]);
+
+    // Ensure no mismatch rows returned
+    let rows: Vec<(i32,)> = "SELECT id, category FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    assert_eq!(rows.len(), 0);
+
+    // Insert multiple tuples only 1 matches predicate and query
+    "INSERT INTO paradedb.partial_idx (description, category, rating, in_stock, metadata, created_at, last_updated_date) VALUES 
+    ('Product 1', 'Electronics', 6, true, '{\"colors\": [\"red\", \"green\"]}', now(), current_date),
+    ('Product 2', 'Electronics', 3, false, '{\"colors\": [\"blue\", \"yellow\"]}', now(), current_date),
+    ('Product 3', 'Footwear', 7, true, '{\"colors\": [\"green\", \"blue\"]}', now(), current_date)".execute(&mut conn);
+
+    let rows: Vec<(String, i32, String)> = "SELECT description, rating, category FROM partial_idx.search( 'rating:>3', limit_rows => 20) ORDER BY rating DESC".fetch(&mut conn);
+    assert_eq!(rows.len(), 5);
+
+    let (desc, rating, category) = rows[0].clone();
+    assert_eq!(desc, "Product 1");
+    assert_eq!(rating, 6);
+    assert_eq!(category, "Electronics");
+
+    // Update one tuple to make it no longer match the predicate
+    "UPDATE paradedb.partial_idx SET category = 'Footwear' WHERE description = 'Product 1'"
+        .execute(&mut conn);
+
+    let rows: Vec<(String, i32, String)> = "SELECT description, rating, category FROM partial_idx.search( 'rating:>3', limit_rows => 20) ORDER BY rating DESC".fetch(&mut conn);
+    assert_eq!(rows.len(), 4);
+    let (desc, ..) = rows[0].clone();
+    assert_ne!(desc, "Product 1");
+
+    // Update one tuple to make it match the predicate
+    "UPDATE paradedb.partial_idx SET category = 'Electronics' WHERE description = 'Product 3'"
+        .execute(&mut conn);
+
+    let rows: Vec<(String, i32, String)> = "SELECT description, rating, category FROM partial_idx.search( 'rating:>3', limit_rows => 20) ORDER BY rating DESC".fetch(&mut conn);
+    assert_eq!(rows.len(), 5);
+
+    let (desc, rating, category) = rows[0].clone();
+    assert_eq!(desc, "Product 3");
+    assert_eq!(rating, 7);
+    assert_eq!(category, "Electronics");
+}

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -854,7 +854,9 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     .execute_result(&mut conn);
     assert!(ret.is_ok());
 
-    r#"ALTER TABLE paradedb.test_partial_explain ADD COLUMN embedding vector(3);
+    r#"
+    CREATE EXTENSION vector;
+    ALTER TABLE paradedb.test_partial_explain ADD COLUMN embedding vector(3);
 
     UPDATE paradedb.test_partial_explain m
     SET embedding = ('[' ||

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -840,12 +840,12 @@ fn bm25_partial_index_explain(mut conn: PgConnection) {
 fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_explain', schema_name => 'paradedb');".execute(&mut conn);
+    "CALL paradedb.create_bm25_test_table(table_name => 'test_partial_hybrid', schema_name => 'paradedb');".execute(&mut conn);
 
     let ret = "CALL paradedb.create_bm25(
         index_name => 'partial_idx',
         schema_name => 'paradedb',
-        table_name => 'test_partial_explain',
+        table_name => 'test_partial_hybrid',
         key_field => 'id',
         text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
         numeric_fields => '{rating: {}}',
@@ -856,22 +856,22 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
 
     r#"
     CREATE EXTENSION vector;
-    ALTER TABLE paradedb.test_partial_explain ADD COLUMN embedding vector(3);
+    ALTER TABLE paradedb.test_partial_hybrid ADD COLUMN embedding vector(3);
 
-    UPDATE paradedb.test_partial_explain m
+    UPDATE paradedb.test_partial_hybrid m
     SET embedding = ('[' ||
     ((m.id + 1) % 10 + 1)::integer || ',' ||
     ((m.id + 2) % 10 + 1)::integer || ',' ||
     ((m.id + 3) % 10 + 1)::integer || ']')::vector;
 
-    CREATE INDEX on paradedb.test_partial_explain
+    CREATE INDEX on paradedb.test_partial_hybrid
     USING hnsw (embedding vector_l2_ops)"#
         .execute(&mut conn);
 
     // Ensure all of them match the predicate
     let columns: SimpleProductsTableVec = r#"
     SELECT t.*, s.rank_hybrid
-    FROM paradedb.test_partial_explain t
+    FROM paradedb.test_partial_hybrid t
     RIGHT JOIN (
         SELECT * FROM partial_idx.rank_hybrid(
             bm25_query => paradedb.parse('rating:>1'),
@@ -886,6 +886,39 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     assert_eq!(
         columns.category,
         "Electronics,Electronics,Electronics,Electronics,Electronics"
+            .split(',')
+            .collect::<Vec<_>>()
+    );
+
+    "INSERT INTO paradedb.test_partial_hybrid (description, category, rating, in_stock) VALUES
+    ('Product 1', 'Electronics', 2, true),
+    ('Product 2', 'Electronics', 1, false),
+    ('Product 3', 'Footwear', 2, true);
+
+    UPDATE paradedb.test_partial_hybrid m
+    SET embedding = ('[' ||
+    ((m.id + 1) % 10 + 1)::integer || ',' ||
+    ((m.id + 2) % 10 + 1)::integer || ',' ||
+    ((m.id + 3) % 10 + 1)::integer || ']')::vector;"
+        .execute(&mut conn);
+
+    let rows: Vec<(String,)> = r#"
+    SELECT t.category
+    FROM paradedb.test_partial_hybrid t
+    RIGHT JOIN (
+        SELECT * FROM partial_idx.rank_hybrid(
+            bm25_query => paradedb.parse('rating:>1'),
+            similarity_query => '''[1,2,3]'' <-> embedding',
+            bm25_weight => 0.9,
+            similarity_weight => 0.1
+        )
+    ) s ON t.id = s.id"#
+        .fetch(&mut conn);
+
+    assert_eq!(rows.len(), 7);
+    assert_eq!(
+        rows.into_iter().map(|(s,)| s).collect::<Vec<_>>(),
+        "Electronics,Electronics,Electronics,Electronics,Electronics,Electronics,Electronics"
             .split(',')
             .collect::<Vec<_>>()
     );

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -761,7 +761,7 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(columns.rating, vec![4, 4, 4, 5]);
 
     // Ensure no mismatch rows returned
-    let rows: Vec<(String,)> = "SELECT description FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    let rows: Vec<String> = "SELECT description FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
     assert_eq!(rows.len(), 0);
 
     // Insert multiple tuples only 1 matches predicate and query

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -751,19 +751,19 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
 
     // Ensure returned rows match the predicate
     let columns: SimpleProductsTableVec =
-        "SELECT * FROM partial_idx.search( 'rating:>3', limit_rows => 20) ORDER BY rating"
+        "SELECT * FROM partial_idx.search( 'rating:>1', limit_rows => 20) ORDER BY rating"
             .fetch_collect(&mut conn);
-    assert_eq!(columns.category.len(), 4);
+    assert_eq!(columns.category.len(), 5);
     assert_eq!(
         columns.category,
-        "Electronics,Electronics,Electronics,Electronics"
+        "Electronics,Electronics,Electronics,Electronics,Electronics"
             .split(',')
             .collect::<Vec<_>>()
     );
-    assert_eq!(columns.rating, vec![4, 4, 4, 5]);
+    assert_eq!(columns.rating, vec![3, 4, 4, 4, 5]);
 
     // Ensure no mismatch rows returned
-    let rows: Vec<(String, String)> = "SELECT description, category FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    let rows: Vec<(String, String)> = "SELECT description, category FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>1', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
     assert_eq!(rows.len(), 0);
 
     // Insert multiple tuples only 1 matches predicate and query
@@ -801,6 +801,10 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(desc, "Product 3");
     assert_eq!(rating, 2);
     assert_eq!(category, "Electronics");
+
+    // Insert one row without specifying the column referenced by the predicate.
+    let rows: Vec<(String, i32, String)> = "SELECT description, rating, category FROM partial_idx.search( 'rating:>1', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    assert_eq!(rows.len(), 6);
 }
 
 #[rstest]

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -761,7 +761,7 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(columns.rating, vec![4, 4, 4, 5]);
 
     // Ensure no mismatch rows returned
-    let rows: Vec<()> = "SELECT description FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    let rows: Vec<(String, )> = "SELECT description, category FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
     assert_eq!(rows.len(), 0);
 
     // Insert multiple tuples only 1 matches predicate and query

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -761,7 +761,7 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
     assert_eq!(columns.rating, vec![4, 4, 4, 5]);
 
     // Ensure no mismatch rows returned
-    let rows: Vec<String> = "SELECT description FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
+    let rows: Vec<()> = "SELECT description FROM partial_idx.search( '(description:jeans OR category:Footwear) AND rating:>2', limit_rows => 20) ORDER BY rating".fetch(&mut conn);
     assert_eq!(rows.len(), 0);
 
     // Insert multiple tuples only 1 matches predicate and query


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1012

## What
support partial index for bm25
## Why

## How
just pass where conditions, and finally index_build_range_scan should handle this.

## Tests
```sql

CALL paradedb.create_bm25_test_table(
  schema_name => 'public',
  table_name => 'mock_items'
);
CALL paradedb.create_bm25(
        index_name => 'search_idx2',
        schema_name => 'public',
        table_name => 'mock_items',
        key_field => 'id',
        text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}',
        numeric_fields => '{rating: {}}',
        predicates => 'category = ''Electronics'''
);

SELECT description, rating, category
FROM search_idx2.search(
  'rating:>2',
  limit_rows => 20
);

```

<img width="541" alt="image" src="https://github.com/paradedb/paradedb/assets/73871299/8fcd4233-8919-4ced-a2ab-f6ea9feec36b">
