### PR TITLE
fix: and pg_depend entry for drop schema + index

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -399,7 +399,9 @@ fn create_bm25_impl(
     ))?;
 
     // Add the dependency between the index and schema
-    add_pg_depend_entry(pg_sys::Oid::from(index_oid), pg_relation.namespace_oid());
+    unsafe {
+        add_pg_depend_entry(pg_sys::Oid::from(index_oid), pg_relation.namespace_oid());
+    }
 
     Spi::run(&format!(
         "SET client_min_messages TO {}",
@@ -493,7 +495,7 @@ fn index_size(index_name: &str) -> Result<i64> {
     Ok(total_size as i64)
 }
 
-fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
+unsafe fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
     unsafe {
         let index_dep = pg_sys::ObjectAddress {
             classId: pg_sys::RelationRelationId,
@@ -521,4 +523,6 @@ fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
             pg_sys::DependencyType::DEPENDENCY_NORMAL,
         );
     }
+
+    pg_sys::CommandCounterIncrement();
 }

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -504,13 +504,13 @@ fn index_size(index_name: &str) -> Result<i64> {
 
 fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
     unsafe {
-        let mut index_dep = pg_sys::ObjectAddress {
+        let index_dep = pg_sys::ObjectAddress {
             classId: pg_sys::RelationRelationId,
             objectId: index_oid,
             objectSubId: 0,
         };
 
-        let mut schema_dep = pg_sys::ObjectAddress {
+        let schema_dep = pg_sys::ObjectAddress {
             classId: pg_sys::NamespaceRelationId,
             objectId: schema_oid,
             objectSubId: 0,
@@ -518,15 +518,15 @@ fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
 
         // Create dependency from index to schema
         pg_sys::recordDependencyOn(
-            &mut index_dep,
-            &mut schema_dep,
+            &index_dep,
+            &schema_dep,
             pg_sys::DependencyType::DEPENDENCY_NORMAL,
         );
 
         // Create dependency from schema to index
         pg_sys::recordDependencyOn(
-            &mut schema_dep,
-            &mut index_dep,
+            &schema_dep,
+            &index_dep,
             pg_sys::DependencyType::DEPENDENCY_NORMAL,
         );
     }

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -503,6 +503,9 @@ fn index_size(index_name: &str) -> Result<i64> {
 }
 
 fn add_pg_depend_entry(index_oid: pg_sys::Oid, schema_oid: pg_sys::Oid) {
+    // SAFETY:  The calls to [`pg_sys::recordDependencyOn`] are unsafe purely because of FFI.
+    //    They operate on const pointers, which we stack allocate, and will raise their own ERRORs
+    //    should they fail.
     unsafe {
         let index_dep = pg_sys::ObjectAddress {
             classId: pg_sys::RelationRelationId,

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -398,17 +398,8 @@ fn create_bm25_impl(
         $func$ LANGUAGE plpgsql"
     ))?;
 
-    let schema_oid_query = format!(
-        "SELECT oid FROM pg_namespace WHERE nspname = {}",
-        spi::quote_literal(index_name)
-    );
-    let schema_oid = Spi::get_one::<pg_sys::Oid>(&schema_oid_query)
-        .expect("error looking up schema in create_bm25")
-        .expect("no oid for schema created in create_bm25")
-        .as_u32();
-
     // Add the dependency between the index and schema
-    add_pg_depend_entry(pg_sys::Oid::from(index_oid), pg_sys::Oid::from(schema_oid));
+    add_pg_depend_entry(pg_sys::Oid::from(index_oid), pg_relation.namespace_oid());
 
     Spi::run(&format!(
         "SET client_min_messages TO {}",

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1077,15 +1077,12 @@ fn bm25_partial_index_alter_and_drop(mut conn: PgConnection) {
         "SELECT nspname FROM pg_namespace WHERE nspname = 'partial_idx';".fetch(&mut conn);
     assert_eq!(rows.len(), 1);
 
-    // When the predicate column is dropped, partial index will be dropped, but the schema will remain.
-    // This behavior is the same as normal postgres index.
-    "ALTER TABLE paradedb.test_partial_index DROP COLUMN category;".execute(&mut conn);
+    // When the predicate column is dropped with CASCADE, the index and the corresponding
+    // schema are both dropped.
+    "ALTER TABLE paradedb.test_partial_index DROP COLUMN category CASCADE;".execute(&mut conn);
     let rows: Vec<(String,)> =
         "SELECT relname FROM pg_class WHERE relname = 'partial_idx_bm25_index';".fetch(&mut conn);
     assert_eq!(rows.len(), 0);
-    let rows: Vec<(String,)> =
-        "SELECT nspname FROM pg_namespace WHERE nspname = 'partial_idx';".fetch(&mut conn);
-    assert_eq!(rows.len(), 1);
 
     // We need to comment this test out for now, because we've had to change the implementation
     // of paradedb.drop_bm25 to rely on the index OID, which is used to determine the file path

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -645,20 +645,20 @@ fn partitioned_index(mut conn: PgConnection) {
 #[rstest]
 fn drop_schema_cascades_index(mut conn: PgConnection) {
     // Test that dropping a schema cascades to drop the index as well
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'public')"
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
         index_name => 'index_config',
         table_name => 'index_config',
-        schema_name => 'paradedb',
+        schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
 
     // Drop the schema and ensure the index is also dropped
-    "DROP SCHEMA paradedb CASCADE".execute(&mut conn);
+    "DROP SCHEMA index_config CASCADE".execute(&mut conn);
 
     let index_exists =
         "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'index_config_bm25_index');"
@@ -674,20 +674,20 @@ fn drop_schema_cascades_index(mut conn: PgConnection) {
 #[rstest]
 fn drop_index_cascades_schema(mut conn: PgConnection) {
     // Test that dropping an index cascades to drop the schema as well
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'public')"
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
         index_name => 'index_config',
         table_name => 'index_config',
-        schema_name => 'paradedb',
+        schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
 
     // Drop the index and ensure the schema is also dropped
-    "DROP INDEX paradedb.index_config_bm25_index CASCADE".execute(&mut conn);
+    "DROP INDEX public.index_config_bm25_index CASCADE".execute(&mut conn);
 
     let schema_exists =
         "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'index_config');"
@@ -703,20 +703,20 @@ fn drop_index_cascades_schema(mut conn: PgConnection) {
 #[rstest]
 fn drop_table_cascades_bm25_schema(mut conn: PgConnection) {
     // Create the test table and BM25 index
-    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
+    "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'public')"
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
         index_name => 'index_config',
         table_name => 'index_config',
-        schema_name => 'paradedb',
+        schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')
     )"
     .execute(&mut conn);
 
     // Drop the table and check if the index schema is dropped
-    "DROP TABLE paradedb.index_config CASCADE;".execute(&mut conn);
+    "DROP TABLE public.index_config CASCADE;".execute(&mut conn);
 
     let schema_exists =
         "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'index_config');"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1577

## What
Add a `pg_catalog.pg_depend` entry for the created schema + index in a `create_bm25` call.

## Why
Although we encourage users to use `drop_bm25` to remove their `pg_search` indexes, its not too difficult to provide more broad support for cascading drops when using `DROP SCHEMA` and `DROP INDEX`.

## How
We can just do this inside the implementation of `create_bm25`, where other dynamically-formatted SQL is run.

## Tests

Two new tests added for dropping schema + index in each direction.
