### PR TITLE
fix(doc): Change pg_lakehouse to pg_search.

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -274,7 +274,7 @@ CREATE EXTENSION pg_search;
 
 ### Testing
 
-We use `cargo test` as our runner for `pg_lakehouse` tests.
+We use `cargo test` as our runner for `pg_search` tests.
 
 ## License
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1459

## What

Change text "pg_lakehouse" to "pg_search".

## Why

This text appears to have been copied from the `pg_lakehouse` README to the `pg_search` one but never updated.

## How

Trivial text change in README file

## Tests

N/a