### PR TITLE
docs: Colocate quickstart guide with API reference

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,7 @@
 **/*.txt
 **/*.zip
 /docker/.docker_cache_dev/
-/docs/welcome/quickstart.mdx
+/docs/api-reference/getting-started/quickstart.mdx
 /docs/api-reference/full-text/fuzzy.mdx
 /docs/api-reference/full-text/scoring.mdx
 /docs/api-reference/full-text/highlighting.mdx

--- a/docs/api-reference/getting-started/install.mdx
+++ b/docs/api-reference/getting-started/install.mdx
@@ -2,7 +2,7 @@
 title: Install ParadeDB
 ---
 
-The fastest way to install ParadeDB is by pulling the ParadeDB docker image and running it locally.
+The fastest way to install ParadeDB is by pulling the ParadeDB Docker image and running it locally.
 
 ```bash
 docker run \
@@ -16,8 +16,8 @@ docker run \
   paradedb/paradedb:latest
 ```
 
-You may replace `myuser`, `mypassword`, and `mydatabase` with whatever values you want — these will be your database
-connection credentials. By default, this will start a ParadeDB instance at `http://localhost:5432`.
+You may replace `myuser`, `mypassword`, and `mydatabase` with whatever values you want. These will be your database
+connection credentials.
 
 To connect to ParadeDB, install the `psql` client and run
 
@@ -32,4 +32,4 @@ docker exec -it paradedb psql -U myuser -d mydatabase -W
   database.
 </Note>
 
-That's it! Next, let's [run a few queries](/welcome/quickstart) over mock data with ParadeDB.
+That's it! Next, let's [run a few queries](/api-reference/getting-started/quickstart) over mock data with ParadeDB.

--- a/docs/api-reference/getting-started/quickstart.mdx
+++ b/docs/api-reference/getting-started/quickstart.mdx
@@ -35,16 +35,19 @@ LIMIT 3;
 ```
 </Accordion>
 
-Next, let's create a BM25 index called `default_idx` on this table. We'll index the
-`description`, `category`, and `rating` fields.
+Next, let's create a BM25 index called `search_idx` on this table. A BM25 index is a covering index, which means that multiple columns can be included in the same index.
+The following code block demonstrates the various Postgres types that can be combined inside a single index.
 
 ```sql
 CALL paradedb.create_bm25(
-  index_name => 'default_idx',
+  index_name => 'search_idx',
   table_name => 'mock_items',
   key_field => 'id',
   text_fields => paradedb.field('description') || paradedb.field('category'),
-  numeric_fields => paradedb.field('rating')
+  numeric_fields => paradedb.field('rating'),
+  boolean_fields => paradedb.field('in_stock'),
+  datetime_fields => paradedb.field('created_at'),
+  json_fields => paradedb.field('metadata')
 );
 ```
 
@@ -54,12 +57,16 @@ be the name of a column that will function as a row's unique identifier within t
 can just be the name of your table's primary key column.
 </Note>
 
+<Note>
+The [indexing](/api-reference/indexing) documentation provides an in-depth explanation of what each of these options means.
+</Note>
+
 We're now ready to execute a full-text search. We'll look for rows with a `rating` greater than `2` where `description` matches `keyboard`
 or `category` matches `electronics`.
 
 ```sql
 SELECT description, rating, category
-FROM default_idx.search(
+FROM search_idx.search(
   '(description:keyboard OR category:electronics) AND rating:>2',
   limit_rows => 5
 );
@@ -91,7 +98,7 @@ if there is a word between `bluetooth` and `speaker`.
 
 ```sql
 SELECT description, rating, category
-FROM default_idx.search('description:"bluetooth speaker"~1');
+FROM search_idx.search('description:"bluetooth speaker"~1');
 ```
 
 <Accordion title="Expected Response">
@@ -110,7 +117,7 @@ Finally, let's use the `snippet` function to examine the BM25 scores and generat
 highlighted snippets for our results.
 
 ```sql
-SELECT * FROM default_idx.snippet(
+SELECT * FROM search_idx.snippet(
   'description:bluetooth',
   highlight_field => 'description'
 );
@@ -130,7 +137,7 @@ next to the original data:
 
 ```sql
 WITH snippet AS (
-    SELECT * FROM default_idx.snippet(
+    SELECT * FROM search_idx.snippet(
       'description:bluetooth',
       highlight_field => 'description'
     )

--- a/docs/api-reference/guides/hybrid.mdx
+++ b/docs/api-reference/guides/hybrid.mdx
@@ -6,7 +6,7 @@ ParadeDB's full text and similarity search APIs can be combined in the same quer
 
 <Note>
 This guide uses the [`mock_items` table](/api-reference/introduction#get-started). It assumes that the entire
-[quickstart](/welcome/quickstart) tutorial has been completed, including the vector search section.
+[quickstart](/api-reference/getting-started/quickstart) tutorial has been completed, including the vector search section.
 </Note>
 
 ## Reciprocal Rank Fusion

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -5,34 +5,7 @@ title: Introduction
 ## Overview
 
 ParadeDB uses PostgreSQL operators and functions to enable full text and similarity search over Postgres tables.
-To develop a feel for the API, we recommend going through the [quickstart](/welcome/quickstart) first.
 
-## Get Started
-
-All code blocks in this section reference a table called `mock_items` and a BM25 index called `search_idx`.
-We recommend creating these relations in your database to follow along.
-
-To create `mock_items`, simply run the `paradedb.create_bm25_test_table` procedure.
-
-```sql
-CALL paradedb.create_bm25_test_table(
-  schema_name => 'public',
-  table_name => 'mock_items'
-);
-```
-
-To create `search_idx`, run the following procedure. The [indexing](/api-reference/indexing) section provides details on how this
-statement works.
-
-```sql
-CALL paradedb.create_bm25(
-  index_name => 'search_idx',
-  table_name => 'mock_items',
-  key_field => 'id',
-  text_fields => paradedb.field('description') || paradedb.field('category'),
-  numeric_fields => paradedb.field('rating'),
-  boolean_fields => paradedb.field('in_stock'),
-  datetime_fields => paradedb.field('created_at'),
-  json_fields => paradedb.field('metadata')
-);
-```
+All code blocks in this section reference a table called `mock_items` and a BM25 index called `search_idx`, which were created in the
+[quickstart](/api-reference/getting-started/quickstart). We recommend going through the [quickstart](/api-reference/getting-started/quickstart) first to develop a feel for the API
+and create the example BM25 index.

--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -92,7 +92,7 @@ Once the extension binary is installed on your system, connect to your Postgres 
 CREATE EXTENSION pg_search;
 ```
 
-That's it! You're all set to use `pg_search` in your database. To get started, we suggest you follow the [quickstart guide](/welcome/quickstart).
+That's it! You're all set to use `pg_search` in your database. To get started, we suggest you follow the [quickstart guide](/api-reference/getting-started/quickstart).
 
 <Note>
   `pg_search` can be combined with `pgvector` for hybrid search. You can find

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -79,38 +79,23 @@
       "group": "Welcome",
       "pages": [
         "welcome/introduction",
-        {
-          "group": "Getting Started",
-          "pages": [
-            "welcome/install",
-            "welcome/quickstart"
-          ]
-        },
         "welcome/support"
       ]
     },
     {
       "group": "Search",
       "pages": [
-        "api-reference/introduction",
         {
-          "group": "Concepts",
+          "group": "Getting Started",
           "pages": [
-            "api-reference/concepts/aggregation",
-            "api-reference/concepts/bm25",
-            "api-reference/concepts/faceting",
-            "api-reference/concepts/index",
-            "api-reference/concepts/matching",
-            "api-reference/concepts/phrase",
-            "api-reference/concepts/search",
-            "api-reference/concepts/stemming",
-            "api-reference/concepts/tantivy",
-            "api-reference/concepts/term"
+            "api-reference/getting-started/install",
+            "api-reference/getting-started/quickstart"
           ]
         },
         {
           "group": "Reference",
           "pages": [
+            "api-reference/introduction",
             {
               "group": "Indexing",
               "pages": [
@@ -195,6 +180,21 @@
             "api-reference/guides/overview",
             "api-reference/guides/autocomplete",
             "api-reference/guides/hybrid"
+          ]
+        },
+        {
+          "group": "Concepts",
+          "pages": [
+            "api-reference/concepts/aggregation",
+            "api-reference/concepts/bm25",
+            "api-reference/concepts/faceting",
+            "api-reference/concepts/index",
+            "api-reference/concepts/matching",
+            "api-reference/concepts/phrase",
+            "api-reference/concepts/search",
+            "api-reference/concepts/stemming",
+            "api-reference/concepts/tantivy",
+            "api-reference/concepts/term"
           ]
         }
       ]

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -31,10 +31,14 @@ ParadeDB is a good fit for:
 You're now ready to jump into our guides.
 
 <CardGroup cols={2}>
-  <Card title="Getting Started" icon="forward-fast" href="/welcome/install">
+  <Card
+    title="Getting Started"
+    icon="forward-fast"
+    href="/api-reference/getting-started"
+  >
     Get started with ParadeDB in under five minutes.
   </Card>
-  <Card title="API" icon="code" href="/api-reference/introduction">
+  <Card title="API" icon="code" href="/api-reference">
     API reference for full text, similarity, and hybrid search.
   </Card>
   <Card title="Ingest" icon="merge" href="/ingest/quickstart">


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Moves the quickstart guide to the same page as the API reference/tutorials. We had a user report that they weren't able to find the reference page after completing the quickstart, this makes it easier to find.

I also modified the quickstart guide to use the same exact table and BM25 index as the reference tutorial so there would be no confusion.

## Why

## How

## Tests
