### PR TITLE
feat: Add `ExistsQuery`

### DIFF
--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -119,6 +119,21 @@ SELECT * FROM search_idx.search(
 );
 ```
 
+### Exists
+
+Matches all documents with a non-null value in the specified field. All matched documents get a BM25 score of `1.0`.
+
+<Note>
+  Will error if the field has not been indexed as a [fast
+  field](/search/full-text/index#fast-fields).
+</Note>
+
+```sql
+SELECT * FROM search_idx.search(
+	query => paradedb.exists('rating')
+);
+```
+
 ### Fuzzy Term
 
 Fuzzy search allows users to obtain search results that approximately match the query term,

--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -147,7 +147,7 @@ SELECT * FROM search_idx.search(
 );
 ```
 
-This query is useful for filtering on null values inside a boolean query. For instance, the follwing query
+This query is useful for filtering on `NULL` values inside a boolean query. For instance, the following code block
 finds all rows with `description` matching `shoes` that have a non-null `rating`.
 
 ```sql

--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -64,6 +64,19 @@ SELECT * FROM search_idx.search(
   one must be matched.
 </ParamField>
 
+Note that in order for a boolean query to return a result, one of `must` or `should` must be provided.
+`must_not` acts as a mask and does not produce a result set. For instance, in order to find
+all rows from `mock_items` where `description` does not contain `shoes`, `paradedb.all()` should be used:
+
+```sql
+SELECT * FROM search_idx.search(
+  query => paradedb.boolean(
+    should => paradedb.all(),
+    must_not => paradedb.parse('description:shoes')
+  )
+);
+```
+
 ### Boost
 
 A boost query wraps around another query to amplify its scoring impact, without altering the set of matched documents.
@@ -83,7 +96,7 @@ SELECT * FROM search_idx.search(
 
 Applies a constant score across all documents matched by the underlying query. It can avoid unnecessary score computation on the wrapped query.
 
-```
+```sql
 SELECT * FROM search_idx.search(
     query => paradedb.const_score(query => paradedb.all(), score => 3.9)
 );
@@ -131,6 +144,20 @@ Matches all documents with a non-null value in the specified field. All matched 
 ```sql
 SELECT * FROM search_idx.search(
 	query => paradedb.exists('rating')
+);
+```
+
+This query is useful for filtering on null values inside a boolean query. For instance, the follwing query
+finds all rows with `description` matching `shoes` that have a non-null `rating`.
+
+```sql
+SELECT * FROM search_idx.search(
+  query => paradedb.boolean(
+    must => ARRAY[
+      paradedb.parse('description:shoes'),
+      paradedb.exists('rating')
+    ]
+  )
 );
 ```
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -184,6 +184,11 @@ pub fn empty() -> SearchQueryInput {
     SearchQueryInput::Empty
 }
 
+#[pg_extern(immutable, parallel_safe)]
+pub fn exists(field: String) -> SearchQueryInput {
+    SearchQueryInput::Exists { field }
+}
+
 // Not clear on whether this query makes sense to support, as only our "key_field" is a fast
 // field... and the user can just use SQL to select a range. We'll keep the implementation here
 // for now, but we should remove when we decide definitively that we don't need this.

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -25,8 +25,8 @@ use serde::{Deserialize, Serialize};
 use tantivy::{
     query::{
         AllQuery, BooleanQuery, BoostQuery, ConstScoreQuery, DisjunctionMaxQuery, EmptyQuery,
-        FastFieldRangeWeight, FuzzyTermQuery, MoreLikeThisQuery, PhrasePrefixQuery, PhraseQuery,
-        Query, QueryParser, RangeQuery, RegexQuery, TermQuery, TermSetQuery,
+        ExistsQuery, FastFieldRangeWeight, FuzzyTermQuery, MoreLikeThisQuery, PhrasePrefixQuery,
+        PhraseQuery, Query, QueryParser, RangeQuery, RegexQuery, TermQuery, TermSetQuery,
     },
     query_grammar::Occur,
     schema::{Field, FieldType, IndexRecordOption, OwnedValue},
@@ -56,6 +56,9 @@ pub enum SearchQueryInput {
     },
     #[default]
     Empty,
+    Exists {
+        field: String,
+    },
     FastFieldRangeWeight {
         field: String,
         lower_bound: std::ops::Bound<u64>,
@@ -250,6 +253,7 @@ impl SearchQueryInput {
                 }
             }
             Self::Empty => Ok(Box::new(EmptyQuery)),
+            Self::Exists { field } => Ok(Box::new(ExistsQuery::new_exists_query(field))),
             Self::FastFieldRangeWeight {
                 field,
                 lower_bound,

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -310,12 +310,18 @@ fn exists_query(mut conn: PgConnection) {
     }
 
     // Exists with boolean query
-    "INSERT INTO paradedb.bm25_search (id, rating) VALUES (42, NULL)".execute(&mut conn);
+    "INSERT INTO paradedb.bm25_search (id, description, rating) VALUES (42, 'shoes', NULL)"
+        .execute(&mut conn);
 
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.boolean(must => paradedb.exists('rating'))
+        query => paradedb.boolean(
+            must => ARRAY[
+                paradedb.exists('rating'),
+                paradedb.parse('description:shoes')
+            ]
+        )
     )"#
     .fetch_collect(&mut conn);
-    assert_eq!(columns.len(), 41);
+    assert_eq!(columns.len(), 3);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -285,3 +285,37 @@ fn single_queries(mut conn: PgConnection) {
     .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 5);
 }
+
+#[rstest]
+fn exists_query(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Simple exists query
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.exists('rating')
+    )"#
+    .fetch_collect(&mut conn);
+    assert_eq!(columns.len(), 41);
+
+    // Non fast field should fail
+    match r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.exists('description')
+    )"#
+    .execute_result(&mut conn)
+    {
+        Err(err) => assert!(err.to_string().contains("not a fast field")),
+        _ => panic!("exists() over non-fast field should fail"),
+    }
+
+    // Exists with boolean query
+    "INSERT INTO paradedb.bm25_search (id, rating) VALUES (42, NULL)".execute(&mut conn);
+
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.boolean(must => paradedb.exists('rating'))
+    )"#
+    .fetch_collect(&mut conn);
+    assert_eq!(columns.len(), 41);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1442 

## What
Adds `paradedb.exists`, which executes the Tantivy `ExistsQuery`.

## Why
See Github issue.

## How

## Tests
See `exists_query` test.