### PR TITLE
chore: Allow missing keys in detect-aws-credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
       - id: check-vcs-permalinks
       - id: detect-private-key
       - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
       - id: debug-statements
       - id: destroyed-symlinks
       - id: fix-encoding-pragma


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Allow passing pre-commit check when there exists no configuration for AWS credentials.

## Why

Programmers may not have set up AWS credentials. This helps them pass the pre-commit check.

## How

## Tests
