### PR TITLE
chore: Remove Postgres 12 Support

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -40,9 +40,6 @@ jobs:
       matrix:
         include:
           - runner: depot-ubuntu-latest-8
-            pg_version: 12
-            arch: amd64
-          - runner: depot-ubuntu-latest-8
             pg_version: 13
             arch: amd64
           - runner: depot-ubuntu-latest-8

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For more information, including enterprise features and support, please [contact
 
 ### Extensions
 
-You can find prebuilt binaries for all ParadeDB extensions on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15 and 16 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). We officially support Postgres 12 and above, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
+You can find prebuilt binaries for all ParadeDB extensions on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15 and 16 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). ParadeDB supports all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 13+, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
 
 ### Docker Image
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["pg16"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -10,7 +10,7 @@
 
 `pg_search` is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using `pgrx`.
 
-`pg_search` is supported on all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 12+.
+`pg_search` is supported on all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 13+.
 
 Check out the `pg_search` benchmarks [here](../benchmarks/README.md).
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -263,20 +263,6 @@ fn do_heap_scan<'a>(
     state
 }
 
-#[cfg(feature = "pg12")]
-#[pg_guard]
-unsafe extern "C" fn build_callback(
-    index: pg_sys::Relation,
-    htup: pg_sys::HeapTuple,
-    values: *mut pg_sys::Datum,
-    isnull: *mut bool,
-    _tuple_is_alive: bool,
-    state: *mut std::os::raw::c_void,
-) {
-    let htup = htup.as_ref().expect("HeapTuple pointer should not be null");
-    build_callback_internal(htup.t_self, values, isnull, state, index);
-}
-
 #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
 #[pg_guard]
 unsafe extern "C" fn build_callback(

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn aminsert(
     aminsert_internal(index_relation, values, isnull, heap_tid, &uuid)
 }
 
-#[cfg(any(feature = "pg12", feature = "pg13"))]
+#[cfg(feature = "pg13")]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -228,7 +228,7 @@ pub fn relfilenode_from_index_oid(index_oid: u32) -> pg_sys::Oid {
 
 /// Retrieves the `relfilenode` from a `PgRelation`, handling PostgreSQL version differences.
 pub fn relfilenode_from_pg_relation(index_relation: &PgRelation) -> pg_sys::Oid {
-    #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
+    #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
     {
         index_relation.rd_node.relNode
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Imagine supporting Postgres 12. Yuck.

## Why
It's getting deprecated by the PGDG now that 17 is just about out. Time to move on.

## How
Remove code!

## Tests
CI passes on all other versions