### PR TITLE
chore: Don't hardcode such a specific PostGIS version & remove pgvectorscale

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -234,14 +234,11 @@ RUN apt-get update && \
 
 # Install Postgis and ca-certificates
 # ca-certificates required for TLS connection to PostHog (which is used for telemetry) and PostGIS
-ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg120+1
-
+ENV POSTGIS_VERSION_MAJOR 3
 RUN apt-get update \
-    && apt-cache showpkg postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR \
     && apt-get install -y --no-install-recommends \
-    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_VERSION_MAJOR \
+    postgresql-$PG_VERSION_MAJOR-postgis-$POSTGIS_VERSION_MAJOR-scripts \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,9 +46,8 @@ COPY pg_search/Cargo.toml ./
 RUN PGRX_VERSION=$(sed -n 's/^pgrx *= *"=*\([0-9.]*\)"/\1/p' Cargo.toml) && \
     echo "PGRX_VERSION=$PGRX_VERSION" && \
     cargo install --locked cargo-pgrx --version "${PGRX_VERSION}" && \
-    cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
-
-RUN rm -rf /tmp/Cargo.toml
+    cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config" && \
+    rm -rf /tmp/Cargo.toml
 
 ######################
 # pg_search
@@ -147,6 +146,11 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 ######################
 
 FROM builder AS builder-pg_cron
+
+ARG PG_VERSION_MAJOR=16
+
+# Ensure we're using the correct PostgreSQL version
+ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
 
 # Build the extension
 WORKDIR /tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,35 +113,6 @@ RUN export PG_CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-comp
     make USE_PGXS=1 OPTFLAGS="" -j
 
 ######################
-# pgvectorscale
-######################
-
-FROM builder AS builder-pgvectorscale
-
-ARG TARGETARCH
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
-
-# Clone the pgvectorscale repository
-WORKDIR /tmp
-RUN git clone --branch 0.3.0 https://github.com/timescale/pgvectorscale.git
-WORKDIR /tmp/pgvectorscale/pgvectorscale
-
-# Intall the pgrx version of pgvectorscale
-RUN PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pgvectorscale | head -n 1 | cut -f2 -dv) && \
-    echo "PGRX_VERSION=$PGRX_VERSION" && \
-    cargo install --locked cargo-pgrx --version "${PGRX_VERSION}" && \
-    cargo pgrx init "--pg${PG_VERSION_MAJOR}=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
-
-# Build the extension
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        # Required for pgvectorscale to compile on x86_64/amd64
-        RUSTFLAGS="-C target-feature=+avx2,+fma" cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"; \
-    else \
-        cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"; \
-    fi
-
-######################
 # pg_cron
 ######################
 
@@ -190,13 +161,10 @@ ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
 
-
 # Copy third-party extensions from their builder stages
 COPY --from=builder-pgvector /tmp/pgvector/*.so /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
 COPY --from=builder-pgvector /tmp/pgvector/*.control /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 COPY --from=builder-pgvector /tmp/pgvector/sql/*.sql /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
-COPY --from=builder-pgvectorscale /tmp/pgvectorscale/pgvectorscale/target/release/vectorscale-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
-COPY --from=builder-pgvectorscale /tmp/pgvectorscale/pgvectorscale/target/release/vectorscale-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 COPY --from=builder-pg_cron /tmp/pg_cron/*.so /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
 COPY --from=builder-pg_cron /tmp/pg_cron/*.control /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 COPY --from=builder-pg_cron /tmp/pg_cron/*.sql /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,6 +103,9 @@ RUN cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/
 
 FROM builder AS builder-pgvector
 
+ARG PG_VERSION_MAJOR=16
+ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
+
 # Build the extension
 WORKDIR /tmp
 RUN git clone --branch v0.7.4 https://github.com/pgvector/pgvector.git
@@ -119,8 +122,6 @@ RUN export PG_CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-comp
 FROM builder AS builder-pg_cron
 
 ARG PG_VERSION_MAJOR=16
-
-# Ensure we're using the correct PostgreSQL version
 ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
 
 # Build the extension
@@ -137,6 +138,9 @@ RUN echo "trusted = true" >> pg_cron.control && \
 
 FROM builder AS builder-pg_ivm
 
+ARG PG_VERSION_MAJOR=16
+ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
+
 # Build the extension
 WORKDIR /tmp
 RUN git clone --branch v1.9 https://github.com/sraoss/pg_ivm.git
@@ -148,6 +152,7 @@ RUN echo "trusted = true" >> pg_ivm.control && \
 ###############################################
 # Second Stage: PostgreSQL and Barman Cloud
 ###############################################
+
 FROM postgres:${PG_VERSION_MAJOR}-bookworm AS paradedb
 
 LABEL maintainer="ParadeDB - https://paradedb.com" \

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -24,7 +24,6 @@ for DB in template_paradedb "$POSTGRES_DB"; do
     CREATE EXTENSION IF NOT EXISTS pg_analytics;
     CREATE EXTENSION IF NOT EXISTS pg_ivm;
     CREATE EXTENSION IF NOT EXISTS vector;
-    CREATE EXTENSION IF NOT EXISTS vectorscale;
 
     CREATE EXTENSION IF NOT EXISTS postgis;
     CREATE EXTENSION IF NOT EXISTS postgis_topology;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This was causing issues with needing to update often, as in #1707. This should be more maintainable.

No one is using `pgvectorscale` and it's bloating the Dockerfile, so I'm removing it.

We also need to remove it on our Helm Chart

## Why
^

## How
Only use the major version.

## Tests
See CI