### PR TITLE
fix: explicitly call `IndexWriter::wait_merging_threads()`

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -77,7 +77,9 @@ impl SearchIndex {
     /// be entirely owned by the new process, with no references.
     pub fn get_writer(&self) -> Result<SearchIndexWriter> {
         let underlying_writer = self.underlying_index.writer(INDEX_TANTIVY_MEMORY_BUDGET)?;
-        Ok(SearchIndexWriter { underlying_writer })
+        Ok(SearchIndexWriter {
+            underlying_writer: Some(underlying_writer),
+        })
     }
 
     #[allow(static_mut_refs)]


### PR DESCRIPTION
We need to wait for an open IndexWriter to finish merging, or it eventually never will.

We choose to do this in the background whenever our `SearchIndexWriter` wrapper is dropped.

If this turns out to be too aggressive, we could instead move this to only happen during VACUUM... which is an intersting idea.

# Ticket(s) Closed

- Closes #1763 (probably)

## What

Fixes the fact index segments have stopped merging.  I believe this is the root cause behind #1763.

## Why

Index segment is very important to keep index sizes reasonable.

## How

By asking tantivy to `wait_merging_threads()`, in the background, at the end of any INSERT/UPDATE statement.

## Tests

All existing tests pass.