### PR TITLE
chore: check `shared_preload_libraries` in `pg_init`

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -75,7 +75,7 @@ pub fn MyDatabaseId() -> u32 {
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
     if !pg_sys::process_shared_preload_libraries_in_progress {
-        ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_RAISE_EXCEPTION, "pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to the shared_preload_libraries configuration in the postgresql.conf file and restart Postgres.");
+        error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }
 
     postgres::options::init();

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -75,7 +75,7 @@ pub fn MyDatabaseId() -> u32 {
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
     if !pg_sys::process_shared_preload_libraries_in_progress {
-        ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_RAISE_EXCEPTION, "pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to the shared_preload_libraries configuration in the postgresql.conf file.");
+        ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_RAISE_EXCEPTION, "pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to the shared_preload_libraries configuration in the postgresql.conf file and restart Postgres.");
     }
 
     postgres::options::init();

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -74,6 +74,10 @@ pub fn MyDatabaseId() -> u32 {
 #[allow(non_snake_case)]
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
+    if !pg_sys::process_shared_preload_libraries_in_progress {
+        ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_RAISE_EXCEPTION, "pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to the shared_preload_libraries configuration in the postgresql.conf file.");
+    }
+
     postgres::options::init();
     GUCS.init("pg_search");
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Introduces a check for whether the extension has been added in `pg_init`. Now when the extension is missing an error is thrown at `CREATE EXTENSION` time.

```sql
CREATE EXTENSION pg_search;

ERROR:  pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to the shared_preload_libraries configuration in the postgresql.conf file.
```

## Why
Reduces user error.

## How
See similar implementation by Citus: https://github.com/citusdata/citus/blob/f6959715dc49404510f2f3340b9719b33ddd152b/src/backend/distributed/shared_library_init.c#L392

## Tests
