### PR TITLE
fix(comment): Remove duplicate text "for production usage".

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 #
 # This docker-compose.dev.yml file is for development deployments of ParadeDB only. It directly builds our
 # Dockerfile, which has all ParadeDB extensions pre-installed and properly configured. It is not intended for
-# production use. For production usage, please use docker-compose.yml for production usage.
+# production use. For production usage, please use docker-compose.yml.
 #
 # There are several other environment variables which can be specified here to configure replication, TLS,
 # and a few other settings. They can be found here:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1449

## What

Remove duplicate text "for production usage" from a comment.

## Why

Grammar.

## How

Trivial text change to comment.

## Tests

N/a