### PR TITLE
fix: Properly install `pg_cron` and add CI check

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -67,3 +67,9 @@ jobs:
             echo "Error: Container failed to start properly"
             exit 1
           fi
+
+          # Fail the run if there are any Postgres ERRORs in the logs
+          if docker logs $CONTAINER_ID | grep -q ERROR; then
+            echo "Error: ParadeDB Docker container logs contain an error"
+            exit 1
+          fi

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -9,8 +9,12 @@ set -Eeuo pipefail
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
-# Create the 'template_paradedb' template db
+# Create the `template_paradedb`` template db
 psql -d postgres -c "CREATE DATABASE template_paradedb IS_TEMPLATE true;"
+
+# The `pg_cron` extension can only be installed in the `postgres` database, as per
+# our configuration in our Dockerfile. Therefore, we install it separately here.
+psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_cron;"
 
 # Load ParadeDB extensions into both template_database and $POSTGRES_DB
 for DB in template_paradedb "$POSTGRES_DB"; do
@@ -18,7 +22,6 @@ for DB in template_paradedb "$POSTGRES_DB"; do
   psql -d "$DB" <<-'EOSQL'
     CREATE EXTENSION IF NOT EXISTS pg_search;
     CREATE EXTENSION IF NOT EXISTS pg_analytics;
-    CREATE EXTENSION IF NOT EXISTS pg_cron;
     CREATE EXTENSION IF NOT EXISTS pg_ivm;
     CREATE EXTENSION IF NOT EXISTS vector;
     CREATE EXTENSION IF NOT EXISTS vectorscale;

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -9,7 +9,7 @@ set -Eeuo pipefail
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
-# Create the `template_paradedb`` template db
+# Create the `template_paradedb` template db
 psql -d postgres -c "CREATE DATABASE template_paradedb IS_TEMPLATE true;"
 
 # The `pg_cron` extension can only be installed in the `postgres` database, as per

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -16,7 +16,7 @@ psql -d postgres -c "CREATE DATABASE template_paradedb IS_TEMPLATE true;"
 # our configuration in our Dockerfile. Therefore, we install it separately here.
 psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_cron;"
 
-# Load ParadeDB extensions into both template_database and $POSTGRES_DB
+# Load ParadeDB and third-party extensions into both template_database and $POSTGRES_DB
 for DB in template_paradedb "$POSTGRES_DB"; do
   echo "Loading ParadeDB extensions into $DB"
   psql -d "$DB" <<-'EOSQL'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR properly installs `pg_cron` and adds a CI check for failing runs when ERRORs are detected in the logs.

## Why

## How

## Tests
