### PR TITLE
feat: support Index Only Scans

### DIFF
--- a/pg_search/src/api/search.rs
+++ b/pg_search/src/api/search.rs
@@ -92,13 +92,15 @@ unsafe fn score_bm25(
         .filter(move |(scored, _)| vischeck.ctid_satisfies_snapshot(scored.ctid))
         .map(move |(scored, _)| {
             let key = unsafe {
+                let datum = scored
+                    .key
+                    .expect("key should have been retrieved")
+                    .try_into_datum(PgOid::from_untagged(key_oid))
+                    .expect("failed to convert key_field to datum");
+                let isnull = datum.is_none();
                 datum::AnyElement::from_polymorphic_datum(
-                    scored
-                        .key
-                        .expect("key should have been retrieved")
-                        .try_into_datum(PgOid::from_untagged(key_oid))
-                        .expect("failed to convert key_field to datum"),
-                    false,
+                    datum.unwrap_or(pg_sys::Datum::null()),
+                    isnull,
                     key_oid,
                 )
                 .expect("null found in key_field")
@@ -163,13 +165,15 @@ unsafe fn snippet(
         .filter(move |(scored, _)| vischeck.ctid_satisfies_snapshot(scored.ctid))
         .map(move |(scored, doc_address)| {
             let key = unsafe {
+                let datum = scored
+                    .key
+                    .expect("key should have been retrieved")
+                    .try_into_datum(PgOid::from_untagged(key_oid))
+                    .expect("failed to convert key_field to datum");
+                let isnull = datum.is_none();
                 datum::AnyElement::from_polymorphic_datum(
-                    scored
-                        .key
-                        .expect("key should have been retrieved")
-                        .try_into_datum(PgOid::from_untagged(key_oid))
-                        .expect("failed to convert key_field to datum"),
-                    false,
+                    datum.unwrap_or(pg_sys::Datum::null()),
+                    isnull,
                     key_oid,
                 )
                 .expect("null found in key_field")

--- a/pg_search/src/index/state.rs
+++ b/pg_search/src/index/state.rs
@@ -467,8 +467,11 @@ mod collector {
 
         fn harvest(mut self) -> Self::Fruit {
             // ordering by ctid helps to avoid random heap access, at least for the docs that
-            // were found in this segment
-            self.fruit.sort_by_key(|(scored, _)| scored.ctid);
+            // were found in this segment.  But we don't need to do it if we're also retrieving
+            // the "key_field".
+            if self.key_ff.is_none() {
+                self.fruit.sort_by_key(|(scored, _)| scored.ctid);
+            }
 
             // if send fails that likely means the receiver was dropped so we have nowhere
             // to send the result.  That's okay

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -84,6 +84,7 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     amroutine.amgettuple = Some(scan::amgettuple);
     amroutine.amgetbitmap = Some(scan::amgetbitmap);
     amroutine.amendscan = Some(scan::amendscan);
+    amroutine.amcanreturn = Some(scan::amcanreturn);
 
     amroutine.into_pg_boxed()
 }

--- a/pg_search/tests/index_only_scan.rs
+++ b/pg_search/tests/index_only_scan.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use shared::fixtures::db::Query;
+use sqlx::PgConnection;
+
+#[rstest]
+fn index_only_scan_on_key_field(mut conn: PgConnection) {
+    use serde_json::Value;
+
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT id FROM paradedb.bm25_search WHERE id @@@ 'description:keyboard'".fetch_one::<(Value,)>(&mut conn);
+    let plan = plan
+        .get(0)
+        .unwrap()
+        .as_object()
+        .unwrap()
+        .get("Plan")
+        .unwrap()
+        .as_object()
+        .unwrap();
+    eprintln!("{plan:#?}");
+    pretty_assertions::assert_eq!(
+        plan.get("Node Type"),
+        Some(&Value::String(String::from("Index Only Scan")))
+    );
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # n/a

## What

This teaches our IAM impl how to do "Index Only Scans', but only for the index's "key_field".

## Why

Speed.

## How

We now implement the `amcanreturn` function and return true for the first index attribute if it's a number/float/bool.  This enables Postgres to plan an Index Only Scan for queries that only return that field, which can be quite many.

In one particular case, a query planned as a regular Index Scan took about 6s to return 21M rows and now it takes about 2.4s to return those same 21M rows right out of the underlying tantivy index.

In other cases, with a smaller number of rows, I've seen queries go from about 300ms to 25ms.

## Tests

Existing tests pass and added a new one to verify we get an Index Only Scan when we think we should.