### PR TITLE
fix: transparently turn on scoring when a query uses "more like this"

### DIFF
--- a/pg_search/tests/mlt.rs
+++ b/pg_search/tests/mlt.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn mlt_enables_scoring_issue1747(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let (id,) = "SELECT id FROM paradedb.bm25_search WHERE id @@@ paradedb.more_like_this(with_document_id => 3, with_min_term_frequency => 1) ORDER BY id LIMIT 1"
+        .fetch_one::<(i32,)>(&mut conn);
+    assert_eq!(id, 3);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1747

## What

First, make some changes to be able to bubble up `Result::Err`s from inside the tantivy search executor to the main thread.

Secondly, fix the actual issue reported by #1747, which is that when a query uses "more like this", we need to transparently turn on scoring.

## Why

My CTO reported this bug and I don't want to disappoint him.

## How

When we convert our `SearchQueryInput` into a tantivy `dyn Query`, we now set a `requires_scoring: &mut bool` flag to true while recursing through the query tree.  That is then used when constructing the new `SearchState`.

## Tests

Yeppers