### PR TITLE
fix: issue #1693:  `Var` relation lookup is more correct

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -27,11 +27,11 @@ use crate::schema::SearchConfig;
 use crate::writer::WriterDirectory;
 use pgrx::callconv::{BoxRet, FcInfo};
 use pgrx::datum::Datum;
-use pgrx::pg_sys::{planner_rt_fetch, Node, SupportRequestSimplify};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
 use pgrx::*;
+use std::ffi::CStr;
 use std::ptr::NonNull;
 
 #[repr(transparent)]
@@ -131,8 +131,8 @@ fn estimate_selectivity(
 }
 
 unsafe fn make_search_config_opexpr_node(
-    srs: *mut SupportRequestSimplify,
-    input_args: &mut PgList<Node>,
+    srs: *mut pg_sys::SupportRequestSimplify,
+    input_args: &mut PgList<pg_sys::Node>,
     var: *mut pg_sys::Var,
     query: SearchQueryInput,
 ) -> ReturnedNodePointer {
@@ -152,10 +152,14 @@ unsafe fn make_search_config_opexpr_node(
         location: (*(*srs).fcall).location,
     };
 
+    let (relid, varattno) = find_var_relation(var, (*srs).root);
+    if relid == pg_sys::Oid::INVALID {
+        panic!("could not determine relation for var");
+    }
+
     // we need to use what should be the only `USING bm25` index on the table
-    let rte = planner_rt_fetch((*var).varno as pg_sys::Index, (*srs).root);
-    let heaprel = PgRelation::open((*rte).relid);
-    let indexrel = locate_bm25_index((*rte).relid).unwrap_or_else(|| {
+    let heaprel = PgRelation::open(relid);
+    let indexrel = locate_bm25_index(relid).unwrap_or_else(|| {
         panic!(
             "relation `{}.{}` must have a `USING bm25` index",
             heaprel.namespace(),
@@ -165,7 +169,7 @@ unsafe fn make_search_config_opexpr_node(
 
     let keys = &(*indexrel.rd_index).indkey;
     let keys = keys.values.as_slice(keys.dim1 as usize);
-    if keys[0] != (*var).varattno {
+    if keys[0] != varattno {
         panic!("left-hand side of the @@@ operator must match the first column of the only `USING bm25` index");
     }
 
@@ -199,6 +203,89 @@ unsafe fn make_search_config_opexpr_node(
         .copy_ptr_into(&mut newopexpr, std::mem::size_of::<pg_sys::OpExpr>());
 
     ReturnedNodePointer(NonNull::new(node.cast()))
+}
+
+/// Given a [`pg_sys::Var`] and a [`pg_sys::PlannerInfo`], attempt to find the relation Oid that
+/// contains the var.
+///
+/// It's possible the returned Oid will be [`pg_sys::Oid::INVALID`] if the Var doesn't eventually
+/// come from a relation relation.
+///
+/// The returned [`pg_sys::AttrNumber`] is the physical attribute number in the relation the Var
+/// is from.
+unsafe fn find_var_relation(
+    var: *mut pg_sys::Var,
+    root: *mut pg_sys::PlannerInfo,
+) -> (pg_sys::Oid, pg_sys::AttrNumber) {
+    let query = (*root).parse;
+    let rte = pg_sys::rt_fetch((*var).varno as pg_sys::Index, (*query).rtable);
+
+    match (*rte).rtekind {
+        // the Var comes from a relation
+        pg_sys::RTEKind::RTE_RELATION => ((*rte).relid, (*var).varattno),
+
+        // the Var comes from a subquery, so dig into its target list and find the original
+        // table it comes from along with its original column AttributeNumber
+        pg_sys::RTEKind::RTE_SUBQUERY => {
+            let targetlist = PgList::<pg_sys::TargetEntry>::from_pg((*(*rte).subquery).targetList);
+            let te = targetlist
+                .get_ptr((*var).varattno as usize - 1)
+                .expect("var should exist in subquery TargetList");
+            ((*te).resorigtbl, (*te).resorigcol)
+        }
+
+        // the Var comes from a CTE, so lookup that CTE and find it in the CTE's target list
+        pg_sys::RTEKind::RTE_CTE => {
+            let mut levelsup = (*rte).ctelevelsup;
+            let mut cteroot = root;
+            while levelsup > 0 {
+                cteroot = (*cteroot).parent_root;
+                if cteroot.is_null() {
+                    // shouldn't happen
+                    panic!(
+                        "bad levelsup for CTE \"{}\"",
+                        CStr::from_ptr((*rte).ctename).to_string_lossy()
+                    )
+                }
+                levelsup -= 1;
+            }
+
+            let rte_ctename = CStr::from_ptr((*rte).ctename);
+            let ctelist = PgList::<pg_sys::CommonTableExpr>::from_pg((*(*cteroot).parse).cteList);
+            let mut matching_cte = None;
+            for cte in ctelist.iter_ptr() {
+                let ctename = CStr::from_ptr((*cte).ctename);
+
+                if ctename == rte_ctename {
+                    matching_cte = Some(cte);
+                    break;
+                }
+            }
+
+            let cte = matching_cte.unwrap_or_else(|| {
+                panic!(
+                    "unable to find cte named \"{}\"",
+                    rte_ctename.to_string_lossy()
+                )
+            });
+
+            if !is_a((*cte).ctequery, pg_sys::NodeTag::T_Query) {
+                panic!("CTE is not a query")
+            }
+            let query = (*cte).ctequery.cast::<pg_sys::Query>();
+            let targetlist = if !(*query).returningList.is_null() {
+                PgList::<pg_sys::TargetEntry>::from_pg((*query).returningList)
+            } else {
+                PgList::<pg_sys::TargetEntry>::from_pg((*query).targetList)
+            };
+            let te = targetlist
+                .get_ptr((*var).varattno as usize - 1)
+                .expect("var should exist in cte TargetList");
+
+            ((*te).resorigtbl, (*te).resorigcol)
+        }
+        _ => panic!("unsupported RTEKind: {}", (*rte).rtekind),
+    }
 }
 
 extension_sql!(

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -16,14 +16,13 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::operator::{
-    anyelement_query_input_opoid, estimate_selectivity, make_search_config_opexpr_node,
-    ReturnedNodePointer,
+    anyelement_query_input_opoid, estimate_selectivity, find_var_relation,
+    make_search_config_opexpr_node, ReturnedNodePointer,
 };
 use crate::postgres::utils::{locate_bm25_index, relfilenode_from_pg_relation};
 use crate::query::SearchQueryInput;
 use crate::schema::SearchConfig;
 use crate::UNKNOWN_SELECTIVITY;
-use pgrx::pg_sys::planner_rt_fetch;
 use pgrx::{is_a, pg_extern, pg_sys, AnyElement, FromDatum, Internal, PgList};
 
 /// This is the function behind the `@@@(anyelement, paradedb.searchqueryinput)` operator. Since we
@@ -99,18 +98,15 @@ pub fn query_input_restrict(
                 let var = lhs.cast::<pg_sys::Var>();
                 let const_ = rhs.cast::<pg_sys::Const>();
 
-                let rte = planner_rt_fetch((*var).varno as pg_sys::Index, info);
-                if !rte.is_null() {
-                    let heaprelid = (*rte).relid;
-                    let indexrel = locate_bm25_index(heaprelid)?;
-                    let relfilenode = relfilenode_from_pg_relation(&indexrel);
+                let (heaprelid, _) = find_var_relation(var, info);
+                let indexrel = locate_bm25_index(heaprelid)?;
+                let relfilenode = relfilenode_from_pg_relation(&indexrel);
 
-                    let query =
-                        SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
-                    let search_config = SearchConfig::from((query, indexrel));
+                let query =
+                    SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
+                let search_config = SearchConfig::from((query, indexrel));
 
-                    return estimate_selectivity(heaprelid, relfilenode, &search_config);
-                }
+                return estimate_selectivity(heaprelid, relfilenode, &search_config);
             }
 
             None

--- a/pg_search/tests/find_var_relation.rs
+++ b/pg_search/tests/find_var_relation.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use shared::fixtures::db::Query;
+use sqlx::PgConnection;
+
+#[rstest]
+fn test_subselect(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE test_subselect(id serial8, t text);
+        INSERT INTO test_subselect(t) VALUES ('this is a test');
+        CALL paradedb.create_bm25(
+            index_name => 'test_subselect',
+            table_name => 'test_subselect',
+            key_field => 'id',
+            text_fields => paradedb.field('t')
+        );
+    "#
+    .execute(&mut conn);
+
+    let (id,) = r#"
+        select id from (select random(), * from (select random(), t, id from test_subselect) x) test_subselect 
+        where id @@@ 't:test';"#
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(id, 1);
+}
+
+#[rstest]
+fn test_cte(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE test_cte(id serial8, t text);
+        INSERT INTO test_cte(t) VALUES ('beer wine cheese');
+        INSERT INTO test_cte(t) VALUES ('beer cheese');
+        CALL paradedb.create_bm25(
+            index_name => 'test_cte',
+            table_name => 'test_cte',
+            key_field => 'id',
+            text_fields => paradedb.field('t')
+        );
+    "#
+    .execute(&mut conn);
+
+    let (id,) = r#"
+        with my_cte as (select * from test_cte)
+        select * from my_cte a inner join my_cte b on a.id = b.id
+        where a.id @@@ 't:beer' and b.id @@@ 't:cheese' order by a.id;"#
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(id, 1);
+}
+
+#[rstest]
+fn test_cte2(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE test_cte(id serial8, t text);
+        INSERT INTO test_cte(t) VALUES ('beer wine cheese');
+        INSERT INTO test_cte(t) VALUES ('beer cheese');
+        CALL paradedb.create_bm25(
+            index_name => 'test_cte',
+            table_name => 'test_cte',
+            key_field => 'id',
+            text_fields => paradedb.field('t')
+        );
+    "#
+    .execute(&mut conn);
+
+    let (id,) = r#"
+        with my_cte as (select * from test_cte)
+        select * from my_cte where id @@@ 't:beer' order by id;"#
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(id, 1);
+}
+
+#[rstest]
+fn test_plain_relation(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE test_plain_relation(id serial8, t text);
+        INSERT INTO test_plain_relation(t) VALUES ('beer wine cheese');
+        INSERT INTO test_plain_relation(t) VALUES ('beer cheese');
+        CALL paradedb.create_bm25(
+            index_name => 'test_plain_relation',
+            table_name => 'test_plain_relation',
+            key_field => 'id',
+            text_fields => paradedb.field('t')
+        );
+    "#
+    .execute(&mut conn);
+
+    let (id,) =
+        "select id from test_plain_relation where id @@@ 't:beer'".fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(id, 1);
+}

--- a/pg_search/tests/find_var_relation.rs
+++ b/pg_search/tests/find_var_relation.rs
@@ -93,7 +93,6 @@ fn test_plain_relation(mut conn: PgConnection) {
     r#"
         CREATE TABLE test_plain_relation(id serial8, t text);
         INSERT INTO test_plain_relation(t) VALUES ('beer wine cheese');
-        INSERT INTO test_plain_relation(t) VALUES ('beer cheese');
         CALL paradedb.create_bm25(
             index_name => 'test_plain_relation',
             table_name => 'test_plain_relation',


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1693

## What

This addresses issue #1693 by implementing a more robust function for finding a `Var`'s original relation (if it has one).

## Why

To support more query plans, because we should not limit the SQL a user can execute.

## How

By better looking through the [`pg_sys::PlannerInfo`] structure's Query, differently, depending on if the referenced field (`Var`) comes from a relation, a subquery, or a CTE.

It's likely this isn't complete, but it directly addresses the edge cases I've uncovered thus far.  If we have to revisit this in the future we now have a single function that can be improved.

## Tests

A few new tests were added in the new `find_var_relation.rs` file