### PR TITLE
docs: use -Fc on pg_restore too

### DIFF
--- a/docs/ingest/postgres.mdx
+++ b/docs/ingest/postgres.mdx
@@ -9,6 +9,8 @@ install `psql`.
 
 Run `pg_dump` to create a copy of your database.
 
+Below, we use the "custom" format (`-Fc`) for both `pg_dump` and `pg_restore`. Please review the [Postgres `pg_dump` documentation](https://www.postgresql.org/docs/current/app-pgdump.html) for other options that may be more appropriate for your environment.
+
 <Note>
   Replace `host`, `username`, and `dbname` with your existing database
   credentials.
@@ -44,5 +46,6 @@ pg_restore --verbose --clean --no-acl --no-owner \
     -h <host> \
     -U <username> \
     -d <dbname> \
+    -Fc \
     old_db.dump
 ```


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Our "Ingest" docs use `-Fc` when dumping the database but fail to use it on the corresponding `pg_restore` command.

Also add a link to the Postgres `pg_dump` docs.

## Why

## How

## Tests
