### PR TITLE
ci: [Phil + Weijun] Create GitHub Actions workflow to allow users to self-assign issues

### DIFF
--- a/.github/workflows/assign-github-issue.yml
+++ b/.github/workflows/assign-github-issue.yml
@@ -1,24 +1,30 @@
-name: Assign Issue via 'take' Comment
+# workflows/assign-github-issue.yml
+#
+# Assign GitHub Issue
+# Automatically assign an issue to the commenter if they use the '/take' command.
+
+name: Assign GitHub Issue
 
 on:
   issue_comment:
     types: [created]
 
+# Required to assign the issue to the commenter
 permissions:
   issues: write
 
+concurrency:
+  group: assign-github-issue-${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
-  issue_assign:
-    runs-on: ubuntu-latest
-    if: |
-      !github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/take')
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.issue.number }}
-      cancel-in-progress: true
+  assign-github-issue:
+    name: Assign GitHub Issue to Commente
+    runs-on: depot-ubuntu-latest-2
+    if: !github.event.issue.pull_request && contains(github.event.comment.body, '/take')
 
     steps:
-      - name: Check if commenter can be assigned
+      - name: Check if Commenter Can Be Assigned
         id: check_assignee
         run: |
           HTTP_CODE=$(curl -X GET \
@@ -33,7 +39,7 @@ jobs:
             echo "can_assign=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Assign issue
+      - name: Assign GitHub Issue
         if: steps.check_assignee.outputs.can_assign == 'true'
         run: |
           curl -X POST \
@@ -44,7 +50,7 @@ jobs:
 
           echo "Issue #${{ github.event.issue.number }} assigned to ${{ github.event.comment.user.login }}"
 
-      - name: Comment if assignment failed
+      - name: Notify of Assignment Failure
         if: steps.check_assignee.outputs.can_assign == 'false'
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/assign-github-issue.yml
+++ b/.github/workflows/assign-github-issue.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   assign-github-issue:
-    name: Assign GitHub Issue to Commente
+    name: Assign GitHub Issue to Commenter
     runs-on: depot-ubuntu-latest-2
     if: !github.event.issue.pull_request && contains(github.event.comment.body, '/take')
 

--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,58 @@
+name: Assign Issue via 'take' Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  issue_assign:
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/take')
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check if commenter can be assigned
+        id: check_assignee
+        run: |
+          HTTP_CODE=$(curl -X GET \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -o /dev/null -w '%{http_code}\n' -s \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees/${{ github.event.comment.user.login }}")
+
+          if [ "$HTTP_CODE" -eq "204" ]; then
+            echo "can_assign=true" >> $GITHUB_OUTPUT
+          else
+            echo "can_assign=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Assign issue
+        if: steps.check_assignee.outputs.can_assign == 'true'
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees"
+
+          echo "Issue #${{ github.event.issue.number }} assigned to ${{ github.event.comment.user.login }}"
+
+      - name: Comment if assignment failed
+        if: steps.check_assignee.outputs.can_assign == 'false'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              body: '@${{ github.event.comment.user.login }} Unable to assign this issue to you. You may not have the necessary permissions.'
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,10 @@ from a maintainer to pick an issue.
 
 1. Before claiming an issue, ensure that:
 
-   - It's not already assigned to someone else
-   - There are no comments indicating ongoing work
+- It's not already assigned to someone else
+- There are no comments indicating ongoing work
 
-2. To claim an unassigned issue, simply comment `/take` on the issue.
-   This will automatically assign the issue to you.
+2. To claim an unassigned issue, simply comment `/take` on the issue. This will automatically assign the issue to you.
 
 If you find yourself unable to make progress, don't hesitate to seek help in the issue comments or in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ). If you no longer wish to
 work on the issue(s) you self-assigned, please use the `unassign me` link at the top of the issue(s) page to release it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,18 @@
 # **Contributing to ParadeDB**
 
-Welcome! We're excited that you're interested in contributing to ParadeDB and want
-to make the process as smooth as possible.
+Welcome! We're excited that you're interested in contributing to ParadeDB and want to make the process as smooth as possible.
 
-## Claiming and Working on Issues
+## Technical Info
 
-### How to Claim an Issue
+Before submitting a pull request, please review this document, which outlines what
+conventions to follow when submitting changes. If you have any questions not covered
+in this document, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ)
+or via [email](mailto:support@paradedb.com).
+
+### Claiming GitHub Issues
+
+This repository has a workflow to automatically assign issues to new contributors. This ensures that you don't need approval
+from a maintainer to pick an issue.
 
 1. Before claiming an issue, ensure that:
 
@@ -15,30 +22,8 @@ to make the process as smooth as possible.
 2. To claim an unassigned issue, simply comment `/take` on the issue.
    This will automatically assign the issue to you.
 
-### Unable to Make Progress?
-
-If you find yourself unable to make progress on an assigned issue:
-
-1. Unassign yourself:
-
-   - Use the `unassign me` link at the top of the issue page
-
-2. Seek help:
-
-   - If you're stuck, don't hesitate to ask for help in the issue comments
-   - Explain what you've tried and where you're having difficulties
-
-3. Allow others to contribute:
-   - By unassigning yourself, you open the opportunity for others to work on the issue
-
-Remember, our goal is to maintain an efficient workflow and foster collaboration. If you're unable to continue work on an issue, it's best to unassign yourself promptly so that others can pick up where you left off.
-
-## Technical Info
-
-Before submitting a pull request, please review this document, which outlines what
-conventions to follow when submitting changes. If you have any questions not covered
-in this document, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ)
-or via [email](mailto:support@paradedb.com).
+If you find yourself unable to make progress, don't hesitate to seek help in the issue comments or in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ). If you no longer wish to
+work on the issue(s) you self-assigned, please use the `unassign me` link at the top of the issue(s) page to release it.
 
 ### Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,36 @@
 Welcome! We're excited that you're interested in contributing to ParadeDB and want
 to make the process as smooth as possible.
 
+## Claiming and Working on Issues
+
+### How to Claim an Issue
+
+1. Before claiming an issue, ensure that:
+
+   - It's not already assigned to someone else
+   - There are no comments indicating ongoing work
+
+2. To claim an unassigned issue, simply comment `/take` on the issue.
+   This will automatically assign the issue to you.
+
+### Unable to Make Progress?
+
+If you find yourself unable to make progress on an assigned issue:
+
+1. Unassign yourself:
+
+   - Use the `unassign me` link at the top of the issue page
+
+2. Seek help:
+
+   - If you're stuck, don't hesitate to ask for help in the issue comments
+   - Explain what you've tried and where you're having difficulties
+
+3. Allow others to contribute:
+   - By unassigning yourself, you open the opportunity for others to work on the issue
+
+Remember, our goal is to maintain an efficient workflow and foster collaboration. If you're unable to continue work on an issue, it's best to unassign yourself promptly so that others can pick up where you left off.
+
 ## Technical Info
 
 Before submitting a pull request, please review this document, which outlines what


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1657 

## What
This is a small commit on top of @Weijun-H's work for a workflow for external contributors to self-assign issues.

## Why
See #1679 

## How
^

## Tests
^