### PR TITLE
feat: Postgis support in ParadeDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ParadeDB is currently in Public Beta. Star and watch this repository to get noti
   - [x] Docker image based on [Postgres](https://hub.docker.com/_/postgres) ([see deployment instructions](https://docs.paradedb.com/deploy/aws))
   - [x] Kubernetes Helm chart based on [CloudNativePG](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg) ([see deployment instructions](https://docs.paradedb.com/deploy/helm))
 - [x] Specialized Workloads
-  - [ ] Support for geospatial data with [PostGIS](https://github.com/postgis/postgis)
+  - [x] Support for geospatial data with [PostGIS](https://github.com/postgis/postgis)
   - [x] Support for cron jobs with [pg_cron](https://github.com/citusdata/pg_cron)
   - [x] Support for basic incremental view maintenance (IVM) via [pg_ivm](https://github.com/sraoss/pg_ivm)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -179,15 +179,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 ENV POSTGIS_MAJOR 3
 ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg120+1
 
-RUN apt-get update
-RUN apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR \
+    && apt-get install -y --no-install-recommends \
             postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
             postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
             # ca-certificates: for accessing remote raster files;
             #   fix: https://github.com/postgis/docker-postgis/issues/307
-            ca-certificates 
-RUN rm -rf /var/lib/apt/lists/*
+            ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy third-party extensions from their builder stages
 COPY --from=builder-pgvector /tmp/pgvector/*.so /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -175,6 +175,20 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 
+# Install Postgis
+ENV POSTGIS_MAJOR 3
+ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg120+1
+
+RUN apt-get update
+RUN apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR 
+RUN apt-get install -y --no-install-recommends \
+            postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+            postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+            # ca-certificates: for accessing remote raster files;
+            #   fix: https://github.com/postgis/docker-postgis/issues/307
+            ca-certificates 
+RUN rm -rf /var/lib/apt/lists/*
+
 # Copy third-party extensions from their builder stages
 COPY --from=builder-pgvector /tmp/pgvector/*.so /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
 COPY --from=builder-pgvector /tmp/pgvector/*.control /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -175,19 +175,6 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 
-# Install Postgis
-ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg120+1
-
-RUN apt-get update \
-    && apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR \
-    && apt-get install -y --no-install-recommends \
-            postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-            postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
-            # ca-certificates: for accessing remote raster files;
-            #   fix: https://github.com/postgis/docker-postgis/issues/307
-            ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy third-party extensions from their builder stages
 COPY --from=builder-pgvector /tmp/pgvector/*.so /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
@@ -234,8 +221,16 @@ RUN apt-get update && \
     find /var/cache -type f -exec truncate --size 0 {} \; && \
     find /var/log -type f -exec truncate --size 0 {} \;
 
-# This is required for TLS connection to PostHog, which is used for telemetry.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install Postgis and ca-certificates
+# ca-certificates required for TLS connection to PostHog (which is used for telemetry) and PostGIS
+ENV POSTGIS_MAJOR 3
+ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg120+1
+
+RUN apt-get update \
+    && apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR \
+    && apt-get install -y --no-install-recommends \
+    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -27,12 +27,12 @@ for DB in template_paradedb "$POSTGRES_DB"; do
     CREATE EXTENSION IF NOT EXISTS vectorscale;
 
     CREATE EXTENSION IF NOT EXISTS postgis;
-		CREATE EXTENSION IF NOT EXISTS postgis_topology;
-		-- Reconnect to update pg_setting.resetval
-		-- See https://github.com/postgis/docker-postgis/issues/288
-		\c
-		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
-		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
+    CREATE EXTENSION IF NOT EXISTS postgis_topology;
+    -- Reconnect to update pg_setting.resetval
+    -- See https://github.com/postgis/docker-postgis/issues/288
+    \c
+    CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+    CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done
 

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -25,6 +25,14 @@ for DB in template_paradedb "$POSTGRES_DB"; do
     CREATE EXTENSION IF NOT EXISTS pg_ivm;
     CREATE EXTENSION IF NOT EXISTS vector;
     CREATE EXTENSION IF NOT EXISTS vectorscale;
+
+    CREATE EXTENSION IF NOT EXISTS postgis;
+		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
+		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
+		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL
 done
 

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -87,4 +87,4 @@ CREATE EXTENSION pg_partman;
 
 pg_partman is now ready to use!
 
-Note that this is a very simple example of installing pg_partman, there are more steps you probably want to do listed in the official [install instructions](https://github.com/pgpartman/pg_partman?tab=readme-ov-file#installation)
+Note that this is a simple example of installing `pg_partman`. The full list of settings and optional dependencies can be found in the [official installation instructions](https://github.com/pgpartman/pg_partman?tab=readme-ov-file#installation).

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -59,14 +59,15 @@ apt-get install -y --no-install-recommends postgresql-16-partman
 ### Add to `shared_preload_libraries`
 
 <Accordion title = "Modifying shared_preload_libraries">
+
 If you are installing an extension which requires this step, you can do so
-via the following command, replacing `\<extension_name\>` with your extension's name:
+via the following command, replacing `<extension_name>` with your extension's name:
 
 ```bash
 sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,<extension_name>'/" /var/lib/postgresql/data/postgresql.conf
 ```
 
-So in case of pg_partman the command will be:
+So in case of `pg_partman` the command will be:
 
 ```bash
 sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,pg_partman_bgw'/" /var/lib/postgresql/data/postgresql.conf

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -42,7 +42,7 @@ docker exec -it --user root paradedb bash
   This command assumes that your ParadeDB container name is `paradedb`.
 </Note>
 
-Next, install the [prebuilt binaries](https://debian.pkgs.org/sid/debian-main-amd64/postgresql-16-partman_5.1.0-1_amd64.deb.html).
+Next, install the [prebuilt binaries](https://pkgs.org/search/?q=partman).
 Most popular Postgres extensions can be installed with `apt-get install`.
 
 ```bash

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -60,7 +60,7 @@ apt-get install -y --no-install-recommends postgresql-16-partman
 
 <Accordion title = "Modifying shared_preload_libraries">
 If you are installing an extension which requires this step, you can do so
-via the following command, replacing `<extension_name>` with your extension's name:
+via the following command, replacing `\<extension_name\>` with your extension's name:
 
 ```bash
 sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,<extension_name>'/" /var/lib/postgresql/data/postgresql.conf

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -67,7 +67,7 @@ via the following command, replacing `<extension_name>` with your extension's na
 sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,<extension_name>'/" /var/lib/postgresql/data/postgresql.conf
 ```
 
-So in case of `pg_partman` the command will be:
+For `pg_partman`, the command is:
 
 ```bash
 sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,pg_partman_bgw'/" /var/lib/postgresql/data/postgresql.conf

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -7,6 +7,7 @@ Postgres has a rich ecosystem of extensions. To keep the size of the ParadeDB Do
 - `pg_search` for full text search
 - `pg_analytics` for fast queries over data lakes
 - `pgvector` for vector search
+- `postgis` for geospatial search
 - `pg_ivm` for incremental materialized views
 - `pg_cron` for cron jobs
 
@@ -27,7 +28,7 @@ The process for installing an extension varies by extension. Generally speaking,
 - Run `CREATE EXTENSION <extension name>`
 
 We recommend installing third party extensions from prebuilt binaries to keep the image size small. As an
-example, let's install [PostGIS](https://github.com/postgis/postgis), an extension for geospatial data.
+example, let's install [pg_partman](https://github.com/pgpartman/pg_partman), an extension for managing table partition sets.
 
 ### Install Prebuilt Binaries
 
@@ -41,12 +42,12 @@ docker exec -it --user root paradedb bash
   This command assumes that your ParadeDB container name is `paradedb`.
 </Note>
 
-Next, install the [prebuilt binaries](https://postgis.net/documentation/getting_started/install_ubuntu/).
+Next, install the [prebuilt binaries](https://debian.pkgs.org/sid/debian-main-amd64/postgresql-16-partman_5.1.0-1_amd64.deb.html).
 Most popular Postgres extensions can be installed with `apt-get install`.
 
 ```bash
 apt-get update
-apt-get install -y --no-install-recommends postgis postgresql-16-postgis-3
+apt-get install -y --no-install-recommends postgresql-16-partman
 ```
 
 <Note>
@@ -57,14 +58,18 @@ apt-get install -y --no-install-recommends postgis postgresql-16-postgis-3
 
 ### Add to `shared_preload_libraries`
 
-PostGIS does not need to be added to `shared_preload_libraries` in `postgresql.conf`, so we skip this step.
-
 <Accordion title = "Modifying shared_preload_libraries">
 If you are installing an extension which requires this step, you can do so
-via the following command, replacing `<extension_name>` by your extension's name:
+via the following command, replacing `<extension_name>` with your extension's name:
 
 ```bash
-sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,<extension_name>'/" /var/lib/postgresql/data/postgresql.conf`
+sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,<extension_name>'/" /var/lib/postgresql/data/postgresql.conf
+```
+
+So in case of pg_partman the command will be:
+
+```bash
+sed -i "/^shared_preload_libraries/s/'\([^']*\)'/'\1,pg_partman_bgw'/" /var/lib/postgresql/data/postgresql.conf
 ```
 
 </Accordion>
@@ -76,7 +81,9 @@ Postgres must be restarted afterwards. We recommend simply restarting the Docker
 Connect to ParadeDB via `psql` and create the extension.
 
 ```sql
-CREATE EXTENSION postgis;
+CREATE EXTENSION pg_partman;
 ```
 
-PostGIS is now ready to use!
+pg_partman is now ready to use!
+
+Note that this is a very simple example of installing pg_partman, there are more steps you probably want to do listed in the official [install instructions](https://github.com/pgpartman/pg_partman?tab=readme-ov-file#installation)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes https://github.com/paradedb/paradedb/issues/1461

## What
Enable ParadeDB users to use PostGIS

## Why
See issue

## How
I opted to use apt-get to install Postgis straight in the final docker image rather than build it in a builder image and copy the files like with other extensions. Main reason for this is that Postgis depends on a bunch of other packages which we would have to install manually if we wanted to compile it ourselves, see: https://packages.ubuntu.com/noble/postgresql-16-postgis-3

Added the SQL from https://github.com/postgis/docker-postgis/blob/master/initdb-postgis.sh to our `bootstrap.sh` to enable the extensions.

## Tests
I ran the SQL from https://github.com/postgis/docker-postgis/blob/master/test/tests/postgis-basics/run.sh on the container to test basic functionality. 