### PR TITLE
fix: DuckDB Delta Lake Extension Autoloading

### DIFF
--- a/docs/analytics/import/delta.mdx
+++ b/docs/analytics/import/delta.mdx
@@ -2,11 +2,6 @@
 title: Delta
 ---
 
-<Note>
-  Delta scans are currently only supported over S3. This is a limitation of the
-  underlying DuckDB Delta extension and will be addressed soon.
-</Note>
-
 ## Overview
 
 This code block demonstrates how to create a foreign table over a Delta table.

--- a/pg_lakehouse/tests/scan.rs
+++ b/pg_lakehouse/tests/scan.rs
@@ -93,7 +93,6 @@ async fn test_arrow_types_s3_listing(#[future(awt)] s3: S3, mut conn: PgConnecti
 }
 
 #[rstest]
-#[ignore = "bug in DuckDB delta_scan over custom endpoints"]
 async fn test_arrow_types_s3_delta(
     #[future(awt)] s3: S3,
     mut conn: PgConnection,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1323 

## What
NOTE: This is branched off #1436, which needs to be merged first!

The error was found to be associated with a typo in the Dockerfile for the `.duckdb` folder permission. This is fixed in my `cnpg-docker` branch, so it should be ready to go. This PR uncomments the test that was failing.

## Why
We want to support the extension, and have a user waiting for it.

## How
^

## Tests
See CI once we PR it against `dev`