### PR TITLE
Add bench functions for GIN-based TSQuery/TSVector

### DIFF
--- a/cargo-paradedb/README.md
+++ b/cargo-paradedb/README.md
@@ -43,9 +43,9 @@ Benchmark tools are run under the `cargo paradedb bench` subcommand, which are o
 cargo paradedb bench eslogs query-search-index
 ```
 
-### Benchmark pg_search
+### Benchmark pg_search, GIN-based tsvector indexes
 
-#### Generating pg_search Benchmark Data
+#### Generating Benchmark Data
 
 Our benchmarks use the same generated data as the [elasticsearch-opensearch-benchmark](https://github.com/elastic/elasticsearch-opensearch-benchmark) project. To run the data generation tool, you must have [Go](https://go.dev/doc/install) installed. Run the generator tool with:
 
@@ -57,11 +57,13 @@ In the command above, `generate` can accept arguments to specify a random seed, 
 
 The `generate` tool is idempotent. It will produce a table in your Postgres database with the number of events that you asked it to generate. As it generates data, it will periodically commit the `INSERT` transaction to Postgres. If you kill the process, it will pick up where it left off the next time you run it.
 
-#### Running pg_search Benchmarks
+#### Running Benchmarks
 
 All commands below operate on default tables, visible with `--help`. Defaults can be overidden with options passed to each command.
 
 Benchmarks that build a table or index are only run once, as these operations usually take a long time. Benchmarks that peform fast operations, like queries, are sampled many times with the [Criterion](https://github.com/bheisler/criterion.rs) library.
+
+##### Running pg_search Benchmarks
 
 Build a `pg_search` index:
 
@@ -73,6 +75,20 @@ Query a `pg_search` index (index must already exist):
 
 ```sh
 cargo paradedb bench eslogs query-search-index
+```
+
+##### Running GIN-based tsvector/tsquery Benchmarks
+
+Build a GIN-based `tsvector` index:
+
+```sh
+cargo paradedb bench eslogs build-gints-index
+```
+
+Query a GIN-based `tsvector` index (index must already exist):
+
+```sh
+cargo paradedb bench eslogs query-gints-index
 ```
 
 ### Benchmark pg_lakehouse

--- a/cargo-paradedb/src/cli.rs
+++ b/cargo-paradedb/src/cli.rs
@@ -109,6 +109,31 @@ pub enum EsLogsCommand {
         #[arg(short, long, env = "DATABASE_URL")]
         url: String,
     },
+    BuildGINTSIndex {
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]
+        table: String,
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_INDEX_NAME)]
+        index: String,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
+    },
+    QueryGINTSIndex {
+        /// Postgres index name to query.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_INDEX_NAME)]
+        index: String,
+        /// Query to run.
+        #[arg(short, long, default_value = "message:flame")]
+        query: String,
+        /// Limit results to return.
+        #[arg(short, long, default_value_t = 1)]
+        limit: u64,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
+    },
     BuildParquetTable {
         /// Postgres table name to build from.
         #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]

--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -58,6 +58,17 @@ fn main() -> Result<()> {
                 } => block_on(subcommand::bench_eslogs_query_search_index(
                     index, query, limit, url,
                 )),
+                EsLogsCommand::BuildGINTSIndex { table, index, url } => block_on(
+                    subcommand::bench_eslogs_build_gints_index(table, index, url),
+                ),
+                EsLogsCommand::QueryGINTSIndex {
+                    index,
+                    query,
+                    limit,
+                    url,
+                } => block_on(subcommand::bench_eslogs_query_gints_index(
+                    index, query, limit, url,
+                )),
                 EsLogsCommand::BuildParquetTable { table, url } => {
                     block_on(subcommand::bench_eslogs_build_parquet_table(table, url))
                 }

--- a/cargo-paradedb/src/subcommand.rs
+++ b/cargo-paradedb/src/subcommand.rs
@@ -219,6 +219,47 @@ pub async fn bench_eslogs_query_search_index(
     .await
 }
 
+pub async fn bench_eslogs_build_gints_index(
+    table: String,
+    index: String,
+    url: String,
+) -> Result<()> {
+    let drop_query =
+        format!("DROP INDEX IF EXISTS {index}");
+
+    let create_query = format!(
+        "CREATE INDEX {index} ON {table} USING gin ((to_tsvector('english', message)));"
+    );
+
+    Benchmark {
+        group_name: "GIN TSQuery/TSVector Index".into(),
+        function_name: "bench_eslogs_build_gints_index".into(),
+        // First, drop any existing index to ensure a clean environment.
+        setup_query: Some(drop_query),
+        query: create_query,
+        database_url: url,
+    }
+    .run_pg_once()
+    .await
+}
+
+pub async fn bench_eslogs_query_gints_index(
+    index: String,
+    query: String,
+    limit: u64,
+    url: String,
+) -> Result<()> {
+    Benchmark {
+        group_name: "GIN TSQuery/TSVector Query".into(),
+        function_name: "bench_eslogs_query_gints_index".into(),
+        setup_query: None,
+        query: format!("SELECT * FROM {table} WHERE to_tsvector('english', message) && '{query}'::tsquery LIMIT {limit};"),
+        database_url: url,
+    }
+    .run_pg()
+    .await
+}
+
 pub async fn bench_eslogs_build_parquet_table(table: String, url: String) -> Result<()> {
     let parquet_table_name = format!("{table}_parquet");
     let drop_query = format!(


### PR DESCRIPTION
# Ticket(s) Closed

Not closed, but some part of https://github.com/paradedb/paradedb/issues/279 is definitely addressed here.

## What

Add a benchmark option for PG's native text search capabilities

## Why

The benchmark suite doesn't currently cover it.

## How

By adding the functions

## Tests

Not tested here, I've used the web UI to modify this file.
