### PR TITLE
fix: Update ALTER TABLE statement to include schema name in construct_alter_table_statement function

### DIFF
--- a/pg_lakehouse/tests/table_config.rs
+++ b/pg_lakehouse/tests/table_config.rs
@@ -189,3 +189,49 @@ async fn test_preserve_casing_on_table_create(
 
     Ok(())
 }
+
+#[rstest]
+async fn test_table_with_custom_schema(mut conn: PgConnection, tempdir: TempDir) -> Result<()> {
+    let stored_batch = primitive_record_batch()?;
+    let parquet_path = tempdir.path().join("test_arrow_types.parquet");
+    let parquet_file = File::create(&parquet_path)?;
+
+    let mut writer = ArrowWriter::try_new(parquet_file, stored_batch.schema(), None).unwrap();
+    writer.write(&stored_batch)?;
+    writer.close()?;
+
+    primitive_setup_fdw_local_file_listing(parquet_path.as_path().to_str().unwrap(), "MyTable")
+        .execute(&mut conn);
+
+    // test quoted schema name
+    format!("CREATE SCHEMA \"MY_SCHEMA\"").execute(&mut conn);
+    match
+        format!( "CREATE FOREIGN TABLE \"MY_SCHEMA\".\"MyTable\" () SERVER parquet_server OPTIONS (files '{}', preserve_casing 'true')",
+                parquet_path.to_str().unwrap()
+        ).execute_result(&mut conn) {
+        Ok(_) => {}
+        Err(error) => {
+            panic!(
+                "should have successfully created table with custom schema \"MY_SCHEMA\".\"MyTable\": {}",
+                error
+            );
+        }
+    }
+
+    // test non-quoted schema name
+    format!("CREATE SCHEMA MY_SCHEMA").execute(&mut conn);
+    match
+        format!( "CREATE FOREIGN TABLE MY_SCHEMA.MyTable () SERVER parquet_server OPTIONS (files '{}', preserve_casing 'true')",
+                parquet_path.to_str().unwrap()
+        ).execute_result(&mut conn) {
+        Ok(_) => {}
+        Err(error) => {
+            panic!(
+                "should have successfully created table with custom schema MY_SCHEMA.MyTable: {}",
+                error
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/pg_lakehouse/tests/table_config.rs
+++ b/pg_lakehouse/tests/table_config.rs
@@ -204,7 +204,7 @@ async fn test_table_with_custom_schema(mut conn: PgConnection, tempdir: TempDir)
         .execute(&mut conn);
 
     // test quoted schema name
-    format!("CREATE SCHEMA \"MY_SCHEMA\"").execute(&mut conn);
+    "CREATE SCHEMA \"MY_SCHEMA\"".to_string().execute(&mut conn);
     match
         format!( "CREATE FOREIGN TABLE \"MY_SCHEMA\".\"MyTable\" () SERVER parquet_server OPTIONS (files '{}', preserve_casing 'true')",
                 parquet_path.to_str().unwrap()
@@ -219,7 +219,7 @@ async fn test_table_with_custom_schema(mut conn: PgConnection, tempdir: TempDir)
     }
 
     // test non-quoted schema name
-    format!("CREATE SCHEMA MY_SCHEMA").execute(&mut conn);
+    "CREATE SCHEMA MY_SCHEMA".to_string().execute(&mut conn);
     match
         format!( "CREATE FOREIGN TABLE MY_SCHEMA.MyTable () SERVER parquet_server OPTIONS (files '{}', preserve_casing 'true')",
                 parquet_path.to_str().unwrap()


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1476

## What

## Why
hardcore the wrong alter statement

## How
introduce `schema_name` to `construct_alter_table_statement`

## Tests
Added tests in `pg_lakehouse/tests/table_config.rs`