### PR TITLE
fix: Fix permissions for creating DuckDB extensions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -197,8 +197,8 @@ USER root
 # If a user connects to ParadeDB with the superuser, the DuckDB folder will be created in the user's home directory. If
 # the user connects with the postgres user, the DuckDB folder will be created in the /var/lib/postgresql directory. We
 # chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
-RUN mkdir .duckdb/ && chmod 777 .duckdb/ && \
-    mkdir /var/lib/postgresql/.duckdb/ && chmod 777 /var/lib/postgresql/.duckdb/ && \
+RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
+    mkdir /var/lib/postgresql/.duckdb/ && chmod -R a+rwX /var/lib/postgresql/.duckdb/ && \    
     apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
 
 # The postgresql.conf.sample file is used as a template for the postgresql.conf file, which

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -198,7 +198,7 @@ USER root
 # the user connects with the postgres user, the DuckDB folder will be created in the /var/lib/postgresql directory. We
 # chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
 RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
-    mkdir /var/lib/postgresql/.duckdb/ && chmod -R a+rwX /var/lib/postgresql/.duckdb/ && \    
+    mkdir /var/lib/postgresql/.duckdb/ && chmod -R a+rwX /var/lib/postgresql/.duckdb/ && \
     apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
 
 # The postgresql.conf.sample file is used as a template for the postgresql.conf file, which


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We needed to recursively set the permissions for installing DuckDB extensions as part of `pg_analytics`. This does it.

## Why
Create DuckDB extensions

## How
Recursively set permissions

## Tests
Manually tested