### PR TITLE
feat(doc): Document `DATABASE_URL` in `pg_search/README.md`

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -302,7 +302,7 @@ DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
 
 USER_NAME should be replaced with your system user name. (eg: output of `whoami`)
 
-PORT should be replaced witrh 28800 + your postgres version. (eg: 28816 for postgres 16)
+PORT should be replaced with 28800 + your postgres version. (eg: 28816 for postgres 16)
 
 ## License
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -294,6 +294,16 @@ CREATE EXTENSION pg_search;
 
 We use `cargo test` as our runner for `pg_search` tests.
 
+The tests require a `DATABASE_URL` envirobnment variable to be set. The easiest way to do this is to create a `.env` file with the following contents.
+
+```env
+DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
+```
+
+USER_NAME should be replaced with your system user name. (eg: output of `whoami`)
+
+PORT should be replaced witrh 28800 + your postgres version. (eg: 28816 for postgres 16)
+
 ## License
 
 `pg_search` is licensed under the [GNU Affero General Public License v3.0](../LICENSE) and as commercial software. For commercial licensing, please contact us at [sales@paradedb.com](mailto:sales@paradedb.com).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1495

## What

Documents `DATABASE_URL` in `pg_search/README.md`

## Why

`DATABASE_URL` is necessary. I also wasn't immediately intuitive what I should set it to. 

## How

Add text to `pg_search/README.md`

## Tests

Work much better after setting this :P