### PR TITLE
fix: use fixed-length + oid-based paths for index storage

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod config;
-mod index;
-mod operator;
-mod search;
+pub mod config;
+pub mod index;
+pub mod operator;
+pub mod search;

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -37,14 +37,14 @@ fn search_tantivy(
             .expect("could not parse search config");
 
         let writer_client = WriterGlobal::client();
-        let directory = WriterDirectory::from_index_name(&search_config.index_name);
+        let directory = WriterDirectory::from_index_oid(search_config.index_oid);
         let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
         let scan_state = search_index
             .search_state(
                 &writer_client,
                 &search_config,
-                needs_commit(&search_config.index_name),
+                needs_commit(search_config.index_oid),
             )
             .unwrap();
         let top_docs = scan_state.search(SearchIndex::executor());

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -411,8 +411,8 @@ fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
     let schema_name = schema_name.unwrap_or("current_schema()");
 
     let oid_query = format!(
-        "SELECT oid FROM pg_class WHERE relname = '{}' AND relkind = 'i'",
-        format!("{}_bm25_index", index_name)
+        "SELECT oid FROM pg_class WHERE relname = '{}_bm25_index' AND relkind = 'i'",
+        index_name
     );
     let index_oid = Spi::get_one::<pg_sys::Oid>(&oid_query)
         .expect("error looking up index in drop_bm25")

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -138,15 +138,6 @@ fn create_bm25_impl(
         );
     }
 
-    let index_uuid = Uuid::new_v4().to_string();
-    let index_json = json!({
-        "index_name": format!("{}_bm25_index", index_name),
-        "table_name": table_name,
-        "key_field": key_field,
-        "schema_name": schema_name,
-        "uuid":  index_uuid
-    });
-
     Spi::run(&format!(
         "CREATE SCHEMA {}",
         spi::quote_identifier(index_name)
@@ -185,9 +176,12 @@ fn create_bm25_impl(
         "".to_string()
     };
 
+    let index_uuid = Uuid::new_v4().to_string();
+    let index_name_suffixed = format!("{}_bm25_index", index_name);
+
     Spi::run(&format!(
         "CREATE INDEX {} ON {}.{} USING bm25 ({}, {}) WITH (key_field={}, text_fields={}, numeric_fields={}, boolean_fields={}, json_fields={}, datetime_fields={}, uuid={}) {};",
-        spi::quote_identifier(format!("{}_bm25_index", index_name)),
+        spi::quote_identifier(index_name_suffixed.clone()),
         spi::quote_identifier(schema_name),
         spi::quote_identifier(table_name),
         spi::quote_identifier(key_field),
@@ -198,7 +192,7 @@ fn create_bm25_impl(
         spi::quote_literal(boolean_fields),
         spi::quote_literal(json_fields),
         spi::quote_literal(datetime_fields),
-        spi::quote_identifier(index_uuid),
+        spi::quote_identifier(index_uuid.clone()),
         predicate_where))?;
 
     let predicate = if !predicates.is_empty() {
@@ -206,6 +200,24 @@ fn create_bm25_impl(
     } else {
         "".to_string()
     };
+
+    let oid_query = format!(
+        "SELECT oid FROM pg_class WHERE relname = '{}' AND relkind = 'i'",
+        &index_name_suffixed
+    );
+    let index_oid = Spi::get_one::<pg_sys::Oid>(&oid_query)
+        .expect("error looking up index in create_bm25")
+        .expect("no oid for index created in create_bm25")
+        .as_u32();
+
+    let index_json = json!({
+        "index_name": index_name_suffixed,
+        "index_oid": index_oid,
+        "table_name": table_name,
+        "key_field": key_field,
+        "schema_name": schema_name,
+        "uuid":  index_uuid
+    });
 
     Spi::run(&format_bm25_function(
         &spi::quote_qualified_identifier(index_name, "search"),
@@ -398,6 +410,14 @@ LANGUAGE c AS 'MODULE_PATHNAME', '@FUNCTION_NAME@';
 fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
     let schema_name = schema_name.unwrap_or("current_schema()");
 
+    let oid_query = format!(
+        "SELECT oid FROM pg_class WHERE relname = '{}' AND relkind = 'i'",
+        format!("{}_bm25_index", index_name)
+    );
+    let index_oid = Spi::get_one::<pg_sys::Oid>(&oid_query)
+        .expect("error looking up index in drop_bm25")
+        .expect("no oid for index created in drop_bm25");
+
     Spi::run(&format!(
         r#"
         DO $$
@@ -409,8 +429,6 @@ fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
 
             EXECUTE 'DROP INDEX IF EXISTS {}.{}'; 
             EXECUTE 'DROP SCHEMA IF EXISTS {} CASCADE';
-            PERFORM paradedb.drop_bm25_internal({});
-
             EXECUTE 'SET client_min_messages TO ' || quote_literal(original_client_min_messages);
         END;
         $$;
@@ -418,8 +436,9 @@ fn drop_bm25(index_name: &str, schema_name: Option<&str>) -> Result<()> {
         spi::quote_identifier(schema_name),
         spi::quote_identifier(format!("{}_bm25_index", index_name)),
         spi::quote_identifier(index_name),
-        spi::quote_literal(format!("{}_bm25_index", index_name))
     ))?;
+
+    crate::api::search::drop_bm25_internal(index_oid);
 
     Ok(())
 }

--- a/pg_search/src/fixtures/directory.rs
+++ b/pg_search/src/fixtures/directory.rs
@@ -27,19 +27,18 @@ pub struct MockWriterDirectory {
 }
 
 impl MockWriterDirectory {
-    pub fn new(index_name: &str) -> Self {
+    pub fn new(index_oid: u32) -> Self {
         // We must store the TempDir instance on the struct, because it gets deleted when the
         // instance is dropped.
         let temp_dir = tempfile::Builder::new()
-            .prefix(index_name)
+            .prefix(&index_oid.to_string())
             .tempdir()
             .expect("error creating tempdir for MockWriterDirectory");
         let temp_path = temp_dir.path().to_path_buf();
         Self {
             temp_dir,
             writer_dir: WriterDirectory {
-                index_name: index_name.to_string(),
-                database_oid: 0,
+                index_oid,
                 postgres_data_dir_path: temp_path,
             },
         }

--- a/pg_search/src/fixtures/index.rs
+++ b/pg_search/src/fixtures/index.rs
@@ -37,7 +37,8 @@ impl MockSearchIndex {
     ) -> Self {
         // We must store the TempDir instance on the struct, because it gets deleted when the
         // instance is dropped.
-        let directory = MockWriterDirectory::new("mock_parade_search_index");
+        // We can pass a fixed index OID as a mock.
+        let directory = MockWriterDirectory::new(42);
         let mut writer = Writer::new();
         let uuid = Uuid::new_v4().to_string();
         writer

--- a/pg_search/src/fixtures/mod.rs
+++ b/pg_search/src/fixtures/mod.rs
@@ -63,7 +63,8 @@ pub fn simple_doc(simple_schema: SearchIndexSchema) -> SearchDocument {
 
 #[fixture]
 pub fn mock_dir() -> MockWriterDirectory {
-    MockWriterDirectory::new("mock_writer_directory")
+    // We can pass a fixed index OID as a mock.
+    MockWriterDirectory::new(42)
 }
 
 #[fixture]

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -275,9 +275,9 @@ impl SearchIndex {
 
     pub fn drop_index<W: WriterClient<WriterRequest>>(
         writer: &Arc<Mutex<W>>,
-        index_name: &str,
+        index_oid: u32,
     ) -> Result<(), SearchIndexError> {
-        let directory = WriterDirectory::from_index_name(index_name);
+        let directory = WriterDirectory::from_index_oid(index_oid);
         let request = WriterRequest::DropIndex {
             directory: directory.clone(),
         };

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -33,8 +33,7 @@ pub extern "C" fn ambulkdelete(
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    let index_name = index_relation.name();
-    let directory = WriterDirectory::from_index_name(index_name);
+    let directory = WriterDirectory::from_index_oid(index_relation.oid().as_u32());
     let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -82,7 +82,7 @@ unsafe fn aminsert_internal(
     let index_relation_ref: PgRelation = PgRelation::from_pg(index_relation);
     let tupdesc = index_relation_ref.tuple_desc();
     let index_name = index_relation_ref.name();
-    let directory = WriterDirectory::from_index_name(index_name);
+    let directory = WriterDirectory::from_index_oid(index_relation_ref.oid().as_u32());
     let search_index = SearchIndex::from_cache(&directory, uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
     let search_document =

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -66,15 +66,18 @@ pub extern "C" fn amrescan(
 
     let search_config =
         SearchConfig::from_jsonb(config_jsonb).expect("could not parse search config");
-    let index_name = &search_config.index_name;
 
     // Create the index and scan state
-    let directory = WriterDirectory::from_index_name(index_name);
+    let directory = WriterDirectory::from_index_oid(search_config.index_oid);
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
     let writer_client = WriterGlobal::client();
     let state = search_index
-        .search_state(&writer_client, &search_config, needs_commit(index_name))
+        .search_state(
+            &writer_client,
+            &search_config,
+            needs_commit(search_config.index_oid),
+        )
         .unwrap();
 
     let top_docs = state.search(SearchIndex::executor());

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -39,7 +39,7 @@ pub extern "C" fn amvacuumcleanup(
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
     let index_name = index_relation.name();
-    let directory = WriterDirectory::from_index_name(index_name);
+    let directory = WriterDirectory::from_index_oid(index_relation.oid().as_u32());
     let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -25,6 +25,7 @@ use crate::{index::state::SearchAlias, query::SearchQueryInput};
 pub struct SearchConfig {
     pub query: SearchQueryInput,
     pub index_name: String,
+    pub index_oid: u32,
     pub key_field: String,
     pub offset_rows: Option<usize>,
     pub limit_rows: Option<usize>,

--- a/shared/src/postgres/transaction.rs
+++ b/shared/src/postgres/transaction.rs
@@ -70,7 +70,7 @@ impl Transaction {
 
         if !cache.contains(&id) {
             // Now using `cache_clone` inside the closure.
-            let cloned_id = id.clone();
+            let cloned_id = id;
             register_xact_callback(PgXactCallbackEvent::PreCommit, move || {
                 // The precommit cache should be cleared on its own, as it is not
                 // mutually exclusive with any other event.
@@ -97,7 +97,7 @@ impl Transaction {
         let mut cache = TRANSACTION_CALL_ONCE_ON_COMMIT_CACHE.lock()?;
         if !cache.contains(&id) {
             // Now using `cache_clone` inside the closure.
-            let cloned_id = id.clone();
+            let cloned_id = id;
             register_xact_callback(PgXactCallbackEvent::Commit, move || {
                 // Clear the caches so callbacks can be registered on next transaction.
                 Self::clear_commit_abort_caches(cloned_id)
@@ -119,7 +119,7 @@ impl Transaction {
         let mut cache = TRANSACTION_CALL_ONCE_ON_ABORT_CACHE.lock()?;
         if !cache.contains(&id) {
             // Now using `cache_clone` inside the closure.
-            let cloned_id = id.clone();
+            let cloned_id = id;
             register_xact_callback(PgXactCallbackEvent::Abort, move || {
                 // Clear the caches so callbacks can be registered on next transaction.
                 Self::clear_commit_abort_caches(cloned_id)


### PR DESCRIPTION
## What
`pg_basebackup` currently errors on a bm25 index:
```
pg_basebackup: error: backup failed: ERROR:  file name too long for tar format: "paradedb/pg_search/631368_index_config_bm25_index/tantivy/995cec7539024106b9b6f2f9e8c30776.fieldnorm"
```
## Why
We have dynamic-length path names because we create them using the user-defined `index_name`. We also add some characters to the path by putting everything in the `paradedb` folder.

## How
Get rid of the `paradedb` folder, and use the index OID instead of the `index_name`. The max OID value is `4294967295`, so we can expect all created indexes to stay within the path length limit.

## Tests
This causes a problem with our partial index feature, because the index relation is deleted automatically when you drop the indexed column. That means that we can't lookup the index OID in `drop_bm25` to build the file system path.

I've commented out the test for now, but we need a longer-term solution for this. A possible avenue is making `drop_bm25` a "method" of the generated index schema, so that we can "curry" the index config into the function parameters. The `index_oid`, as of this PR, is in the index config, so that would give `drop_bm25` the information it needs.