### PR TITLE
chore: Avoid `unwrap()` and replace it by `expect()`

### DIFF
--- a/cargo-paradedb/src/tables/mod.rs
+++ b/cargo-paradedb/src/tables/mod.rs
@@ -30,7 +30,7 @@ impl PathSource for &String {
     fn paths(&self) -> Box<dyn Iterator<Item = PathBuf>> {
         // Use a globbing library to interpret the string as a glob pattern
         // and return an iterator over the matching paths
-        let glob_pattern = glob::glob(self).expect("Failed to interpret glob pattern");
+        let glob_pattern = glob::glob(self).expect("glob pattern should be valid");
         Box::new(glob_pattern.filter_map(Result::ok))
     }
 }
@@ -39,7 +39,7 @@ impl PathSource for &str {
     fn paths(&self) -> Box<dyn Iterator<Item = PathBuf>> {
         // Use a globbing library to interpret the string as a glob pattern
         // and return an iterator over the matching paths
-        let glob_pattern = glob::glob(self).expect("Failed to interpret glob pattern");
+        let glob_pattern = glob::glob(self).expect("glob pattern should be valid");
         Box::new(glob_pattern.filter_map(Result::ok))
     }
 }

--- a/cargo-paradedb/src/tables/mod.rs
+++ b/cargo-paradedb/src/tables/mod.rs
@@ -30,7 +30,8 @@ impl PathSource for &String {
     fn paths(&self) -> Box<dyn Iterator<Item = PathBuf>> {
         // Use a globbing library to interpret the string as a glob pattern
         // and return an iterator over the matching paths
-        Box::new(glob::glob(self).unwrap().filter_map(Result::ok))
+        let glob_pattern = glob::glob(self).expect("Failed to interpret glob pattern");
+        Box::new(glob_pattern.filter_map(Result::ok))
     }
 }
 
@@ -38,7 +39,8 @@ impl PathSource for &str {
     fn paths(&self) -> Box<dyn Iterator<Item = PathBuf>> {
         // Use a globbing library to interpret the string as a glob pattern
         // and return an iterator over the matching paths
-        Box::new(glob::glob(self).unwrap().filter_map(Result::ok))
+        let glob_pattern = glob::glob(self).expect("Failed to interpret glob pattern");
+        Box::new(glob_pattern.filter_map(Result::ok))
     }
 }
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -415,13 +415,21 @@ pub fn range_numeric(field: String, range: Range<pgrx::AnyNumeric>) -> SearchQue
             field,
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(n.try_into().unwrap())),
-                RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(n.try_into().unwrap())),
+                RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(
+                    n.try_into().expect("Failed to convert numeric to f64"),
+                )),
+                RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(
+                    n.try_into().expect("Failed to convert numeric to f64"),
+                )),
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
-                RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(n.try_into().unwrap())),
-                RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(n.try_into().unwrap())),
+                RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(
+                    n.try_into().expect("Failed to convert numeric to f64"),
+                )),
+                RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(
+                    n.try_into().expect("Failed to convert numeric to f64"),
+                )),
             },
         },
     }
@@ -446,30 +454,38 @@ macro_rules! datetime_range_fn {
                     lower_bound: match lower {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
-                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                            (&TantivyValue::try_from(n)
+                                .expect("Failed to convert to tantivy value")
+                                .tantivy_schema_value())
                                 .as_datetime()
-                                .unwrap()
+                                .expect("Failed to convert to datetime")
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
-                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                            (&TantivyValue::try_from(n)
+                                .expect("Failed to convert to tantivy value")
+                                .tantivy_schema_value())
                                 .as_datetime()
-                                .unwrap()
+                                .expect("Failed to convert to datetime")
                                 .into(),
                         ),
                     },
                     upper_bound: match upper {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
-                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                            (&TantivyValue::try_from(n)
+                                .expect("Failed to convert to tantivy value")
+                                .tantivy_schema_value())
                                 .as_datetime()
-                                .unwrap()
+                                .expect("Failed to convert to datetime")
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
-                            (&TantivyValue::try_from(n).unwrap().tantivy_schema_value())
+                            (&TantivyValue::try_from(n)
+                                .expect("Failed to convert to tantivy value")
+                                .tantivy_schema_value())
                                 .as_datetime()
-                                .unwrap()
+                                .expect("Failed to convert to datetime")
                                 .into(),
                         ),
                     },
@@ -499,7 +515,7 @@ macro_rules! term_fn {
                 SearchQueryInput::Term {
                     field,
                     value: TantivyValue::try_from(value)
-                        .unwrap()
+                        .expect("Failed to convert value to tantivy value")
                         .tantivy_schema_value(),
                 }
             } else {

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -416,19 +416,19 @@ pub fn range_numeric(field: String, range: Range<pgrx::AnyNumeric>) -> SearchQue
             lower_bound: match lower {
                 RangeBound::Infinite => Bound::Unbounded,
                 RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(
-                    n.try_into().expect("Failed to convert numeric to f64"),
+                    n.try_into().expect("numeric should be a valid f64"),
                 )),
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(
-                    n.try_into().expect("Failed to convert numeric to f64"),
+                    n.try_into().expect("numeric should be a valid f64"),
                 )),
             },
             upper_bound: match upper {
                 RangeBound::Infinite => Bound::Unbounded,
                 RangeBound::Inclusive(n) => Bound::Included(OwnedValue::F64(
-                    n.try_into().expect("Failed to convert numeric to f64"),
+                    n.try_into().expect("numeric should be a valid f64"),
                 )),
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::F64(
-                    n.try_into().expect("Failed to convert numeric to f64"),
+                    n.try_into().expect("numeric should be a valid f64"),
                 )),
             },
         },
@@ -455,18 +455,18 @@ macro_rules! datetime_range_fn {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
                             (&TantivyValue::try_from(n)
-                                .expect("Failed to convert to tantivy value")
+                                .expect("n should be a valid TantivyValue representation")
                                 .tantivy_schema_value())
                                 .as_datetime()
-                                .expect("Failed to convert to datetime")
+                                .expect("OwnedValue should be a valid datetime value")
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
                             (&TantivyValue::try_from(n)
-                                .expect("Failed to convert to tantivy value")
+                                .expect("n should be a valid TantivyValue representation")
                                 .tantivy_schema_value())
                                 .as_datetime()
-                                .expect("Failed to convert to datetime")
+                                .expect("OwnedValue should be a valid datetime value")
                                 .into(),
                         ),
                     },
@@ -474,18 +474,18 @@ macro_rules! datetime_range_fn {
                         RangeBound::Infinite => Bound::Unbounded,
                         RangeBound::Inclusive(n) => Bound::Included(
                             (&TantivyValue::try_from(n)
-                                .expect("Failed to convert to tantivy value")
+                                .expect("n should be a valid TantivyValue representation")
                                 .tantivy_schema_value())
                                 .as_datetime()
-                                .expect("Failed to convert to datetime")
+                                .expect("OwnedValue should be a valid datetime value")
                                 .into(),
                         ),
                         RangeBound::Exclusive(n) => Bound::Excluded(
                             (&TantivyValue::try_from(n)
-                                .expect("Failed to convert to tantivy value")
+                                .expect("n should be a valid TantivyValue representation")
                                 .tantivy_schema_value())
                                 .as_datetime()
-                                .expect("Failed to convert to datetime")
+                                .expect("OwnedValue should be a valid datetime value")
                                 .into(),
                         ),
                     },
@@ -515,7 +515,7 @@ macro_rules! term_fn {
                 SearchQueryInput::Term {
                     field,
                     value: TantivyValue::try_from(value)
-                        .expect("Failed to convert value to tantivy value")
+                        .expect("value should be a valid TantivyValue representation")
                         .tantivy_schema_value(),
                 }
             } else {

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -24,7 +24,7 @@ pub fn format_bm25_function(
     index_json: &Value,
 ) -> String {
     let index_json_str = serde_json::to_string(&index_json)
-        .expect("Failed to convert index json to string in format_bm25_function");
+        .expect("index json should be serializable for format_bm25_function");
     let formatted_sql = format!(
         r#"
         CREATE OR REPLACE FUNCTION {function_name}(
@@ -161,7 +161,7 @@ pub fn format_hybrid_function(
         function_name = function_name,
         return_type = return_type,
         index_json = serde_json::to_string(&index_json)
-            .expect("Failed to convert index json to string in format_hybrid_function"),
+            .expect("index json should be serializable for format_hybrid_function"),
         function_body = function_body
     );
 

--- a/pg_search/src/bootstrap/format.rs
+++ b/pg_search/src/bootstrap/format.rs
@@ -23,7 +23,8 @@ pub fn format_bm25_function(
     function_body: &str,
     index_json: &Value,
 ) -> String {
-    let index_json_str = serde_json::to_string(&index_json).unwrap();
+    let index_json_str = serde_json::to_string(&index_json)
+        .expect("Failed to convert index json to string in format_bm25_function");
     let formatted_sql = format!(
         r#"
         CREATE OR REPLACE FUNCTION {function_name}(
@@ -159,7 +160,8 @@ pub fn format_hybrid_function(
         "#,
         function_name = function_name,
         return_type = return_type,
-        index_json = serde_json::to_string(&index_json).unwrap(),
+        index_json = serde_json::to_string(&index_json)
+            .expect("Failed to convert index json to string in format_hybrid_function"),
         function_body = function_body
     );
 

--- a/pg_search/src/fixtures/client.rs
+++ b/pg_search/src/fixtures/client.rs
@@ -44,9 +44,10 @@ impl TestClient {
 impl WriterClient<WriterRequest> for TestClient {
     fn request(&mut self, request: WriterRequest) -> Result<(), ClientError> {
         // Serialize the data to emulate the real transfer process.
-        let serialized_request = bincode::serialize(&request).unwrap();
-        let deserialized_request: WriterRequest =
-            bincode::deserialize(&serialized_request).unwrap();
+        let serialized_request = bincode::serialize(&request)
+            .expect("Failed to serialize request in TestClient::request");
+        let deserialized_request: WriterRequest = bincode::deserialize(&serialized_request)
+            .expect("Failed to deserialize request in TestClient::request");
         self.writer
             .handle(deserialized_request)
             .map_err(|err| ClientError::ServerError(err.to_string()))
@@ -58,9 +59,10 @@ impl WriterClient<WriterRequest> for TestClient {
         request: WriterRequest,
     ) -> Result<(), ClientError> {
         // Serialize the data to emulate the real transfer process.
-        let serialized_request = bincode::serialize(&request).unwrap();
-        let deserialized_request: WriterRequest =
-            bincode::deserialize(&serialized_request).unwrap();
+        let serialized_request = bincode::serialize(&request)
+            .expect("Failed to serialize request in TestClient::transfer");
+        let deserialized_request: WriterRequest = bincode::deserialize(&serialized_request)
+            .expect("Failed to deserialize request in TestClient::transfer");
         self.request(deserialized_request)
     }
 }

--- a/pg_search/src/fixtures/client.rs
+++ b/pg_search/src/fixtures/client.rs
@@ -45,9 +45,9 @@ impl WriterClient<WriterRequest> for TestClient {
     fn request(&mut self, request: WriterRequest) -> Result<(), ClientError> {
         // Serialize the data to emulate the real transfer process.
         let serialized_request = bincode::serialize(&request)
-            .expect("Failed to serialize request in TestClient::request");
+            .expect("request should be serializable for TestClient::request");
         let deserialized_request: WriterRequest = bincode::deserialize(&serialized_request)
-            .expect("Failed to deserialize request in TestClient::request");
+            .expect("request should be deserializable for TestClient::request");
         self.writer
             .handle(deserialized_request)
             .map_err(|err| ClientError::ServerError(err.to_string()))
@@ -59,10 +59,10 @@ impl WriterClient<WriterRequest> for TestClient {
         request: WriterRequest,
     ) -> Result<(), ClientError> {
         // Serialize the data to emulate the real transfer process.
-        let serialized_request = bincode::serialize(&request)
-            .expect("Failed to serialize request in TestClient::transfer");
+        let serialized_request =
+            bincode::serialize(&request).expect("request should be serializable for transfer");
         let deserialized_request: WriterRequest = bincode::deserialize(&serialized_request)
-            .expect("Failed to deserialize request in TestClient::transfer");
+            .expect("request should be deserializable for transfer");
         self.request(deserialized_request)
     }
 }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -456,7 +456,9 @@ impl<'de> Deserialize<'de> for SearchIndex {
             uuid,
         } = SearchIndexHelper::deserialize(deserializer)?;
 
-        let TantivyDirPath(tantivy_dir_path) = directory.tantivy_dir_path(true).unwrap();
+        let TantivyDirPath(tantivy_dir_path) = directory
+            .tantivy_dir_path(true)
+            .expect("Failed to get tantivy directory path while deserializing SearchIndex");
 
         let mut underlying_index =
             Index::open_in_dir(tantivy_dir_path).expect("failed to open index");

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -458,10 +458,10 @@ impl<'de> Deserialize<'de> for SearchIndex {
 
         let TantivyDirPath(tantivy_dir_path) = directory
             .tantivy_dir_path(true)
-            .expect("Failed to get tantivy directory path while deserializing SearchIndex");
+            .expect("tantivy directory path should be valid");
 
         let mut underlying_index =
-            Index::open_in_dir(tantivy_dir_path).expect("failed to open index");
+            Index::open_in_dir(tantivy_dir_path).expect("index should be openable");
 
         // We need to setup tokenizers again after retrieving an index from disk.
         Self::setup_tokenizers(&mut underlying_index, &schema);

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -324,7 +324,7 @@ impl FFType {
         let value = match self {
             FFType::Text(ff) => {
                 let mut s = String::new();
-                let ord = ff.term_ords(doc).next().unwrap();
+                let ord = ff.term_ords(doc).next().expect("no term ord for doc");
                 ff.ord_to_str(ord, &mut s).expect("no string for term ord");
                 TantivyValue(s.into())
             }
@@ -346,7 +346,7 @@ impl FFType {
         let value = match self {
             FFType::Text(ff) => {
                 // just use the first term ord here.  that's enough to do a tie-break quickly
-                let ord = ff.term_ords(doc).next().unwrap();
+                let ord = ff.term_ords(doc).next().expect("no term ord for doc");
                 TantivyValue(ord.into())
             }
             other => other.value(doc),

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -324,8 +324,12 @@ impl FFType {
         let value = match self {
             FFType::Text(ff) => {
                 let mut s = String::new();
-                let ord = ff.term_ords(doc).next().expect("no term ord for doc");
-                ff.ord_to_str(ord, &mut s).expect("no string for term ord");
+                let ord = ff
+                    .term_ords(doc)
+                    .next()
+                    .expect("term ord should be retrievable");
+                ff.ord_to_str(ord, &mut s)
+                    .expect("string should be retrievable for term ord");
                 TantivyValue(s.into())
             }
             FFType::I64(ff) => TantivyValue(ff.get_val(doc).into()),
@@ -346,7 +350,10 @@ impl FFType {
         let value = match self {
             FFType::Text(ff) => {
                 // just use the first term ord here.  that's enough to do a tie-break quickly
-                let ord = ff.term_ords(doc).next().expect("no term ord for doc");
+                let ord = ff
+                    .term_ords(doc)
+                    .next()
+                    .expect("term ord should be retrievable");
                 TantivyValue(ord.into())
             }
             other => other.value(doc),

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -273,8 +273,7 @@ unsafe extern "C" fn build_callback(
     _tuple_is_alive: bool,
     state: *mut std::os::raw::c_void,
 ) {
-    let htup = htup.as_ref().unwrap();
-
+    let htup = htup.as_ref().expect("HeapTuple pointer is null");
     build_callback_internal(htup.t_self, values, isnull, state, index);
 }
 
@@ -300,7 +299,9 @@ unsafe fn build_callback_internal(
     index: pg_sys::Relation,
 ) {
     check_for_interrupts!();
-    let state = (state as *mut BuildState).as_mut().unwrap();
+    let state = (state as *mut BuildState)
+        .as_mut()
+        .expect("BuildState pointer is null");
 
     // In the block below, we switch to the memory context we've defined on our build
     // state, resetting it before and after. We do this because we're looking up a

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -273,7 +273,7 @@ unsafe extern "C" fn build_callback(
     _tuple_is_alive: bool,
     state: *mut std::os::raw::c_void,
 ) {
-    let htup = htup.as_ref().expect("HeapTuple pointer is null");
+    let htup = htup.as_ref().expect("HeapTuple pointer should not be null");
     build_callback_internal(htup.t_self, values, isnull, state, index);
 }
 
@@ -301,7 +301,7 @@ unsafe fn build_callback_internal(
     check_for_interrupts!();
     let state = (state as *mut BuildState)
         .as_mut()
-        .expect("BuildState pointer is null");
+        .expect("BuildState pointer should not be null");
 
     // In the block below, we switch to the memory context we've defined on our build
     // state, resetting it before and after. We do this because we're looking up a

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -25,7 +25,8 @@ pub fn datetime_components_to_tantivy_date(
     hms_micro: (u8, u8, u8, u32),
 ) -> Result<tantivy::schema::OwnedValue, DateTimeConversionError> {
     let naive_dt = match ymd {
-        Some(ymd) => NaiveDate::from_ymd_opt(ymd.0, ymd.1.into(), ymd.2.into()).unwrap(),
+        Some(ymd) => NaiveDate::from_ymd_opt(ymd.0, ymd.1.into(), ymd.2.into())
+            .expect("failed to convert ymd to naive date"),
         None => NaiveDateTime::UNIX_EPOCH.date(),
     }
     .and_hms_micro_opt(

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -26,7 +26,7 @@ pub fn datetime_components_to_tantivy_date(
 ) -> Result<tantivy::schema::OwnedValue, DateTimeConversionError> {
     let naive_dt = match ymd {
         Some(ymd) => NaiveDate::from_ymd_opt(ymd.0, ymd.1.into(), ymd.2.into())
-            .expect("failed to convert ymd to naive date"),
+            .expect("ymd should be valid for NaiveDate::from_ymd_opt"),
         None => NaiveDateTime::UNIX_EPOCH.date(),
     }
     .and_hms_micro_opt(

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -215,8 +215,11 @@ unsafe fn build_relopts(
     }
 
     for relopt in std::slice::from_raw_parts_mut(p_options, n_options as usize) {
-        relopt.gen.as_mut().expect("relopt is null").lockmode =
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE;
+        relopt
+            .gen
+            .as_mut()
+            .expect("relopt should be non-null")
+            .lockmode = pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE;
     }
 
     let rdopts = pg_sys::allocateReloptStruct(
@@ -258,7 +261,8 @@ impl SearchIndexCreateOptions {
             .map(|(field_name, field_config)| {
                 (
                     field_name.clone().into(),
-                    parser(field_config).expect("failed to deserialize {field_name} config"),
+                    parser(field_config)
+                        .expect("field config should be valid for SearchFieldConfig::{field_name}"),
                 )
             })
             .collect()
@@ -332,7 +336,7 @@ impl SearchIndexCreateOptions {
 
             value
                 .to_str()
-                .expect("failed to parse fields as utf-8")
+                .expect("value should be valid utf-8")
                 .to_owned()
         }
     }

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -120,7 +120,7 @@ pub extern "C" fn amrescan(
     let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode.as_u32());
 
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
-        .expect("Failed to get SearchIndex from cache in amrescan");
+        .expect("index should be valid for SearchIndex::from_cache");
     let writer_client = WriterGlobal::client();
     let state = search_index
         .search_state(&writer_client, &search_config)

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -120,7 +120,7 @@ pub extern "C" fn amrescan(
     let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode.as_u32());
 
     let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
-        .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
+        .expect("Failed to get SearchIndex from cache in amrescan");
     let writer_client = WriterGlobal::client();
     let state = search_index
         .search_state(&writer_client, &search_config)

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -42,59 +42,40 @@ impl TantivyValue {
     }
 
     pub unsafe fn try_into_datum(self, oid: PgOid) -> Result<Datum, TantivyValueError> {
-        Ok(match &oid {
-            PgOid::BuiltIn(builtin) => match builtin {
-                PgBuiltInOids::BOOLOID => bool::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::INT2OID => i16::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::INT4OID => i32::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::INT8OID => i64::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::OIDOID => Oid::from(u32::try_from(self).unwrap())
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::FLOAT4OID => f32::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::FLOAT8OID => f64::try_from(self).unwrap().into_datum().unwrap(),
-                PgBuiltInOids::NUMERICOID => pgrx::AnyNumeric::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
-                    String::try_from(self).unwrap().into_datum().unwrap()
-                }
-                PgBuiltInOids::JSONOID => pgrx::datum::JsonString::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::JSONBOID => {
-                    pgrx::JsonB::try_from(self).unwrap().into_datum().unwrap()
-                }
-                PgBuiltInOids::DATEOID => pgrx::datum::Date::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::TIMESTAMPOID => pgrx::datum::Timestamp::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::TIMESTAMPTZOID => pgrx::datum::TimestampWithTimeZone::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::TIMEOID => pgrx::datum::Time::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::TIMETZOID => pgrx::datum::TimeWithTimeZone::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                PgBuiltInOids::UUIDOID => pgrx::datum::Uuid::try_from(self)
-                    .unwrap()
-                    .into_datum()
-                    .unwrap(),
-                _ => return Err(TantivyValueError::UnsupportedOid(oid.value())),
-            },
-            _ => return Err(TantivyValueError::InvalidOid),
-        })
+        match &oid {
+            PgOid::BuiltIn(builtin) => {
+                let datum = match builtin {
+                    PgBuiltInOids::BOOLOID => bool::try_from(self)?.into_datum(),
+                    PgBuiltInOids::INT2OID => i16::try_from(self)?.into_datum(),
+                    PgBuiltInOids::INT4OID => i32::try_from(self)?.into_datum(),
+                    PgBuiltInOids::INT8OID => i64::try_from(self)?.into_datum(),
+                    PgBuiltInOids::OIDOID => Oid::from(u32::try_from(self)?).into_datum(),
+                    PgBuiltInOids::FLOAT4OID => f32::try_from(self)?.into_datum(),
+                    PgBuiltInOids::FLOAT8OID => f64::try_from(self)?.into_datum(),
+                    PgBuiltInOids::NUMERICOID => pgrx::AnyNumeric::try_from(self)?.into_datum(),
+                    PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
+                        String::try_from(self)?.into_datum()
+                    }
+                    PgBuiltInOids::JSONOID => pgrx::datum::JsonString::try_from(self)?.into_datum(),
+                    PgBuiltInOids::JSONBOID => pgrx::JsonB::try_from(self)?.into_datum(),
+                    PgBuiltInOids::DATEOID => pgrx::datum::Date::try_from(self)?.into_datum(),
+                    PgBuiltInOids::TIMESTAMPOID => {
+                        pgrx::datum::Timestamp::try_from(self)?.into_datum()
+                    }
+                    PgBuiltInOids::TIMESTAMPTZOID => {
+                        pgrx::datum::TimestampWithTimeZone::try_from(self)?.into_datum()
+                    }
+                    PgBuiltInOids::TIMEOID => pgrx::datum::Time::try_from(self)?.into_datum(),
+                    PgBuiltInOids::TIMETZOID => {
+                        pgrx::datum::TimeWithTimeZone::try_from(self)?.into_datum()
+                    }
+                    PgBuiltInOids::UUIDOID => pgrx::datum::Uuid::try_from(self)?.into_datum(),
+                    _ => return Err(TantivyValueError::UnsupportedOid(oid.value())),
+                };
+                datum.ok_or_else(|| TantivyValueError::DatumConversionError)
+            }
+            _ => Err(TantivyValueError::InvalidOid),
+        }
     }
 
     fn json_value_to_tantivy_value(value: Value) -> Vec<TantivyValue> {
@@ -257,7 +238,11 @@ impl fmt::Display for TantivyValue {
                 write!(f, "{}", datetime.into_primitive())
             }
             tantivy::schema::OwnedValue::Bytes(bytes) => {
-                write!(f, "{}", String::from_utf8(bytes.clone()).unwrap())
+                write!(
+                    f,
+                    "{}",
+                    String::from_utf8(bytes.clone()).expect("Failed to convert bytes to string")
+                )
             }
             tantivy::schema::OwnedValue::Object(_) => write!(f, "json object"),
             _ => panic!("tantivy owned value not supported"),
@@ -1025,4 +1010,7 @@ pub enum TantivyValueError {
 
     #[error("Cannot convert TantivyValue to type {0}")]
     UnsupportedIntoConversion(String),
+
+    #[error("Failed to convert tantivy value to datum")]
+    DatumConversionError,
 }

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -241,7 +241,7 @@ impl fmt::Display for TantivyValue {
                 write!(
                     f,
                     "{}",
-                    String::from_utf8(bytes.clone()).expect("Failed to convert bytes to string")
+                    String::from_utf8(bytes.clone()).expect("bytes should be valid utf-8")
                 )
             }
             tantivy::schema::OwnedValue::Object(_) => write!(f, "json object"),

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -373,7 +373,8 @@ impl SearchFieldConfig {
 
 impl SearchFieldConfig {
     pub fn from_json(value: serde_json::Value) -> Self {
-        serde_json::from_value(value).expect("Failed to deserialize search field config")
+        serde_json::from_value(value)
+            .expect("value should be a valid SearchFieldConfig representation")
     }
 
     pub fn default_text() -> Self {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -373,7 +373,7 @@ impl SearchFieldConfig {
 
 impl SearchFieldConfig {
     pub fn from_json(value: serde_json::Value) -> Self {
-        serde_json::from_value(value).unwrap()
+        serde_json::from_value(value).expect("Failed to deserialize search field config")
     }
 
     pub fn default_text() -> Self {

--- a/pg_search/src/writer/client.rs
+++ b/pg_search/src/writer/client.rs
@@ -80,7 +80,8 @@ impl<T: Serialize> Client<T> {
         // If there is an open pending transfer, stop it so that we can continue
         // with more requests.
         self.stop_transfer();
-        let bytes = bincode::serialize(&request).expect("Failed to serialize request");
+        let bytes =
+            bincode::serialize(&request).expect("request should be serializable for send_request");
         let response = self.http.post(self.url()).body::<Vec<u8>>(bytes).send()?;
 
         match response.status() {
@@ -110,7 +111,7 @@ impl<T: Serialize> Client<T> {
         // There is an existing producer in client state, use it to send the request.
         self.producer
             .as_mut()
-            .expect("No producer in client state")
+            .expect("producer should be valid for transfer")
             .write_message(&request)?;
         Ok(())
     }

--- a/pg_search/src/writer/client.rs
+++ b/pg_search/src/writer/client.rs
@@ -80,7 +80,7 @@ impl<T: Serialize> Client<T> {
         // If there is an open pending transfer, stop it so that we can continue
         // with more requests.
         self.stop_transfer();
-        let bytes = bincode::serialize(&request).unwrap();
+        let bytes = bincode::serialize(&request).expect("Failed to serialize request");
         let response = self.http.post(self.url()).body::<Vec<u8>>(bytes).send()?;
 
         match response.status() {
@@ -108,7 +108,10 @@ impl<T: Serialize> Client<T> {
         }
 
         // There is an existing producer in client state, use it to send the request.
-        self.producer.as_mut().unwrap().write_message(&request)?;
+        self.producer
+            .as_mut()
+            .expect("No producer in client state")
+            .write_message(&request)?;
         Ok(())
     }
 

--- a/shared/src/fixtures/arrow.rs
+++ b/shared/src/fixtures/arrow.rs
@@ -38,7 +38,7 @@ fn array_data() -> ArrayData {
         .add_buffer(Buffer::from_slice_ref(&offsets[..]))
         .add_buffer(Buffer::from_slice_ref(&values[..]))
         .build()
-        .expect("Failed to build array data")
+        .expect("binary array data should be valid for BinaryArray")
 }
 
 // Fixed size binary is not supported yet, but this will be useful for test data when we do support.
@@ -50,7 +50,7 @@ fn fixed_size_array_data() -> ArrayData {
         .len(3)
         .add_buffer(Buffer::from(&values[..]))
         .build()
-        .expect("Failed to build fixed size array data")
+        .expect("fixed size binary array data should be valid for FixedSizeBinaryArray")
 }
 
 fn binary_array_data() -> ArrayData {
@@ -62,7 +62,7 @@ fn binary_array_data() -> ArrayData {
         .add_buffer(Buffer::from_slice_ref(&offsets[..]))
         .add_buffer(Buffer::from_slice_ref(&values[..]))
         .build()
-        .expect("Failed to build binary array data")
+        .expect("binary array data should be valid for LargeBinaryArray")
 }
 
 #[derive(Debug)]

--- a/shared/src/fixtures/db.rs
+++ b/shared/src/fixtures/db.rs
@@ -38,7 +38,7 @@ impl Db {
         // Use a timestamp as a unique identifier.
         let path = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .expect("Failed to get current time")
             .as_micros()
             .to_string();
 
@@ -63,7 +63,9 @@ impl Drop for Db {
     fn drop(&mut self) {
         let db_name = self.context.db_name.to_string();
         async_std::task::spawn(async move {
-            Postgres::cleanup_test(db_name.as_str()).await.unwrap();
+            Postgres::cleanup_test(db_name.as_str())
+                .await
+                .expect("Failed to drop test database");
         });
     }
 }
@@ -74,7 +76,10 @@ where
 {
     fn execute(self, connection: &mut PgConnection) {
         block_on(async {
-            connection.execute(self.as_ref()).await.unwrap();
+            connection
+                .execute(self.as_ref())
+                .await
+                .expect("Failed to execute query");
         })
     }
 
@@ -217,7 +222,7 @@ pub trait DisplayAsync: Stream<Item = Result<Bytes, sqlx::Error>> + Sized {
         let mut stream = Box::pin(self);
 
         while let Some(chunk) = block_on(stream.as_mut().next()) {
-            let chunk = chunk.unwrap();
+            let chunk = chunk.expect("Failed to get chunk");
             csv_str.push_str(&String::from_utf8_lossy(&chunk));
         }
 

--- a/shared/src/fixtures/db.rs
+++ b/shared/src/fixtures/db.rs
@@ -38,7 +38,7 @@ impl Db {
         // Use a timestamp as a unique identifier.
         let path = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Failed to get current time")
+            .expect("current time should be retrievable")
             .as_micros()
             .to_string();
 
@@ -65,7 +65,7 @@ impl Drop for Db {
         async_std::task::spawn(async move {
             Postgres::cleanup_test(db_name.as_str())
                 .await
-                .expect("Failed to drop test database");
+                .expect("dropping test database should succeed");
         });
     }
 }
@@ -79,7 +79,7 @@ where
             connection
                 .execute(self.as_ref())
                 .await
-                .expect("Failed to execute query");
+                .expect("query execution should succeed");
         })
     }
 
@@ -222,7 +222,7 @@ pub trait DisplayAsync: Stream<Item = Result<Bytes, sqlx::Error>> + Sized {
         let mut stream = Box::pin(self);
 
         while let Some(chunk) = block_on(stream.as_mut().next()) {
-            let chunk = chunk.expect("Failed to get chunk");
+            let chunk = chunk.expect("chunk should be valid for DisplayAsync");
             csv_str.push_str(&String::from_utf8_lossy(&chunk));
         }
 

--- a/tokenizers/src/icu.rs
+++ b/tokenizers/src/icu.rs
@@ -43,7 +43,7 @@ impl<'a> std::fmt::Debug for ICUBreakingWord<'a> {
 impl<'a> From<&'a str> for ICUBreakingWord<'a> {
     fn from(text: &'a str) -> Self {
         let loc = rust_icu_uloc::get_default();
-        let ustr = &UChar::try_from(text).expect("is an encodable character");
+        let ustr = &UChar::try_from(text).expect("text should be an encodable character");
         // Implementation from a similar fix in https://github.com/jiegec/tantivy-jieba/pull/5
         // referenced by Tantivy issue https://github.com/quickwit-oss/tantivy/issues/1134
         // Append null byte to the end because Tantivy defines the end of a token to be the
@@ -75,7 +75,7 @@ impl<'a> Iterator for ICUBreakingWord<'a> {
         let mut end = self.default_breaking_iterator.next();
         while cont && end.is_some() {
             if end.is_some() && self.default_breaking_iterator.get_rule_status() == 0 {
-                start = end.expect("Invalid end iterator");
+                start = end.expect("end iterator should be valid for ICUBreakingWord");
                 end = self.default_breaking_iterator.next();
             }
             if let Some(index) = end {

--- a/tokenizers/src/icu.rs
+++ b/tokenizers/src/icu.rs
@@ -75,7 +75,7 @@ impl<'a> Iterator for ICUBreakingWord<'a> {
         let mut end = self.default_breaking_iterator.next();
         while cont && end.is_some() {
             if end.is_some() && self.default_breaking_iterator.get_rule_status() == 0 {
-                start = end.unwrap();
+                start = end.expect("Invalid end iterator");
                 end = self.default_breaking_iterator.next();
             }
             if let Some(index) = end {

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -96,12 +96,12 @@ impl SearchTokenizerFilters {
 
         if let Some(value) = self.remove_long {
             write!(buffer, "{}remove_long={value}", sep(is_empty))
-                .expect("Failed to write to buffer");
+                .expect("Writing to String buffer should never fail");
             is_empty = false;
         }
         if let Some(value) = self.lowercase {
             write!(buffer, "{}lowercase={value}", sep(is_empty))
-                .expect("Failed to write to buffer");
+                .expect("Writing to String buffer should never fail");
             is_empty = false;
         }
         if let Some(value) = self.stemmer {
@@ -336,7 +336,7 @@ impl SearchTokenizer {
             } => Some(
                 TextAnalyzer::builder(
                     NgramTokenizer::new(*min_gram, *max_gram, *prefix_only)
-                        .expect("Invalid ngram parameters"),
+                        .expect("Ngram parameters should be valid parameters for NgramTokenizer"),
                 )
                 .filter(filters.remove_long_filter())
                 .filter(filters.lower_caser())

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -95,11 +95,13 @@ impl SearchTokenizerFilters {
         }
 
         if let Some(value) = self.remove_long {
-            write!(buffer, "{}remove_long={value}", sep(is_empty)).unwrap();
+            write!(buffer, "{}remove_long={value}", sep(is_empty))
+                .expect("Failed to write to buffer");
             is_empty = false;
         }
         if let Some(value) = self.lowercase {
-            write!(buffer, "{}lowercase={value}", sep(is_empty)).unwrap();
+            write!(buffer, "{}lowercase={value}", sep(is_empty))
+                .expect("Failed to write to buffer");
             is_empty = false;
         }
         if let Some(value) = self.stemmer {
@@ -333,7 +335,8 @@ impl SearchTokenizer {
                 filters,
             } => Some(
                 TextAnalyzer::builder(
-                    NgramTokenizer::new(*min_gram, *max_gram, *prefix_only).unwrap(),
+                    NgramTokenizer::new(*min_gram, *max_gram, *prefix_only)
+                        .expect("Invalid ngram parameters"),
                 )
                 .filter(filters.remove_long_filter())
                 .filter(filters.lower_caser())


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
I noticed several instances of the `unwrap()` function throughout the project. To improve debugging and provide better context when handling errors, we should make a concerted effort to avoid using `unwrap()` whenever possible.
## Why

## How

## Tests
