### PR TITLE
ci: Add build provenance attestation

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -22,6 +22,11 @@ concurrency:
   group: publish-paradedb-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
   publish-paradedb-container-image:
     name: Publish ParadeDB Container Image for PostgreSQL ${{ matrix.pg_version }}
@@ -69,6 +74,7 @@ jobs:
 
       # The pg_version-tag Docker tag syntax is necessary for our K8s CloudNativePG operator
       - name: Build and Push Docker Image to Docker Hub
+        id: build-push
         uses: depot/build-push-action@v1
         with:
           context: .
@@ -87,6 +93,13 @@ jobs:
             paradedb/paradedb:${{ steps.version.outputs.tag }}
             paradedb/paradedb:${{ steps.version.outputs.version }}
             paradedb/paradedb:${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: index.docker.io/paradedb/paradedb
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true
 
   publish-paradedb-helm-chart:
     name: Publish ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}

--- a/.github/workflows/publish-pg_lakehouse.yml
+++ b/.github/workflows/publish-pg_lakehouse.yml
@@ -20,6 +20,11 @@ concurrency:
   group: publish-pg_lakehouse-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
   publish-pg_lakehouse:
     name: Publish pg_lakehouse for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
@@ -394,6 +399,13 @@ jobs:
 
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_lakehouse.spec
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            ./pg_lakehouse-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+            ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_lakehouse-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.rpm_os }}.${{ steps.version.outputs.rpm_arch }}.rpm
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - phil/attest # TODO: Remove once done testing
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -9,8 +9,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - phil/attest # TODO: Remove once done testing
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -20,6 +20,11 @@ concurrency:
   group: publish-pg_search-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
@@ -395,6 +400,13 @@ jobs:
 
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+            ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.rpm_os }}.${{ steps.version.outputs.rpm_arch }}.rpm
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This PR uses: https://github.com/actions/attest-build-provenance to sign our builds generated from our CI. This is increasingly required by organizations who follow the SBOM approach to sourcing software.

## Why
^

## How
^

## Tests
See the test run here: https://github.com/paradedb/paradedb/actions/runs/9979512112/job/27578778868?pr=1391