### PR TITLE
chore: Add Koala API Key

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -224,6 +224,9 @@
     },
     "gtm": {
       "tagId": "GTM-KMGRG564"
+    },
+    "koala": {
+      "publicApiKey": "pk_05f8f4ec527669d1e8f88783a4dccdf37407"
     }
   },
   "backgroundImage": "/background.png"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Koala is used to traffic deanonymization, to help uncover leads that look at our documentation.

It was recommended by Mintlify, Mongo and a few others.
## Why
^

## How
^

## Tests
^