### PR TITLE
chore: Add missing details to `pg_lakehouse` README

### DIFF
--- a/.github/workflows/benchmark-pg_lakehouse.yml
+++ b/.github/workflows/benchmark-pg_lakehouse.yml
@@ -15,10 +15,12 @@ on:
       - dev
       - main
     paths:
+      - ".github/workflows/benchmark-pg_lakehouse.yml"
       - "docker/Dockerfile"
       - "pg_lakehouse/**"
       - "shared/Cargo.toml"
-      - ".github/workflows/benchmark-pg_lakehouse.yml"
+    paths-ignore:
+      - "pg_lakehouse/README.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -15,12 +15,13 @@ on:
       - dev
       - main
     paths:
+      - ".github/workflows/benchmark-pg_search.yml"
       - "docker/Dockerfile"
       - "pg_search/**"
-      - "!pg_search/README.md"
       - "shared/Cargo.toml"
       - "tokenizers/Cargo.toml"
-      - ".github/workflows/benchmark-pg_search.yml"
+    paths-ignore:
+      - "pg_search/README.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - "docker/Dockerfile"
       - "pg_search/**"
+      - "!pg_search/README.md"
       - "shared/Cargo.toml"
       - "tokenizers/Cargo.toml"
       - ".github/workflows/benchmark-pg_search.yml"

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - "docker/*"
       - ".github/workflows/lint-docker.yml"
+      - "docker/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "**/*.yml"
       - "**/*.yaml"
+      - ".github/workflows/lint-yaml.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -12,8 +12,8 @@ on:
       - main
       - dev
     paths:
-      - "docs/**"
       - ".github/workflows/test-docs.yml"
+      - "docs/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -18,6 +18,9 @@ on:
       - "pg_search/**"
       - "shared/**"
       - "tokenizers/**"
+    paths-ignore:
+      - "pg_lakehouse/README.md"
+      - "pg_search/README.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -12,12 +12,12 @@ on:
       - main
       - dev
     paths:
+      - ".github/workflows/test-paradedb.yml"
       - "docker/**"
       - "pg_lakehouse/**"
       - "pg_search/**"
       - "shared/**"
       - "tokenizers/**"
-      - ".github/workflows/test-paradedb.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -12,10 +12,11 @@ on:
       - dev
       - main
     paths:
-      - "pg_lakehouse/**"
-      - "!pg_lakehouse/README.md"
-      - "shared/**"
       - ".github/workflows/test-pg_lakehouse.yml"
+      - "pg_lakehouse/**"
+      - "shared/**"
+    paths-ignore:
+      - "pg_lakehouse/README.md"
   push:
     branches:
       - dev # Run CI on dev. This is important to fill the GitHub Actions cache in a way that pull requests can see it

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -12,11 +12,12 @@ on:
       - dev
       - main
     paths:
+      - ".github/workflows/test-pg_search.yml"
       - "pg_search/**"
       - "tokenizers/**"
       - "shared/**"
-      - "!pg_search/README.md"
-      - ".github/workflows/test-pg_search.yml"
+    paths-ignore:
+      - "pg_search/README.md"
   push:
     branches:
       - dev # Run CI on dev. This is important to fill the GitHub Actions cache in a way that pull requests can see it

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ ParadeDB collects anonymous telemetry to help us understand how many people are 
 
 ```sql
 ALTER SYSTEM SET paradedb.pg_search_telemetry TO 'off';
+ALTER SYSTEM SET paradedb.pg_lakehouse_telemetry TO 'off';
 ```
 
 ### Helm Chart

--- a/pg_lakehouse/README.md
+++ b/pg_lakehouse/README.md
@@ -3,33 +3,16 @@
 <br>
 </h1>
 
+[![Test pg_lakehouse](https://github.com/paradedb/paradedb/actions/workflows/test-pg_lakehouse.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/test-pg_lakehouse.yml)
+[![Benchmark pg_lakehouse](https://github.com/paradedb/paradedb/actions/workflows/benchmark-pg_lakehouse.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/benchmark-pg_lakehouse.yml)
+
 ## Overview
 
 `pg_lakehouse` puts DuckDB inside Postgres.
 
 With `pg_lakehouse` installed, Postgres can query foreign object stores like S3 and table formats like Iceberg or Delta Lake. Queries are pushed down to DuckDB, a high performance analytical query engine. The following object stores and table formats are supported:
 
-### Object Stores
-
-- [x] Amazon S3
-- [x] S3-compatible stores (MinIO, R2)
-- [x] Azure Blob Storage
-- [x] Azure Data Lake Storage Gen2
-- [x] Google Cloud Storage
-- [x] HTTP server
-- [x] Local file system
-
-### Table Formats
-
-- [x] Parquet
-- [x] CSV
-- [x] Apache Iceberg
-- [x] Delta Lake
-- [ ] JSON (Coming Soon)
-
-`pg_lakehouse` uses DuckDB v1.0.0 and is supported on Postgres 14, 15, and 16. Support for Postgres 12 and 13 is coming soon.
-
-## Motivation
+### Motivation
 
 Today, a vast amount of non-operational data — events, metrics, historical snapshots, vendor data, etc. — is ingested into data lakes like S3. Querying this data by moving it into a cloud data warehouse or operating a new query engine is expensive and time-consuming. The goal of `pg_lakehouse` is to enable this data to be queried directly from Postgres. This eliminates the need for new infrastructure, loss of data freshness, data movement, and non-Postgres dialects of other query engines.
 
@@ -40,7 +23,90 @@ Today, a vast amount of non-operational data — events, metrics, historical sna
 
 `pg_lakehouse` differentiates itself by supporting a wide breadth of stores and formats and by being very fast (thanks to DuckDB).
 
-## Getting Started
+### Roadmap
+
+- [ ] Read support for `pg_lakehouse`
+- [ ] Write support for `pg_lakehouse`
+- [ ] `EXPLAIN` support
+- [ ] Automatic schema detection
+- [ ] Integration with the catalog providers
+
+#### Object Stores
+
+- [x] Amazon S3
+- [x] S3-compatible stores (MinIO, R2)
+- [x] Azure Blob Storage
+- [x] Azure Data Lake Storage Gen2
+- [x] Google Cloud Storage
+- [x] HTTP server
+- [x] Local file system
+
+#### Table Formats
+
+- [x] Parquet
+- [x] CSV
+- [x] Apache Iceberg
+- [x] Delta Lake
+- [ ] JSON (Coming Soon)
+
+`pg_lakehouse` uses DuckDB v1.0.0 and is supported on Postgres 14, 15, and 16. Support for Postgres 12 and 13 is coming soon.
+
+## Installation
+
+### From ParadeDB
+
+The easiest way to use the extension is to run the ParadeDB Dockerfile:
+
+```bash
+docker run \
+  --name paradedb \
+  -e POSTGRESQL_USERNAME=<user> \
+  -e POSTGRESQL_PASSWORD=<password> \
+  -e POSTGRESQL_DATABASE=<dbname> \
+  -e POSTGRESQL_POSTGRES_PASSWORD=<superuser_password> \
+  -v paradedb_data:/bitnami/postgresql \
+  -p 5432:5432 \
+  -d \
+  paradedb/paradedb:latest
+```
+
+This will spin up a Postgres instance with `pg_lakehouse` preinstalled.
+
+### From Self-Hosted PostgreSQL
+
+If you are self-hosting Postgres and would like to use the extension within your existing Postgres, follow the steps below.
+
+It's **very important** to make the following change to your `postgresql.conf` configuration file. `pg_lakehouse` must be in the list of `shared_preload_libraries`:
+
+```c
+shared_preload_libraries = 'pg_lakehouse'
+```
+
+This ensures the best query performance from the extension .
+
+#### Debian/Ubuntu
+
+We provide prebuilt binaries for Debian-based Linux for Postgres 16, 15 and 14. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+
+ParadeDB collects anonymous telemetry to help us understand how many people are using the project. You can opt out of telemetry by setting `export PARADEDB_TELEMETRY=false` (or unsetting the variable) in your shell or in your `~/.bashrc` file before running the extension.
+
+#### macOS
+
+We don't suggest running production workloads on macOS. As a result, we don't provide prebuilt binaries for macOS. If you are running Postgres on macOS and want to install `pg_lakehouse`, please follow the [development](#development) instructions, but do `cargo pgrx install --release` instead of `cargo pgrx run`. This will build the extension from source and install it in your Postgres instance.
+
+You can then create the extension in your database by running:
+
+```sql
+CREATE EXTENSION pg_lakehouse;
+```
+
+Note: If you are using a managed Postgres service like Amazon RDS, you will not be able to install `pg_lakehouse` until the Postgres service explicitly supports it.
+
+#### Windows
+
+Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
+
+## Usage
 
 The following example uses `pg_lakehouse` to query an example dataset of 3 million NYC taxi trips from January 2024, hosted in a public `us-east-1` S3 bucket provided by ParadeDB.
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -4,6 +4,7 @@
 </h1>
 
 [![Test pg_search](https://github.com/paradedb/paradedb/actions/workflows/test-pg_search.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/test-pg_search.yml)
+[![Benchmark pg_search](https://github.com/paradedb/paradedb/actions/workflows/benchmark-pg_search.yml/badge.svg)](https://github.com/paradedb/paradedb/actions/workflows/benchmark-pg_search.yml)
 
 ## Overview
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
While looking to configure telemetry on `pg_lakehouse`, I noticed a few things were missing to tell users to remove it, and to adjust the README to be similar structure as the `pg_search` one.

## Why
N/A

## How
N/A

## Tests
N/A