### PR TITLE
chore: change fuzzy term default to `prefix = false`

### DIFF
--- a/docs/api-reference/full-text/complex.mdx
+++ b/docs/api-reference/full-text/complex.mdx
@@ -196,9 +196,9 @@ SELECT * FROM search_idx.search(
   single edit in the Levenshtein distance calculation, while `false` considers
   it two separate edits (a deletion and an insertion).
 </ParamField>
-<ParamField body="prefix" default={false}>
+<ParamField body="prefix" default={true}>
   When set to `true`, the initial substring (prefix) of the query term is
-  exempted from the fuzzy edit distance calculation, while false includes the
+  exempted from the fuzzy edit distance calculation, while `false` includes the
   entire string in the calculation.
 </ParamField>
 

--- a/docs/api-reference/full-text/complex.mdx
+++ b/docs/api-reference/full-text/complex.mdx
@@ -196,7 +196,7 @@ SELECT * FROM search_idx.search(
   single edit in the Levenshtein distance calculation, while `false` considers
   it two separate edits (a deletion and an insertion).
 </ParamField>
-<ParamField body="prefix" default={true}>
+<ParamField body="prefix" default={false}>
   When set to `true`, the initial substring (prefix) of the query term is
   exempted from the fuzzy edit distance calculation, while `false` includes the
   entire string in the calculation.

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -303,7 +303,7 @@ impl SearchQueryInput {
                 let term = Term::from_field_text(field, &value);
                 let distance = distance.unwrap_or(2);
                 let transposition_cost_one = transposition_cost_one.unwrap_or(true);
-                if prefix.unwrap_or(false) {
+                if prefix.unwrap_or(true) {
                     Ok(Box::new(FuzzyTermQuery::new(
                         term,
                         distance,

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -303,14 +303,14 @@ impl SearchQueryInput {
                 let term = Term::from_field_text(field, &value);
                 let distance = distance.unwrap_or(2);
                 let transposition_cost_one = transposition_cost_one.unwrap_or(true);
-                if prefix.unwrap_or(true) {
-                    Ok(Box::new(FuzzyTermQuery::new(
+                if prefix.unwrap_or(false) {
+                    Ok(Box::new(FuzzyTermQuery::new_prefix(
                         term,
                         distance,
                         transposition_cost_one,
                     )))
                 } else {
-                    Ok(Box::new(FuzzyTermQuery::new_prefix(
+                    Ok(Box::new(FuzzyTermQuery::new(
                         term,
                         distance,
                         transposition_cost_one,

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -457,7 +457,7 @@ fn multi_tree(mut conn: PgConnection) {
 			    paradedb.parse('description:shoes'),
 			    paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
 			    paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1)
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false)
 		    ]
 	    ),
 	    stable_sort => true

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -457,7 +457,7 @@ fn multi_tree(mut conn: PgConnection) {
 			    paradedb.parse('description:shoes'),
 			    paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
 			    paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false)
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => true)
 		    ]
 	    ),
 	    stable_sort => true

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -34,7 +34,7 @@ fn boolean_tree(mut conn: PgConnection) {
                 paradedb.parse('description:shoes'),
                 paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
                 paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1)
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false)
             ]
         ),
         stable_sort => true
@@ -49,7 +49,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.fuzzy_term(field => 'category', value => 'elector'),
+        query => paradedb.fuzzy_term(field => 'category', value => 'elector', prefix => false),
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
@@ -160,7 +160,7 @@ fn single_queries(mut conn: PgConnection) {
     // FuzzyTerm
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-		paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1),
+		paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false),
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -34,7 +34,7 @@ fn boolean_tree(mut conn: PgConnection) {
                 paradedb.parse('description:shoes'),
                 paradedb.phrase_prefix(field => 'description', phrases => ARRAY['book']),
                 paradedb.term(field => 'description', value => 'speaker'),
-			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false)
+			    paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => true)
             ]
         ),
         stable_sort => true
@@ -49,7 +49,7 @@ fn fuzzy_fields(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-        query => paradedb.fuzzy_term(field => 'category', value => 'elector', prefix => false),
+        query => paradedb.fuzzy_term(field => 'category', value => 'elector', prefix => true),
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);
@@ -69,7 +69,8 @@ fn fuzzy_fields(mut conn: PgConnection) {
             field => 'description',
             value => 'keybaord',
             transposition_cost_one => false,
-            distance => 1
+            distance => 1,
+            prefix => true
         ),
         stable_sort => true
     )"#
@@ -85,7 +86,8 @@ fn fuzzy_fields(mut conn: PgConnection) {
             field => 'description',
             value => 'keybaord',
             transposition_cost_one => true,
-            distance => 1
+            distance => 1,
+            prefix => true
         ),
         stable_sort => true
     )"#
@@ -100,7 +102,8 @@ fn fuzzy_fields(mut conn: PgConnection) {
     SELECT * FROM bm25_search.search(
         query => paradedb.fuzzy_term(
             field => 'description',
-            value => 'keybaord'
+            value => 'keybaord',
+            prefix => true
         ),
         stable_sort => true
     )"#
@@ -160,7 +163,7 @@ fn single_queries(mut conn: PgConnection) {
     // FuzzyTerm
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM bm25_search.search(
-		paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => false),
+		paradedb.fuzzy_term(field => 'description', value => 'wolo', transposition_cost_one => false, distance => 1, prefix => true),
         stable_sort => true
     )"#
     .fetch_collect(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Now, the fuzzy term query defaults to using `FuzzyTermQuery::new` instead of `FuzzyTermQuery::new_prefix`.

## Why
`new_prefix` causes some strange matches. For instance, `zz` matches against the document `Chris`. I couldn't figure out why Tantivy considers this a match, and `FuzzyTermQuery::new` seems like a more appropriate default.

## How

## Tests
