### PR TITLE
chore: rely on tweak_score fast_field lookups for key + ctid

### DIFF
--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -80,16 +80,11 @@ pub fn score_bm25(
     let top_docs = scan_state
         .search(SearchIndex::executor())
         .into_iter()
-        .filter(|(_, doc_address, _, _)| unsafe {
-            let ctid = scan_state.ctid_value(*doc_address);
-            ctid_satisfies_snapshot(ctid, relation, snapshot)
-        })
-        .map(|(score, doc_address, _, _)| {
+        .filter(|(_, _, _, ctid)| unsafe { ctid_satisfies_snapshot(*ctid, relation, snapshot) })
+        .map(|(score, _, key, _)| {
             let key = unsafe {
                 datum::AnyElement::from_polymorphic_datum(
-                    scan_state
-                        .key_value(doc_address)
-                        .try_into_datum(PgOid::from_untagged(key_oid))
+                    key.try_into_datum(PgOid::from_untagged(key_oid))
                         .expect("failed to convert key_field to datum"),
                     false,
                     key_oid,
@@ -147,16 +142,11 @@ pub fn snippet(
     let top_docs = scan_state
         .search(SearchIndex::executor())
         .into_iter()
-        .filter(|(_, doc_address, _, _)| unsafe {
-            let ctid = scan_state.ctid_value(*doc_address);
-            ctid_satisfies_snapshot(ctid, relation, snapshot)
-        })
-        .map(|(score, doc_address, _, _)| {
+        .filter(|(_, _, _, ctid)| unsafe { ctid_satisfies_snapshot(*ctid, relation, snapshot) })
+        .map(|(score, doc_address, key, _)| {
             let key = unsafe {
                 datum::AnyElement::from_polymorphic_datum(
-                    scan_state
-                        .key_value(doc_address)
-                        .try_into_datum(PgOid::from_untagged(key_oid))
+                    key.try_into_datum(PgOid::from_untagged(key_oid))
                         .expect("failed to convert key_field to datum"),
                     false,
                     key_oid,

--- a/pg_search/src/index/score.rs
+++ b/pg_search/src/index/score.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 pub struct SearchIndexScore {
     pub bm25: f32,
     pub key: TantivyValue,
+    pub ctid: u64,
 }
 
 // We do these custom trait impls, because we want these to be sortable so:

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -28,7 +28,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use tantivy::schema::{
     DateOptions, Field, IndexRecordOption, JsonObjectOptions, NumericOptions, Schema,
-    TextFieldIndexing, TextOptions, FAST, INDEXED, STORED,
+    TextFieldIndexing, TextOptions, FAST, INDEXED,
 };
 use thiserror::Error;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
@@ -577,9 +577,7 @@ impl SearchIndexSchema {
             }
 
             let id: SearchFieldId = match &config {
-                SearchFieldConfig::Ctid => {
-                    builder.add_u64_field(name.as_ref(), INDEXED | STORED | FAST)
-                }
+                SearchFieldConfig::Ctid => builder.add_u64_field(name.as_ref(), INDEXED | FAST),
                 _ => match field_type {
                     SearchFieldType::Text => builder.add_text_field(name.as_ref(), config.clone()),
                     SearchFieldType::I64 => builder.add_i64_field(name.as_ref(), config.clone()),


### PR DESCRIPTION
## What

Through profiling, we've discovered performance bottlenecks stemming from fetching document fields from the documents returned by Tantivy queries.

This PR introduces an improved approach with fewer lookups, representing up to a 4x speedup in query times with large result sets.

## How

We index the `key_field` and `ctid` for a row as `FAST` fields in Tantivy, and its cheaper to look these up in the fast field columnar store as the index segment is being read, as opposed to looking up the actual document from the resulting `DocAddress` set.

The easiest way to do this was in the Tantivy collector's `tweak_score` modifier, which builds a custom `Score` object that we currently use for stable sorting. The `Score` object now contains a `ctid` as well as a `key` and a `bm25` score.

The implementation in this PR is not optimal, and our team has already begun investigation other strategies to mitigate lookups. This implementation will eventually be superseded by an approach like storing the `ctid` directly in the inverted index, or using its value as the Tantivy `DocId`. I propose we move forward with the work in this PR so users can benefit from a speedup in the short term, and we can compare the complexity and stability of future approaches against this one.

As a side effect, all searches are (for now) stable-sorted, since we're using `tweak_score` in all cases. We should not expect this to be the behavior when we land on our optimal implementation, as it requires a `key_field` lookup that we eventually would like to avoid.

## Tests

Index and query behavior should be exactly the same, just faster, so no new tests.
