### PR TITLE
feat: Install extensions in template1

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -9,15 +9,13 @@ set -Eeuo pipefail
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
-# Create the `template_paradedb` template db
-psql -d postgres -c "CREATE DATABASE template_paradedb IS_TEMPLATE true;"
-
 # The `pg_cron` extension can only be installed in the `postgres` database, as per
 # our configuration in our Dockerfile. Therefore, we install it separately here.
 psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_cron;"
 
-# Load ParadeDB and third-party extensions into both template_database and $POSTGRES_DB
-for DB in template_paradedb "$POSTGRES_DB"; do
+# Load ParadeDB and third-party extensions into both template1 and $POSTGRES_DB
+# Creating extensions in template1 ensures that they are available in all new databases.
+for DB in template1 "$POSTGRES_DB"; do
   echo "Loading ParadeDB extensions into $DB"
   psql -d "$DB" <<-'EOSQL'
     CREATE EXTENSION IF NOT EXISTS pg_search;
@@ -35,8 +33,8 @@ for DB in template_paradedb "$POSTGRES_DB"; do
 EOSQL
 done
 
-# Add the `paradedb` schema to both template_database and $POSTGRES_DB
-for DB in template_paradedb "$POSTGRES_DB"; do
+# Add the `paradedb` schema to both template1 and $POSTGRES_DB
+for DB in template1 "$POSTGRES_DB"; do
   echo "Adding 'paradedb' search_path to $DB"
   psql -d "$DB" -c "ALTER DATABASE \"$DB\" SET search_path TO public,paradedb;"
 done

--- a/docker/update_pg_analytics.sh
+++ b/docker/update_pg_analytics.sh
@@ -11,8 +11,9 @@ export PGUSER="$POSTGRES_USER"
 
 PARADEDB_VERSION="${PARADEDB_VERSION%%+*}"
 
-# Update ParadeDB pg_analytics into both template_database and $POSTGRES_DB
-for DB in template_paradedb "$POSTGRES_DB" "${@}"; do
+# Update ParadeDB pg_analytics into both template1 and $POSTGRES_DB
+# Creating the extension in template1 ensures that it is available in all new databases.
+for DB in template1 "$POSTGRES_DB" "${@}"; do
   echo "Updating ParadeDB pg_analytics '$DB' to $PARADEDB_VERSION"
   psql -d "$DB" -c "
     -- Upgrade ParadeDB extensions

--- a/docker/update_pg_search.sh
+++ b/docker/update_pg_search.sh
@@ -11,8 +11,9 @@ export PGUSER="$POSTGRES_USER"
 
 PARADEDB_VERSION="${PARADEDB_VERSION%%+*}"
 
-# Update ParadeDB pg_search into both template_database and $POSTGRES_DB
-for DB in template_paradedb "$POSTGRES_DB" "${@}"; do
+# Update ParadeDB pg_search into both template1 and $POSTGRES_DB
+# Creating the extension in template1 ensures that it is available in all new databases.
+for DB in template1 "$POSTGRES_DB" "${@}"; do
   echo "Updating ParadeDB pg_search '$DB' to $PARADEDB_VERSION"
   psql -d "$DB" -c "
     -- Upgrade ParadeDB extensions


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We were installing our extensions in a custom template database. This meant that tools like pgAdmin wouldn't automatically use this template when creating new databases. By installing in `template1` instead all new databases will have our extensions pre-installed, which is what users expect.

## Why
^

## How
^

## Tests
^