### PR TITLE
docs: Update quickstart

### DIFF
--- a/docs/search/quickstart.mdx
+++ b/docs/search/quickstart.mdx
@@ -57,7 +57,7 @@ be the name of a column that will function as a row's unique identifier within t
 can just be the name of your table's primary key column.
 </Note>
 
-We're now ready to execute a full-text search. We'll look for rows with a `rating` greater than `2` where `description` matches `shoes`
+We're now ready to execute a full-text search. We'll look for rows with a `rating` greater than `2` where `description` matches `keyboard`
 or `category` matches `electronics`.
 
 ```sql


### PR DESCRIPTION
## What
Changed the search term from ‘shoes’ to ‘keyboard’ to match with the SQL query.

## Why
The text and the SQL query were inconsistent. The original text mentioned searching for ‘shoes’, but the SQL query was searching for ‘keyboard’. 

## Tests
No tests required for this change.