### PR TITLE
fix: Fix CNPG uid issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -211,8 +211,14 @@ RUN mkdir .duckdb/ && chmod 777 .duckdb/ && \
 RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_search,pg_analytics,pg_cron'/" /usr/share/postgresql/postgresql.conf.sample && \
     echo "cron.database_name = 'postgres'" >> /usr/share/postgresql/postgresql.conf.sample
 
-# Switch back to the postgres user
-USER postgres
+# Change the uid of the postgres user to 26, for CloudNativePG compatibility
+RUN usermod -u 26 postgres \
+    && chown -R 26:999 /var/lib/postgresql \
+    && chown -R 26:999 /var/run/postgresql \
+    && chmod -R 700 /var/lib/postgresql
+
+# Switch back to the postgres user, with the new uid
+USER 26
 
 # Copy ParadeDB scripts to install extensions, configure postgresql.conf, update extensions, etc.
 COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This fixes a bug, which was reported in Slack, that our Helm Chart is failing to launch due to UID configuration issue. We *need* to add a test for this to our CI, which will come in a separate PR. This is a hotfix PR to get the user unblocked.

## Why
^

## How
Switch the postgres user uid to map what CNPG expects.

## Tests
Manually tested