### PR TITLE
fix: Fix CI with log printing

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -215,8 +215,9 @@ jobs:
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
           cargo pgrx test "pg${{ matrix.pg_version }}" --features icu
           cat ~/.pgrx/${{ matrix.pg_version}}.log
+
       - name: Show the Postgres log
-        if: "!cancelled()"
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && !cancelled()
         run: |
           cat ~/.pgrx/${{ matrix.pg_version}}.log
 
@@ -311,7 +312,8 @@ jobs:
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 28816 -h localhost pg_search
           DATABASE_URL=postgresql://localhost:28816/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
           cat ~/.pgrx/${{ matrix.pg_version}}.log
+
       - name: Show the Postgres log
-        if: "!cancelled()"
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && !cancelled()
         run: |
           cat ~/.pgrx/${{ matrix.pg_version}}.log

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -216,8 +216,8 @@ jobs:
           cargo pgrx test "pg${{ matrix.pg_version }}" --features icu
           cat ~/.pgrx/${{ matrix.pg_version}}.log
 
-      - name: Show the Postgres log
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && !cancelled()
+      - name: Print the Postgres Logs
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()
         run: |
           cat ~/.pgrx/${{ matrix.pg_version}}.log
 
@@ -313,7 +313,7 @@ jobs:
           DATABASE_URL=postgresql://localhost:28816/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
           cat ~/.pgrx/${{ matrix.pg_version}}.log
 
-      - name: Show the Postgres log
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && !cancelled()
+      - name: Print the Postgres Logs
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()
         run: |
           cat ~/.pgrx/${{ matrix.pg_version}}.log

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -218,8 +218,7 @@ jobs:
 
       - name: Print the Postgres Logs
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()
-        run: |
-          cat ~/.pgrx/${{ matrix.pg_version}}.log
+        run: cat ~/.pgrx/${{ matrix.pg_version}}.log
 
   test-pg_search-pgrx-postgres:
     name: Test pg_search on pgrx PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
@@ -315,5 +314,4 @@ jobs:
 
       - name: Print the Postgres Logs
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()
-        run: |
-          cat ~/.pgrx/${{ matrix.pg_version}}.log
+        run: cat ~/.pgrx/${{ matrix.pg_version}}.log


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Eric's PR added new log printing to our CI, but on `dev` we skip some of the runs to avoid running the CI unnecessarily. You can see that here: https://github.com/paradedb/paradedb/actions/runs/10814680271/job/30001714090

This PR just adds the proper check.

## Why
No failed CI

## How
^

## Tests
Tested manually