### PR TITLE
chore: Prepare v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-paradedb"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -6080,7 +6080,7 @@ checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokenizers"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "lindera-core",

--- a/cargo-paradedb/Cargo.toml
+++ b/cargo-paradedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-paradedb"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/changelog/0.9.2.mdx
+++ b/docs/changelog/0.9.2.mdx
@@ -1,0 +1,32 @@
+---
+title: 0.9.2
+---
+
+## pg_search
+
+### Bug Fixes
+
+- Fixed a bug where `score_bm25` and `snippet` could return rows that are not visible to the current transaction snapshot.
+
+### New Features
+
+- Improved query times with large results sets by up to 4x.
+- Revamped our documentation to improve developer experience.
+
+## pg_analytics
+
+### New Features
+
+- Added support for spatial data in `pg_analytics` via the DuckDB spatial extension.
+- Added support for DuckDB's `time_bucket` function, which enables basic time-series workloads in `pg_analytics`.
+- Improved performance in scenarios where queries fall back to the Foreign Data Wrapper.
+
+## ParadeDB
+
+### Bug Fixes
+
+- Fixed a permission issue when installing DuckDB extensions inside ParadeDB.
+
+## Full Changelog
+
+The full changelog is available [here](https://github.com/paradedb/paradedb/releases/tag/v0.9.2).

--- a/docs/deploy/pg_analytics.mdx
+++ b/docs/deploy/pg_analytics.mdx
@@ -22,45 +22,45 @@ are using a different version of Postgres or a different operating system, you w
 ```bash Ubuntu 24.04
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.0/postgresql-16-pg-analytics_0.1.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.1/postgresql-16-pg-analytics_0.1.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.0/postgresql-16-pg-analytics_0.1.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.1/postgresql-16-pg-analytics_0.1.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.0/postgresql-16-pg-analytics_0.1.0-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.1/postgresql-16-pg-analytics_0.1.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available Postgres version are 14, 15, 16
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.0/pg_analytics_16-0.1.0-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.1/pg_analytics_16-0.1.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available Postgres version are 14, 15, 16
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.0/pg_analytics_16-0.1.0-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.1/pg_analytics_16-0.1.1-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 </CodeGroup>
 
-Note: You can replace `v0.1.0` with the `pg_analytics` version you wish to install, and `16` with the version of Postgres you are using.
+Note: You can replace `v0.1.1` with the `pg_analytics` version you wish to install, and `16` with the version of Postgres you are using.
 
 ## Building from Source
 
-Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.1.0/pg_analytics#installation).
+Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.1.1/pg_analytics#installation).
 
 # Update `postgresql.conf`
 

--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -32,45 +32,45 @@ are using a different version of Postgres or a different operating system, you w
 ```bash Ubuntu 24.04
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.1/postgresql-16-pg-search_0.9.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.2/postgresql-16-pg-search_0.9.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.1/postgresql-16-pg-search_0.9.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.2/postgresql-16-pg-search_0.9.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available Postgres version are 14, 15, 16
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.1/postgresql-16-pg-search_0.9.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.2/postgresql-16-pg-search_0.9.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available Postgres version are 14, 15, 16
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.1/pg_search_16-0.9.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.2/pg_search_16-0.9.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available Postgres version are 14, 15, 16
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.1/pg_search_16-0.9.1-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.9.2/pg_search_16-0.9.2-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 </CodeGroup>
 
-Note: You can replace `v0.9.1` with the `pg_search` version you wish to install, and `16` with the version of Postgres you are using.
+Note: You can replace `v0.9.2` with the `pg_search` version you wish to install, and `16` with the version of Postgres you are using.
 
 ## Building from Source
 
-Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.9.1/pg_search#installation).
+Please follow these [instructions](https://github.com/paradedb/paradedb/tree/v0.9.2/pg_search#installation).
 
 # Update `postgresql.conf`
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -27,7 +27,7 @@ SELECT extversion FROM pg_extension WHERE extname = 'pg_analytics';
 Because `pg_search`, `pg_analytics`, and `pgvector` are independent extensions, they each have their own versions.
 For the latest available version, please refer to the respective Github repos:
 
-1. [`pg_search`](https://github.com/paradedb/paradedb/releases) is on version `0.9.1`
+1. [`pg_search`](https://github.com/paradedb/paradedb/releases) is on version `0.9.2`
 2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.1.0`
 3. [`pgvector`](https://github.com/pgvector/pgvector/tags) is on version `0.7.4`
 
@@ -40,10 +40,10 @@ to `latest` to pull the latest Docker image.
 docker pull paradedb/paradedb:<version_number>
 ```
 
-The latest version of the Docker image should be `0.9.1`. Then, run the following commands to upgrade all extensions to their latest version.
+The latest version of the Docker image should be `0.9.2`. Then, run the following commands to upgrade all extensions to their latest version.
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.9.1';
+ALTER EXTENSION pg_search UPDATE TO '0.9.2';
 ALTER EXTENSION pg_analytics UPDATE TO '0.1.0';
 ALTER EXTENSION pgvector UPDATE TO '0.7.4';
 ```

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -28,7 +28,7 @@ Because `pg_search`, `pg_analytics`, and `pgvector` are independent extensions, 
 For the latest available version, please refer to the respective Github repos:
 
 1. [`pg_search`](https://github.com/paradedb/paradedb/releases) is on version `0.9.2`
-2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.1.0`
+2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.1.1`
 3. [`pgvector`](https://github.com/pgvector/pgvector/tags) is on version `0.7.4`
 
 ## Updating ParadeDB Docker Image
@@ -44,7 +44,7 @@ The latest version of the Docker image should be `0.9.2`. Then, run the followin
 
 ```sql
 ALTER EXTENSION pg_search UPDATE TO '0.9.2';
-ALTER EXTENSION pg_analytics UPDATE TO '0.1.0';
+ALTER EXTENSION pg_analytics UPDATE TO '0.1.1';
 ALTER EXTENSION pgvector UPDATE TO '0.7.4';
 ```
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -74,7 +74,7 @@
       "url": "changelog"
     }
   ],
-  "versions": ["v0.9.1"],
+  "versions": ["v0.9.2"],
   "navigation": [
     {
       "group": "Welcome",
@@ -171,6 +171,7 @@
     {
       "group": "Changelog",
       "pages": [
+        "changelog/0.9.2",
         "changelog/0.9.1",
         "changelog/0.9.0",
         "changelog/0.8.6",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg_search"
 description = "Full text search for PostgreSQL using BM25"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "AGPL-3.0"
 
@@ -30,7 +30,7 @@ json5 = "0.4.1"
 libc = "0.2.152"
 memoffset = "0.9.0"
 once_cell = "1.18.0"
-tokenizers = { version = "0.9.1", path = "../tokenizers" }
+tokenizers = { version = "0.9.2", path = "../tokenizers" }
 pgrx = "0.12.1"
 reqwest = "0.11.22"
 rustc-hash = "1.1.0"

--- a/pg_search/sql/pg_search--0.9.1--0.9.2.sql
+++ b/pg_search/sql/pg_search--0.9.1--0.9.2.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.9.2'" to load this file. \quit

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared"
 description = "Shared code for ParadeDB crates"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokenizers"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Update the changelog for `v0.9.2` of `pg_search` and `v0.1.1` of `pg_analytics`.

## Why
^

## How
^

## Tests
^