### PR TITLE
feat(doc): Add link to pre-commit.com in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ flow for making a change:
 2. If there is not, please open an issue first. This gives the community visibility
    into what you're working on and allows others to make suggestions and leave comments.
 3. Fork the ParadeDB repo and branch out from the `dev` branch.
-4. Install pre-commit hooks within your fork with `pre-commit install`, to ensure code quality and consistency with upstream.
+4. Install pre-commit hooks within your fork with `pre-commit install` (see [pre-commit.com](https://pre-commit.com/)), to ensure code quality and consistency with upstream.
 5. Make your changes. If you've added new functionality, please add tests.
 6. Open a pull request towards the `dev` branch. Ensure that all tests and checks
    pass. Note that the ParadeDB repository has pull request title linting in place


### PR DESCRIPTION
# Ticket(s) Closed

Closes: #1445

## What

Adds a link to pre-commit.com in CONTRIBUTING.md

## Why

As per #1445 there is the possibility for confusion without such a link.

## How

Trivial addition to markdown documentation.

## Tests

N/a