### PR TITLE
chore: Remove the need on token for workflow dispatch

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -125,12 +125,9 @@ jobs:
   # Only run this job on the `main` branch since it requires access to GitHub Secrets, which
   # community contributors don't have access to.
   test-paradedb-helm-chart:
-    name: Test ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
+    name: Test ParadeDB Helm Chart
     runs-on: depot-ubuntu-latest-2
     if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main'
-    strategy:
-      matrix:
-        pg_version: [16]
 
     steps:
       - name: Trigger paradedb/charts Test Workflow

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -131,9 +131,8 @@ jobs:
 
     steps:
       - name: Trigger paradedb/charts Test Workflow
-        uses: multinarity/workflow-dispatch@master
+        uses: benc-uk/workflow-dispatch@v1.2.4
         with:
-          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           workflow: paradedb-test-eks.yml
           repo: paradedb/charts
           ref: main

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -122,9 +122,12 @@ jobs:
             exit 1
           fi
 
+  # Only run this job on the `main` branch since it requires access to GitHub Secrets, which
+  # community contributors don't have access to.
   test-paradedb-helm-chart:
     name: Test ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
     runs-on: depot-ubuntu-latest-2
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main'
     strategy:
       matrix:
         pg_version: [16]
@@ -133,6 +136,7 @@ jobs:
       - name: Trigger paradedb/charts Test Workflow
         uses: benc-uk/workflow-dispatch@v1.2.4
         with:
+          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           workflow: paradedb-test-eks.yml
           repo: paradedb/charts
           ref: main


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
The token is not necessary since the repo is public. External contributors don't have access to GitHub Secrets, so this was blocking them. Should be fixed now. I've also updated to a more maintained version of the workflow.

## Why

## How

## Tests
