### PR TITLE
feat: introduce aliases for paradedb.field, allowing for multiple tokenizer configurations

### DIFF
--- a/docs/api-reference/indexing/tokenizers.mdx
+++ b/docs/api-reference/indexing/tokenizers.mdx
@@ -180,7 +180,7 @@ CALL paradedb.create_bm25(
   text_fields =>
     paradedb.field('description', tokenizer => paradedb.tokenizer('whitespace')) ||
     paradedb.field('description', alias => 'description_ngram', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 3, prefix_only => false)) ||
-    paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('en_stem'))
+    paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
 );
 
 -- Example queries

--- a/docs/api-reference/indexing/tokenizers.mdx
+++ b/docs/api-reference/indexing/tokenizers.mdx
@@ -167,22 +167,25 @@ SELECT * FROM paradedb.tokenize(
 
 ## Multiple Tokenizers
 
-In ParadeDB, only one tokenizer is allowed per field and only one BM25 index is allowed per table. However, some scenarios may require the same field to be tokenized in multiple ways. For instance, suppose we wish to use both the `whitespace` and `ngrams` tokenizer
-to tokenize the `description` field. One way to achieve this is to use generated columns.
+ParadeDB supports using multiple tokenizers for the same field within a single BM25 index. This feature allows for more flexible and powerful querying capabilities, enabling you to employ various strategies to match against an index term. You can apply different tokenizers to the same field by using the `alias` parameter in the `paradedb.field` function.
+
+Here's an example of how to create a BM25 index with multiple tokenizers for the same field:
 
 ```sql
-ALTER TABLE mock_items
-ADD COLUMN description_ngrams TEXT GENERATED ALWAYS AS (description) STORED;
-
--- Optional: Drop existing search_idx if exists
-CALL paradedb.drop_bm25('search_idx')
-
 CALL paradedb.create_bm25(
   index_name => 'search_idx',
   table_name => 'mock_items',
+  schema_name => 'public',
   key_field => 'id',
   text_fields =>
     paradedb.field('description', tokenizer => paradedb.tokenizer('whitespace')) ||
-    paradedb.field('description_ngrams', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 3, prefix_only => false))
+    paradedb.field('description', alias => 'description_ngram', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 3, prefix_only => false)) ||
+    paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('en_stem'))
 );
+
+-- Example queries
+
+SELECT * FROM search_idx.search('description_ngram:cam AND description_stem:digitally');
+
+SELECT * FROM search_idx.search('description:"Soft cotton" OR description_stem:shirts');
 ```

--- a/pg_search/sql/pg_search--0.10.2--0.10.3.sql
+++ b/pg_search/sql/pg_search--0.10.2--0.10.3.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS field(name text, indexed bool, stored bool, fast bool, fieldnorms bool, record text, expand_dots bool, tokenizer jsonb, normalizer text);
+CREATE OR REPLACE FUNCTION field(name text, indexed bool DEFAULT NULL, stored bool DEFAULT NULL, fast bool DEFAULT NULL, fieldnorms bool DEFAULT NULL, record text DEFAULT NULL, expand_dots bool DEFAULT NULL, tokenizer jsonb DEFAULT NULL, normalizer text DEFAULT NULL, alias text DEFAULT NULL) RETURNS jsonb AS 'MODULE_PATHNAME', 'field_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -208,7 +208,7 @@ fn create_bm25_impl(
                 obj[key]["field_name_at_index_build"] = field_name_at_index_build.into();
 
                 // Insert the actual field name into the column set for CREATE INDEX.
-                column_names.insert(spi::quote_identifier(field_name_at_index_build.to_string()));
+                column_names.insert(spi::quote_identifier(field_name_at_index_build));
             }
         }
     }

--- a/pg_search/src/fixtures/mod.rs
+++ b/pg_search/src/fixtures/mod.rs
@@ -69,10 +69,18 @@ pub fn mock_dir() -> MockWriterDirectory {
 
 #[fixture]
 pub fn default_fields() -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)> {
-    let text: SearchFieldConfig = serde_json::from_value(json!({"Text": {}})).unwrap();
-    let numeric: SearchFieldConfig = serde_json::from_value(json!({"Numeric": {}})).unwrap();
-    let json: SearchFieldConfig = serde_json::from_value(json!({"Json": {}})).unwrap();
-    let boolean: SearchFieldConfig = serde_json::from_value(json!({"Boolean": {}})).unwrap();
+    let text: SearchFieldConfig = serde_json::from_value(json!({"Text": {
+        "field_name_at_index_build": "somename"
+    }}))
+    .unwrap();
+    let numeric: SearchFieldConfig =
+        serde_json::from_value(json!({"Numeric": {"field_name_at_index_build": "somename"}}))
+            .unwrap();
+    let json: SearchFieldConfig =
+        serde_json::from_value(json!({"Json": {"field_name_at_index_build": "somename"}})).unwrap();
+    let boolean: SearchFieldConfig =
+        serde_json::from_value(json!({"Boolean": {"field_name_at_index_build": "somename"}}))
+            .unwrap();
 
     vec![
         ("id".into(), numeric.clone(), SearchFieldType::I64),

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -187,7 +187,8 @@ mod tests {
             "fieldnorms": true,
             "type": "default",
             "record": "basic",
-            "normalizer": "raw"
+            "normalizer": "raw",
+            "field_name_at_index_build": "somename"
         }"#;
         let config: serde_json::Value = serde_json::from_str(json).unwrap();
         let search_text_option: SearchFieldConfig =
@@ -211,7 +212,8 @@ mod tests {
             "indexed": true,
             "stored": true,
             "fieldnorms": false,
-            "fast": true
+            "fast": true,
+            "field_name_at_index_build": "somename"
         }"#;
         let config: serde_json::Value = serde_json::from_str(json).unwrap();
         let expected: SearchFieldConfig =
@@ -227,7 +229,8 @@ mod tests {
             "indexed": true,
             "stored": true,
             "fieldnorms": false,
-            "fast": true
+            "fast": true,
+            "field_name_at_index_build": "somename"
         }"#;
         let config: serde_json::Value = serde_json::from_str(json).unwrap();
         let expected: SearchFieldConfig =
@@ -246,7 +249,8 @@ mod tests {
             "expand_dots": true,
             "type": "default",
             "record": "basic",
-            "normalizer": "raw"
+            "normalizer": "raw",
+            "field_name_at_index_build": "somename"
         }"#;
         let config: serde_json::Value = serde_json::from_str(json).unwrap();
         let search_json_option: SearchFieldConfig =

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -107,6 +107,7 @@ pub enum SearchFieldConfig {
         record: IndexRecordOption,
         #[serde(default)]
         normalizer: SearchNormalizer,
+        field_name_at_index_build: String,
     },
     Json {
         #[serde(default = "default_as_true")]
@@ -124,6 +125,7 @@ pub enum SearchFieldConfig {
         record: IndexRecordOption,
         #[serde(default)]
         normalizer: SearchNormalizer,
+        field_name_at_index_build: String,
     },
     Numeric {
         #[serde(default = "default_as_true")]
@@ -132,6 +134,7 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        field_name_at_index_build: String,
     },
     Boolean {
         #[serde(default = "default_as_true")]
@@ -140,6 +143,7 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        field_name_at_index_build: String,
     },
     Date {
         #[serde(default = "default_as_true")]
@@ -148,6 +152,7 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        field_name_at_index_build: String,
     },
     Ctid,
 }
@@ -201,6 +206,12 @@ impl SearchFieldConfig {
             None => Ok(SearchNormalizer::Raw),
         }?;
 
+        let field_name_at_index_build = obj
+            .get("field_name_at_index_build")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .expect("SearchFieldConfig expects a field_name_at_index_build string");
+
         Ok(SearchFieldConfig::Text {
             indexed,
             fast,
@@ -209,6 +220,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
+            field_name_at_index_build,
         })
     }
 
@@ -260,6 +272,12 @@ impl SearchFieldConfig {
             None => Ok(SearchNormalizer::Raw),
         }?;
 
+        let field_name_at_index_build = obj
+            .get("field_name_at_index_build")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .expect("SearchFieldConfig expects a field_name_at_index_build string");
+
         Ok(SearchFieldConfig::Json {
             indexed,
             fast,
@@ -268,6 +286,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
+            field_name_at_index_build,
         })
     }
 
@@ -297,10 +316,17 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let field_name_at_index_build = obj
+            .get("field_name_at_index_build")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .expect("SearchFieldConfig expects a field_name_at_index_build string");
+
         Ok(SearchFieldConfig::Numeric {
             indexed,
             fast,
             stored,
+            field_name_at_index_build,
         })
     }
 
@@ -330,10 +356,17 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let field_name_at_index_build = obj
+            .get("field_name_at_index_build")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .expect("SearchFieldConfig expects a field_name_at_index_build string");
+
         Ok(SearchFieldConfig::Boolean {
             indexed,
             fast,
             stored,
+            field_name_at_index_build,
         })
     }
 
@@ -363,10 +396,17 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let field_name_at_index_build = obj
+            .get("field_name_at_index_build")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .expect("SearchFieldConfig expects a field_name_at_index_build string");
+
         Ok(SearchFieldConfig::Date {
             indexed,
             fast,
             stored,
+            field_name_at_index_build,
         })
     }
 }
@@ -378,23 +418,23 @@ impl SearchFieldConfig {
     }
 
     pub fn default_text() -> Self {
-        Self::from_json(json!({"Text": {}}))
+        Self::from_json(json!({"Text": {"field_name_at_index_build": "somename"}}))
     }
 
     pub fn default_numeric() -> Self {
-        Self::from_json(json!({"Numeric": {}}))
+        Self::from_json(json!({"Numeric": {"field_name_at_index_build": "somename"}}))
     }
 
     pub fn default_boolean() -> Self {
-        Self::from_json(json!({"Boolean": {}}))
+        Self::from_json(json!({"Boolean": {"field_name_at_index_build": "somename"}}))
     }
 
     pub fn default_json() -> Self {
-        Self::from_json(json!({"Json": {}}))
+        Self::from_json(json!({"Json": {"field_name_at_index_build": "somename"}}))
     }
 
     pub fn default_date() -> Self {
-        Self::from_json(json!({"Date": {}}))
+        Self::from_json(json!({"Date": {"field_name_at_index_build": "somename"}}))
     }
 }
 
@@ -410,6 +450,7 @@ impl From<SearchFieldConfig> for TextOptions {
                 tokenizer,
                 record,
                 normalizer,
+                ..
             } => {
                 if stored {
                     text_options = text_options.set_stored();
@@ -440,9 +481,10 @@ impl From<SearchFieldConfig> for NumericOptions {
                 indexed,
                 fast,
                 stored,
+                ..
             }
             // Following the example of Quickwit, which uses NumericOptions for boolean options.
-            | SearchFieldConfig::Boolean { indexed, fast, stored } => {
+            | SearchFieldConfig::Boolean { indexed, fast, stored, .. } => {
                 if stored {
                     numeric_options = numeric_options.set_stored();
                 }
@@ -475,6 +517,7 @@ impl From<SearchFieldConfig> for JsonObjectOptions {
                 tokenizer,
                 record,
                 normalizer,
+                ..
             } => {
                 if stored {
                     json_options = json_options.set_stored();
@@ -510,6 +553,7 @@ impl From<SearchFieldConfig> for DateOptions {
                 indexed,
                 fast,
                 stored,
+                ..
             } => {
                 if stored {
                     date_options = date_options.set_stored();
@@ -560,7 +604,8 @@ pub struct SearchIndexSchema {
     pub schema: Schema,
     /// A lookup cache for retrieving search fields.
     #[serde(skip_serializing)]
-    pub lookup: Option<HashMap<SearchFieldName, usize>>,
+    lookup: Option<HashMap<SearchFieldName, usize>>,
+    alias_lookup: HashMap<SearchFieldName, Vec<SearchFieldName>>,
 }
 
 impl SearchIndexSchema {
@@ -572,8 +617,8 @@ impl SearchIndexSchema {
         let mut search_fields = vec![];
 
         let mut ctid_index = 0;
-        for (index, (name, config, field_type)) in fields.into_iter().enumerate() {
-            if config == SearchFieldConfig::Ctid {
+        for (index, (name, config, field_type)) in fields.iter().enumerate() {
+            if config == &SearchFieldConfig::Ctid {
                 ctid_index = index
             }
 
@@ -598,11 +643,45 @@ impl SearchIndexSchema {
 
             search_fields.push(SearchField {
                 id,
-                name,
-                config,
-                type_: field_type,
+                name: name.clone(),
+                config: config.clone(),
+                type_: field_type.clone(),
             });
         }
+
+        let alias_lookup: HashMap<SearchFieldName, Vec<SearchFieldName>> =
+            fields
+                .iter()
+                .fold(HashMap::new(), |mut acc, (name, config, _)| {
+                    if let Some(field_name_at_index_build) = match config {
+                        SearchFieldConfig::Text {
+                            field_name_at_index_build,
+                            ..
+                        }
+                        | SearchFieldConfig::Json {
+                            field_name_at_index_build,
+                            ..
+                        }
+                        | SearchFieldConfig::Numeric {
+                            field_name_at_index_build,
+                            ..
+                        }
+                        | SearchFieldConfig::Boolean {
+                            field_name_at_index_build,
+                            ..
+                        }
+                        | SearchFieldConfig::Date {
+                            field_name_at_index_build,
+                            ..
+                        } => Some(field_name_at_index_build),
+                        _ => None,
+                    } {
+                        acc.entry(SearchFieldName(field_name_at_index_build.clone()))
+                            .or_insert_with(Vec::new)
+                            .push(name.clone());
+                    }
+                    acc
+                });
 
         let schema = builder.build();
 
@@ -612,6 +691,7 @@ impl SearchIndexSchema {
             schema,
             lookup: Self::build_lookup(&search_fields).into(),
             fields: search_fields,
+            alias_lookup,
         })
     }
 
@@ -655,6 +735,10 @@ impl SearchIndexSchema {
             let lookup = Self::build_lookup(&self.fields);
             lookup.get(name).and_then(|idx| self.fields.get(*idx))
         }
+    }
+
+    pub fn get_aliases(&self, name: &SearchFieldName) -> Option<&Vec<SearchFieldName>> {
+        self.alias_lookup.get(name)
     }
 }
 
@@ -737,6 +821,7 @@ mod tests {
                 indexed: true,
                 fast: true,
                 stored: true,
+                field_name_at_index_build: "dummy_key_field".into(),
             },
             SearchFieldType::U64,
         )];

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -645,7 +645,7 @@ impl SearchIndexSchema {
                 id,
                 name: name.clone(),
                 config: config.clone(),
-                type_: field_type.clone(),
+                type_: *field_type,
             });
         }
 
@@ -677,7 +677,7 @@ impl SearchIndexSchema {
                         _ => None,
                     } {
                         acc.entry(SearchFieldName(field_name_at_index_build.clone()))
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push(name.clone());
                     }
                     acc

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1102,9 +1102,9 @@ fn multiple_tokenizers_with_alias(mut conn: PgConnection) {
         key_field => 'id',
         text_fields => 
             paradedb.field('name', tokenizer => paradedb.tokenizer('default')) ||
-            paradedb.field('name', alias => 'name_stem', tokenizer => paradedb.tokenizer('en_stem')) ||
+            paradedb.field('name', alias => 'name_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English')) ||
             paradedb.field('description', tokenizer => paradedb.tokenizer('default')) ||
-            paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('en_stem'))
+            paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
     );"
     .execute(&mut conn);
 
@@ -1175,7 +1175,7 @@ fn alias_cannot_be_key_field(mut conn: PgConnection) {
         key_field => 'id',
         text_fields => 
             paradedb.field('name', tokenizer => paradedb.tokenizer('default')) ||
-            paradedb.field('description', alias => 'id', tokenizer => paradedb.tokenizer('en_stem'))
+            paradedb.field('description', alias => 'id', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
     );"
     .execute_result(&mut conn);
 
@@ -1192,7 +1192,7 @@ fn alias_cannot_be_key_field(mut conn: PgConnection) {
         key_field => 'id',
         text_fields => 
             paradedb.field('name', tokenizer => paradedb.tokenizer('default')) ||
-            paradedb.field('description', alias => 'desc_stem', tokenizer => paradedb.tokenizer('en_stem'))
+            paradedb.field('description', alias => 'desc_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
     );"
     .execute_result(&mut conn);
 
@@ -1232,7 +1232,7 @@ fn multiple_tokenizers_same_field_in_query(mut conn: PgConnection) {
             paradedb.field('product_name', tokenizer => paradedb.tokenizer('default')) ||
             paradedb.field('product_name', alias => 'product_name_ngram', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 3, prefix_only => false)) ||
             paradedb.field('review_text', tokenizer => paradedb.tokenizer('default')) ||
-            paradedb.field('review_text', alias => 'review_text_stem', tokenizer => paradedb.tokenizer('en_stem'))
+            paradedb.field('review_text', alias => 'review_text_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
     );"
     .execute(&mut conn);
 
@@ -1249,7 +1249,7 @@ fn multiple_tokenizers_same_field_in_query(mut conn: PgConnection) {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].1, "SmartPhone X");
 
-    // Stemmed search using en_stem tokenizer
+    // Stemmed search using English stemmer tokenizer
     let rows: Vec<(i32, String)> =
         "SELECT id, product_name FROM product_reviews_index.search('review_text_stem:gaming')"
             .fetch(&mut conn);

--- a/pg_search/tests/documentation.rs
+++ b/pg_search/tests/documentation.rs
@@ -495,7 +495,7 @@ fn multiple_tokenizers_example(mut conn: PgConnection) {
       text_fields =>
         paradedb.field('description', tokenizer => paradedb.tokenizer('whitespace')) ||
         paradedb.field('description', alias => 'description_ngram', tokenizer => paradedb.tokenizer('ngram', min_gram => 3, max_gram => 3, prefix_only => false)) ||
-        paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('en_stem'))
+        paradedb.field('description', alias => 'description_stem', tokenizer => paradedb.tokenizer('default', stemmer => 'English'))
     );"#
     .execute(&mut conn);
 

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1119,7 +1119,7 @@ fn more_like_this_with_alias(mut conn: PgConnection) {
     );
     "#
     .fetch_collect(&mut conn);
-    
+
     assert_eq!(rows.len(), 2);
     assert!(rows.iter().any(|(_, flavour, _)| flavour == "banana"));
     assert!(rows.iter().any(|(_, flavour, _)| flavour == "banana split"));


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #575

## What
Introduce the ability to add a Postgres field to the Tantivy index more than once, using an `alias` to disambiguate. The alias can be used in the query to specify the field with particular tokenization, etc: `name:Mouse OR description_stem:mouses`.

## How
We need to store the column name inside each `SearchFieldConfig` so that we can correctly map the types of each `alias` to the column type. We use this information later on to build a lookup on the `SearchIndexSchema` so that at insert time, a column can be correctly mapped to possibly many index fields.

## Tests

I've added some new tests for `alias => ` with a few different tokenizers, as well as another against some validation on `alias`.
