### PR TITLE
feat: make `stemmer` a filter

### DIFF
--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -56,6 +56,7 @@ pub fn tokenizer(
     prefix_only: default!(Option<bool>, "NULL"),
     language: default!(Option<String>, "NULL"),
     pattern: default!(Option<String>, "NULL"),
+    stemmer: default!(Option<String>, "NULL"),
 ) -> JsonB {
     let mut config = Map::new();
 
@@ -64,6 +65,7 @@ pub fn tokenizer(
     // Options for all types
     remove_long.map(|v| config.insert("remove_long".to_string(), Value::Number(v.into())));
     lowercase.map(|v| config.insert("lowercase".to_string(), Value::Bool(v)));
+    stemmer.map(|v| config.insert("stemmer".to_string(), Value::String(v)));
     // Options for type = ngram
     min_gram.map(|v| config.insert("min_gram".to_string(), Value::Number(v.into())));
     max_gram.map(|v| config.insert("max_gram".to_string(), Value::Number(v.into())));
@@ -91,7 +93,8 @@ mod tests {
                 "record": "position",
                 "expand_dots": true,
                 "tokenizer": {"type": "ngram", "min_gram": 4, "max_gram": 4, "prefix_only": false},
-                "normalizer": "lowercase"
+                "normalizer": "lowercase",
+                "stemmer": "English"
             }
         });
 
@@ -112,6 +115,7 @@ mod tests {
                 Some(false),
                 None,
                 None,
+                Some("English".to_string()),
             )),
             Some("lowercase".to_string()),
         );

--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -92,9 +92,8 @@ mod tests {
                 "fieldnorms": false,
                 "record": "position",
                 "expand_dots": true,
-                "tokenizer": {"type": "ngram", "min_gram": 4, "max_gram": 4, "prefix_only": false},
-                "normalizer": "lowercase",
-                "stemmer": "English"
+                "tokenizer": {"type": "ngram", "min_gram": 4, "max_gram": 4, "prefix_only": false, "stemmer": "English"},
+                "normalizer": "lowercase"
             }
         });
 

--- a/pg_search/tests/search_config.rs
+++ b/pg_search/tests/search_config.rs
@@ -515,7 +515,7 @@ fn regex_tokenizer_config(mut conn: PgConnection) {
 fn language_stem_tokenizer_deprecated(mut conn: PgConnection) {
     for (language, data, author_query, title_query, message_query) in LANGUAGES {
         // Prepare test data setup for each language
-        let language_str = language_to_str(&language);
+        let language_str = language_to_str(language);
         let setup_query = format!(
             r#"
             DROP TABLE IF EXISTS test_table;
@@ -574,7 +574,7 @@ fn language_stem_tokenizer_deprecated(mut conn: PgConnection) {
 fn language_stem_filter(mut conn: PgConnection) {
     for (language, data, author_query, title_query, message_query) in LANGUAGES {
         // Prepare test data setup for each language
-        let language_str = language_to_str(&language);
+        let language_str = language_to_str(language);
         let setup_query = format!(
             r#"
             DROP TABLE IF EXISTS test_table;

--- a/pg_search/tests/search_config.rs
+++ b/pg_search/tests/search_config.rs
@@ -25,6 +25,172 @@ use sqlx::PgConnection;
 use tantivy::tokenizer::Language;
 use tokenizers::manager::language_to_str;
 
+// Define languages and corresponding test data
+static LANGUAGES: &[(Language, &str, &str, &str, &str)] = &[
+    (
+        Language::Arabic,
+        "('محمد','رحلة إلى السوق مع أبي', 'مرحباً بك في المقالة الأولى. أتمنى أن تجد المحتوى مفيدًا ومثيرًا للاهتمام'),
+        ('فاطمة', 'رحلة إلى الشرق', 'في هذا المقال، سنستكشف رحلة مثيرة إلى الشرق ونتعرف على ثقافات مختلفة وتاريخها الغني'),
+        ('أحمد', 'نصائح للنجاح', 'هنا نقدم لك بعض النصائح القيمة لتحقيق النجاح في حياتك المهنية والشخصية. استفد منها وحقق أهدافك')",
+        "محمد",
+        "شرق",
+        "هنا",
+    ),
+    (
+        Language::Danish,
+        "('Mette Hansen', 'Ny Bogudgivelse', 'Spændende ny bog udgivet af anerkendt forfatter.'),
+        ('Lars Jensen', 'Teknologikonference Højdepunkter', 'Højdepunkter fra den seneste teknologikonference.'),
+        ('Anna Nielsen', 'Lokal Kulturfestival', 'Der afholdes en lokal kulturfestival i weekenden med forventede madboder og forestillinger.')",
+        "met",
+        "højdepunk",
+        "weekend",
+    ),
+    (
+        Language::Dutch,
+        " ('Pieter de Vries', 'Nieuw Boek Uitgebracht', 'Spannend nieuw boek uitgebracht door een bekende auteur.'),
+        ('Annelies Bakker', 'Technologie Conferentie Hoogtepunten', 'Hoogtepunten van de laatste technologie conferentie.'),
+        ('Jan Jansen', 'Lokale Culturele Festival', 'Dit weekend wordt er een lokaal cultureel festival gehouden met verwachte eetkraampjes en optredens.')",
+        "vries",
+        "hoogtepunt",
+        "lokal",
+    ),
+    (
+        Language::English,
+        "('John Doe', 'New Book Release', 'Exciting new book released by renowned author.'),
+        ('Jane Smith', 'Tech Conference Highlights', 'Highlights from the latest tech conference.'),
+        ('Michael Brown', 'Local Charity Event', 'Upcoming charity event featuring local artists and performers.')",
+        "john",
+        "confer",
+        "perform",
+    ),
+    (
+        Language::Finnish,
+        "('Matti Virtanen', 'Uusi Kirjan Julkaisu', 'Jännittävä uusi kirja julkaistu tunnetulta kirjailijalta.'),
+        ('Anna Lehtonen', 'Teknologiakonferenssin Keskustelut', 'Viimeisimmän teknologiakonferenssin keskustelut ja huomiot.'),
+        ('Juha Mäkinen', 'Paikallinen Kulttuuritapahtuma', 'Viikonloppuna järjestetään paikallinen kulttuuritapahtuma, jossa on odotettavissa erilaisia ruokakojuja ja esityksiä.')",
+        "mat",
+        "keskustelu",
+        "järjest",
+    ),
+    (
+        Language::French,
+        "('Jean Dupont', 'Nouvelle Publication', 'Nouveau livre passionnant publié par un auteur renommé.'),
+            ('Marie Leclerc', 'Points Forts de la Conférence Technologique', 'Points forts de la dernière conférence technologique.'),
+            ('Pierre Martin', 'Festival Culturel Local', 'Ce week-end se tiendra un festival culturel local avec des stands de nourriture et des spectacles prévus.')",
+        "dupont",
+        "technolog",
+        "tiendr",
+    ),
+    (
+        Language::German,
+        "('Hans Müller', 'Neue Buchveröffentlichung', 'Spannendes neues Buch veröffentlicht von einem bekannten Autor.'),
+            ('Anna Schmidt', 'Highlights der Technologiekonferenz', 'Höhepunkte der letzten Technologiekonferenz.'),
+            ('Michael Wagner', 'Lokales Kulturfestival', 'Am Wochenende findet ein lokales Kulturfestival statt, mit erwarteten Essensständen und Auftritten.')",
+        "mull",
+        "technologiekonferenz",
+        "essensstand",
+    ),
+    (
+        Language::Greek,
+        "('Γιάννης Παπαδόπουλος', 'Νέα Έκδοση Βιβλίου', 'Συναρπαστικό νέο βιβλίο κυκλοφόρησε από γνωστό συγγραφέα.'),
+            ('Αννα Στεφανίδου', 'Κορυφαίες Στιγμές της Τεχνολογικής Διάσκεψης', 'Κορυφαίες στιγμές από την τελευταία τεχνολογική διάσκεψη.'),
+            ('Μιχάλης Παπαδόπουλος', 'Τοπικό Πολιτιστικό Φεστιβάλ', 'Το Σαββατοκύριακο θα πραγματοποιηθεί τοπικό πολιτιστικό φεστιβάλ με αναμενόμενα περίπτερα φαγητού και εμφανίσεις.')",
+        "Παπαδόπουλος",
+        "διασκεψ",
+        "σαββατοκυριακ",
+    ),
+    (
+        Language::Hungarian,
+        "('János Kovács', 'Új Könyv Megjelenése', 'Izgalmas új könyv jelent meg egy ismert szerzőtől.'),
+            ('Anna Nagy', 'Technológiai Konferencia Kiemelkedői', 'A legutóbbi technológiai konferencia kiemelkedő pillanatai.'),
+            ('Gábor Tóth', 'Helyi Kulturális Fesztivál', 'Hétvégén helyi kulturális fesztivált rendeznek, várhatóan ételstandokkal és előadásokkal.')",
+        "jános",
+        "kiemelkedő",
+        "várható",
+    ),
+    (
+        Language::Italian,
+        "('Giuseppe Rossi', 'Nuova Pubblicazione Libro', 'Nuovo libro emozionante pubblicato da un autore famoso.'),
+            ('Maria Bianchi', 'Highlights della Conferenza Tecnologica', 'I momenti salienti della recente conferenza tecnologica.'),
+            ('Luca Verdi', 'Festival Culturale Locale', 'Questo fine settimana si terrà un festival culturale locale, con previsti stand gastronomici e spettacoli.')",
+        "ross",
+        "conferent",
+        "gastronom",
+    ),
+    (
+        Language::Norwegian,
+        "('Ole Hansen', 'Ny Bokutgivelse', 'Spennende ny bok utgitt av en kjent forfatter.'),
+            ('Kari Olsen', 'Høydepunkter fra Teknologikonferansen', 'Høydepunkter fra den siste teknologikonferansen.'),
+            ('Per Johansen', 'Lokal Kulturfestival', 'Denne helgen arrangeres det en lokal kulturfestival med forventede matboder og forestillinger.')",
+        "ole",
+        "høydepunkt",
+        "forestilling",
+    ),
+    (
+        Language::Portuguese,
+        "('João Silva', 'Novo Lançamento de Livro', 'Novo livro emocionante lançado por um autor famoso.'),
+            ('Maria Santos', 'Destaques da Conferência de Tecnologia', 'Os destaques da última conferência de tecnologia.'),
+            ('Pedro Oliveira', 'Festival Cultural Local', 'Neste fim de semana será realizado um festival cultural local, com barracas de comida e apresentações esperadas.')",
+        "joã",
+        "conferent",
+        "será",
+    ),
+    (
+        Language::Romanian,
+        "('Ion Popescu', 'Nouă Publicație de Carte', 'O carte nouă și captivantă publicată de un autor renumit.'),
+            ('Ana Ionescu', 'Momentele Cheie ale Conferinței Tehnologice', 'Cele mai importante momente ale ultimei conferințe tehnologice.'),
+            ('Mihai Radu', 'Festival Cultural Local', 'În acest weekend va avea loc un festival cultural local, cu standuri de mâncare și spectacole programate.')",
+        "popescu",
+        "moment",
+        "mânc",
+    ),
+    (
+        Language::Russian,
+        "('Иван Иванов', 'Новое издание книги', 'Увлекательная новая книга, выпущенная известным автором.'),
+            ('Мария Петрова', 'Основные моменты технологической конференции', 'Основные моменты последней технологической конференции.'),
+            ('Алексей Сидоров', 'Местный культурный фестиваль', 'В этот уикенд состоится местный культурный фестиваль с предполагаемыми палатками с едой и выступлениями.')",
+        "иван",
+        "технологическ",
+        "культурн",
+    ),
+    (
+        Language::Spanish,
+        "('Juan Pérez', 'Nuevo Lanzamiento de Libro', 'Nuevo libro emocionante publicado por un autor famoso.'),
+            ('María García', 'Aspectos Destacados de la Conferencia Tecnológica', 'Los momentos más destacados de la última conferencia tecnológica.'),
+            ('Carlos Martínez', 'Festival Cultural Local', 'Este fin de semana se llevará a cabo un festival cultural local, con puestos de comida y actuaciones programadas.')",
+        "pérez",
+        "destac",
+        "com",
+    ),
+    (
+        Language::Swedish,
+        "('Anna Andersson', 'Ny Bokutgivning', 'Spännande ny bok utgiven av en känd författare.'),
+            ('Johan Eriksson', 'Höjdpunkter från Teknologikonferensen', 'Höjdpunkter från den senaste teknologikonferensen.'),
+            ('Emma Nilsson', 'Lokalt Kulturfestival', 'Den här helgen hålls en lokal kulturfestival med förväntade matstånd och föreställningar.')",
+        "ann",
+        "höjdpunk",
+        "föreställning",
+    ),
+    (
+        Language::Tamil,
+        "('சுப்ரமணியம் சுப்பிரமணியம்', 'புதிய புத்தக வெளியிடுதல்', 'ஒரு பிரபல எழுத்தாளரால் வெளியிடப்பட்ட புதிய புத்தகம்.'),
+            ('லக்ஷ்மி சுந்தரம்', 'தொழில்நுட்ப மாநாடு முக்கியப்பட்டவை', 'கடைசி தொழில்நுட்ப மாநாட்டின் முக்கிய நிகழ்வுகள்.'),
+            ('அருணா குமார்', 'உள்ளூர் கலாச்சார திருவிழா', 'இந்த வாரம் ஒரு உள்ளூர் கலாச்சார திருவிழா நடைபெறும், எங்களுக்கு உண்டாக்கப்பட்ட உணவு முன்னேற்றங்களுடன்.')",
+        "சுப்பிரமணியம",
+        "மாநாடு",
+        "திருவிழா",
+    ),
+    (
+        Language::Turkish,
+        "('Ahmet Yılmaz', 'Yeni Kitap Yayınlandı', 'Ünlü bir yazar tarafından heyecan verici yeni bir kitap yayınlandı.'),
+        ('Ayşe Kaya', 'Teknoloji Konferansının Öne Çıkanları', 'Son teknoloji konferansının öne çıkanları.'),
+        ('Mehmet Demir', 'Yerel Kültür Festivali', 'Bu hafta sonu yerel bir kültür festivali düzenlenecek, yiyecek standları ve planlanmış gösterilerle.')",
+        "yılmaz",
+        "konferansı",
+        "göster",
+    )
+];
+
 #[rstest]
 fn basic_search_query(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
@@ -346,174 +512,8 @@ fn regex_tokenizer_config(mut conn: PgConnection) {
 }
 
 #[rstest]
-fn language_stem_tokenizer_config(mut conn: PgConnection) {
-    // Define languages and corresponding test data
-    let languages = vec![
-        (
-            Language::Arabic,
-            "('محمد','رحلة إلى السوق مع أبي', 'مرحباً بك في المقالة الأولى. أتمنى أن تجد المحتوى مفيدًا ومثيرًا للاهتمام'),
-            ('فاطمة', 'رحلة إلى الشرق', 'في هذا المقال، سنستكشف رحلة مثيرة إلى الشرق ونتعرف على ثقافات مختلفة وتاريخها الغني'),
-            ('أحمد', 'نصائح للنجاح', 'هنا نقدم لك بعض النصائح القيمة لتحقيق النجاح في حياتك المهنية والشخصية. استفد منها وحقق أهدافك')",
-            "محمد",
-            "شرق",
-            "هنا",
-        ),
-        (
-            Language::Danish,
-            "('Mette Hansen', 'Ny Bogudgivelse', 'Spændende ny bog udgivet af anerkendt forfatter.'),
-            ('Lars Jensen', 'Teknologikonference Højdepunkter', 'Højdepunkter fra den seneste teknologikonference.'),
-            ('Anna Nielsen', 'Lokal Kulturfestival', 'Der afholdes en lokal kulturfestival i weekenden med forventede madboder og forestillinger.')",
-            "met",
-            "højdepunk",
-            "weekend",
-        ),
-        (
-            Language::Dutch,
-            " ('Pieter de Vries', 'Nieuw Boek Uitgebracht', 'Spannend nieuw boek uitgebracht door een bekende auteur.'),
-            ('Annelies Bakker', 'Technologie Conferentie Hoogtepunten', 'Hoogtepunten van de laatste technologie conferentie.'),
-            ('Jan Jansen', 'Lokale Culturele Festival', 'Dit weekend wordt er een lokaal cultureel festival gehouden met verwachte eetkraampjes en optredens.')",
-            "vries",
-            "hoogtepunt",
-            "lokal",
-        ),
-        (
-            Language::English,
-            "('John Doe', 'New Book Release', 'Exciting new book released by renowned author.'),
-            ('Jane Smith', 'Tech Conference Highlights', 'Highlights from the latest tech conference.'),
-            ('Michael Brown', 'Local Charity Event', 'Upcoming charity event featuring local artists and performers.')",
-            "john",
-            "confer",
-            "perform",
-        ),
-        (
-            Language::Finnish,
-            "('Matti Virtanen', 'Uusi Kirjan Julkaisu', 'Jännittävä uusi kirja julkaistu tunnetulta kirjailijalta.'),
-            ('Anna Lehtonen', 'Teknologiakonferenssin Keskustelut', 'Viimeisimmän teknologiakonferenssin keskustelut ja huomiot.'),
-            ('Juha Mäkinen', 'Paikallinen Kulttuuritapahtuma', 'Viikonloppuna järjestetään paikallinen kulttuuritapahtuma, jossa on odotettavissa erilaisia ruokakojuja ja esityksiä.')",
-            "mat",
-            "keskustelu",
-            "järjest",
-        ),
-        (
-            Language::French,
-            "('Jean Dupont', 'Nouvelle Publication', 'Nouveau livre passionnant publié par un auteur renommé.'),
-             ('Marie Leclerc', 'Points Forts de la Conférence Technologique', 'Points forts de la dernière conférence technologique.'),
-             ('Pierre Martin', 'Festival Culturel Local', 'Ce week-end se tiendra un festival culturel local avec des stands de nourriture et des spectacles prévus.')",
-            "dupont",
-            "technolog",
-            "tiendr",
-        ),
-        (
-            Language::German,
-            "('Hans Müller', 'Neue Buchveröffentlichung', 'Spannendes neues Buch veröffentlicht von einem bekannten Autor.'),
-             ('Anna Schmidt', 'Highlights der Technologiekonferenz', 'Höhepunkte der letzten Technologiekonferenz.'),
-             ('Michael Wagner', 'Lokales Kulturfestival', 'Am Wochenende findet ein lokales Kulturfestival statt, mit erwarteten Essensständen und Auftritten.')",
-            "mull",
-            "technologiekonferenz",
-            "essensstand",
-        ),
-        (
-            Language::Greek,
-            "('Γιάννης Παπαδόπουλος', 'Νέα Έκδοση Βιβλίου', 'Συναρπαστικό νέο βιβλίο κυκλοφόρησε από γνωστό συγγραφέα.'),
-             ('Αννα Στεφανίδου', 'Κορυφαίες Στιγμές της Τεχνολογικής Διάσκεψης', 'Κορυφαίες στιγμές από την τελευταία τεχνολογική διάσκεψη.'),
-             ('Μιχάλης Παπαδόπουλος', 'Τοπικό Πολιτιστικό Φεστιβάλ', 'Το Σαββατοκύριακο θα πραγματοποιηθεί τοπικό πολιτιστικό φεστιβάλ με αναμενόμενα περίπτερα φαγητού και εμφανίσεις.')",
-            "Παπαδόπουλος",
-            "διασκεψ",
-            "σαββατοκυριακ",
-        ),
-        (
-            Language::Hungarian,
-            "('János Kovács', 'Új Könyv Megjelenése', 'Izgalmas új könyv jelent meg egy ismert szerzőtől.'),
-             ('Anna Nagy', 'Technológiai Konferencia Kiemelkedői', 'A legutóbbi technológiai konferencia kiemelkedő pillanatai.'),
-             ('Gábor Tóth', 'Helyi Kulturális Fesztivál', 'Hétvégén helyi kulturális fesztivált rendeznek, várhatóan ételstandokkal és előadásokkal.')",
-            "jános",
-            "kiemelkedő",
-            "várható",
-        ),
-        (
-            Language::Italian,
-            "('Giuseppe Rossi', 'Nuova Pubblicazione Libro', 'Nuovo libro emozionante pubblicato da un autore famoso.'),
-             ('Maria Bianchi', 'Highlights della Conferenza Tecnologica', 'I momenti salienti della recente conferenza tecnologica.'),
-             ('Luca Verdi', 'Festival Culturale Locale', 'Questo fine settimana si terrà un festival culturale locale, con previsti stand gastronomici e spettacoli.')",
-            "ross",
-            "conferent",
-            "gastronom",
-        ),
-        (
-            Language::Norwegian,
-            "('Ole Hansen', 'Ny Bokutgivelse', 'Spennende ny bok utgitt av en kjent forfatter.'),
-             ('Kari Olsen', 'Høydepunkter fra Teknologikonferansen', 'Høydepunkter fra den siste teknologikonferansen.'),
-             ('Per Johansen', 'Lokal Kulturfestival', 'Denne helgen arrangeres det en lokal kulturfestival med forventede matboder og forestillinger.')",
-            "ole",
-            "høydepunkt",
-            "forestilling",
-        ),
-        (
-            Language::Portuguese,
-            "('João Silva', 'Novo Lançamento de Livro', 'Novo livro emocionante lançado por um autor famoso.'),
-             ('Maria Santos', 'Destaques da Conferência de Tecnologia', 'Os destaques da última conferência de tecnologia.'),
-             ('Pedro Oliveira', 'Festival Cultural Local', 'Neste fim de semana será realizado um festival cultural local, com barracas de comida e apresentações esperadas.')",
-            "joã",
-            "conferent",
-            "será",
-        ),
-        (
-            Language::Romanian,
-            "('Ion Popescu', 'Nouă Publicație de Carte', 'O carte nouă și captivantă publicată de un autor renumit.'),
-             ('Ana Ionescu', 'Momentele Cheie ale Conferinței Tehnologice', 'Cele mai importante momente ale ultimei conferințe tehnologice.'),
-             ('Mihai Radu', 'Festival Cultural Local', 'În acest weekend va avea loc un festival cultural local, cu standuri de mâncare și spectacole programate.')",
-            "popescu",
-            "moment",
-            "mânc",
-        ),
-        (
-            Language::Russian,
-            "('Иван Иванов', 'Новое издание книги', 'Увлекательная новая книга, выпущенная известным автором.'),
-             ('Мария Петрова', 'Основные моменты технологической конференции', 'Основные моменты последней технологической конференции.'),
-             ('Алексей Сидоров', 'Местный культурный фестиваль', 'В этот уикенд состоится местный культурный фестиваль с предполагаемыми палатками с едой и выступлениями.')",
-            "иван",
-            "технологическ",
-            "культурн",
-        ),
-        (
-            Language::Spanish,
-            "('Juan Pérez', 'Nuevo Lanzamiento de Libro', 'Nuevo libro emocionante publicado por un autor famoso.'),
-             ('María García', 'Aspectos Destacados de la Conferencia Tecnológica', 'Los momentos más destacados de la última conferencia tecnológica.'),
-             ('Carlos Martínez', 'Festival Cultural Local', 'Este fin de semana se llevará a cabo un festival cultural local, con puestos de comida y actuaciones programadas.')",
-            "pérez",
-            "destac",
-            "com",
-        ),
-        (
-            Language::Swedish,
-            "('Anna Andersson', 'Ny Bokutgivning', 'Spännande ny bok utgiven av en känd författare.'),
-             ('Johan Eriksson', 'Höjdpunkter från Teknologikonferensen', 'Höjdpunkter från den senaste teknologikonferensen.'),
-             ('Emma Nilsson', 'Lokalt Kulturfestival', 'Den här helgen hålls en lokal kulturfestival med förväntade matstånd och föreställningar.')",
-            "ann",
-            "höjdpunk",
-            "föreställning",
-        ),
-        (
-            Language::Tamil,
-            "('சுப்ரமணியம் சுப்பிரமணியம்', 'புதிய புத்தக வெளியிடுதல்', 'ஒரு பிரபல எழுத்தாளரால் வெளியிடப்பட்ட புதிய புத்தகம்.'),
-             ('லக்ஷ்மி சுந்தரம்', 'தொழில்நுட்ப மாநாடு முக்கியப்பட்டவை', 'கடைசி தொழில்நுட்ப மாநாட்டின் முக்கிய நிகழ்வுகள்.'),
-             ('அருணா குமார்', 'உள்ளூர் கலாச்சார திருவிழா', 'இந்த வாரம் ஒரு உள்ளூர் கலாச்சார திருவிழா நடைபெறும், எங்களுக்கு உண்டாக்கப்பட்ட உணவு முன்னேற்றங்களுடன்.')",
-            "சுப்பிரமணியம",
-            "மாநாடு",
-            "திருவிழா",
-        ),
-        (
-            Language::Turkish,
-            "('Ahmet Yılmaz', 'Yeni Kitap Yayınlandı', 'Ünlü bir yazar tarafından heyecan verici yeni bir kitap yayınlandı.'),
-            ('Ayşe Kaya', 'Teknoloji Konferansının Öne Çıkanları', 'Son teknoloji konferansının öne çıkanları.'),
-            ('Mehmet Demir', 'Yerel Kültür Festivali', 'Bu hafta sonu yerel bir kültür festivali düzenlenecek, yiyecek standları ve planlanmış gösterilerle.')",
-            "yılmaz",
-            "konferansı",
-            "göster",
-        )
-    ];
-
-    for (language, data, author_query, title_query, message_query) in languages {
+fn language_stem_tokenizer_deprecated(mut conn: PgConnection) {
+    for (language, data, author_query, title_query, message_query) in LANGUAGES {
         // Prepare test data setup for each language
         let language_str = language_to_str(&language);
         let setup_query = format!(
@@ -534,6 +534,65 @@ fn language_stem_tokenizer_config(mut conn: PgConnection) {
                 text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position') ||
                                paradedb.field('title', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position') ||
                                paradedb.field('message', tokenizer => paradedb.tokenizer('stem', language => '{}'), record => 'position')
+            );"#,
+            data, language_str, language_str, language_str
+        );
+
+        setup_query.execute(&mut conn);
+
+        let author_search_query = format!(
+            "SELECT id FROM stem_test.search('author:{}', stable_sort => true)",
+            author_query
+        );
+        let title_search_query = format!(
+            "SELECT id FROM stem_test.search('title:{}', stable_sort => true)",
+            title_query
+        );
+        let message_search_query = format!(
+            "SELECT id FROM stem_test.search('message:{}', stable_sort => true)",
+            message_query
+        );
+
+        let row: (i32,) = author_search_query.fetch_one(&mut conn);
+        assert_eq!(row.0, 1);
+
+        let row: (i32,) = title_search_query.fetch_one(&mut conn);
+        assert_eq!(row.0, 2);
+
+        let row: (i32,) = message_search_query.fetch_one(&mut conn);
+        assert_eq!(row.0, 3);
+
+        r#"
+        CALL paradedb.drop_bm25('stem_test');
+        DROP TABLE IF EXISTS test_table;
+        "#
+        .execute(&mut conn);
+    }
+}
+
+#[rstest]
+fn language_stem_filter(mut conn: PgConnection) {
+    for (language, data, author_query, title_query, message_query) in LANGUAGES {
+        // Prepare test data setup for each language
+        let language_str = language_to_str(&language);
+        let setup_query = format!(
+            r#"
+            DROP TABLE IF EXISTS test_table;
+            CREATE TABLE IF NOT EXISTS test_table(
+                id SERIAL PRIMARY KEY,
+                author TEXT,
+                title TEXT,
+                message TEXT
+            );
+            INSERT INTO test_table (author, title, message)
+            VALUES {};
+            CALL paradedb.create_bm25(
+                index_name => 'stem_test',
+                table_name => 'test_table',
+                key_field => 'id',
+                text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('default', stemmer => '{}'), record => 'position') ||
+                               paradedb.field('title', tokenizer => paradedb.tokenizer('default', stemmer => '{}'), record => 'position') ||
+                               paradedb.field('message', tokenizer => paradedb.tokenizer('default', stemmer => '{}'), record => 'position')
             );"#,
             data, language_str, language_str, language_str
         );

--- a/pg_search/tests/tokenize.rs
+++ b/pg_search/tests/tokenize.rs
@@ -43,7 +43,7 @@ fn defult_tokenizer(mut conn: PgConnection) {
 
 #[rstest]
 fn tokenizer_filters(mut conn: PgConnection) {
-    // Test en_stem tokenizer with deafult layers (lowercase => true, remove_long => 255).
+    // Test en_stem tokenizer with default layers (lowercase => true, remove_long => 255).
     let rows: Vec<(String, i32)> = r#"
     SELECT * FROM paradedb.tokenize(
       paradedb.tokenizer('en_stem'), 

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -300,7 +300,6 @@ impl SearchTokenizer {
             SearchTokenizer::Raw(filters) => Some(
                 TextAnalyzer::builder(RawTokenizer::default())
                     .filter(filters.remove_long_filter())
-                    .filter(filters.lower_caser())
                     .filter(filters.stemmer())
                     .build(),
             ),

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -38,6 +38,7 @@ use tantivy::tokenizer::{
 pub struct SearchTokenizerFilters {
     remove_long: Option<usize>,
     lowercase: Option<bool>,
+    stemmer: Option<Language>,
 }
 
 impl SearchTokenizerFilters {
@@ -60,6 +61,11 @@ impl SearchTokenizerFilters {
                 )
             })?);
         };
+        if let Some(stemmer) = value.get("stemmer") {
+            filters.stemmer = Some(serde_json::from_value(stemmer.clone()).map_err(|_| {
+                anyhow::anyhow!("stemmer tokenizer requires a valid 'stemmer' field")
+            })?);
+        }
 
         Ok(filters)
     }
@@ -96,6 +102,10 @@ impl SearchTokenizerFilters {
             write!(buffer, "{}lowercase={value}", sep(is_empty)).unwrap();
             is_empty = false;
         }
+        if let Some(value) = self.stemmer {
+            write!(buffer, "{}stemmer={value:?}", sep(is_empty)).unwrap();
+            is_empty = false;
+        }
 
         if is_empty {
             "".into()
@@ -114,6 +124,10 @@ impl SearchTokenizerFilters {
             Some(false) => None, // Only disable if explicitly requested.
             _ => Some(LowerCaser),
         }
+    }
+
+    fn stemmer(&self) -> Option<Stemmer> {
+        self.stemmer.map(Stemmer::new)
     }
 }
 
@@ -280,42 +294,36 @@ impl SearchTokenizer {
                 TextAnalyzer::builder(SimpleTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::Raw(filters) => Some(
                 TextAnalyzer::builder(RawTokenizer::default())
                     .filter(filters.remove_long_filter())
+                    .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
+            // Deprecated, use `lowercase` filter instead
             SearchTokenizer::Lowercase(filters) => Some(
                 TextAnalyzer::builder(RawTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::WhiteSpace(filters) => Some(
                 TextAnalyzer::builder(WhitespaceTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::RegexTokenizer { pattern, filters } => Some(
                 TextAnalyzer::builder(RegexTokenizer::new(pattern.as_str()).unwrap())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
-                    .build(),
-            ),
-            SearchTokenizer::ChineseCompatible(filters) => Some(
-                TextAnalyzer::builder(ChineseTokenizer)
-                    .filter(filters.remove_long_filter())
-                    .filter(filters.lower_caser())
-                    .build(),
-            ),
-            SearchTokenizer::SourceCode(filters) => Some(
-                TextAnalyzer::builder(CodeTokenizer::default())
-                    .filter(filters.remove_long_filter())
-                    .filter(filters.lower_caser())
-                    .filter(AsciiFoldingFilter)
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::Ngram {
@@ -329,7 +337,21 @@ impl SearchTokenizer {
                 )
                 .filter(filters.remove_long_filter())
                 .filter(filters.lower_caser())
+                .filter(filters.stemmer())
                 .build(),
+            ),
+            SearchTokenizer::ChineseCompatible(filters) => Some(
+                TextAnalyzer::builder(ChineseTokenizer)
+                    .filter(filters.remove_long_filter())
+                    .filter(filters.lower_caser())
+                    .build(),
+            ),
+            SearchTokenizer::SourceCode(filters) => Some(
+                TextAnalyzer::builder(CodeTokenizer::default())
+                    .filter(filters.remove_long_filter())
+                    .filter(filters.lower_caser())
+                    .filter(AsciiFoldingFilter)
+                    .build(),
             ),
             SearchTokenizer::ChineseLindera(filters) => Some(
                 TextAnalyzer::builder(LinderaChineseTokenizer::default())
@@ -349,6 +371,7 @@ impl SearchTokenizer {
                     .filter(filters.lower_caser())
                     .build(),
             ),
+            // Deprecated, use `stemmer` filter instead
             SearchTokenizer::EnStem(filters) => Some(
                 TextAnalyzer::builder(SimpleTokenizer::default())
                     .filter(filters.remove_long_filter())
@@ -356,6 +379,7 @@ impl SearchTokenizer {
                     .filter(Stemmer::new(Language::English))
                     .build(),
             ),
+            // Deprecated, use `stemmer` filter instead
             SearchTokenizer::Stem { language, filters } => Some(
                 TextAnalyzer::builder(SimpleTokenizer::default())
                     .filter(filters.remove_long_filter())

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -511,6 +511,7 @@ mod tests {
         let tokenizer = SearchTokenizer::EnStem(SearchTokenizerFilters {
             remove_long: Some(999),
             lowercase: Some(true),
+            stemmer: None,
         });
         assert_eq!(
             tokenizer.name(),
@@ -538,6 +539,7 @@ mod tests {
                 filters: SearchTokenizerFilters {
                     remove_long: Some(123),
                     lowercase: Some(false),
+                    stemmer: None
                 }
             }
         );
@@ -555,6 +557,7 @@ mod tests {
             filters: SearchTokenizerFilters {
                 remove_long: Some(100),
                 lowercase: None,
+                stemmer: None,
             },
         };
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
We expose `stem` as a tokenizer, but it's actually a token filter in Tantivy. This means that `stem` can be applied to any tokenizer and doesn't need to be a separate tokenizer. This PR introduces the `stemmer` option to `paradedb.tokenizer`. Now, like lowercasing, you can stem any tokenizer:

```sql
paradedb.tokenizer('default', stemmer => 'English');
paradedb.tokenizer('ngrams', stemmer => 'English', min_gram => 2, max_gram => 2, prefix_only => false);
```

## Why
More tokenizer configurability.

## How

## Tests
See added `language_stem_filter` test. The old `stem` tokenizer has been preserved for backward compatibility. Since I'm working on a docs PR, I'll just update the documentation there.