### PR TITLE
chore: Remove outdated references to DataFusion

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,3 @@
-# Global settings - optimize for the native CPU for all targets. This
-# is required by the 'datafusion` crate for maximum performance, and
-# applies in addition to the target-specific settings below.
-[build]
-rustflags = ["-Ctarget-cpu=native"]
-
 # on macOS, PostgreSQL symbols won't be available until runtime
 [target.'cfg(target_os="macos")']
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -302,14 +302,9 @@ jobs:
           fi
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
-      # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
-      # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should
-      # build the extension directly on their target machine, or use our Docker image.
       - name: Package pg_lakehouse Extension with pgrx
         working-directory: pg_lakehouse/
-        run: |
-          sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
-          cargo pgrx package
+        run: cargo pgrx package
 
       - name: Create .deb Package
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
@@ -374,8 +369,7 @@ jobs:
 
           %description
           pg_lakehouse is a Postgres extension that enables fast analytics over
-          data lakes from Postgres. It is built on top of DataFusion, the Rust-based
-          analytics query engine, using pgrx.
+          data lakes from Postgres. It is built on top of DuckDB, using pgrx.
 
           %install
           %{__rm} -rf %{buildroot}

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -302,14 +302,9 @@ jobs:
           fi
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
-      # We remove the native CPU optimization for the build, as we don't know what CPU architecture the user will be running our
-      # prebuilt binaries on. This reduces performance, but is necessary for compatibility. For the most optimized build, users should
-      # build the extension directly on their target machine, or use our Docker image.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        run: |
-          sed -i '/# Global settings - optimize for the native CPU for all targets./,/\[build\]/d; /rustflags = \["-Ctarget-cpu=native"\]/d' ../.cargo/config.toml
-          cargo pgrx package --features icu
+        run: cargo pgrx package --features icu
 
       - name: Create .deb Package
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}

--- a/THANKYOU.md
+++ b/THANKYOU.md
@@ -36,27 +36,9 @@ the first PGRX extension and primary example, for the architecture of our own ex
 inspired by Apache Lucene, written entirely in Rust. ParadeDB uses Tantivy to power
 part of our search functionalities.
 
-## Apache Arrow
+## DuckDB
 
-[Apache Arrow](https://arrow.apache.org/) is a cross-language development platform for in-memory analytics. It is
-the industry's standard in-memory columnar format. ParadeDB uses Apache Arrow to do optimized in-memory columnar
-processing.
-
-## Apache Parquet
-
-[Apache Parquet](https://parquet.apache.org/) is an open source, column-oriented data file format designed for efficient data storage and retrieval. It provides efficient data compression and encoding schemes with enhanced performance to handle complex data in bulk. ParadeDB uses Apache Parquet to store data in columnar format.
-
-## Apache DataFusion
-
-[Apache DataFusion](https://arrow.apache.org/datafusion/) is a very fast, extensible query engine for building high-quality data-centric systems in Rust, using the Apache Arrow in-memory format. ParadeDB uses Apache DataFusion to do vectorized query processing for columnar data.
-
-## Apache OpenDAL
-
-[Apache OpenDAL](https://opendal.apache.org/) offers a unified data access layer, empowering users to seamlessly and efficiently retrieve data from diverse storage services. ParadeDB uses Apache OpenDAL to do fast analytics from Postgres over data stored in various storage services, like S3, GCS, and more.
-
-## Delta Rust
-
-[Delta Lake Rust](https://github.com/delta-io/delta-rs) is a Rust implementation of the Delta Lake transactional storage layer. ParadeDB uses Delta Rust implement ACID transactions over Parquet files.
+[DuckDB](https://github.com/duckdb/duckdb) is a high-performance analytical database system. It is designed to be fast, reliable, portable, and easy to use. ParadeDB uses DuckDB do vectorized query processing for columnar data.
 
 ## Docker
 

--- a/pg_lakehouse/README.md
+++ b/pg_lakehouse/README.md
@@ -16,7 +16,7 @@ With `pg_lakehouse` installed, Postgres can query foreign object stores like S3 
 
 Today, a vast amount of non-operational data — events, metrics, historical snapshots, vendor data, etc. — is ingested into data lakes like S3. Querying this data by moving it into a cloud data warehouse or operating a new query engine is expensive and time-consuming. The goal of `pg_lakehouse` is to enable this data to be queried directly from Postgres. This eliminates the need for new infrastructure, loss of data freshness, data movement, and non-Postgres dialects of other query engines.
 
-`pg_lakehouse` uses the foreign data wrapper (FDW) API to connect to any object store or table format and the executor hook API to push queries to DataFusion. While other FDWs like `aws_s3` have existed in the Postgres extension ecosystem, these FDWs suffer from two limitations:
+`pg_lakehouse` uses the foreign data wrapper (FDW) API to connect to any object store or table format and the executor hook API to push queries to DuckDB. While other FDWs like `aws_s3` have existed in the Postgres extension ecosystem, these FDWs suffer from two limitations:
 
 1. Lack of support for most object stores and table formats
 2. Too slow over large datasets to be a viable analytical engine
@@ -134,7 +134,7 @@ To query your own data, please refer to the [documentation](https://docs.paraded
 
 ## Shared Preload Libraries
 
-Because this extension uses Postgres hooks to intercept and push queries down to DataFusion, it is **very important** that it is added to `shared_preload_libraries` inside `postgresql.conf`.
+Because this extension uses Postgres hooks to intercept and push queries down to DuckDB, it is **very important** that it is added to `shared_preload_libraries` inside `postgresql.conf`.
 
 ```bash
 # Inside postgresql.conf


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This was pointed out by someone on HackerNews -- we had forgotten to update some DataFusion references.

## Why

## How

## Tests
