### PR TITLE
fix: throw error if `key_field` is indexed

### DIFF
--- a/docs/search/full-text/index.mdx
+++ b/docs/search/full-text/index.mdx
@@ -226,6 +226,21 @@ CALL paradedb.create_bm25(
   and filtering.
 </ParamField>
 
+## Choosing a Key Field
+
+The `key_field` option is used to uniquely identify documents within an index and cannot be tokenized. For instance,
+the following configuration is not allowed:
+
+```sql
+-- This will throw an error
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'description',
+  text_fields => paradedb.field('description')
+);
+```
+
 ## Multiple Fields
 
 The `||` operator can be used to index multiple fields.

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -176,6 +176,13 @@ fn create_bm25_impl(
             Ok(obj) => {
                 if let Value::Object(map) = obj {
                     for key in map.keys() {
+                        if key == key_field {
+                            bail!(
+                                "key_field {} cannot be included in text_fields, numeric_fields, boolean_fields, json_fields, or datetime_fields",
+                                spi::quote_identifier(key.clone())
+                            );
+                        }
+
                         column_names.insert(spi::quote_identifier(key.clone()));
                     }
                 }

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -55,8 +55,6 @@ pub extern "C" fn ambuild(
     let index_relation = unsafe { PgRelation::from_pg(indexrel) };
     let index_oid = index_relation.oid();
 
-    info!("ambuild {:?}", index_oid);
-
     let rdopts: PgBox<SearchIndexCreateOptions> = if !index_relation.rd_options.is_null() {
         unsafe { PgBox::from_pg(index_relation.rd_options as *mut SearchIndexCreateOptions) }
     } else {
@@ -210,8 +208,6 @@ pub extern "C" fn ambuild(
 
     let writer_client = WriterGlobal::client();
     let directory = WriterDirectory::from_index_oid(index_oid.as_u32());
-
-    info!("create index {:?}", directory);
 
     SearchIndex::create_index(
         &writer_client,

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -64,6 +64,18 @@ fn invalid_create_bm25(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with invalid field"),
         Err(err) => assert!(err.to_string().contains("not exist"), "{}", fmt_err(err)),
     };
+
+    match "CALL paradedb.create_bm25(
+	    index_name => 'index_config',
+	    table_name => 'index_config',
+	    key_field => 'id',
+	    numeric_fields => paradedb.field('id')		
+    )"
+    .execute_result(&mut conn)
+    {
+        Ok(_) => panic!("should fail with invalid field"),
+        Err(err) => assert_eq!(err.to_string(), "error returned from database: key_field id cannot be included in text_fields, numeric_fields, boolean_fields, json_fields, or datetime_fields")
+    };
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Right now if a `key_field` is passed into `_fields`, the server throws an error and the user gets an opaque crash error. Now, we catch this in `create_bm25` and display a better error. I've also updated the docs and removed some accidentally committed debug statements.

## Why

## How

## Tests
See added test to `invalid_create_bm25`