### PR TITLE
feat: Move `lenient` and `conjunction_mode` to `paradedb.parse`/`paradedb.parse_with_field`

### DIFF
--- a/pg_search/sql/pg_search--0.10.3--0.10.4.sql
+++ b/pg_search/sql/pg_search--0.10.3--0.10.4.sql
@@ -171,7 +171,6 @@ CREATE  FUNCTION "index_info"(
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'index_info_wrapper';
 
-
 DROP TYPE paradedb.TestTable;
 CREATE TYPE paradedb.TestTable AS ENUM (
 	'Items',
@@ -292,3 +291,8 @@ CREATE  FUNCTION "range_term"(
 IMMUTABLE STRICT PARALLEL SAFE 
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'range_term_timestamp_with_time_zone_wrapper';
+
+DROP FUNCTION IF EXISTS parse(query_string text);
+CREATE OR REPLACE FUNCTION parse(query_string text, lenient bool DEFAULT NULL, conjunction_mode bool DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'parse_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS parse_with_field(field fieldname, query_string text);
+CREATE OR REPLACE FUNCTION parse_with_field(field fieldname, query_string text, lenient bool DEFAULT NULL, conjunction_mode bool DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'parse_with_field_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -339,15 +339,30 @@ pub fn more_like_this_id(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn parse(query_string: String) -> SearchQueryInput {
-    SearchQueryInput::Parse { query_string }
+pub fn parse(
+    query_string: String,
+    lenient: default!(Option<bool>, "NULL"),
+    conjunction_mode: default!(Option<bool>, "NULL"),
+) -> SearchQueryInput {
+    SearchQueryInput::Parse {
+        query_string,
+        lenient,
+        conjunction_mode,
+    }
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn parse_with_field(field: FieldName, query_string: String) -> SearchQueryInput {
+pub fn parse_with_field(
+    field: FieldName,
+    query_string: String,
+    lenient: default!(Option<bool>, "NULL"),
+    conjunction_mode: default!(Option<bool>, "NULL"),
+) -> SearchQueryInput {
     SearchQueryInput::ParseWithField {
         field: field.into_inner(),
         query_string,
+        lenient,
+        conjunction_mode,
     }
 }
 

--- a/pg_search/src/api/operator/text.rs
+++ b/pg_search/src/api/operator/text.rs
@@ -128,11 +128,17 @@ unsafe fn make_query_from_var_and_const(
         Some(field) => SearchQueryInput::ParseWithField {
             field,
             query_string,
+            lenient: None,
+            conjunction_mode: None,
         },
 
         // the Var represents a table reference, and that means the Const value is to be used
         // as-is as a query
-        None => SearchQueryInput::Parse { query_string },
+        None => SearchQueryInput::Parse {
+            query_string,
+            lenient: None,
+            conjunction_mode: None,
+        },
     };
     (heaprelid, query)
 }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -119,25 +119,19 @@ impl SearchIndex {
         Ok(new_self)
     }
 
-    pub fn query_parser(&self, config: &SearchConfig) -> QueryParser {
-        let mut query_parser = QueryParser::for_index(
+    pub fn query_parser(&self) -> QueryParser {
+        QueryParser::for_index(
             &self.underlying_index,
             self.schema
                 .fields
                 .iter()
                 .map(|search_field| search_field.id.0)
                 .collect::<Vec<_>>(),
-        );
-
-        if let Some(true) = config.conjunction_mode {
-            query_parser.set_conjunction_by_default();
-        }
-
-        query_parser
+        )
     }
 
     pub fn query(&self, config: &SearchConfig, reader: &SearchIndexReader) -> Box<dyn Query> {
-        let mut parser = self.query_parser(config);
+        let mut parser = self.query_parser();
         let searcher = reader.underlying_reader.searcher();
         config
             .query

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -144,7 +144,14 @@ pub type IndexRelation = PgRelation;
 impl From<(String, IndexRelation)> for SearchConfig {
     fn from(value: (String, IndexRelation)) -> Self {
         let (query_string, indexrel) = value;
-        SearchConfig::from((SearchQueryInput::Parse { query_string }, indexrel))
+        SearchConfig::from((
+            SearchQueryInput::Parse {
+                query_string,
+                lenient: None,
+                conjunction_mode: None,
+            },
+            indexrel,
+        ))
     }
 }
 

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -1049,7 +1049,7 @@ fn parse_lenient(mut conn: PgConnection) {
 }
 
 #[rstest]
-fn parse_conjunction_mode(mut conn: PgConnection) {
+fn parse_conjunction(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let rows: Vec<(i32,)> = r#"
@@ -1070,31 +1070,6 @@ fn parse_with_field_conjunction(mut conn: PgConnection) {
     ORDER BY id;
     "#.fetch(&mut conn);
     assert_eq!(rows, vec![(3,)]);
-}
-
-#[rstest]
-fn conjunction_config_search(mut conn: PgConnection) {
-    SimpleProductsTable::setup().execute(&mut conn);
-
-    let mut columns: SimpleProductsTableVec = r#"
-    SELECT * FROM bm25_search.search(
-        'description:keyboard rating:>2',
-        conjunction_mode => true,
-        stable_sort => true
-    );
-    "#
-    .fetch_collect(&mut conn);
-
-    assert_eq!(columns.len(), 2);
-
-    columns = r#"
-    SELECT * FROM bm25_search.search(
-        'description:keyboard rating:>2'
-    );
-    "#
-    .fetch_collect(&mut conn);
-
-    assert!(columns.len() > 2);
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1748 

## What
Lets the user specify `lenient` and `conjunction_mode` in `parse` and `parse_with_field`. These are the only two functions that actually take raw Tantivy query strings from the user, so it makes so much sense to put these options here.

For example:

```sql
SELECT * FROM mock_items WHERE id @@@ paradedb.parse('shoes running', lenient => true);
```

## Why
Migrate these options to the new syntax.

## How

## Tests
See added tests: `parse_lenient`, `parse_conjunction`, and `parse_with_field_conjunction`