### PR TITLE
feat: Introduce `fuzzy_phrase` query

### DIFF
--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -235,6 +235,25 @@ pub fn fuzzy_term(
     }
 }
 
+#[pg_extern(immutable, parallel_safe)]
+pub fn fuzzy_phrase(
+    field: String,
+    value: String,
+    distance: default!(Option<i32>, "NULL"),
+    transposition_cost_one: default!(Option<bool>, "NULL"),
+    prefix: default!(Option<bool>, "NULL"),
+    conjunction_mode: default!(Option<bool>, "NULL"),
+) -> SearchQueryInput {
+    SearchQueryInput::FuzzyPhrase {
+        field,
+        value,
+        distance: distance.map(|n| n as u8),
+        transposition_cost_one,
+        prefix,
+        conjunction_mode,
+    }
+}
+
 #[pg_extern(name = "more_like_this", immutable, parallel_safe)]
 pub fn more_like_this_empty() -> SearchQueryInput {
     panic!("more_like_this must be called with either with_document_id or with_document_fields");

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -242,7 +242,7 @@ pub fn fuzzy_phrase(
     distance: default!(Option<i32>, "NULL"),
     transposition_cost_one: default!(Option<bool>, "NULL"),
     prefix: default!(Option<bool>, "NULL"),
-    conjunction_mode: default!(Option<bool>, "NULL"),
+    match_all_terms: default!(Option<bool>, "NULL"),
 ) -> SearchQueryInput {
     SearchQueryInput::FuzzyPhrase {
         field,
@@ -250,7 +250,7 @@ pub fn fuzzy_phrase(
         distance: distance.map(|n| n as u8),
         transposition_cost_one,
         prefix,
-        conjunction_mode,
+        match_all_terms,
     }
 }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -36,9 +36,6 @@ use tantivy::{
 };
 use thiserror::Error;
 
-use crate::index::SearchIndex;
-use crate::writer::WriterDirectory;
-
 #[derive(Debug, PostgresType, Deserialize, Serialize, Clone, PartialEq, Default)]
 pub enum SearchQueryInput {
     All,
@@ -341,15 +338,11 @@ impl SearchQueryInput {
                 let conjunction_mode = conjunction_mode.unwrap_or(false);
                 let prefix = prefix.unwrap_or(false);
 
-                let index_oid = config.index_oid;
-                let directory = WriterDirectory::from_index_oid(index_oid);
-                let search_index = SearchIndex::from_disk(&directory)
-                    .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
                 let field = field_lookup
                     .as_str(&field)
                     .ok_or_else(|| QueryError::WrongFieldType(field.clone()))?;
 
-                let mut analyzer = search_index.underlying_index.tokenizer_for_field(field)?;
+                let mut analyzer = searcher.index().tokenizer_for_field(field)?;
                 let mut stream = analyzer.token_stream(&value);
                 let mut terms = Vec::new();
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -338,7 +338,7 @@ impl SearchQueryInput {
             } => {
                 let distance = distance.unwrap_or(2);
                 let transposition_cost_one = transposition_cost_one.unwrap_or(true);
-                let conjunction_mode = conjunction_mode.unwrap_or(true);
+                let conjunction_mode = conjunction_mode.unwrap_or(false);
                 let prefix = prefix.unwrap_or(false);
 
                 let index_oid = config.index_oid;

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -79,7 +79,7 @@ pub enum SearchQueryInput {
         distance: Option<u8>,
         transposition_cost_one: Option<bool>,
         prefix: Option<bool>,
-        conjunction_mode: Option<bool>,
+        match_all_terms: Option<bool>,
     },
     MoreLikeThis {
         min_doc_frequency: Option<u64>,
@@ -331,11 +331,11 @@ impl SearchQueryInput {
                 distance,
                 transposition_cost_one,
                 prefix,
-                conjunction_mode,
+                match_all_terms,
             } => {
                 let distance = distance.unwrap_or(2);
                 let transposition_cost_one = transposition_cost_one.unwrap_or(true);
-                let conjunction_mode = conjunction_mode.unwrap_or(false);
+                let match_all_terms = match_all_terms.unwrap_or(false);
                 let prefix = prefix.unwrap_or(false);
 
                 let field = field_lookup
@@ -358,7 +358,7 @@ impl SearchQueryInput {
                     } else {
                         Box::new(FuzzyTermQuery::new(term, distance, transposition_cost_one))
                     };
-                    let occur = if conjunction_mode {
+                    let occur = if match_all_terms {
                         Occur::Must
                     } else {
                         Occur::Should


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
`fuzzy_phrase` is the first ParadeDB-specific query builder function. `fuzzy_phrase` matches documents according to the following criteria:

"Given a field and value, tokenize value and match documents if ANY ONE of the tokens are a `fuzzy_term` match against the document." 

This query demonstrates the usage of `fuzzy_phrase`:


```sql
SELECT description, rating, category 
FROM search_idx.search(query => paradedb.fuzzy_phrase(field => 'description', value => 'ruining shoez'));
     description     | rating | category
---------------------+--------+----------
 Sleek running shoes |      5 | Footwear
 White jogging shoes |      3 | Footwear
 Generic shoes       |      4 | Footwear
(3 rows)
```

`fuzzy_phrase` can also be configured to match documents if **ALL TOKENS** are a `fuzzy_term` match with the `match_all_terms` argument.

```sql
CALL paradedb.create_bm25(
        index_name => 'search_idx',
        schema_name => 'public',
        table_name => 'mock_items',
        key_field => 'id',
        text_fields => paradedb.field('description')
);

SELECT description, rating, category 
FROM search_idx.search(query => paradedb.fuzzy_phrase(field => 'description', value => 'ruining shoez', match_all_terms => true));
     description     | rating | category
---------------------+--------+----------
 Sleek running shoes |      5 | Footwear
(1 row)
```

## Why
We've been getting a lot of feature requests for fuzzy phrase search. While it's technically possible to create fuzzy phrase search by stitching together boolean + fuzzy term queries, this makes the query syntax complicated and is not clearly documented.

## How
The following queries are identical:

```sql
select description, rating, category 
from search_idx.search(query => paradedb.fuzzy_phrase(field => 'description', value => 'ruining shoez', match_all_terms => true));

WITH tokenized AS (
    SELECT token FROM paradedb.tokenize(
        paradedb.tokenizer('default'),
        'ruining shoez'
    )
)
-- Match a document if any of the tokens match
SELECT description, rating, category
FROM search_idx.search(
    query => paradedb.boolean(
        must => ARRAY[(
            SELECT array_agg(paradedb.fuzzy_term(field => 'description', value => token))
            FROM tokenized
        )]
    )
);
```

And the following queries are identical:

```sql
select description, rating, category 
from search_idx.search(query => paradedb.fuzzy_phrase(field => 'description', value => 'ruining shoez', match_all_terms => false));

WITH tokenized AS (
    SELECT token FROM paradedb.tokenize(
        paradedb.tokenizer('default'),
        'ruining shoez'
    )
)
-- Match a document if any of the tokens match
SELECT description, rating, category
FROM search_idx.search(
    query => paradedb.boolean(
        should => ARRAY[(
            SELECT array_agg(paradedb.fuzzy_term(field => 'description', value => token))
            FROM tokenized
        )]
    )
);
```

## Tests
See the new `fuzzy_phrase` test.