### PR TITLE
feat(doc): Add instructions for Arch Linux to Development section of pg_search and pg_lakehouse README files

### DIFF
--- a/pg_lakehouse/README.md
+++ b/pg_lakehouse/README.md
@@ -168,6 +168,9 @@ brew install make gcc pkg-config openssl
 
 # Ubuntu
 sudo apt-get install -y make gcc pkg-config libssl-dev
+
+# Arch Linux
+sudo pacman -S core/openssl
 ```
 
 ### Install Postgres
@@ -180,6 +183,9 @@ brew install postgresql@16
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
+
+# Arch Linux
+sudo pacman -S extra/postgresql
 ```
 
 If you are using Postgres.app to manage your macOS PostgreSQL, you'll need to add the `pg_config` binary to your path before continuing:
@@ -204,11 +210,24 @@ cargo pgrx init --pg16=/usr/local/opt/postgresql@16/bin/pg_config
 
 # Ubuntu
 cargo pgrx init --pg16=/usr/lib/postgresql/16/bin/pg_config
+
+# Arch Linux
+cargo pgrx init --pg16=/usr/bin/pg_config
 ```
 
 If you prefer to use a different version of Postgres, update the `--pg` flag accordingly.
 
 Note: While it is possible to develop using pgrx's own Postgres installation(s), via `cargo pgrx init` without specifying a `pg_config` path, we recommend using your system package manager's Postgres as we've observed inconsistent behaviours when using pgrx's.
+
+`pgrx` requires `libclang`. To install it:
+
+```bash
+# Ubuntu
+sudo apt install libclang-dev
+
+# Arch Linux
+sudo pacman -S extra/clang
+```
 
 ### Running Tests
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -182,6 +182,9 @@ brew install postgresql@16
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
+
+# Arch
+sudo pacman -S extra/postgresql
 ```
 
 If you are using Postgres.app to manage your macOS PostgreSQL, you'll need to add the `pg_config` binary to your path before continuing:
@@ -204,6 +207,9 @@ cargo pgrx init --pg16=/usr/local/opt/postgresql@16/bin/pg_config
 
 # Ubuntu
 cargo pgrx init --pg16=/usr/lib/postgresql/16/bin/pg_config
+
+# Arch
+cargo pgrx init --pg16=/usr/bin/pg_config
 ```
 
 If you prefer to use a different version of Postgres, update the `--pg` flag accordingly.
@@ -225,6 +231,9 @@ sudo apt-get install -y libicu70
 
 # Ubuntu 24.04
 sudo apt-get install -y libicu74
+
+# Arch
+sudo pacman -S core/icu
 ```
 
 Additionally, on macOS you'll need to add the `icu-config` binary to your path before continuing:

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -221,8 +221,6 @@ Note: While it is possible to develop using pgrx's own Postgres installation(s),
 ```bash
 # Ubuntu
 sudo apt install libclang-dev
-# or
-sudo apt install clang
 
 # Arch
 sudo pacman -S extra/clang

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -183,7 +183,7 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
 
-# Arch
+# Arch Linux
 sudo pacman -S extra/postgresql
 ```
 
@@ -208,7 +208,7 @@ cargo pgrx init --pg16=/usr/local/opt/postgresql@16/bin/pg_config
 # Ubuntu
 cargo pgrx init --pg16=/usr/lib/postgresql/16/bin/pg_config
 
-# Arch
+# Arch Linux
 cargo pgrx init --pg16=/usr/bin/pg_config
 ```
 
@@ -222,7 +222,7 @@ Note: While it is possible to develop using pgrx's own Postgres installation(s),
 # Ubuntu
 sudo apt install libclang-dev
 
-# Arch
+# Arch Linux
 sudo pacman -S extra/clang
 ```
 
@@ -242,7 +242,7 @@ sudo apt-get install -y libicu70
 # Ubuntu 24.04
 sudo apt-get install -y libicu74
 
-# Arch
+# Arch Linux
 sudo pacman -S core/icu
 ```
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -216,6 +216,18 @@ If you prefer to use a different version of Postgres, update the `--pg` flag acc
 
 Note: While it is possible to develop using pgrx's own Postgres installation(s), via `cargo pgrx init` without specifying a `pg_config` path, we recommend using your system package manager's Postgres as we've observed inconsistent behaviours when using pgrx's.
 
+`pgrx` requires `libclang`. To install it:
+
+```bash
+# Ubuntu
+sudo apt install libclang-dev
+# or
+sudo apt install clang
+
+# Arch
+sudo pacman -S extra/clang
+```
+
 #### ICU Tokenizer
 
 `pg_search` comes with multiple tokenizers for different languages. The ICU tokenizer, which enables tokenization for Arabic, Amharic, Czech and Greek, is not enabled by default in development due to the additional dependencies it requires. To develop with the ICU tokenizer enabled, first:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1456

## What

Add instructions for Arch Linux to Development section of pg_search/README.md

## Why

I use Arch

## How

Edited README

## Tests

These steps allow me to successfully run `cargo build` in the `./pg_search` and `./pg_lakehouse` directories.