### PR TITLE
chore: add docs entry for cardinality aggregation

### DIFF
--- a/docs/api-reference/faceting/metric.mdx
+++ b/docs/api-reference/faceting/metric.mdx
@@ -152,3 +152,28 @@ SELECT search_idx.aggregate('{
   The value to use for documents missing the field. By default, missing values
   are ignored.
 </ParamField>
+
+## Cardinality
+
+A cardinality aggregation estimates the number of unique values in the specified field using the HyperLogLog++ algorithm.
+This is useful for understanding the uniqueness of values in a large dataset.
+
+The cardinality aggregation provides an approximate count, which is accurate within a small error range.
+This trade-off allows for efficient computation even on very large datasets.
+
+```sql
+SELECT search_idx.aggregate('{
+  "unique_users": {
+    "cardinality": {"field": "user_id", "missing": "unknown"}
+  }
+}');
+```
+
+
+<ParamField body="field" required>
+  The field name to compute the cardinality on.
+</ParamField>
+<ParamField body="missing">
+  The value to use for documents missing the field. By default, missing values are ignored.
+</ParamField>
+

--- a/docs/api-reference/faceting/metric.mdx
+++ b/docs/api-reference/faceting/metric.mdx
@@ -169,11 +169,10 @@ SELECT search_idx.aggregate('{
 }');
 ```
 
-
 <ParamField body="field" required>
   The field name to compute the cardinality on.
 </ParamField>
 <ParamField body="missing">
-  The value to use for documents missing the field. By default, missing values are ignored.
+  The value to use for documents missing the field. By default, missing values
+  are ignored.
 </ParamField>
-


### PR DESCRIPTION
closes #1547

## What

Short doc entry for cardinality, based on Tantivy's docs added here:
https://github.com/quickwit-oss/tantivy/pull/2446/files

This new feature is limited to enterprise ParadeDB, along with the rest of aggregation queries.