### PR TITLE
feat: Introduce functions to generate `_field` configurations

### DIFF
--- a/cargo-paradedb/src/subcommand.rs
+++ b/cargo-paradedb/src/subcommand.rs
@@ -181,13 +181,12 @@ pub async fn bench_eslogs_build_search_index(
     let drop_query =
         format!("CREATE EXTENSION IF NOT EXISTS pg_search; CALL paradedb.drop_bm25('{index}');");
 
-    let text_fields = r#"{"message": {}}"#;
     let create_query = format!(
         "CALL paradedb.create_bm25(
             table_name => '{table}',
             index_name => '{index}',
             key_field => 'id',
-            text_fields => '{text_fields}'
+            text_fields => paradedb.field('message')
         );"
     );
 

--- a/docs/search/full-text/aggregations.mdx
+++ b/docs/search/full-text/aggregations.mdx
@@ -38,7 +38,9 @@ CALL paradedb.create_bm25(
     numeric_fields => paradedb.field('rating'),
     boolean_fields => paradedb.field('in_stock'),
     json_fields => paradedb.field('metadata'),
-    datetime_fields => paradedb.field('created_at') || paradedb.field('last_updated_date') || paradedb.field('latest_available_time')
+    datetime_fields => paradedb.field('created_at') ||
+                       paradedb.field('last_updated_date') ||
+                       paradedb.field('latest_available_time')
 );
 ```
 

--- a/docs/search/full-text/aggregations.mdx
+++ b/docs/search/full-text/aggregations.mdx
@@ -34,11 +34,11 @@ CALL paradedb.create_bm25(
     table_name => 'bm25_search',
     schema_name => 'paradedb',
     key_field => 'id',
-    text_fields => '{"description": {}}',
-    numeric_fields => '{"rating": {}}',
-    boolean_fields => '{"in_stock": {}}',
-    json_fields => '{"metadata": {}}',
-    datetime_fields => '{"created_at": {}, "last_updated_date": {}, "latest_available_time": {}}'
+    text_fields => paradedb.field('description'),
+    numeric_fields => paradedb.field('rating'),
+    boolean_fields => paradedb.field('in_stock'),
+    json_fields => paradedb.field('metadata'),
+    datetime_fields => paradedb.field('created_at') || paradedb.field('last_updated_date') || paradedb.field('latest_available_time')
 );
 ```
 

--- a/docs/search/full-text/bm25.mdx
+++ b/docs/search/full-text/bm25.mdx
@@ -12,16 +12,15 @@ title: Basic Full Text Search
 The `search` function returns rows of a table that match a search query. By default, rows are sorted by relevance.
 
 ```sql
-SELECT *
-FROM <index_name>.search('<query>');
+SELECT * FROM <index_name>.search('<query>');
 ```
 
 <ParamField body="index_name" required>
   The name of the index.
 </ParamField>
 <ParamField body="query" required>
-  The query string. See the query options below for how to construct this
-  string.
+  The [ParadeQL](#paradeql) query string. See the documentation below for how to
+  construct this string.
 </ParamField>
 
 ## ParadeQL
@@ -44,22 +43,6 @@ Phrases containing spaces should be wrapped in double quotes.
 ```sql
 'description:"plastic keyboard"'
 ```
-
-### Slop Operator
-
-The `~` slop operator is used to match phrases separated by words in between. For instance, let's say
-there exists a row with `description` set to "ergonomic metal keyboard." Because words "ergonomic" and "keyboard"
-are separated by one word, the following query would find this row.
-
-```sql
-'"ergonomic keyboard"~1'
-```
-
-<Note>
-  The slop operator is distinct from [fuzzy
-  search](/search/full-text/complex#fuzzy-term), which is used for typo
-  tolerance.
-</Note>
 
 ### Efficient Filtering
 
@@ -92,8 +75,9 @@ Filters can be applied over numeric fields, which improves query times compared 
 
 Use `.` to search over text values nested inside JSON. For instance, the following query would search over a field with values like `{"metadata": {"color": "white"}}`.
 
-````sql
+```sql
 'metadata.color:white'
+```
 
 When dealing with JSON arrays, the array elements are “flattened” so that each element can be searched individually. This means that if a JSON array is encountered, each element in the array is treated as a separate value and indexed accordingly. For example, given the following JSON structure:
 
@@ -103,7 +87,7 @@ When dealing with JSON arrays, the array elements are “flattened” so that ea
     "colors": ["red", "green", "blue"]
   }
 }
-````
+```
 
 The JSON array in the colors field is flattened to emit separate terms for each color. This allows for individual search queries like:
 
@@ -121,6 +105,16 @@ Each of these queries would correctly match the document containing the JSON arr
   SELECT * FROM <index_name>.search('metadata.attributes:4', stable_sort => true)
   ```
 </Note>
+
+### Datetime Fields
+
+Search terms will use the UTC time zone if not specified and need to be in RFC3339 format for the `search` function.
+
+```sql
+-- To demonstrate time zones, these query strings are equivalent
+'created_at:"2023-05-01T09:12:34Z"'
+'created_at:"2023-05-01T04:12:34-05:00"'
+```
 
 ### Boosting
 
@@ -144,6 +138,22 @@ Use parentheses to group terms and control the order of operations.
 ```sql
 '(description:keyboard OR category:toy) AND description:metal'
 ```
+
+### Slop Operator
+
+The `~` slop operator is used to match phrases separated by words in between. For instance, let's say
+there exists a row with `description` set to "ergonomic metal keyboard." Because words "ergonomic" and "keyboard"
+are separated by one word, the following query would find this row.
+
+```sql
+'"ergonomic keyboard"~1'
+```
+
+<Note>
+  The slop operator is distinct from [fuzzy
+  search](/search/full-text/complex#fuzzy-term), which is used for typo
+  tolerance.
+</Note>
 
 ### Set Operator
 

--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -253,11 +253,20 @@ SELECT * FROM search_idx.search(
 
 ### Term
 
-Matches documents containing a specified term, with scoring based on term frequency, inverse document frequency, and field normalization. The term value passed is not tokenized for searching, it is matched directly against terms in the index.
+Matches documents containing a specified term, with scoring based on term frequency, inverse document
+frequency, and field normalization. The term value is treated as a token and is not tokenized further. It is
+matched directly against terms in the index.
 
 ```sql
 SELECT * FROM search_idx.search(
 	query => paradedb.term(field => 'description', value => 'shoes')
+);
+
+SELECT * FROM search_idx.search(
+  query => paradedb.term(
+    field => 'created_at',
+    value => TIMESTAMP '2023-05-01 09:12:34'
+  )
 );
 ```
 

--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -466,8 +466,7 @@ CALL paradedb.create_bm25(
 ## Legacy Syntax
 
 The `paradedb.field` and `paradedb.tokenizer` functions were introduced in `0.8.6`. These functions are
-syntactic sugar for generating `JSONB`. Users that prefer the old syntax can still pass `jsonb` or
-JSON5-formatted strings into `_fields`.
+syntactic sugar for generating `JSONB`. Users that prefer the old syntax can still pass `jsonb` into `_fields`.
 
 ```sql
 -- These two queries are equivalent
@@ -475,7 +474,7 @@ CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{description: {tokenizer: {type: "en_stem"}}}'
+  text_fields => '{"description": {"tokenizer": {"type": "en_stem"}}}'
 );
 
 CALL paradedb.create_bm25(

--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -81,7 +81,7 @@ CALL paradedb.create_bm25(
   Fieldnorms store information about the length of the text field. Must be
   `true` to calculate the BM25 score.
 </ParamField>
-<ParamField body="tokenizer">
+<ParamField body="tokenizer" default="default">
   A `JSONB` produced by `paradedb.tokenizer` which specifies the tokenizer and
   tokenizer configuration options. See [tokenizers](#tokenizers) for a list of
   available tokenizers.

--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -4,268 +4,279 @@ title: Index Creation
 
 ## Overview
 
-A BM25 index must be created over a table before it can be searched.
+A BM25 index must be created over table's columns before they can be searched.
 This index is strongly consistent, which means that new data is immediately searchable across all connections.
 Once an index is created, it automatically stays in sync with the underlying table as the data changes.
 
-## Creating a BM25 Index
+## Basic Usage
 
-The following command creates a BM25 index over a table along with a new schema containing query functions.
-
-```sql
-paradedb.create_bm25(
-  index_name => '<index_name>',
-  table_name => '<table_name>',
-  key_field => '<key_field>'
-  text_fields => '<text_fields>',
-  numeric_fields => '<numeric_fields>',
-  boolean_fields => '<boolean_fields>',
-  json_fields => '<json_fields>',
-  datetime_fields => '<datetime_fields>',
-);
-```
-
-The `index_name` input will become the name of the new schema that is created. Querying that schema makes use
-of an "object.method" syntax, with methods like `search`, `rank`, and `highlight`.
-
-<Accordion title="Example Usage">
+The following code block creates an index called `search_idx` over the `description` and `rating` columns of the `mock_items`
+table, which was created in the [quickstart](/search/quickstart#full-text-search).
 
 ```sql
 CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{
-    description: {tokenizer: {type: "en_stem"}}, category: {}
-  }'
+  text_fields => paradedb.field('description'),
+  numeric_fields => paradedb.field('rating')
 );
 ```
 
-After executing the example above, a new schema called `mock_items` will be created. You can search the `mock_items`
-table with the BM25 index with the associated `search` function:
-
-```sql
-SELECT * FROM search_idx.search('description:shoes');
-```
-
-</Accordion>
-
-Each `_fields` input to `create_bm25()` accepts a [JSON5](https://json5.org)-formatted string. Keys don't need to be quoted, and trailing commas and comments are allowed. JSON5 is backwards-compatible, so standard JSON works too.
-
 <ParamField body="index_name" required>
   The name of the index. The index name can be anything, as long as doesn't
-  conflict with an existing index or schema. A new schema with associated query functions will be created with this name.
+  conflict with an existing index or schema. A new schema with associated query
+  functions will be created with this name.
 </ParamField>
 <ParamField body="table_name" required>
   The name of the table being indexed.
 </ParamField>
 <ParamField body="key_field" required>
-  The name of a column in the table that represents a unique identifier for each record. Usually, this
-  is the same column that is the primary key of the table. In version 0.7.5 and earlier, only integer IDs were supported.
-  From version 0.7.6 onwards, [non-integer IDs are also supported.](https://github.com/paradedb/paradedb/pull/1174).
+  The name of a column in the table that represents a unique identifier for each
+  record. Usually, this is the same column that is the primary key of the table.
+  In version 0.7.5 and earlier, only integer IDs were supported. From version
+  0.7.6 onwards, [non-integer IDs are also
+  supported.](https://github.com/paradedb/paradedb/pull/1174).
 </ParamField>
 <ParamField body="schema_name" default="CURRENT SCHEMA">
   The name of the schema, or namespace, of the table.
 </ParamField>
-<ParamField body="text_fields">
-  A JSON5 string which specifies which text columns should be indexed and how they should be indexed.
-  Keys are the names of columns, and values are config options. Accepts columns of type `varchar`, `text`,
-  `varchar[]`, and `text[]`.
-  <Expandable title="Config Options">
-    <ParamField body="indexed" default={true}>
-      Whether the field is indexed. Must be `true` in order for the field to be tokenized and
-      searchable.
-    </ParamField>
-    <ParamField body="stored" default={true}>
-      Whether the original value of the field is stored.
-    </ParamField>
-    <ParamField body="fast" default={false}>
-      Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
-      Fast fields are also useful for accelerated scoring and filtering.
-    </ParamField>
-    <ParamField body="fieldnorms" default={true}>
-      Fieldnorms store information about the length of the text field. Must be `true` to calculate
-      the BM25 score.
-    </ParamField>
-    <ParamField body="tokenizer">
-      A JSON5 string which specifies the tokenizer and tokenizer configuration options.
-      See [tokenizers](#tokenizers) for a list of available tokenizers.
-    </ParamField>
-    <ParamField body="record" default="position">
-      Describes the amount of information indexed. See [records](#records) for a list of available
-      record types.
-    </ParamField>
-    <ParamField body="normalizer" default="raw">
-      The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](#normalizers) for a list of available normalizers.
-    </ParamField>
 
-  </Expandable>
-</ParamField>
-<ParamField body="numeric_fields">
-  A JSON5 string which specifies which numeric columns should be indexed and how they should be indexed.
-  Keys are the names of columns, and values are config options. Accepts columns of type `int2`, `int4`, `int8`, `oid`, `xid`, `float4`, `float8`, and `numeric`.
-  <Expandable title="Config Options">
-    <ParamField body="indexed" default={true}>
-      Whether the field is indexed. Must be `true` in order for the field to be tokenized and
-      searchable.
-    </ParamField>
-    <ParamField body="stored" default={true}>
-      Whether the original value of the field is stored.
-    </ParamField>
-    <ParamField body="fast" default={true}>
-      Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
-      Fast fields are also useful for accelerated scoring and filtering.
-    </ParamField>
-  </Expandable>
-</ParamField>
-<ParamField body="boolean_fields">
-  A JSON5 string which specifies which boolean columns should be indexed and how they should be indexed.
-  Keys are the names of columns, and values are config options. Accepts columns of type `boolean`.
-  <Expandable title="Config Options">
-    <ParamField body="indexed" default={true}>
-      Whether the field is indexed. Must be `true` in order for the field to be tokenized and
-      searchable.
-    </ParamField>
-    <ParamField body="stored" default={true}>
-      Whether the original value of the field is stored.
-    </ParamField>
-    <ParamField body="fast" default={true}>
-      Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
-      Fast fields are also useful for accelerated scoring and filtering.
-    </ParamField>
-  </Expandable>
-</ParamField>
-<ParamField body="json_fields">
-  A JSON5 string which specifies which JSON columns should be indexed and how they should be indexed.
-  Keys are the names of columns, and values are config options. Accepts columns of type `json` and `jsonb`.
-  Once indexed, search can be performed on nested text fields within JSON values.
-  <Expandable title="Config Options">
-    <ParamField body="indexed" default={true}>
-      Whether the field is indexed. Must be `true` in order for the field to be tokenized and
-      searchable.
-    </ParamField>
-    <ParamField body="stored" default={true}>
-      Whether the original value of the field is stored.
-    </ParamField>
-    <ParamField body="fast" default={false}>
-      Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
-      Fast fields are also useful for accelerated scoring and filtering.
-    </ParamField>
-    <ParamField body="expand_dots" default={true}>
-      If `true`, JSON keys containing a `.` will be expanded. For instance, if `expand_dots` is `true`,
-      `{"metadata.color": "red"}` will be indexed as if it was `{"metadata": {"color": "red"}}`.
-    </ParamField>
-    <ParamField body="tokenizer" default="default">
-      The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
-    </ParamField>
-    <ParamField body="record" default="position">
-      Describes the amount of information indexed. See [records](#records) for a list of available
-      record types.
-    </ParamField>
-    <ParamField body="normalizer" default="raw">
-      The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
-      [normalizers](#normalizers) for a list of available normalizers.
-    </ParamField>
-  </Expandable>
-</ParamField>
-<ParamField body="datetime_fields">
-  A JSON5 string which specifies which datetime columns should be indexed and how they should be indexed.
-  Keys are the names of columns, and values are config options. Accepts columns of type `date`, `timestamp`,
-  `timestamptz`, `time`, and `timetz`.
-  Search terms will use the UTC time zone if not specified and need to be in RFC3339 format for the `search` function.
+This example query will create a schema called `search_idx`, which contains a `search` function.
 
 ```sql
--- To demonstrate time zones, all of these queries are equivalent
-SELECT * FROM bm25_search.search('created_at:"2023-05-01T09:12:34Z"');
-SELECT * FROM bm25_search.search('created_at:"2023-05-01T04:12:34-05:00"');
-SELECT * FROM bm25_search.search(
-  query => paradedb.term(
-    field => 'created_at',
-    value => TIMESTAMP '2023-05-01 09:12:34'
-  )
-);
-SELECT * FROM bm25_search.search(
-  query => paradedb.term(
-    field => 'created_at',
-    value => TIMESTAMP WITH TIME ZONE '2023-05-01 04:12:34 EST'
-  )
-);
+SELECT * FROM search_idx.search('description:keyboard');
 ```
 
-  <Expandable title="Config Options">
-    <ParamField body="indexed" default={true}>
-      Whether the field is indexed. Must be `true` in order for the field to be tokenized and
-      searchable.
-    </ParamField>
-    <ParamField body="stored" default={true}>
-      Whether the original value of the field is stored.
-    </ParamField>
-    <ParamField body="fast" default={true}>
-      Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
-      Fast fields are also useful for accelerated scoring and filtering.
-    </ParamField>
-  </Expandable>
-</ParamField>
+## Field Types
 
-## Deleting a BM25 Index
+### Text Fields
 
-The following command deletes a BM25 index, as well as its associated schema and query functions:
-
-```sql
-CALL paradedb.drop_bm25('<index_name>');
-```
-
-<Accordion title="Example Usage">
-
-```sql
-CALL paradedb.drop_bm25('mock_items');
-```
-
-</Accordion>
-
-<ParamField body="index_name" required>
-  The name of the index you wish to delete.
-</ParamField>
-
-## Partial BM25 Index
-
-The following code block demonstrates how to pass predicates to `create_bm25`
-to construct a [partial index](https://www.postgresql.org/docs/current/indexes-partial.html). Partial indexes
-are useful for reducing index size on disk and improving update speeds over non-indexed rows.
+Columns of type `VARCHAR`, `TEXT`, `UUID`, `VARCHAR[]`, and `TEXT[]` can be indexed as text fields.
 
 ```sql
 CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{
-    description: {tokenizer: {type: "en_stem"}}, category: {}
-  }',
-  predicates => 'category = ''Electronics'' AND rating > 2'
+  text_fields => paradedb.field('description', indexed => true)
 );
 ```
 
-## Tokenizers
+`paradedb.field` accepts the following configuration options for text fields:
+
+<ParamField body="indexed" default={true}>
+  Whether the field is indexed. Must be `true` in order for the field to be
+  tokenized and searchable.
+</ParamField>
+<ParamField body="stored" default={true}>
+  Whether the original value of the field is stored.
+</ParamField>
+<ParamField body="fast" default={false}>
+  Fast fields can be random-accessed rapidly. Fields used for aggregation must
+  have `fast` set to `true`. Fast fields are also useful for accelerated scoring
+  and filtering.
+</ParamField>
+<ParamField body="fieldnorms" default={true}>
+  Fieldnorms store information about the length of the text field. Must be
+  `true` to calculate the BM25 score.
+</ParamField>
+<ParamField body="tokenizer">
+  A `JSONB` produced by `paradedb.tokenizer` which specifies the tokenizer and
+  tokenizer configuration options. See [tokenizers](#tokenizers) for a list of
+  available tokenizers.
+</ParamField>
+<ParamField body="record" default="position">
+  Describes the amount of information indexed. See [record](#record) for a list
+  of available record types.
+</ParamField>
+<ParamField body="normalizer" default="raw">
+  The name of the tokenizer used for fast fields. This field is ignored unless
+  `fast=true`. See [normalizers](#normalizers) for a list of available
+  normalizers.
+</ParamField>
+
+### Numeric Fields
+
+Columns of type `SMALLINT`, `INTEGER`, `BIGINT`, `OID`, `REAL`, `DOUBLE PRECISION`, and `NUMERIC` can be indexed
+as `numeric_fields`. The main reason to index a numeric field is if it is used for filtering
+or aggregations as part of the search query.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  numeric_fields => paradedb.field('rating', indexed => true)
+);
+```
+
+`paradedb.field` accepts the following configuration options numeric fields:
+
+<ParamField body="indexed" default={true}>
+  Whether the field is indexed. Must be `true` in order for the field to be
+  tokenized and searchable.
+</ParamField>
+<ParamField body="stored" default={true}>
+  Whether the original value of the field is stored.
+</ParamField>
+<ParamField body="fast" default={true}>
+  Fast fields can be random-accessed rapidly. Fields used for aggregation must
+  have `fast` set to `true`. Fast fields are also useful for accelerated scoring
+  and filtering.
+</ParamField>
+
+### Boolean Fields
+
+Columns of type `BOOLEAN` can be indexed as `boolean_fields`. Indexing a boolean field is useful if
+it is used for filtering as part of the search query.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  boolean_fields => paradedb.field('in_stock')
+);
+```
+
+`paradedb.field` accepts several configuration options for boolean fields:
+
+<ParamField body="indexed" default={true}>
+  Whether the field is indexed. Must be `true` in order for the field to be
+  tokenized and searchable.
+</ParamField>
+<ParamField body="stored" default={true}>
+  Whether the original value of the field is stored.
+</ParamField>
+<ParamField body="fast" default={true}>
+  Fast fields can be random-accessed rapidly. Fields used for aggregation must
+  have `fast` set to `true`. Fast fields are also useful for accelerated scoring
+  and filtering.
+</ParamField>
+
+### JSON Fields
+
+Columns of type `JSON` and `JSONB` can be indexed as `json_fields`. Once indexed, search can be
+performed on nested text fields within JSON values.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  json_fields => paradedb.field('metadata')
+);
+```
+
+`paradedb.field` accepts several configuration options for JSON fields:
+
+<ParamField body="indexed" default={true}>
+  Whether the field is indexed. Must be `true` in order for the field to be tokenized and
+  searchable.
+</ParamField>
+<ParamField body="stored" default={true}>
+  Whether the original value of the field is stored.
+</ParamField>
+<ParamField body="fast" default={false}>
+  Fast fields can be random-accessed rapidly. Fields used for aggregation must have `fast` set to `true`.
+  Fast fields are also useful for accelerated scoring and filtering.
+</ParamField>
+<ParamField body="expand_dots" default={true}>
+  If `true`, JSON keys containing a `.` will be expanded. For instance, if `expand_dots` is `true`,
+  `{"metadata.color": "red"}` will be indexed as if it was `{"metadata": {"color": "red"}}`.
+</ParamField>
+<ParamField body="tokenizer" default="default">
+  The name of the tokenizer. See [tokenizers](#tokenizers) for a list of available tokenizers.
+</ParamField>
+<ParamField body="record" default="position">
+  Describes the amount of information indexed. See [record](#record) for a list of available
+  record types.
+</ParamField>
+<ParamField body="normalizer" default="raw">
+  The name of the tokenizer used for fast fields. This field is ignored unless `fast=true`. See
+  [normalizers](#normalizers) for a list of available normalizers.
+</ParamField>
+
+### Datetime Fields
+
+Columns of type `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, `TIME`, and `TIMETZ` can be indexed as `datetime_fields`.
+Indexing a datetime field is useful if it is used for filtering as part of the search query.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  datetime_fields => paradedb.field('created_at')
+);
+```
+
+`paradedb.field` accepts several configuration options for boolean fields:
+
+<ParamField body="indexed" default={true}>
+  Whether the field is indexed. Must be `true` in order for the field to be
+  tokenized and searchable.
+</ParamField>
+<ParamField body="stored" default={true}>
+  Whether the original value of the field is stored.
+</ParamField>
+<ParamField body="fast" default={true}>
+  Fast fields can be random-accessed rapidly. Fields used for aggregation must
+  have `fast` set to `true`. Fast fields are also useful for accelerated scoring
+  and filtering.
+</ParamField>
+
+## Multiple Fields
+
+The `||` operator can be used to index multiple fields.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => paradedb.field('description') || paradedb.field('category')
+);
+```
+
+## Configuration Options
+
+### Tokenizers
 
 Tokenizers are responsible for breaking down text fields into smaller, searchable components called tokens.
 Once a field is tokenized, all search queries against that field are automatically tokenized the same way.
 
-The following code block demonstrates the syntax for specifying a tokenizer for each text field.
+The following code block demonstrates the syntax for specifying a tokenizer for a text field.
 
 ```sql
 CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{
-    description: {tokenizer: {type: "stem", language: "English"}},
-    category: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 5, prefix_only: false}},
-  }'
+  text_fields => paradedb.field(
+    name => 'description',
+    tokenizer => paradedb.tokenizer('en_stem')
+  )
 );
 ```
 
-The following tokenizer `type` options are accepted:
+Some tokenizers like the `stem` and `ngram` tokenizer accept configuration options. They can be passed to the
+`paradedb.tokenizer` function.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => paradedb.field(
+    name => 'description',
+    tokenizer => paradedb.tokenizer('stem', language => 'French')
+  )
+);
+```
+
+The following tokenizer names are accepted by the `paradedb.tokenizer` function.
 
 <ParamField body="default">
   Chops the text on according to whitespace and punctuation, removes tokens that
@@ -328,10 +339,10 @@ The following tokenizer `type` options are accepted:
 
 </ParamField>
 
-## Fast Fields
+### Fast Fields
 
-Fast fields are stored in a column-oriented fashion. Fast fields are necessary to
-perform [aggregations/faceting](/search/full-text/aggregations). They can also improve the query times of [filters](/search/full-text/bm25#efficient-filtering)
+A field that is indexed as `fast` is stored in a column-oriented fashion. Fast fields are necessary for
+[aggregations/faceting](/search/full-text/aggregations). They can also improve the query times of [filters](/search/full-text/bm25#efficient-filtering)
 and BM25 scoring.
 
 The following code block demonstrates how to specify a fast field.
@@ -341,12 +352,11 @@ CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{description: {}}',
-  numeric_fields => '{rating: {fast: true}}'
+  numeric_fields => paradedb.field('rating', fast => true)
 );
 ```
 
-## Normalizers
+### Normalizers
 
 Normalizers specify how text and JSON fast fields should be processed. This option is ignored over any
 other type of field.
@@ -356,7 +366,7 @@ CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{description: {fast: true, normalizer: "lowercase"}}'
+  text_fields => paradedb.field('category', fast => true, normalizer => 'raw')
 );
 ```
 
@@ -368,17 +378,16 @@ CALL paradedb.create_bm25(
   bytes.
 </ParamField>
 
-## Records
+### Record
 
-Records specify how much information is recorded with an indexed field. The following code
-block demonstrates how to configure records.
+The `record` option specifies how much information is recorded with an indexed field.
 
 ```sql
 CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
-  text_fields => '{description: {record: "position"}}'
+  text_fields => paradedb.field('description', record => 'position')
 );
 ```
 
@@ -392,7 +401,33 @@ CALL paradedb.create_bm25(
   to run a phrase query.
 </ParamField>
 
-## Getting Info on a BM25 Index
+## Deleting a BM25 Index
+
+The following command deletes a BM25 index, as well as its associated schema and query functions:
+
+```sql
+CALL paradedb.drop_bm25(index_name => '<index_name>');
+```
+
+<Accordion title="Example Usage">
+
+```sql
+CALL paradedb.drop_bm25(
+  index_name => 'search_idx',
+  schema_name => 'public'
+);
+```
+
+</Accordion>
+
+<ParamField body="index_name" required>
+  The name of the index you wish to delete.
+</ParamField>
+<ParamField body="schema_name" default="CURRENT SCHEMA">
+  The name of the schema that the index was created in.
+</ParamField>
+
+## Inspecting a BM25 Index
 
 The `schema` function returns a table with information about the index schema.
 
@@ -411,3 +446,45 @@ SELECT * FROM search_idx.schema();
 <ParamField body="index_name" required>
   The name of the index.
 </ParamField>
+
+## Partial BM25 Index
+
+The following code block demonstrates how to pass predicates to `create_bm25`
+to construct a [partial index](https://www.postgresql.org/docs/current/indexes-partial.html). Partial
+indexes are useful for reducing index size on disk and improving update speeds over non-indexed rows.
+
+```sql
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => paradedb.field('description'),
+  predicates => 'category = ''Electronics'' AND rating > 2'
+);
+```
+
+## Legacy Syntax
+
+The `paradedb.field` and `paradedb.tokenizer` functions were introduced in `0.8.6`. These functions are
+syntactic sugar for generating `JSONB`. Users that prefer the old syntax can still pass `jsonb` or
+JSON5-formatted strings into `_fields`.
+
+```sql
+-- These two queries are equivalent
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => '{description: {tokenizer: {type: "en_stem"}}}'
+);
+
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => paradedb.field(
+    'description',
+    tokenizer => paradedb.tokenizer('en_stem')
+  )
+);
+```

--- a/docs/search/quickstart.mdx
+++ b/docs/search/quickstart.mdx
@@ -45,7 +45,7 @@ CALL paradedb.create_bm25(
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category')
         numeric_fields => '{rating: {}}'
 );
 ```
@@ -116,7 +116,7 @@ CALL paradedb.create_bm25(
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}, category: {}}'
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false)) || paradedb.field('category')
 );
 
 SELECT description, rating, category

--- a/docs/search/quickstart.mdx
+++ b/docs/search/quickstart.mdx
@@ -45,14 +45,17 @@ CALL paradedb.create_bm25(
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category')
-        numeric_fields => '{rating: {}}'
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) ||
+                       paradedb.field('category')
+        numeric_fields => paradedb.field('rating')
 );
 ```
 
+<Note>
 Note the mandatory `key_field` option. Every BM25 index needs a `key_field`, which should
 be the name of a column that will function as a row's unique identifier within the index. Usually, the `key_field`
 can just be the name of your table's primary key column.
+</Note>
 
 We're now ready to execute a full-text search. We'll look for rows with a `rating` greater than `2` where `description` matches `shoes`
 or `category` matches `electronics`.
@@ -116,7 +119,8 @@ CALL paradedb.create_bm25(
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false)) || paradedb.field('category')
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false)) ||
+                       paradedb.field('category')
 );
 
 SELECT description, rating, category

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -114,12 +114,12 @@ To index the table, use the following SQL command:
 
 ```sql
 CALL paradedb.create_bm25(
-        index_name => 'search_idx',
-        schema_name => 'public',
-        table_name => 'mock_items',
-        key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}',
-        numeric_fields => '{rating: {}}'
+  index_name => 'search_idx',
+  schema_name => 'public',
+  table_name => 'mock_items',
+  key_field => 'id',
+  text_fields => paradedb.field('description') || paradedb.field('category'),
+  numeric_fields => paradedb.field('rating')
 );
 ```
 

--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -47,3 +47,37 @@ pub fn tokenizer(
 
     JsonB(json!(config))
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_field() {
+        let expected = json!({
+            "field1": {
+                "indexed": true,
+                "stored": false,
+                "fast": true,
+                "fieldnorms": false,
+                "record": "position",
+                "expand_dots": true,
+                "tokenizer": {"type": "ngram", "min_gram": 4, "max_gram": 4, "prefix_only": false},
+                "normalizer": "lowercase"
+            }
+        });
+
+        let JsonB(actual) = field(
+            "field1",
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(false),
+            Some("position".to_string()),
+            Some(true),
+            Some(tokenizer("ngram", Some(4), Some(4), Some(false), None)),
+            Some("lowercase".to_string()),
+        );
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -1,0 +1,49 @@
+use pgrx::*;
+use serde_json::{json, Map, Value};
+
+#[pg_extern(immutable, parallel_safe)]
+#[allow(clippy::too_many_arguments)]
+pub fn field(
+    name: &str,
+    indexed: default!(Option<bool>, "NULL"),
+    stored: default!(Option<bool>, "NULL"),
+    fast: default!(Option<bool>, "NULL"),
+    fieldnorms: default!(Option<bool>, "NULL"),
+    record: default!(Option<String>, "NULL"),
+    expand_dots: default!(Option<bool>, "NULL"),
+    tokenizer: default!(Option<JsonB>, "NULL"),
+    normalizer: default!(Option<String>, "NULL"),
+) -> JsonB {
+    let mut config = Map::new();
+
+    indexed.map(|v| config.insert("indexed".to_string(), Value::Bool(v)));
+    stored.map(|v| config.insert("stored".to_string(), Value::Bool(v)));
+    fast.map(|v| config.insert("fast".to_string(), Value::Bool(v)));
+    fieldnorms.map(|v| config.insert("fieldnorms".to_string(), Value::Bool(v)));
+    record.map(|v| config.insert("record".to_string(), Value::String(v)));
+    expand_dots.map(|v| config.insert("expand_dots".to_string(), Value::Bool(v)));
+    tokenizer.map(|v| config.insert("tokenizer".to_string(), v.0));
+    normalizer.map(|v| config.insert("normalizer".to_string(), Value::String(v)));
+
+    JsonB(json!({ name: config }))
+}
+
+#[pg_extern(immutable, parallel_safe)]
+pub fn tokenizer(
+    name: &str,
+    min_gram: default!(Option<i32>, "NULL"),
+    max_gram: default!(Option<i32>, "NULL"),
+    prefix_only: default!(Option<bool>, "NULL"),
+    language: default!(Option<String>, "NULL"),
+) -> JsonB {
+    let mut config = Map::new();
+
+    config.insert("type".to_string(), Value::String(name.to_string()));
+
+    min_gram.map(|v| config.insert("min_gram".to_string(), Value::Number(v.into())));
+    max_gram.map(|v| config.insert("max_gram".to_string(), Value::Number(v.into())));
+    prefix_only.map(|v| config.insert("prefix_only".to_string(), Value::Bool(v)));
+    language.map(|v| config.insert("language".to_string(), Value::String(v)));
+
+    JsonB(json!(config))
+}

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod config;
 mod index;
 mod operator;
 mod search;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -33,54 +33,9 @@ const MAX_INDEX_NAME_LENGTH: usize = 52;
 #[pg_extern(
     sql = "
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
-    index_name text,
-    table_name text,
-    key_field text,
-    schema_name text DEFAULT CURRENT_SCHEMA,
-    text_fields text DEFAULT '{}',
-    numeric_fields text DEFAULT '{}',
-    boolean_fields text DEFAULT '{}',
-    json_fields text DEFAULT '{}',
-    datetime_fields text DEFAULT '{}',
-    predicates text DEFAULT ''
-)
-LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
-",
-    name = "create_bm25"
-)]
-#[allow(clippy::too_many_arguments)]
-fn create_bm25_str(
-    index_name: &str,
-    table_name: &str,
-    key_field: &str,
-    schema_name: &str,
-    text_fields: &str,
-    numeric_fields: &str,
-    boolean_fields: &str,
-    json_fields: &str,
-    datetime_fields: &str,
-    predicates: &str,
-) -> Result<()> {
-    create_bm25_impl(
-        index_name,
-        table_name,
-        key_field,
-        schema_name,
-        text_fields,
-        numeric_fields,
-        boolean_fields,
-        json_fields,
-        datetime_fields,
-        predicates,
-    )
-}
-
-#[pg_extern(
-    sql = "
-CREATE OR REPLACE PROCEDURE paradedb.create_bm25(
-    index_name text,
-    table_name text,
-    key_field text,
+    index_name text DEFAULT '',
+    table_name text DEFAULT '',
+    key_field text DEFAULT '',
     schema_name text DEFAULT CURRENT_SCHEMA,
     text_fields jsonb DEFAULT '{}',
     numeric_fields jsonb DEFAULT '{}',

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -168,7 +168,7 @@ fn quoted_table_name(mut conn: PgConnection) {
     	index_name => 'activity',
     	table_name => 'Activity',
     	key_field => 'key',
-    	text_fields => '{"name": {}}'
+    	text_fields => paradedb.field('name')
     )"#
     .execute(&mut conn);
     let row: (i32, String, i32) =
@@ -192,7 +192,7 @@ fn text_arrays(mut conn: PgConnection) {
     	index_name => 'example_table',
     	table_name => 'example_table',
     	key_field => 'id',
-    	text_fields => '{text_array: {}, varchar_array: {}}'
+    	text_fields => paradedb.field('text_array') || paradedb.field('varchar_array')
     )"#
     .execute(&mut conn);
     let row: (i32,) =
@@ -238,7 +238,7 @@ fn uuid(mut conn: PgConnection) {
     	index_name => 'uuid_table',
         table_name => 'uuid_table',
         key_field => 'id',
-        text_fields => '{"some_text": {}}'
+        text_fields => paradedb.field('some_text')
     );
     
     CALL paradedb.drop_bm25('uuid_table');"#
@@ -249,7 +249,7 @@ fn uuid(mut conn: PgConnection) {
         index_name => 'uuid_table',
         table_name => 'uuid_table',
         key_field => 'id',
-        text_fields => '{"some_text": {}, "random_uuid": {}}'
+        text_fields => paradedb.field('some_text') || paradedb.field('random_uuid')
     )"#
     .execute(&mut conn);
 
@@ -607,7 +607,7 @@ fn explain(mut conn: PgConnection) {
             schema_name => 'public',
             table_name => 'mock_items',
             key_field => 'id',
-            text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}'
+            text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category')
     )"
     .execute(&mut conn);
 
@@ -634,7 +634,7 @@ fn update_non_indexed_column(mut conn: PgConnection) -> Result<()> {
             schema_name => 'public',
             table_name => 'mock_items',
             key_field => 'id',
-            text_fields => '{description: {tokenizer: {type: \"en_stem\"}}}'
+            text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem'))
     )"
     .execute(&mut conn);
 
@@ -821,8 +821,8 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics'''
     );"
     .execute_result(&mut conn);
@@ -897,8 +897,8 @@ fn bm25_partial_index_explain(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_explain',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics'''
     );"
     .execute_result(&mut conn);
@@ -926,8 +926,8 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_hybrid',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics'''
     );"
     .execute_result(&mut conn);
@@ -1016,8 +1016,8 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'city = ''Electronics'''
     );"
     .execute_result(&mut conn);
@@ -1029,8 +1029,8 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''123''::INTEGER'
     );"
     .execute_result(&mut conn);
@@ -1042,8 +1042,8 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics''' 
     );"
     .execute_result(&mut conn);
@@ -1054,8 +1054,8 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics'''
     );"
     .execute_result(&mut conn);
@@ -1073,8 +1073,8 @@ fn bm25_partial_index_alter_and_drop(mut conn: PgConnection) {
         schema_name => 'paradedb',
         table_name => 'test_partial_index',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: \"en_stem\"}}, category: {}}',
-        numeric_fields => '{rating: {}}',
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating'),
         predicates => 'category = ''Electronics'''
     );"
     .execute(&mut conn);
@@ -1125,7 +1125,7 @@ fn high_limit_rows(mut conn: PgConnection) {
         schema_name => 'public', 
         index_name => 'large_series', 
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     );"
     .execute(&mut conn);
 

--- a/pg_search/tests/icu.rs
+++ b/pg_search/tests/icu.rs
@@ -32,11 +32,9 @@ fn test_icu_arabic_tokenizer(mut conn: PgConnection) {
 	    index_name => 'idx_arabic',
 	    table_name => 'icu_arabic_posts',
 	    key_field => 'id',
-	    text_fields => '{
-            author:  {tokenizer: {type: "icu"},},
-            title:   {tokenizer: {type: "icu"},},
-            message: {tokenizer: {type: "icu"},}
-        }'
+	    text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('icu')) || 
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('icu')) ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('icu'))
     )"#
     .execute(&mut conn);
 
@@ -64,11 +62,9 @@ fn test_icu_amharic_tokenizer(mut conn: PgConnection) {
 	    index_name => 'idx_amharic',
 	    table_name => 'icu_amharic_posts',
 	    key_field => 'id',
-	    text_fields => '{
-            author:  {tokenizer: {type: "icu"},},
-            title:   {tokenizer: {type: "icu"},},
-            message: {tokenizer: {type: "icu"},}
-        }'
+	    text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('icu')) || 
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('icu')) ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('icu'))
     )"#
     .execute(&mut conn);
 
@@ -96,11 +92,9 @@ fn test_icu_greek_tokenizer(mut conn: PgConnection) {
 	    index_name => 'idx_greek',
 	    table_name => 'icu_greek_posts',
 	    key_field => 'id',
-	    text_fields => '{
-            author:  {tokenizer: {type: "icu"},},
-            title:   {tokenizer: {type: "icu"},},
-            message: {tokenizer: {type: "icu"},}
-        }'
+	    text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('icu')) || 
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('icu')) ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('icu'))
     )"#
     .execute(&mut conn);
 
@@ -128,11 +122,9 @@ fn test_icu_czech_tokenizer(mut conn: PgConnection) {
 	    index_name => 'idx_czech',
 	    table_name => 'icu_czech_posts',
 	    key_field => 'id',
-	    text_fields => '{
-            author:  {tokenizer: {type: "icu"},},
-            title:   {tokenizer: {type: "icu"},},
-            message: {tokenizer: {type: "icu"},}
-        }'
+	    text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('icu')) || 
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('icu')) ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('icu'))
     )"#
     .execute(&mut conn);
 
@@ -160,7 +152,7 @@ fn test_icu_czech_content_tokenizer(mut conn: PgConnection) {
 	    index_name => 'idx_czech_content',
 	    table_name => 'icu_czech_posts',
 	    key_field => 'id',
-	    text_fields => '{message: {tokenizer: {type: "icu"}}}'
+	    text_fields => paradedb.field('message', tokenizer => paradedb.tokenizer('icu'))
     )"#
     .execute(&mut conn);
 

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -39,7 +39,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     .execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with no key_field"),
-        Err(err) => assert!(err.to_string().contains("no key_field parameter")),
+        Err(err) => assert!(err.to_string().contains("not exist")),
     };
 
     match "CALL paradedb.create_bm25(
@@ -50,7 +50,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     .execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with no fields"),
-        Err(err) => assert!(err.to_string().contains("specified"), "{}", fmt_err(err)),
+        Err(err) => assert!(err.to_string().contains("not unique")),
     };
 
     match "CALL paradedb.create_bm25(

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -39,7 +39,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     .execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with no key_field"),
-        Err(err) => assert!(err.to_string().contains("not exist")),
+        Err(err) => assert!(err.to_string().contains("no key_field parameter")),
     };
 
     match "CALL paradedb.create_bm25(
@@ -50,7 +50,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     .execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with no fields"),
-        Err(err) => assert!(err.to_string().contains("not unique")),
+        Err(err) => assert!(err.to_string().contains("specified"), "{}", fmt_err(err)),
     };
 
     match "CALL paradedb.create_bm25(
@@ -76,7 +76,7 @@ fn prevent_duplicate(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}')"
+        text_fields => paradedb.field('description'))"
         .execute(&mut conn);
 
     match "CALL paradedb.create_bm25(
@@ -84,7 +84,7 @@ fn prevent_duplicate(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}')"
+        text_fields => paradedb.field('description'))"
         .execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with relation already exists"),
@@ -121,7 +121,7 @@ async fn drop_column(mut conn: PgConnection) {
         schema_name => 'public',
         table_name => 'test_table',
         key_field => 'id',
-        text_fields => '{fulltext: {}}'
+        text_fields => paradedb.field('fulltext')
     );
 
     CALL paradedb.drop_bm25('test_index');
@@ -135,7 +135,7 @@ async fn drop_column(mut conn: PgConnection) {
         schema_name => 'public',
         table_name => 'test_table',
         key_field => 'id',
-        text_fields => '{fulltext: {}}'
+        text_fields => paradedb.field('fulltext')
     );
     "#
     .execute(&mut conn);
@@ -158,7 +158,7 @@ fn default_text_field(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    text_fields => '{description: {}}')"
+	    text_fields => paradedb.field('description'))"
         .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
@@ -180,10 +180,7 @@ fn text_field_with_options(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    text_fields => '{description: {
-	        fast: true, "tokenizer": { type: "en_stem" },
-	        record: "freq", normalizer: "raw"
-	     }}'
+	    text_fields => paradedb.field('description', fast => true, record => 'freq', normalizer => 'raw', tokenizer => paradedb.tokenizer('en_stem'))
     )"#
     .execute(&mut conn);
 
@@ -206,9 +203,8 @@ fn multiple_text_fields(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    text_fields => '{
-	        "description": {fast: true, tokenizer: { type: "en_stem" }, record: "freq", normalizer: "raw"},
-	        category: {}}'
+	    text_fields => paradedb.field('description', fast => true, record => 'freq', normalizer => 'raw', tokenizer => paradedb.tokenizer('en_stem')) ||
+                       paradedb.field('category')
     )"#
     .execute(&mut conn);
 
@@ -231,7 +227,7 @@ fn default_numeric_field(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    numeric_fields => '{rating: {}}'
+	    numeric_fields => paradedb.field('rating')
     );"
     .execute(&mut conn);
 
@@ -253,7 +249,7 @@ fn numeric_field_with_options(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    numeric_fields => '{rating: {fast: false}}'
+	    numeric_fields => paradedb.field('rating', fast => false)
     )"
     .execute(&mut conn);
 
@@ -275,7 +271,7 @@ fn default_boolean_field(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    boolean_fields => '{in_stock: {}}'
+	    boolean_fields => paradedb.field('in_stock')
     )"
     .execute(&mut conn);
 
@@ -297,7 +293,7 @@ fn boolean_field_with_options(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    boolean_fields => '{in_stock: {fast: false}}'
+	    boolean_fields => paradedb.field('in_stock', fast => false)
     )"
     .execute(&mut conn);
 
@@ -319,7 +315,7 @@ fn default_json_field(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    json_fields => '{metadata: {}}'
+	    json_fields => paradedb.field('metadata')
     )"
     .execute(&mut conn);
 
@@ -341,9 +337,7 @@ fn json_field_with_options(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    json_fields => '{
-	        metadata: {fast: true, expand_dots: false, tokenizer: { type: "raw" }, normalizer: "raw"}
-	    }'
+	    json_fields => paradedb.field('metadata', fast => true, expand_dots => false, tokenizer => paradedb.tokenizer('raw'), normalizer => 'raw')
     )"#
     .execute(&mut conn);
 
@@ -365,7 +359,7 @@ fn default_datetime_field(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        datetime_fields => '{created_at: {}, last_updated_date: {}}'
+        datetime_fields => paradedb.field('created_at') || paradedb.field('last_updated_date')
     )"
     .execute(&mut conn);
 
@@ -388,10 +382,7 @@ fn datetime_field_with_options(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        datetime_fields => '{
-            created_at: {fast: true},
-            last_updated_date: {fast: false}
-        }'
+        datetime_fields => paradedb.field('created_at', fast => true) || paradedb.field('last_updated_date', fast => false)
     )"#
     .execute(&mut conn);
 
@@ -413,10 +404,10 @@ fn multiple_fields(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    text_fields => '{description: {}, category: {}}',
-	    numeric_fields => '{rating: {}}',
-	    boolean_fields => '{in_stock: {}}',
-	    json_fields => '{metadata: {}}'
+	    text_fields => paradedb.field('description') || paradedb.field('category'),
+	    numeric_fields => paradedb.field('rating'),
+	    boolean_fields => paradedb.field('in_stock'),
+	    json_fields => paradedb.field('metadata')
     )"
     .execute(&mut conn);
 
@@ -445,10 +436,10 @@ fn null_values(mut conn: PgConnection) {
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
-	    text_fields => '{description: {}, category: {}}',
-	    numeric_fields => '{rating: {}}',
-	    boolean_fields => '{in_stock: {}}',
-	    json_fields => '{metadata: {}}'
+	    text_fields => paradedb.field('description') || paradedb.field('category'),
+	    numeric_fields => paradedb.field('rating'),
+	    boolean_fields => paradedb.field('in_stock'),
+	    json_fields => paradedb.field('metadata')
     )"
     .execute(&mut conn);
 
@@ -479,7 +470,7 @@ fn null_key_field_build(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )".execute_result(&mut conn)
     {
         Ok(_) => panic!("should fail with null key_field"),
@@ -501,7 +492,7 @@ fn null_key_field_insert(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
 
@@ -527,7 +518,7 @@ fn column_name_camelcase(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'IdName',
-        text_fields => '{ColumnName: {}}'
+        text_fields => paradedb.field('ColumnName')
     )"
     .execute(&mut conn);
 
@@ -547,7 +538,7 @@ fn multi_index_insert_in_transaction(mut conn: PgConnection) {
         table_name => 'index_config1',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
     "CALL paradedb.create_bm25(
@@ -555,7 +546,7 @@ fn multi_index_insert_in_transaction(mut conn: PgConnection) {
         table_name => 'index_config2',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
     "BEGIN".execute(&mut conn);
@@ -582,7 +573,7 @@ fn index_name_too_long(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute_result(&mut conn) {
         Ok(_) => panic!("should fail with index name too long"),

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -44,7 +44,7 @@ fn boolean_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -123,7 +123,7 @@ fn uuid_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -267,7 +267,7 @@ fn i64_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -375,7 +375,7 @@ fn i32_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -447,7 +447,7 @@ fn i16_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -519,7 +519,7 @@ fn f32_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -591,7 +591,7 @@ fn f64_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -663,7 +663,7 @@ fn numeric_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -735,7 +735,7 @@ fn string_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -825,7 +825,7 @@ fn date_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -897,7 +897,7 @@ fn time_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -969,7 +969,7 @@ fn timestamp_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -1041,7 +1041,7 @@ fn timestamptz_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);
@@ -1149,7 +1149,7 @@ fn timetz_key(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{value: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}}'
+        text_fields => paradedb.field('value', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false))
     );
     "#
     .execute(&mut conn);

--- a/pg_search/tests/lindera.rs
+++ b/pg_search/tests/lindera.rs
@@ -42,11 +42,9 @@ async fn lindera_korean_tokenizer(mut conn: PgConnection) {
     	index_name => 'korean',
     	table_name => 'korean',
     	key_field => 'id',
-        text_fields => '{
-            author: {tokenizer: {type: "korean_lindera"}, record: "position"},
-            title: {tokenizer: {type: "korean_lindera"}, record: "position"},
-            message: {tokenizer: {type: "korean_lindera"}, record: "position"}
-        }'
+        text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('korean_lindera'), record => 'position') ||
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('korean_lindera'), record => 'position') ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('korean_lindera'), record => 'position')
     )"#
     .execute(&mut conn);
 
@@ -80,11 +78,9 @@ async fn lindera_chinese_tokenizer(mut conn: PgConnection) {
     	index_name => 'chinese',
     	table_name => 'chinese',
         key_field => 'id',
-        text_fields => '{
-            author: {tokenizer: {type: "chinese_lindera"}, record: "position"},
-            title: {tokenizer: {type: "chinese_lindera"}, record: "position"},
-            message: {tokenizer: {type: "chinese_lindera"}, record: "position"}
-        }'
+        text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('chinese_lindera'), record => 'position') ||
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('chinese_lindera'), record => 'position') ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('chinese_lindera'), record => 'position')
     )"#
     .execute(&mut conn);
 
@@ -119,11 +115,9 @@ async fn lindera_japenese_tokenizer(mut conn: PgConnection) {
     	index_name => 'japanese',
     	table_name => 'japanese',
         key_field => 'id',
-        text_fields => '{
-            author: {tokenizer: {type: "japanese_lindera"}, record: "position"},
-            title: {tokenizer: {type: "japanese_lindera"}, record: "position"},
-            message: {tokenizer: {type: "japanese_lindera"}, record: "position"}
-        }'
+        text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('japanese_lindera'), record => 'position') ||
+                       paradedb.field('title', tokenizer => paradedb.tokenizer('japanese_lindera'), record => 'position') ||
+                       paradedb.field('message', tokenizer => paradedb.tokenizer('japanese_lindera'), record => 'position')
     )"#
     .execute(&mut conn);
 

--- a/pg_search/tests/quickstart.rs
+++ b/pg_search/tests/quickstart.rs
@@ -54,7 +54,7 @@ fn quickstart(mut conn: PgConnection) {
             schema_name => 'public',
             table_name => 'mock_items',
             key_field => 'id',
-            text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}'
+            text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category')
     );
     "#
     .execute(&mut conn);
@@ -85,7 +85,7 @@ fn quickstart(mut conn: PgConnection) {
             schema_name => 'public',
             table_name => 'mock_items',
             key_field => 'id',
-            text_fields => '{description: {tokenizer: {type: "ngram", min_gram: 4, max_gram: 4, prefix_only: false}}, category: {}}'
+            text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('ngram', min_gram => 4, max_gram => 4, prefix_only => false)) || paradedb.field('category')
     );
     "#.execute(&mut conn);
     let rows: Vec<(String, i32, String)> = r#"
@@ -248,7 +248,7 @@ fn identical_queries(mut conn: PgConnection) {
             schema_name => 'public',
             table_name => 'mock_items',
             key_field => 'id',
-            text_fields => '{description: {}, category: {}}'
+            text_fields => paradedb.field('description') || paradedb.field('category')
     );
     "#
     .execute(&mut conn);
@@ -287,8 +287,8 @@ fn score_bm25(mut conn: PgConnection) {
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}',
-        numeric_fields => '{rating: {}}'
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating')
     );
     "#
     .execute(&mut conn);
@@ -346,8 +346,8 @@ fn snippet(mut conn: PgConnection) {
         schema_name => 'public',
         table_name => 'mock_items',
         key_field => 'id',
-        text_fields => '{description: {tokenizer: {type: "en_stem"}}, category: {}}',
-        numeric_fields => '{rating: {}}'
+        text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category'),
+        numeric_fields => paradedb.field('rating')
     );
     "#
     .execute(&mut conn);

--- a/pg_search/tests/range.rs
+++ b/pg_search/tests/range.rs
@@ -44,7 +44,7 @@ fn integer_range(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => '{"value_int4": {}, "value_int8": {}}'
+        numeric_fields => paradedb.field('value_int4') || paradedb.field('value_int8')
     );
     "#
     .execute(&mut conn);
@@ -93,7 +93,7 @@ fn float_range(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => '{"value_float4": {}, "value_float8": {}, "value_numeric": {}}'
+        numeric_fields => paradedb.field('value_float4') || paradedb.field('value_float8') || paradedb.field('value_numeric')
     );
     "#
     .execute(&mut conn);
@@ -152,7 +152,9 @@ fn datetime_range(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        datetime_fields => '{"value_date": {}, "value_timestamp": {}, "value_timestamptz": {}}'
+        datetime_fields => paradedb.field('value_date') || 
+                           paradedb.field('value_timestamp') || 
+                           paradedb.field('value_timestamptz')
     );
     "#
     .execute(&mut conn);

--- a/pg_search/tests/replication.rs
+++ b/pg_search/tests/replication.rs
@@ -169,7 +169,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
         index_name => 'mock_items',
         schema_name => 'public',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute(&mut source_conn);
     "CALL paradedb.create_bm25(
@@ -177,7 +177,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
         index_name => 'mock_items',
         schema_name => 'public',
         key_field => 'id',
-        text_fields => '{description: {}}'
+        text_fields => paradedb.field('description')
     )"
     .execute(&mut target_conn);
 

--- a/pg_search/tests/search_config.rs
+++ b/pg_search/tests/search_config.rs
@@ -61,7 +61,7 @@ fn default_tokenizer_config(mut conn: PgConnection) {
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
-    	text_fields => '{"description": {}}'
+    	text_fields => paradedb.field('description')
     )"#
     .execute(&mut conn);
 
@@ -82,7 +82,7 @@ fn en_stem_tokenizer_config(mut conn: PgConnection) {
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
-    	text_fields => '{"description": {"tokenizer": { "type": "en_stem" }}}'
+    	text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem'))
     )"#
     .execute(&mut conn);
 
@@ -103,7 +103,7 @@ fn ngram_tokenizer_config(mut conn: PgConnection) {
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
-	    text_fields => '{"description": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 8, "prefix_only": false}}}'
+	    text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 8, prefix_only => false))
     )"#
     .execute(&mut conn);
 
@@ -126,7 +126,7 @@ fn chinese_compatible_tokenizer_config(mut conn: PgConnection) {
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
-	    text_fields => '{"description": {"tokenizer": {"type": "chinese_compatible"}, "record": "position"}}'
+	    text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('chinese_compatible'), record => 'position')
     );
     INSERT INTO paradedb.tokenizer_config (description, rating, category) VALUES ('电脑', 4, 'Electronics');
     "#

--- a/pg_search/tests/stemmer.rs
+++ b/pg_search/tests/stemmer.rs
@@ -211,11 +211,9 @@ fn language_stem_search_test(mut conn: PgConnection) {
                 index_name => 'stem_test',
                 table_name => 'test_table',
                 key_field => 'id',
-                text_fields => '{{
-                    author: {{tokenizer: {{type: "stem", language:"{}"}}, record: "position"}},
-                    title: {{tokenizer: {{type: "stem", language:"{}"}}, record: "position"}},
-                    message: {{tokenizer: {{type: "stem", language:"{}"}}, record: "position"}}
-                }}'
+                text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position') ||
+                               paradedb.field('title', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position') ||
+                               paradedb.field('message', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position')
             );"#,
             data, language_str, language_str, language_str
         );

--- a/pg_search/tests/term.rs
+++ b/pg_search/tests/term.rs
@@ -136,7 +136,7 @@ fn float_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => 'paradedb.field("value_float4") || paradedb.field("value_float8") || paradedb.field("value_numeric")'
+        numeric_fields => paradedb.field("value_float4") || paradedb.field("value_float8") || paradedb.field("value_numeric")
     );
     "#
     .execute(&mut conn);

--- a/pg_search/tests/term.rs
+++ b/pg_search/tests/term.rs
@@ -136,7 +136,7 @@ fn float_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => paradedb.field("value_float4") || paradedb.field("value_float8") || paradedb.field("value_numeric")
+        numeric_fields => paradedb.field('value_float4') || paradedb.field('value_float8') || paradedb.field('value_numeric')
     );
     "#
     .execute(&mut conn);

--- a/pg_search/tests/term.rs
+++ b/pg_search/tests/term.rs
@@ -39,7 +39,7 @@ fn boolean_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        boolean_fields => '{"value": {}}'
+        boolean_fields => paradedb.field('value')
     );
     "#
     .execute(&mut conn);
@@ -77,7 +77,7 @@ fn integer_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => '{"value_int2": {}, "value_int4": {}, "value_int8": {}}'
+        numeric_fields => paradedb.field('value_int2') || paradedb.field('value_int4') || paradedb.field('value_int8')
     );
     "#
     .execute(&mut conn);
@@ -136,7 +136,7 @@ fn float_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        numeric_fields => '{"value_float4": {}, "value_float8": {}, "value_numeric": {}}'
+        numeric_fields => 'paradedb.field("value_float4") || paradedb.field("value_float8") || paradedb.field("value_numeric")'
     );
     "#
     .execute(&mut conn);
@@ -195,7 +195,9 @@ fn text_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        text_fields => '{"value_text": {}, "value_varchar": {}, "value_uuid": {tokenizer: { type: "raw" }, normalizer: "raw", record: "basic", fieldnorms: false}}'
+        text_fields => paradedb.field('value_text') || 
+                       paradedb.field('value_varchar') || 
+                       paradedb.field('value_uuid', tokenizer => paradedb.tokenizer('raw'), normalizer => 'raw', record => 'basic', fieldnorms => false)        
     );
     "#
     .execute(&mut conn);
@@ -254,7 +256,11 @@ fn datetime_term(mut conn: PgConnection) {
         table_name => 'test_table',
         index_name => 'test_index',
         key_field => 'id',
-        datetime_fields => '{"value_date": {}, "value_timestamp": {}, "value_timestamptz": {}, "value_time": {}, "value_timetz": {}}'
+        datetime_fields => paradedb.field('value_date') || 
+                           paradedb.field('value_timestamp') || 
+                           paradedb.field('value_timestamptz') || 
+                           paradedb.field('value_time') || 
+                           paradedb.field('value_timetz')
     );
     "#
     .execute(&mut conn);

--- a/shared/src/fixtures/tables/simple_products.rs
+++ b/shared/src/fixtures/tables/simple_products.rs
@@ -50,11 +50,11 @@ BEGIN;
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
         key_field => '%s',
-        text_fields => '{"description": {}, "category": {}}',
-    	numeric_fields => '{"rating": {}}',
-    	boolean_fields => '{"in_stock": {}}',
-    	json_fields => '{"metadata": {}}',
-        datetime_fields => '{"created_at": {}, "last_updated_date": {}, "latest_available_time": {}}'
+        text_fields => paradedb.field('description') || paradedb.field('category'),
+    	numeric_fields => paradedb.field('rating'),
+    	boolean_fields => paradedb.field('in_stock'),
+    	json_fields => paradedb.field('metadata'),
+        datetime_fields => paradedb.field('created_at') || paradedb.field('last_updated_date') || paradedb.field('latest_available_time')        
     );
 COMMIT;
 "#;

--- a/shared/src/sql/index_setup.sql
+++ b/shared/src/sql/index_setup.sql
@@ -26,14 +26,6 @@ CALL paradedb.create_bm25(
     index_name => 'one_republic_songs',
     table_name => 'one_republic_songs',
     key_field => 'song_id',
-    text_fields => '{
-        title: {},
-        album: {},
-        genre: {},
-        description: {},
-        lyrics: {fast: true}
-    }',
-    numeric_fields => '{
-        release_year: {},
-    }'
+    text_fields => paradedb.field('title') || paradedb.field('album') || paradedb.field('genre') || paradedb.field('description') || paradedb.field('lyrics', fast => true),
+    numeric_fields => paradedb.field('release_year')
 );


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Introduces two new functions, `paradedb.field` and `paradedb.tokenizer`, that generate the JSON configuration options passed into `create_bm25`. This makes configuration options easier to document and removes the need for the user to format JSON themselves. Support for the old JSON5 string syntax has been preserved for backward compatibility.

```sql
-- These two queries are equivalent
-- BEFORE
CALL paradedb.create_bm25(
  index_name => 'search_idx',
  table_name => 'mock_items',
  key_field => 'id',
  text_fields => '{description: {} category: {}}'
);

-- AFTER
CALL paradedb.create_bm25(
  index_name => 'search_idx',
  table_name => 'mock_items',
  key_field => 'id',
  text_fields => paradedb.field('description') || paradedb.field('category')
);

--Nested JSON for tokenizers can be constructed as well
CALL paradedb.create_bm25(
  index_name => 'search_idx',
  table_name => 'mock_items',
  key_field => 'id',
  text_fields => paradedb.field('description', tokenizer => paradedb.tokenizer('en_stem')) || paradedb.field('category')
);
```

As part of this PR I've gone through our documentation and cleaned things up/clarified some sections.

## Why

## How

## Tests
