### PR TITLE
chore: Add toml formatting check

### DIFF
--- a/.github/workflows/lint-cargo-toml.yml
+++ b/.github/workflows/lint-cargo-toml.yml
@@ -1,0 +1,34 @@
+# workflows/lint-cargo-toml.yml
+#
+# Lint Cargo.toml
+# Lint Cargo.toml files using taplo
+
+name: Lint Cargo.toml
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.toml"
+      - ".github/workflows/lint-cargo-toml.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: lint-cargo-toml-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-toml:
+    name: Lint Cargo.toml Files
+    runs-on: depot-ubuntu-latest-2
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Install taplo
+        run: cargo +stable install taplo-cli --version ^0.9 --locked
+      # if you encounter an error, try running 'taplo format' to fix the formatting automatically.
+      - name: Check Cargo.toml formatting
+        run: taplo format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,3 +80,8 @@ repos:
     hooks:
       - id: mintlify-validate
         args: [docs]
+
+  - repo: https://github.com/ComPWA/mirrors-taplo
+    rev: "v0.9.3"
+    hooks:
+      - id: taplo-format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "cargo-paradedb",
-    "pg_search",
-    "shared",
-    "tokenizers",
-]
+members = ["cargo-paradedb", "pg_search", "shared", "tokenizers"]
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

When working on #1550 , I found the CI lacks the `Cargo.toml` formatting check.	

## Why

It is better to enforces a consistent formatting style across TOML files, making them easier to read and understand

## How
- use `taplo-cli` to check and format `Cargo.toml` files
- add `taplo-cli` format to pre-commit

## Tests
