### PR TITLE
fix: Reverted the Docker UID/GID change as the issue can be fixed in the H…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -271,14 +271,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# Change the uid of the postgres user to 26, for CloudNativePG compatibility
-RUN usermod -u 26 postgres \
-    && chown -R 26:999 /var/lib/postgresql \
-    && chown -R 26:999 /var/run/postgresql \
-    && chmod -R 700 /var/lib/postgresql
-
 # Switch back to the postgres user, with the new uid
-USER 26
+USER postgres
 
 # Copy ParadeDB scripts to install extensions, configure postgresql.conf, update extensions, etc.
 COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh


### PR DESCRIPTION
The change added in [dbc953e](https://github.com/paradedb/paradedb/commit/dbc953e50d84ddf2e911f775a90d182d84431366) can break backwards compatibility with people already using your Docker image, but the issue can actually be addressed from the Helm chart instead - https://github.com/paradedb/charts/pull/26