### PR TITLE
fix: crashing bug in the `VisibilityChecker`. 

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -18,8 +18,8 @@
 use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchDocument, SearchFieldName, SearchIndexSchema};
 use crate::writer::IndexError;
-use pgrx::itemptr::{item_pointer_get_block_number, item_pointer_get_offset_number};
-use pgrx::pg_sys::{Buffer, BuiltinOid, ItemPointerData, OffsetNumber};
+use pgrx::itemptr::item_pointer_get_block_number;
+use pgrx::pg_sys::{Buffer, BuiltinOid, ItemPointerData};
 use pgrx::*;
 
 pub unsafe fn row_to_search_document(
@@ -141,11 +141,10 @@ impl VisibilityChecker {
             pgrx::itemptr::u64_to_item_pointer(ctid, &mut self.ipd);
 
             let blockno = item_pointer_get_block_number(&self.ipd);
-            let offsetno = item_pointer_get_offset_number(&self.ipd);
 
             if blockno == self.last_blockno {
                 // this ctid is on the buffer we already have locked
-                return self.check_page_vis(self.ipd, offsetno, self.last_buffer);
+                return self.check_page_vis(self.last_buffer);
             } else if self.last_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer {
                 // this ctid is on a different buffer, so release the one we've got locked
                 pg_sys::UnlockReleaseBuffer(self.last_buffer);
@@ -156,33 +155,18 @@ impl VisibilityChecker {
 
             pg_sys::LockBuffer(self.last_buffer, pg_sys::BUFFER_LOCK_SHARE as i32);
 
-            self.check_page_vis(self.ipd, offsetno, self.last_buffer)
+            self.check_page_vis(self.last_buffer)
         }
     }
 
-    unsafe fn check_page_vis(
-        &mut self,
-        mut item_pointer: ItemPointerData,
-        offsetno: OffsetNumber,
-        buffer: Buffer,
-    ) -> bool {
+    unsafe fn check_page_vis(&mut self, buffer: Buffer) -> bool {
         unsafe {
-            let page = pg_sys::BufferGetPage(buffer);
-            let item_id = pg_sys::PageGetItemId(page, offsetno);
-            if (*item_id).lp_len() == 0 {
-                return false;
-            }
-            let mut heap_tuple = pg_sys::HeapTupleData {
-                t_data: pg_sys::PageGetItem(page, item_id) as pg_sys::HeapTupleHeader,
-                t_len: item_id.as_ref().unwrap().lp_len(),
-                t_tableOid: (*self.relation).rd_id,
-                t_self: item_pointer,
-            };
+            let mut heap_tuple = pg_sys::HeapTupleData::default();
 
             // Check if heaptuple is visible
             // In Postgres, the indexam `amgettuple` calls `heap_hot_search_buffer` for its visibility check
             pg_sys::heap_hot_search_buffer(
-                &mut item_pointer,
+                &mut self.ipd,
                 self.relation,
                 buffer,
                 self.snapshot,

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -169,6 +169,9 @@ impl VisibilityChecker {
         unsafe {
             let page = pg_sys::BufferGetPage(buffer);
             let item_id = pg_sys::PageGetItemId(page, offsetno);
+            if (*item_id).lp_len() == 0 {
+                return false;
+            }
             let mut heap_tuple = pg_sys::HeapTupleData {
                 t_data: pg_sys::PageGetItem(page, item_id) as pg_sys::HeapTupleHeader,
                 t_len: item_id.as_ref().unwrap().lp_len(),

--- a/pg_search/tests/documentation.rs
+++ b/pg_search/tests/documentation.rs
@@ -181,16 +181,18 @@ fn quickstart(mut conn: PgConnection) {
     ) LIMIT 5;
     "#
     .fetch(&mut conn);
-    assert_eq!(rows[0].0, 2); // For integer comparison, regular assert_eq! is fine
-    assert_eq!(rows[1].0, 1);
-    assert_eq!(rows[2].0, 29);
-    assert_eq!(rows[3].0, 39);
-    assert_eq!(rows[4].0, 9);
-    assert_relative_eq!(rows[0].1, 0.95714283, epsilon = 1e-6); // Adjust epsilon as needed
-    assert_relative_eq!(rows[1].1, 0.8490507, epsilon = 1e-6);
+
+    eprintln!("rows={rows:#?}");
+    assert_eq!(rows[0].0, 29); // For integer comparison, regular assert_eq! is fine
+    assert_eq!(rows[1].0, 39);
+    assert_eq!(rows[2].0, 9);
+    assert_eq!(rows[3].0, 19);
+    assert_eq!(rows[4].0, 10);
+    assert_relative_eq!(rows[0].1, 0.1, epsilon = 1e-6); // Adjust epsilon as needed
+    assert_relative_eq!(rows[1].1, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[2].1, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].1, 0.1, epsilon = 1e-6);
-    assert_relative_eq!(rows[4].1, 0.1, epsilon = 1e-6);
+    assert_relative_eq!(rows[4].1, 0.08571429, epsilon = 1e-6);
 
     let rows: Vec<(String, String, Vector, f32)> = r#"
     SELECT m.description, m.category, m.embedding, s.score_hybrid
@@ -207,22 +209,24 @@ fn quickstart(mut conn: PgConnection) {
     LIMIT 5;
     "#
     .fetch(&mut conn);
+
+    eprintln!("rows={rows:#?}");
     assert_eq!(rows.len(), 5);
-    assert_eq!(rows[0].0, "Plastic Keyboard");
-    assert_eq!(rows[1].0, "Ergonomic metal keyboard");
-    assert_eq!(rows[2].0, "Designer wall paintings");
-    assert_eq!(rows[3].0, "Handcrafted wooden frame");
-    assert_eq!(rows[4].0, "Modern wall clock");
-    assert_eq!(rows[0].2, Vector::from(vec![4.0, 5.0, 6.0]));
-    assert_eq!(rows[1].2, Vector::from(vec![3.0, 4.0, 5.0]));
+    assert_eq!(rows[0].0, "Designer wall paintings");
+    assert_eq!(rows[1].0, "Handcrafted wooden frame");
+    assert_eq!(rows[2].0, "Modern wall clock");
+    assert_eq!(rows[3].0, "Artistic ceramic vase");
+    assert_eq!(rows[4].0, "Colorful kids toy");
+    assert_eq!(rows[0].2, Vector::from(vec![1.0, 2.0, 3.0]));
+    assert_eq!(rows[1].2, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(rows[2].2, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(rows[3].2, Vector::from(vec![1.0, 2.0, 3.0]));
-    assert_eq!(rows[4].2, Vector::from(vec![1.0, 2.0, 3.0]));
-    assert_relative_eq!(rows[0].3, 0.95714283, epsilon = 1e-6);
-    assert_relative_eq!(rows[1].3, 0.8490507, epsilon = 1e-6);
+    assert_eq!(rows[4].2, Vector::from(vec![2.0, 3.0, 4.0]));
+    assert_relative_eq!(rows[0].3, 0.1, epsilon = 1e-6);
+    assert_relative_eq!(rows[1].3, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[2].3, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].3, 0.1, epsilon = 1e-6);
-    assert_relative_eq!(rows[4].3, 0.1, epsilon = 1e-6);
+    assert_relative_eq!(rows[4].3, 0.08571429, epsilon = 1e-6);
 }
 
 #[rstest]

--- a/pg_search/tests/documentation.rs
+++ b/pg_search/tests/documentation.rs
@@ -181,18 +181,16 @@ fn quickstart(mut conn: PgConnection) {
     ) LIMIT 5;
     "#
     .fetch(&mut conn);
-
-    eprintln!("rows={rows:#?}");
-    assert_eq!(rows[0].0, 29); // For integer comparison, regular assert_eq! is fine
-    assert_eq!(rows[1].0, 39);
-    assert_eq!(rows[2].0, 9);
-    assert_eq!(rows[3].0, 19);
-    assert_eq!(rows[4].0, 10);
-    assert_relative_eq!(rows[0].1, 0.1, epsilon = 1e-6); // Adjust epsilon as needed
-    assert_relative_eq!(rows[1].1, 0.1, epsilon = 1e-6);
+    assert_eq!(rows[0].0, 2); // For integer comparison, regular assert_eq! is fine
+    assert_eq!(rows[1].0, 1);
+    assert_eq!(rows[2].0, 29);
+    assert_eq!(rows[3].0, 39);
+    assert_eq!(rows[4].0, 9);
+    assert_relative_eq!(rows[0].1, 0.95714283, epsilon = 1e-6); // Adjust epsilon as needed
+    assert_relative_eq!(rows[1].1, 0.8490507, epsilon = 1e-6);
     assert_relative_eq!(rows[2].1, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].1, 0.1, epsilon = 1e-6);
-    assert_relative_eq!(rows[4].1, 0.08571429, epsilon = 1e-6);
+    assert_relative_eq!(rows[4].1, 0.1, epsilon = 1e-6);
 
     let rows: Vec<(String, String, Vector, f32)> = r#"
     SELECT m.description, m.category, m.embedding, s.score_hybrid
@@ -209,24 +207,22 @@ fn quickstart(mut conn: PgConnection) {
     LIMIT 5;
     "#
     .fetch(&mut conn);
-
-    eprintln!("rows={rows:#?}");
     assert_eq!(rows.len(), 5);
-    assert_eq!(rows[0].0, "Designer wall paintings");
-    assert_eq!(rows[1].0, "Handcrafted wooden frame");
-    assert_eq!(rows[2].0, "Modern wall clock");
-    assert_eq!(rows[3].0, "Artistic ceramic vase");
-    assert_eq!(rows[4].0, "Colorful kids toy");
-    assert_eq!(rows[0].2, Vector::from(vec![1.0, 2.0, 3.0]));
-    assert_eq!(rows[1].2, Vector::from(vec![1.0, 2.0, 3.0]));
+    assert_eq!(rows[0].0, "Plastic Keyboard");
+    assert_eq!(rows[1].0, "Ergonomic metal keyboard");
+    assert_eq!(rows[2].0, "Designer wall paintings");
+    assert_eq!(rows[3].0, "Handcrafted wooden frame");
+    assert_eq!(rows[4].0, "Modern wall clock");
+    assert_eq!(rows[0].2, Vector::from(vec![4.0, 5.0, 6.0]));
+    assert_eq!(rows[1].2, Vector::from(vec![3.0, 4.0, 5.0]));
     assert_eq!(rows[2].2, Vector::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(rows[3].2, Vector::from(vec![1.0, 2.0, 3.0]));
-    assert_eq!(rows[4].2, Vector::from(vec![2.0, 3.0, 4.0]));
-    assert_relative_eq!(rows[0].3, 0.1, epsilon = 1e-6);
-    assert_relative_eq!(rows[1].3, 0.1, epsilon = 1e-6);
+    assert_eq!(rows[4].2, Vector::from(vec![1.0, 2.0, 3.0]));
+    assert_relative_eq!(rows[0].3, 0.95714283, epsilon = 1e-6);
+    assert_relative_eq!(rows[1].3, 0.8490507, epsilon = 1e-6);
     assert_relative_eq!(rows[2].3, 0.1, epsilon = 1e-6);
     assert_relative_eq!(rows[3].3, 0.1, epsilon = 1e-6);
-    assert_relative_eq!(rows[4].3, 0.08571429, epsilon = 1e-6);
+    assert_relative_eq!(rows[4].3, 0.1, epsilon = 1e-6);
 }
 
 #[rstest]


### PR DESCRIPTION
Our `ctid_satisfies_snapshot()` function was doing too much work, which would lead to a crash on `--enable-cassert` Postgres builds, and undefined behavior in production builds.

The long and short of it is that we were trying to construct a valid `pg_sys::HeapTupleData` on the stack, by calling into `pg_sys::PageGetItemId()` and then passing that to `pg_sys::PageGetItem()`.

In reality, the call to `pg_sys::heap_hot_search_buffer()` wants a pointer to an uninitialized (or zero'd) `pg_sys::HeapTupleData` so that it can fill in the fields properly.

Us trying to inspect the page item without knowing if we have a valid ctid is what was causing Postgres to crash in the case where the ctid being validated represents a HOT update.  There's probably plenty of other cases where it might have also crashed.

## Tests

All the tests still pass, but I put this together based on one of our hybrid tests in order to let me debug the crash:

```sql
drop schema bm25_search cascade;
drop table paradedb.bm25_search cascade;
BEGIN;
CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
ALTER TABLE paradedb.bm25_search ADD COLUMN custom_key_field SERIAL;

CALL paradedb.create_bm25(
        index_name => 'bm25_search',
        table_name => 'bm25_search',
        schema_name => 'paradedb',
        key_field => 'custom_key_field',
        text_fields => paradedb.field('description') || paradedb.field('category'),
        numeric_fields => paradedb.field('rating'),
        boolean_fields => paradedb.field('in_stock'),
        json_fields => paradedb.field('metadata'),
        datetime_fields => paradedb.field('created_at') || paradedb.field('last_updated_date') || paradedb.field('latest_available_time')
     );
COMMIT;

CREATE EXTENSION IF NOT EXISTS vector;
ALTER TABLE paradedb.bm25_search ADD COLUMN embedding vector(3);



UPDATE paradedb.bm25_search m
SET embedding = ('[' ||
                 ((m.id + 1) % 10 + 1)::integer || ',' ||
                 ((m.id + 2) % 10 + 1)::integer || ',' ||
                 ((m.id + 3) % 10 + 1)::integer || ']')::vector;

CREATE INDEX on paradedb.bm25_search
    USING hnsw (embedding vector_l2_ops);


-- this fixes crash
VACUUM FULL paradedb.bm25_search;


-- this will crash without the above VACUUM FULL
SELECT m.*, s.score_hybrid
FROM paradedb.bm25_search m
         LEFT JOIN (
    SELECT * FROM bm25_search.score_hybrid(
            bm25_query => paradedb.parse('description:keyboard OR category:electronics'),
            similarity_query => '''[1,2,3]'' <-> embedding',
            bm25_weight => 0.9,
            similarity_weight => 0.1
                  )
) s ON m.custom_key_field = s.custom_key_field
LIMIT 5;
```

If the `VACUUM FULL` is run, then the subsequent SELECT works fine.  If it doesn't then it crashed.
