### PR TITLE
chore: document scoring limitation for TermSet query

### DIFF
--- a/docs/search/full-text/complex.mdx
+++ b/docs/search/full-text/complex.mdx
@@ -403,6 +403,12 @@ SELECT * FROM search_idx.search(
 );
 ```
 
+<Note>
+  **Limitation:** BM25 scoring is not enabled for TermSet queries. As a result,
+  the scores returned may not be accurate. This behavior reflects the underlying
+  implementation in Tantivy.
+</Note>
+
 <ParamField body="terms">
   An `ARRAY` of `paradedb.term` query objects.
 </ParamField>


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1385

## What
As described in #1385, there's a Tantivy-level limitation that prevents proper scoring with `TermSet` queries. This PR adds a documentation note about that.
