### PR TITLE
fix: Chown duckdb inside the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ COPY --from=builder-pg_lakehouse /tmp/pg_lakehouse/target/release/pg_lakehouse-p
 # Switch to root for installing and configuring runtime dependencies
 USER root
 RUN install_packages curl uuid-runtime libpq5
-RUN chown 777 .duckdb/
+RUN mkdir .duckdb/ && chown 777 .duckdb/
 USER 1001
 
 # Copy ParadeDB bootstrap script to install extensions, configure postgresql.conf, etc.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -169,9 +169,10 @@ COPY --from=builder-pg_search /tmp/pg_search/target/release/pg_search-pg${PG_VER
 COPY --from=builder-pg_lakehouse /tmp/pg_lakehouse/target/release/pg_lakehouse-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /opt/bitnami/postgresql/lib/
 COPY --from=builder-pg_lakehouse /tmp/pg_lakehouse/target/release/pg_lakehouse-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /opt/bitnami/postgresql/share/extension/
 
-# Install runtime dependencies (requires switching to root temporarily)
+# Switch to root for installing and configuring runtime dependencies
 USER root
 RUN install_packages curl uuid-runtime libpq5
+RUN chown 777 .duckdb/
 USER 1001
 
 # Copy ParadeDB bootstrap script to install extensions, configure postgresql.conf, etc.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes part of #1323

## What
We were missing a permission to write to DuckDB internally.

## Why
N/A

## How
N/A

## Tests
Needs testing