### PR TITLE
feat: support querying nested json objects a separate documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,12 +416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,12 +1041,6 @@ dependencies = [
  "phf",
  "phf_codegen",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -2814,32 +2802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "interprocess"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
-dependencies = [
- "blocking",
- "cfg-if",
- "futures-core",
- "futures-io",
- "intmap",
- "libc",
- "once_cell",
- "rustc_version 0.4.1",
- "spinning",
- "thiserror",
- "to_method",
- "winapi",
-]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,7 +3965,6 @@ dependencies = [
  "fs2",
  "futures",
  "indexmap",
- "interprocess",
  "json5",
  "libc",
  "memoffset",
@@ -4017,7 +3978,6 @@ dependencies = [
  "portpicker",
  "pretty_assertions",
  "rand",
- "reqwest 0.11.27",
  "rstest",
  "rustc-hash",
  "serde",
@@ -4030,7 +3990,6 @@ dependencies = [
  "tantivy-common",
  "tempfile",
  "thiserror",
- "tiny_http",
  "tokenizers",
  "tokio",
  "tracing",
@@ -5358,15 +5317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,18 +6019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6104,12 +6042,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
 name = "tokenizers"

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -200,6 +200,6 @@ pub enum IndexError {
     #[error("couldn't remove index files on drop_index: {0}")]
     DeleteDirectory(#[from] SearchDirectoryError),
 
-    #[error("key_field column '{0}' cannot be NULL")]
-    KeyIdNull(String),
+    #[error("key_field column cannot be NULL")]
+    KeyIdNull,
 }

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -321,9 +321,8 @@ unsafe fn build_callback_internal(
                     .insert(writer, document)
                     .unwrap_or_else(|err| {
                         panic!("error inserting document during build callback.  See Postgres log for more information: {err:?}")
-                    });                         
+                    });
                 }
-            
         });
         state.memctx.reset();
 

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -65,9 +65,9 @@ pub fn u64_to_item_pointer(value: u64, tid: &mut pg_sys::ItemPointerData) {
     item_pointer_set_all(tid, blockno, offno);
 }
 
-pub unsafe fn row_to_search_documents<'a>(
+pub unsafe fn row_to_search_documents(
     ctid: pg_sys::ItemPointerData,
-    tupdesc: &'a PgTupleDesc,
+    tupdesc: &PgTupleDesc,
     values: *mut pg_sys::Datum,
     isnull: *mut bool,
     schema: &SearchIndexSchema,

--- a/pg_search/src/schema/document.rs
+++ b/pg_search/src/schema/document.rs
@@ -33,6 +33,10 @@ impl SearchDocument {
     pub fn insert(&mut self, SearchFieldId(key): SearchFieldId, value: OwnedValue) {
         self.doc.add_field_value(key, &value)
     }
+
+    pub fn has_key_field(&self) -> bool {
+        self.doc.get_first(self.key.0).is_some()
+    }
 }
 
 impl From<SearchDocument> for TantivyDocument {

--- a/pg_search/tests/index_config.rs
+++ b/pg_search/tests/index_config.rs
@@ -491,7 +491,7 @@ fn null_key_field_build(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column 'id' cannot be NULL"
+            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column cannot be NULL"
         ),
     };
 }
@@ -516,7 +516,7 @@ fn null_key_field_insert(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column 'id' cannot be NULL"
+            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column cannot be NULL"
         ),
     };
 }


### PR DESCRIPTION
## What
This PR improves how ParadeDB handles nested JSON arrays in PostgreSQL `JSONB` fields, particularly focusing on ensuring that search results reflect conditions that apply to specific JSON objects within an array, rather than flattened results across the entire array. 

We modify the indexing logic to treat each nested JSON object as a separate document, ensuring that search queries accurately reflect the structure of the data.

## Why
Currently, searches for nested JSON arrays incorrectly return results because we flatten all objects in the array. We are falling back on [Tantivy's behavior](https://github.com/quickwit-oss/tantivy/blob/main/doc/src/json.md) here.

For example, searching for `crm_data.interaction:call AND crm_data.details.subject:Goodbye` on a `crm_data` array with two objects (`interaction:call` and `subject:Welcome` in one object and `interaction:email` and `subject:Goodbye` in another) would incorrectly return a match, even though no single object in the array satisfies both conditions.


This change ensures that only JSON objects which meet both conditions within the same nested object are returned, improving search accuracy for use cases involving complex, nested data structures.

## How
- Refactored `row_to_search_document` into `row_to_search_documents` to generate multiple Tantivy documents from a single row when JSON arrays are present.
- Ensured that each document in the array is indexed independently, with its own search fields and values.

## Tests
- Added a new test `separate_nested_json_docs` to verify that search conditions are correctly applied to each JSON object in an array.
- Added a new test `large_dataset_nested_json` to test behavior with many documents and complex queries, ensuring performance and accuracy in larger datasets.
- Confirmed that no false positives are returned when search conditions span multiple JSON objects within an array.