### PR TITLE
feat: support pg_basebackup

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -134,8 +134,14 @@ impl SearchIndex {
     }
 
     pub fn from_disk<'a>(directory: &WriterDirectory) -> Result<&'a mut Self, SearchIndexError> {
-        let new_self: Self = directory.load_index()?;
+        let mut new_self: Self = directory.load_index()?;
         let uuid = new_self.uuid.clone();
+
+        // In the case of a physical replication of the database, the absolute path that is stored
+        // in the serialized WriterDirectory might refer to the source database's file system.
+        // We should overwrite it with the dynamically generated one that's been passed as an
+        // argument here.
+        new_self.directory = directory.clone();
 
         // Since we've re-fetched the index, save it to the cache.
         unsafe {

--- a/pg_search/tests/replication.rs
+++ b/pg_search/tests/replication.rs
@@ -292,7 +292,6 @@ async fn test_ephemeral_postgres() -> Result<()> {
     Ok(())
 }
 
-// Test function to test the ephemeral PostgreSQL setup
 #[rstest]
 async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
     let source_postgres = EphemeralPostgres::new();

--- a/pg_search/tests/replication.rs
+++ b/pg_search/tests/replication.rs
@@ -4,6 +4,7 @@ use dotenvy::dotenv;
 use rstest::*;
 use shared::fixtures::db::Query;
 use sqlx::{Connection, PgConnection};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Once;
@@ -61,35 +62,35 @@ impl Drop for EphemeralPostgres {
 
 // Implementation of EphemeralPostgres
 impl EphemeralPostgres {
-    fn new() -> Self {
-        // Make sure .env files are loaded before reading env vars.
-        dotenv().ok();
-
+    fn pg_bin_path() -> PathBuf {
         let pg_config_path = std::env::var("PG_CONFIG").expect(
             "PG_CONFIG variable must be set to enable creating ephemeral Postgres instances",
         );
-
         if !PathBuf::from(&pg_config_path).exists() {
             panic!("PG_CONFIG variable must a valid path to enable creating ephemeral Postgres instances, received {pg_config_path}");
         }
-
-        let pg_bin_path = match run_fun!($pg_config_path --bindir) {
+        match run_fun!($pg_config_path --bindir) {
             Ok(path) => PathBuf::from(path.trim().to_string()),
             Err(err) => panic!("could run pg_config --bindir to get Postgres bin folder: {err}"),
-        };
+        }
+    }
 
-        let init_db_path = pg_bin_path.join("initdb");
-        let pg_ctl_path = pg_bin_path.join("pg_ctl");
+    fn pg_basebackup_path() -> PathBuf {
+        Self::pg_bin_path().join("pg_basebackup")
+    }
 
-        let port = get_free_port();
-        let tempdir = TempDir::new().expect("Failed to create temp dir");
+    fn initdb_path() -> PathBuf {
+        Self::pg_bin_path().join("initdb")
+    }
+
+    fn pg_ctl_path() -> PathBuf {
+        Self::pg_bin_path().join("pg_ctl")
+    }
+
+    fn new_from_initialized(tempdir: TempDir) -> Self {
         let tempdir_path = tempdir.path().to_str().unwrap().to_string();
-        let timestamp = chrono::Utc::now().timestamp_millis();
-        let logfile = format!("/tmp/ephemeral_postgres_logs/{}.log", timestamp);
-
-        // Initialize PostgreSQL data directory
-        run_cmd!($init_db_path -D $tempdir_path &> /dev/null)
-            .expect("Failed to initialize Postgres data directory");
+        let port = get_free_port();
+        let pg_ctl_path = Self::pg_ctl_path();
 
         // Write to postgresql.conf
         let config_content = format!(
@@ -102,18 +103,23 @@ impl EphemeralPostgres {
             ",
             port
         );
+
         let config_path = format!("{}/postgresql.conf", tempdir_path);
         std::fs::write(config_path, config_content).expect("Failed to write to postgresql.conf");
 
         // Create log directory
+        let timestamp = chrono::Utc::now().timestamp_millis();
+        let logfile = format!("/tmp/ephemeral_postgres_logs/{}.log", timestamp);
         std::fs::create_dir_all(Path::new(&logfile).parent().unwrap())
             .expect("Failed to create log directory");
 
         // Start PostgreSQL
-        run_cmd!($pg_ctl_path -D $tempdir_path -l $logfile start &> /dev/null)
+        run_cmd!($pg_ctl_path -D $tempdir_path -l $logfile start)
             .expect("Failed to start Postgres");
 
-        EphemeralPostgres {
+        Self {
+            // TempDir needs to be stored on the struct to avoid being dropped, otherwise the
+            // temp folder will be deleted before the test finishes.
             _tempdir: tempdir,
             tempdir_path,
             host: "localhost".to_string(),
@@ -121,6 +127,21 @@ impl EphemeralPostgres {
             dbname: "postgres".to_string(),
             pg_ctl_path,
         }
+    }
+
+    fn new() -> Self {
+        // Make sure .env files are loaded before reading env vars.
+        dotenv().ok();
+
+        let init_db_path = Self::initdb_path();
+        let tempdir = TempDir::new().expect("Failed to create temp dir");
+        let tempdir_path = tempdir.path().to_str().unwrap().to_string();
+
+        // Initialize PostgreSQL data directory
+        run_cmd!($init_db_path -D $tempdir_path &> /dev/null)
+            .expect("Failed to initialize Postgres data directory");
+
+        Self::new_from_initialized(tempdir)
     }
 
     // Method to establish a connection to the PostgreSQL instance
@@ -267,6 +288,94 @@ async fn test_ephemeral_postgres() -> Result<()> {
 
     assert_eq!(source_results.len(), 0);
     assert_eq!(target_results.len(), 0);
+
+    Ok(())
+}
+
+// Test function to test the ephemeral PostgreSQL setup
+#[rstest]
+async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
+    let source_postgres = EphemeralPostgres::new();
+    let mut source_conn = source_postgres.connection().await?;
+    let source_port = source_postgres.port;
+    let source_username = "SELECT CURRENT_USER"
+        .fetch_one::<(String,)>(&mut source_conn)
+        .0;
+
+    "CREATE TABLE text_array_table (
+            id SERIAL PRIMARY KEY,
+            text_array TEXT[]
+        )"
+    .execute(&mut source_conn);
+
+    "INSERT INTO text_array_table (text_array) VALUES
+        (ARRAY['apple', 'banana', 'cherry']),
+        (ARRAY['dog', 'elephant', 'fox']),
+        (ARRAY['grape', 'honeydew', 'kiwi']),
+        (ARRAY['lion', 'monkey', 'newt']),
+        (ARRAY['octopus', 'penguin', 'quail']),
+        (ARRAY['rabbit', 'snake', 'tiger']),
+        (ARRAY['umbrella', 'vulture', 'wolf']),
+        (ARRAY['x-ray', 'yak', 'zebra']),
+        (ARRAY['alpha', 'bravo', 'charlie']),
+        (ARRAY['delta', 'echo', 'foxtrot'])"
+        .execute(&mut source_conn);
+
+    // Create pg_search extension and bm25 index
+    "CREATE EXTENSION pg_search".execute(&mut source_conn);
+
+    "CALL paradedb.create_bm25(
+        table_name => 'text_array_table',
+        index_name => 'text_array_table',
+        schema_name => 'public',
+        key_field => 'id',
+        text_fields => paradedb.field('text_array')
+    )"
+    .execute(&mut source_conn);
+
+    // Verify search results before pg_basebackup
+    let source_results: Vec<(i32,)> =
+        sqlx::query_as("SELECT id FROM text_array_table.search('text_array:dog')")
+            .fetch_all(&mut source_conn)
+            .await?;
+    assert_eq!(source_results.len(), 1);
+
+    let target_tempdir = TempDir::new().expect("Failed to create temp dir");
+    let target_tempdir_path = target_tempdir.path().to_str().unwrap().to_string();
+
+    // Permissions for the --pgdata directory passed to pg_basebackup
+    // should be u=rwx (0700) or u=rwx,g=rx (0750)
+    std::fs::set_permissions(
+        target_tempdir.path(),
+        std::fs::Permissions::from_mode(0o700),
+    )
+    .expect("couldn't set permissions on target_tempdir path");
+
+    // Run pg_basebackup
+    let pg_basebackup = EphemeralPostgres::pg_basebackup_path();
+    run_cmd!($pg_basebackup --pgdata $target_tempdir_path --host localhost --port $source_port --username $source_username)
+    .expect("Failed to run pg_basebackup");
+
+    let target_postgres = EphemeralPostgres::new_from_initialized(target_tempdir);
+    let mut target_conn = target_postgres.connection().await?;
+
+    // Verify the content in the target database
+    let target_results: Vec<(i32,)> =
+        sqlx::query_as("SELECT id FROM text_array_table.search('text_array:dog')")
+            .fetch_all(&mut target_conn)
+            .await?;
+
+    assert_eq!(source_results.len(), target_results.len());
+
+    // Verify the table content
+    let source_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM text_array_table")
+        .fetch_one(&mut source_conn)
+        .await?;
+    let target_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM text_array_table")
+        .fetch_one(&mut target_conn)
+        .await?;
+
+    assert_eq!(source_count, target_count);
 
     Ok(())
 }


### PR DESCRIPTION
## What

`pg_basebackup` hasn't been working. We fixed a major issue with it in #1439, where the file paths generated by `pg_search` were too long for `pg_basebackup` to even run.

Now that its running, we're seeing a segmentation fault when trying to `.search` after completing the replication.

## Why

The segfault is caused by infinite recursion that occurs when the replica tries to read the serialized `SearchIndex` config from disk.

The root cause is that the `WriterDirectory` from the _source database_ is serialized and copied over to the _replica_ along with the `SearchIndex`. The `WriterDirectory`, however, contains an absolute file path referencing the _source database's_ file system.

This was repeatedly invalidating our in-memory `SearchIndex` cache, causing the replicate to recursively keep trying to read a new `SearchIndex` from disk.

## Tests

Now that `pg_basebackup` is fully supported, I've added a test for it using our native `EphemeralPostgres` fixture.
