### PR TITLE
docs: timestampformat in csv options

### DIFF
--- a/docs/ingest/import/csv.mdx
+++ b/docs/ingest/import/csv.mdx
@@ -112,7 +112,12 @@ OPTIONS (
 
 <ParamField body="dateformat">
   Specifies the date format to use when parsing dates. See [Date
-  Format](https://duckdb.org/docs/sql/functions/dateformat.html).
+  Format](https://duckdb.org/docs/sql/functions/dateformat).
+</ParamField>
+
+<ParamField body="timestampformat">
+  Specifies the timestamp format to use when parsing timestamps. See [Date
+  Format](https://duckdb.org/docs/sql/functions/dateformat).
 </ParamField>
 
 <ParamField body="decimal_separator" default=".">


### PR DESCRIPTION
## What
Adds timestampformat to CSV Options, after dateformat option

## Why
dateformat is already defined in options, but timestampformat not.

It's mentioned in [CSV Parsing](https://duckdb.org/docs/sql/functions/dateformat#csv-parsing) section too

