### PR TITLE
fix: the prepare statement pushdown to DuckDB unexpected

### DIFF
--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -66,20 +66,11 @@ pub async fn executor_run(
         // Tech Debt: Find a less hacky way to let COPY/CREATE go through
         || query.to_lowercase().starts_with("copy")
         || query.to_lowercase().starts_with("create")
+        || query.to_lowercase().starts_with("prepare")
     {
         prev_hook(query_desc, direction, count, execute_once);
         return Ok(());
     }
-
-    let query = if query.to_lowercase().starts_with("prepare") {
-        // PREPARE name [ ( data_type [, ...] ) ] AS statement, it always includes keyword AS
-        let query_with_placeholder = query[query.to_lowercase().find("as").unwrap() + "AS".len()..]
-            .trim()
-            .to_owned();
-        fill_prepare_query_string(query_desc.clone(), query_with_placeholder)?
-    } else {
-        query
-    };
 
     match connection::create_arrow(query.as_str()) {
         Err(err) => {

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -66,6 +66,7 @@ pub async fn executor_run(
         // Tech Debt: Find a less hacky way to let COPY/CREATE go through
         || query.to_lowercase().starts_with("copy")
         || query.to_lowercase().starts_with("create")
+        || query.to_lowercase().starts_with("prepare")
     {
         prev_hook(query_desc, direction, count, execute_once);
         return Ok(());

--- a/pg_lakehouse/src/hooks/executor.rs
+++ b/pg_lakehouse/src/hooks/executor.rs
@@ -66,11 +66,20 @@ pub async fn executor_run(
         // Tech Debt: Find a less hacky way to let COPY/CREATE go through
         || query.to_lowercase().starts_with("copy")
         || query.to_lowercase().starts_with("create")
-        || query.to_lowercase().starts_with("prepare")
     {
         prev_hook(query_desc, direction, count, execute_once);
         return Ok(());
     }
+
+    let query = if query.to_lowercase().starts_with("prepare") {
+        // PREPARE name [ ( data_type [, ...] ) ] AS statement, it always includes keyword AS
+        let query_with_placeholder = query[query.to_lowercase().find("as").unwrap() + "AS".len()..]
+            .trim()
+            .to_owned();
+        fill_prepare_query_string(query_desc.clone(), query_with_placeholder)?
+    } else {
+        query
+    };
 
     match connection::create_arrow(query.as_str()) {
         Err(err) => {

--- a/pg_lakehouse/src/hooks/mod.rs
+++ b/pg_lakehouse/src/hooks/mod.rs
@@ -15,8 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod executor;
+#[macro_use]
 mod query;
+mod executor;
 mod utility;
 
 use async_std::task::block_on;

--- a/pg_lakehouse/src/hooks/query.rs
+++ b/pg_lakehouse/src/hooks/query.rs
@@ -15,9 +15,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::{anyhow, Result};
 use pgrx::*;
 use std::ffi::CStr;
 use std::str::Utf8Error;
+
+use crate::fdw::handler::FdwHandler;
+use crate::schema::cell::*;
+use duckdb::arrow::array::RecordBatch;
+
+macro_rules! fallback_warning {
+    ($msg:expr) => {
+        warning!("This query was not fully pushed down to DuckDB because DuckDB returned an error. Query times may be impacted. If you would like to see this query pushed down, please submit a request to https://github.com/paradedb/paradedb/issues with the following context:\n{}", $msg);
+    };
+}
 
 pub fn get_current_query(
     planned_stmt: *mut pg_sys::PlannedStmt,
@@ -78,4 +89,81 @@ pub fn get_query_relations(planned_stmt: *mut pg_sys::PlannedStmt) -> Vec<PgRela
     }
 
     relations
+}
+
+pub fn is_duckdb_query(relations: &[PgRelation]) -> bool {
+    !relations.is_empty()
+        && relations.iter().all(|pg_relation| {
+            if pg_relation.is_foreign_table() {
+                let foreign_table = unsafe { pg_sys::GetForeignTable(pg_relation.oid()) };
+                let foreign_server = unsafe { pg_sys::GetForeignServer((*foreign_table).serverid) };
+                let fdw_handler = FdwHandler::from(foreign_server);
+                fdw_handler != FdwHandler::Other
+            } else {
+                false
+            }
+        })
+}
+
+#[inline]
+pub fn write_batches_to_slots<T:WhoAllocated>(
+    query_desc: PgBox<pg_sys::QueryDesc, T>,
+    mut batches: Vec<RecordBatch>,
+) -> Result<()> {
+    // Convert the DataFusion batches to Postgres tuples and send them to the destination
+    unsafe {
+        let tuple_desc = PgTupleDesc::from_pg(query_desc.tupDesc);
+        let estate = query_desc.estate;
+        (*estate).es_processed = 0;
+
+        let dest = query_desc.dest;
+        let startup = (*dest)
+            .rStartup
+            .ok_or_else(|| anyhow!("rStartup not found"))?;
+        startup(dest, query_desc.operation as i32, query_desc.tupDesc);
+
+        let receive = (*dest)
+            .receiveSlot
+            .ok_or_else(|| anyhow!("receiveSlot not found"))?;
+
+        for batch in batches.iter_mut() {
+            for row_index in 0..batch.num_rows() {
+                let tuple_table_slot =
+                    pg_sys::MakeTupleTableSlot(query_desc.tupDesc, &pg_sys::TTSOpsVirtual);
+
+                pg_sys::ExecStoreVirtualTuple(tuple_table_slot);
+
+                for (col_index, _) in tuple_desc.iter().enumerate() {
+                    let attribute = tuple_desc
+                        .get(col_index)
+                        .ok_or_else(|| anyhow!("attribute at {col_index} not found in tupdesc"))?;
+                    let column = batch.column(col_index);
+                    let tts_value = (*tuple_table_slot).tts_values.add(col_index);
+                    let tts_isnull = (*tuple_table_slot).tts_isnull.add(col_index);
+
+                    match column.get_cell(row_index, attribute.atttypid, attribute.name())? {
+                        Some(cell) => {
+                            if let Some(datum) = cell.into_datum() {
+                                *tts_value = datum;
+                            }
+                        }
+                        None => {
+                            *tts_isnull = true;
+                        }
+                    };
+                }
+
+                receive(tuple_table_slot, dest);
+                (*estate).es_processed += 1;
+                pg_sys::ExecDropSingleTupleTableSlot(tuple_table_slot);
+            }
+        }
+
+        let shutdown = (*dest)
+            .rShutdown
+            .ok_or_else(|| anyhow!("rShutdown not found"))?;
+        shutdown(dest);
+    }
+
+    Ok(())
 }

--- a/pg_lakehouse/src/hooks/query.rs
+++ b/pg_lakehouse/src/hooks/query.rs
@@ -79,31 +79,3 @@ pub fn get_query_relations(planned_stmt: *mut pg_sys::PlannedStmt) -> Vec<PgRela
 
     relations
 }
-
-pub fn fill_prepare_query_string(
-    query_desc: PgBox<pg_sys::QueryDesc>,
-    mut query: String,
-) -> Result<String, Utf8Error> {
-    unsafe {
-        let params = query_desc.params;
-        let param_list = (*params).params.as_mut_slice((*params).numParams as usize);
-        let num_params = (*params).numParams as usize;
-
-        // build placeholder pattern, $1, $2 .. $n
-        let replacements: Vec<String> = (1..=num_params).map(|i| format!("${}", i)).collect();
-        for i in 0..num_params {
-            let param = param_list[i];
-            let replace_str = if param.isnull {
-                "NULL"
-            } else {
-                let mut type_output: pg_sys::Oid = pg_sys::InvalidOid;
-                let mut _is_varlena: bool = false;
-                pg_sys::getTypeOutputInfo(param.ptype, &mut type_output, &mut _is_varlena);
-                CStr::from_ptr(pg_sys::OidOutputFunctionCall(type_output, param.value)).to_str()?
-            };
-            query = query.replace(&replacements[i], replace_str);
-        }
-    }
-
-    Ok(query)
-}

--- a/pg_lakehouse/src/hooks/utility.rs
+++ b/pg_lakehouse/src/hooks/utility.rs
@@ -17,6 +17,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
+use crate::duckdb::connection;
 use anyhow::Result;
 use pgrx::*;
 
@@ -44,9 +45,12 @@ pub async fn process_utility(
 ) -> Result<()> {
     unsafe {
         match pstmt.utilityStmt.as_ref().unwrap().type_ {
-            pg_sys::NodeTag::T_PrepareStmt => unimplemented!(),
-            pg_sys::NodeTag::T_ExecuteStmt => unimplemented!(),
-            pg_sys::NodeTag::T_DeallocateStmt => unimplemented!(),
+            pg_sys::NodeTag::T_PrepareStmt
+            | pg_sys::NodeTag::T_DeallocateStmt
+            | pg_sys::NodeTag::T_ExecuteStmt => {
+                let utility_query = query_string.to_str()?;
+                connection::execute(utility_query, [])?;
+            }
             _ => (),
         }
     }

--- a/pg_lakehouse/src/hooks/utility.rs
+++ b/pg_lakehouse/src/hooks/utility.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(clippy::too_many_arguments)]
+
+use anyhow::Result;
+use pgrx::*;
+
+type ProcessUtilityHook = fn(
+    pstmt: PgBox<prelude::pg_sys::PlannedStmt>,
+    query_string: &core::ffi::CStr,
+    read_only_tree: Option<bool>,
+    context: prelude::pg_sys::ProcessUtilityContext,
+    params: PgBox<prelude::pg_sys::ParamListInfoData>,
+    query_env: PgBox<prelude::pg_sys::QueryEnvironment>,
+    dest: PgBox<prelude::pg_sys::DestReceiver>,
+    completion_tag: *mut prelude::pg_sys::QueryCompletion,
+) -> HookResult<()>;
+
+pub async fn process_utility(
+    pstmt: PgBox<prelude::pg_sys::PlannedStmt>,
+    query_string: &core::ffi::CStr,
+    read_only_tree: Option<bool>,
+    context: prelude::pg_sys::ProcessUtilityContext,
+    params: PgBox<prelude::pg_sys::ParamListInfoData>,
+    query_env: PgBox<prelude::pg_sys::QueryEnvironment>,
+    dest: PgBox<prelude::pg_sys::DestReceiver>,
+    completion_tag: *mut prelude::pg_sys::QueryCompletion,
+    prev_hook: ProcessUtilityHook,
+) -> Result<()> {
+    unsafe {
+        match pstmt.utilityStmt.as_ref().unwrap().type_ {
+            pg_sys::NodeTag::T_PrepareStmt => unimplemented!(),
+            pg_sys::NodeTag::T_ExecuteStmt => unimplemented!(),
+            pg_sys::NodeTag::T_DeallocateStmt => unimplemented!(),
+            _ => (),
+        }
+    }
+
+    prev_hook(
+        pstmt,
+        query_string,
+        read_only_tree,
+        context,
+        params,
+        query_env,
+        dest,
+        completion_tag,
+    );
+
+    Ok(())
+}

--- a/pg_lakehouse/src/hooks/utility.rs
+++ b/pg_lakehouse/src/hooks/utility.rs
@@ -17,9 +17,14 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::duckdb::connection;
+use std::ptr::null_mut;
+
 use anyhow::Result;
+use pg_sys::{CreateQueryDesc, NodeTag, QueryDesc};
 use pgrx::*;
+
+use super::query::*;
+use crate::duckdb::connection;
 
 type ProcessUtilityHook = fn(
     pstmt: PgBox<prelude::pg_sys::PlannedStmt>,
@@ -43,28 +48,111 @@ pub async fn process_utility(
     completion_tag: *mut prelude::pg_sys::QueryCompletion,
     prev_hook: ProcessUtilityHook,
 ) -> Result<()> {
-    unsafe {
-        match pstmt.utilityStmt.as_ref().unwrap().type_ {
-            pg_sys::NodeTag::T_PrepareStmt
-            | pg_sys::NodeTag::T_DeallocateStmt
-            | pg_sys::NodeTag::T_ExecuteStmt => {
-                let utility_query = query_string.to_str()?;
-                connection::execute(utility_query, [])?;
-            }
-            _ => (),
+    let stmt_type = unsafe { pstmt.utilityStmt.as_ref().unwrap().type_ };
+
+    let is_prepare_related_stmt = is_prepare_related_stmt(stmt_type);
+    // It can't check directly. need to
+    // let is_duckdb_query = is_duckdb_query(&query_relations);
+
+    if !is_prepare_related_stmt {
+        prev_hook(
+            pstmt,
+            query_string,
+            read_only_tree,
+            context,
+            params,
+            query_env,
+            dest,
+            completion_tag,
+        );
+
+        return Ok(());
+    }
+
+    let query_desc = unsafe {
+        PgBox::<QueryDesc, AllocatedByRust>::from_rust(CreateQueryDesc(
+            pstmt.as_ptr(),
+            query_string.as_ptr(),
+            null_mut(),
+            null_mut(),
+            dest.as_ptr(),
+            null_mut(),
+            query_env.as_ptr(),
+            0,
+        ))
+    };
+
+    let need_exec_prev_hook = match stmt_type {
+        pg_sys::NodeTag::T_PrepareStmt => prepare_query(query_string)?,
+        pg_sys::NodeTag::T_ExecuteStmt => execute_query(query_string, query_desc)?,
+        pg_sys::NodeTag::T_DeallocateStmt => true,
+        _ => unreachable!(),
+    };
+
+    if need_exec_prev_hook {
+        prev_hook(
+            pstmt,
+            query_string,
+            read_only_tree,
+            context,
+            params,
+            query_env,
+            dest,
+            completion_tag,
+        );
+    }
+
+    Ok(())
+}
+
+fn is_prepare_related_stmt(stmt_type: NodeTag) -> bool {
+    stmt_type == pg_sys::NodeTag::T_PrepareStmt
+        || stmt_type == pg_sys::NodeTag::T_DeallocateStmt
+        || stmt_type == pg_sys::NodeTag::T_ExecuteStmt
+}
+
+fn prepare_query(query: &core::ffi::CStr) -> Result<bool> {
+    // need to parse query and check if OK to pushdown to duckDB
+    // check CMD_TYPE, tables ...etc
+    if let Err(e) = connection::execute(query.to_str()?, []) {
+        fallback_warning!(e.to_string());
+        return Ok(true);
+    }
+
+    // It's always necessary to execute the previous hook to store a prepared statement in PostgreSQL
+    Ok(true)
+}
+
+fn execute_query<T: WhoAllocated>(
+    query: &core::ffi::CStr,
+    query_desc: PgBox<QueryDesc, T>,
+) -> Result<bool> {
+    // 1. need to make sure the duckdb views exist
+    // 2. need to set schema correctly
+    // 3. Identifying whether this query should be pushed down. (Or just use fallback pattern)
+    match connection::create_arrow(query.to_str()?) {
+        Err(_) => {
+            connection::clear_arrow();
+            return Ok(true);
+        }
+        Ok(false) => {
+            connection::clear_arrow();
+            return Ok(false);
+        }
+        _ => {}
+    }
+
+    match connection::get_batches() {
+        Ok(batches) => write_batches_to_slots(query_desc, batches)?,
+        Err(err) => {
+            connection::clear_arrow();
+            // Should this warning be here ? If we use fallback pattern, we can't warning here.
+            // If it involves a regular PostgreSQL table, this will also trigger a warning. So I prefer to get prepare statement info to distinguish.
+            fallback_warning!(err.to_string());
+            return Ok(true);
         }
     }
 
-    prev_hook(
-        pstmt,
-        query_string,
-        read_only_tree,
-        context,
-        params,
-        query_env,
-        dest,
-        completion_tag,
-    );
-
-    Ok(())
+    connection::clear_arrow();
+    Ok(false)
 }

--- a/pg_lakehouse/tests/scan.rs
+++ b/pg_lakehouse/tests/scan.rs
@@ -306,7 +306,8 @@ async fn test_prepare_stmt_execute(#[future(awt)] s3: S3, mut conn: PgConnection
     )
     .execute(&mut conn);
 
-    "PREPARE test_query(int) AS SELECT count(*) FROM trips WHERE VendorID = $1;".execute(&mut conn);
+    r#"PREPARE test_query(int) AS SELECT count(*) FROM trips WHERE "VendorID" = $1;"#
+        .execute(&mut conn);
 
     let count: (i64,) = "EXECUTE test_query(1)".fetch_one(&mut conn);
     assert_eq!(count.0, 39);


### PR DESCRIPTION
Prepare statement execution's behavior isn't as expected.

# Ticket(s) Closed 

- Closes paradedb/pg_analytics#51

## What

## Why

## How
I let it goes to FDW directly first, and then implement a way that construct query string and pushdown it to Duckdb.
## Tests
