### PR TITLE
chore: assign `requires = []` arrays to `extension_sql!()` usages

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -531,5 +531,6 @@ extension_sql!(
     ON sql_drop
     EXECUTE FUNCTION paradedb.drop_bm25_event_trigger();
     "#
-    name = "create_drop_bm25_event_trigger"
+    name = "create_drop_bm25_event_trigger",
+    requires = [ delete_bm25_index_by_oid ]
 );

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -50,7 +50,11 @@ const DEFAULT_STARTUP_COST: f64 = 10.0;
 
 pgrx::pg_module_magic!();
 
-extension_sql!("GRANT ALL ON SCHEMA paradedb TO PUBLIC;" name = "paradedb_grant_all");
+extension_sql!(
+    "GRANT ALL ON SCHEMA paradedb TO PUBLIC;",
+    name = "paradedb_grant_all",
+    finalize
+);
 
 static mut TRACE_HOOK: shared::trace::TraceHook = shared::trace::TraceHook;
 


### PR DESCRIPTION

# Ticket(s) Closed

- Closes #

## What

This ensures these blocks will be emitted in the generated extension schema after the object(s) they themselves depend on.

## Why

It's a little unclear to me if these blocks could be emitted prior to the objects they depend on during pgrx's schema generation.  Now we define their dependency relationships explicitly.

This hasn't been a problem, and maybe never would be one, but pgrx's schema generator isn't deterministic along the edges (that's another issue!), so making sure these blocks are linked up correctly is *probably* important.

## How

## Tests

Existing tests pass.