### PR TITLE
fix: Set `default_language_version`->`python` to `python3` instead of `python-3.11`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
# Ticket(s) Closed

Closes #1446

## What

Set `default_language_version`->`python` to `python3` instead of `python-3.11`

## Why

Pre-commit hooks break if (only) a newer version than `python-3.11` is installed.

See #1446. As per discussion in issue `python3` is probably the most maintainable value.

## How

Trivial change to config file.

## Tests

I manually verified that the pre-commit hooks still work by committing this change.

The hooks still work on my system before I uninstalled `python-3.11` and after.