### PR TITLE
fix: re-implement scoring check for more like this queries

### DIFF
--- a/pg_search/src/index/reader.rs
+++ b/pg_search/src/index/reader.rs
@@ -264,7 +264,8 @@ impl SearchIndexReader {
             collector::ChannelCollector::new(sender, config.key_field.clone(), include_key);
         let searcher = self.searcher.clone();
         let schema = self.schema.schema.clone();
-        let need_scores = config.need_scores;
+        let need_scores =
+            config.need_scores || SearchConfig::contains_more_like_this(&config.query);
 
         let owned_query = query.box_clone();
         std::thread::spawn(move || {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1747

## What
Re-implement a scoring check for `MoreLikeThis`.

## Why
I removed it in #1762 because it was complication my reading refactor by mutating the SearchConfig.

## How
We just recurse through the SearchConfig query to check if MoreLikeThis is present.

## Tests
I've added a few tests against nesting MoreLikeThis inside some higher-order queries.
