### PR TITLE
chore: Reboot no longer necessary in Postgis install

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -22,12 +22,8 @@ for DB in template1 "$POSTGRES_DB"; do
     CREATE EXTENSION IF NOT EXISTS pg_analytics;
     CREATE EXTENSION IF NOT EXISTS pg_ivm;
     CREATE EXTENSION IF NOT EXISTS vector;
-
     CREATE EXTENSION IF NOT EXISTS postgis;
     CREATE EXTENSION IF NOT EXISTS postgis_topology;
-    -- Reconnect to update pg_setting.resetval
-    -- See https://github.com/postgis/docker-postgis/issues/288
-    \c
     CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
     CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
See here: https://trac.osgeo.org/postgis/ticket/5125

We no longer need to reconnect, so removing. I found this out while adding support for our Helm chart.

## Why
Faster boot, less logs

## How
^

## Tests
Install properly without it, tested in Kubernetes