### PR TITLE
feat: JSON support for query builder term/phrase functions

### DIFF
--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -541,23 +541,19 @@ macro_rules! term_fn {
             value: default!(Option<$value_type>, "NULL"),
         ) -> SearchQueryInput {
             if let Some(value) = value {
-                if let Some(field) = field {
+                let (field, path) = if let Some(field) = field {
                     let (field, path) = split_field_and_path(&field);
-                    SearchQueryInput::Term {
-                        field: Some(field),
-                        value: TantivyValue::try_from(value)
-                            .expect("value should be a valid TantivyValue representation")
-                            .tantivy_schema_value(),
-                        path,
-                    }
+                    (Some(field), path)
                 } else {
-                    SearchQueryInput::Term {
-                        field,
-                        value: TantivyValue::try_from(value)
-                            .expect("value should be a valid TantivyValue representation")
-                            .tantivy_schema_value(),
-                        path: None,
-                    }
+                    (None, None)
+                };
+
+                SearchQueryInput::Term {
+                    field,
+                    value: TantivyValue::try_from(value)
+                        .expect("value should be a valid TantivyValue representation")
+                        .tantivy_schema_value(),
+                    path,
                 }
             } else {
                 panic!("no value provided to term query")

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -389,6 +389,7 @@ pub fn range_i32(field: FieldName, range: Range<i32>) -> SearchQueryInput {
             lower_bound: Bound::Included(OwnedValue::I64(0)),
             upper_bound: Bound::Excluded(OwnedValue::I64(0)),
             path,
+            is_datetime: false,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -403,6 +404,7 @@ pub fn range_i32(field: FieldName, range: Range<i32>) -> SearchQueryInput {
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::I64(n as i64)),
             },
             path,
+            is_datetime: false,
         },
     }
 }
@@ -415,6 +417,7 @@ pub fn range_i64(field: FieldName, range: Range<i64>) -> SearchQueryInput {
             lower_bound: Bound::Included(OwnedValue::I64(0)),
             upper_bound: Bound::Excluded(OwnedValue::I64(0)),
             path,
+            is_datetime: false,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -429,6 +432,7 @@ pub fn range_i64(field: FieldName, range: Range<i64>) -> SearchQueryInput {
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::I64(n)),
             },
             path,
+            is_datetime: false,
         },
     }
 }
@@ -441,6 +445,7 @@ pub fn range_numeric(field: FieldName, range: Range<AnyNumeric>) -> SearchQueryI
             lower_bound: Bound::Included(OwnedValue::F64(0.0)),
             upper_bound: Bound::Excluded(OwnedValue::F64(0.0)),
             path,
+            is_datetime: false,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -463,6 +468,7 @@ pub fn range_numeric(field: FieldName, range: Range<AnyNumeric>) -> SearchQueryI
                 )),
             },
             path,
+            is_datetime: false,
         },
     }
 }
@@ -481,6 +487,7 @@ macro_rules! datetime_range_fn {
                         tantivy::DateTime::from_timestamp_micros(0),
                     )),
                     path,
+                    is_datetime: true,
                 },
                 Some((lower, upper)) => SearchQueryInput::Range {
                     field: field.into_inner(),
@@ -523,6 +530,7 @@ macro_rules! datetime_range_fn {
                         ),
                     },
                     path,
+                    is_datetime: true,
                 },
             }
         }

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -388,6 +388,7 @@ pub fn range_i32(field: FieldName, range: Range<i32>) -> SearchQueryInput {
             field: field.into_inner(),
             lower_bound: Bound::Included(OwnedValue::I64(0)),
             upper_bound: Bound::Excluded(OwnedValue::I64(0)),
+            path,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -401,6 +402,7 @@ pub fn range_i32(field: FieldName, range: Range<i32>) -> SearchQueryInput {
                 RangeBound::Inclusive(n) => Bound::Included(OwnedValue::I64(n as i64)),
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::I64(n as i64)),
             },
+            path,
         },
     }
 }
@@ -412,6 +414,7 @@ pub fn range_i64(field: FieldName, range: Range<i64>) -> SearchQueryInput {
             field: field.into_inner(),
             lower_bound: Bound::Included(OwnedValue::I64(0)),
             upper_bound: Bound::Excluded(OwnedValue::I64(0)),
+            path,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -425,6 +428,7 @@ pub fn range_i64(field: FieldName, range: Range<i64>) -> SearchQueryInput {
                 RangeBound::Inclusive(n) => Bound::Included(OwnedValue::I64(n)),
                 RangeBound::Exclusive(n) => Bound::Excluded(OwnedValue::I64(n)),
             },
+            path,
         },
     }
 }
@@ -436,6 +440,7 @@ pub fn range_numeric(field: FieldName, range: Range<AnyNumeric>) -> SearchQueryI
             field: field.into_inner(),
             lower_bound: Bound::Included(OwnedValue::F64(0.0)),
             upper_bound: Bound::Excluded(OwnedValue::F64(0.0)),
+            path,
         },
         Some((lower, upper)) => SearchQueryInput::Range {
             field: field.into_inner(),
@@ -457,6 +462,7 @@ pub fn range_numeric(field: FieldName, range: Range<AnyNumeric>) -> SearchQueryI
                     n.try_into().expect("numeric should be a valid f64"),
                 )),
             },
+            path,
         },
     }
 }
@@ -474,6 +480,7 @@ macro_rules! datetime_range_fn {
                     upper_bound: Bound::Excluded(tantivy::schema::OwnedValue::Date(
                         tantivy::DateTime::from_timestamp_micros(0),
                     )),
+                    path,
                 },
                 Some((lower, upper)) => SearchQueryInput::Range {
                     field: field.into_inner(),
@@ -515,6 +522,7 @@ macro_rules! datetime_range_fn {
                                 .into(),
                         ),
                     },
+                    path,
                 },
             }
         }

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -29,8 +29,8 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt::{Display, Formatter};
 use std::ops::Bound;
-use tantivy::schema::{FieldType, OwnedValue, Value};
 use tantivy::json_utils::split_json_path;
+use tantivy::schema::{FieldType, OwnedValue, Value};
 
 #[allow(clippy::type_complexity)]
 #[pg_extern]

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -74,7 +74,7 @@ pub enum SearchQueryInput {
     },
     FuzzyTerm {
         field: String,
-        value: tantivy::schema::OwnedValue,
+        value: String,
         distance: Option<u8>,
         transposition_cost_one: Option<bool>,
         prefix: Option<bool>,
@@ -326,8 +326,10 @@ impl SearchQueryInput {
                     .ok_or_else(|| QueryError::NonIndexedField(field))?;
 
                 let term = match path {
-                    Some(path) => value_to_term_with_path(field, &value, &field_type, path)?,
-                    None => value_to_term(field, &value, &field_type)?,
+                    Some(path) => {
+                        value_to_term_with_path(field, &OwnedValue::Str(value), &field_type, path)?
+                    }
+                    None => value_to_term(field, &OwnedValue::Str(value), &field_type)?,
                 };
 
                 let distance = distance.unwrap_or(2);
@@ -653,7 +655,6 @@ fn value_to_term_with_path(
         FieldType::JsonObject(options) => options,
         _ => panic!("path is not allowed for non-JSON field types"),
     };
-
     let mut term = Term::from_field_json_path(field, &path, options.is_expand_dots_enabled());
 
     match value {

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -592,9 +592,7 @@ impl SearchQueryInput {
                     let (field_type, field) = field_lookup
                         .as_field_type(&field_name)
                         .ok_or_else(|| QueryError::NonIndexedField(field_name))?;
-                    let term = value_to_term(field, &field_value, &field_type, path)?;
-
-                    terms.push(term);
+                    terms.push(value_to_term(field, &field_value, &field_type, path)?);
                 }
 
                 Ok(Box::new(TermSetQuery::new(terms)))

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -124,6 +124,7 @@ pub enum SearchQueryInput {
         field: String,
         lower_bound: std::ops::Bound<tantivy::schema::OwnedValue>,
         upper_bound: std::ops::Bound<tantivy::schema::OwnedValue>,
+        path: Option<String>,
     },
     Regex {
         field: String,
@@ -528,6 +529,7 @@ impl SearchQueryInput {
                 field,
                 lower_bound,
                 upper_bound,
+                path,
             } => {
                 let field_name = field;
                 let (field_type, field) = field_lookup
@@ -536,20 +538,20 @@ impl SearchQueryInput {
 
                 let lower_bound = match lower_bound {
                     Bound::Included(value) => {
-                        Bound::Included(value_to_term(field, &value, &field_type, None)?)
+                        Bound::Included(value_to_term(field, &value, &field_type, path.clone())?)
                     }
                     Bound::Excluded(value) => {
-                        Bound::Excluded(value_to_term(field, &value, &field_type, None)?)
+                        Bound::Excluded(value_to_term(field, &value, &field_type, path.clone())?)
                     }
                     Bound::Unbounded => Bound::Unbounded,
                 };
 
                 let upper_bound = match upper_bound {
                     Bound::Included(value) => {
-                        Bound::Included(value_to_term(field, &value, &field_type, None)?)
+                        Bound::Included(value_to_term(field, &value, &field_type, path.clone())?)
                     }
                     Bound::Excluded(value) => {
-                        Bound::Excluded(value_to_term(field, &value, &field_type, None)?)
+                        Bound::Excluded(value_to_term(field, &value, &field_type, path.clone())?)
                     }
                     Bound::Unbounded => Bound::Unbounded,
                 };
@@ -651,8 +653,7 @@ fn value_to_term(
         _ => None,
     };
 
-    if let Some(json_options) = json_options {
-        let path = path.expect("path must be provided for a JSON field");
+    if let (Some(json_options), Some(path)) = (json_options, path) {
         return value_to_json_term(field, value, path, json_options.is_expand_dots_enabled());
     }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -761,7 +761,6 @@ fn value_to_term(
 }
 
 struct TantivyDateTime(pub tantivy::DateTime);
-
 impl TryFrom<&str> for TantivyDateTime {
     type Error = QueryError;
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -29,7 +29,7 @@ use tantivy::{
         PhraseQuery, Query, QueryParser, RangeQuery, RegexQuery, TermQuery, TermSetQuery,
     },
     query_grammar::Occur,
-    schema::{Field, FieldType, IndexRecordOption, OwnedValue, DATE_TIME_PRECISION_INDEXED},
+    schema::{Field, FieldType, OwnedValue, DATE_TIME_PRECISION_INDEXED},
     Searcher, Term,
 };
 use thiserror::Error;
@@ -616,7 +616,7 @@ impl SearchQueryInput {
                         .ok_or_else(|| QueryError::NonIndexedField(field))?;
                     let term = value_to_term(field, &value, &field_type, path, is_datetime)?;
 
-                    Ok(Box::new(TermQuery::new(term, record_option)))
+                    Ok(Box::new(TermQuery::new(term, record_option.into())))
                 } else {
                     // If no field is passed, then search all fields.
                     let all_fields = field_lookup.fields();

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -1195,11 +1195,11 @@ fn json_range(mut conn: PgConnection) {
 
     r#"
     UPDATE paradedb.bm25_search
-    SET metadata = '{"attributes": {"score": 3, "date": "2024-10-02", "timestamp": "2023-05-01T08:12:34"}}'::jsonb 
+    SET metadata = '{"attributes": {"score": 3, "tstz": "2023-05-01T08:12:34Z"}}'::jsonb 
     WHERE id = 1;
 
     UPDATE paradedb.bm25_search
-    SET metadata = '{"attributes": {"score": 4, "date": "2024-10-03", "timestamp": "2023-05-01T09:12:34"}}'::jsonb 
+    SET metadata = '{"attributes": {"score": 4, "tstz": "2023-05-01T09:12:34Z"}}'::jsonb 
     WHERE id = 2;
     "#
     .execute(&mut conn);
@@ -1220,11 +1220,11 @@ fn json_range(mut conn: PgConnection) {
     .fetch(&mut conn);
     assert_eq!(rows, vec![(2,)]);
 
-    // let rows: Vec<(i32,)> = "
-    // SELECT id FROM paradedb.bm25_search
-    // WHERE paradedb.bm25_search.id @@@ paradedb.range('metadata.attributes.date', daterange('2024-10-02', NULL, '[)'))
-    // ORDER BY id
-    // "
-    // .fetch(&mut conn);
-    // assert_eq!(rows, vec![(2,)]);
+    let rows: Vec<(i32,)> = "
+    SELECT id FROM paradedb.bm25_search
+    WHERE paradedb.bm25_search.id @@@ paradedb.range('metadata.attributes.tstz', tstzrange('2023-05-01T09:12:00Z', NULL, '[)'))
+    ORDER BY id
+    "
+    .fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
JSON support for the following query builder functions: `term`, `fuzzy_term`, `phrase`, `phrase_prefix`, `fuzzy_phrase`, and `range`.

You can now do

```sql
SELECT * FROM mock_items
WHERE id @@@ paradedb.fuzzy_term('metadata.color', 'whiet');
```

I'm working on documentation in another PR so I'll add docs for this separately. Important details to document:

1. For `range` to work over JSON fields, it must be indexed as `fast`.
2. Datetime fields in JSON MUST be RFC 3339 compliant, otherwise Tantivy is not able to tell whether it's a datetime value or a string and will incorrectly cast it to a string. For instance, `{"date": "2024-01-01"}` will not work with range queries.

## Why
JSON can now be searched with query builder functions in addition to the query string syntax.

## How
Tantivy `0.23.0` made it possible to construct `Term`s from JSON paths. I made the query builder functions add a `path` field to the JSON query object.

There was a bit of drama with `range` queries over JSON: in the existing implementation, we use the Tantivy field type to tell us whether the field is a datetime or string field. We don't have this option for JSON, since datetime values inside JSON get serialized to strings. To get around this, I made the `range` query builder add a `is_datetime` field to the query object. `is_datetime` is set to true if the range query uses a `daterange`, `tsrange`, or `tstzrange`. For consistency, I applied the same logic to the `term` query.

## Tests
See added tests in `bm25_search.rs`