### PR TITLE
feat: adding lenient and conjuction configs

### DIFF
--- a/docs/api-reference/full-text/conjunction.mdx
+++ b/docs/api-reference/full-text/conjunction.mdx
@@ -1,0 +1,30 @@
+---
+title: Query Term Conjunction
+---
+
+## Basic Usage
+
+The `conjunction_mode` parameter controls the default boolean logic applied to query terms. When not specified, the search function employs disjunction (OR) logic.
+Setting `conjunction_mode` to `true` switches the default logic to conjunction (AND).
+
+```sql
+SELECT * FROM <index_name>.search(
+  '<query>',
+  conjunction_mode => true
+);
+```
+
+<Accordion title="Example Usage">
+
+```sql
+-- Search with conjunction_mode set to true (AND logic applied)
+SELECT * FROM search_idx.search(
+  'description:keyboard rating:>2',
+  conjunction_mode => true
+);
+
+-- Equivalent query using the explicit AND operator
+SELECT \* FROM search_idx.search('description:keyboard AND rating:>2');
+```
+
+</Accordion>

--- a/docs/api-reference/full-text/lenient_parsing.mdx
+++ b/docs/api-reference/full-text/lenient_parsing.mdx
@@ -1,0 +1,15 @@
+---
+title: Lenient Parsing
+---
+
+## Basic Usage
+
+By default, lenient parsing is disabled. Enable it by setting the `lenient_parsing` parameter to `true`.
+When enabled, the query parser will attempt to construct a valid query on a best-effort basis, ignoring invalid components such as missing or non-existent fields.
+
+```sql
+SELECT * FROM <index_name>.search(
+  '<query>',
+  lenient_parsing => true
+);
+```

--- a/docs/api-reference/full-text/overview.mdx
+++ b/docs/api-reference/full-text/overview.mdx
@@ -51,3 +51,12 @@ SELECT * FROM search_idx.search('description:keyboard', limit_rows => 10);
   Configures whether `order_by_field` orders in ascending or descending order.
   Ascending is `asc`, descending is `desc`.
 </ParamField>
+<ParamField body="lenient_parsing" default={false}>
+  If set to `true`, the query parser will attempt to construct a valid query on
+  a best-effort basis, ignoring invalid components such as missing or
+  non-existent fields.
+</ParamField>
+<ParamField body="conjunction_mode" default={false}>
+  If set to `true`, the search function employs conjunction (AND) logic by
+  default.
+</ParamField>

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -39,7 +39,7 @@ pub fn format_bm25_function(
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL,
-            conjunction_by_default boolean DEFAULT NULL
+            use_conjunction boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         BEGIN
             RETURN QUERY SELECT * FROM {function_name}(
@@ -55,7 +55,7 @@ pub fn format_bm25_function(
                 order_by_field => order_by_field,
                 order_by_direction => order_by_direction,
                 lenient_parsing => lenient_parsing,
-                conjunction_by_default => conjunction_by_default
+                use_conjunction => use_conjunction
             );
         END
         $func$ LANGUAGE plpgsql;
@@ -73,7 +73,7 @@ pub fn format_bm25_function(
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL,
-            conjunction_by_default boolean DEFAULT NULL
+            use_conjunction boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         DECLARE
             __paradedb_search_config__ JSONB;
@@ -91,7 +91,7 @@ pub fn format_bm25_function(
                 'order_by_field', order_by_field,
                 'order_by_direction', order_by_direction,
                 'lenient_parsing', lenient_parsing,
-                'conjunction_by_default', conjunction_by_default
+                'use_conjunction', use_conjunction
             );
             {function_body};
         END

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -38,6 +38,7 @@ pub fn format_bm25_function(
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL
+            lenient_parsing boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         BEGIN
             RETURN QUERY SELECT * FROM {function_name}(
@@ -52,6 +53,7 @@ pub fn format_bm25_function(
                 max_num_chars => max_num_chars,
                 order_by_field => order_by_field,
                 order_by_direction => order_by_direction
+                lenient_parsing => lenient_parsing
             );
         END
         $func$ LANGUAGE plpgsql;
@@ -68,6 +70,7 @@ pub fn format_bm25_function(
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL
+            lenient_parsing boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         DECLARE
             __paradedb_search_config__ JSONB;
@@ -84,6 +87,7 @@ pub fn format_bm25_function(
                 'max_num_chars', max_num_chars,
                 'order_by_field', order_by_field,
                 'order_by_direction', order_by_direction
+                'lenient_parsing', lenient_parsing
             );
             {function_body};
         END

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -39,7 +39,7 @@ pub fn format_bm25_function(
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL,
-            use_conjunction boolean DEFAULT NULL
+            conjunction_mode boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         BEGIN
             RETURN QUERY SELECT * FROM {function_name}(
@@ -55,7 +55,7 @@ pub fn format_bm25_function(
                 order_by_field => order_by_field,
                 order_by_direction => order_by_direction,
                 lenient_parsing => lenient_parsing,
-                use_conjunction => use_conjunction
+                conjunction_mode => conjunction_mode
             );
         END
         $func$ LANGUAGE plpgsql;
@@ -73,7 +73,7 @@ pub fn format_bm25_function(
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL,
-            use_conjunction boolean DEFAULT NULL
+            conjunction_mode boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         DECLARE
             __paradedb_search_config__ JSONB;
@@ -91,7 +91,7 @@ pub fn format_bm25_function(
                 'order_by_field', order_by_field,
                 'order_by_direction', order_by_direction,
                 'lenient_parsing', lenient_parsing,
-                'use_conjunction', use_conjunction
+                'conjunction_mode', conjunction_mode
             );
             {function_body};
         END

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -37,7 +37,7 @@ pub fn format_bm25_function(
             prefix text DEFAULT NULL,
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
-            order_by_direction text DEFAULT NULL
+            order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         BEGIN
@@ -52,7 +52,7 @@ pub fn format_bm25_function(
                 prefix => prefix,
                 max_num_chars => max_num_chars,
                 order_by_field => order_by_field,
-                order_by_direction => order_by_direction
+                order_by_direction => order_by_direction,
                 lenient_parsing => lenient_parsing
             );
         END
@@ -69,7 +69,7 @@ pub fn format_bm25_function(
             prefix text DEFAULT NULL,
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
-            order_by_direction text DEFAULT NULL
+            order_by_direction text DEFAULT NULL,
             lenient_parsing boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         DECLARE
@@ -86,7 +86,7 @@ pub fn format_bm25_function(
                 'prefix', prefix,
                 'max_num_chars', max_num_chars,
                 'order_by_field', order_by_field,
-                'order_by_direction', order_by_direction
+                'order_by_direction', order_by_direction,
                 'lenient_parsing', lenient_parsing
             );
             {function_body};

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -38,7 +38,8 @@ pub fn format_bm25_function(
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
-            lenient_parsing boolean DEFAULT NULL
+            lenient_parsing boolean DEFAULT NULL,
+            conjunction_by_default boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         BEGIN
             RETURN QUERY SELECT * FROM {function_name}(
@@ -53,7 +54,8 @@ pub fn format_bm25_function(
                 max_num_chars => max_num_chars,
                 order_by_field => order_by_field,
                 order_by_direction => order_by_direction,
-                lenient_parsing => lenient_parsing
+                lenient_parsing => lenient_parsing,
+                conjunction_by_default => conjunction_by_default
             );
         END
         $func$ LANGUAGE plpgsql;
@@ -70,7 +72,8 @@ pub fn format_bm25_function(
             max_num_chars integer DEFAULT NULL,
             order_by_field text DEFAULT NULL,
             order_by_direction text DEFAULT NULL,
-            lenient_parsing boolean DEFAULT NULL
+            lenient_parsing boolean DEFAULT NULL,
+            conjunction_by_default boolean DEFAULT NULL
         ) RETURNS {return_type} AS $func$
         DECLARE
             __paradedb_search_config__ JSONB;
@@ -87,7 +90,8 @@ pub fn format_bm25_function(
                 'max_num_chars', max_num_chars,
                 'order_by_field', order_by_field,
                 'order_by_direction', order_by_direction,
-                'lenient_parsing', lenient_parsing
+                'lenient_parsing', lenient_parsing,
+                'conjunction_by_default', conjunction_by_default
             );
             {function_body};
         END

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -192,7 +192,7 @@ impl SearchIndex {
                 .collect::<Vec<_>>(),
         );
 
-        if let Some(true) = config.conjunction_by_default {
+        if let Some(true) = config.conjunction_mode {
             query_parser.set_conjunction_by_default();
         }
 

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -192,9 +192,9 @@ impl SearchIndex {
                 .collect::<Vec<_>>(),
         );
 
-if let Some(true) = config.conjunction_by_default {
-    query_parser.set_conjunction_by_default();
-}
+        if let Some(true) = config.conjunction_by_default {
+            query_parser.set_conjunction_by_default();
+        }
 
         query_parser
     }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -182,15 +182,23 @@ impl SearchIndex {
             .map(|space| space.total().get_bytes())?)
     }
 
-    pub fn query_parser(&self) -> QueryParser {
-        QueryParser::for_index(
+    pub fn query_parser(&self, config: &SearchConfig) -> QueryParser {
+        let mut query_parser = QueryParser::for_index(
             &self.underlying_index,
             self.schema
                 .fields
                 .iter()
                 .map(|search_field| search_field.id.0)
                 .collect::<Vec<_>>(),
-        )
+        );
+
+        if let Some(conjunction) = config.conjunction_by_default {
+            if conjunction {
+                query_parser.set_conjunction_by_default();
+            }
+        }
+
+        query_parser
     }
 
     pub fn search_state<W: WriterClient<WriterRequest>>(

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -192,11 +192,9 @@ impl SearchIndex {
                 .collect::<Vec<_>>(),
         );
 
-        if let Some(conjunction) = config.conjunction_by_default {
-            if conjunction {
-                query_parser.set_conjunction_by_default();
-            }
-        }
+if let Some(true) = config.conjunction_by_default {
+    query_parser.set_conjunction_by_default();
+}
 
         query_parser
     }

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -75,7 +75,7 @@ pub struct SearchState {
 impl SearchState {
     pub fn new(search_index: &SearchIndex, config: &SearchConfig) -> Self {
         let schema = search_index.schema.clone();
-        let mut parser = search_index.query_parser();
+        let mut parser = search_index.query_parser(config);
         let searcher = search_index.searcher();
         let query = config
             .query

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -462,8 +462,7 @@ impl SearchQueryInput {
                 }
                 Ok(Box::new(query))
             }
-            Self::Parse { query_string } => {
-	match config.lenient_parsing {
+            Self::Parse { query_string } => match config.lenient_parsing {
                 Some(true) => {
                     let (parsed_query, _) = parser.parse_query_lenient(&query_string);
                     Ok(Box::new(parsed_query))
@@ -474,7 +473,6 @@ impl SearchQueryInput {
                     )?))
                 }
             },
-            }
             Self::Phrase {
                 field,
                 phrases,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -463,14 +463,17 @@ impl SearchQueryInput {
                 Ok(Box::new(query))
             }
             Self::Parse { query_string } => {
-                if config.lenient_parsing.unwrap_or(false) {
+	match config.lenient_parsing {
+                Some(true) => {
                     let (parsed_query, _) = parser.parse_query_lenient(&query_string);
                     Ok(Box::new(parsed_query))
-                } else {
+                }
+                _ => {
                     Ok(Box::new(parser.parse_query(&query_string).map_err(
-                        |err| QueryError::ParseError(err, query_string.clone()),
+                        |err| QueryError::ParseError(err, query_string),
                     )?))
                 }
+            },
             }
             Self::Phrase {
                 field,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -463,9 +463,14 @@ impl SearchQueryInput {
                 Ok(Box::new(query))
             }
             Self::Parse { query_string } => {
-                Ok(Box::new(parser.parse_query(&query_string).map_err(
-                    |err| QueryError::ParseError(err, query_string),
-                )?))
+                if config.lenient_parsing.unwrap_or(false) {
+                    let (parsed_query, _) = parser.parse_query_lenient(&query_string);
+                    Ok(Box::new(parsed_query))
+                } else {
+                    Ok(Box::new(parser.parse_query(&query_string).map_err(
+                        |err| QueryError::ParseError(err, query_string.clone()),
+                    )?))
+                }
             }
             Self::Phrase {
                 field,

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -39,7 +39,7 @@ pub struct SearchConfig {
     pub order_by_field: Option<String>,
     pub order_by_direction: Option<String>,
     pub lenient_parsing: Option<bool>,
-    pub conjunction_by_default: Option<bool>,
+    pub conjunction_mode: Option<bool>,
 }
 
 impl SearchConfig {

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -38,6 +38,8 @@ pub struct SearchConfig {
     pub uuid: String,
     pub order_by_field: Option<String>,
     pub order_by_direction: Option<String>,
+    pub lenient_parsing: Option<bool>,
+    pub conjunction_by_default: Option<bool>,
 }
 
 impl SearchConfig {

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -163,6 +163,8 @@ impl From<(SearchQueryInput, IndexRelation)> for SearchConfig {
             uuid: ops.get_uuid().unwrap(),
             order_by_field: None,
             order_by_direction: None,
+            conjunction_mode: None,
+            lenient_parsing: None,
         }
     }
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -37,7 +37,6 @@ fn boolean_tree(mut conn: PgConnection) {
 			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => true)
             ]
         ),
-        lenient_parsing => false,
         stable_sort => true
     );
     "#
@@ -1032,12 +1031,7 @@ fn lenient_config_search(mut conn: PgConnection) {
     // Test lenient configuration: lenient flag enabled, should allow for minor errors like typos
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.fuzzy_term(
-            field => 'description',
-            value => 'wolo',
-            transposition_cost_one => false,
-            distance => 1
-        ),
+        query => paradedb.fuzzy_term(field => 'category', value => 'elector'),
         lenient_parsing => true,
         stable_sort => true
     )"#

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1025,6 +1025,7 @@ fn fuzzy_phrase(mut conn: PgConnection) {
     assert_eq!(columns.id.len(), 0);
 }
 
+#[rstest]
 fn lenient_config_search(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1056,7 +1056,7 @@ fn conjunction_config_search(mut conn: PgConnection) {
     let mut columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
         'description:keyboard rating:>2',
-        conjunction_by_default => true,
+        conjunction_mode => true,
         stable_sort => true
     );
     "#

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1031,24 +1031,16 @@ fn lenient_config_search(mut conn: PgConnection) {
     // Test lenient configuration: lenient flag enabled, should allow for minor errors like typos
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.term(field => 'description', value => 'laptap'),
+        query => paradedb.fuzzy_term(
+            field => 'description',
+            value => 'wolo',
+            transposition_cost_one => false,
+            distance => 1
+        ),
         lenient_parsing => true,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
-    assert_eq!(
-        columns.id,
-        vec![12, 15, 18],
-        "lenient search should tolerate minor typo"
-    );
 
-    // Test strict configuration for comparison: lenient flag disabled, should not allow typos
-    let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM bm25_search.search(
-        query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient_parsing => false,
-        stable_sort => true
-    )"#
-    .fetch_collect(&mut conn);
-    assert!(columns.is_empty(), "strict search should not tolerate typo");
+    assert_eq!(columns.len(), 4);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1032,7 +1032,7 @@ fn lenient_config_search(mut conn: PgConnection) {
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
         query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient => true,
+        lenient_parsing => true,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
@@ -1046,7 +1046,7 @@ fn lenient_config_search(mut conn: PgConnection) {
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
         query => paradedb.term(field => 'description', value => 'laptap'),
-        lenient => false,
+        lenient_parsing => false,
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1029,13 +1029,47 @@ fn lenient_config_search(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     // Test lenient configuration: lenient flag enabled, should allow for minor errors like typos
+    let result = r#"
+    SELECT * FROM bm25_search.search(
+        query => paradedb.parse('descriptioNN:teddy'),
+    );
+    "#
+    .execute_result(&mut conn);
+
+    assert!(result.is_err());
+
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.fuzzy_term(field => 'category', value => 'elector'),
-        lenient_parsing => true,
-        stable_sort => true
-    )"#
+        query => paradedb.parse('descriptioNN:teddy'),
+        lenient_parsing => true
+    );
+    "#
     .fetch_collect(&mut conn);
 
-    assert_eq!(columns.len(), 4);
+    assert!(columns.is_empty());
+}
+
+#[rstest]
+fn conjunction_config_search(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let mut columns: SimpleProductsTableVec = r#"
+    SELECT * FROM bm25_search.search(
+        'description:keyboard rating:>2',
+        conjunction_by_default => true,
+        stable_sort => true
+    );
+    "#
+    .fetch_collect(&mut conn);
+
+    assert_eq!(columns.len(), 2);
+
+    columns = r#"
+    SELECT * FROM bm25_search.search(
+        'description:keyboard rating:>2'
+    );
+    "#
+    .fetch_collect(&mut conn);
+
+    assert!(columns.len() > 2);
 }

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -37,6 +37,7 @@ fn boolean_tree(mut conn: PgConnection) {
 			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => true)
             ]
         ),
+        lenient_parsing => false,
         stable_sort => true
     );
     "#


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1112 

## What

## Why

## How
introduce `lenient_parsing: Option<bool>` and `conjunction_mode: Option<bool>` in `SearchConfig`
## Tests
see `lenient_config_search` and `conjunction_config_search` in `tests/query.rs`
