### PR TITLE
test: Add query benchmarking suite for pg_analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.4.1",
- "indexmap",
+ "indexmap 2.6.0",
  "lexical-core",
  "num",
  "serde",
@@ -640,6 +640,381 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-config"
+version = "1.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f2a62020f3e06f9b352b2a23547f6e1d110b6bf1e18a6b588ae36114eaf6e2"
+dependencies = [
+ "ahash",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33ae899566f3d395cbf42858e433930682cc9c1889fa89318896082fef45efb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c09e199ebd96b9f860b0fce4b6625f211e064ad7c8693b72ecf7ef03881e0"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d95f93a98130389eb6233b9d615249e543f6c24a68ca1f109af9ca5164a8765"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.1.1",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +1030,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +1046,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -831,6 +1222,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls 0.23.14",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.45.0-rc.26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "brotli"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +1311,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,24 +1355,37 @@ name = "cargo-paradedb"
 version = "0.10.3"
 dependencies = [
  "anyhow",
+ "async-lock 3.4.0",
  "async-std",
+ "aws-config",
+ "aws-sdk-s3",
+ "bytes",
+ "camino",
+ "cargo_metadata",
  "chrono",
  "clap 4.5.19",
  "cmd_lib",
  "criterion",
+ "datafusion 37.1.0",
  "dotenvy",
  "futures",
  "glob",
  "itertools 0.12.1",
  "once_cell",
+ "rand",
+ "rayon",
  "reqwest 0.12.8",
- "rstest",
  "serde",
  "serde_json",
  "sqlx",
  "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
+ "url",
 ]
 
 [[package]]
@@ -1302,6 +1766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1884,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1937,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1982,57 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85069782056753459dc47e386219aa1fdac5b731f26c28abb8c0ffd4b7c5ab11"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2",
+ "chrono",
+ "dashmap",
+ "datafusion-common 37.1.0",
+ "datafusion-common-runtime 37.1.0",
+ "datafusion-execution 37.1.0",
+ "datafusion-expr 37.1.0",
+ "datafusion-functions 37.1.0",
+ "datafusion-functions-array 37.1.0",
+ "datafusion-optimizer 37.1.0",
+ "datafusion-physical-expr 37.1.0",
+ "datafusion-physical-plan 37.1.0",
+ "datafusion-sql 37.1.0",
+ "flate2",
+ "futures",
+ "glob",
+ "half 2.4.1",
+ "hashbrown 0.14.5",
+ "indexmap 2.6.0",
+ "itertools 0.12.1",
+ "log",
+ "num_cpus",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "pin-project-lite",
+ "rand",
+ "sqlparser 0.44.0",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+ "xz2",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -1471,23 +2052,23 @@ dependencies = [
  "bzip2",
  "chrono",
  "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
+ "datafusion-common 38.0.0",
+ "datafusion-common-runtime 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
+ "datafusion-functions 38.0.0",
  "datafusion-functions-aggregate",
- "datafusion-functions-array",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-sql",
+ "datafusion-functions-array 38.0.0",
+ "datafusion-optimizer 38.0.0",
+ "datafusion-physical-expr 38.0.0",
+ "datafusion-physical-plan 38.0.0",
+ "datafusion-sql 38.0.0",
  "flate2",
  "futures",
  "glob",
  "half 2.4.1",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "log",
  "num_cpus",
@@ -1496,7 +2077,7 @@ dependencies = [
  "parquet",
  "pin-project-lite",
  "rand",
- "sqlparser",
+ "sqlparser 0.45.0",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -1504,6 +2085,27 @@ dependencies = [
  "uuid",
  "xz2",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309d9040751f6dc9e33c85dce6abb55a46ef7ea3644577dd014611c379447ef3"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "chrono",
+ "half 2.4.1",
+ "instant",
+ "libc",
+ "num_cpus",
+ "object_store",
+ "parquet",
+ "sqlparser 0.44.0",
 ]
 
 [[package]]
@@ -1524,7 +2126,16 @@ dependencies = [
  "num_cpus",
  "object_store",
  "parquet",
- "sqlparser",
+ "sqlparser 0.45.0",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e4a44d8ef1b1e85d32234e6012364c411c3787859bb3bba893b0332cb03dfd"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -1538,6 +2149,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a3a29ae36bcde07d179cc33b45656a8e7e4d023623e320e48dcf1200eeee95"
+dependencies = [
+ "arrow",
+ "chrono",
+ "dashmap",
+ "datafusion-common 37.1.0",
+ "datafusion-expr 37.1.0",
+ "futures",
+ "hashbrown 0.14.5",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-execution"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
@@ -1545,8 +2177,8 @@ dependencies = [
  "arrow",
  "chrono",
  "dashmap",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-expr 38.0.0",
  "futures",
  "hashbrown 0.14.5",
  "log",
@@ -1559,6 +2191,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3542aa322029c2121a671ce08000d4b274171070df13f697b14169ccf4f628"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "chrono",
+ "datafusion-common 37.1.0",
+ "paste",
+ "sqlparser 0.44.0",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
+name = "datafusion-expr"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
@@ -1567,12 +2216,37 @@ dependencies = [
  "arrow",
  "arrow-array",
  "chrono",
- "datafusion-common",
+ "datafusion-common 38.0.0",
  "paste",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.45.0",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd221792c666eac174ecc09e606312844772acc12cbec61a420c2fca1ee70959"
+dependencies = [
+ "arrow",
+ "base64 0.22.1",
+ "blake2",
+ "blake3",
+ "chrono",
+ "datafusion-common 37.1.0",
+ "datafusion-execution 37.1.0",
+ "datafusion-expr 37.1.0",
+ "datafusion-physical-expr 37.1.0",
+ "hex",
+ "itertools 0.12.1",
+ "log",
+ "md-5",
+ "regex",
+ "sha2",
+ "unicode-segmentation",
+ "uuid",
 ]
 
 [[package]]
@@ -1586,10 +2260,10 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
+ "datafusion-physical-expr 38.0.0",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -1609,13 +2283,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
  "datafusion-physical-expr-common",
  "log",
  "paste",
- "sqlparser",
+ "sqlparser 0.45.0",
+]
+
+[[package]]
+name = "datafusion-functions-array"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e501801e84d9c6ef54caaebcda1b18a6196a24176c12fb70e969bc0572e03c55"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "datafusion-common 37.1.0",
+ "datafusion-execution 37.1.0",
+ "datafusion-expr 37.1.0",
+ "datafusion-functions 37.1.0",
+ "itertools 0.12.1",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -1629,13 +2323,31 @@ dependencies = [
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
+ "datafusion-common 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
+ "datafusion-functions 38.0.0",
  "itertools 0.12.1",
  "log",
  "paste",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bd7f5087817deb961764e8c973d243b54f8572db414a8f0a8f33a48f991e0a"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common 37.1.0",
+ "datafusion-expr 37.1.0",
+ "datafusion-physical-expr 37.1.0",
+ "hashbrown 0.14.5",
+ "itertools 0.12.1",
+ "log",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1647,14 +2359,49 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-expr 38.0.0",
+ "datafusion-physical-expr 38.0.0",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "log",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cabc0d9aaa0f5eb1b472112f16223c9ffd2fb04e58cbf65c0a331ee6e993f96"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-string",
+ "base64 0.22.1",
+ "blake2",
+ "blake3",
+ "chrono",
+ "datafusion-common 37.1.0",
+ "datafusion-execution 37.1.0",
+ "datafusion-expr 37.1.0",
+ "half 2.4.1",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.6.0",
+ "itertools 0.12.1",
+ "log",
+ "md-5",
+ "paste",
+ "petgraph",
+ "rand",
+ "regex",
+ "sha2",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1672,15 +2419,15 @@ dependencies = [
  "arrow-string",
  "base64 0.22.1",
  "chrono",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
  "datafusion-functions-aggregate",
  "datafusion-physical-expr-common",
  "half 2.4.1",
  "hashbrown 0.14.5",
  "hex",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -1695,8 +2442,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-expr 38.0.0",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c0523e9c8880f2492a88bbd857dde02bed1ed23f3e9211a89d3d7ec3b44af9"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common 37.1.0",
+ "datafusion-common-runtime 37.1.0",
+ "datafusion-execution 37.1.0",
+ "datafusion-expr 37.1.0",
+ "datafusion-physical-expr 37.1.0",
+ "futures",
+ "half 2.4.1",
+ "hashbrown 0.14.5",
+ "indexmap 2.6.0",
+ "itertools 0.12.1",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -1713,17 +2491,17 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-common-runtime 38.0.0",
+ "datafusion-execution 38.0.0",
+ "datafusion-expr 38.0.0",
  "datafusion-functions-aggregate",
- "datafusion-physical-expr",
+ "datafusion-physical-expr 38.0.0",
  "datafusion-physical-expr-common",
  "futures",
  "half 2.4.1",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -1735,6 +2513,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
+version = "37.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49eb54b42227136f6287573f2434b1de249fe1b8e6cd6cc73a634e4a3ec29356"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
+ "datafusion-common 37.1.0",
+ "datafusion-expr 37.1.0",
+ "log",
+ "sqlparser 0.44.0",
+ "strum",
+]
+
+[[package]]
+name = "datafusion-sql"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
@@ -1742,11 +2536,21 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 38.0.0",
+ "datafusion-expr 38.0.0",
  "log",
- "sqlparser",
+ "sqlparser 0.45.0",
  "strum",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1802,10 +2606,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "docker_credential"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "dotenvy"
@@ -1826,12 +2662,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2063,6 +2931,16 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "filetime"
@@ -2355,6 +3233,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +3255,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2385,7 +3274,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2417,6 +3306,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2648,11 +3543,43 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2665,10 +3592,10 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -2721,6 +3648,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyperloglogplus"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +3695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +3715,17 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -3698,6 +4657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +4701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +4728,17 @@ checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.1",
+]
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -3821,6 +4803,31 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.8.5",
+ "structmeta",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3950,7 +4957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -3969,7 +4976,7 @@ dependencies = [
  "dotenvy",
  "fs2",
  "futures",
- "indexmap",
+ "indexmap 2.6.0",
  "json5",
  "libc",
  "memoffset",
@@ -4206,9 +5213,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.9",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -4217,8 +5234,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4564,6 +5581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,6 +5622,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -4670,7 +5704,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -4695,6 +5729,17 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -4724,10 +5769,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4906,15 +5951,54 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4940,6 +6024,16 @@ name = "rustls-pki-types"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -5001,10 +6095,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -5115,6 +6233,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,6 +6262,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5175,7 +6334,7 @@ dependencies = [
  "bigdecimal",
  "bytes",
  "chrono",
- "datafusion",
+ "datafusion 38.0.0",
  "humansize",
  "libc",
  "mockall",
@@ -5203,6 +6362,25 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "signature"
@@ -5324,12 +6502,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -5346,6 +6534,16 @@ checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf9c7ff146298ffda83a200f8d5084f08dcee1edfc135fcc1d646a45d50ffd6"
+dependencies = [
+ "log",
+ "sqlparser_derive",
 ]
 
 [[package]]
@@ -5407,7 +6605,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap",
+ "indexmap 2.6.0",
  "log",
  "memchr",
  "native-tls",
@@ -5614,6 +6812,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "strum"
@@ -5935,6 +7156,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "testcontainers"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef8374cea2c164699681ecc39316c3e1d953831a7a5721e36c7736d974e15fa"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "dirs",
+ "docker_credential",
+ "either",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "359d9a225791e1b9f60aab01f9ae9471898b9b9904b5db192104a71e96785079"
+dependencies = [
+ "testcontainers",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6082,7 +7340,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -6137,12 +7397,33 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls",
+ "rustls 0.23.14",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6186,7 +7467,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6256,6 +7537,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6353,6 +7635,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.14",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6361,6 +7661,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6387,7 +7688,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6444,6 +7745,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -6566,6 +7873,15 @@ checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6857,6 +8173,12 @@ dependencies = [
  "linux-raw-sys 0.4.14",
  "rustix 0.38.37",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "rand",
  "rayon",
  "reqwest 0.12.8",
+ "rstest",
  "serde",
  "serde_json",
  "sqlx",

--- a/cargo-paradedb/Cargo.toml
+++ b/cargo-paradedb/Cargo.toml
@@ -3,11 +3,10 @@ name = "cargo-paradedb"
 version = "0.10.3"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1.0.87"
 async-std = "1.13.0"
+async-lock = "3.4.0"
 chrono = { version = "0.4.38", features = ["clock", "alloc", "serde"] }
 clap = { version = "4.5.17", features = ["derive", "env"] }
 cmd_lib = "1.9.4"
@@ -18,20 +17,28 @@ glob = "0.3.1"
 itertools = "0.12.1"
 once_cell = "1.19.0"
 reqwest = { version = "0.12.7", features = ["json", "blocking"] }
+ureq = { version = "2.6", features = ["json"] }
 serde = "1.0.210"
 serde_json = "1.0.128"
 sqlx = { version = "0.7.4", features = [
   "postgres",
   "runtime-async-std",
+  "uuid",
   "chrono",
   "tls-native-tls",
 ] }
 tempfile = "3.12.0"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-
-[dev-dependencies]
-rstest = "0.18.2"
-
-[package.metadata.cargo-machete]
-ignored = ["chrono"]
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "time"] }
+datafusion = { version = "37.1.0" }
+tokio = { version = "1.0", features = ["full"] }
+bytes = { version = "1.7.1" }
+rand = { version = "0.8.5" }
+aws-config = { version = "1.5.6" }
+aws-sdk-s3 = { version = "1.49.0" }
+testcontainers = { version = "0.22.0" }
+testcontainers-modules = { version = "0.10.0", features = ["localstack"] }
+cargo_metadata = { version = "0.18.0" }
+camino = { version = "1.0.7", features = ["serde1"] }
+rayon = { version = "1.5" }
+url = { version = "2.3" }

--- a/cargo-paradedb/Cargo.toml
+++ b/cargo-paradedb/Cargo.toml
@@ -42,3 +42,9 @@ cargo_metadata = { version = "0.18.0" }
 camino = { version = "1.0.7", features = ["serde1"] }
 rayon = { version = "1.5" }
 url = { version = "2.3" }
+
+[dev-dependencies]
+rstest = "0.18.2"
+
+[package.metadata.cargo-machete]
+ignored = ["chrono"]

--- a/cargo-paradedb/env.template
+++ b/cargo-paradedb/env.template
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://localhost:28817/postgres

--- a/cargo-paradedb/env.template
+++ b/cargo-paradedb/env.template
@@ -1,1 +1,0 @@
-DATABASE_URL=postgresql://localhost:28817/postgres

--- a/cargo-paradedb/src/cli.rs
+++ b/cargo-paradedb/src/cli.rs
@@ -21,19 +21,8 @@ const DEFAULT_BENCH_ESLOGS_TABLE: &str = "benchmark_eslogs";
 const DEFAULT_BENCH_ESLOGS_INDEX_NAME: &str = "benchmark_eslogs_pg_search";
 
 #[derive(Debug, Parser)]
-#[command(bin_name = "cargo-paradedb")]
+#[command(version, about, long_about = None, bin_name = "cargo")]
 pub struct Cli {
-    #[command(subcommand)]
-    pub command: Commands,
-}
-
-#[derive(Debug, clap::Subcommand)]
-pub enum Commands {
-    Paradedb(ParadedbCommands),
-}
-
-#[derive(Debug, clap::Parser)]
-pub struct ParadedbCommands {
     #[command(subcommand)]
     pub subcommand: Subcommand,
 }
@@ -228,10 +217,10 @@ impl Cli {
 
         tracing::trace!("Entering parse_args method");
 
-        // Parse all arguments without skipping
-        let parsed = Self::parse();
-        tracing::debug!("Parsed result: {:#?}", parsed);
-        parsed
+        match args.get(1) {
+            Some(arg) if arg == "paradedb" => Self::parse_from(&args[1..]),
+            _ => Self::parse(),
+        }
     }
 }
 

--- a/cargo-paradedb/src/cli.rs
+++ b/cargo-paradedb/src/cli.rs
@@ -14,30 +14,41 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-
 use clap::Parser;
+use std::env;
 
 const DEFAULT_BENCH_ESLOGS_TABLE: &str = "benchmark_eslogs";
 const DEFAULT_BENCH_ESLOGS_INDEX_NAME: &str = "benchmark_eslogs_pg_search";
 
-/// A wrapper struct for subcommands.
-#[derive(Parser)]
-#[command(version, about, long_about = None, bin_name = "cargo")]
+#[derive(Debug, Parser)]
+#[command(bin_name = "cargo-paradedb")]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Commands {
+    Paradedb(ParadedbCommands),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct ParadedbCommands {
     #[command(subcommand)]
     pub subcommand: Subcommand,
 }
 
 // Top-level commands for the cargo-paradedb tool.
-#[derive(clap::Subcommand)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
     Install,
     Bench(CorpusArgs),
+    PgaBench(PgaBenchArgs),
 }
 
 // A wrapper struct for a subcommand under 'cargo paradedb bench' which
 // select a corpus to generate/run.
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Parser)]
 pub struct CorpusArgs {
     #[command(subcommand)]
     pub corpus: Corpus,
@@ -52,17 +63,33 @@ pub enum Corpus {
 }
 
 /// A wrapper struct for the command to run on the eslogs corpus.
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Parser)]
 pub struct EsLogsArgs {
     #[command(subcommand)]
     pub command: EsLogsCommand,
 }
 
 /// A wrapper struct for the command to run on the hits corpus.
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Parser)]
 pub struct HitsArgs {
     #[command(subcommand)]
     pub command: HitsCommand,
+}
+
+/// Wrapper for pg_analytics benchmark subcommands.
+#[derive(Debug, clap::Parser)]
+pub struct PgaBenchArgs {
+    #[command(subcommand)]
+    pub command: PgaBenchCommand,
+    /// Postgres database url to connect to.
+    #[arg(short, long, env = "DATABASE_URL")]
+    pub url: String,
+}
+
+/// Runs pg_analytics benchmark sub-commands
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum PgaBenchCommand {
+    ParquetRunAll,
 }
 
 /// The command to run on the eslogs corpus.
@@ -194,26 +221,22 @@ pub enum HitsCommand {
     },
 }
 
+impl Cli {
+    pub fn parse_args() -> Self {
+        let args: Vec<String> = env::args().collect();
+        tracing::info!("Collected args: {:#?}", args);
+
+        tracing::trace!("Entering parse_args method");
+
+        // Parse all arguments without skipping
+        let parsed = Self::parse();
+        tracing::debug!("Parsed result: {:#?}", parsed);
+        parsed
+    }
+}
+
 impl Default for Cli {
     fn default() -> Self {
-        // Usually, clap CLI tools can just use `Self::parse()` to initialize a
-        // struct with the CLI arguments... but seeing as this will be run as a
-        // cargo subcommand, we need to do some extra work.
-        //
-        // Because we're running e.g. "cargo paradedb install"... clap will think
-        // that "paradedb" is the first argument that was passed to the binary.
-        // Instead we want "install" to be the first argument, with "paradedb"
-        // ignored. For this reason, we'll manually collect and process the CLI
-        // arguments ourselves.
-        //
-        // We check to see if the argument at index 1 is "paradedb"...
-        // as the argument at index 0 is always the path to the binary executable.
-        // If "paradedb" is found, we'll parse the arguments starting at index 1.
-        // Otherwise, we'll use Self::parse() like usual.
-        let args = std::env::args().collect::<Vec<String>>();
-        match args.get(1) {
-            Some(arg) if arg == "paradedb" => Self::parse_from(&args[1..]),
-            _ => Self::parse(),
-        }
+        Self::parse_args()
     }
 }

--- a/cargo-paradedb/src/fixtures/io_s3_obj_store.rs
+++ b/cargo-paradedb/src/fixtures/io_s3_obj_store.rs
@@ -1,0 +1,302 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+use anyhow::{Context, Result};
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::Object;
+use bytes::Bytes;
+use datafusion::{
+    arrow::record_batch::RecordBatch,
+    parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder, parquet::arrow::ArrowWriter,
+    parquet::file::properties::WriterProperties,
+};
+use futures::future::BoxFuture;
+use std::io::Cursor;
+use std::sync::Arc;
+use std::{
+    fs::{self},
+    path::Path,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::{localstack::LocalStack, testcontainers::ImageExt};
+use tokio::runtime::Runtime;
+
+/// A wrapper type to own both the testcontainers container for localstack
+/// and the S3 client. It's important that they be owned together, because
+/// testcontainers will stop the Docker container is stopped once the variable
+/// is dropped.
+#[allow(unused)]
+pub struct LocalStackS3Client {
+    container: Arc<ContainerAsync<LocalStack>>,
+    pub client: aws_sdk_s3::Client,
+    pub url: String,
+    runtime: Runtime,
+}
+
+impl LocalStackS3Client {
+    pub fn new() -> Result<Self> {
+        let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+        let (container, client, url) = runtime.block_on(async {
+            let request = LocalStack::default().with_env_var("SERVICES", "s3");
+            let container = request
+                .start()
+                .await
+                .context("Failed to start the container")?;
+
+            let host_ip = container.get_host().await.expect("failed to get Host IP");
+            let host_port = container
+                .get_host_port_ipv4(4566)
+                .await
+                .context("Failed to get Host Port")?;
+            let url = format!("{host_ip}:{host_port}");
+            let creds = aws_sdk_s3::config::Credentials::new("fake", "fake", None, None, "test");
+
+            let config = aws_sdk_s3::config::Builder::default()
+                .behavior_version(BehaviorVersion::v2024_03_28())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(creds)
+                .endpoint_url(format!("http://{}", url.clone()))
+                .force_path_style(true)
+                .build();
+
+            let client = aws_sdk_s3::Client::from_conf(config);
+            Ok::<_, anyhow::Error>((container, client, url))
+        })?;
+
+        Ok(Self {
+            container: Arc::new(container),
+            client,
+            url,
+            runtime,
+        })
+    }
+
+    #[allow(unused)]
+    pub fn create_bucket(&self, bucket: &str) -> Result<()> {
+        self.runtime.block_on(async {
+            let _ = self
+                .client
+                .create_bucket()
+                .bucket(bucket)
+                .send()
+                .await
+                .context("Failed to create bucket");
+            Ok(())
+        })
+    }
+
+    #[allow(unused)]
+    pub fn put_batch(&self, bucket: &str, key: &str, batch: &RecordBatch) -> Result<()> {
+        self.runtime.block_on(async {
+            // Create a cursor to write the batch data
+            let mut cursor = Cursor::new(Vec::new());
+
+            // Create ArrowWriter with default properties
+            let props = WriterProperties::builder().build();
+            let mut writer = ArrowWriter::try_new(&mut cursor, batch.schema(), Some(props))
+                .context("Failed to create ArrowWriter")?;
+
+            // Write the batch
+            writer.write(batch).context("Failed to write batch")?;
+
+            // Finish writing and flush the data
+            writer.close().context("Failed to close ArrowWriter")?;
+
+            // Get the written data
+            let data = cursor.into_inner();
+
+            // Upload the data to S3
+            let _ = self
+                .client
+                .put_object()
+                .bucket(bucket)
+                .key(key)
+                .body(ByteStream::from(data))
+                .send()
+                .await
+                .context("Failed to put batch");
+            Ok(())
+        })
+    }
+
+    #[allow(unused)]
+    pub fn get_batch(&self, bucket: &str, key: &str) -> Result<RecordBatch> {
+        self.runtime.block_on(async {
+            // Retrieve the object from S3
+            let get_object_output = self
+                .client
+                .get_object()
+                .bucket(bucket)
+                .key(key)
+                .send()
+                .await
+                .context("Failed to get object from S3")?;
+
+            // Read the body of the object
+            let body = get_object_output.body.collect().await?;
+            let bytes: Bytes = body.into_bytes();
+
+            // Create a Parquet reader
+            let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
+                .context("Failed to create Parquet reader builder")?;
+
+            // Create the reader
+            let mut reader = builder.build().context("Failed to build Parquet reader")?;
+
+            // Read the first batch
+            reader
+                .next()
+                .context("No batches found in Parquet file")?
+                .context("Failed to read batch")
+        })
+    }
+
+    // #[allow(dead_code)]
+    pub fn put_directory(&self, bucket: &str, s3_prefix: &str, local_dir: &Path) -> Result<()> {
+        self.runtime.block_on(async {
+            self.put_directory_recursive(bucket, s3_prefix, local_dir)
+                .await
+        })
+    }
+
+    fn put_directory_recursive<'a>(
+        &'a self,
+        bucket: &'a str,
+        s3_prefix: &'a str,
+        local_dir: &'a Path,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let base_path = local_dir.to_path_buf();
+            let entries = fs::read_dir(local_dir).context("Failed to read directory")?;
+
+            for entry in entries {
+                let entry = entry.context("Failed to read directory entry")?;
+                let path = entry.path();
+                let relative_path = path.strip_prefix(&base_path)?;
+                let s3_key = if s3_prefix.is_empty() {
+                    relative_path.to_string_lossy().to_string()
+                } else {
+                    format!("{}/{}", s3_prefix, relative_path.to_string_lossy())
+                };
+
+                if path.is_file() {
+                    tracing::info!("Uploading file: local_path={:?}, s3_key={}", path, s3_key);
+
+                    let content = fs::read(&path).context("Failed to read file")?;
+                    self.client
+                        .put_object()
+                        .bucket(bucket)
+                        .key(&s3_key)
+                        .body(ByteStream::from(content))
+                        .send()
+                        .await
+                        .context("Failed to upload file to S3")?;
+
+                    tracing::info!("Uploaded file: s3_key={}", s3_key);
+                } else if path.is_dir() {
+                    self.put_directory_recursive(bucket, &s3_key, &path).await?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    pub fn print_object_list(&self, bucket: &str, prefix: &str) -> Result<()> {
+        self.runtime.block_on(async {
+            let objects = self
+                .list_objects(bucket, prefix)
+                .await
+                .context("Failed to list bucket objects")?;
+
+            tracing::info!("Objects in s3://{}/{}", bucket, prefix);
+            for object in objects {
+                tracing::info!(
+                    "  {} ({})",
+                    object.key().unwrap_or(""),
+                    object.size().unwrap_or(0)
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    async fn list_objects(&self, bucket: &str, prefix: &str) -> Result<Vec<Object>> {
+        let mut objects = Vec::new();
+
+        let mut paginator = self
+            .client
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix(prefix)
+            .into_paginator()
+            .send();
+
+        while let Some(page) = paginator.next().await {
+            match page {
+                Ok(output) => {
+                    if let Some(contents) = output.contents {
+                        objects.extend(contents);
+                    }
+                }
+                Err(err) => {
+                    return Err(anyhow::anyhow!("Failed to list objects: {:?}", err));
+                }
+            }
+        }
+
+        Ok(objects)
+    }
+}
+
+impl Drop for LocalStackS3Client {
+    fn drop(&mut self) {
+        tracing::info!("S3 resource drop initiated");
+
+        // Clone the container to avoid borrowing issues
+        let container = Arc::clone(&self.container);
+
+        // Create a future that doesn't capture `self`
+        let future = async move {
+            if let Err(e) = container.stop().await {
+                tracing::error!("Failed to stop container: {:?}", e);
+            } else {
+                tracing::info!("Container stopped successfully");
+            }
+        };
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                tracing::debug!("Existing Tokio runtime found, executing in current context");
+                tokio::task::block_in_place(move || {
+                    handle.block_on(future);
+                });
+            }
+            Err(e) => {
+                tracing::warn!("No Tokio runtime found, spawning new thread: {:?}", e);
+                std::thread::spawn(move || {
+                    let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+                    rt.block_on(future);
+                });
+            }
+        }
+
+        tracing::info!("S3 resource drop completed");
+    }
+}

--- a/cargo-paradedb/src/fixtures/mod.rs
+++ b/cargo-paradedb/src/fixtures/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+pub mod io_s3_obj_store;
+pub mod postgres_test_client;

--- a/cargo-paradedb/src/fixtures/postgres_test_client.rs
+++ b/cargo-paradedb/src/fixtures/postgres_test_client.rs
@@ -1,0 +1,156 @@
+#![allow(dead_code)]
+
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+// TECH DEBT: This file is a copy of the `db.rs` file from https://github.com/paradedb/paradedb/blob/dev/shared/src/fixtures/db.rs
+// We duplicated because the paradedb repo may use a different version of pgrx than pg_analytics, but eventually we should
+// move this into a separate crate without any dependencies on pgrx.
+use anyhow::{Context, Result};
+use async_lock::{Semaphore, SemaphoreGuardArc};
+use rand::Rng;
+use sqlx::{postgres::PgPoolOptions, ConnectOptions, PgConnection, PgPool};
+// use sqlx::Connection;
+use std::sync::Arc;
+use url::Url;
+
+pub struct ActivePoolConnGuard {
+    pub inner_conn: PgConnection,
+    guard: SemaphoreGuardArc,
+}
+
+impl ActivePoolConnGuard {
+    pub fn new(pg_conn: PgConnection, guard: SemaphoreGuardArc) -> Self {
+        Self {
+            inner_conn: pg_conn,
+            guard,
+        }
+    }
+}
+
+pub struct PostgresTestClient {
+    admin_pool: PgPool,
+    test_pool: PgPool,
+    test_db_name: String,
+    connection_semaphore: Arc<Semaphore>,
+}
+
+impl PostgresTestClient {
+    pub async fn new(database_url: &str, max_connections: usize) -> Result<Self> {
+        let admin_pool = PgPoolOptions::new()
+            .max_connections(2) // Limit connections for admin tasks
+            .connect(database_url)
+            .await
+            .context("Failed to create admin connection pool")?;
+
+        let test_db_name = format!("test_db_{}", rand::thread_rng().gen::<u32>());
+        let create_db_query = format!("CREATE DATABASE {}", test_db_name);
+
+        sqlx::query(&create_db_query)
+            .execute(&admin_pool)
+            .await
+            .context("Failed to create test database")?;
+
+        let mut test_url = Url::parse(database_url).context("Failed to parse database URL")?;
+        test_url.set_path(&test_db_name);
+
+        let test_pool = PgPoolOptions::new()
+            .max_connections(max_connections as u32) // Adjust based on your needs
+            .connect(test_url.as_str())
+            .await
+            .context("Failed to create test database connection pool")?;
+
+        tracing::info!(
+            "Created test database: {} with connection pool",
+            test_db_name
+        );
+
+        let connection_semaphore = Arc::new(Semaphore::new(max_connections));
+
+        Ok(Self {
+            admin_pool,
+            test_pool,
+            test_db_name,
+            connection_semaphore,
+        })
+    }
+
+    pub async fn acquire_connection(&self) -> Result<ActivePoolConnGuard> {
+        let guard = self.connection_semaphore.acquire_arc().await;
+
+        let connect_options = self.test_pool.connect_options().clone();
+
+        match connect_options.connect().await {
+            Ok(conn) => Ok(ActivePoolConnGuard::new(conn, guard)),
+
+            Err(e) => Err(e).context("Failed to acquire a connection from the test database pool"),
+        }
+    }
+
+    async fn execute_admin_query(&self, query: &str) -> Result<()> {
+        sqlx::query(query)
+            .execute(&self.admin_pool)
+            .await
+            .context("Failed to execute admin query")?;
+        Ok(())
+    }
+
+    async fn terminate_connections(&self) -> Result<()> {
+        let terminate_query = format!(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{}'",
+            self.test_db_name
+        );
+        self.execute_admin_query(&terminate_query).await?;
+        tracing::info!(
+            "Terminated connections to test database: {}",
+            self.test_db_name
+        );
+        Ok(())
+    }
+
+    async fn drop_database(&self) -> Result<()> {
+        let drop_db_query = format!("DROP DATABASE IF EXISTS {}", self.test_db_name);
+        self.execute_admin_query(&drop_db_query).await?;
+        tracing::info!("Dropped test database: {}", self.test_db_name);
+        Ok(())
+    }
+}
+
+impl Drop for PostgresTestClient {
+    fn drop(&mut self) {
+        let runtime = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+
+        runtime.block_on(async {
+            // Close all connections in the test pool
+            self.test_pool.close().await;
+
+            if let Err(e) = self.terminate_connections().await {
+                tracing::error!("Failed to terminate connections: {}", e);
+            }
+
+            // Wait a moment to ensure connections are fully closed
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+            if let Err(e) = self.drop_database().await {
+                tracing::error!("Failed to drop test database: {}", e);
+            }
+
+            // Close the admin pool
+            self.admin_pool.close().await;
+        });
+    }
+}

--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -19,88 +19,128 @@ mod bench_hits;
 mod benchmark;
 mod cli;
 mod elastic;
+mod fixtures;
+mod pga_benches;
 mod subcommand;
 mod tables;
 
 use anyhow::Result;
 use async_std::task::block_on;
-use cli::{Cli, Corpus, EsLogsCommand, HitsCommand, Subcommand};
+use cli::{Cli, Corpus, EsLogsCommand, HitsCommand, PgaBenchCommand, Subcommand};
 use dotenvy::dotenv;
+use pga_benches::pga_benchlogs_hsp_pq;
 use tracing_subscriber::EnvFilter;
 
-fn main() -> Result<()> {
+fn handle_pga_bench_command(pga_bench_args: cli::PgaBenchArgs) -> Result<()> {
+    tracing::info!("Handling pga-bench command: {:?}", pga_bench_args);
+
+    match pga_bench_args.command {
+        PgaBenchCommand::ParquetRunAll => {
+            block_on(pga_benchlogs_hsp_pq::run_all_bench(&pga_bench_args.url))
+        }
+    }
+}
+
+fn handle_hits_command(hits: cli::HitsArgs) -> Result<()> {
+    match hits.command {
+        HitsCommand::Run {
+            workload,
+            url,
+            full,
+        } => block_on(bench_hits::bench_hits(&url, &workload, full)),
+    }
+}
+
+fn handle_eslogs_command(eslogs: cli::EsLogsArgs) -> Result<()> {
+    use EsLogsCommand::*;
+
+    match eslogs.command {
+        Generate {
+            seed,
+            events,
+            table,
+            url,
+        } => block_on(subcommand::bench_eslogs_generate(seed, events, table, url)),
+        BuildSearchIndex { table, index, url } => block_on(
+            subcommand::bench_eslogs_build_search_index(table, index, url),
+        ),
+        QuerySearchIndex {
+            index,
+            query,
+            limit,
+            url,
+        } => block_on(subcommand::bench_eslogs_query_search_index(
+            index, query, limit, url,
+        )),
+        BuildGinIndex { table, index, url } => {
+            block_on(subcommand::bench_eslogs_build_gin_index(table, index, url))
+        }
+        QueryGinIndex {
+            table,
+            query,
+            limit,
+            url,
+        } => block_on(subcommand::bench_eslogs_query_gin_index(
+            table, query, limit, url,
+        )),
+        BuildParquetTable { table, url } => {
+            block_on(subcommand::bench_eslogs_build_parquet_table(table, url))
+        }
+        CountParquetTable { table, url } => {
+            block_on(subcommand::bench_eslogs_count_parquet_table(table, url))
+        }
+        BuildElasticIndex {
+            table,
+            url,
+            elastic_url,
+        } => block_on(subcommand::bench_eslogs_build_elastic_table(
+            url,
+            table,
+            elastic_url,
+        )),
+        QueryElasticIndex {
+            elastic_url,
+            field,
+            term,
+        } => block_on(subcommand::bench_eslogs_query_elastic_table(
+            elastic_url,
+            field,
+            term,
+        )),
+    }
+}
+
+fn handle_bench_command(bench: cli::CorpusArgs) -> Result<()> {
+    match bench.corpus {
+        Corpus::Eslogs(eslogs) => handle_eslogs_command(eslogs),
+        Corpus::Hits(hits) => handle_hits_command(hits),
+    }
+}
+
+fn setup_logging() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
-        .init();
+        .try_init()
+        .map_err(|e| anyhow::anyhow!("Failed to initialize logging: {}", e))
+}
 
-    // Load env vars from a .env in any parent folder.
+fn main() -> Result<()> {
+    setup_logging()?;
     dotenv().ok();
 
     let cli = Cli::default();
-    match cli.subcommand {
-        Subcommand::Install => subcommand::install(),
-        Subcommand::Bench(bench) => match bench.corpus {
-            Corpus::Eslogs(eslogs) => match eslogs.command {
-                EsLogsCommand::Generate {
-                    seed,
-                    events,
-                    table,
-                    url,
-                } => block_on(subcommand::bench_eslogs_generate(seed, events, table, url)),
-                EsLogsCommand::BuildSearchIndex { table, index, url } => block_on(
-                    subcommand::bench_eslogs_build_search_index(table, index, url),
-                ),
-                EsLogsCommand::QuerySearchIndex {
-                    index,
-                    query,
-                    limit,
-                    url,
-                } => block_on(subcommand::bench_eslogs_query_search_index(
-                    index, query, limit, url,
-                )),
-                EsLogsCommand::BuildGinIndex { table, index, url } => {
-                    block_on(subcommand::bench_eslogs_build_gin_index(table, index, url))
-                }
-                EsLogsCommand::QueryGinIndex {
-                    table,
-                    query,
-                    limit,
-                    url,
-                } => block_on(subcommand::bench_eslogs_query_gin_index(
-                    table, query, limit, url,
-                )),
-                EsLogsCommand::BuildParquetTable { table, url } => {
-                    block_on(subcommand::bench_eslogs_build_parquet_table(table, url))
-                }
-                EsLogsCommand::CountParquetTable { table, url } => {
-                    block_on(subcommand::bench_eslogs_count_parquet_table(table, url))
-                }
-                EsLogsCommand::BuildElasticIndex {
-                    table,
-                    url,
-                    elastic_url,
-                } => block_on(subcommand::bench_eslogs_build_elastic_table(
-                    url,
-                    table,
-                    elastic_url,
-                )),
-                EsLogsCommand::QueryElasticIndex {
-                    elastic_url,
-                    field,
-                    term,
-                } => block_on(subcommand::bench_eslogs_query_elastic_table(
-                    elastic_url,
-                    field,
-                    term,
-                )),
-            },
-            Corpus::Hits(hits) => match hits.command {
-                HitsCommand::Run {
-                    workload,
-                    url,
-                    full,
-                } => block_on(bench_hits::bench_hits(&url, &workload, full)),
-            },
-        },
-    }
+    tracing::info!("Parsed CLI structure: {:#?}", cli);
+
+    let _ = match cli.command {
+        cli::Commands::Paradedb(paradedb_cmd) => {
+            tracing::info!("Handling Paradedb command with args: {:#?}", paradedb_cmd);
+            match paradedb_cmd.subcommand {
+                Subcommand::Install => subcommand::install(),
+                Subcommand::Bench(bench_args) => handle_bench_command(bench_args),
+                Subcommand::PgaBench(pga_bench_args) => handle_pga_bench_command(pga_bench_args),
+            }
+        }
+    };
+
+    Ok(())
 }

--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -131,15 +131,10 @@ fn main() -> Result<()> {
     let cli = Cli::default();
     tracing::info!("Parsed CLI structure: {:#?}", cli);
 
-    let _ = match cli.command {
-        cli::Commands::Paradedb(paradedb_cmd) => {
-            tracing::info!("Handling Paradedb command with args: {:#?}", paradedb_cmd);
-            match paradedb_cmd.subcommand {
-                Subcommand::Install => subcommand::install(),
-                Subcommand::Bench(bench_args) => handle_bench_command(bench_args),
-                Subcommand::PgaBench(pga_bench_args) => handle_pga_bench_command(pga_bench_args),
-            }
-        }
+    let _ = match cli.subcommand {
+        Subcommand::Install => subcommand::install(),
+        Subcommand::Bench(bench_args) => handle_bench_command(bench_args),
+        Subcommand::PgaBench(pga_bench_args) => handle_pga_bench_command(pga_bench_args),
     };
 
     Ok(())

--- a/cargo-paradedb/src/pga_benches/mod.rs
+++ b/cargo-paradedb/src/pga_benches/mod.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+pub(crate) mod pga_benchlogs_hsp_pq;

--- a/cargo-paradedb/src/pga_benches/pga_benchlogs_hsp_pq.rs
+++ b/cargo-paradedb/src/pga_benches/pga_benchlogs_hsp_pq.rs
@@ -1,0 +1,446 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+use crate::fixtures::io_s3_obj_store::LocalStackS3Client;
+use anyhow::{Context, Result};
+use cargo_metadata::MetadataCommand;
+use criterion::{BenchmarkId, Criterion};
+use datafusion::dataframe::DataFrame;
+use rand::Rng;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::fixtures::postgres_test_client::{ActivePoolConnGuard, PostgresTestClient};
+use crate::tables::benchlogs_extn_hsp_pq::{
+    EsLogBenchManager, EsLogParquetForeignTableManager, EsLogParquetManager,
+};
+use camino::Utf8PathBuf;
+
+const TOTAL_RECORDS: usize = 10_000;
+
+// Constants for benchmark configuration
+const SAMPLE_SIZE: usize = 10;
+const MEASUREMENT_TIME_SECS: u64 = 30;
+const WARM_UP_TIME_SECS: u64 = 2;
+
+const PG_POOL_CONN_MAX: usize = 1;
+
+const S3_BUCKET_ID: &str = "demo-mlp-eslogs";
+const S3_PREFIX: &str = "eslogs_dataset";
+
+#[derive(Clone)]
+struct BenchResource {
+    df: Arc<DataFrame>,
+    // pg_conn: Arc<Mutex<PgConnection>>,
+    s3_storage: Arc<LocalStackS3Client>,
+    db: Arc<PostgresTestClient>,
+}
+
+impl BenchResource {
+    async fn new(postgres_url: &str) -> Result<Self> {
+        let (df, s3_storage, db) = Self::setup_benchmark(postgres_url)
+            .await
+            .with_context(|| "Failed to setup benchmark".to_string())?;
+
+        Ok(Self {
+            df: Arc::new(df),
+            // pg_conn: Arc::new(Mutex::new(pg_conn)),
+            s3_storage: Arc::new(s3_storage),
+            db: Arc::new(db),
+        })
+    }
+
+    async fn setup_benchmark(
+        postgres_url: &str,
+    ) -> Result<(DataFrame, LocalStackS3Client, PostgresTestClient)> {
+        // Initialize database
+        let db = PostgresTestClient::new(postgres_url, PG_POOL_CONN_MAX).await?;
+        let mut pg_conn: ActivePoolConnGuard = db.acquire_connection().await?;
+
+        sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_analytics;")
+            .execute(&mut pg_conn.inner_conn)
+            .await?;
+
+        // Generate and load data
+        let parquet_dataset_path = Self::parquet_path();
+        tracing::warn!("parquet_path :: {:#?}", parquet_dataset_path);
+
+        // Check if the Parquet file already exists at the specified path.
+        if !parquet_dataset_path.exists() || !Self::dataset_exists(&parquet_dataset_path) {
+            let seed = Self::generate_seed();
+            tracing::info!("Generating ESLogs dataset with seed: {}", seed);
+            EsLogParquetManager::create_hive_partitioned_parquet(
+                10000,
+                seed,
+                1000,
+                &parquet_dataset_path,
+            )
+            .context("Failed to generate and save ESLogs dataset as local Parquet")?;
+        } else {
+            tracing::warn!(
+                "Path Status :: exists: {}, contains files: {}",
+                parquet_dataset_path.exists(),
+                Self::dataset_exists(&parquet_dataset_path)
+            );
+        }
+
+        // Verify that the Parquet files were created
+        if !Self::dataset_exists(&parquet_dataset_path) {
+            tracing::error!(
+                "Parquet dataset was not created at {:?}",
+                parquet_dataset_path
+            );
+            return Err(anyhow::anyhow!("Parquet dataset was not created"));
+        }
+
+        // List the contents of the dataset directory
+        tracing::debug!("Listing contents of dataset directory:");
+        for entry in fs::read_dir(&parquet_dataset_path)? {
+            let entry = entry?;
+            tracing::debug!("{:?}", entry.path());
+        }
+
+        // Create DataFrame from Parquet file
+        let eslogs_df = EsLogParquetManager::read_parquet_dataset(&parquet_dataset_path)
+            .await
+            .context("Failed to read ESLogs dataset from local Parquet")?;
+
+        // Set up S3
+        let s3_storage = LocalStackS3Client::new()?;
+
+        EsLogParquetManager::upload_parquet_dataset_to_s3(
+            &s3_storage,
+            S3_BUCKET_ID,
+            S3_PREFIX,
+            parquet_dataset_path,
+        )
+        .await
+        .context("Failed to upload Parquet dataset to S3")?;
+
+        s3_storage.print_object_list(S3_BUCKET_ID, S3_PREFIX)?;
+
+        Ok((eslogs_df, s3_storage, db))
+    }
+
+    fn parquet_path() -> PathBuf {
+        let target_dir = MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .map(|metadata| metadata.workspace_root)
+            .unwrap_or_else(|err| {
+                tracing::warn!(
+                    "Failed to get workspace root: {}. Using 'target' as fallback.",
+                    err
+                );
+                Utf8PathBuf::from("target")
+            });
+
+        let parquet_path = target_dir
+            .join("target")
+            .join("tmp_dataset")
+            .join("eslogs_dataset");
+
+        // Check if the file exists; if not, create the necessary directories
+        if !parquet_path.exists() {
+            if let Some(parent_dir) = parquet_path.parent() {
+                fs::create_dir_all(parent_dir)
+                    .with_context(|| format!("Failed to create directory: {:#?}", parent_dir))
+                    .unwrap_or_else(|err| {
+                        tracing::error!("{}", err);
+                        panic!("Critical error: {}", err);
+                    });
+            }
+        }
+
+        parquet_path.into()
+    }
+
+    /// Generates a random seed for reproducible data generation.
+    fn generate_seed() -> u64 {
+        let mut rng = rand::thread_rng();
+        let seed: u32 = rng.gen();
+        tracing::debug!("Generated random seed: {}", seed);
+        u64::from(seed)
+    }
+
+    /// Checks if the given path is a directory and is empty.
+    fn dataset_exists(base_path: &Path) -> bool {
+        let exists = base_path.exists()
+            && base_path
+                .read_dir()
+                .map(|mut i| i.next().is_some())
+                .unwrap_or(false);
+        tracing::debug!("Dataset exists at {:?}: {}", base_path, exists);
+        exists
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    async fn setup_tables(
+        &self,
+        foreign_table_id: &str,
+        with_disk_cache: bool,
+        with_mem_cache: bool,
+    ) -> Result<()> {
+        // Clone Arc to avoid holding the lock across await points
+        let db = Arc::clone(&self.db);
+        // let pg_conn = Arc::clone(&self.pg_conn);
+        let s3_storage = Arc::clone(&self.s3_storage);
+
+        // Use a separate block to ensure the lock is released as soon as possible
+        {
+            let mut pg_conn: ActivePoolConnGuard = db.acquire_connection().await?;
+
+            EsLogParquetForeignTableManager::setup_tables(
+                &mut pg_conn.inner_conn,
+                &s3_storage,
+                S3_BUCKET_ID,
+                S3_PREFIX,
+                foreign_table_id,
+                with_disk_cache,
+            )
+            .await?;
+
+            let with_mem_cache_cfg = if with_mem_cache { "true" } else { "false" };
+            let query = format!(
+                "SELECT duckdb_execute($$SET enable_object_cache={}$$)",
+                with_mem_cache_cfg
+            );
+            sqlx::query(&query).execute(&mut pg_conn.inner_conn).await?;
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    async fn bench_total_sales(&self, foreign_table_id: &str) -> Result<()> {
+        let db = Arc::clone(&self.db);
+        // let pg_conn = Arc::clone(&self.pg_conn);
+        // let mut conn = pg_conn.lock().await;
+
+        let mut pg_conn: ActivePoolConnGuard = db.acquire_connection().await?;
+
+        let _ = EsLogBenchManager::bench_time_range_query(
+            &mut pg_conn.inner_conn,
+            &self.df,
+            foreign_table_id,
+        )
+        .await;
+
+        Ok(())
+    }
+}
+
+async fn eslog_pq_disk_cache_bench(postgres_url: &str, c: &mut Criterion) {
+    tracing::info!("Starting ESLog PQ disk cache benchmark");
+
+    let bench_resource = match BenchResource::new(postgres_url).await {
+        Ok(resource) => resource,
+        Err(e) => {
+            tracing::error!("Failed to initialize BenchResource: {}", e);
+            return;
+        }
+    };
+
+    let foreign_table_id = "eslog_pq_disk_cache";
+
+    let mut group = c.benchmark_group("Eslog PQ Disk Cache Benchmarks");
+    group.sample_size(10); // Adjust sample size if necessary
+
+    // Setup tables for the benchmark
+    if let Err(e) = bench_resource
+        .setup_tables(foreign_table_id, true, false)
+        .await
+    {
+        tracing::error!("Table setup failed: {}", e);
+    }
+
+    group
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(Duration::from_secs(MEASUREMENT_TIME_SECS))
+        .warm_up_time(Duration::from_secs(WARM_UP_TIME_SECS))
+        .throughput(criterion::Throughput::Elements(TOTAL_RECORDS as u64))
+        .bench_function(BenchmarkId::new("ESLog PQ", "Disk Cache"), |runner| {
+            runner.iter(|| {
+                let _ =
+                    async_std::task::block_on(bench_resource.bench_total_sales(foreign_table_id))
+                        .context("Benchmark execution failed");
+            });
+        });
+
+    tracing::info!("Mem cache benchmark completed");
+    group.finish();
+}
+
+async fn eslog_pq_mem_cache_bench(postgres_url: &str, c: &mut Criterion) {
+    tracing::info!("Starting ESLog PQ mem cache benchmark");
+
+    let bench_resource = match BenchResource::new(postgres_url).await {
+        Ok(resource) => resource,
+        Err(e) => {
+            tracing::error!("Failed to initialize BenchResource: {}", e);
+            return;
+        }
+    };
+
+    let foreign_table_id = "eslog_pq_mem_cache";
+
+    let mut group = c.benchmark_group("Eslog PQ Mem Cache Benchmarks");
+    group.sample_size(10); // Adjust sample size if necessary
+
+    // Setup tables for the benchmark
+    if let Err(e) = bench_resource
+        .setup_tables(foreign_table_id, false, true)
+        .await
+    {
+        tracing::error!("Table setup failed: {}", e);
+    }
+
+    bench_resource
+        .bench_total_sales(foreign_table_id)
+        .await
+        .unwrap();
+
+    group
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(Duration::from_secs(MEASUREMENT_TIME_SECS))
+        .warm_up_time(Duration::from_secs(WARM_UP_TIME_SECS))
+        .throughput(criterion::Throughput::Elements(TOTAL_RECORDS as u64))
+        .bench_function(BenchmarkId::new("ESLog PQ", "Mem Cache"), |runner| {
+            runner.iter(|| {
+                let _ =
+                    async_std::task::block_on(bench_resource.bench_total_sales(foreign_table_id))
+                        .context("Benchmark execution failed");
+            });
+        });
+
+    tracing::info!("Mem cache benchmark completed");
+    group.finish();
+}
+
+async fn eslog_pq_full_cache_bench(postgres_url: &str, c: &mut Criterion) {
+    tracing::info!("Starting ESLog PQ Full cache benchmark");
+
+    let bench_resource = match BenchResource::new(postgres_url).await {
+        Ok(resource) => resource,
+        Err(e) => {
+            tracing::error!("Failed to initialize BenchResource: {}", e);
+            return;
+        }
+    };
+
+    let foreign_table_id = "eslog_pq_full_cache";
+
+    let mut group = c.benchmark_group("Eslog PQ Full Cache Benchmarks");
+    group.sample_size(10); // Adjust sample size if necessary
+
+    // Setup tables for the benchmark
+    if let Err(e) = bench_resource
+        .setup_tables(foreign_table_id, true, true)
+        .await
+    {
+        tracing::error!("Table setup failed: {}", e);
+    }
+
+    bench_resource
+        .bench_total_sales(foreign_table_id)
+        .await
+        .unwrap();
+
+    // Run the benchmark with no cache
+    group
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(Duration::from_secs(MEASUREMENT_TIME_SECS))
+        .warm_up_time(Duration::from_secs(WARM_UP_TIME_SECS))
+        .throughput(criterion::Throughput::Elements(TOTAL_RECORDS as u64))
+        .bench_function(BenchmarkId::new("ESLog PQ", "Full Cache"), |runner| {
+            runner.iter(|| {
+                let _ =
+                    async_std::task::block_on(bench_resource.bench_total_sales(foreign_table_id))
+                        .context("Benchmark execution failed");
+            });
+        });
+
+    tracing::info!("Full cache benchmark completed");
+    group.finish();
+}
+
+async fn eslog_pq_no_cache_bench(postgres_url: &str, c: &mut Criterion) {
+    tracing::info!("Starting ESLog PQ no cache benchmark");
+
+    let bench_resource = match BenchResource::new(postgres_url).await {
+        Ok(resource) => resource,
+        Err(e) => {
+            tracing::error!("Failed to initialize BenchResource: {}", e);
+            return;
+        }
+    };
+
+    let foreign_table_id = "eslog_no_cache";
+
+    let mut group = c.benchmark_group("Eslog PQ No Cache Benchmarks");
+    group.sample_size(10); // Adjust sample size if necessary
+
+    // Setup tables for the benchmark
+    if let Err(e) = bench_resource
+        .setup_tables(foreign_table_id, false, false)
+        .await
+    {
+        tracing::error!("Table setup failed: {}", e);
+    }
+
+    bench_resource
+        .bench_total_sales(foreign_table_id)
+        .await
+        .unwrap();
+
+    // Run the benchmark with no cache
+    group
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(Duration::from_secs(MEASUREMENT_TIME_SECS))
+        .warm_up_time(Duration::from_secs(WARM_UP_TIME_SECS))
+        .throughput(criterion::Throughput::Elements(TOTAL_RECORDS as u64))
+        .bench_function(BenchmarkId::new("ESLog PQ", "No Cache"), |runner| {
+            runner.iter(|| {
+                let _ =
+                    async_std::task::block_on(bench_resource.bench_total_sales(foreign_table_id))
+                        .context("Benchmark execution failed");
+            });
+        });
+
+    tracing::info!("No cache benchmark completed");
+    group.finish();
+}
+
+async fn pga_benchlogs_hsp_pq(postgres_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize criterion
+    let mut criterion = Criterion::default();
+
+    eslog_pq_disk_cache_bench(postgres_url, &mut criterion).await;
+    eslog_pq_mem_cache_bench(postgres_url, &mut criterion).await;
+    eslog_pq_full_cache_bench(postgres_url, &mut criterion).await;
+    eslog_pq_no_cache_bench(postgres_url, &mut criterion).await;
+
+    Ok(())
+}
+
+pub async fn run_all_bench(postgres_url: &str) -> Result<()> {
+    if let Err(err) = pga_benchlogs_hsp_pq(postgres_url).await {
+        tracing::error!("TODO:: {}", err);
+    }
+    Ok(())
+}

--- a/cargo-paradedb/src/tables/benchlogs.rs
+++ b/cargo-paradedb/src/tables/benchlogs.rs
@@ -27,22 +27,22 @@ use super::{PathReader, PathSource};
 #[derive(Debug, Deserialize)]
 pub struct EsLog {
     #[serde(rename = "@timestamp")]
-    timestamp: DateTime<Utc>,
+    pub timestamp: DateTime<Utc>,
     #[serde(rename = "aws.cloudwatch")]
-    aws_cloudwatch: serde_json::Value,
-    cloud: serde_json::Value,
+    pub aws_cloudwatch: serde_json::Value,
+    pub cloud: serde_json::Value,
     #[serde(rename = "log.file.path")]
-    log_file_path: String,
-    input: serde_json::Value,
-    data_stream: serde_json::Value,
-    process: serde_json::Value,
-    message: String,
-    event: serde_json::Value,
-    host: serde_json::Value,
+    pub log_file_path: String,
+    pub input: serde_json::Value,
+    pub data_stream: serde_json::Value,
+    pub process: serde_json::Value,
+    pub message: String,
+    pub event: serde_json::Value,
+    pub host: serde_json::Value,
     #[serde(rename = "metrics", deserialize_with = "deserialize_metrics_size")]
-    metrics_size: i32,
-    agent: serde_json::Value,
-    tags: Vec<String>,
+    pub metrics_size: i32,
+    pub agent: serde_json::Value,
+    pub tags: Vec<String>,
 }
 
 impl EsLog {

--- a/cargo-paradedb/src/tables/benchlogs_extn_hsp_pq.rs
+++ b/cargo-paradedb/src/tables/benchlogs_extn_hsp_pq.rs
@@ -1,0 +1,870 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+use super::benchlogs::EsLog;
+use crate::fixtures::io_s3_obj_store::LocalStackS3Client;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Datelike, Utc};
+use datafusion::arrow::array::*;
+use datafusion::arrow::array::{
+    Int32Builder, ListBuilder, StringBuilder, StructBuilder, TimestampMillisecondBuilder,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::prelude::*;
+use rayon::prelude::*;
+use sqlx::Executor;
+use sqlx::PgConnection;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+pub struct EsLogParquetManager;
+
+impl EsLogParquetManager {
+    fn download_file(url: &str, path: &Path) -> Result<()> {
+        let response = ureq::get(url).call()?;
+        let mut file = std::fs::File::create(path)?;
+        std::io::copy(&mut response.into_reader(), &mut file)?;
+        Ok(())
+    }
+
+    pub async fn read_parquet_dataset(base_path: &Path) -> Result<DataFrame> {
+        tracing::debug!("Reading Parquet dataset from {:?}", base_path);
+        let ctx = SessionContext::new();
+        let df = ctx
+            .read_parquet(
+                base_path.to_str().unwrap(),
+                ParquetReadOptions::default().table_partition_cols(vec![
+                    ("year".to_string(), DataType::Utf8),
+                    ("month".to_string(), DataType::Utf8),
+                ]),
+            )
+            .await
+            .with_context(|| format!("Failed to read Parquet dataset from {:?}", base_path))?;
+        tracing::info!("Successfully read Parquet dataset from {:?}", base_path);
+        Ok(df)
+    }
+
+    fn check_golang_installation() -> Result<()> {
+        Command::new("go")
+            .arg("version")
+            .output()
+            .context("Golang is not installed")?;
+        Ok(())
+    }
+
+    fn install_generator_tool() -> Result<()> {
+        tracing::debug!("Installing elastic-integration-corpus-generator-tool");
+        Command::new("go")
+            .args([
+                "install",
+                "github.com/elastic/elastic-integration-corpus-generator-tool@latest",
+            ])
+            .output()
+            .context("Failed to install generator tool")?;
+        Ok(())
+    }
+
+    fn download_config_files(config_tempdir: &Path) -> Result<(PathBuf, PathBuf, PathBuf)> {
+        let template_file = config_tempdir.join("template.tpl");
+        let fields_file = config_tempdir.join("fields.yml");
+        let config_file = config_tempdir.join("config-1.yml");
+
+        let opensearch_repo_url =
+            "https://raw.githubusercontent.com/elastic/elasticsearch-opensearch-benchmark/main";
+
+        let files = [
+            ("template.tpl", &template_file),
+            ("fields.yml", &fields_file),
+            ("config-1.yml", &config_file),
+        ];
+
+        files.iter().try_for_each(|(filename, path)| {
+            Self::download_file(
+                &format!("{}/dataset/{}", opensearch_repo_url, filename),
+                path,
+            )
+        })?;
+
+        Ok((template_file, fields_file, config_file))
+    }
+
+    fn get_generator_exe_path() -> Result<String> {
+        let go_path = String::from_utf8(
+            Command::new("go")
+                .args(["env", "GOPATH"])
+                .output()
+                .context("Failed to get GOPATH")?
+                .stdout,
+        )?;
+        Ok(format!(
+            "{}/bin/elastic-integration-corpus-generator-tool",
+            go_path.trim()
+        ))
+    }
+
+    fn create_output_directory() -> Result<PathBuf> {
+        let generated_tempdir =
+            tempdir().context("Failed to create temporary directory for generated files")?;
+        let generated_dir = generated_tempdir.path().join("generated");
+        fs::create_dir_all(&generated_dir)
+            .context("Failed to create directory for generated files")?;
+        std::env::set_var("DATA_DIR", &generated_dir);
+        Ok(generated_dir)
+    }
+
+    fn run_generator_tool(
+        generator_exe: &str,
+        template_file: &Path,
+        fields_file: &Path,
+        config_file: &Path,
+        events: u64,
+        seed: u64,
+    ) -> Result<std::process::Output> {
+        tracing::debug!("Running generator tool");
+        let output = Command::new(generator_exe)
+            .args([
+                "generate-with-template",
+                template_file.to_str().unwrap(),
+                fields_file.to_str().unwrap(),
+                "--tot-events",
+                &events.to_string(),
+                "--config-file",
+                config_file.to_str().unwrap(),
+                "--template-type",
+                "gotext",
+                "--seed",
+                &seed.to_string(),
+            ])
+            .output()
+            .context("Failed to run generator tool")?;
+
+        if !output.status.success() {
+            tracing::error!(
+                "Generator tool failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            anyhow::bail!("Generator tool failed");
+        }
+
+        tracing::info!(
+            "Generator tool stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        tracing::debug!(
+            "Generator tool stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        Ok(output)
+    }
+
+    fn extract_output_file_path(stdout: &[u8]) -> Result<PathBuf> {
+        let stdout = String::from_utf8_lossy(stdout);
+        let file_path = stdout
+            .lines()
+            .find(|line| line.starts_with("File generated:"))
+            .and_then(|line| line.split(": ").nth(1))
+            .context("Could not find generated file path in output")?;
+
+        let output_file_path = PathBuf::from(file_path);
+        tracing::debug!("Extracted output file path: {:?}", output_file_path);
+        Ok(output_file_path)
+    }
+
+    fn validate_output_file(output_file_path: &Path) -> Result<()> {
+        if !output_file_path.exists() {
+            tracing::error!("Output file does not exist: {:?}", output_file_path);
+            anyhow::bail!("Output file does not exist");
+        }
+        Ok(())
+    }
+
+    fn read_and_parse_logs(output_file_path: &Path) -> Result<impl Iterator<Item = EsLog>> {
+        let file = fs::File::open(output_file_path)?;
+        let reader = BufReader::new(file);
+
+        let logs: Vec<EsLog> = reader
+            .lines()
+            .enumerate()
+            .par_bridge() // Use Rayon for parallel processing
+            .filter_map(|(i, line)| match line {
+                Ok(json_str) => match serde_json::from_str::<EsLog>(&json_str) {
+                    Ok(log) => {
+                        if i % 1000 == 0 {
+                            tracing::debug!("Generated log {}", i);
+                        }
+                        Some(log)
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to parse log entry {}: {}", i, e);
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::error!("Failed to read line {} from file: {}", i, e);
+                    None
+                }
+            })
+            .collect();
+
+        Ok(logs.into_iter())
+    }
+
+    fn verify_files(files: &[&Path]) -> Result<()> {
+        for file in files {
+            if !file.exists() {
+                tracing::error!("File does not exist: {:?}", file);
+                anyhow::bail!("Required file does not exist: {:?}", file);
+            }
+
+            if let Err(e) = fs::File::open(file) {
+                tracing::error!("Unable to open file {:?}: {}", file, e);
+                anyhow::bail!("Unable to open required file: {:?}", file);
+            }
+
+            tracing::debug!("Verified file exists and is readable: {:?}", file);
+        }
+
+        tracing::info!("All required files verified successfully");
+        Ok(())
+    }
+
+    pub fn generate_dataset(events: u64, seed: u64) -> Result<impl Iterator<Item = EsLog>> {
+        tracing::info!(
+            "Generating dataset with {} events and seed {}",
+            events,
+            seed
+        );
+
+        Self::check_golang_installation()?;
+        Self::install_generator_tool()?;
+
+        let config_tempdir = tempdir().context("Failed to create temporary directory")?;
+
+        let (template_file, fields_file, config_file) =
+            Self::download_config_files(config_tempdir.path())?;
+
+        // Verify that all files exist and are readable
+        Self::verify_files(&[&template_file, &fields_file, &config_file])?;
+
+        let generator_exe = Self::get_generator_exe_path()?;
+        let _generated_dir = Self::create_output_directory()?;
+
+        let output = Self::run_generator_tool(
+            &generator_exe,
+            &template_file,
+            &fields_file,
+            &config_file,
+            events,
+            seed,
+        )?;
+        let output_file_path = Self::extract_output_file_path(&output.stdout)?;
+
+        Self::validate_output_file(&output_file_path)?;
+
+        let logs = Self::read_and_parse_logs(&output_file_path)?;
+
+        tracing::info!("Successfully generated dataset");
+        Ok(logs)
+    }
+
+    pub fn create_hive_partitioned_parquet(
+        events: u64,
+        seed: u64,
+        chunk_size: usize,
+        base_path: &Path,
+    ) -> Result<()> {
+        tracing::info!(
+            "Creating Hive-partitioned Parquet with {} events, seed {}, chunk size {}",
+            events,
+            seed,
+            chunk_size
+        );
+        tracing::debug!("Base path for Parquet files: {:?}", base_path);
+
+        let logs = Self::generate_dataset(events, seed)?;
+        let mut log_cache: HashMap<(i32, u32), Vec<EsLog>> = HashMap::new();
+        let mut log_count = 0;
+
+        tracing::debug!("Starting to process logs");
+        for log in logs {
+            log_count += 1;
+            if log_count % 1000 == 0 {
+                tracing::debug!("Processed {} logs", log_count);
+            }
+
+            let year = log.timestamp.year();
+            let month = log.timestamp.month();
+            let key = (year, month);
+
+            log_cache.entry(key).or_default().push(log);
+
+            if log_cache.get(&key).unwrap().len() >= chunk_size {
+                let partition_path = base_path.join(format!("year={}/month={:02}", year, month));
+                tracing::debug!("Creating partition directory: {:?}", partition_path);
+                fs::create_dir_all(&partition_path).with_context(|| {
+                    format!("Failed to create partition directory: {:?}", partition_path)
+                })?;
+
+                let file_path =
+                    partition_path.join(format!("data_{:x}.parquet", Utc::now().timestamp()));
+                tracing::debug!("Saving Parquet file: {:?}", file_path);
+
+                if let Some(logs_to_write) = log_cache.remove(&key) {
+                    Self::save_to_parquet(logs_to_write, &file_path)
+                        .with_context(|| format!("Failed to save Parquet file: {:?}", file_path))?;
+                }
+            }
+        }
+        tracing::debug!(
+            "Finished processing logs. Total logs processed: {}",
+            log_count
+        );
+
+        // Write any remaining logs in the cache
+        for ((year, month), logs) in log_cache {
+            let partition_path = base_path.join(format!("year={}/month={:02}", year, month));
+            tracing::debug!("Creating partition directory: {:?}", partition_path);
+            fs::create_dir_all(&partition_path).with_context(|| {
+                format!("Failed to create partition directory: {:?}", partition_path)
+            })?;
+
+            let file_path = partition_path.join(format!("data_{}.parquet", Utc::now().timestamp()));
+            tracing::debug!("Saving Parquet file: {:?}", file_path);
+            Self::save_to_parquet(logs, &file_path)
+                .with_context(|| format!("Failed to save Parquet file: {:?}", file_path))?;
+        }
+
+        tracing::info!(
+            "Successfully created Hive-partitioned Parquet at {:?}",
+            base_path
+        );
+        Ok(())
+    }
+
+    pub fn save_to_parquet(logs: Vec<EsLog>, path: &Path) -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new(
+                "aws_cloudwatch",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("log_stream", DataType::Utf8, true),
+                    Field::new("ingestion_time", DataType::Utf8, true),
+                    Field::new("log_group", DataType::Utf8, true),
+                ])),
+                true,
+            ),
+            Field::new(
+                "cloud",
+                DataType::Struct(Fields::from(vec![Field::new(
+                    "region",
+                    DataType::Utf8,
+                    true,
+                )])),
+                true,
+            ),
+            Field::new("log_file_path", DataType::Utf8, false),
+            Field::new(
+                "input",
+                DataType::Struct(Fields::from(vec![Field::new("type", DataType::Utf8, true)])),
+                true,
+            ),
+            Field::new(
+                "data_stream",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("namespace", DataType::Utf8, true),
+                    Field::new("type", DataType::Utf8, true),
+                    Field::new("dataset", DataType::Utf8, true),
+                ])),
+                true,
+            ),
+            Field::new(
+                "process",
+                DataType::Struct(Fields::from(vec![Field::new("name", DataType::Utf8, true)])),
+                true,
+            ),
+            Field::new("message", DataType::Utf8, false),
+            Field::new(
+                "event",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("id", DataType::Utf8, true),
+                    Field::new("ingested", DataType::Utf8, true),
+                    Field::new("dataset", DataType::Utf8, true),
+                ])),
+                true,
+            ),
+            Field::new(
+                "host",
+                DataType::Struct(Fields::from(vec![Field::new("name", DataType::Utf8, true)])),
+                true,
+            ),
+            Field::new("metrics_size", DataType::Int32, false),
+            Field::new(
+                "agent",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("id", DataType::Utf8, true),
+                    Field::new("name", DataType::Utf8, true),
+                    Field::new("type", DataType::Utf8, true),
+                    Field::new("version", DataType::Utf8, true),
+                    Field::new("ephemeral_id", DataType::Utf8, true),
+                ])),
+                true,
+            ),
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+        ]));
+
+        let file = fs::File::create(path).context("Failed to create Parquet file")?;
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None)?;
+
+        let mut timestamp_builder = TimestampMillisecondBuilder::new();
+        let mut aws_cloudwatch_builder = StructBuilder::from_fields(
+            Fields::from(vec![
+                Field::new("log_stream", DataType::Utf8, true),
+                Field::new("ingestion_time", DataType::Utf8, true),
+                Field::new("log_group", DataType::Utf8, true),
+            ]),
+            logs.len(),
+        );
+        let mut cloud_builder = StructBuilder::from_fields(
+            Fields::from(vec![Field::new("region", DataType::Utf8, true)]),
+            logs.len(),
+        );
+        let mut log_file_path_builder = StringBuilder::new();
+        let mut input_builder = StructBuilder::from_fields(
+            Fields::from(vec![Field::new("type", DataType::Utf8, true)]),
+            logs.len(),
+        );
+        let mut data_stream_builder = StructBuilder::from_fields(
+            Fields::from(vec![
+                Field::new("namespace", DataType::Utf8, true),
+                Field::new("type", DataType::Utf8, true),
+                Field::new("dataset", DataType::Utf8, true),
+            ]),
+            logs.len(),
+        );
+        let mut process_builder = StructBuilder::from_fields(
+            Fields::from(vec![Field::new("name", DataType::Utf8, true)]),
+            logs.len(),
+        );
+        let mut message_builder = StringBuilder::new();
+        let mut event_builder = StructBuilder::from_fields(
+            Fields::from(vec![
+                Field::new("id", DataType::Utf8, true),
+                Field::new("ingested", DataType::Utf8, true),
+                Field::new("dataset", DataType::Utf8, true),
+            ]),
+            logs.len(),
+        );
+        let mut host_builder = StructBuilder::from_fields(
+            Fields::from(vec![Field::new("name", DataType::Utf8, true)]),
+            logs.len(),
+        );
+        let mut metrics_size_builder = Int32Builder::new();
+        let mut agent_builder = StructBuilder::from_fields(
+            Fields::from(vec![
+                Field::new("id", DataType::Utf8, true),
+                Field::new("name", DataType::Utf8, true),
+                Field::new("type", DataType::Utf8, true),
+                Field::new("version", DataType::Utf8, true),
+                Field::new("ephemeral_id", DataType::Utf8, true),
+            ]),
+            logs.len(),
+        );
+        let mut tags_builder = ListBuilder::new(StringBuilder::new());
+
+        for log in &logs {
+            timestamp_builder.append_value(log.timestamp.timestamp_millis());
+
+            // AWS Cloudwatch
+            aws_cloudwatch_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(
+                    log.aws_cloudwatch
+                        .get("log_stream")
+                        .and_then(|v| v.as_str()),
+                );
+            aws_cloudwatch_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_option(
+                    log.aws_cloudwatch
+                        .get("ingestion_time")
+                        .and_then(|v| v.as_str()),
+                );
+            aws_cloudwatch_builder
+                .field_builder::<StringBuilder>(2)
+                .unwrap()
+                .append_option(log.aws_cloudwatch.get("log_group").and_then(|v| v.as_str()));
+            aws_cloudwatch_builder.append(true);
+
+            // Cloud
+            cloud_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.cloud.get("region").and_then(|v| v.as_str()));
+            cloud_builder.append(true);
+
+            log_file_path_builder.append_value(&log.log_file_path);
+
+            // Input
+            input_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.input.get("type").and_then(|v| v.as_str()));
+            input_builder.append(true);
+
+            // Data Stream
+            data_stream_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.data_stream.get("namespace").and_then(|v| v.as_str()));
+            data_stream_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_option(log.data_stream.get("type").and_then(|v| v.as_str()));
+            data_stream_builder
+                .field_builder::<StringBuilder>(2)
+                .unwrap()
+                .append_option(log.data_stream.get("dataset").and_then(|v| v.as_str()));
+            data_stream_builder.append(true);
+
+            // Process
+            process_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.process.get("name").and_then(|v| v.as_str()));
+            process_builder.append(true);
+
+            message_builder.append_value(&log.message);
+
+            // Event
+            event_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.event.get("id").and_then(|v| v.as_str()));
+            event_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_option(log.event.get("ingested").and_then(|v| v.as_str()));
+            event_builder
+                .field_builder::<StringBuilder>(2)
+                .unwrap()
+                .append_option(log.event.get("dataset").and_then(|v| v.as_str()));
+            event_builder.append(true);
+
+            // Host
+            host_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.host.get("name").and_then(|v| v.as_str()));
+            host_builder.append(true);
+
+            metrics_size_builder.append_value(log.metrics_size);
+
+            // Agent
+            agent_builder
+                .field_builder::<StringBuilder>(0)
+                .unwrap()
+                .append_option(log.agent.get("id").and_then(|v| v.as_str()));
+            agent_builder
+                .field_builder::<StringBuilder>(1)
+                .unwrap()
+                .append_option(log.agent.get("name").and_then(|v| v.as_str()));
+            agent_builder
+                .field_builder::<StringBuilder>(2)
+                .unwrap()
+                .append_option(log.agent.get("type").and_then(|v| v.as_str()));
+            agent_builder
+                .field_builder::<StringBuilder>(3)
+                .unwrap()
+                .append_option(log.agent.get("version").and_then(|v| v.as_str()));
+            agent_builder
+                .field_builder::<StringBuilder>(4)
+                .unwrap()
+                .append_option(log.agent.get("ephemeral_id").and_then(|v| v.as_str()));
+            agent_builder.append(true);
+
+            // Tags
+            let tag_builder = tags_builder.values();
+            for tag in &log.tags {
+                tag_builder.append_value(tag);
+            }
+            tags_builder.append(true);
+        }
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(timestamp_builder.finish()),
+                Arc::new(aws_cloudwatch_builder.finish()),
+                Arc::new(cloud_builder.finish()),
+                Arc::new(log_file_path_builder.finish()),
+                Arc::new(input_builder.finish()),
+                Arc::new(data_stream_builder.finish()),
+                Arc::new(process_builder.finish()),
+                Arc::new(message_builder.finish()),
+                Arc::new(event_builder.finish()),
+                Arc::new(host_builder.finish()),
+                Arc::new(metrics_size_builder.finish()),
+                Arc::new(agent_builder.finish()),
+                Arc::new(tags_builder.finish()),
+            ],
+        )?;
+
+        writer.write(&batch)?;
+        writer.close()?;
+
+        Ok(())
+    }
+
+    #[allow(unused)]
+    pub async fn upload_parquet_dataset_to_s3(
+        s3: &LocalStackS3Client,
+        s3_bucket: &str,
+        s3_prefix: &str,
+        parquet_dataset_path: PathBuf,
+    ) -> Result<()> {
+        tracing::info!("Starting upload of Parquet dataset to S3");
+
+        // Ensure the S3 bucket exists
+        s3.create_bucket(s3_bucket)
+            .context("Failed to create S3 bucket")?;
+
+        // Use the put_directory method to upload the entire dataset
+        s3.put_directory(s3_bucket, s3_prefix, &parquet_dataset_path)
+            .context("Failed to upload Parquet dataset to S3")?;
+
+        tracing::info!("Completed upload of Parquet dataset to S3");
+        Ok(())
+    }
+}
+
+pub struct EsLogParquetForeignTableManager;
+
+impl EsLogParquetForeignTableManager {
+    #[allow(unused)]
+    pub async fn teardown_tables(pg_conn: &mut PgConnection, foreign_table_id: &str) -> Result<()> {
+        let sql_statements = [
+            format!("DROP FOREIGN TABLE IF EXISTS {foreign_table_id} CASCADE"),
+            "DROP SERVER IF EXISTS eslogs_ftw_server CASCADE".to_string(),
+            "DROP FOREIGN DATA WRAPPER IF EXISTS parquet_wrapper CASCADE".to_string(),
+            "DROP USER MAPPING IF EXISTS FOR public SERVER eslogs_ftw_server".to_string(),
+        ];
+
+        for statement in sql_statements {
+            if let Err(err) = pg_conn.execute(&*statement).await {
+                tracing::warn!("Failed to execute: {} :: Err: {}", statement, err);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[allow(unused)]
+    pub async fn setup_tables(
+        pg_conn: &mut PgConnection,
+        s3: &LocalStackS3Client,
+        s3_bucket: &str,
+        s3_prefix: &str,
+        foreign_table_id: &str,
+        use_disk_cache: bool,
+    ) -> Result<()> {
+        tracing::info!(
+            "Starting setup_tables for foreign_table_id: {}",
+            foreign_table_id
+        );
+
+        // First, tear down any existing tables
+        if let Err(e) = Self::teardown_tables(pg_conn, foreign_table_id).await {
+            tracing::warn!(
+                "Error during teardown_tables: {:?}. Continuing with setup.",
+                e
+            );
+        }
+
+        // Setup S3 Foreign Data Wrapper commands
+        let s3_fdw_setup = Self::setup_s3_fdw(&s3.url);
+        for (i, command) in s3_fdw_setup.split(';').enumerate() {
+            let trimmed_command = command.trim();
+            if !trimmed_command.is_empty() {
+                match pg_conn.execute(trimmed_command).await {
+                    Ok(_) => tracing::info!("Successfully executed S3 FDW setup command {}", i + 1),
+                    Err(e) => {
+                        tracing::error!("Error executing S3 FDW setup command {}: {:?}", i + 1, e);
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+
+        // Create partitioned foreign table
+        let create_ftw_command = Self::create_partitioned_foreign_table(
+            s3_bucket,
+            s3_prefix,
+            foreign_table_id,
+            use_disk_cache,
+        );
+        match pg_conn.execute(&*create_ftw_command).await {
+            Ok(_) => tracing::info!("Successfully created partitioned foreign table"),
+            Err(e) => {
+                tracing::error!("Error creating partitioned foreign table: {:?}", e);
+                return Err(e.into());
+            }
+        }
+
+        tracing::info!(
+            "Completed setup_tables for foreign_table_id: {}",
+            foreign_table_id
+        );
+        Ok(())
+    }
+
+    fn setup_s3_fdw(s3_endpoint: &str) -> String {
+        format!(
+            r#"
+            CREATE FOREIGN DATA WRAPPER parquet_wrapper
+                HANDLER parquet_fdw_handler
+                VALIDATOR parquet_fdw_validator;
+    
+            CREATE SERVER eslogs_ftw_server
+                FOREIGN DATA WRAPPER parquet_wrapper;
+    
+            CREATE USER MAPPING FOR public
+                SERVER eslogs_ftw_server
+                OPTIONS (
+                    type 'S3',
+                    region 'us-east-1',
+                    endpoint '{s3_endpoint}',
+                    use_ssl 'false',
+                    url_style 'path'
+                );
+            "#
+        )
+    }
+
+    fn create_partitioned_foreign_table(
+        s3_bucket: &str,
+        s3_prefix: &str,
+        foreign_table_id: &str,
+        use_disk_cache: bool,
+    ) -> String {
+        format!(
+            r#"
+            CREATE FOREIGN TABLE {foreign_table_id} (
+                timestamp               TIMESTAMP WITH TIME ZONE,
+                aws_cloudwatch          JSONB,
+                cloud                   JSONB,
+                log_file_path           TEXT,
+                input                   JSONB,
+                data_stream             JSONB,
+                process                 JSONB,
+                message                 TEXT,
+                event                   JSONB,
+                host                    JSONB,
+                metrics_size            INT,
+                agent                   JSONB,
+                tags                    TEXT[]
+            )
+            SERVER eslogs_ftw_server
+            OPTIONS (
+                files 's3://{s3_bucket}/{s3_prefix}/year=*/month=*/data_*.parquet',
+                hive_partitioning '1',
+                cache '{}'
+            );
+            "#,
+            use_disk_cache
+        )
+    }
+}
+
+pub struct EsLogBenchManager;
+
+impl EsLogBenchManager {
+    pub async fn bench_time_range_query(
+        pg_conn: &mut PgConnection,
+        eslogs_local_df: &DataFrame,
+        foreign_table_id: &str,
+    ) -> Result<()> {
+        // Calculate min and max timestamps
+        let min_max_df = eslogs_local_df
+            .clone()
+            .aggregate(
+                vec![],
+                vec![
+                    min(col("timestamp")).alias("min_timestamp"),
+                    max(col("timestamp")).alias("max_timestamp"),
+                ],
+            )?
+            .collect()
+            .await?;
+
+        let min_max_batch = &min_max_df[0];
+
+        let min_ts = min_max_batch
+            .column_by_name("min_timestamp")
+            .ok_or_else(|| anyhow::anyhow!("min_timestamp column not found"))?
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to downcast min_timestamp to TimestampMillisecondArray")
+            })?
+            .value(0);
+
+        let max_ts = min_max_batch
+            .column_by_name("max_timestamp")
+            .ok_or_else(|| anyhow::anyhow!("max_timestamp column not found"))?
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to downcast max_timestamp to TimestampMillisecondArray")
+            })?
+            .value(0);
+
+        let min_ts_str = DateTime::from_timestamp_millis(min_ts)
+            .ok_or_else(|| anyhow::anyhow!("Invalid min timestamp"))?
+            .format("%Y-%m-%d %H:%M:%S%.3f")
+            .to_string();
+        let max_ts_str = DateTime::from_timestamp_millis(max_ts)
+            .ok_or_else(|| anyhow::anyhow!("Invalid max timestamp"))?
+            .format("%Y-%m-%d %H:%M:%S%.3f")
+            .to_string();
+
+        let query = format!(
+            "SELECT * FROM {} WHERE timestamp >= '{}' AND timestamp < '{}'",
+            foreign_table_id, min_ts_str, max_ts_str
+        );
+
+        let _pg_result = sqlx::query(&query).fetch_all(pg_conn).await?;
+
+        Ok(())
+    }
+}

--- a/cargo-paradedb/src/tables/mod.rs
+++ b/cargo-paradedb/src/tables/mod.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod benchlogs;
+pub mod benchlogs_extn_hsp_pq;
 
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;


### PR DESCRIPTION
# Implement Benchmarking for Query Performance Analysis

**This PR is part of a pair; please consider both for review, validation and merge.**

https://github.com/paradedb/paradedb/pull/1751
https://github.com/paradedb/pg_analytics/pull/148

## Scope

This PR replaces and consolidates requirements from the following closed PRs:
- https://github.com/paradedb/paradedb/pull/1703
- https://github.com/paradedb/pg_analytics/pull/131

Key improvements:
- Removed dependency on Postgres (pgrx) crates.
- Eliminated dependency on `pg_analytics` internal test ecosystem, resulting in a more loosely coupled `paradedb/cargo-paradedb`.
- Now accepts a Postgres URL to execute the benchmark against.

## What

This PR implements benchmarking functionality to analyze query performance under different caching conditions for hive-style partitioned Parquet data sources supported by `pg_analytics`.

| Cache Configuration | Time | Throughput |
| --- | --- | --- |
| Disk Cache | [88.727 ms **89.345 ms** 89.870 ms] | [111.27 Kelem/s **111.93 Kelem/s** 112.71 Kelem/s] |
| In-memory metadata cache | [557.97 ms **566.85 ms** 576.15 ms] | [17.357 Kelem/s **17.641 Kelem/s** 17.922 Kelem/s] |
| Full Cache | [87.383 ms **88.465 ms** 89.527 ms] | [111.70 Kelem/s **113.04 Kelem/s** 114.44 Kelem/s] |
| No Cache | [585.65 ms **597.08 ms** 609.14 ms] | [16.417 Kelem/s **16.748 Kelem/s** 17.075 Kelem/s] |

## Why

This benchmarking functionality allows us to evaluate how different cache configurations impact query performance, ensuring that the system optimally handles various data sources and caching scenarios.

## How

The test function follows a structured flow:

1. **Parquet File Check**: Verifies the existence of a Parquet file at a specified path; if absent, generates the file.
2. **Data Loading**: Loads the Parquet data into a DataFrame using a DataFusion session context.
3. **S3 Setup**: Configures an S3 bucket for storing partitioned data.
4. **Data Partitioning**: Partitions the data and uploads it to the S3 bucket.
5. **Database Setup**: Sets up PostgreSQL tables using the data from S3.
6. **Cache Configuration**: Configures caching options such as disk or memory cache.
7. **Benchmark Execution**: Executes benchmark iterations with different cache configurations using the `criterion` framework.
8. **Benchmark Analysis**: Analyzes the results using the default metrics from `criterion`.

The SQL command below is used to toggle Parquet metadata caching (In-memory):

```sql
SELECT duckdb_execute($$SET enable_object_cache={cache_setting}$$)
```

Where `cache_setting` can be either "true" or "false", depending on the test scenario.

## Benchmarking

To run the benchmarking:

1. Ensure the `pg_analytics` extension is installed based on https://github.com/paradedb/pg_analytics/pull/148

2. Execute the following command:

```bash
export DATABASE_URL=postgresql://localhost:28817/postgres

cd ./cargo-paradedb

clear && RUST_LOG=info \
    cargo run \
    -- \
    paradedb \
    pga-bench \
    --url postgresql://localhost:28817/postgres \
    parquet-run-all
```

This will initiate the benchmarking process and provide performance metrics for different caching configurations.