### PR TITLE
fix: Don't allow index names that are too long

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -65,15 +65,12 @@ fn create_bm25(
         bail!("no index_name parameter given for bm25 index");
     }
 
-    let index_name = if index_name.len() > MAX_INDEX_NAME_LENGTH {
-        warning!(
-            "identifier {} will be truncated to {}",
+    if index_name.len() > MAX_INDEX_NAME_LENGTH {
+        bail!(
+            "identifier {} exceeds maximum allowed length of {} characters",
             spi::quote_identifier(index_name),
-            spi::quote_identifier(&index_name[..MAX_INDEX_NAME_LENGTH])
+            MAX_INDEX_NAME_LENGTH
         );
-        &index_name[..MAX_INDEX_NAME_LENGTH]
-    } else {
-        index_name
     };
 
     if Spi::get_one::<bool>(&format!(

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -25,6 +25,10 @@ use super::format::format_bm25_function;
 use super::format::format_empty_function;
 use super::format::format_hybrid_function;
 
+// The maximum length of an index name in Postgres is 63 characters,
+// but we need to account for the trailing _bm25_index suffix
+const MAX_INDEX_NAME_LENGTH: usize = 52;
+
 #[pg_extern(sql = "
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
     index_name text DEFAULT '',
@@ -60,6 +64,17 @@ fn create_bm25(
     if index_name.is_empty() {
         bail!("no index_name parameter given for bm25 index");
     }
+
+    let index_name = if index_name.len() > MAX_INDEX_NAME_LENGTH {
+        warning!(
+            "identifier {} will be truncated to {}",
+            spi::quote_identifier(index_name),
+            spi::quote_identifier(&index_name[..MAX_INDEX_NAME_LENGTH])
+        );
+        &index_name[..MAX_INDEX_NAME_LENGTH]
+    } else {
+        index_name
+    };
 
     if Spi::get_one::<bool>(&format!(
         "SELECT EXISTS (SELECT i.schema_name FROM information_schema.schemata i WHERE i.schema_name = {})",
@@ -360,7 +375,7 @@ fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
             SELECT INTO original_client_min_messages current_setting('client_min_messages');
             SET client_min_messages TO WARNING;
 
-            EXECUTE 'DROP INDEX IF EXISTS {}.{}_bm25_index'; 
+            EXECUTE 'DROP INDEX IF EXISTS {}.{}'; 
             EXECUTE 'DROP SCHEMA IF EXISTS {} CASCADE';
             PERFORM paradedb.drop_bm25_internal({});
 
@@ -369,7 +384,7 @@ fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
         $$;
         "#,
         spi::quote_identifier(schema_name),
-        spi::quote_identifier(index_name),
+        spi::quote_identifier(format!("{}_bm25_index", index_name)),
         spi::quote_identifier(index_name),
         spi::quote_literal(format!("{}_bm25_index", index_name))
     ))?;

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -92,7 +92,6 @@ impl SearchIndex {
         let schema = SearchIndexSchema::new(fields)?;
 
         let tantivy_dir_path = directory.tantivy_dir_path(true)?;
-
         let mut underlying_index = Index::builder()
             .schema(schema.schema.clone())
             .create_in_dir(tantivy_dir_path)

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -92,6 +92,7 @@ impl SearchIndex {
         let schema = SearchIndexSchema::new(fields)?;
 
         let tantivy_dir_path = directory.tantivy_dir_path(true)?;
+
         let mut underlying_index = Index::builder()
             .schema(schema.schema.clone())
             .create_in_dir(tantivy_dir_path)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1331 

## What
Postgres truncates identifiers to 63 characters. Because `create_bm25` appends `_bm25_index` to the index name, we should truncate the index name to 52 characters to account for the `_bm25_index` suffix.

## Why
See user-reported issue.

## How

## Tests
Added test for truncation.