### PR TITLE
chore: remove `search_dedup`

### DIFF
--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -67,7 +67,7 @@ pub fn score_bm25(
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
     let writer_client = WriterGlobal::client();
-    let mut scan_state = search_index
+    let scan_state = search_index
         .search_state(
             &writer_client,
             &search_config,
@@ -78,12 +78,13 @@ pub fn score_bm25(
     let relation = unsafe { pg_sys::RelationIdGetRelation(search_config.table_oid.into()) };
     let snapshot = unsafe { pg_sys::GetTransactionSnapshot() };
     let top_docs = scan_state
-        .search_dedup(SearchIndex::executor())
-        .filter(|(_, doc_address)| unsafe {
+        .search(SearchIndex::executor())
+        .into_iter()
+        .filter(|(_, doc_address, _, _)| unsafe {
             let ctid = scan_state.ctid_value(*doc_address);
             ctid_satisfies_snapshot(ctid, relation, snapshot)
         })
-        .map(|(score, doc_address)| {
+        .map(|(score, doc_address, _, _)| {
             let key = unsafe {
                 datum::AnyElement::from_polymorphic_datum(
                     scan_state
@@ -125,7 +126,7 @@ pub fn snippet(
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
     let writer_client = WriterGlobal::client();
-    let mut scan_state = search_index
+    let scan_state = search_index
         .search_state(
             &writer_client,
             &search_config,
@@ -144,12 +145,13 @@ pub fn snippet(
     let relation = unsafe { pg_sys::RelationIdGetRelation(search_config.table_oid.into()) };
     let snapshot = unsafe { pg_sys::GetTransactionSnapshot() };
     let top_docs = scan_state
-        .search_dedup(SearchIndex::executor())
-        .filter(|(_, doc_address)| unsafe {
+        .search(SearchIndex::executor())
+        .into_iter()
+        .filter(|(_, doc_address, _, _)| unsafe {
             let ctid = scan_state.ctid_value(*doc_address);
             ctid_satisfies_snapshot(ctid, relation, snapshot)
         })
-        .map(|(score, doc_address)| {
+        .map(|(score, doc_address, _, _)| {
             let key = unsafe {
                 datum::AnyElement::from_polymorphic_datum(
                     scan_state


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Replace `search_dedup` with `search`.

## Why
With #1535 , `search_dedup` is no longer necessary and adds extra query latency.

## How

## Tests
