### PR TITLE
chore: upgrade all dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -470,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -643,17 +637,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -727,7 +721,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2108,7 +2102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2341,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -2706,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2849,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is-terminal"
@@ -3430,15 +3424,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -3799,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4042,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aed772d438046c382a6096ca4588e121075a69286654bf093363c8621e47cc"
+checksum = "02c651b123539e407c6b1fe057c085f6c2b3b029ddd2abad422318af703068d7"
 dependencies = [
  "atomic-traits",
  "bitflags 2.6.0",
@@ -4066,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab508b078aaa23d6b27c845ca1a1c8f4d79b6f07228a3354a45a3b83b781eaa"
+checksum = "9e94a55b560852da3c9654443724e0384479625f4818963bf9f183b01e86f388"
 dependencies = [
  "bindgen 0.69.4",
  "clang-sys",
@@ -4083,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489d141533da7af37511a8f31c117e92dedd549655af1abfc3368cf20636b5b"
+checksum = "275d4d0e61cead4f8dc5e9f6eae71a836bdaa1febb58d4660e1afb22fa3a6b2d"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -4095,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebff52173960338fd3bef92cdc2c7e9955e46fc5400f1036874ab64660f7f210"
+checksum = "ae249b42b2a59086a61841b060bf8a16f8d0d98dc73fa5cf4316d63a7c4642d9"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -4113,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce45d3e3960937ecbaa800b173823fb366651d06d70aa9c419a5a983cf9baf7f"
+checksum = "a9fb86be16627822b158688919fb87d322ffa40379511b14a740ba1f2c16ddbb"
 dependencies = [
  "cee-scape",
  "libc",
@@ -4128,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9e1b15c41d0af283825ad03c2216bfb5bccc8b9029cd4f2f800f42380bc513"
+checksum = "3af3f3d9e734e9196eb630f6bfb745e5997efeaf1ab8b47b8365d9ab02a28f06"
 dependencies = [
  "convert_case 0.6.0",
  "eyre",
@@ -4144,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5b6525ba7bda5dc5922cc1ddde43802ba339a25d6fd217772ad797d885a57e"
+checksum = "395526c697094524c7bfc3afaa19b8843d655f0d348b032ba3f13c95ebdfd665"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -4285,9 +4270,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -4298,15 +4283,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -4940,9 +4925,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -4978,9 +4963,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/cargo-paradedb/Cargo.toml
+++ b/cargo-paradedb/Cargo.toml
@@ -6,26 +6,26 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.81"
-async-std = "1.12.0"
-chrono = { version = "0.4.34", features = ["clock", "alloc", "serde"] }
-clap = { version = "4.5.4", features = ["derive", "env"] }
-cmd_lib = "1.9.3"
+anyhow = "1.0.87"
+async-std = "1.13.0"
+chrono = { version = "0.4.38", features = ["clock", "alloc", "serde"] }
+clap = { version = "4.5.17", features = ["derive", "env"] }
+cmd_lib = "1.9.4"
 criterion = { version = "0.5.1", features = ["async_std"] }
 dotenvy = "0.15.7"
 futures = "0.3.30"
 glob = "0.3.1"
 itertools = "0.12.1"
 once_cell = "1.19.0"
-reqwest = { version = "0.12.3", features = ["json", "blocking"] }
-serde = "1.0.197"
-serde_json = "1.0.115"
+reqwest = { version = "0.12.7", features = ["json", "blocking"] }
+serde = "1.0.210"
+serde_json = "1.0.128"
 sqlx = { version = "0.7.4", features = [
   "postgres",
   "runtime-async-std",
   "chrono",
 ] }
-tempfile = "3.10.1"
+tempfile = "3.12.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,58 +19,58 @@ pg_test = []
 icu = ["tokenizers/icu"]
 
 [dependencies]
-anyhow = { version = "1.0.79", features = ["backtrace"] }
+anyhow = { version = "1.0.87", features = ["backtrace"] }
 bincode = "1.3.3"
 crossbeam = "0.8.4"
-csv = "1.2.2"
-derive_more = "0.99.17"
+csv = "1.3.0"
+derive_more = "0.99.18"
 fs2 = "0.4.3"
-indexmap = "2.1.0"
+indexmap = "2.5.0"
 interprocess = "1.2.1"
 json5 = "0.4.1"
-libc = "0.2.152"
-memoffset = "0.9.0"
-once_cell = "1.18.0"
+libc = "0.2.158"
+memoffset = "0.9.1"
+once_cell = "1.19.0"
 tokenizers = { version = "0.9.4", path = "../tokenizers" }
-pgrx = "0.12.1"
-reqwest = "0.11.22"
+pgrx = "0.12.3"
+reqwest = "0.11.27"
 rustc-hash = "1.1.0"
-serde = "1.0.188"
-serde_json = "1.0.105"
-serde_path_to_error = "0.1.14"
+serde = "1.0.210"
+serde_json = "1.0.128"
+serde_path_to_error = "0.1.16"
 shared = { path = "../shared" }
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "33be46c" }
 tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "33be46c" }
-thiserror = "1.0.56"
+thiserror = "1.0.63"
 tiny_http = "0.12.0"
 tracing = "0.1.40"
-utoipa = "4.2.0"
+utoipa = "4.2.3"
 walkdir = "2.5.0"
 num_cpus = "1.16.0"
 chrono = "0.4.38"
-ordered-float = "4.2.0"
+ordered-float = "4.2.2"
 uuid = "1.10.0"
 strum = { version = "0.26.3" }
 
 [dev-dependencies]
 approx = "0.5.1"
-async-std = { version = "1.12.0", features = ["attributes"] }
+async-std = { version = "1.13.0", features = ["attributes"] }
 cmd_lib = "1.9.4"
 dotenvy = "0.15.7"
-pgrx-tests = "0.12.1"
-pgvector = { version = "0.3.2", features = ["sqlx"] }
+pgrx-tests = "0.12.3"
+pgvector = { version = "0.3.4", features = ["sqlx"] }
 portpicker = "0.1.1"
 pretty_assertions = "1.4.0"
 rstest = "0.18.2"
 shared = { path = "../shared", features = ["fixtures"] }
-sqlx = { version = "0.7.3", features = [
+sqlx = { version = "0.7.4", features = [
   "postgres",
   "runtime-async-std",
   "time",
   "bigdecimal",
   "uuid",
 ] }
-tempfile = "3.9.0"
+tempfile = "3.12.0"
 
 [package.metadata.cargo-machete]
 ignored = ["indexmap", "libc", "tantivy-common"]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -9,17 +9,17 @@ license = "AGPL-3.0"
 fixtures = ["async-std", "rstest", "soa_derive", "sqlx", "bigdecimal"]
 
 [dependencies]
-pgrx = "0.12.1"
-reqwest = { version = "0.11.22", features = ["blocking"] }
-serde = "1.0.189"
-serde_json = "1.0.107"
-time = { version = "0.3.34", features = ["serde"] }
+pgrx = "0.12.3"
+reqwest = { version = "0.11.27", features = ["blocking"] }
+serde = "1.0.210"
+serde_json = "1.0.128"
+time = { version = "0.3.36", features = ["serde"] }
 tracing = "0.1.40"
-uuid = "1.5.0"
-async-std = { version = "1.12.0", features = ["attributes"], optional = true }
+uuid = "1.10.0"
+async-std = { version = "1.13.0", features = ["attributes"], optional = true }
 rstest = { version = "0.18.2", optional = true }
 soa_derive = { version = "0.13.0", optional = true }
-sqlx = { version = "0.7.3", features = [
+sqlx = { version = "0.7.4", features = [
   "postgres",
   "runtime-async-std",
   "time",
@@ -27,24 +27,24 @@ sqlx = { version = "0.7.3", features = [
   "uuid",
   "chrono",
 ], optional = true }
-bigdecimal = { version = "0.3.0", features = ["serde"], optional = true }
-bytes = "1.5.0"
-thiserror = "1.0.57"
+bigdecimal = { version = "0.3.1", features = ["serde"], optional = true }
+bytes = "1.7.1"
+thiserror = "1.0.63"
 once_cell = "1.19.0"
-url = "2.5.0"
+url = "2.5.2"
 walkdir = "2.5.0"
 os_info = { version = "3", default-features = false }
-chrono = { version = "0.4.34", features = ["clock", "alloc"] }
+chrono = { version = "0.4.38", features = ["clock", "alloc"] }
 humansize = "2.1.3"
-anyhow = "1.0.83"
+anyhow = "1.0.87"
 datafusion = "38.0.0"
-tempfile = "3.10.1"
+tempfile = "3.12.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-libc = "0.2.155"
+libc = "0.2.158"
 
 [dev-dependencies]
 mockall = "0.12.1"
-pgrx-tests = "0.12.1"
+pgrx-tests = "0.12.3"
 
 [package.metadata.cargo-machete]
 ignored = ["rstest"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 icu = ["rust_icu_ubrk", "rust_icu_sys", "rust_icu_uloc", "rust_icu_ustring"]
 
 [dependencies]
-anyhow = "1.0.86"
-lindera-core = "0.27.1"
-lindera-dictionary = "0.27.1"
-lindera-tokenizer = { version = "0.27.1", features = [
+anyhow = "1.0.87"
+lindera-core = "0.27.2"
+lindera-dictionary = "0.27.2"
+lindera-tokenizer = { version = "0.27.2", features = [
   "cc-cedict-compress",
   "cc-cedict",
   "ipadic-compress",
@@ -18,12 +18,12 @@ lindera-tokenizer = { version = "0.27.1", features = [
   "ko-dic-compress",
   "ko-dic",
 ] }
-once_cell = "1.18.0"
-serde = "1.0.188"
-serde_json = "1.0.105"
+once_cell = "1.19.0"
+serde = "1.0.210"
+serde_json = "1.0.128"
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "33be46c" }
 tracing = "0.1.40"
-strum_macros = "0.26.3"
+strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }
 
 [dependencies.rust_icu_ubrk]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # n/a

## What

I used the `cargo-edit` plugin from  https://github.com/killercup/cargo-edit to update all our dependencies to their latest versions.

## Why

Some have asked for specific deps to be updated, so might as well just do all of them.

## How

## Tests
