### PR TITLE
fix: BM25 indexing on case sensitive columns

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -116,7 +116,7 @@ fn create_bm25(
             Ok(obj) => {
                 if let Value::Object(map) = obj {
                     for key in map.keys() {
-                        column_names.insert(key.clone());
+                        column_names.insert(spi::quote_identifier(key.clone()));
                     }
                 }
             }

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -535,5 +535,5 @@ fn column_name_camelcase(mut conn: PgConnection) {
         "SELECT * FROM index_config.search('ColumnName:keyboard')".fetch(&mut conn);
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0], (1.into(), "Plastic Keyboard".into()));
+    assert_eq!(rows[0], (1, "Plastic Keyboard".into()));
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes a user-reported issue that indexing on case sensitive columns no longer works.

## Why

## How
In the BM25 creation SQL, we need to wrap column names in quotes to preserve casing.

## Tests
See added test.