### PR TITLE
chore: Upgrade `pgrx` to `0.12.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c51534de8e03d0273449051f241deac924987567fc6ddd15e1bd2260ab56518"
+checksum = "39464992d5b3cdda6b390efe51c27e849d2e93c1811e7610cf88f82d5b6a1a23"
 dependencies = [
  "atomic-traits",
  "bitflags 2.6.0",
@@ -4062,11 +4062,12 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bb1a63b6c255648f4fbd44ba69358cf539dc8bbe6a74939877f5ddccb50285"
+checksum = "84b03b74332a89c852486c0a53c33e049fb56d7911e251ddd05b7820b2963592"
 dependencies = [
  "bindgen 0.70.1",
+ "cc",
  "clang-sys",
  "eyre",
  "pgrx-pg-config",
@@ -4079,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89503e532947a7801a70be031e7d574f348d21f2b45a42c0b7c7ff15be532c8e"
+checksum = "822e16af0dfc820dbd407b19538fde0def27c7d1913dea47a42c040c8bcf8b56"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -4091,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d96d25297a5a554e87459aa45c5c132513050afb0ae9e7de615747cac56c07"
+checksum = "31061cc1a9f860d1302ba952ccf3b3d0eec59be94f0a32bcc8ba858fdd44a824"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -4109,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c33e4d17c64ca3f8f5443b98eeb18f433be2d46ab4251ad8814c2bb0c79c9b1"
+checksum = "0225f2eeacf00702a705cbeb50252f4279169cd08501f73889b479d23a4250e1"
 dependencies = [
  "cee-scape",
  "libc",
@@ -4124,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8a4ed2d8aefe96ff1a5bd57b2c374a5e54db6f2fb5ed7813bdd6e5ad919216"
+checksum = "f9c9dfdc4b31b381405b9735b7d674680b42584ea2ef89f3668a21be57a39310"
 dependencies = [
  "convert_case 0.6.0",
  "eyre",
@@ -4140,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49bd8c99fde247ca8bee64a240f56e26c906b9b7e01dfcc9bfe9d6bc957590d"
+checksum = "992bb74e9cd178a55eab23f7a4b890a5427a411bbaf9588c86d435a3664eb4d2"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ ENV POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     COMMIT_SHA=${COMMIT_SHA} \
     PARADEDB_TELEMETRY=${PARADEDB_TELEMETRY}
 
-RUN git clone --branch v0.1.4 https://github.com/paradedb/pg_analytics.git /tmp/pg_analytics/
+RUN git clone --branch v0.2.0 https://github.com/paradedb/pg_analytics.git /tmp/pg_analytics/
 
 # Build the extension
 WORKDIR /tmp/pg_analytics

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -32,7 +32,7 @@ memoffset = "0.9.1"
 once_cell = "1.19.0"
 parking_lot = "0.12.3"
 tokenizers = { version = "0.10.2", path = "../tokenizers" }
-pgrx = "0.12.4"
+pgrx = "0.12.5"
 reqwest = "0.11.27"
 rustc-hash = "1.1.0"
 serde = "1.0.210"
@@ -57,7 +57,7 @@ approx = "0.5.1"
 async-std = { version = "1.13.0", features = ["attributes"] }
 cmd_lib = "1.9.4"
 dotenvy = "0.15.7"
-pgrx-tests = "0.12.4"
+pgrx-tests = "0.12.5"
 pgvector = { version = "0.3.4", features = ["sqlx"] }
 portpicker = "0.1.1"
 pretty_assertions = "1.4.0"

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -198,7 +198,7 @@ Then, install and initialize `pgrx`:
 
 ```bash
 # Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
-cargo install --locked cargo-pgrx --version 0.12.4
+cargo install --locked cargo-pgrx --version 0.12.5
 
 # macOS arm64
 cargo pgrx init --pg16=/opt/homebrew/opt/postgresql@16/bin/pg_config

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,7 +10,7 @@ fixtures = ["async-std", "rstest", "soa_derive", "sqlx", "bigdecimal"]
 
 [dependencies]
 parking_lot = "0.12.3"
-pgrx = "0.12.4"
+pgrx = "0.12.5"
 reqwest = { version = "0.11.27", features = ["blocking"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
@@ -43,7 +43,7 @@ libc = "0.2.158"
 
 [dev-dependencies]
 mockall = "0.12.1"
-pgrx-tests = "0.12.4"
+pgrx-tests = "0.12.5"
 
 [package.metadata.cargo-machete]
 ignored = ["rstest"]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1719

## What

Upgrade `pgrx` to `0.12.5`.

## Why

This is required for PG17 support.

## How

Update Cargo files and corresponding README guides.

## Tests

See CI.
