### PR TITLE
feat: add `index_size` method to get index directory size in bytes

### DIFF
--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -440,14 +440,20 @@ CALL paradedb.drop_bm25(
 
 The `schema` function returns a table with information about the index schema.
 
+You can also check the size of an index in bytes with `index_size`.
+
 ```sql
 SELECT * FROM <index_name>.schema();
+
+SELECT * FROM <index_name>.index_size();
 ```
 
 <Accordion title="Example Usage">
 
 ```sql
 SELECT * FROM search_idx.schema();
+
+SELECT * FROM search_idx.index_size();
 ```
 
 </Accordion>

--- a/pg_search/src/writer/directory.rs
+++ b/pg_search/src/writer/directory.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::env;
+use anyhow::Result;
 use derive_more::AsRef;
 use fs2::FileExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -64,6 +65,20 @@ pub trait SearchFs {
         &self,
         ensure_exists: bool,
     ) -> Result<WriterTransferPipeFilePath, SearchDirectoryError>;
+    /// Get the total size in bytes of the directory.
+    fn total_size(&self) -> Result<u64> {
+        let path = self.tantivy_dir_path(false)?;
+        let mut total_size = 0;
+
+        for entry_result in WalkDir::new(path) {
+            let entry = entry_result?;
+            if entry.path().is_file() {
+                total_size += entry.metadata()?.len();
+            }
+        }
+
+        Ok(total_size)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1200,3 +1200,16 @@ fn high_limit_rows(mut conn: PgConnection) {
             .fetch(&mut conn);
     assert_eq!(rows.len(), 200000);
 }
+
+#[rstest]
+fn index_size(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Calculate the index size using the new method
+    let size: i64 = "SELECT bm25_search.index_size()"
+        .fetch_one::<(i64,)>(&mut conn)
+        .0;
+
+    // Ensure the size is greater than zero, meaning the index has been created
+    assert!(size > 0);
+}

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1207,8 +1207,14 @@ fn index_size(mut conn: PgConnection) {
 
     let data_directory = "SHOW data_directory;".fetch_one::<(String,)>(&mut conn).0;
 
+    let index_oid =
+        "SELECT oid::int4 FROM pg_class WHERE relname = 'bm25_search_bm25_index' AND relkind = 'i'"
+            .fetch_one::<(i32,)>(&mut conn)
+            .0;
+
     let index_dir = PathBuf::from(data_directory)
         .join("pg_search")
+        .join(&index_oid.to_string())
         .join("tantivy");
 
     assert!(

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1214,7 +1214,7 @@ fn index_size(mut conn: PgConnection) {
 
     let index_dir = PathBuf::from(data_directory)
         .join("pg_search")
-        .join(&index_oid.to_string())
+        .join(index_oid.to_string())
         .join("tantivy");
 
     assert!(


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #[633](https://github.com/paradedb/paradedb/issues/633)

## What
Users have requested being able to see the size of their BM25 indexes.

## How
This PR adds a method on the dynamic index schema to check the size.

## Tests
Added a new test.
