### PR TITLE
chore: remove caching and load index instance from disk on each query.

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -133,7 +133,7 @@ pub(crate) fn estimate_selectivity(
         search_config.index_oid,
         relfilenode.as_u32(),
     );
-    let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
+    let search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
     let search_reader = search_index
         .get_reader()

--- a/pg_search/src/api/operator/searchconfig.rs
+++ b/pg_search/src/api/operator/searchconfig.rs
@@ -49,7 +49,7 @@ pub fn search_with_search_config(
         let relfilenode = relfilenode_from_index_oid(index_oid);
 
         let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode.as_u32());
-        let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
+        let search_index = SearchIndex::from_disk(&directory)
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
         let scan_state = search_index.get_reader().unwrap();
         let query = search_index.query(&search_config, &scan_state);

--- a/pg_search/src/fixtures/index.rs
+++ b/pg_search/src/fixtures/index.rs
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use uuid::Uuid;
-
 use crate::index::SearchIndexWriter;
 use crate::{
     index::SearchIndex,
@@ -27,7 +25,7 @@ use super::MockWriterDirectory;
 
 pub struct MockSearchIndex {
     pub directory: MockWriterDirectory,
-    pub index: &'static mut SearchIndex,
+    pub index: SearchIndex,
 }
 
 impl MockSearchIndex {
@@ -39,14 +37,8 @@ impl MockSearchIndex {
         // instance is dropped.
         // We can pass a fixed index OID as a mock.
         let directory = MockWriterDirectory::new(42);
-        let uuid = Uuid::new_v4().to_string();
-        SearchIndexWriter::create_index(
-            directory.writer_dir.clone(),
-            fields,
-            uuid,
-            key_field_index,
-        )
-        .expect("error creating index instance");
+        SearchIndexWriter::create_index(directory.writer_dir.clone(), fields, key_field_index)
+            .expect("error creating index instance");
 
         let index = SearchIndex::from_disk(&directory.writer_dir)
             .expect("error reading new index from cache");

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -28,8 +28,7 @@ use crate::schema::{
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
-use std::ptr::addr_of_mut;
+use std::collections::HashSet;
 use tantivy::query::Query;
 use tantivy::{query::QueryParser, Executor, Index};
 use thiserror::Error;
@@ -39,24 +38,11 @@ use tracing::trace;
 // Must be at least 15,000,000 or Tantivy will panic.
 pub const INDEX_TANTIVY_MEMORY_BUDGET: usize = 500_000_000;
 
-pub type SearchIndexCacheType = Lazy<HashMap<WriterDirectory, SearchIndex>>;
-
 /// PostgreSQL operates in a process-per-client model, meaning every client connection
 /// to PostgreSQL results in a new backend process being spawned on the PostgreSQL server.
-///
-/// `SEARCH_INDEX_MEMORY` is designed to act as a cache that persists for the lifetime of a
-/// single backend process. When a client connects to PostgreSQL and triggers the extension's
-/// functionality, this cache is initialized the first time it's accessed in that specific process.
-///
-/// In scenarios where connection pooling is used, such as by web servers maintaining
-/// a pool of connections to PostgreSQL, the connections (and the associated backend processes)
-/// are typically long-lived. While this cache initialization might happen once per connection,
-/// it does not happen per query, leading to performance benefits for expensive operations.
-///
-/// It's also crucial to remember that this cache is NOT shared across different backend
-/// processes. Each PostgreSQL backend process will have its own separate instance of
-/// this cache, tied to its own lifecycle.
-static mut SEARCH_INDEX_MEMORY: SearchIndexCacheType = Lazy::new(HashMap::new);
+
+static mut PENDING_INDEX_CREATES: Lazy<HashSet<WriterDirectory>> = Lazy::new(HashSet::new);
+static mut PENDING_INDEX_DROPS: Lazy<HashSet<WriterDirectory>> = Lazy::new(HashSet::new);
 
 pub static mut SEARCH_EXECUTOR: Lazy<Executor> = Lazy::new(|| {
     let num_threads = num_cpus::get();
@@ -69,19 +55,15 @@ pub struct SearchIndex {
     pub directory: WriterDirectory,
     #[serde(skip_serializing)]
     pub underlying_index: Index,
-    pub uuid: String,
-    pub is_pending_create: bool,
-    pub is_pending_drop: bool,
 }
 
 impl SearchIndex {
     pub fn create_index(
         directory: WriterDirectory,
         fields: Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)>,
-        uuid: String,
         key_field_index: usize,
-    ) -> Result<&'static mut Self, SearchIndexError> {
-        SearchIndexWriter::create_index(directory.clone(), fields, uuid, key_field_index)?;
+    ) -> Result<Self, SearchIndexError> {
+        SearchIndexWriter::create_index(directory.clone(), fields, key_field_index)?;
 
         // As the new index instance was created in a background process, we need
         // to load it from disk to use it.
@@ -89,7 +71,7 @@ impl SearchIndex {
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
         // flag for later if the creating transaction is aborted
-        new_self_ref.is_pending_create = true;
+        new_self_ref.mark_pending_create();
 
         Ok(new_self_ref)
     }
@@ -131,24 +113,8 @@ impl SearchIndex {
         underlying_index.set_fast_field_tokenizers(create_normalizer_manager());
     }
 
-    unsafe fn into_cache(self) {
-        SEARCH_INDEX_MEMORY.insert(self.directory.clone(), self);
-    }
-
-    /// # Safety
-    ///
-    /// This function is unsafe as it returns a mutable reference to a mutable static global.  It is your
-    /// responsibility to ensure, at the time of calling this function, there are no other outstanding
-    /// references to the returned static global.
-    pub unsafe fn get_cache() -> &'static mut SearchIndexCacheType {
-        addr_of_mut!(SEARCH_INDEX_MEMORY)
-            .as_mut()
-            .expect("global SEARCH_INDEX_MEMORY must not be null")
-    }
-
-    pub fn from_disk(directory: &WriterDirectory) -> Result<&'static mut Self, SearchIndexError> {
+    pub fn from_disk(directory: &WriterDirectory) -> Result<Self, SearchIndexError> {
         let mut new_self: Self = directory.load_index()?;
-        let uuid = new_self.uuid.clone();
 
         // In the case of a physical replication of the database, the absolute path that is stored
         // in the serialized WriterDirectory might refer to the source database's file system.
@@ -156,52 +122,31 @@ impl SearchIndex {
         // argument here.
         new_self.directory = directory.clone();
 
-        // Since we've re-fetched the index, save it to the cache.
-        unsafe {
-            new_self.into_cache();
-        }
-
-        Self::from_cache(directory, &uuid)
+        Ok(new_self)
     }
 
-    pub fn open_direct(directory: &WriterDirectory) -> Result<Self, SearchDirectoryError> {
-        directory.load_index()
+    pub fn mark_pending_create(&self) -> bool {
+        unsafe { PENDING_INDEX_CREATES.insert(self.directory.clone()) }
     }
 
-    pub fn from_cache(
-        directory: &WriterDirectory,
-        uuid: &str,
-    ) -> Result<&'static mut Self, SearchIndexError> {
-        unsafe {
-            if let Some(new_self) = SEARCH_INDEX_MEMORY.get_mut(directory) {
-                let cached_uuid = &new_self.uuid;
-                if cached_uuid == uuid {
-                    return Ok(new_self);
-                }
-            }
-        }
-
-        Self::from_disk(directory)
+    pub fn mark_pending_drop(&self) -> bool {
+        unsafe { PENDING_INDEX_DROPS.insert(self.directory.clone()) }
     }
 
-    /// Remove the specified `directory` from the internal cache
-    ///
-    /// # Safety
-    ///
-    /// It is the caller's responsibility to ensure they don't have an outstanding mutable reference
-    /// to the internal cache object
-    pub unsafe fn drop_from_cache(directory: &WriterDirectory) {
-        SEARCH_INDEX_MEMORY.remove(directory);
+    pub fn clear_pending_creates() {
+        unsafe { PENDING_INDEX_CREATES.clear() }
     }
 
-    /// If this [`SearchIndex`] is newly created, return true
-    pub fn is_pending_create(&self) -> bool {
-        self.is_pending_create
+    pub fn clear_pending_drops() {
+        unsafe { PENDING_INDEX_DROPS.clear() }
     }
 
-    /// If this [`SearchIndex`] has been dropped, return true
-    pub fn is_pending_drop(&self) -> bool {
-        self.is_pending_drop
+    pub fn pending_creates() -> impl Iterator<Item = &'static WriterDirectory> {
+        unsafe { PENDING_INDEX_CREATES.iter() }
+    }
+
+    pub fn pending_drops() -> impl Iterator<Item = &'static WriterDirectory> {
+        unsafe { PENDING_INDEX_DROPS.iter() }
     }
 
     pub fn query_parser(&self, config: &SearchConfig) -> QueryParser {
@@ -268,7 +213,7 @@ impl SearchIndex {
         // the index is about to be queued to drop and that requires our transaction callbacks be registered
         crate::postgres::transaction::register_callback();
 
-        self.is_pending_drop = true;
+        self.mark_pending_drop();
 
         Ok(())
     }
@@ -289,18 +234,10 @@ impl<'de> Deserialize<'de> for SearchIndex {
         struct SearchIndexHelper {
             schema: SearchIndexSchema,
             directory: WriterDirectory,
-            // An index created in an older version of pg_search may not have serialized a uuid
-            // to disk. Just use an empty string for backwards compatibility.
-            #[serde(default)]
-            uuid: String,
         }
 
         // Deserialize into the struct with automatic handling for most fields
-        let SearchIndexHelper {
-            schema,
-            directory,
-            uuid,
-        } = SearchIndexHelper::deserialize(deserializer)?;
+        let SearchIndexHelper { schema, directory } = SearchIndexHelper::deserialize(deserializer)?;
 
         let TantivyDirPath(tantivy_dir_path) = directory
             .tantivy_dir_path(true)
@@ -318,9 +255,6 @@ impl<'de> Deserialize<'de> for SearchIndex {
             underlying_index,
             directory,
             schema,
-            uuid,
-            is_pending_drop: false,
-            is_pending_create: false,
         })
     }
 }

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -114,7 +114,7 @@ impl Directory for BlockingDirectory {
 /// so that they can be committed or rolled back in case of an abort.
 static mut PENDING_INDEX_CREATES: Lazy<HashSet<WriterDirectory>> = Lazy::new(HashSet::new);
 
-/// A global store of which indexes have been droped during a transaction,
+/// A global store of which indexes have been dropped during a transaction,
 /// so that they can be committed or rolled back in case of an abort.
 static mut PENDING_INDEX_DROPS: Lazy<HashSet<WriterDirectory>> = Lazy::new(HashSet::new);
 

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -155,7 +155,6 @@ impl SearchIndexWriter {
     pub fn create_index(
         directory: WriterDirectory,
         fields: Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)>,
-        uuid: String,
         key_field_index: usize,
     ) -> Result<()> {
         let schema = SearchIndexSchema::new(fields, key_field_index)?;
@@ -171,9 +170,6 @@ impl SearchIndexWriter {
             underlying_index,
             directory: directory.clone(),
             schema,
-            uuid,
-            is_pending_drop: false,
-            is_pending_create: true,
         };
 
         // Serialize SearchIndex to disk so it can be initialized by other connections.

--- a/pg_search/src/postgres/cost.rs
+++ b/pg_search/src/postgres/cost.rs
@@ -17,7 +17,6 @@
 
 use crate::index::SearchIndex;
 use crate::index::WriterDirectory;
-use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::utils::relfilenode_from_index_oid;
 use crate::{DEFAULT_STARTUP_COST, UNKNOWN_SELECTIVITY};
 use pgrx::*;
@@ -51,18 +50,12 @@ pub unsafe extern "C" fn amcostestimate(
         .unwrap_or(1.0) as f64;
     let page_estimate = {
         assert!(!indexrel.rd_options.is_null());
-        let options = indexrel.rd_options as *mut SearchIndexCreateOptions;
         let database_oid = crate::MyDatabaseId();
         let index_oid = indexrel.oid().as_u32();
         let relfilenode = relfilenode_from_index_oid(index_oid).as_u32();
         let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode);
-        let search_index = SearchIndex::from_cache(
-            &directory,
-            &(*options)
-                .get_uuid()
-                .expect("`SearchIndexCreateOptions` must have a `uuid` property"),
-        )
-        .expect("should be able to retrieve a SearchIndex from internal cache");
+        let search_index = SearchIndex::from_disk(&directory)
+            .expect("should be able to retrieve a SearchIndex from internal cache");
         search_index
             .get_reader()
             .expect("must be able to initialize index reader in amcostestimate")

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -615,7 +615,7 @@ impl CustomScan for PdbScan {
 
         let directory =
             WriterDirectory::from_oids(database_oid, indexrelid.as_u32(), relfilenode.as_u32());
-        let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
+        let search_index = SearchIndex::from_disk(&directory)
             .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
         let search_reader = search_index

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -38,7 +38,7 @@ pub extern "C" fn ambulkdelete(
     let database_oid = crate::MyDatabaseId();
 
     let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode);
-    let search_index = SearchIndex::from_disk(&directory)
+    let mut search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
     let reader = search_index

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -67,7 +67,7 @@ impl InsertState {
             relfilenode.as_u32(),
         );
 
-        let index = SearchIndex::open_direct(&directory)?;
+        let index = SearchIndex::from_disk(&directory)?;
         let writer = index.get_writer()?;
         Ok(Self {
             index,

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -127,7 +127,7 @@ pub extern "C" fn amrescan(
     let database_oid = search_config.database_oid;
     let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode.as_u32());
 
-    let search_index = SearchIndex::from_cache(&directory, &search_config.uuid)
+    let search_index = SearchIndex::from_disk(&directory)
         .expect("index should be valid for SearchIndex::from_cache");
     let state = search_index
         .get_reader()

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -48,7 +48,7 @@ pub extern "C" fn amvacuumcleanup(
     let database_oid = crate::MyDatabaseId();
 
     let directory = WriterDirectory::from_oids(database_oid, index_oid, relfilenode);
-    let search_index = SearchIndex::from_disk(&directory)
+    let mut search_index = SearchIndex::from_disk(&directory)
         .unwrap_or_else(|err| panic!("error loading index from directory: {err}"));
 
     let mut writer = search_index


### PR DESCRIPTION
## What
Following up on #1762, I've proceeded with removing the global `SEARCH_INDEX_MEMORY` cache. This means we no longer keep any Tantivy-related state in memory between queries, which we expect to eliminate our window for race conditions as different connections compete for Tantivy resources.

## Why
Since #1707, we've seen some rare instances of concurrent Tantivy readers and writers competing for the Tantivy directory lock and throwing errors. We believe we can eliminate this issue by no longer caching either the Tantivy `Reader` instance or the `Index` instance in memory, and reloading them on every query.

## How
I've moved the remaining global state to the `SearchIndexWriter` file, where we just track the index/db oids so that we can properly commit + abort indexes on creation + drop.

## Tests

No new tests, but we should be aware that loading an index instance from disk will add overhead to each query. I've run some minimal benchmarks with a bare Tantivy `main.rs` file, and I'm seeing `495.542µs` to load an `Index` instance from disk.