### PR TITLE
feat: Support all types of arrays

### DIFF
--- a/.github/workflows/test-pg_lakehouse.yml
+++ b/.github/workflows/test-pg_lakehouse.yml
@@ -105,11 +105,10 @@ jobs:
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
-      - name: Install pgrx, grcov & llvm-tools-preview
+      - name: Install pgrx & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
           cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.3
-          cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
           cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -121,11 +121,10 @@ jobs:
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
 
-      - name: Install pgrx, grcov & llvm-tools-preview
+      - name: Install pgrx & llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
           cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.3
-          cargo install -j $(nproc) --locked grcov
           rustup component add llvm-tools-preview
           cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 

--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -52,7 +52,7 @@ SELECT * FROM search_idx.search('description:keyboard');
 
 ### Text Fields
 
-Columns of type `VARCHAR`, `TEXT`, `UUID`, `VARCHAR[]`, and `TEXT[]` can be indexed as text fields.
+Columns of type `VARCHAR`, `TEXT`, `UUID`, and their corresponding array types can be indexed as text fields.
 
 ```sql
 CALL paradedb.create_bm25(
@@ -98,9 +98,8 @@ CALL paradedb.create_bm25(
 
 ### Numeric Fields
 
-Columns of type `SMALLINT`, `INTEGER`, `BIGINT`, `OID`, `REAL`, `DOUBLE PRECISION`, and `NUMERIC` can be indexed
-as `numeric_fields`. The main reason to index a numeric field is if it is used for filtering
-or aggregations as part of the search query.
+Columns of type `SMALLINT`, `INTEGER`, `BIGINT`, `OID`, `REAL`, `DOUBLE PRECISION`, `NUMERIC`, and their corresponding array types can be indexed
+as `numeric_fields`. The main reason to index a numeric field is if it is used for filtering or aggregations as part of the search query.
 
 ```sql
 CALL paradedb.create_bm25(
@@ -128,7 +127,7 @@ CALL paradedb.create_bm25(
 
 ### Boolean Fields
 
-Columns of type `BOOLEAN` can be indexed as `boolean_fields`. Indexing a boolean field is useful if
+Columns of type `BOOLEAN` and `BOOLEAN[]` can be indexed as `boolean_fields`. Indexing a boolean field is useful if
 it is used for filtering as part of the search query.
 
 ```sql
@@ -200,7 +199,7 @@ CALL paradedb.create_bm25(
 
 ### Datetime Fields
 
-Columns of type `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, `TIME`, and `TIMETZ` can be indexed as `datetime_fields`.
+Columns of type `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, `TIME`, `TIMETZ`, and their corresponding array types can be indexed as `datetime_fields`.
 Indexing a datetime field is useful if it is used for filtering as part of the search query.
 
 ```sql

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -68,8 +68,12 @@ pub unsafe fn row_to_search_document(
             continue;
         }
 
-        if is_array || is_json {
-            for value in TantivyValue::try_from_datum_array(datum, base_oid).unwrap() {
+        if is_array {
+            for value in TantivyValue::try_from_datum_array(datum, base_oid)? {
+                document.insert(search_field.id, value.tantivy_schema_value());
+            }
+        } else if is_json {
+            for value in TantivyValue::try_from_datum_json(datum, base_oid)? {
                 document.insert(search_field.id, value.tantivy_schema_value());
             }
         } else {

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -195,7 +195,6 @@ fn text_arrays(mut conn: PgConnection) {
     	text_fields => paradedb.field('text_array') || paradedb.field('varchar_array')
     )"#
     .execute(&mut conn);
-
     let row: (i32,) =
         r#"SELECT * FROM example_table.search('text_array:text1')"#.fetch_one(&mut conn);
 

--- a/shared/src/fixtures/tables/simple_products.rs
+++ b/shared/src/fixtures/tables/simple_products.rs
@@ -49,7 +49,7 @@ BEGIN;
     	index_name => 'bm25_search',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
-        key_field => '%s',
+        key_field => 'id',
         text_fields => paradedb.field('description') || paradedb.field('category'),
     	numeric_fields => paradedb.field('rating'),
     	boolean_fields => paradedb.field('in_stock'),

--- a/shared/src/fixtures/tables/simple_products.rs
+++ b/shared/src/fixtures/tables/simple_products.rs
@@ -49,7 +49,7 @@ BEGIN;
     	index_name => 'bm25_search',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
-        key_field => 'id',
+        key_field => '%s',
         text_fields => paradedb.field('description') || paradedb.field('category'),
     	numeric_fields => paradedb.field('rating'),
     	boolean_fields => paradedb.field('in_stock'),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1226 

## What

We discovered today that you can add the same key with different values multiple times to the same Tantivy Document, and it'll be treated as an array: https://github.com/quickwit-oss/tantivy/issues/464.

This means that we should be able to index and search arrays of any type in pg_search (aside from JSON arrays, which I realized are still not supported).

As part of this I split json handling out of `try_from_datum_array`. Because both json and array types were being handled by this function, if the user tried to index a JSON array they would receive a cryptic error instead of one telling them that json arrays are not supported.

## Why
Support for more types.

## How

## Tests
See tests