### PR TITLE
feat:  add a "fast path" for the `.search(query=>'...', stable_sort=>false)` case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,6 +3983,7 @@ dependencies = [
  "bincode",
  "chrono",
  "cmd_lib",
+ "crossbeam",
  "csv",
  "derive_more",
  "dotenvy",

--- a/docs/api-reference/full-text/bm25.mdx
+++ b/docs/api-reference/full-text/bm25.mdx
@@ -184,14 +184,19 @@ FROM <index_name>.search(
 
 ## Stable Ordering
 
-Search results are ordered based on their BM25 score, unless specified otherwise using the `order_by_field` parameter, but we can use the `stable_sort`
-parameter for control over the order of equally-scored results.
+By default, search results are ordered in descending order by their BM25 score, unless specified otherwise using the `order_by_field` parameter,
+and the primary key field is used as a tie-breaker.
 
-If `false`, equally-scored results will be ordered based on their insertion order into the index.
-This is the default, and allows for the fastest possible query times.
+This behavior can be controlled for the `<index_name>.search()` function with the the `stable_sort` parameter.
 
-If `true`, equally-scored results will be ordered based on their `key_field`, but query times will be slower.
-This is useful for testing or anytime where results need to be deterministic.
+If `true`, the default if unspecified, equally-scored or ordered results will be sub-sorted by their `key_field`. As a
+consequence of score evaluation and sorting, query times will be slower. This is useful for testing or anytime where
+results need to be deterministic but the score itself is not necessary. See the `<index_name>.score_bm25()` function
+for retrieving document scores.
+
+If `false`, scores are not generated and instead results are returned in an un-deterministic index order. The benefit
+of this is that the results are returned as quickly as possible. This is useful for queries that are known to return
+many thousands or millions of rows.
 
 ```sql
 SELECT *

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -21,6 +21,7 @@ icu = ["tokenizers/icu"]
 [dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 bincode = "1.3.3"
+crossbeam = "0.8.4"
 csv = "1.2.2"
 derive_more = "0.99.17"
 fs2 = "0.4.3"

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -50,7 +50,7 @@ fn search_tantivy(
         let mut hs = FxHashSet::default();
 
         for (scored, _) in top_docs {
-            hs.insert(scored.key);
+            hs.insert(scored.key.expect("key should have been retrieved"));
         }
 
         (search_config, hs)

--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -90,6 +90,7 @@ unsafe fn score_bm25(
                 datum::AnyElement::from_polymorphic_datum(
                     scored
                         .key
+                        .expect("key should have been retrieved")
                         .try_into_datum(PgOid::from_untagged(key_oid))
                         .expect("failed to convert key_field to datum"),
                     false,
@@ -154,6 +155,7 @@ unsafe fn snippet(
                 datum::AnyElement::from_polymorphic_datum(
                     scored
                         .key
+                        .expect("key should have been retrieved")
                         .try_into_datum(PgOid::from_untagged(key_oid))
                         .expect("failed to convert key_field to datum"),
                     false,

--- a/pg_search/src/index/score.rs
+++ b/pg_search/src/index/score.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchIndexScore {
     pub bm25: f32,
-    pub key: TantivyValue,
+    pub key: Option<TantivyValue>,
     pub ctid: u64,
 
     /// if we have a specific order by requirement, use that first, instead of sorting by the bm25 score

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -135,7 +135,7 @@ impl SearchState {
         executor: &'static Executor,
         include_key: bool,
     ) -> crossbeam::channel::Receiver<(SearchIndexScore, DocAddress)> {
-        let (sender, receiver) = crossbeam::channel::bounded(10_000); // arbitrary bound
+        let (sender, receiver) = crossbeam::channel::unbounded();
         let collector =
             collector::ChannelCollector::new(sender, self.config.key_field.clone(), include_key);
         let searcher = self.searcher.clone();

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -117,7 +117,7 @@ impl SearchState {
         }
     }
 
-    pub fn search_no_key(&self, executor: &'static Executor) -> SearchResults {
+    pub fn search_key_if_required(&self, executor: &'static Executor) -> SearchResults {
         match (
             self.config.limit_rows,
             self.config.stable_sort.unwrap_or(true),
@@ -126,7 +126,7 @@ impl SearchState {
             (None, false, None) => {
                 SearchResults::Channel(self.search_via_channel(executor, false).into_iter())
             }
-            _ => SearchResults::AllFeatures(self.search_with_all_features(executor, false)),
+            _ => SearchResults::AllFeatures(self.search_with_all_features(executor, true)),
         }
     }
 

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -86,8 +86,10 @@ pub extern "C" fn amrescan(
         let state = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(state);
 
         // SAFETY:  `leak_and_drop_on_delete()` gave us a non-null, aligned pointer to the SearchState
-        let results_iter: SearchResultIter =
-            state.as_ref().unwrap().search(SearchIndex::executor());
+        let results_iter: SearchResultIter = state
+            .as_ref()
+            .unwrap()
+            .search_no_key(SearchIndex::executor());
 
         PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(results_iter)
     };

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -89,7 +89,7 @@ pub extern "C" fn amrescan(
         let results_iter: SearchResultIter = state
             .as_ref()
             .unwrap()
-            .search_key_if_required(SearchIndex::executor());
+            .search_minimal(SearchIndex::executor());
 
         PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(results_iter)
     };
@@ -120,7 +120,7 @@ pub extern "C" fn amgettuple(
     scan.xs_recheck = false;
 
     match iter.next() {
-        Some((scored, _doc_address)) => {
+        Some((scored, _)) => {
             let tid = &mut scan.xs_heaptid;
             u64_to_item_pointer(scored.ctid, tid);
 

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -89,7 +89,7 @@ pub extern "C" fn amrescan(
         let results_iter: SearchResultIter = state
             .as_ref()
             .unwrap()
-            .search_no_key(SearchIndex::executor());
+            .search_key_if_required(SearchIndex::executor());
 
         PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(results_iter)
     };

--- a/pg_search/tests/stable_sort.rs
+++ b/pg_search/tests/stable_sort.rs
@@ -51,3 +51,25 @@ fn stable_sort_false(mut conn: PgConnection) {
     let expected: HashSet<i32> = HashSet::from_iter(vec![37, 7]);
     assert_eq!(ids, expected);
 }
+
+#[rstest]
+fn score_bm25_stable_sort_false(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    let rows: Vec<(i32, f32)> = r#"
+    SELECT * FROM bm25_search.score_bm25(
+        query => 'description:book',
+        stable_sort => false
+    );
+    "#
+    .fetch_collect(&mut conn);
+
+    // make sure we have the ids we expect
+    let ids: HashSet<i32> = HashSet::from_iter(rows.iter().map(|(id, _)| *id));
+    let expected: HashSet<i32> = HashSet::from_iter(vec![37, 7]);
+    assert_eq!(ids, expected);
+
+    // and that they have scores, whatever they are
+    let ids: HashSet<bool> = HashSet::from_iter(rows.iter().map(|(_, score)| *score != 0.0));
+    let expected: HashSet<bool> = HashSet::from_iter(vec![true, true]);
+    assert_eq!(ids, expected);
+}

--- a/pg_search/tests/stable_sort.rs
+++ b/pg_search/tests/stable_sort.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+use std::collections::HashSet;
+
+#[rstest]
+fn stable_sort_true(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => 'description:book',
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![37, 7]);
+}
+
+#[rstest]
+fn stable_sort_false(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    let columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        query => 'description:book',
+        stable_sort => false
+    );
+    "#
+    .fetch_collect(&mut conn);
+
+    let ids: HashSet<i32> = HashSet::from_iter(columns.id.clone());
+    let expected: HashSet<i32> = HashSet::from_iter(vec![37, 7]);
+    assert_eq!(ids, expected);
+}


### PR DESCRIPTION
# Ticket(s) Closed

n/a 

## What

This adds a "fast path" for the `.search()` function for when there's no limit, no order by, and `stable_sort = false` (default is true!).  Cuts execution time nearly in half or even more for queries returning very large sets.

## Why

To speed things up

## How

By detecting if we can do the fast path mode and using a custom tantivy `Collector` that streams results through a crossbeam **un**bounded channel.

The only case we can do this is with: 

 ```sql
SELECT * FROM idxname.search(query=>'...', stable_sort=>false)
```

But if the user doesn't care about scores or ordering and needs *all* the matching rows back, this is now ***much*** faster.

Current `dev` branch, using a 15G tantivy index with about 51M docs:

```sql
[v16.2][1802739] reddit=# select count(*) from idxreddit.search(query => 'body:(the)', stable_sort => false);
  count   
----------
 21599227
(1 row)

Time: 116081.549 ms (01:56.082)
```

This PR:

```sql
[v16.2][1930767] reddit=# select count(*) from idxreddit.search(query => 'body:(the)', stable_sort => false);
  count   
----------
 21599227
(1 row)

Time: 29245.247 ms (00:29.245)
```

For at least queries returning large resultsets like this (21M rows in this case), this is about a 4x improvement.  For smaller sets of a few hundred thousand, I see around 2x improvement.

## Tests

Added a few tests to make sure that `stable_sort => false` is indeed unstable and that we don't accidentally turn off scoring for the `.score_bm25(stable_sort => false)` case (which is a bug I had in the first commit!).