### PR TITLE
chore: Update comment from schema upgrade if already exists

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -146,9 +146,28 @@ jobs:
         if: steps.generate_commit_message.outputs.schema_diff_detected == 'true'
         with:
           script: |
-            github.rest.issues.createComment({
+            const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: process.env.DIFF
-            })
+              repo: context.repo.repo
+            });
+
+            const botComment = comments.data.find(comment => comment.user.type === 'Bot' && comment.body.includes('A schema difference was detected.'));
+
+            if (botComment) {
+              // Update the existing comment
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.DIFF
+              });
+            } else {
+              // Create a new comment if none exists
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.DIFF
+              });
+            }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Our PRs are now getting an avalanche of schema diff comments. This small change will make it so the comment is updated with new commits rather than creating a brand new one.

## Why
Avoid too many comments, but keep the correctness so the developer can know what to add to the upgrade script.

## How
Retrieve comment by type + content and update the body.

## Tests
See CI!