### PR TITLE
fix: #1579 -- Organize the `$PGDATA/pg_search/` directory by database oid

### DIFF
--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -53,7 +53,7 @@ pub fn schema_bm25(
         .expect("error looking up index in schema_bm25")
         .expect("no oid for index passed to schema_bm25");
 
-    let directory = WriterDirectory::from_index_oid(index_oid.as_u32());
+    let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid.as_u32());
     let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -36,7 +36,8 @@ fn search_tantivy(
             .expect("could not parse search config");
 
         let writer_client = WriterGlobal::client();
-        let directory = WriterDirectory::from_index_oid(search_config.index_oid);
+        let directory =
+            WriterDirectory::from_index_oid(crate::MyDatabaseId(), search_config.index_oid);
         let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
         let scan_state = search_index

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -71,7 +71,7 @@ unsafe fn score_bm25(
     let JsonB(search_config_json) = config_json;
     let search_config: SearchConfig =
         serde_json::from_value(search_config_json.clone()).expect("could not parse search config");
-    let directory = WriterDirectory::from_index_oid(search_config.index_oid);
+    let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), search_config.index_oid);
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
@@ -125,7 +125,7 @@ unsafe fn snippet(
     let JsonB(search_config_json) = config_json;
     let search_config: SearchConfig =
         serde_json::from_value(search_config_json.clone()).expect("could not parse search config");
-    let directory = WriterDirectory::from_index_oid(search_config.index_oid);
+    let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), search_config.index_oid);
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -482,7 +482,7 @@ fn index_size(index_name: &str) -> Result<i64> {
         .as_u32();
 
     // Create a WriterDirectory with the obtained index_oid
-    let writer_directory = WriterDirectory::from_index_oid(index_oid);
+    let writer_directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid);
 
     // Call the total_size method to get the size in bytes
     let total_size = writer_directory.total_size()?;

--- a/pg_search/src/fixtures/directory.rs
+++ b/pg_search/src/fixtures/directory.rs
@@ -38,6 +38,7 @@ impl MockWriterDirectory {
         Self {
             temp_dir,
             writer_dir: WriterDirectory {
+                database_oid: 42, // any number will do
                 index_oid,
                 postgres_data_dir_path: temp_path,
             },

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -283,7 +283,7 @@ impl SearchIndex {
         writer: &Arc<Mutex<W>>,
         index_oid: u32,
     ) -> Result<(), SearchIndexError> {
-        let directory = WriterDirectory::from_index_oid(index_oid);
+        let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid);
         let request = WriterRequest::DropIndex {
             directory: directory.clone(),
         };

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -46,6 +46,17 @@ extension_sql!("GRANT ALL ON SCHEMA paradedb TO PUBLIC;" name = "paradedb_grant_
 
 static mut TRACE_HOOK: shared::trace::TraceHook = shared::trace::TraceHook;
 
+/// Convenience method for [`pgrx::pg_sys::MyDatabaseId`]
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn MyDatabaseId() -> u32 {
+    unsafe {
+        // SAFETY:  this static is set by Postgres when the backend first connects and is
+        // never changed afterwards.  As such, it'll always be set whenever this code runs
+        pg_sys::MyDatabaseId.as_u32()
+    }
+}
+
 /// Initializes option parsing and telemetry
 #[allow(clippy::missing_safety_doc)]
 #[allow(non_snake_case)]

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -207,7 +207,7 @@ pub extern "C" fn ambuild(
     }
 
     let writer_client = WriterGlobal::client();
-    let directory = WriterDirectory::from_index_oid(index_oid.as_u32());
+    let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid.as_u32());
 
     SearchIndex::create_index(
         &writer_client,
@@ -302,7 +302,8 @@ unsafe fn build_callback_internal(
             let tupdesc = index_relation_ref.tuple_desc();
             let index_name = index_relation_ref.name();
             let index_oid = index_relation_ref.oid();
-            let directory = WriterDirectory::from_index_oid(index_oid.as_u32());
+            let directory =
+                WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid.as_u32());
             let search_index = SearchIndex::from_cache(&directory, &state.uuid)
                 .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
             let search_document =

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -33,7 +33,8 @@ pub extern "C" fn ambulkdelete(
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
-    let directory = WriterDirectory::from_index_oid(index_relation.oid().as_u32());
+    let directory =
+        WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_relation.oid().as_u32());
     let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -82,7 +82,8 @@ unsafe fn aminsert_internal(
     let index_relation_ref: PgRelation = PgRelation::from_pg(index_relation);
     let tupdesc = index_relation_ref.tuple_desc();
     let index_name = index_relation_ref.name();
-    let directory = WriterDirectory::from_index_oid(index_relation_ref.oid().as_u32());
+    let directory =
+        WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_relation_ref.oid().as_u32());
     let search_index = SearchIndex::from_cache(&directory, uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
     let search_document =

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -71,7 +71,7 @@ pub extern "C" fn amrescan(
 
     // Create the index and scan state
     let index_oid = unsafe { (*scan.indexRelation).rd_id.as_u32() };
-    let directory = WriterDirectory::from_index_oid(index_oid);
+    let directory = WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_oid);
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
     let writer_client = WriterGlobal::client();

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -39,7 +39,8 @@ pub extern "C" fn amvacuumcleanup(
     let index_rel: pg_sys::Relation = info.index;
     let index_relation = unsafe { PgRelation::from_pg(index_rel) };
     let index_name = index_relation.name();
-    let directory = WriterDirectory::from_index_oid(index_relation.oid().as_u32());
+    let directory =
+        WriterDirectory::from_index_oid(crate::MyDatabaseId(), index_relation.oid().as_u32());
     let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -23,6 +23,7 @@ use core::panic;
 use fixtures::*;
 use pretty_assertions::assert_eq;
 use rstest::*;
+use shared::fixtures::utils::database_oid;
 use sqlx::PgConnection;
 use std::path::PathBuf;
 use tantivy::Index;
@@ -628,6 +629,7 @@ fn update_non_indexed_column(mut conn: PgConnection) -> Result<()> {
     let data_directory = "SHOW data_directory;".fetch_one::<(String,)>(&mut conn).0;
     let index_dir_path = PathBuf::from(data_directory)
         .join("pg_search")
+        .join(database_oid(&mut conn))
         .join(index_oid.to_string())
         .join("tantivy");
 
@@ -1138,6 +1140,7 @@ fn index_size(mut conn: PgConnection) {
 
     let index_dir = PathBuf::from(data_directory)
         .join("pg_search")
+        .join(database_oid(&mut conn))
         .join(index_oid.to_string())
         .join("tantivy");
 

--- a/shared/src/fixtures/utils.rs
+++ b/shared/src/fixtures/utils.rs
@@ -21,12 +21,9 @@ use sqlx::PgConnection;
 use std::path::PathBuf;
 
 pub fn database_oid(conn: &mut PgConnection) -> String {
-    let db_name = "SELECT current_database()".fetch_one::<(String,)>(conn).0;
-
-    format!("SELECT oid FROM pg_database WHERE datname='{db_name}'")
-        .fetch_one::<(sqlx::postgres::types::Oid,)>(conn)
+    "select oid::int4 from pg_database where datname = current_database()"
+        .fetch_one::<(i32,)>(conn)
         .0
-         .0
         .to_string()
 }
 


### PR DESCRIPTION
As noted in #1579, it's possible for two databases in the same cluster to end up using the same OID for a `USING bm25` index, which could lead to all kinds of unknown problems at runtime.

This addresses that by organizing the data directory first by database OID, then by index OID.

There's a few touch points in this PR because we need to pass the database OID to `WriterDirectory::from_index_oid` now.

## 🚨🚨🚨 We need a migration plan for users

I don't know if it's fine to say, "hey, REINDEX each of your pg_search indexes" or if we need to do something more sophisticated.  @rebasedming / @philippemnoel we should discuss.

# Ticket(s) Closed

- Closes #1579

## What

## Why

## How

## Tests

Existing test suite passes, and a few were updated to account for the new directory entry.