### PR TITLE
(POC)fix: explain query on foreign table 

### DIFF
--- a/pg_lakehouse/src/hooks/explain.rs
+++ b/pg_lakehouse/src/hooks/explain.rs
@@ -1,0 +1,54 @@
+use pgrx::*;
+use std::ffi::CStr;
+
+use crate::PREV_EXPLAIN_ONE_QUERY_HOOK;
+
+use super::query::*;
+
+#[pg_guard]
+pub unsafe extern "C" fn explain_forign_query(
+    query: *mut pg_sys::Query,
+    cursor_options: ::std::os::raw::c_int,
+    into: *mut pg_sys::IntoClause,
+    es: *mut pg_sys::ExplainState,
+    query_string: *const ::std::os::raw::c_char,
+    params: pg_sys::ParamListInfo,
+    query_env: *mut pg_sys::QueryEnvironment,
+) {
+    let rtable = unsafe { (*query).rtable };
+    let query_start_index = unsafe { (*query).stmt_location };
+    let query_len = unsafe { (*query).stmt_len };
+    let query_str = unsafe { CStr::from_ptr(query_string) };
+    let curr_query = get_current_query(query_start_index, query_len, query_str)
+        .expect("should be a valid UTF8 query string");
+    let query_relations = get_query_relations(rtable);
+
+    // fall back to original hook
+    if rtable.is_null()
+        || (*query).commandType != pg_sys::CmdType_CMD_SELECT
+        || !is_duckdb_query(&query_relations)
+        || curr_query.to_lowercase().starts_with("copy")
+        || curr_query.to_lowercase().starts_with("create")
+    {
+        if let Some(prev_hook) = PREV_EXPLAIN_ONE_QUERY_HOOK {
+            prev_hook(
+                query,
+                cursor_options,
+                into,
+                es,
+                query_string,
+                params,
+                query_env,
+            );
+        } else {
+            // TODO: call standard hook, it will be available from PG17
+            //standard_ExplainOneQuery(query, cursor_options, into, es, query_string, params, query_env);
+        }
+        return;
+    }
+
+    let ctx = PgMemoryContexts::CurrentMemoryContext;
+    let label = ctx.pstrdup("DuckDB Scan");
+    let value = ctx.pstrdup(&curr_query);
+    pg_sys::ExplainPropertyText(label, value, es);
+}

--- a/pg_lakehouse/src/hooks/mod.rs
+++ b/pg_lakehouse/src/hooks/mod.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod executor;
+pub mod explain;
 mod query;
 
 use async_std::task::block_on;


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What

This PR is an alternative solution POC for #1298. This PR doesn't need to be merged and feel free to close or modify, it just to demonstrate a solution option. 

## Why

Currently the EXPLAIN on `pg_lakehouse` foreign tables doesn't work well, especially when the query can be fully pushed down to duckdb. More details are described in #1298.

## How

This PR demonstrates using [ExplainOneQuery_hook](https://github.com/taminomara/psql-hooks/blob/master/Detailed.md#ExplainOneQuery_hook) to overwrite EXPLAIN output. `pgrx` currently doesn't support override that hook, so we have to do the overwriting work by ourselves.

This solution can produce correct output for fully pushed down queries, but failed to fall back to the default EXPLAIN behaviour. The reason is that the standard hook [standard_ExplainOneQuery](https://github.com/postgres/postgres/blob/c37267162e889fe783786b9e28d1b65b82365a00/src/include/commands/explain.h#L91) is only available on PG17, `pgrx` hasn't supported it yet. Without it the EXPLAIN fallback doesn't work because we cannot call the default hook provided by postgres.

Another issue is the custom hook only works after the extension is loaded, so the first time run EXPLAIN will still use the standard hook, following EXPLAIN will work because the custom hook is set up after the extension installed.

To fully solve those issues, we might need to wait for PG17 and `pgrx` support for it. Once that are ready, we can implement the trait [pgrx::hooks::PgHooks](https://docs.rs/pgrx/latest/pgrx/hooks/trait.PgHooks.html) by providing our custom `explain_query` hook.

## Tests

```bash
cd pg_lakehouse
cargo pgrx run
```

Run setup queries:

```sql
CREATE EXTENSION pg_lakehouse;
CREATE FOREIGN DATA WRAPPER parquet_wrapper HANDLER parquet_fdw_handler VALIDATOR parquet_fdw_validator;

-- Provide S3 credentials
CREATE SERVER parquet_server FOREIGN DATA WRAPPER parquet_wrapper;

-- Create foreign table with auto schema creation
CREATE FOREIGN TABLE trips ()
SERVER parquet_server
OPTIONS (files 's3://paradedb-benchmarks/yellow_tripdata_2024-01.parquet');

-- Success! Now you can query the remote Parquet file like a regular Postgres table
SELECT COUNT(*) FROM trips;
```

Then run EXPLAIN:

```sql
pg_lakehouse=# explain SELECT COUNT(*) from trips;
                    QUERY PLAN
--------------------------------------------------
 DuckDB Scan: explain SELECT COUNT(*) from trips;
(1 row)
```

EXPLAIN fallback doesn't work :disappointed:

```sql
pg_lakehouse=# explain select 42;
 QUERY PLAN
------------
(0 rows)
```
