### PR TITLE
fix: Throw better error on partitioned BM25 indexes

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -17,7 +17,6 @@
 
 use crate::env::needs_commit;
 use crate::globals::WriterGlobal;
-use crate::index::state::SearchStateManager;
 use crate::index::SearchIndex;
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchConfig;
@@ -54,7 +53,6 @@ fn search_tantivy(
             hs.insert(key);
         }
 
-        SearchStateManager::set_state(scan_state).expect("could not store search state in manager");
         (search_config, hs)
     };
 

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -128,6 +128,25 @@ fn create_bm25_impl(
         );
     }
 
+    let is_partitioned_query = format!(
+        "SELECT EXISTS (SELECT 1 FROM pg_inherits WHERE inhparent = '{}.{}'::regclass)",
+        spi::quote_identifier(schema_name),
+        spi::quote_identifier(table_name),
+    );
+    let partitioned = Spi::get_one::<bool>(&is_partitioned_query)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not check if {}.{} is partitioned",
+            schema_name,
+            table_name
+        )
+    })?;
+
+    if partitioned {
+        bail!(
+            "Creating BM25 indexes over partitioned tables is a ParadeDB enterprise feature. Contact support@paradedb.com for access."
+        );
+    }
+
     if text_fields == "{}"
         && numeric_fields == "{}"
         && boolean_fields == "{}"
@@ -321,6 +340,7 @@ fn create_bm25_impl(
                                 (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ())
                         END AS score
                     FROM {}.{}
+                    {}
                     ORDER BY __similarity_query__
                     LIMIT $2
                 ),
@@ -335,48 +355,6 @@ fn create_bm25_impl(
                                 (MAX(score_bm25) OVER () - MIN(score_bm25) OVER ())
                         END AS score
                     FROM paradedb.score_bm25($1, NULL::{}, {})
-                )
-                SELECT
-                    COALESCE(similarity.key_field, bm25.key_field) AS __key_field__,
-                    (COALESCE(similarity.score, 0.0) * $3 + COALESCE(bm25.score, 0.0) * $4)::real AS score_hybrid
-                FROM similarity
-                FULL OUTER JOIN bm25 ON similarity.key_field = bm25.key_field
-                ORDER BY score_hybrid DESC;
-            ",
-            spi::quote_identifier(schema_name),
-            spi::quote_identifier(table_name),
-            key_type,
-            key_oid.as_u32()
-        ),
-        &index_json
-    ))?;
-
-    // This function has been deprecated in favor of `score_hybrid` as of version 0.8.5.
-    Spi::run(&format_hybrid_function(
-        &spi::quote_qualified_identifier(index_name, "rank_hybrid"),
-        &format!("TABLE({} {}, rank_hybrid real)", spi::quote_identifier(key_field), key_type),
-        &format!(
-            "
-                WITH similarity AS (
-                    SELECT
-                        __key_field__ as key_field,
-                        CASE
-                            WHEN (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ()) = 0 THEN
-                                0
-                            ELSE
-                                1 - ((__similarity_query__) - MIN(__similarity_query__) OVER ()) / 
-                                (MAX(__similarity_query__) OVER () - MIN(__similarity_query__) OVER ())
-                        END AS score
-                    FROM {}.{}
-                    {}
-                    ORDER BY __similarity_query__
-                    LIMIT $2
-                ),
-                bm25 AS (
-                    SELECT 
-                        id as key_field,
-                        rank_bm25 as score 
-                    FROM paradedb.minmax_bm25($1, NULL::{}, {})
                 )
                 SELECT
                     COALESCE(similarity.key_field, bm25.key_field) AS __key_field__,

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -55,6 +55,8 @@ pub extern "C" fn ambuild(
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
     let index_oid = index_relation.oid();
 
+    info!("ambuild {:?}", index_oid);
+
     let rdopts: PgBox<SearchIndexCreateOptions> = if !index_relation.rd_options.is_null() {
         unsafe { PgBox::from_pg(index_relation.rd_options as *mut SearchIndexCreateOptions) }
     } else {
@@ -208,6 +210,9 @@ pub extern "C" fn ambuild(
 
     let writer_client = WriterGlobal::client();
     let directory = WriterDirectory::from_index_oid(index_oid.as_u32());
+
+    info!("create index {:?}", directory);
+
     SearchIndex::create_index(
         &writer_client,
         directory,

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -19,7 +19,7 @@ use pgrx::JsonB;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};
 use std::str::FromStr;
 
-use crate::{index::state::SearchAlias, query::SearchQueryInput};
+use crate::query::SearchQueryInput;
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
 pub struct SearchConfig {
@@ -33,7 +33,6 @@ pub struct SearchConfig {
     pub highlight_field: Option<String>,
     pub prefix: Option<String>,
     pub postfix: Option<String>,
-    pub alias: Option<SearchAlias>,
     pub stable_sort: Option<bool>,
     pub uuid: String,
 }

--- a/pg_search/src/writer/index.rs
+++ b/pg_search/src/writer/index.rs
@@ -121,6 +121,7 @@ impl Writer {
         uuid: String,
         key_field_index: usize,
     ) -> Result<()> {
+        pgrx::info!("Creating index with fields: {:?}", fields);
         let schema = SearchIndexSchema::new(fields, key_field_index)?;
 
         let tantivy_dir_path = directory.tantivy_dir_path(true)?;

--- a/pg_search/tests/documentation.rs
+++ b/pg_search/tests/documentation.rs
@@ -125,17 +125,6 @@ fn quickstart(mut conn: PgConnection) {
     assert_eq!(rows[0].1, "<b>Blue</b>tooth-enabled speaker");
     assert_relative_eq!(rows[0].2, 2.9903657, epsilon = 1e-6);
 
-    // This deprecated query used to be in the quickstart and has been preserved to check backwards compatibility
-    let rows: Vec<(String, String, f32)> = r#"
-    SELECT description, paradedb.highlight(id, field => 'description'), paradedb.rank_bm25(id)
-    FROM ngrams_idx.search('description:blue', stable_sort => true)
-    "#
-    .fetch(&mut conn);
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].0, "Bluetooth-enabled speaker");
-    assert_eq!(rows[0].1, "<b>Blue</b>tooth-enabled speaker");
-    assert_relative_eq!(rows[0].2, 2.9903657, epsilon = 1e-6);
-
     r#"
     CREATE EXTENSION vector;
     ALTER TABLE mock_items ADD COLUMN embedding vector(3);

--- a/pg_search/tests/icu.rs
+++ b/pg_search/tests/icu.rs
@@ -157,7 +157,7 @@ fn test_icu_czech_content_tokenizer(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let columns: IcuCzechPostsTableVec =
-        r#"SELECT *, paradedb.rank_bm25("id") FROM idx_czech_content.search(query => paradedb.phrase(field => 'message', phrases => ARRAY['šla', 'sbírat']));"#
+        r#"SELECT * FROM idx_czech_content.search(query => paradedb.phrase(field => 'message', phrases => ARRAY['šla', 'sbírat']));"#
             .fetch_collect(&mut conn);
 
     assert_eq!(columns.id, vec![1]);

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -51,15 +51,6 @@ fn boolean_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(bool, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
-        stable_sort => true
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows, vec![(false, 0.25759196), (true, 0.14109309)]);
-
-    let rows: Vec<(bool, f32)> = r#"
     SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
@@ -70,31 +61,12 @@ fn boolean_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 2);
-
-    let rows: Vec<(f32,)> = r#"
     SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 2);
-
-    // alias
-    let rows: Vec<(bool, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 3);
 }
 
 #[rstest]
@@ -129,43 +101,6 @@ fn uuid_key(mut conn: PgConnection) {
     .execute(&mut conn);
 
     // stable_sort
-    let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
-        stable_sort => true
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(
-        rows,
-        vec![
-            (
-                "b5faacc0-9eba-441a-81f8-820b46a3b57e".to_string(),
-                0.61846066
-            ),
-            (
-                "38bf27a0-1aa8-42cd-9cb0-993025e0b8d0".to_string(),
-                0.57459813
-            ),
-            (
-                "f159c89e-2162-48cd-85e3-e42b71d2ecd0".to_string(),
-                0.53654534
-            ),
-            (
-                "40bc9216-66d0-4ae8-87ee-ddb02e3e1b33".to_string(),
-                0.50321954
-            ),
-            (
-                "ea1181a0-5d3e-4f5f-a6ab-b1354ffc91ad".to_string(),
-                0.47379148
-            ),
-            (
-                "eb833eb6-c598-4042-b84a-0045828fceea".to_string(),
-                0.44761515
-            ),
-        ]
-    );
-
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
@@ -205,31 +140,12 @@ fn uuid_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 6);
-
-    let rows: Vec<(f32,)> = r#"
     SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), snippet FROM test_index.snippet('value:blue', highlight_field => 'value')
@@ -274,25 +190,6 @@ fn i64_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(i64, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
-        stable_sort => true
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(
-        rows,
-        vec![
-            (3, 0.61846066),
-            (2, 0.57459813),
-            (1, 0.53654534),
-            (9, 0.50321954),
-            (5, 0.47379148),
-            (4, 0.44761515),
-        ]
-    );
-
-    let rows: Vec<(i64, f32)> = r#"
     SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
@@ -313,31 +210,12 @@ fn i64_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue')
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 6);
-
-    let rows: Vec<(f32,)> = r#"
     SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(i64, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 
     let rows: Vec<(i64, String)> = r#"
     SELECT id, snippet FROM test_index.snippet('value:blue', highlight_field => 'value')
@@ -382,7 +260,7 @@ fn i32_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(i32, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -402,23 +280,12 @@ fn i32_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(i32, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -454,7 +321,7 @@ fn i16_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(i16, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -474,23 +341,12 @@ fn i16_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(i16, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -526,7 +382,7 @@ fn f32_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(f32, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -546,23 +402,12 @@ fn f32_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(f32, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -598,7 +443,7 @@ fn f64_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(f64, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -618,23 +463,12 @@ fn f64_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(f64, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -670,7 +504,7 @@ fn numeric_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(f64, f32)> = r#"
-    SELECT CAST(id AS FLOAT8), paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT CAST(id AS FLOAT8), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -690,23 +524,12 @@ fn numeric_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(f64, String)> = r#"
-    SELECT CAST(id AS FLOAT8), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS FLOAT8), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -742,7 +565,7 @@ fn string_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT id, paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT * FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -780,23 +603,12 @@ fn string_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT id, paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT id, paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -832,7 +644,7 @@ fn date_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -852,23 +664,12 @@ fn date_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -904,7 +705,7 @@ fn time_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -924,23 +725,12 @@ fn time_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -976,7 +766,7 @@ fn timestamp_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -996,23 +786,12 @@ fn timestamp_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }
 
 #[rstest]
@@ -1048,25 +827,6 @@ fn timestamptz_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
-        query => paradedb.term(field => 'value', value => 'blue'),
-        stable_sort => true
-    );
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(
-        rows,
-        vec![
-            ("2023-05-05 17:11:12+00".to_string(), 0.61846066),
-            ("2023-05-04 17:10:11+00".to_string(), 0.57459813),
-            ("2023-05-03 13:09:10+00".to_string(), 0.53654534),
-            ("2023-05-11 21:17:18+00".to_string(), 0.50321954),
-            ("2023-05-07 17:13:14+00".to_string(), 0.47379148),
-            ("2023-05-06 17:12:13+00".to_string(), 0.44761515),
-        ]
-    );
-
-    let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
@@ -1087,7 +847,7 @@ fn timestamptz_key(mut conn: PgConnection) {
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
@@ -1101,17 +861,6 @@ fn timestamptz_key(mut conn: PgConnection) {
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), snippet FROM test_index.snippet('value:blue', highlight_field => 'value')
@@ -1156,7 +905,7 @@ fn timetz_key(mut conn: PgConnection) {
 
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT CAST(id AS TEXT), score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue'),
         stable_sort => true
     );
@@ -1165,32 +914,21 @@ fn timetz_key(mut conn: PgConnection) {
     assert_eq!(
         rows,
         vec![
-            ("10:11:12-07".to_string(), 0.61846066),
-            ("09:10:11-08".to_string(), 0.57459813),
-            ("08:09:10-05".to_string(), 0.53654534),
-            ("16:17:18-05".to_string(), 0.50321954),
-            ("12:13:14-05".to_string(), 0.47379148),
-            ("11:12:13-06".to_string(), 0.44761515),
+            ("17:11:12+00".to_string(), 0.61846066),
+            ("17:10:11+00".to_string(), 0.57459813),
+            ("13:09:10+00".to_string(), 0.53654534),
+            ("21:17:18+00".to_string(), 0.50321954),
+            ("17:13:14+00".to_string(), 0.47379148),
+            ("17:12:13+00".to_string(), 0.44761515),
         ]
     );
 
     // no stable_sort
     let rows: Vec<(f32,)> = r#"
-    SELECT paradedb.rank_bm25(id) FROM test_index.search(
+    SELECT score_bm25 FROM test_index.score_bm25(
         query => paradedb.term(field => 'value', value => 'blue')
     );
     "#
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 6);
-
-    // alias
-    let rows: Vec<(String, String)> = r#"
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value') FROM test_index.search('value:blue')
-    UNION
-    SELECT CAST(id AS TEXT), paradedb.highlight(id, field => 'value', alias => 'tooth')
-    FROM test_index.search('value:tooth', alias => 'tooth')
-    ORDER BY id
-    "#
-    .fetch_collect(&mut conn);
-    assert_eq!(rows.len(), 8);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1491 

## What
Partitioned BM25 indexes are an enterprise feature, but we weren't throwing a clear error for it.

## Why

## How
As part of this, I have removed the deprecated `SearchStateManager` as well as the deprecated `rank_bm25`, `rank_hybrid`, and `highlight` functions that depended on it. The `SearchStateManager` was causing issues with partitioned indexing.

## Tests
Added a test for partitioned indexes. Removed all tests for the deprecated functions.