### PR TITLE
fix: Add missing `stemmer` and `lowercase` filters to `raw` and language tokenizers

### DIFF
--- a/pg_search/tests/search_config.rs
+++ b/pg_search/tests/search_config.rs
@@ -381,7 +381,7 @@ fn raw_tokenizer_config(mut conn: PgConnection) {
 
     let count: (i64,) = r#"SELECT COUNT(*) FROM bm25_search.search('description:"GENERIC SHOES"')"#
         .fetch_one(&mut conn);
-    assert_eq!(count.0, 0);
+    assert_eq!(count.0, 1);
 
     let count: (i64,) = r#"SELECT COUNT(*) FROM bm25_search.search('description:"Generic shoes"')"#
         .fetch_one(&mut conn);

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -300,10 +300,11 @@ impl SearchTokenizer {
             SearchTokenizer::Raw(filters) => Some(
                 TextAnalyzer::builder(RawTokenizer::default())
                     .filter(filters.remove_long_filter())
+                    .filter(filters.lower_caser())
                     .filter(filters.stemmer())
                     .build(),
             ),
-            // Deprecated, use `lowercase` filter instead
+            // Deprecated, use `raw` with `lowercase` filter instead
             SearchTokenizer::Lowercase(filters) => Some(
                 TextAnalyzer::builder(RawTokenizer::default())
                     .filter(filters.remove_long_filter())
@@ -343,6 +344,7 @@ impl SearchTokenizer {
                 TextAnalyzer::builder(ChineseTokenizer)
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::SourceCode(filters) => Some(
@@ -350,24 +352,28 @@ impl SearchTokenizer {
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
                     .filter(AsciiFoldingFilter)
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::ChineseLindera(filters) => Some(
                 TextAnalyzer::builder(LinderaChineseTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::JapaneseLindera(filters) => Some(
                 TextAnalyzer::builder(LinderaJapaneseTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             SearchTokenizer::KoreanLindera(filters) => Some(
                 TextAnalyzer::builder(LinderaKoreanTokenizer::default())
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
             // Deprecated, use `stemmer` filter instead
@@ -391,6 +397,7 @@ impl SearchTokenizer {
                 TextAnalyzer::builder(ICUTokenizer)
                     .filter(filters.remove_long_filter())
                     .filter(filters.lower_caser())
+                    .filter(filters.stemmer())
                     .build(),
             ),
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
- The lowercase filter can now be configured for the `raw` tokenizer
- The stemmer filter can be configured for language tokenizers (CJK, Lindera, and ICU)

This is a **breaking change** for the `raw` tokenizer. Since the lowercase filter defaults to `true`, by default the `raw` tokenizer now lowercases. This is consistent with the behavior of all other tokenizers.

This can be disabled with `paradedb.tokenizer('raw', lowercase => false)`. 

## Why
Make all tokenizers equally configurable.

## How

## Tests
