### PR TITLE
fix: Make ICU test get triggered

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -221,7 +221,7 @@ jobs:
           echo "Running Rust tests..."
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          cargo pgrx test "--features icu pg${{ matrix.pg_version }}"
+          cargo pgrx test "--features icu" "pg${{ matrix.pg_version }}"
 
       # On promotion PRs, we test packaging the extension with production features enabled
       - name: Test Packaging pg_search

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -221,7 +221,7 @@ jobs:
           echo "Running Rust tests..."
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          cargo pgrx test "pg${{ matrix.pg_version }}" --features icu
+          cargo pgrx test "--features icu pg${{ matrix.pg_version }}"
 
       # On promotion PRs, we test packaging the extension with production features enabled
       - name: Test Packaging pg_search

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -221,7 +221,7 @@ jobs:
           echo "Running Rust tests..."
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          cargo pgrx test "--features icu" "pg${{ matrix.pg_version }}"
+          cargo pgrx test --features icu "pg${{ matrix.pg_version }}"
 
       # On promotion PRs, we test packaging the extension with production features enabled
       - name: Test Packaging pg_search


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I randomly noticed that our `cargo pgrx test` builds without ICU support, so this doesn't get tested. We had the order of arguments wrong.

## Why
Run the test

## How
Reordered the arguments

## Tests
See in CI, it shouldn't print:

```
warning: unused import: `crate::icu::ICUTokenizer`
  --> tokenizers/src/manager.rs:19:5
   |
19 | use crate::icu::ICUTokenizer;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

Anymore