### PR TITLE
docs: Fix typo in docs

### DIFF
--- a/docs/documentation/full-text/term.mdx
+++ b/docs/documentation/full-text/term.mdx
@@ -57,4 +57,4 @@ SELECT * FROM search_idx.search(
 
 ## Special Characters
 
-The special characters `+` , `^`, ```, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `\*`, and `SPACE` must be escaped by a`\` inside the query term.
+The special characters `+` , `^`, `'`, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `\*`, and `SPACE` must be escaped by a`\` inside the query term.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes the apostrophe, which wasn't being parsed correctly here:

<img width="775" alt="Capture d’écran, le 2024-10-08 à 15 19 30" src="https://github.com/user-attachments/assets/ecc5e3b4-f754-44fe-bd0c-61a3d68a51e4">

## Why
^

## How
^

## Tests
^