### PR TITLE
feat: only allow one USING bm25 index per relation

### DIFF
--- a/pg_search/tests/one_index.rs
+++ b/pg_search/tests/one_index.rs
@@ -1,0 +1,43 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn only_one_index_allowed(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(
+      schema_name => 'public',
+      table_name => 'mock_items'
+    )
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CALL paradedb.create_bm25(
+            index_name => 'index_one',
+            schema_name => 'public',
+            table_name => 'mock_items',
+            key_field => 'id',
+            text_fields => paradedb.field('description')
+    );
+    "#
+    .execute(&mut conn);
+
+    match r#"
+    CALL paradedb.create_bm25(
+            index_name => 'index_two',
+            schema_name => 'public',
+            table_name => 'mock_items',
+            key_field => 'id',
+            text_fields => paradedb.field('description')
+    );
+    "#
+    .execute_result(&mut conn)
+    {
+        Ok(_) => panic!("created a second `USING bm25` index"),
+        Err(e) if format!("{e}").contains("a relation may only have one `USING bm25` index") => (), // all good
+        Err(e) => panic!("{}", e),
+    }
+}


### PR DESCRIPTION
# Ticket(s) Closed

n/a

## What

Currently, pg_search allows for creating multiple `USING bm25` indexes per table.  This is problematic as Postgres isn't guaranteed to choose the index the user has specified with their `SELECT idxname.search()` query.  It may, in fact, choose any one of the other indexes.  When all costs are equal, it's not clear which index Postgres decides to choose, but the last one created seems to be the favorite.

## Why

Knowing this, the thought process then becomes "how do we allow multiple `USING bm25` indexes per table"?.  As things stand right now, I don't believe we can.

There's not enough context in the CREATE INDEX statement and the corresponding SELECT for postgres to choose a specific index, and even if we lie and open/query a different one (as we do now), we're past the point of being able to properly lock the index relation actually being used by pg_search.

This could very easily cause problems with concurrent transactions.  I believe that deadlocks are possible due to lock acquisition/release ordering along with not having the proper locks when a concurrent DROP INDEX or ALTER index or even VACUUM might happen.

With the latter, the problem would be that Postgres has generated a plan that it believes to be safely executable because it holds the locks it thinks are necessary, then a concurrent DROP INDEX could drop the index we're actually using out from underneath an actively executing IndexScan.  It's also not clear what concurrent INSERTs/UPDATEs would do against an index that's being actively scanned that doesn't also have the necessary locks for that scan.

(I could see a theory of "well, that's a highly unlikely situation", and while yeah, it probably is, the solution would be this PR -- to only allow one index per table.  So I'm very cautious of going down a path where we allow a "feature" that users begin to rely on that we then have to completely remove.  I feel like it's better to head that off as soon as we can.)

## How

During `ambuild()`, make sure there's not an existing `USING bm25` index, accounting for the fact a REINDEX will discover the only existing index.

## Tests

Had to split the `quickstart()` tests into two and also added a new test to ensure the proper ERROR is raised when trying to create a second index.

# Future Work To Address This

This isn't the place to design something, but I believe as we continue to investigate and implement our own CustomScan machinery, we'll be able to at least support partial indexes (`CREATE INDEX ... WHERE ...`) very easily, and we'll also be able to improve our general `CREATE INDEX ... WITH (...)` syntax such that it's much easier for users to specify different tokenization rules for the same field -- and this seems to be the primary use case for wanting multiple indexes.

The latter, which would mean a field is tokenized different ways in the same index, has many other benefits as well, especially around INSERT/UPDATE throughput.
