### PR TITLE
fix: Fix DuckDB permission in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -193,7 +193,12 @@ COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-p
 USER root
 
 # Required for pg_analytics, pg_cron
+#
+# If a user connects to ParadeDB with the superuser, the DuckDB folder will be created in the user's home directory. If
+# the user connects with the postgres user, the DuckDB folder will be created in the /var/lib/postgresql directory. We
+# chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
 RUN mkdir .duckdb/ && chmod 777 .duckdb/ && \
+    mkdir /var/lib/postgresql/.duckdb/ && chmod 777 /var/lib/postgresql/.duckdb/ && \
     apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
 
 # The postgresql.conf.sample file is used as a template for the postgresql.conf file, which


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This fixes an issue where the user would not be able to install DuckDB extensions if not connected as superuser.

## Why
^

## How
^

## Tests
N/A