### PR TITLE
docs: Add license comparison page

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -215,8 +215,8 @@
             "documentation/concepts/term"
           ]
         },
-        "welcome/support",
-        "welcome/license"
+        "welcome/license",
+        "welcome/support"
       ]
     },
     {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -215,7 +215,8 @@
             "documentation/concepts/term"
           ]
         },
-        "welcome/support"
+        "welcome/support",
+        "welcome/license"
       ]
     },
     {

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -11,7 +11,7 @@ title: Licensing
 ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 and as commercial software. By using the
 open source version of ParadeDB, you certify that you comply with the requirements of the AGPLv3.
 
-The ParadeDB Enterprise license waives the copyleft requirements of the AGPL-3.0 and includes the closed source features listed
+The ParadeDB Enterprise license waives the copyleft requirements of the AGPLv3 and includes the closed source features listed
 below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
 
 ## ParadeDB License Comparison
@@ -65,7 +65,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Most Postgres types support
+      Support for most Postgres types
     </td>
     <td
       align="center"
@@ -172,6 +172,28 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
       ✅
     </td>
   </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Multiple tokenizers over the same field
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
   <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
     <td
       align="center"
@@ -194,7 +216,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Basic search API
+      Full text search API
     </td>
     <td
       align="center"
@@ -225,7 +247,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Advanced search API
+      Query builder API
     </td>
     <td
       align="center"
@@ -256,38 +278,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Joined search
-    </td>
-    <td
-      align="center"
-      style={{
-        width: "36%",
-        textAlign: "center",
-        paddingLeft: 32,
-      }}
-    >
-      ✅
-    </td>
-    <td
-      align="center"
-      style={{
-        width: "36%",
-        textAlign: "center",
-        paddingLeft: 32,
-      }}
-    >
-      ✅
-    </td>
-  </tr>
-  <tr style={{ display: "flex" }}>
-    <td
-      align="center"
-      style={{
-        width: "64%",
-        textAlign: "left",
-      }}
-    >
-      Hybrid search
+      Lenient query parsing
     </td>
     <td
       align="center"
@@ -380,7 +371,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Bucket aggregations
+      Nested document search
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -402,7 +393,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Metric aggregations
+      Accelerated SQL bucket aggregations
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -424,7 +415,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Result counts
+      Accelerated SQL metric aggregations
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -446,7 +437,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Lenient query parsing
+      Distributed search (on roadmap)
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -575,7 +566,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Logical replication support
+      Logical replication
     </td>
     <td
       align="center"
@@ -606,7 +597,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      Concurrent index writes
+      Concurrent writes to the same index
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -695,7 +686,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
         textAlign: "left",
       }}
     >
-      High Availability
+      High Availability (Streaming replication)
     </td>
     <td
       align="center"

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -9,13 +9,9 @@ title: License Comparison
   for access.
 </Note>
 
-ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 (AGPLv3) and as commercial license.
-
-The Community License is the AGPL-3.0 license, which permits free use, modification, and distribution of software, provided that distributed, derivative works of the software
-are released under the same license. This provision is called the copyleft provision.
-
-The Enterprise License waives the copyleft requirements of the AGPL-3.0 license and includes the enterprise-only features listed below. It is available under a shelf-hosted
-or BYOC (Bring Your Own Cloud) model. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
+ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 and as commercial software. The ParadeDB
+Enterprise license waives the copyleft requirements of the AGPL-3.0 and includes the closed source features listed
+below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
 
 ## ParadeDB License Comparison
 
@@ -162,6 +158,28 @@ or BYOC (Bring Your Own Cloud) model. To purchase a ParadeDB Enterprise License,
       }}
     >
       Partitioned indexes
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      IVM indexes*
     </td>
     <td style={{ width: "36%" }}></td>
     <td
@@ -612,6 +630,96 @@ or BYOC (Bring Your Own Cloud) model. To purchase a ParadeDB Enterprise License,
       }}
     >
       ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+        fontWeight: "bold",
+      }}
+    >
+      Cluster Management
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td style={{ width: "36%" }}></td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      CloudNativePG Support
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      High Availability
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    ></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex", borderTop: "solid 1px #ddd" }}>
+    <td
+      colSpan="3"
+      style={{
+        width: "100%",
+        textAlign: "left",
+        padding: "10px 0",
+        fontSize: "0.9em",
+        color: "#666",
+      }}
+    >
+      *IVM indexes are BM25 indexes over incrementally-maintained materialized
+      views. They enable creating a BM25 index over the JOIN of two or more
+      tables with fast-changing data.
     </td>
   </tr>
 </table>

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -1,0 +1,49 @@
+---
+title: License Comparison
+---
+
+<Note>
+  ParadeDB BYOC (Bring Your Own Cloud), a managed deployment of ParadeDB inside
+  your AWS account, is coming soon. Please fill out the [interest
+  form](https://form.typeform.com/to/jHkLmIzx?typeform-source=paradedb.typeform.com)
+  for access.
+</Note>
+
+ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 (AGPLv3) and as commercial license with some. The Community License is the AGPL-3.0 license,
+which permits free use, modification, and distribution of software, provided that distributed, derivative works of the software are released under the same license. This
+provision is called the copyleft provision.
+
+The Enterprise License waives the copyleft requirements of the AGPL-3.0 license and includes the enterprise-only features listed below. It is available under a shelf-hosted
+or BYOC (Bring Your Own Cloud) model. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
+
+## ParadeDB License Comparison
+
+| Feature                     | **Community License** | **Enterprise License** |
+| --------------------------- | :-------------------: | :--------------------: |
+| **Index Configuration**     |                       |                        |
+| Most Postgres types support |          ✅           |           ✅           |
+| Custom tokenizers           |          ✅           |           ✅           |
+| Multi-language stemming     |          ✅           |           ✅           |
+| Partitioned indexes         |                       |           ✅           |
+|                             |                       |                        |
+| **Search API**              |                       |                        |
+| Basic search API            |          ✅           |           ✅           |
+| Advanced search API         |          ✅           |           ✅           |
+| Hybrid search               |          ✅           |           ✅           |
+| BM25 scoring                |          ✅           |           ✅           |
+| Highlighting                |          ✅           |           ✅           |
+| Bucket aggregations         |                       |           ✅           |
+| Metric aggregations         |                       |           ✅           |
+| Result counts               |                       |           ✅           |
+| Lenient query parsing       |                       |           ✅           |
+|                             |                       |                        |
+| **Index Operations**        |                       |                        |
+| Strong index consistency    |          ✅           |           ✅           |
+| Automatic index compaction  |          ✅           |           ✅           |
+| Base backup support         |          ✅           |           ✅           |
+| Logical replication support |          ✅           |           ✅           |
+| Concurrent index writes     |                       |           ✅           |
+| Eventual index consistency  |                       |           ✅           |
+
+For any questions, please don't hesitate to contact us at [hello@paradedb.com](mailto:hello@paradedb.com) or in
+the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ).

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -9,41 +9,612 @@ title: License Comparison
   for access.
 </Note>
 
-ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 (AGPLv3) and as commercial license with some. The Community License is the AGPL-3.0 license,
-which permits free use, modification, and distribution of software, provided that distributed, derivative works of the software are released under the same license. This
-provision is called the copyleft provision.
+ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 (AGPLv3) and as commercial license.
+
+The Community License is the AGPL-3.0 license, which permits free use, modification, and distribution of software, provided that distributed, derivative works of the software
+are released under the same license. This provision is called the copyleft provision.
 
 The Enterprise License waives the copyleft requirements of the AGPL-3.0 license and includes the enterprise-only features listed below. It is available under a shelf-hosted
 or BYOC (Bring Your Own Cloud) model. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
 
 ## ParadeDB License Comparison
 
-| Feature                     | **Community License** | **Enterprise License** |
-| --------------------------- | :-------------------: | :--------------------: |
-| **Index Configuration**     |                       |                        |
-| Most Postgres types support |          ✅           |           ✅           |
-| Custom tokenizers           |          ✅           |           ✅           |
-| Multi-language stemming     |          ✅           |           ✅           |
-| Partitioned indexes         |                       |           ✅           |
-|                             |                       |                        |
-| **Search API**              |                       |                        |
-| Basic search API            |          ✅           |           ✅           |
-| Advanced search API         |          ✅           |           ✅           |
-| Hybrid search               |          ✅           |           ✅           |
-| BM25 scoring                |          ✅           |           ✅           |
-| Highlighting                |          ✅           |           ✅           |
-| Bucket aggregations         |                       |           ✅           |
-| Metric aggregations         |                       |           ✅           |
-| Result counts               |                       |           ✅           |
-| Lenient query parsing       |                       |           ✅           |
-|                             |                       |                        |
-| **Index Operations**        |                       |                        |
-| Strong index consistency    |          ✅           |           ✅           |
-| Automatic index compaction  |          ✅           |           ✅           |
-| Base backup support         |          ✅           |           ✅           |
-| Logical replication support |          ✅           |           ✅           |
-| Concurrent index writes     |                       |           ✅           |
-| Eventual index consistency  |                       |           ✅           |
+<table
+  id="table"
+  style={{
+    width: "100%",
+    borderRadius: "10px",
+  }}
+>
+  <tr
+    style={{
+      display: "flex",
+      borderBottom: "solid 1px #ddd",
+    }}
+  >
+    <th align="center" style={{ width: "64%", textAlign: "left" }}></th>
+    <th
+      align="center"
+      style={{ width: "36%", textAlign: "center", paddingLeft: 32 }}
+    >
+      Community License
+    </th>
+    <th
+      align="center"
+      style={{ width: "36%", textAlign: "center", paddingLeft: 32 }}
+    >
+      Enterprise License
+    </th>
+  </tr>
+  <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+        fontWeight: "bold",
+      }}
+    >
+      Index Configuration
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td style={{ width: "36%" }}></td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Most Postgres types support
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Custom tokenizers
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Multi-language stemming
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Partitioned indexes
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+        fontWeight: "bold",
+      }}
+    >
+      Search API
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td style={{ width: "36%" }}></td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Basic search API
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Advanced search API
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Hybrid search
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      BM25 scoring
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Highlighting
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Bucket aggregations
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Metric aggregations
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Result counts
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Lenient query parsing
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+        fontWeight: "bold",
+      }}
+    >
+      Index Operations
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td style={{ width: "36%" }}></td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Strong index consistency
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Automatic index compaction
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Base backup support
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Logical replication support
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Concurrent index writes
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Eventual index consistency
+    </td>
+    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+</table>
 
 For any questions, please don't hesitate to contact us at [hello@paradedb.com](mailto:hello@paradedb.com) or in
 the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ).

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -160,7 +160,16 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
     >
       Partitioned indexes
     </td>
-    <td style={{ width: "36%" }}></td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
     <td
       align="center"
       style={{
@@ -598,28 +607,6 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
       }}
     >
       Concurrent writes to the same index
-    </td>
-    <td style={{ width: "36%" }}></td>
-    <td
-      align="center"
-      style={{
-        width: "36%",
-        textAlign: "center",
-        paddingLeft: 32,
-      }}
-    >
-      ✅
-    </td>
-  </tr>
-  <tr style={{ display: "flex" }}>
-    <td
-      align="center"
-      style={{
-        width: "64%",
-        textAlign: "left",
-      }}
-    >
-      Eventual index consistency
     </td>
     <td style={{ width: "36%" }}></td>
     <td

--- a/docs/welcome/license.mdx
+++ b/docs/welcome/license.mdx
@@ -1,16 +1,17 @@
 ---
-title: License Comparison
+title: Licensing
 ---
 
 <Note>
   ParadeDB BYOC (Bring Your Own Cloud), a managed deployment of ParadeDB inside
-  your AWS account, is coming soon. Please fill out the [interest
-  form](https://form.typeform.com/to/jHkLmIzx?typeform-source=paradedb.typeform.com)
-  for access.
+  your AWS, Azure, or GCP account, is now available. Please [contact
+  sales](mailto:sales@paradedb.com) for access.
 </Note>
 
-ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 and as commercial software. The ParadeDB
-Enterprise license waives the copyleft requirements of the AGPL-3.0 and includes the closed source features listed
+ParadeDB is dual-licensed under the GNU Affero General Public License 3.0 and as commercial software. By using the
+open source version of ParadeDB, you certify that you comply with the requirements of the AGPLv3.
+
+The ParadeDB Enterprise license waives the copyleft requirements of the AGPL-3.0 and includes the closed source features listed
 below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:sales@paradedb.com).
 
 ## ParadeDB License Comparison
@@ -171,28 +172,6 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
       ✅
     </td>
   </tr>
-  <tr style={{ display: "flex" }}>
-    <td
-      align="center"
-      style={{
-        width: "64%",
-        textAlign: "left",
-      }}
-    >
-      IVM indexes*
-    </td>
-    <td style={{ width: "36%" }}></td>
-    <td
-      align="center"
-      style={{
-        width: "36%",
-        textAlign: "center",
-        paddingLeft: 32,
-      }}
-    >
-      ✅
-    </td>
-  </tr>
   <tr style={{ display: "flex", borderBottom: "solid 1px #ddd" }}>
     <td
       align="center"
@@ -247,6 +226,37 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
       }}
     >
       Advanced search API
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+    <td
+      align="center"
+      style={{
+        width: "36%",
+        textAlign: "center",
+        paddingLeft: 32,
+      }}
+    >
+      ✅
+    </td>
+  </tr>
+  <tr style={{ display: "flex" }}>
+    <td
+      align="center"
+      style={{
+        width: "64%",
+        textAlign: "left",
+      }}
+    >
+      Joined search
     </td>
     <td
       align="center"
@@ -706,23 +716,7 @@ below. To purchase a ParadeDB Enterprise License, please [contact sales](mailto:
       ✅
     </td>
   </tr>
-  <tr style={{ display: "flex", borderTop: "solid 1px #ddd" }}>
-    <td
-      colSpan="3"
-      style={{
-        width: "100%",
-        textAlign: "left",
-        padding: "10px 0",
-        fontSize: "0.9em",
-        color: "#666",
-      }}
-    >
-      *IVM indexes are BM25 indexes over incrementally-maintained materialized
-      views. They enable creating a BM25 index over the JOIN of two or more
-      tables with fast-changing data.
-    </td>
-  </tr>
 </table>
 
-For any questions, please don't hesitate to contact us at [hello@paradedb.com](mailto:hello@paradedb.com) or in
+For any questions, please don't hesitate to contact us via [email](mailto:hello@paradedb.com) or in
 the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We had this on a Notion doc, which meant users couldn't see the value of the enterprise license right away. This should make it much easier for users to decide to reach out to us for a commercial license.

## Why
^

## How
^

## Tests
Tested locally