### PR TITLE
fix: Various `pg_search` transaction bugs

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -37,7 +37,11 @@ fn search_tantivy(
         let writer_client = WriterGlobal::client();
         let search_index = get_search_index(&search_config.index_name);
         let scan_state = search_index
-            .search_state(&writer_client, &search_config, needs_commit())
+            .search_state(
+                &writer_client,
+                &search_config,
+                needs_commit(&search_config.index_name),
+            )
             .unwrap();
         let top_docs = scan_state.search(search_index.executor);
         let mut hs = FxHashSet::default();

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -19,7 +19,6 @@ use crate::env::needs_commit;
 use crate::index::state::{SearchAlias, SearchStateManager};
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchConfig;
-use crate::writer::{WriterClient, WriterDirectory};
 use crate::{globals::WriterGlobal, index::SearchIndex, postgres::utils::get_search_index};
 use pgrx::{prelude::TableIterator, *};
 
@@ -80,7 +79,11 @@ pub fn minmax_bm25(
 
     let writer_client = WriterGlobal::client();
     let mut scan_state = search_index
-        .search_state(&writer_client, &search_config, needs_commit())
+        .search_state(
+            &writer_client,
+            &search_config,
+            needs_commit(&search_config.index_name),
+        )
         .unwrap();
 
     // Collect into a Vec to allow multiple iterations
@@ -123,7 +126,6 @@ pub fn minmax_bm25(
 #[pg_extern]
 fn drop_bm25_internal(index_name: &str) {
     let writer_client = WriterGlobal::client();
-    let writer_directory = WriterDirectory::from_index_name(index_name);
 
     // Drop the Tantivy data directory.
     SearchIndex::drop_index(&writer_client, index_name)

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -124,15 +124,7 @@ pub fn minmax_bm25(
 fn drop_bm25_internal(index_name: &str) {
     let writer_client = WriterGlobal::client();
     let writer_directory = WriterDirectory::from_index_name(index_name);
-    if needs_commit() {
-        writer_client
-            .lock()
-            .expect("could not lock writer on drop_bm25")
-            .request(crate::writer::WriterRequest::Commit {
-                directory: writer_directory,
-            })
-            .expect("error committing existing transaction during drop_bm25");
-    }
+
     // Drop the Tantivy data directory.
     SearchIndex::drop_index(&writer_client, index_name)
         .unwrap_or_else(|err| panic!("error dropping index {index_name}: {err}"));

--- a/pg_search/src/env.rs
+++ b/pg_search/src/env.rs
@@ -25,8 +25,6 @@ use std::{
 
 use crate::writer::{SearchFs, WriterClient, WriterDirectory, WriterRequest};
 
-const TRANSACTION_CALLBACK_CACHE_ID: &str = "parade_search_index";
-
 /// We use this global variable to cache any values that can be re-used
 /// after initialization.
 static SEARCH_ENV: Lazy<SearchEnv> = Lazy::new(|| SearchEnv {
@@ -67,7 +65,7 @@ pub fn register_commit_callback<W: WriterClient<WriterRequest> + Send + Sync + '
 ) -> Result<(), TransactionError> {
     let writer_client = writer.clone();
     let commit_directory = directory.clone();
-    Transaction::call_once_on_precommit(TRANSACTION_CALLBACK_CACHE_ID, move || {
+    Transaction::call_once_on_precommit(directory.clone().index_name, move || {
         let mut error: Option<Box<dyn std::error::Error>> = None;
         {
             // This lock must happen in an enclosing block so it is dropped and
@@ -94,7 +92,7 @@ pub fn register_commit_callback<W: WriterClient<WriterRequest> + Send + Sync + '
 
     let writer_client = writer.clone();
     let abort_directory = directory.clone();
-    Transaction::call_once_on_abort(TRANSACTION_CALLBACK_CACHE_ID, move || {
+    Transaction::call_once_on_abort(directory.clone().index_name, move || {
         let mut error: Option<Box<dyn std::error::Error>> = None;
         {
             // This lock must happen in an enclosing block so it is dropped and
@@ -122,23 +120,16 @@ pub fn register_commit_callback<W: WriterClient<WriterRequest> + Send + Sync + '
     Ok(())
 }
 
-pub fn needs_commit() -> bool {
-    Transaction::needs_commit(TRANSACTION_CALLBACK_CACHE_ID)
+pub fn needs_commit(index_name: &str) -> bool {
+    Transaction::needs_commit(index_name)
         .expect("error performing commit check in transaction cache")
 }
 
-pub fn clear_commit_abort_caches() -> Result<(), TransactionError> {
-    Transaction::clear_commit_abort_caches(TRANSACTION_CALLBACK_CACHE_ID)
-}
-
 pub fn drop_index_on_commit(directory: WriterDirectory) -> Result<(), TransactionError> {
-    let directory = directory.clone();
-    let index_name = directory.index_name.clone();
-
-    Transaction::call_once_on_commit(&index_name, move || {
+    Transaction::call_once_on_commit(directory.clone().index_name, move || {
         directory
             .remove()
-            .expect(&format!("failed to remove directory for {index_name}",))
+            .unwrap_or_else(|_| panic!("failed to remove directory for {}", directory.index_name))
     })?;
 
     Ok(())

--- a/pg_search/src/postgres/hooks.rs
+++ b/pg_search/src/postgres/hooks.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use pgrx::*;
+
+use crate::index::state::SearchStateManager;
+
+pub struct SearchHook;
+
+impl hooks::PgHooks for SearchHook {
+    fn executor_start(
+        &mut self,
+        query_desc: PgBox<pg_sys::QueryDesc>,
+        eflags: i32,
+        prev_hook: fn(query_desc: PgBox<pg_sys::QueryDesc>, eflags: i32) -> HookResult<()>,
+    ) -> HookResult<()> {
+        SearchStateManager::drain();
+        prev_hook(query_desc, eflags)
+    }
+}

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -27,6 +27,7 @@ mod vacuum;
 mod validate;
 
 pub mod datetime;
+pub mod hooks;
 pub mod types;
 pub mod utils;
 

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -71,7 +71,7 @@ pub extern "C" fn amrescan(
     let search_index = get_search_index(index_name);
     let writer_client = WriterGlobal::client();
     let state = search_index
-        .search_state(&writer_client, &search_config, needs_commit())
+        .search_state(&writer_client, &search_config, needs_commit(index_name))
         .unwrap();
 
     let top_docs = state.search(search_index.executor);

--- a/pg_search/src/writer/directory.rs
+++ b/pg_search/src/writer/directory.rs
@@ -225,8 +225,9 @@ impl WriterDirectory {
 impl SearchFs for WriterDirectory {
     fn load_index<T: DeserializeOwned>(&self) -> Result<T, SearchDirectoryError> {
         let SearchIndexConfigFilePath(config_path) = self.search_index_config_file_path(true)?;
-        let serialized_data = fs::read_to_string(config_path)
-            .map_err(|err| SearchDirectoryError::IndexFileRead(self.clone(), err))?;
+
+        let serialized_data = fs::read_to_string(config_path.clone())
+            .map_err(|err| SearchDirectoryError::IndexFileRead(self.clone(), config_path, err))?;
 
         let new_self = serde_json::from_str(&serialized_data)
             .map_err(|err| SearchDirectoryError::IndexDeserialize(self.clone(), err))?;
@@ -301,8 +302,8 @@ pub enum SearchDirectoryError {
     #[error("could not deserialize index at '{0:?}, {1}")]
     IndexDeserialize(WriterDirectory, #[source] serde_json::Error),
 
-    #[error("could not read from file to load index {0:?} at {1}")]
-    IndexFileRead(WriterDirectory, #[source] std::io::Error),
+    #[error("could not read from file to load index {0:?} from {1} at {2}")]
+    IndexFileRead(WriterDirectory, PathBuf, #[source] std::io::Error),
 
     #[error("could not serialize index '{0:?}': {1}")]
     IndexSerialize(WriterDirectory, #[source] serde_json::Error),

--- a/pg_search/src/writer/index.rs
+++ b/pg_search/src/writer/index.rs
@@ -15,12 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::{Handler, IndexError, SearchFs, ServerError, WriterDirectory, WriterRequest};
-use crate::{
-    env::{clear_commit_abort_caches, drop_index_on_commit},
-    index::SearchIndex,
-    schema::SearchDocument,
-};
+use super::{Handler, IndexError, ServerError, WriterDirectory, WriterRequest};
+use crate::{env::drop_index_on_commit, index::SearchIndex, schema::SearchDocument};
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
     HashMap,
@@ -113,7 +109,6 @@ impl Writer {
             std::mem::drop(writer);
         };
 
-        clear_commit_abort_caches()?;
         drop_index_on_commit(directory)?;
 
         Ok(())

--- a/pg_search/src/writer/index.rs
+++ b/pg_search/src/writer/index.rs
@@ -16,7 +16,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::{Handler, IndexError, SearchFs, ServerError, WriterDirectory, WriterRequest};
-use crate::{index::SearchIndex, schema::SearchDocument};
+use crate::{
+    env::{clear_commit_abort_caches, drop_index_on_commit},
+    index::SearchIndex,
+    schema::SearchDocument,
+};
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
     HashMap,
@@ -109,7 +113,9 @@ impl Writer {
             std::mem::drop(writer);
         };
 
-        directory.remove()?;
+        clear_commit_abort_caches()?;
+        drop_index_on_commit(directory)?;
+
         Ok(())
     }
 }

--- a/pg_search/src/writer/mod.rs
+++ b/pg_search/src/writer/mod.rs
@@ -102,6 +102,9 @@ pub enum IndexError {
     #[error(transparent)]
     TantivyValueError(#[from] TantivyValueError),
 
+    #[error(transparent)]
+    TransactionError(#[from] shared::postgres::transaction::TransactionError),
+
     #[error("couldn't remove index files on drop_index: {0}")]
     DeleteDirectory(#[from] SearchDirectoryError),
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I found and fixed several bugs that occur when running queries in the same transaction:

1. Calling `highlight` twice in the same transaction causes an `AliasRequired` error to be thrown on the second call.
2. Creating and then calling `drop_bm25` on an index and then committing causes a "file not found" error to be thrown on commit
3. If you insert into two different BM25-indexed tables within the same transaction, inserts into the second table are not committed to the Tantivy index

## Why

## How

## Tests
