### PR TITLE
fix: build more precise TargetEntries to detect usages of `paradedb.score()` and `paradedb.snippet()`

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -80,7 +80,7 @@ pub unsafe fn pullout_funcexprs(
                 let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
                 for arg in args.iter_ptr() {
                     if let Some(var) = nodecast!(Var, T_Var, arg) {
-                        if (*var).varno == data.rti {
+                        if (*var).varno as i32 == data.rti as i32 {
                             data.matches.push((funcexpr, var));
                         }
                     }

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -132,7 +132,7 @@ pub unsafe fn extract_quals(node: *mut pg_sys::Node, pdbopoid: pg_sys::Oid) -> O
 
         // we don't understand this clause so we can't do anything
         _ => {
-//            pgrx::warning!("unsupported qual node kind: {:?}", (*node).type_);
+            // pgrx::warning!("unsupported qual node kind: {:?}", (*node).type_);
             None
         }
     }

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -132,7 +132,7 @@ pub unsafe fn extract_quals(node: *mut pg_sys::Node, pdbopoid: pg_sys::Oid) -> O
 
         // we don't understand this clause so we can't do anything
         _ => {
-            pgrx::warning!("unsupported qual node kind: {:?}", (*node).type_);
+//            pgrx::warning!("unsupported qual node kind: {:?}", (*node).type_);
             None
         }
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1753

## What

Fixes issue #1753.

## Why

Bugs are bad

## How

Actually walk the expression tree attached to each TargetEntry to see if there's any reference to our score/snippet functions that use a Var from the current range table index level.  Pull out the direct function expression that uses the var and add to our target list, if we have one.

## Tests

Of course.