### PR TITLE
chore: bump toolchain and change default cc to clang

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG PG_VERSION_MAJOR=16
 FROM postgres:${PG_VERSION_MAJOR}-bookworm as builder
 
 ARG PG_VERSION_MAJOR=16
-ARG RUST_VERSION=1.79.0
+ARG RUST_VERSION=1.80.0
 ARG PGRX_VERSION=0.11.3
 
 # Declare buildtime environment variables
@@ -34,7 +34,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libopenblas-dev \
     postgresql-server-dev-all \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${RUST_VERSION}" -y
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR bumps rust toolchain and changes the default cc to clang.

## Why

As discussed in #1323 , I find the current Dockerfile has problem in my local building, including rustc SIGSEGV and some compilation errors in buliding duckdb. 

## How

This PR changes the default cc to clang, to make duckdb building successfully. The original my words about removing GCC is not right. GCC is needed for building pg_ivm because it has been hard-coded to gcc in makefile. In fact, build-essential will install kinds of gcc. So, I propose this minimum changes by using update-alternatives. 

This PR also bumps rust toolchain which can fix random  rustc SIGSEGV in my docker building with update-alternatives to clang . For the  rustc SIGSEGV, I guess it is caused by mixed gcc + 1.79 rustc. But why this combination can work on other machine like in our Github action is still needed to investigate.

## Tests

Passed in my local building.