### PR TITLE
chore: Delta scans are no longer S3-only

### DIFF
--- a/docs/analytics/import/delta.mdx
+++ b/docs/analytics/import/delta.mdx
@@ -2,11 +2,6 @@
 title: Delta
 ---
 
-<Note>
-  Delta scans are currently only supported over S3. This is a limitation of the
-  underlying DuckDB Delta extension and will be addressed soon.
-</Note>
-
 ## Overview
 
 This code block demonstrates how to create a foreign table over a Delta table.

--- a/pg_lakehouse/tests/scan.rs
+++ b/pg_lakehouse/tests/scan.rs
@@ -93,7 +93,6 @@ async fn test_arrow_types_s3_listing(#[future(awt)] s3: S3, mut conn: PgConnecti
 }
 
 #[rstest]
-#[ignore = "bug in DuckDB delta_scan over custom endpoints"]
 async fn test_arrow_types_s3_delta(
     #[future(awt)] s3: S3,
     mut conn: PgConnection,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1323 

## What
Waiting for the user to confirm, but this limitation was lifted a few days ago by `duckdb_delta`.

## Why
Update documentation

## How
N/A

## Tests
N/A