### PR TITLE
feat: Introduce dump_bm25 to inspect Tantivy index

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -145,7 +145,6 @@ jobs:
         uses: actions/github-script@v7
         if: steps.generate_commit_message.outputs.schema_diff_detected == 'true'
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -145,11 +145,11 @@ jobs:
         uses: actions/github-script@v7
         if: steps.generate_commit_message.outputs.schema_diff_detected == 'true'
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: process.env.DIFF,
-              github-token: ${{ env.GITHUB_TOKEN }}
+              body: process.env.DIFF
             })

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -150,5 +150,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: process.env.DIFF
+              body: process.env.DIFF,
+              github-token: ${{ env.GITHUB_TOKEN }}
             })

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,12 +416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,12 +1041,6 @@ dependencies = [
  "phf",
  "phf_codegen",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -2814,32 +2802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "interprocess"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
-dependencies = [
- "blocking",
- "cfg-if",
- "futures-core",
- "futures-io",
- "intmap",
- "libc",
- "once_cell",
- "rustc_version 0.4.1",
- "spinning",
- "thiserror",
- "to_method",
- "winapi",
-]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,7 +3965,6 @@ dependencies = [
  "fs2",
  "futures",
  "indexmap",
- "interprocess",
  "json5",
  "libc",
  "memoffset",
@@ -4017,7 +3978,6 @@ dependencies = [
  "portpicker",
  "pretty_assertions",
  "rand",
- "reqwest 0.11.27",
  "rstest",
  "rustc-hash",
  "serde",
@@ -4030,7 +3990,6 @@ dependencies = [
  "tantivy-common",
  "tempfile",
  "thiserror",
- "tiny_http",
  "tokenizers",
  "tokio",
  "tracing",
@@ -5358,15 +5317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,18 +6019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6104,12 +6042,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokenizers"

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -603,7 +603,7 @@ pub fn term_set(
 #[pg_extern]
 pub fn dump_bm25(
     index_name: String,
-) -> TableIterator<'static, (name!(heap_tid, i64), name!(content, pgrx::JsonB))> {
+) -> TableIterator<'static, (name!(ctid, i64), name!(content, pgrx::JsonB))> {
     let bm25_index_name = format!("{}_bm25_index", index_name);
 
     let database_oid = crate::MyDatabaseId();
@@ -627,11 +627,11 @@ pub fn dump_bm25(
 
     let results = top_docs.into_iter().map(move |doc_address| {
         let retrieved_doc: TantivyDocument = searcher.doc(doc_address).unwrap();
-        let heap_tid = retrieved_doc
+        let ctid = retrieved_doc
             .get_first(ctid_field)
-            .expect("Could not get heap_tid field")
+            .expect("Could not get ctid field")
             .as_u64()
-            .expect("Could not convert heap_tid to u64") as i64;
+            .expect("Could not convert ctid to u64") as i64;
 
         let mut json_map = Map::new();
         for (field, _) in schema.fields() {
@@ -689,7 +689,7 @@ pub fn dump_bm25(
             }
         }
 
-        (heap_tid, pgrx::JsonB(Value::Object(json_map)))
+        (ctid, pgrx::JsonB(Value::Object(json_map)))
     });
 
     TableIterator::new(results)

--- a/pg_search/tests/dump_bm25.rs
+++ b/pg_search/tests/dump_bm25.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use anyhow::Result;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+async fn test_dump_bm25(mut conn: PgConnection) -> Result<(), sqlx::Error> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let columns: Vec<(i64,)> =
+        "SELECT * FROM paradedb.dump_bm25('bm25_search')".fetch_collect(&mut conn);
+    assert_eq!(columns.len(), 41);
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1499

## What
support the `dump_bm25`
```sql
SELECT * FROM paradedb.dump_bm25(<bm25_index_name>)
SELECT * FROM paradedb.dump_bm25('bm25_search')
```

## Why

## How
Follow @rebasedming logic on #592

## Tests
I only tested the length of result because it is hard to extract the tuple like json from the tuple. I think https://github.com/paradedb/pg_analytics/issues/144 could benefit this kind of test to guarantee the deterministic tests.
