### PR TITLE
chore: make working with `pg_sys::Integer`/`pg_sys::Value`(pg13/14) a little easier

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use pgrx::{is_a, pg_sys};
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
 
 pub mod config;
 pub mod index;
@@ -39,4 +39,44 @@ macro_rules! nodecast {
     ($type_:ident, $kind:ident, $node:expr) => {
         $crate::api::node::<pg_sys::$type_>($node.cast(), pg_sys::NodeTag::$kind)
     };
+}
+
+pub trait AsInt {
+    unsafe fn as_int(&self) -> Option<i32>;
+}
+
+pub trait AsCStr {
+    unsafe fn as_c_str(&self) -> Option<&CStr>;
+}
+
+#[cfg(any(feature = "pg13", feature = "pg14"))]
+impl AsInt for *mut pg_sys::Node {
+    unsafe fn as_int(&self) -> Option<i32> {
+        let node = nodecast!(Value, T_Integer, *self)?;
+        Some((*node).val.ival)
+    }
+}
+
+#[cfg(not(any(feature = "pg13", feature = "pg14")))]
+impl AsInt for *mut pg_sys::Node {
+    unsafe fn as_int(&self) -> Option<i32> {
+        let node = nodecast!(Integer, T_Integer, *self)?;
+        Some((*node).ival)
+    }
+}
+
+#[cfg(any(feature = "pg13", feature = "pg14"))]
+impl AsCStr for *mut pg_sys::Node {
+    unsafe fn as_c_str(&self) -> Option<&CStr> {
+        let node = nodecast!(Value, T_String, *self)?;
+        Some(CStr::from_ptr((*node).val.str_))
+    }
+}
+
+#[cfg(not(any(feature = "pg13", feature = "pg14")))]
+impl AsCStr for *mut pg_sys::Node {
+    unsafe fn as_c_str(&self) -> Option<&CStr> {
+        let node = nodecast!(String, T_String, *self)?;
+        Some(CStr::from_ptr((*node).sval))
+    }
 }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -15,30 +15,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::{is_a, pg_sys};
-use std::ffi::{c_void, CStr};
-
 pub mod config;
 pub mod index;
 pub mod operator;
 pub mod search;
 pub mod tokenize;
 
-#[track_caller]
-#[inline(always)]
-pub unsafe fn node<T>(void: *mut c_void, tag: pg_sys::NodeTag) -> Option<*mut T> {
-    let node: *mut T = void.cast();
-    if !is_a(node.cast(), tag) {
-        return None;
-    }
-    Some(node)
-}
-
 #[macro_export]
 macro_rules! nodecast {
-    ($type_:ident, $kind:ident, $node:expr) => {
-        $crate::api::node::<pg_sys::$type_>($node.cast(), pg_sys::NodeTag::$kind)
-    };
+    ($type_:ident, $kind:ident, $node:expr) => {{
+        let node = $node;
+        pgrx::is_a(node.cast(), pgrx::pg_sys::NodeTag::$kind)
+            .then(|| node.cast::<pgrx::pg_sys::$type_>())
+    }};
 }
 
 pub trait AsInt {
@@ -46,11 +35,11 @@ pub trait AsInt {
 }
 
 pub trait AsCStr {
-    unsafe fn as_c_str(&self) -> Option<&CStr>;
+    unsafe fn as_c_str(&self) -> Option<&std::ffi::CStr>;
 }
 
 #[cfg(any(feature = "pg13", feature = "pg14"))]
-impl AsInt for *mut pg_sys::Node {
+impl AsInt for *mut pgrx::pg_sys::Node {
     unsafe fn as_int(&self) -> Option<i32> {
         let node = nodecast!(Value, T_Integer, *self)?;
         Some((*node).val.ival)
@@ -58,7 +47,7 @@ impl AsInt for *mut pg_sys::Node {
 }
 
 #[cfg(not(any(feature = "pg13", feature = "pg14")))]
-impl AsInt for *mut pg_sys::Node {
+impl AsInt for *mut pgrx::pg_sys::Node {
     unsafe fn as_int(&self) -> Option<i32> {
         let node = nodecast!(Integer, T_Integer, *self)?;
         Some((*node).ival)
@@ -66,17 +55,17 @@ impl AsInt for *mut pg_sys::Node {
 }
 
 #[cfg(any(feature = "pg13", feature = "pg14"))]
-impl AsCStr for *mut pg_sys::Node {
-    unsafe fn as_c_str(&self) -> Option<&CStr> {
+impl AsCStr for *mut pgrx::pg_sys::Node {
+    unsafe fn as_c_str(&self) -> Option<&std::ffi::CStr> {
         let node = nodecast!(Value, T_String, *self)?;
-        Some(CStr::from_ptr((*node).val.str_))
+        Some(std::ffi::CStr::from_ptr((*node).val.str_))
     }
 }
 
 #[cfg(not(any(feature = "pg13", feature = "pg14")))]
-impl AsCStr for *mut pg_sys::Node {
-    unsafe fn as_c_str(&self) -> Option<&CStr> {
+impl AsCStr for *mut pgrx::pg_sys::Node {
+    unsafe fn as_c_str(&self) -> Option<&std::ffi::CStr> {
         let node = nodecast!(String, T_String, *self)?;
-        Some(CStr::from_ptr((*node).sval))
+        Some(std::ffi::CStr::from_ptr((*node).sval))
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # n/a

## What

Add a few traits to make working with Postgres' `pg_sys::Integer`, `pg_sys::String`, and for older Postgres versions, `pg_sys::Value` consistent.  Mostly to eliminate scattering a bunch of `#[cfg(any(feature = "pg13", "pg14"))]` blocks everywhere in the custom scan code

## Why

## How

## Tests

Existing tests pass on all postgres versions.