### PR TITLE
feat: a GUC for `per_tuple_cost`

### DIFF
--- a/pg_search/src/api/operator/searchconfig.rs
+++ b/pg_search/src/api/operator/searchconfig.rs
@@ -25,12 +25,13 @@ use crate::postgres::utils::relfilenode_from_index_oid;
 use crate::postgres::utils::{locate_bm25_index, relfilenode_from_pg_relation};
 use crate::schema::SearchConfig;
 use crate::writer::WriterDirectory;
-use crate::{DEFAULT_STARTUP_COST, UNKNOWN_SELECTIVITY};
+use crate::{GUCS, UNKNOWN_SELECTIVITY};
 use pgrx::{
     check_for_interrupts, is_a, pg_extern, pg_func_extra, pg_sys, AnyElement, FromDatum, Internal,
     JsonB, PgList, PgOid,
 };
 use rustc_hash::FxHashSet;
+use shared::gucs::GlobalGucSettings;
 use std::ptr::NonNull;
 
 #[pg_extern(immutable, parallel_safe)]
@@ -90,13 +91,23 @@ pub fn search_config_support(arg: Internal) -> ReturnedNodePointer {
 
         match (*node).type_ {
             // our `search_with_*` functions are *incredibly* expensive.  So much so that
-            // we really don't ever want Postgres to prefer them.  As such, hardcode in some
-            // big numbers.
+            // we really don't ever want Postgres to prefer them.
+            //
+            // The higher the `per_tuple` cost is here, the better.
             pg_sys::NodeTag::T_SupportRequestCost => {
                 let src = node.cast::<pg_sys::SupportRequestCost>();
 
-                (*src).startup = DEFAULT_STARTUP_COST;
-                (*src).per_tuple = pg_sys::cpu_index_tuple_cost * 10_000.0;
+                // it can cost a lot to startup the `@@@` operator outside of an IndexScan because
+                // ultimately we have to hash all the resulting ctids in memory.  For lack of a better
+                // value, we say it costs as much as the `GUCS.per_tuple_cost()`.  This is an arbitrary
+                // number that we've documented as needing to be big.
+                (*src).startup = GUCS.per_tuple_cost();
+
+                // similarly, use the same GUC here.  Postgres will then add this into its per-tuple
+                // cost evalutations for whatever scan it's considering using for the `@@@` operator.
+                // our IAM provides more intelligent costs for the IndexScan situation.
+                (*src).per_tuple = GUCS.per_tuple_cost();
+
                 ReturnedNodePointer(NonNull::new(node))
             }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This introduces a new GUC (`paradedb.per_tuple_cost`) that describes how much it costs for us to retrieve a single tuple from a tantivy index in situations that are **NOT** Index Scans.

In our case, it costs **A LOT** and we'd prefer Postgres only consider not using an Index Scan if there's literally no other option.  As such, the default for this new GUC is one hundred million!

## Why

Prior to this, our per-tuple costing calculations were way off.  I think I misread the default value for `pg_sys::cpu_index_tuple_cost`, so our little formula of multiplying that by 10k really didn't do enough to encourage Postgres to not directly use our `@@@` operator.

Having this as a GUC will let us experiment a bit with "what if..." scenarios, if necessary.

## How

Rather than fumble around with some kind of complex formula, just introduce a new GUC with a very large default value.  In our case, we never want Postgres to run the function behind our `@@@` operator unless it literally has no choice.  So a very large value here is much preferred.

## Tests

Existing tests pass