### PR TITLE
chore: adjust tantivy commit and aminsert memory context

### DIFF
--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -141,9 +141,6 @@ impl SearchIndexWriter {
 
     pub fn commit(&mut self) -> Result<()> {
         self.underlying_writer
-            .prepare_commit()
-            .context("error preparing commit to tantivy index")?;
-        self.underlying_writer
             .commit()
             .context("error committing to tantivy index")?;
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # n/a

## What

1) Directly call Tantivy's `.commit()` function -- it does all the preparation for us
2) When leaking the `ii_AmCache` InsertState instance, do that inside the `ii_Context`

## Why

Correctness.  

Neither of these changes appear to fix some of the strange issues we're chasing, but they're more correct.

## How

## Tests
