### PR TITLE
feat: Dockerfile with Barman Cloud for CloudNativePG support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -204,7 +204,7 @@ RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
     mkdir /var/lib/postgresql/.duckdb/ && \
     chmod -R a+rwX /var/lib/postgresql/.duckdb/
 
-# Installs Barman Cloud and its dependencies for Azure, Google, and AWS via NPM and cleans up the installation.
+# Installs Barman Cloud and its dependencies for Azure, Google, and AWS via PIP and cleans up the installation.
 SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libpq5 python3-pip python3-dev python3-psycopg2 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,28 +159,10 @@ RUN echo "trusted = true" >> pg_ivm.control && \
     make clean -j && \
     make USE_PGXS=1 -j
 
-######################
-# Barman Cloud
-######################
-FROM postgres:${PG_VERSION_MAJOR}-bookworm AS barman-cloud-base
-SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-dev python3-psycopg2 && \
-    rm /usr/lib/python*/EXTERNALLY-MANAGED && \
-    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]~=3.11' && \
-    apt-get remove -y python3-dev python3-pip ca-certificates --purge && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf && \
-    find /var/cache -type f -exec truncate --size 0 {} \; && \
-    find /var/log -type f -exec truncate --size 0 {} \;
-
-
 ###############################################
-# Second Stage: PostgreSQL
+# Second Stage: PostgreSQL and Barman Cloud
 ###############################################
-
-# Note: Debian Bookworm = Debian 12
-FROM barman-cloud-base AS paradedb
+FROM postgres:${PG_VERSION_MAJOR}-bookworm AS paradedb
 
 LABEL maintainer="ParadeDB - https://paradedb.com" \
     org.opencontainers.image.description="ParadeDB - Postgres for Search and Analytics" \
@@ -219,12 +201,19 @@ USER root
 # the user connects with the postgres user, the DuckDB folder will be created in the /var/lib/postgresql directory. We
 # chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
 RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
-    mkdir /var/lib/postgresql/.duckdb/ && chmod -R a+rwX /var/lib/postgresql/.duckdb/ && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends libpq5 && \
+    mkdir /var/lib/postgresql/.duckdb/ && \
+    chmod -R a+rwX /var/lib/postgresql/.duckdb/
+
+# Installs Barman Cloud and its dependencies for Azure, Google, and AWS via NPM and cleans up the installation.
+SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libpq5 python3-pip python3-dev python3-psycopg2 && \
+    rm /usr/lib/python*/EXTERNALLY-MANAGED && \
+    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]~=3.11' && \
+    apt-get remove -y python3-dev python3-pip ca-certificates --purge && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
-    set -o pipefail && \
+    find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf && \
     find /var/cache -type f -exec truncate --size 0 {} \; && \
     find /var/log -type f -exec truncate --size 0 {} \;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,12 +159,27 @@ RUN echo "trusted = true" >> pg_ivm.control && \
     make clean -j && \
     make USE_PGXS=1 -j
 
+######################
+# Barman Cloud
+######################
+FROM postgres:${PG_VERSION_MAJOR}-bookworm AS barman-cloud-base
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-dev python3-psycopg2 && \
+    rm /usr/lib/python*/EXTERNALLY-MANAGED && \
+    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]' && \
+    apt-get remove -y python3-dev python3-pip ca-certificates --purge && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$)" | xargs rm -rf && \
+    find /var/cache -type f -exec truncate --size 0 {} \; && \
+    find /var/log -type f -exec truncate --size 0 {} \;
+
+
 ###############################################
 # Second Stage: PostgreSQL
 ###############################################
 
 # Note: Debian Bookworm = Debian 12
-FROM postgres:${PG_VERSION_MAJOR}-bookworm AS paradedb
+FROM barman-cloud-base AS paradedb
 
 LABEL maintainer="ParadeDB - https://paradedb.com" \
     org.opencontainers.image.description="ParadeDB - Postgres for Search and Analytics" \
@@ -204,7 +219,12 @@ USER root
 # chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
 RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
     mkdir /var/lib/postgresql/.duckdb/ && chmod -R a+rwX /var/lib/postgresql/.duckdb/ && \
-    apt-get install -y --no-install-recommends libpq5 && rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -y --no-install-recommends libpq5 && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    find /var/cache -type f -exec truncate --size 0 {} \; && \
+    find /var/log -type f -exec truncate --size 0 {} \;
 
 # The postgresql.conf.sample file is used as a template for the postgresql.conf file, which
 # does not exist until the first time the container is started. By adding our settings to the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,9 +163,10 @@ RUN echo "trusted = true" >> pg_ivm.control && \
 # Barman Cloud
 ######################
 FROM postgres:${PG_VERSION_MAJOR}-bookworm AS barman-cloud-base
+SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-dev python3-psycopg2 && \
     rm /usr/lib/python*/EXTERNALLY-MANAGED && \
-    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]' && \
+    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]~=3.11' && \
     apt-get remove -y python3-dev python3-pip ca-certificates --purge && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
@@ -223,6 +224,7 @@ RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
     apt-get install -y --no-install-recommends libpq5 && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
+    set -o pipefail && \
     find /var/cache -type f -exec truncate --size 0 {} \; && \
     find /var/log -type f -exec truncate --size 0 {} \;
 


### PR DESCRIPTION
## What

This is an alternative implementation of #1554. It uses NPM to install `barman-cloud`. I tried to optimize this as much as possible with a thorough cleans up to reduce the size of the new layer to only `72MB`.

This can be further improved, but I don't think the cost/benefit curve is justified.

Closes #1554

## Why

Adds support for orchestration with CloudNative PG.

## How

Installs `barman-cloud` via NPM on a clean `postgres` image that is then used as the base for the final layer. From a lot of trial and error this is one of the easiest ways producing the least size overhead.

## Tests

Manual tests performed for the presence of Barman Cloud binaries and normal Postgres operation. I'll write a more elaborate test suite for Barman Cloud as part of the Helm Chart testing.