### PR TITLE
feat: Implement `pg_total_relation_size` and `pg_indexes_size`

### DIFF
--- a/pg_search/src/bootstrap/mod.rs
+++ b/pg_search/src/bootstrap/mod.rs
@@ -1,3 +1,4 @@
 mod create_bm25;
 mod format;
 mod test_table;
+mod tantivy_sizes;

--- a/pg_search/src/bootstrap/tantivy_sizes.rs
+++ b/pg_search/src/bootstrap/tantivy_sizes.rs
@@ -1,0 +1,54 @@
+use crate::postgres::utils::get_search_index;
+use pgrx::prelude::*;
+use pgrx::Spi;
+
+#[pg_extern(sql = "
+CREATE OR REPLACE FUNCTION paradedb.pg_total_relation_size_with_tantivy(
+    index_name text,
+    table_name text
+) RETURNS bigint
+LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+")]
+fn pg_total_relation_size_with_tantivy(index_name: &str, table_name: &str) -> i64 {
+    let standard_size =  {
+        Spi::get_one::<i64>(&format!("SELECT pg_total_relation_size('{}')", table_name))
+    }.unwrap_or(Some(0));
+
+    let tantivy_size = match get_tantivy_index_size(index_name) {
+        Ok(size) => size,
+        Err(e) => {
+            log!("Error getting Tantivy index size: {}", e);
+            0
+        }
+    };
+    standard_size.unwrap_or(0) + tantivy_size
+}
+
+#[pg_extern(sql = "
+CREATE OR REPLACE FUNCTION paradedb.pg_indexes_size_with_tantivy(
+    index_name text,
+    table_name text
+) RETURNS bigint
+LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
+")]
+fn pg_indexes_size_with_tantivy(index_name: &str, table_name: &str) -> i64 {
+    let standard_index_size =  {
+        Spi::get_one::<i64>(&format!("SELECT pg_indexes_size('{}')", table_name))
+    }.unwrap_or(Some(0));
+
+    let tantivy_size = match get_tantivy_index_size(index_name) {
+        Ok(size) => size,
+        Err(e) => {
+            eprintln!("Error getting Tantivy index size: {}", e);
+            0
+        }
+    };
+    standard_index_size.unwrap_or(0) + tantivy_size
+}
+
+fn get_tantivy_index_size(index_name: &str) -> Result<i64, String> {
+    let tantivy_index_name = format!("{}_bm25_index", index_name);
+    let search_index = get_search_index(&tantivy_index_name);
+    let index_size = search_index.index_size();
+    Ok(index_size as i64)
+}

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -80,7 +80,6 @@ impl SearchIndex {
                 field: schema.key_field().name.as_ref().into(),
                 order: Order::Asc,
             }),
-            // docstore_compress_dedicated_threadSpi::get: false, // Must run on single thread, or pgrx will panic
             ..Default::default()
         };
 
@@ -112,9 +111,6 @@ impl SearchIndex {
         // We need to return the Self that is borrowed from the cache.
         let new_self_ref = Self::from_cache(&directory)
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
-
-        // let reader = new_self_ref.underlying_index.reader().expect("msg");
-        // let space_usage: Vec<Result<tantivy::space_usage::SegmentSpaceUsage, std::io::Error>> =  reader.searcher().segment_readers().iter().map(| segment_reader | segment_reader.space_usage()).collect();
         
         Ok(new_self_ref)
     }
@@ -129,8 +125,8 @@ impl SearchIndex {
 
         let total_space_usage: u64 = space_usage
             .into_iter() // Convert to an iterator
-            .filter_map(|result| result.ok()) // Use `ok()` to convert `Result` to `Option`
-            .map(|usage| usage.total().get_bytes()) // Access the inner u64 value of ByteCount
+            .filter_map(|result| result.ok())
+            .map(|usage| usage.total().get_bytes())
             .sum();
         
         total_space_usage.try_into().unwrap()


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1061 

## What
Added support for measuring index size (pg_indexes_size) and table size (pg_total_relation_size) in pg_search and pg_analytics extensions. They included underlying Tantivy index size in calculations.

## Why
To enable querying of table and index sizes directly from PostgreSQL, providing essential utility functions for database management and optimization.

## How
Implemented functions:

    pg_total_relation_size_with_tantivy(index_name: text, table_name: text): Computes the total size of a relation including the Tantivy index.
    pg_indexes_size_with_tantivy(index_name: text, table_name: text): Calculates the size of all indexes on a table including the Tantivy index.
