### PR TITLE
chore: introduce retries in replication tests

### DIFF
--- a/pg_search/tests/replication.rs
+++ b/pg_search/tests/replication.rs
@@ -235,7 +235,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
             &mut target_conn,
             5,
             1000,
-            |result| result.len() > 0,
+            |result| !result.is_empty(),
         );
 
     assert_eq!(source_results.len(), 1);
@@ -256,7 +256,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
             &mut target_conn,
             5,
             1000,
-            |result| result.len() > 0,
+            |result| !result.is_empty(),
         );
 
     assert_eq!(source_results.len(), 1);
@@ -276,7 +276,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
             &mut target_conn,
             5,
             1000,
-            |result| result.len() > 0,
+            |result| !result.is_empty(),
         );
 
     assert_eq!(source_results.len(), 1);
@@ -296,7 +296,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
             &mut target_conn,
             5,
             1000,
-            |result| result.len() > 0,
+            |result| !result.is_empty(),
         );
 
     assert_eq!(source_results.len(), 0);
@@ -455,7 +455,7 @@ async fn test_replication_with_pg_search_only_on_replica() -> Result<()> {
             &mut target_conn,
             5,
             1000,
-            |result| result.len() > 0,
+            |result| !result.is_empty(),
         );
 
     assert_eq!(target_results.len(), 1);

--- a/shared/src/fixtures/db.rs
+++ b/shared/src/fixtures/db.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::arrow::schema_to_batch;
+use anyhow::Result;
 use async_std::prelude::Stream;
 use async_std::stream::StreamExt;
 use async_std::task::block_on;
@@ -26,7 +27,7 @@ use sqlx::{
     testing::{TestArgs, TestContext, TestSupport},
     ConnectOptions, Decode, Executor, FromRow, PgConnection, Postgres, Type,
 };
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub struct Db {
     context: TestContext<Postgres>,
@@ -92,6 +93,43 @@ where
                 .await
                 .unwrap_or_else(|e| panic!("{e}:  error in query '{}'", self.as_ref()))
         })
+    }
+
+    fn fetch_retry<T>(
+        self,
+        connection: &mut PgConnection,
+        retries: u32,
+        delay_ms: u64,
+        validate: fn(&[T]) -> bool,
+    ) -> Vec<T>
+    where
+        T: for<'r> FromRow<'r, <Postgres as sqlx::Database>::Row> + Send + Unpin,
+    {
+        for attempt in 0..retries {
+            match block_on(async {
+                sqlx::query_as::<_, T>(self.as_ref())
+                    .fetch_all(&mut *connection)
+                    .await
+                    .map_err(|err| anyhow::Error::from(err))
+            }) {
+                Ok(result) => {
+                    if validate(&result) {
+                        return result;
+                    } else {
+                        if attempt < retries - 1 {
+                            block_on(async_std::task::sleep(Duration::from_millis(delay_ms)));
+                        } else {
+                            return vec![];
+                        }
+                    }
+                }
+                Err(_) if attempt < retries - 1 => {
+                    block_on(async_std::task::sleep(Duration::from_millis(delay_ms)));
+                }
+                Err(e) => panic!("Fetch attempt {}/{} failed: {}", attempt + 1, retries, e),
+            }
+        }
+        panic!("Exhausted retries for query '{}'", self.as_ref());
     }
 
     fn fetch_dynamic(self, connection: &mut PgConnection) -> Vec<PgRow> {


### PR DESCRIPTION
## What

We're seeing intermittent CI failures in the replication tests, likely due to the use of `Thread::sleep` to wait for replication between Postgres instances.

## How

Introduced a `fetch_retry` method on the `Query` trait, which accepts wait time and retry number. We'll retry a few times if we get an invalid result.

## Tests
Modified existing tests.
