### PR TITLE
ci: Add a test for the Helm chart

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -2,7 +2,7 @@
 #
 # Publish ParadeDB
 # Publish ParadeDB as a Docker image to Docker Hub and as a Helm Chart to paradedb.github.io via our
-# `paradedb/helm-charts` repository. This workflow only runs after a GitHub Release gets created, which
+# `paradedb/charts` repository. This workflow only runs after a GitHub Release gets created, which
 # happens once we merge to `main`.
 
 name: Publish ParadeDB
@@ -109,11 +109,11 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Trigger paradedb/helm-charts Release Workflow
+      - name: Trigger paradedb/charts Release Workflow
         uses: multinarity/workflow-dispatch@master
         with:
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           workflow: publish-helm-chart.yml
-          repo: paradedb/helm-charts
+          repo: paradedb/charts
           ref: main
           inputs: '{ "appVersion": "${{ steps.version.outputs.version }}" }'

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -140,25 +140,32 @@ jobs:
 
       - name: Wait for paradedb/charts Test Workflow to Complete
         run: |
-          while true; do
-            status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
+          workflow_run_id=""
+          while [ -z "$workflow_run_id" ]; do
+            workflow_run_id=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
               https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=workflow_dispatch \
-              | jq -r '.workflow_runs[0].status')
-            if [ "$status" = "completed" ]; then
-              break
+              | jq -r '.workflow_runs[] | select(.status == "in_progress" or .status == "queued") | .id' | head -n 1)
+            if [ -z "$workflow_run_id" ]; then
+              echo "Waiting for workflow run to start..."
+              sleep 10
             fi
-            sleep 10
           done
-
-      - name: Report paradedb/charts Test Workflow Conclusion
-        run: |
+      
+          status="in_progress"
+          while [ "$status" != "completed" ]; do
+            status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
+              https://api.github.com/repos/paradedb/charts/actions/runs/$workflow_run_id \
+              | jq -r '.status')
+            echo "Current status: $status"
+            if [ "$status" != "completed" ]; then
+              sleep 10
+            fi
+          done
+      
           conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-            https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=workflow_dispatch \
-            | jq -r '.workflow_runs[0].conclusion')
-          if [ "$conclusion" = "success" ]; then
-            echo "Helm chart test passed"
-            exit 0
-          else
-            echo "Helm chart test failed"
+            https://api.github.com/repos/paradedb/charts/actions/runs/$workflow_run_id \
+            | jq -r '.conclusion')
+          echo "Workflow completed with conclusion: $conclusion"
+          if [ "$conclusion" != "success" ]; then
             exit 1
           fi

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -134,7 +134,7 @@ jobs:
         uses: multinarity/workflow-dispatch@master
         with:
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          workflow: test-helm-chart.yml
+          workflow: paradedb-test-eks.yml
           repo: paradedb/charts
           ref: main
 
@@ -142,7 +142,7 @@ jobs:
         run: |
           while true; do
             status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-              https://api.github.com/repos/paradedb/charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+              https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=repository_dispatch \
               | jq -r '.workflow_runs[0].status')
             if [ "$status" = "completed" ]; then
               break
@@ -153,7 +153,7 @@ jobs:
       - name: Report paradedb/charts Test Workflow Conclusion
         run: |
           conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-            https://api.github.com/repos/paradedb/charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+            https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=repository_dispatch \
             | jq -r '.workflow_runs[0].conclusion')
           if [ "$conclusion" = "success" ]; then
             echo "Helm chart test passed"

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -130,19 +130,19 @@ jobs:
         pg_version: [16]
 
     steps:
-      - name: Trigger paradedb/helm-charts Test Workflow
+      - name: Trigger paradedb/charts Test Workflow
         uses: multinarity/workflow-dispatch@master
         with:
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           workflow: test-helm-chart.yml
-          repo: paradedb/helm-charts
+          repo: paradedb/charts
           ref: main
 
-      - name: Wait for paradedb/helm-charts Test Workflow to Complete
+      - name: Wait for paradedb/charts Test Workflow to Complete
         run: |
           while true; do
             status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-              https://api.github.com/repos/paradedb/helm-charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+              https://api.github.com/repos/paradedb/charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
               | jq -r '.workflow_runs[0].status')
             if [ "$status" = "completed" ]; then
               break
@@ -150,10 +150,10 @@ jobs:
             sleep 10
           done
 
-      - name: Report paradedb/helm-charts Test Workflow Conclusion
+      - name: Report paradedb/charts Test Workflow Conclusion
         run: |
           conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-            https://api.github.com/repos/paradedb/helm-charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+            https://api.github.com/repos/paradedb/charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
             | jq -r '.workflow_runs[0].conclusion')
           if [ "$conclusion" = "success" ]; then
             echo "Helm chart test passed"

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           while true; do
             status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-              https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=repository_dispatch \
+              https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=workflow_dispatch \
               | jq -r '.workflow_runs[0].status')
             if [ "$status" = "completed" ]; then
               break
@@ -153,7 +153,7 @@ jobs:
       - name: Report paradedb/charts Test Workflow Conclusion
         run: |
           conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-            https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=repository_dispatch \
+            https://api.github.com/repos/paradedb/charts/actions/workflows/paradedb-test-eks.yml/runs?event=workflow_dispatch \
             | jq -r '.workflow_runs[0].conclusion')
           if [ "$conclusion" = "success" ]; then
             echo "Helm chart test passed"

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -150,7 +150,7 @@ jobs:
               sleep 10
             fi
           done
-      
+
           status="in_progress"
           while [ "$status" != "completed" ]; do
             status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
@@ -161,7 +161,7 @@ jobs:
               sleep 10
             fi
           done
-      
+
           conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
             https://api.github.com/repos/paradedb/charts/actions/runs/$workflow_run_id \
             | jq -r '.conclusion')

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -121,3 +121,44 @@ jobs:
             echo "Error: ParadeDB Docker container logs contain an error"
             exit 1
           fi
+
+  test-paradedb-helm-chart:
+    name: Test ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
+    runs-on: depot-ubuntu-latest-2
+    strategy:
+      matrix:
+        pg_version: [16]
+
+    steps:
+      - name: Trigger paradedb/helm-charts Test Workflow
+        uses: multinarity/workflow-dispatch@master
+        with:
+          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          workflow: test-helm-chart.yml
+          repo: paradedb/helm-charts
+          ref: main
+
+      - name: Wait for paradedb/helm-charts Test Workflow to Complete
+        run: |
+          while true; do
+            status=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
+              https://api.github.com/repos/paradedb/helm-charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+              | jq -r '.workflow_runs[0].status')
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            sleep 10
+          done
+
+      - name: Report paradedb/helm-charts Test Workflow Conclusion
+        run: |
+          conclusion=$(curl -s -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
+            https://api.github.com/repos/paradedb/helm-charts/actions/workflows/test-helm-chart.yml/runs?event=repository_dispatch \
+            | jq -r '.workflow_runs[0].conclusion')
+          if [ "$conclusion" = "success" ]; then
+            echo "Helm chart test passed"
+            exit 0
+          else
+            echo "Helm chart test failed"
+            exit 1
+          fi


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This workflow will trigger the Helm Chart Test workflow from `paradedb/helm-charts`. This will ensure that modifications to the Dockerfile here are also tested against our Helm Chart, to avoid regressions.

We need to:
- [x] Finish the Helm Chart test workflow
- [x] Add a `repository_dispatch` trigger to it

## Why
^

## How
^

## Tests
See CI