### PR TITLE
chore: Add templates to GitHub Discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/announcements.yml
+++ b/.github/DISCUSSION_TEMPLATE/announcements.yml
@@ -1,0 +1,7 @@
+title: "[Announcements] "
+labels: ["General Introduction"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This discussion type is reserved for maintainers to make announcements about ParadeDB.

--- a/.github/DISCUSSION_TEMPLATE/announcements.yml
+++ b/.github/DISCUSSION_TEMPLATE/announcements.yml
@@ -1,5 +1,5 @@
 title: "[Announcements] "
-labels: ["General Introduction"]
+labels: ["announcement"]
 body:
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,29 +1,34 @@
 title: "[General] "
-labels: ["General Introduction"]
+labels: ["General"]
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >
+        This discussion type is for anything that doesn't fit in another category. If you are looking to raise an issue,
+        please do so on the relevant ParadeDB repository:
 
+        * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+        * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+        * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
 
-        This discussion type is reserved for maintainers to make announcements about ParadeDB.
+        Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 
-  - type: dropdown
-    id: download
+  - type: markdown
     attributes:
-      label: Which area of this project could be most improved?
-      options:
-        - Documentation
-        - Pull request review time
-        - Bug fix time
-        - Release cadence
+      value: "### Identity Disclosure"
+  - type: input
+    attributes:
+      label: "Full Name:"
+      placeholder: e.g., John Doe
     validations:
       required: true
-
-  - type: checkboxes
+  - type: input
     attributes:
-      label: Check that box!
-      options:
-        - label: This one!
-          required: true
-        - label: I won't stop you if you check this one, too
+      label: "Affiliation:"
+      placeholder: e.g., Acme Corporation
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        If the above is not given and is not obvious from your GitHub profile page, we might close your issue without further review. Please refer to the [reasoning behind this rule](https://berthub.eu/articles/posts/anonymous-help/) if you have questions.

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,5 +1,5 @@
 title: "[General] "
-labels: ["General"]
+labels: ["question"]
 body:
   - type: markdown
     attributes:
@@ -7,11 +7,21 @@ body:
         This discussion type is for anything that doesn't fit in another category. If you are looking to raise an issue,
         please do so on the relevant ParadeDB repository:
 
-        * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-        * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
-        * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
+          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+          * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+          * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
+
+
+  - type: textarea
+    attributes:
+      label: What 
+      description: A short, clear and concise description of the current situation.
+    validations:
+      required: true
+
+
 
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,29 @@
+title: "[General] "
+labels: ["General Introduction"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+
+
+        This discussion type is reserved for maintainers to make announcements about ParadeDB.
+
+  - type: dropdown
+    id: download
+    attributes:
+      label: Which area of this project could be most improved?
+      options:
+        - Documentation
+        - Pull request review time
+        - Bug fix time
+        - Release cadence
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Check that box!
+      options:
+        - label: This one!
+          required: true
+        - label: I won't stop you if you check this one, too

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -13,15 +13,12 @@ body:
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 
-
   - type: textarea
     attributes:
-      label: What 
-      description: A short, clear and concise description of the current situation.
+      label: What would you like to discuss?
+      description: Share a project, ask a question, or start a conversation.
     validations:
       required: true
-
-
 
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -4,6 +4,13 @@ body:
   - type: markdown
     attributes:
       value: >
+        This discussion type is for discussing ideas and feature requests for ParadeDB. If you are looking to raise an issue,
+        please do so on the relevant ParadeDB repository:
+
+          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+          * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+          * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
+
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,5 +1,5 @@
 title: "[Ideas] "
-labels: ["feature"]
+labels: ["feature", "idea", "suggestion"]
 body:
   - type: markdown
     attributes:
@@ -8,24 +8,17 @@ body:
 
   - type: textarea
     attributes:
-      label: What feature are you requesting?
-      description: A short, clear and concise description of the desired feature.
+      label: What idea are you proposing?
+      description: A short, clear and concise description of the desired feature or proposed idea.
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: Why are you requesting this feature?
-      description: A short, clear and concise description of why this feature is important.
+      label: Why are you proposing this idea?
+      description: A short, clear and concise description of why this feature or idea is important.
     validations:
       required: true
-
-  - type: textarea
-    attributes:
-      label: What is your proposed implementation for this feature?
-      description: A short, clear and concise description of how you'd implement this feature.
-    validations:
-      required: false
 
   - type: markdown
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,49 @@
+title: "[Ideas] "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
+
+  - type: textarea
+    attributes:
+      label: What feature are you requesting?
+      description: A short, clear and concise description of the desired feature.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Why are you requesting this feature?
+      description: A short, clear and concise description of why this feature is important.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What is your proposed implementation for this feature?
+      description: A short, clear and concise description of how you'd implement this feature.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "### Identity Disclosure:"
+  - type: input
+    attributes:
+      label: "Full Name:"
+      placeholder: e.g., John Doe
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Affiliation:"
+      placeholder: e.g., Acme Corporation
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        If the above is not given and is not obvious from your GitHub profile page, we might close your issue without further review. Please refer to the [reasoning behind this rule](https://berthub.eu/articles/posts/anonymous-help/) if you have questions.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,9 +1,6 @@
 title: "[Q&A] "
-labels: ["bugn"]
+labels: ["bug", "question"]
 body:
-  - type: markdown
-    attributes:
-      value: "### Bug Report"
   - type: markdown
     attributes:
       value: >
@@ -45,7 +42,7 @@ body:
         - ParadeDB Docker Image
         - ParadeDB Helm Chart
         - ParadeDB pg_search Extension
-        - ParadeDB pg_lakehouse Extension
+        - ParadeDB pg_analytics Extension
     validations:
       required: true
 

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -4,11 +4,19 @@ body:
   - type: markdown
     attributes:
       value: >
+        This discussion type is for questions about ParadeDB. If you are looking to raise an issue,
+        please do so on the relevant ParadeDB repository:
+
+          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+          * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+          * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
+
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
+
   - type: textarea
     attributes:
       label: What happens?
-      description: A short, clear and concise description of the bug.
+      description: A short, clear and concise description of the current situation.
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,96 @@
+title: "[Q&A] "
+labels: ["bugn"]
+body:
+  - type: markdown
+    attributes:
+      value: "### Bug Report"
+  - type: markdown
+    attributes:
+      value: >
+        Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
+  - type: textarea
+    attributes:
+      label: What happens?
+      description: A short, clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: |
+        Please provide steps to reproduce the behaviour, preferably a [minimal reproducible example](https://en.wikipedia.org/wiki/Minimal_reproducible_example).
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "### Environment"
+  - type: input
+    attributes:
+      label: "OS:"
+      placeholder: e.g., macOS
+      description: Please include your operating system version and architecture (e.g., aarch64, x86, x64, etc.)
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "ParadeDB Version:"
+      placeholder: e.g., v0.8.0
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Are you using ParadeDB Docker, Helm, or the extension(s) standalone?
+      options:
+        - ParadeDB Docker Image
+        - ParadeDB Helm Chart
+        - ParadeDB pg_search Extension
+        - ParadeDB pg_lakehouse Extension
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "### Identity Disclosure"
+  - type: input
+    attributes:
+      label: "Full Name:"
+      placeholder: e.g., John Doe
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Affiliation:"
+      placeholder: e.g., Acme Corporation
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        If the above is not given and is not obvious from your GitHub profile page, we might close your issue without further review. Please refer to the [reasoning behind this rule](https://berthub.eu/articles/posts/anonymous-help/) if you have questions.
+
+  - type: markdown
+    attributes:
+      value: "### Confirmation"
+  - type: dropdown
+    attributes:
+      label: Did you include all relevant data sets for reproducing the issue?
+      options:
+        - "Yes"
+        - "No - I cannot share the data sets because they are confidential"
+        - "No - I cannot easily share my data sets due to their large size"
+        - "No - Other reason (please specify in the issue body)"
+        - "N/A - The reproduction does not require a data set"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Did you include the code required to reproduce the issue?
+      options:
+        - label: Yes, I have
+  - type: checkboxes
+    attributes:
+      label: Did you include all relevant configurations (e.g., CPU architecture, PostgreSQL version, Linux distribution) to reproduce the issue?
+      options:
+        - label: Yes, I have

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,9 +11,9 @@ body:
       value: >
         ParadeDB has other repositories for different components. Please make sure you are filing your issue in the correct repository:
 
-        * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
-        * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
-        * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
+          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+          * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+          * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
 
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,6 +6,12 @@ body:
   - type: markdown
     attributes:
       value: >
+        ParadeDB has other repositories for different components. Please make sure you are filing your issue in the correct repository:
+
+          * [paradedb/paradedb](https://github.com/paradedb/paradedb/issues/news/) - ParadeDB core and pg_search extension repository
+          * [paradedb/pg_analytics](https://github.com/paradedb/pg_analytics/issues/new/) - ParadeDB pg_analytics extension repository
+          * [paradedb/helm-charts](https://github.com/paradedb/helm-charts/issues/new/) - ParadeDB Helm Chart repository
+
         Please report security vulnerabilities using GitHub's [report vulnerability form](https://github.com/paradedb/paradedb/security/advisories/new).
 
   - type: textarea


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We've got much better issues since introducing templates, and today we got a very unclear discussion opened again. So I'm introducing templates for discussions too!

## Why
^

## How
Followed the GitHub documentation

## Tests
Not sure how to test this until it's merged, tbh.