### PR TITLE
chore: add `GIN`/`tsvector` to benchmarks

### DIFF
--- a/cargo-paradedb/src/cli.rs
+++ b/cargo-paradedb/src/cli.rs
@@ -109,6 +109,31 @@ pub enum EsLogsCommand {
         #[arg(short, long, env = "DATABASE_URL")]
         url: String,
     },
+    BuildGinIndex {
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]
+        table: String,
+        /// Postgres table name to index.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_INDEX_NAME)]
+        index: String,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
+    },
+    QueryGinIndex {
+        /// Postgres index name to query.
+        #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]
+        table: String,
+        /// Query to run.
+        #[arg(short, long, default_value = "flame")]
+        query: String,
+        /// Limit results to return.
+        #[arg(short, long, default_value_t = 1)]
+        limit: u64,
+        /// Postgres database url to connect to.
+        #[arg(short, long, env = "DATABASE_URL")]
+        url: String,
+    },
     BuildParquetTable {
         /// Postgres table name to build from.
         #[arg(short, long, default_value = DEFAULT_BENCH_ESLOGS_TABLE)]

--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -58,6 +58,17 @@ fn main() -> Result<()> {
                 } => block_on(subcommand::bench_eslogs_query_search_index(
                     index, query, limit, url,
                 )),
+                EsLogsCommand::BuildGinIndex { table, index, url } => {
+                    block_on(subcommand::bench_eslogs_build_gin_index(table, index, url))
+                }
+                EsLogsCommand::QueryGinIndex {
+                    table,
+                    query,
+                    limit,
+                    url,
+                } => block_on(subcommand::bench_eslogs_query_gin_index(
+                    table, query, limit, url,
+                )),
                 EsLogsCommand::BuildParquetTable { table, url } => {
                     block_on(subcommand::bench_eslogs_build_parquet_table(table, url))
                 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #279 

## What
Adds the GIN index over tsvector to `cargo-paradedb`.

Commands:

```bash
cargo paradedb bench eslogs build-gin-index --limit 10
cargo paradedb bench eslogs query-gin-index --limit 10
```

## Why
In an upcoming blog post I'd like to bake tsvector against pg_search on various types of queries over 1 billion rows. 
## How

## Tests
