### PR TITLE
chore: Add Postgres 17 Support

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [16, 17]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        pg_version: [16, 17]
+        pg_version: [17]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [16, 17]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        pg_version: [16, 17]
+        pg_version: [16]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
-        pg_version: [16, 17]
+        pg_version: [17]
 
     steps:
       - name: Checkout Git Repository
@@ -102,7 +102,7 @@ jobs:
     runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
-        pg_version: [16, 17]
+        pg_version: [17]
 
     steps:
       - name: Retrieve GitHub Release Version

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [16, 17]
 
     steps:
       - name: Checkout Git Repository
@@ -102,7 +102,7 @@ jobs:
     runs-on: depot-ubuntu-latest-2
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [16, 17]
 
     steps:
       - name: Retrieve GitHub Release Version

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -59,6 +59,14 @@ jobs:
             image: ubuntu:22.04
             pg_version: 16
             arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:22.04
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:22.04
+            pg_version: 17
+            arch: arm64
           # Ubuntu 24.04
           - runner: depot-ubuntu-latest-8
             image: ubuntu:24.04
@@ -83,6 +91,14 @@ jobs:
           - runner: depot-ubuntu-latest-arm-4
             image: ubuntu:24.04
             pg_version: 16
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: ubuntu:24.04
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: ubuntu:24.04
+            pg_version: 17
             arch: arm64
           # Debian 12
           - runner: depot-ubuntu-latest-8
@@ -109,6 +125,14 @@ jobs:
             image: debian:12-slim
             pg_version: 16
             arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: debian:12-slim
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: debian:12-slim
+            pg_version: 17
+            arch: arm64
           # Red Hat Enterprise Linux 8
           - runner: depot-ubuntu-latest-8
             image: redhat/ubi8:latest
@@ -134,6 +158,14 @@ jobs:
             image: redhat/ubi8:latest
             pg_version: 16
             arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: redhat/ubi8:latest
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: redhat/ubi8:latest
+            pg_version: 17
+            arch: arm64
           # Red Hat Enterprise Linux 9
           - runner: depot-ubuntu-latest-8
             image: redhat/ubi9:latest
@@ -158,6 +190,14 @@ jobs:
           - runner: depot-ubuntu-latest-arm-4
             image: redhat/ubi9:latest
             pg_version: 16
+            arch: arm64
+          - runner: depot-ubuntu-latest-8
+            image: redhat/ubi9:latest
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-4
+            image: redhat/ubi9:latest
+            pg_version: 17
             arch: arm64
 
     steps:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -40,6 +40,12 @@ jobs:
           - runner: depot-ubuntu-latest-arm-8
             pg_version: 16
             arch: arm64
+          - runner: depot-ubuntu-latest-8
+            pg_version: 17
+            arch: amd64
+          - runner: depot-ubuntu-latest-arm-8
+            pg_version: 17
+            arch: arm64
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -35,12 +35,6 @@ jobs:
       matrix:
         include:
           - runner: depot-ubuntu-latest-8
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-latest-arm-8
-            pg_version: 16
-            arch: arm64
-          - runner: depot-ubuntu-latest-8
             pg_version: 17
             arch: amd64
           - runner: depot-ubuntu-latest-arm-8

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -311,8 +311,8 @@ jobs:
         run: |
           git clone --branch v0.7.4 https://github.com/pgvector/pgvector.git
           cd pgvector/
-          PG_CONFIG=~/.pgrx/16.*/pgrx-install/bin/pg_config make -j
-          PG_CONFIG=~/.pgrx/16.*/pgrx-install/bin/pg_config make install -j
+          PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make -j
+          PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make install -j
 
       - name: Add pg_search to shared_preload_libraries
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -239,9 +239,6 @@ jobs:
       matrix:
         include:
           - runner: depot-ubuntu-latest-8
-            pg_version: 16
-            arch: amd64
-          - runner: depot-ubuntu-latest-8
             pg_version: 17
             arch: amd64
     env:
@@ -328,7 +325,7 @@ jobs:
           cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=pg${{ matrix.pg_version }},icu
           cargo pgrx start pg${{ matrix.pg_version }}
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
-          DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
+          DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --no-default-features --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
 
       - name: Print the Postgres Logs
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -51,6 +51,9 @@ jobs:
           - runner: depot-ubuntu-latest-8
             pg_version: 16
             arch: amd64
+          - runner: depot-ubuntu-latest-8
+            pg_version: 17
+            arch: amd64
     env:
       default_pg_version: 16
 
@@ -237,6 +240,9 @@ jobs:
         include:
           - runner: depot-ubuntu-latest-8
             pg_version: 16
+            arch: amd64
+          - runner: depot-ubuntu-latest-8
+            pg_version: 17
             arch: amd64
     env:
       default_pg_version: 16

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -325,7 +325,7 @@ jobs:
         run: |
           PARADEDB_TELEMETRY=false
           cargo pgrx stop
-          cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=icu
+          cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=pg${{ matrix.pg_version }},icu
           cargo pgrx start
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
           DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -55,7 +55,7 @@ jobs:
             pg_version: 17
             arch: amd64
     env:
-      default_pg_version: 16
+      default_pg_version: 17
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only
@@ -245,7 +245,7 @@ jobs:
             pg_version: 17
             arch: amd64
     env:
-      default_pg_version: 16
+      default_pg_version: 17
 
     steps:
       # For the Rust cache to get filled, we need to run the CI on the dev branch after every merge. This only

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -327,8 +327,8 @@ jobs:
           cargo pgrx stop
           cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=icu
           cargo pgrx start
-          ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 28816 -h localhost pg_search
-          DATABASE_URL=postgresql://localhost:28816/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
+          ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
+          DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
           cat ~/.pgrx/${{ matrix.pg_version}}.log
 
       - name: Print the Postgres Logs

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -324,12 +324,11 @@ jobs:
         working-directory: pg_search/
         run: |
           PARADEDB_TELEMETRY=false
-          cargo pgrx stop
+          cargo pgrx stop all
           cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=pg${{ matrix.pg_version }},icu
-          cargo pgrx start
+          cargo pgrx start pg${{ matrix.pg_version }}
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
           DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --features=pg${{ matrix.pg_version }},icu -- --skip replication --skip ephemeral
-          cat ~/.pgrx/${{ matrix.pg_version}}.log
 
       - name: Print the Postgres Logs
         if: steps.check_skip.outputs.skip_remaining_steps != 'true' && always()

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For more information, including enterprise features and support, please [contact
 
 ### Extensions
 
-You can find prebuilt binaries for all ParadeDB extensions on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15 and 16 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). ParadeDB supports all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 13+, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
+You can find prebuilt binaries for all ParadeDB extensions on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15, 16 and 17 in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). ParadeDB supports all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 13+, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
 
 ### Docker Image
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 
 ###############################################
 # First Stage: Builder
@@ -121,7 +121,7 @@ RUN export PG_CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-sign-comp
 
 FROM builder AS builder-pg_cron
 
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
 
 # Build the extension
@@ -138,7 +138,7 @@ RUN echo "trusted = true" >> pg_cron.control && \
 
 FROM builder AS builder-pg_ivm
 
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
 
 # Build the extension
@@ -159,7 +159,7 @@ LABEL maintainer="ParadeDB - https://paradedb.com" \
     org.opencontainers.image.description="ParadeDB - Postgres for Search and Analytics" \
     org.opencontainers.image.source="https://github.com/paradedb/paradedb"
 
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 
 # Declare runtime environment variables
 ENV PG_VERSION_MAJOR=${PG_VERSION_MAJOR}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG PG_VERSION_MAJOR=16
 # Note: Debian Bookworm = Debian 12
 FROM postgres:${PG_VERSION_MAJOR}-bookworm AS builder
 
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 ARG RUST_VERSION=1.80.0
 
 # Declare buildtime environment variables
@@ -103,7 +103,7 @@ RUN cargo pgrx package --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/
 
 FROM builder AS builder-pgvector
 
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 ENV PG_CONFIG=/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config
 
 # Build the extension

--- a/docs/deploy/pg_analytics.mdx
+++ b/docs/deploy/pg_analytics.mdx
@@ -14,7 +14,7 @@ Ensure that you have superuser access to the Postgres database.
 
 # Install `pg_analytics`
 
-ParadeDB provides prebuilt binaries for the `pg_analytics` extension on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15 and 16 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_analytics` extension on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15, 16 and 17 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries
@@ -22,35 +22,35 @@ are using a different version of Postgres or a different operating system, you w
 <CodeGroup>
 
 ```bash Ubuntu 24.04
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.4/postgresql-16-pg-analytics_0.1.4-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.4/postgresql-16-pg-analytics_0.1.4-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.4/postgresql-16-pg-analytics_0.1.4-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are x86_64, aarch64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.4/pg_analytics_16-0.1.4-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are x86_64, aarch64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.1.4/pg_analytics_16-0.1.4-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm

--- a/docs/deploy/pg_search.mdx
+++ b/docs/deploy/pg_search.mdx
@@ -24,7 +24,7 @@ sudo apt-get install -y libicu74
 
 # Install `pg_search`
 
-ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15 and 16 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
+ParadeDB provides prebuilt binaries for the `pg_search` extension on Debian 12, Ubuntu 22.04 and 24.04, and Red Hat Enterprise Linux 8 and 9 for Postgres 14, 15, 16 and 17 on both amd64 (x86_64) and arm64. They can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest). If you
 are using a different version of Postgres or a different operating system, you will need to build the extension from source.
 
 ## Using Prebuilt Binaries
@@ -32,35 +32,35 @@ are using a different version of Postgres or a different operating system, you w
 <CodeGroup>
 
 ```bash Ubuntu 24.04
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.10.2/postgresql-16-pg-search_0.10.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.10.2/postgresql-16-pg-search_0.10.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are amd64, arm64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.10.2/postgresql-16-pg-search_0.10.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are x86_64, aarch64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.10.2/pg_search_16-0.10.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
-# Available Postgres version are 14, 15, 16
+# Available Postgres version are 14, 15, 16, 17
 # Available arch versions are x86_64, aarch64
 curl -L "https://github.com/paradedb/paradedb/releases/download/v0.10.2/pg_search_16-0.10.2-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -14,6 +14,7 @@ pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 icu = ["tokenizers/icu"]
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -66,7 +66,7 @@ This enables the extension to spawn a background worker process that performs wr
 
 #### Debian/Ubuntu
 
-We provide prebuilt binaries for Debian-based Linux for Postgres 16, 15 and 14. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+We provide prebuilt binaries for Debian-based Linux for Postgres 17, 16, 15 and 14. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
 Our prebuilt binaries come with the ICU tokenizer enabled, which requires the `libicu` library. If you don't have it installed, you can do so with:
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -263,7 +263,6 @@ fn do_heap_scan<'a>(
     state
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 #[pg_guard]
 unsafe extern "C" fn build_callback(
     index: pg_sys::Relation,

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -263,7 +263,7 @@ fn do_heap_scan<'a>(
     state
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 #[pg_guard]
 unsafe extern "C" fn build_callback(
     index: pg_sys::Relation,

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -25,7 +25,7 @@ use pgrx::*;
 use super::utils::relfilenode_from_index_oid;
 
 #[allow(clippy::too_many_arguments)]
-#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     index_relation: pg_sys::Relation,

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn amoptions(
     build_relopts(reloptions, validate, options)
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 unsafe fn build_relopts(
     reloptions: pg_sys::Datum,
     validate: bool,
@@ -312,7 +312,7 @@ pub unsafe fn init() {
         "JSON string specifying how text fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_text_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -323,7 +323,7 @@ pub unsafe fn init() {
         "JSON string specifying how numeric fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_numeric_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -334,7 +334,7 @@ pub unsafe fn init() {
         "JSON string specifying how boolean fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_boolean_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -345,7 +345,7 @@ pub unsafe fn init() {
         "JSON string specifying how JSON fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_json_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -356,7 +356,7 @@ pub unsafe fn init() {
         "JSON string specifying how date fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_datetime_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -367,7 +367,7 @@ pub unsafe fn init() {
         "Column name as a string specify the unique identifier for a row".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_key_field),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },
@@ -378,7 +378,7 @@ pub unsafe fn init() {
         "Unique uuid for search index instance".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_uuid),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
         {
             pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
         },

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -183,7 +183,6 @@ pub unsafe extern "C" fn amoptions(
     build_relopts(reloptions, validate, options)
 }
 
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 unsafe fn build_relopts(
     reloptions: pg_sys::Datum,
     validate: bool,
@@ -312,10 +311,7 @@ pub unsafe fn init() {
         "JSON string specifying how text fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_text_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -323,10 +319,7 @@ pub unsafe fn init() {
         "JSON string specifying how numeric fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_numeric_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -334,10 +327,7 @@ pub unsafe fn init() {
         "JSON string specifying how boolean fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_boolean_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -345,10 +335,7 @@ pub unsafe fn init() {
         "JSON string specifying how JSON fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_json_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -356,10 +343,7 @@ pub unsafe fn init() {
         "JSON string specifying how date fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_datetime_fields),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -367,10 +351,7 @@ pub unsafe fn init() {
         "Column name as a string specify the unique identifier for a row".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_key_field),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -378,9 +359,6 @@ pub unsafe fn init() {
         "Unique uuid for search index instance".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_uuid),
-        #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
-        {
-            pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE
-        },
+        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
     );
 }

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -311,7 +311,7 @@ pub unsafe fn init() {
         "JSON string specifying how text fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_text_fields),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -319,7 +319,7 @@ pub unsafe fn init() {
         "JSON string specifying how numeric fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_numeric_fields),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -327,7 +327,7 @@ pub unsafe fn init() {
         "JSON string specifying how boolean fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_boolean_fields),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -335,7 +335,7 @@ pub unsafe fn init() {
         "JSON string specifying how JSON fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_json_fields),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -343,7 +343,7 @@ pub unsafe fn init() {
         "JSON string specifying how date fields should be indexed".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_datetime_fields),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -351,7 +351,7 @@ pub unsafe fn init() {
         "Column name as a string specify the unique identifier for a row".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_key_field),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(
         RELOPT_KIND_PDB,
@@ -359,6 +359,6 @@ pub unsafe fn init() {
         "Unique uuid for search index instance".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_uuid),
-        { pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE },
+        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
 }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -232,7 +232,7 @@ pub fn relfilenode_from_pg_relation(index_relation: &PgRelation) -> pg_sys::Oid 
     {
         index_relation.rd_node.relNode
     }
-    #[cfg(feature = "pg16")]
+    #[cfg(any(feature = "pg16", feature = "pg17"))]
     {
         index_relation.rd_locator.relNumber
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1686

## What

This adds Postgres 17 support.

## Why

Postgres 17 released today.

## How

- Add `pg17` Rust features.
- Add `17` to workflow files.

Some edits in workflow files might not be final and should be discussed further.

## Tests

See CI.
