### PR TITLE
feat: adding lenient and conjunction configs

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -182,9 +182,9 @@ impl SearchIndex {
                 .collect::<Vec<_>>(),
         );
 
-if let Some(true) = config.conjunction_by_default {
-    query_parser.set_conjunction_by_default();
-}
+        if let Some(true) = config.conjunction_by_default {
+            query_parser.set_conjunction_by_default();
+        }
 
         query_parser
     }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -172,15 +172,23 @@ impl SearchIndex {
         Ok(())
     }
 
-    pub fn query_parser(&self) -> QueryParser {
-        QueryParser::for_index(
+    pub fn query_parser(&self, config: &SearchConfig) -> QueryParser {
+        let mut query_parser = QueryParser::for_index(
             &self.underlying_index,
             self.schema
                 .fields
                 .iter()
                 .map(|search_field| search_field.id.0)
                 .collect::<Vec<_>>(),
-        )
+        );
+
+        if let Some(conjunction) = config.conjunction_by_default {
+            if conjunction {
+                query_parser.set_conjunction_by_default();
+            }
+        }
+
+        query_parser
     }
 
     pub fn search_state<W: WriterClient<WriterRequest>>(

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -182,11 +182,9 @@ impl SearchIndex {
                 .collect::<Vec<_>>(),
         );
 
-        if let Some(conjunction) = config.conjunction_by_default {
-            if conjunction {
-                query_parser.set_conjunction_by_default();
-            }
-        }
+if let Some(true) = config.conjunction_by_default {
+    query_parser.set_conjunction_by_default();
+}
 
         query_parser
     }

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -36,7 +36,7 @@ pub struct SearchState {
 impl SearchState {
     pub fn new(search_index: &SearchIndex, config: &SearchConfig) -> Self {
         let schema = search_index.schema.clone();
-        let mut parser = search_index.query_parser();
+        let mut parser = search_index.query_parser(config);
         let searcher = search_index.searcher();
         let query = config
             .query

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -400,14 +400,17 @@ impl SearchQueryInput {
                 Ok(Box::new(query))
             }
             Self::Parse { query_string } => {
-                if config.lenient_parsing.unwrap_or(false) {
+	match config.lenient_parsing {
+                Some(true) => {
                     let (parsed_query, _) = parser.parse_query_lenient(&query_string);
                     Ok(Box::new(parsed_query))
-                } else {
+                }
+                _ => {
                     Ok(Box::new(parser.parse_query(&query_string).map_err(
-                        |err| QueryError::ParseError(err, query_string.clone()),
+                        |err| QueryError::ParseError(err, query_string),
                     )?))
                 }
+            },
             }
             Self::Phrase {
                 field,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -400,9 +400,14 @@ impl SearchQueryInput {
                 Ok(Box::new(query))
             }
             Self::Parse { query_string } => {
-                Ok(Box::new(parser.parse_query(&query_string).map_err(
-                    |err| QueryError::ParseError(err, query_string),
-                )?))
+                if config.lenient_parsing.unwrap_or(false) {
+                    let (parsed_query, _) = parser.parse_query_lenient(&query_string);
+                    Ok(Box::new(parsed_query))
+                } else {
+                    Ok(Box::new(parser.parse_query(&query_string).map_err(
+                        |err| QueryError::ParseError(err, query_string.clone()),
+                    )?))
+                }
             }
             Self::Phrase {
                 field,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -399,8 +399,7 @@ impl SearchQueryInput {
                 }
                 Ok(Box::new(query))
             }
-            Self::Parse { query_string } => {
-	match config.lenient_parsing {
+            Self::Parse { query_string } => match config.lenient_parsing {
                 Some(true) => {
                     let (parsed_query, _) = parser.parse_query_lenient(&query_string);
                     Ok(Box::new(parsed_query))
@@ -411,7 +410,6 @@ impl SearchQueryInput {
                     )?))
                 }
             },
-            }
             Self::Phrase {
                 field,
                 phrases,

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -36,6 +36,8 @@ pub struct SearchConfig {
     pub postfix: Option<String>,
     pub stable_sort: Option<bool>,
     pub uuid: String,
+    pub lenient_parsing: Option<bool>,
+    pub conjunction_by_default: Option<bool>,
 }
 
 impl SearchConfig {

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1000,24 +1000,16 @@ fn lenient_config_search(mut conn: PgConnection) {
     // Test lenient configuration: lenient flag enabled, should allow for minor errors like typos
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.term(field => 'description', value => 'laptap'),
+        query => paradedb.fuzzy_term(
+            field => 'description',
+            value => 'wolo',
+            transposition_cost_one => false,
+            distance => 1
+        ),
         lenient_parsing => true,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
-    assert_eq!(
-        columns.id,
-        vec![12, 15, 18],
-        "lenient search should tolerate minor typo"
-    );
 
-    // Test strict configuration for comparison: lenient flag disabled, should not allow typos
-    let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM bm25_search.search(
-        query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient_parsing => false,
-        stable_sort => true
-    )"#
-    .fetch_collect(&mut conn);
-    assert!(columns.is_empty(), "strict search should not tolerate typo");
+    assert_eq!(columns.len(), 4);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -992,3 +992,32 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
     .fetch_collect(&mut conn);
     assert_eq!(rows.len(), 2);
 }
+
+#[rstest]
+fn lenient_config_search(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Test lenient configuration: lenient flag enabled, should allow for minor errors like typos
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.term(field => 'description', value => 'laptap'),
+        lenient => true,
+        stable_sort => true
+    )"#
+    .fetch_collect(&mut conn);
+    assert_eq!(
+        columns.id,
+        vec![12, 15, 18],
+        "lenient search should tolerate minor typo"
+    );
+
+    // Test strict configuration for comparison: lenient flag disabled, should not allow typos
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.term(field => 'description', value => 'laptap'),
+        lenient => false,
+        stable_sort => true
+    )"#
+    .fetch_collect(&mut conn);
+    assert!(columns.is_empty(), "strict search should not tolerate typo");
+}

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -37,6 +37,7 @@ fn boolean_tree(mut conn: PgConnection) {
 			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1)
             ]
         ),
+        lenient_parsing => false,
         stable_sort => true
     );
     "#

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1001,7 +1001,7 @@ fn lenient_config_search(mut conn: PgConnection) {
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
         query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient => true,
+        lenient_parsing => true,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
@@ -1015,7 +1015,7 @@ fn lenient_config_search(mut conn: PgConnection) {
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
         query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient => false,
+        lenient_parsing => false,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1112 

## What
Adds configs for - 
- lenient query parsing 
- conjunction 

## Why
- Users want more control over how their queries are parsed, we might as well expose what Tantivy makes available.

## How
- add more fields in SearchConfigs

## Tests
