### PR TITLE
feat: Add support for publishing Ubuntu 24.04

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   benchmark-pg_lakehouse:
     name: Benchmark pg_lakehouse on ${{ matrix.name }}
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-latest-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-latest-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-bash:
     name: Lint Bash Scripts
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-docker:
     name: Lint Dockerfiles
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint-format:
     name: Lint File Endings & Trailing Whitespaces
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint-markdown:
     name: Lint Markdown Files
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint-pr-title:
     name: Validate PR Title
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-rust:
     name: Lint Rust Files
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-yaml:
     name: Lint YAML Files
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   publish-github-release:
     name: Publish ParadeDB GitHub Release
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   publish-paradedb-container-image:
     name: Publish ParadeDB Container Image for PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
         pg_version: [16]
@@ -90,7 +90,7 @@ jobs:
 
   publish-paradedb-helm-chart:
     name: Publish ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
         pg_version: [16]

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Debian Dependencies
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install RHEL Dependencies
@@ -258,7 +258,7 @@ jobs:
           fi
 
       - name: Install & Configure Supported PostgreSQL Version on Debian
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -312,7 +312,7 @@ jobs:
           cargo pgrx package
 
       - name: Create .deb Package
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: |
           # Create installable package
           mkdir archive
@@ -406,7 +406,7 @@ jobs:
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_lakehouse .deb to GitHub Release
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,6 +7,9 @@ name: Publish pg_lakehouse
 
 on:
   push:
+    # TODO: Remove once done testing
+    branches:
+      - phil/24.04
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -30,102 +30,127 @@ jobs:
       matrix:
         include:
           # Ubuntu 22.04
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
+            pg_version: 16
+            arch: arm64
+          # Ubuntu 24.04
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
             pg_version: 16
             arch: arm64
           # Debian 11
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 16
             arch: arm64
           # Debian 12
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 16
             arch: arm64
           # Red Hat Enterprise Linux 9
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 16
             arch: arm64

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -7,9 +7,6 @@ name: Publish pg_lakehouse
 
 on:
   push:
-    # TODO: Remove once done testing
-    branches:
-      - phil/24.04
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -7,6 +7,9 @@ name: Publish pg_search
 
 on:
   push:
+    # TODO: Remove once done testing
+    branches:
+      - phil/24.04
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Debian Dependencies
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install RHEL Dependencies
@@ -258,7 +258,7 @@ jobs:
           fi
 
       - name: Install & Configure Supported PostgreSQL Version on Debian
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -312,7 +312,7 @@ jobs:
           cargo pgrx package --features icu
 
       - name: Create .deb Package
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: |
           # Create installable package
           mkdir archive
@@ -406,7 +406,7 @@ jobs:
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
       - name: Upload pg_search .deb to GitHub Release
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' }}
+        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -7,9 +7,6 @@ name: Publish pg_search
 
 on:
   push:
-    # TODO: Remove once done testing
-    branches:
-      - phil/24.04
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -30,102 +30,127 @@ jobs:
       matrix:
         include:
           # Ubuntu 22.04
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: ubuntu:22.04
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:22.04
+            pg_version: 16
+            arch: arm64
+          # Ubuntu 24.04
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
             pg_version: 16
             arch: arm64
           # Debian 11
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:11-slim
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:11-slim
             pg_version: 16
             arch: arm64
           # Debian 12
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: debian:12-slim
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: debian:12-slim
             pg_version: 16
             arch: arm64
           # Red Hat Enterprise Linux 9
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 14
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 15
             arch: arm64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
             pg_version: 16
             arch: amd64
-          - runner: depot-ubuntu-22.04-arm-4
+          - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 16
             arch: arm64

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test-docs:
     name: Test Docs for Broken Links
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB on PostgreSQL ${{ matrix.pg_version }}
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-latest-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -38,13 +38,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 16
             arch: amd64
     env:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -39,19 +39,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 12
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 13
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 14
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 15
             arch: amd64
-          - runner: depot-ubuntu-22.04-8
+          - runner: depot-ubuntu-latest-8
             pg_version: 16
             arch: amd64
     env:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1328 

## What
This PR adds support for publishing binaries for Ubuntu 24.04 for our extensions.

## Why
Easier setup for our users

## How
Simply add a new container image as part of our build matrix.

## Tests
- [x] Test that it builds and deploys properly on Ubuntu 24.04 -- See here: https://github.com/paradedb/paradedb/actions/runs/9862369271/job/27232827674
