### PR TITLE
fix: Dynamically determine pgrx version failure when pushing to dev

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -122,6 +122,7 @@ jobs:
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
 
       - name: Extract pgrx version
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
         run: echo "PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)" >> $GITHUB_ENV
 
@@ -284,6 +285,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Extract pgrx version
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
         run: echo "PGRX_VERSION=$(grep '^pgrx = ' Cargo.toml | sed -E 's/pgrx = "(.*)"/\1/')" >> $GITHUB_ENV
 


### PR DESCRIPTION
# Ticket(s) Closed

- Follow up https://github.com/paradedb/paradedb/pull/1655

## What

## Why

## How

## Tests
