### PR TITLE
fix: @@@ crashes, rti/varno confusion, and minor test query cleanup

### DIFF
--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -15,9 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::customscan::path::{plan_custom_path, reparameterize_custom_path_by_child};
 use crate::postgres::customscan::CustomScan;
-use pgrx::{node_to_string, pg_sys, PgList, PgMemoryContexts};
+use pgrx::{node_to_string, pg_sys, PgList};
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 
@@ -123,15 +122,7 @@ impl CustomPathBuilder {
                     pathtarget: unsafe { *rel }.reltarget,
                     ..Default::default()
                 },
-                methods: PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(
-                    pg_sys::CustomPathMethods {
-                        CustomName: CS::NAME.as_ptr(),
-                        PlanCustomPath: Some(plan_custom_path::<CS>),
-                        ReparameterizeCustomPathByChild: Some(
-                            reparameterize_custom_path_by_child::<CS>,
-                        ),
-                    },
-                ),
+                methods: CS::custom_path_methods(),
                 ..Default::default()
             },
             custom_paths: PgList::default(),

--- a/pg_search/src/postgres/customscan/builders/custom_scan.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_scan.rs
@@ -15,9 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::customscan::scan::create_custom_scan_state;
 use crate::postgres::customscan::CustomScan;
-use pgrx::{node_to_string, pg_sys, PgList, PgMemoryContexts};
+use pgrx::{node_to_string, pg_sys, PgList};
 use std::fmt::{Debug, Formatter};
 
 pub struct Args {
@@ -74,12 +73,7 @@ impl CustomScanBuilder {
             flags: unsafe { (*best_path).flags },
             custom_private: unsafe { *best_path }.custom_private,
             custom_plans,
-            methods: PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(
-                pg_sys::CustomScanMethods {
-                    CustomName: CS::NAME.as_ptr(),
-                    CreateCustomScanState: Some(create_custom_scan_state::<CS>),
-                },
-            ),
+            methods: CS::custom_scan_methods(),
             scan: pg_sys::Scan {
                 plan: pg_sys::Plan {
                     type_: pg_sys::NodeTag::T_CustomScan,

--- a/pg_search/src/postgres/customscan/builders/custom_state.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_state.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::postgres::customscan::CustomScan;
-use pgrx::{pg_sys, PgList, PgMemoryContexts};
+use pgrx::{pg_sys, PgList};
 use std::fmt::{Debug, Formatter};
 use std::ptr::addr_of_mut;
 
@@ -131,8 +131,7 @@ impl<CS: CustomScan> CustomScanStateBuilder<CS> {
                 flags: (*self.args.cscan).flags,
                 custom_ps: std::ptr::null_mut(),
                 pscan_len: 0,
-                methods: PgMemoryContexts::CurrentMemoryContext
-                    .leak_and_drop_on_delete(CS::exec_methods()),
+                methods: CS::exec_methods(),
                 #[cfg(any(feature = "pg16", feature = "pg17"))]
                 slotOps: std::ptr::null_mut(),
             };

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -49,9 +49,9 @@ use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
 use crate::postgres::customscan::explainer::Explainer;
-pub use hook::register_rel_pathlist;
 use crate::postgres::customscan::path::{plan_custom_path, reparameterize_custom_path_by_child};
 use crate::postgres::customscan::scan::create_custom_scan_state;
+pub use hook::register_rel_pathlist;
 
 pub trait CustomScanState: Default {}
 
@@ -74,13 +74,15 @@ pub trait CustomScan: Default + Sized {
             static mut METHODS: *mut pg_sys::CustomPathMethods = std::ptr::null_mut();
 
             if METHODS.is_null() {
-                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomPathMethods {
-                    CustomName: Self::NAME.as_ptr(),
-                    PlanCustomPath: Some(plan_custom_path::<Self>),
-                    ReparameterizeCustomPathByChild: Some(
-                        reparameterize_custom_path_by_child::<Self>,
-                    ),
-                });
+                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(
+                    pg_sys::CustomPathMethods {
+                        CustomName: Self::NAME.as_ptr(),
+                        PlanCustomPath: Some(plan_custom_path::<Self>),
+                        ReparameterizeCustomPathByChild: Some(
+                            reparameterize_custom_path_by_child::<Self>,
+                        ),
+                    },
+                );
             }
             METHODS
         }
@@ -88,40 +90,43 @@ pub trait CustomScan: Default + Sized {
 
     fn custom_scan_methods() -> *const pg_sys::CustomScanMethods {
         unsafe {
-            static mut METHODS:*mut pg_sys::CustomScanMethods = std::ptr::null_mut();
+            static mut METHODS: *mut pg_sys::CustomScanMethods = std::ptr::null_mut();
 
-            METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomScanMethods {
-                CustomName: Self::NAME.as_ptr(),
-                CreateCustomScanState: Some(create_custom_scan_state::<Self>),
-            });
+            METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(
+                pg_sys::CustomScanMethods {
+                    CustomName: Self::NAME.as_ptr(),
+                    CreateCustomScanState: Some(create_custom_scan_state::<Self>),
+                },
+            );
             METHODS
         }
     }
 
     fn exec_methods() -> *const pg_sys::CustomExecMethods {
         unsafe {
-            static mut METHODS:*mut pg_sys::CustomExecMethods = std::ptr::null_mut();
+            static mut METHODS: *mut pg_sys::CustomExecMethods = std::ptr::null_mut();
 
             if METHODS.is_null() {
-                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomExecMethods {
-                    CustomName: Self::NAME.as_ptr(),
-                    BeginCustomScan: Some(begin_custom_scan::<Self>),
-                    ExecCustomScan: Some(exec_custom_scan::<Self>),
-                    EndCustomScan: Some(end_custom_scan::<Self>),
-                    ReScanCustomScan: Some(rescan_custom_scan::<Self>),
-                    MarkPosCustomScan: None,
-                    RestrPosCustomScan: None,
-                    EstimateDSMCustomScan: None,
-                    InitializeDSMCustomScan: None,
-                    ReInitializeDSMCustomScan: None,
-                    InitializeWorkerCustomScan: None,
-                    ShutdownCustomScan: Some(shutdown_custom_scan::<Self>),
-                    ExplainCustomScan: Some(explain_custom_scan::<Self>),
-                });
+                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(
+                    pg_sys::CustomExecMethods {
+                        CustomName: Self::NAME.as_ptr(),
+                        BeginCustomScan: Some(begin_custom_scan::<Self>),
+                        ExecCustomScan: Some(exec_custom_scan::<Self>),
+                        EndCustomScan: Some(end_custom_scan::<Self>),
+                        ReScanCustomScan: Some(rescan_custom_scan::<Self>),
+                        MarkPosCustomScan: None,
+                        RestrPosCustomScan: None,
+                        EstimateDSMCustomScan: None,
+                        InitializeDSMCustomScan: None,
+                        ReInitializeDSMCustomScan: None,
+                        InitializeWorkerCustomScan: None,
+                        ShutdownCustomScan: Some(shutdown_custom_scan::<Self>),
+                        ExplainCustomScan: Some(explain_custom_scan::<Self>),
+                    },
+                );
             }
             METHODS
         }
-
     }
 
     fn callback(builder: CustomPathBuilder) -> Option<pg_sys::CustomPath>;

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -21,7 +21,7 @@
 #![allow(dead_code)]
 #![allow(clippy::tabs_in_doc_comments)]
 
-use pgrx::pg_sys;
+use pgrx::{pg_sys, PgMemoryContexts};
 use std::ffi::CStr;
 
 mod builders;
@@ -50,28 +50,78 @@ use crate::postgres::customscan::builders::custom_state::{
 };
 use crate::postgres::customscan::explainer::Explainer;
 pub use hook::register_rel_pathlist;
+use crate::postgres::customscan::path::{plan_custom_path, reparameterize_custom_path_by_child};
+use crate::postgres::customscan::scan::create_custom_scan_state;
+
 pub trait CustomScanState: Default {}
 
 pub trait CustomScan: Default + Sized {
     const NAME: &'static CStr;
     type State: CustomScanState;
 
-    fn exec_methods() -> pg_sys::CustomExecMethods {
-        pg_sys::CustomExecMethods {
-            CustomName: Self::NAME.as_ptr(),
-            BeginCustomScan: Some(begin_custom_scan::<Self>),
-            ExecCustomScan: Some(exec_custom_scan::<Self>),
-            EndCustomScan: Some(end_custom_scan::<Self>),
-            ReScanCustomScan: Some(rescan_custom_scan::<Self>),
-            MarkPosCustomScan: None,
-            RestrPosCustomScan: None,
-            EstimateDSMCustomScan: None,
-            InitializeDSMCustomScan: None,
-            ReInitializeDSMCustomScan: None,
-            InitializeWorkerCustomScan: None,
-            ShutdownCustomScan: Some(shutdown_custom_scan::<Self>),
-            ExplainCustomScan: Some(explain_custom_scan::<Self>),
+    //
+    // SAFETY:  We need to allocate the struct to define the functions once, however
+    // all the methods are generic over this trait ([`CustomScan]).  Because Rust
+    // monomorphizes these functions, they're actually at different addresses per CustomScan
+    // impl.  As such, we allocate them once, in Postgres "TopMemoryContext", which is **never**
+    // freed.  This ensures we don't waste any more memory than we need and more importantly,
+    // ensures the returned pointer holding the function pointers lives for the life of the
+    // process, which Postgres requires of these.
+    //
+
+    fn custom_path_methods() -> *const pg_sys::CustomPathMethods {
+        unsafe {
+            static mut METHODS: *mut pg_sys::CustomPathMethods = std::ptr::null_mut();
+
+            if METHODS.is_null() {
+                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomPathMethods {
+                    CustomName: Self::NAME.as_ptr(),
+                    PlanCustomPath: Some(plan_custom_path::<Self>),
+                    ReparameterizeCustomPathByChild: Some(
+                        reparameterize_custom_path_by_child::<Self>,
+                    ),
+                });
+            }
+            METHODS
         }
+    }
+
+    fn custom_scan_methods() -> *const pg_sys::CustomScanMethods {
+        unsafe {
+            static mut METHODS:*mut pg_sys::CustomScanMethods = std::ptr::null_mut();
+
+            METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomScanMethods {
+                CustomName: Self::NAME.as_ptr(),
+                CreateCustomScanState: Some(create_custom_scan_state::<Self>),
+            });
+            METHODS
+        }
+    }
+
+    fn exec_methods() -> *const pg_sys::CustomExecMethods {
+        unsafe {
+            static mut METHODS:*mut pg_sys::CustomExecMethods = std::ptr::null_mut();
+
+            if METHODS.is_null() {
+                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(pg_sys::CustomExecMethods {
+                    CustomName: Self::NAME.as_ptr(),
+                    BeginCustomScan: Some(begin_custom_scan::<Self>),
+                    ExecCustomScan: Some(exec_custom_scan::<Self>),
+                    EndCustomScan: Some(end_custom_scan::<Self>),
+                    ReScanCustomScan: Some(rescan_custom_scan::<Self>),
+                    MarkPosCustomScan: None,
+                    RestrPosCustomScan: None,
+                    EstimateDSMCustomScan: None,
+                    InitializeDSMCustomScan: None,
+                    ReInitializeDSMCustomScan: None,
+                    InitializeWorkerCustomScan: None,
+                    ShutdownCustomScan: Some(shutdown_custom_scan::<Self>),
+                    ExplainCustomScan: Some(explain_custom_scan::<Self>),
+                });
+            }
+            METHODS
+        }
+
     }
 
     fn callback(builder: CustomPathBuilder) -> Option<pg_sys::CustomPath>;

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -399,7 +399,7 @@ impl CustomScan for PdbScan {
             let snippet_funcoid = builder.custom_state().snippet_funcoid;
             let attname_lookup = &builder.custom_state().var_attname_lookup;
             builder.custom_state().snippet_generators =
-                uses_snippets(attname_lookup, node, snippet_funcoid)
+                uses_snippets(private_data.range_table_index().unwrap(), attname_lookup, node, snippet_funcoid)
                     .into_iter()
                     .map(|field| (field, None))
                     .collect();
@@ -510,6 +510,7 @@ impl CustomScan for PdbScan {
 
             unsafe {
                 let mut projection_info = state.projection_info();
+                let rti = state.custom_state().rti;
 
                 projection_info = if state.custom_state().need_scores()
                     || state.custom_state.need_snippets()
@@ -543,6 +544,7 @@ impl CustomScan for PdbScan {
                         for (snippet_info, generator) in &mut state.custom_state.snippet_generators
                         {
                             const_projected_targetlist = inject_snippet(
+                                rti,
                                 &state.custom_state.var_attname_lookup,
                                 const_projected_targetlist.cast(),
                                 snippet_funcoid,

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -398,11 +398,15 @@ impl CustomScan for PdbScan {
             let node = builder.target_list().as_ptr().cast();
             let snippet_funcoid = builder.custom_state().snippet_funcoid;
             let attname_lookup = &builder.custom_state().var_attname_lookup;
-            builder.custom_state().snippet_generators =
-                uses_snippets(private_data.range_table_index().unwrap(), attname_lookup, node, snippet_funcoid)
-                    .into_iter()
-                    .map(|field| (field, None))
-                    .collect();
+            builder.custom_state().snippet_generators = uses_snippets(
+                private_data.range_table_index().unwrap(),
+                attname_lookup,
+                node,
+                snippet_funcoid,
+            )
+            .into_iter()
+            .map(|field| (field, None))
+            .collect();
 
             builder.build()
         }

--- a/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
@@ -57,11 +57,13 @@ pub fn snippet_funcoid() -> pg_sys::Oid {
 }
 
 pub unsafe fn uses_snippets(
+    rti: pg_sys::Index,
     attname_lookup: &HashMap<(i32, pg_sys::AttrNumber), String>,
     node: *mut pg_sys::Node,
     snippet_funcoid: pg_sys::Oid,
 ) -> Vec<SnippetInfo> {
     struct Context<'a> {
+        rti: pg_sys::Index,
         attname_lookup: &'a HashMap<(i32, pg_sys::AttrNumber), String>,
         snippet_funcoid: pg_sys::Oid,
         snippet_info: Vec<SnippetInfo>,
@@ -92,7 +94,7 @@ pub unsafe fn uses_snippets(
                 {
                     let attname = (*context)
                         .attname_lookup
-                        .get(&((*field_arg).varno as _, (*field_arg).varattno as _))
+                        .get(&((*context).rti as _, (*field_arg).varattno as _))
                         .cloned()
                         .expect("Var attname should be in lookup");
                     let start_tag =
@@ -119,6 +121,7 @@ pub unsafe fn uses_snippets(
     }
 
     let mut context = Context {
+        rti,
         attname_lookup,
         snippet_funcoid,
         snippet_info: vec![],
@@ -130,6 +133,7 @@ pub unsafe fn uses_snippets(
 
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn inject_snippet(
+    rti: pg_sys::Index,
     attname_lookup: &HashMap<(i32, pg_sys::AttrNumber), String>,
     node: *mut pg_sys::Node,
     snippet_funcoid: pg_sys::Oid,
@@ -142,6 +146,7 @@ pub unsafe fn inject_snippet(
     doc_address: DocAddress,
 ) -> *mut pg_sys::Node {
     struct Context<'a> {
+        rti: pg_sys::Index,
         attname_lookup: &'a HashMap<(i32, pg_sys::AttrNumber), String>,
         snippet_funcoid: pg_sys::Oid,
         search_reader: &'a SearchIndexReader,
@@ -173,7 +178,7 @@ pub unsafe fn inject_snippet(
                 if let Some(first_arg) = nodecast!(Var, T_Var, args.get_ptr(0).unwrap()) {
                     let attname = (*context)
                         .attname_lookup
-                        .get(&((*first_arg).varno as _, (*first_arg).varattno as _))
+                        .get(&((*context).rti as _, (*first_arg).varattno as _))
                         .cloned()
                         .expect("Var attname should be in lookup");
                     if attname == (*context).field {
@@ -218,6 +223,7 @@ pub unsafe fn inject_snippet(
     }
 
     let mut context = Context {
+        rti,
         attname_lookup,
         snippet_funcoid,
         search_reader,

--- a/pg_search/tests/bm25_search.rs
+++ b/pg_search/tests/bm25_search.rs
@@ -723,7 +723,7 @@ async fn json_nested_arrays(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
+// // #[ignore = "@@@"]
 fn bm25_partial_index_search(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 

--- a/pg_search/tests/key.rs
+++ b/pg_search/tests/key.rs
@@ -68,7 +68,6 @@ fn boolean_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn uuid_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (
@@ -102,7 +101,7 @@ fn uuid_key(mut conn: PgConnection) {
     // stable_sort
     let rows: Vec<(String, f32)> = r#"
     SELECT CAST(id AS TEXT), paradedb.score(id) FROM test_table WHERE test_table @@@ 
-        paradedb.term(field => 'value', value => 'blue')
+        paradedb.term(field => 'value', value => 'blue') ORDER BY score desc
     "#
     .fetch_collect(&mut conn);
     assert_eq!(
@@ -154,7 +153,6 @@ fn uuid_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn i64_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (
@@ -762,7 +760,6 @@ fn timestamp_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn timestamptz_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -103,7 +103,6 @@ fn fuzzy_term(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn single_queries(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
@@ -294,7 +293,6 @@ fn exists_query(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_raw(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -358,7 +356,6 @@ fn more_like_this_raw(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_empty(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -401,7 +398,6 @@ fn more_like_this_empty(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_text(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -440,7 +436,6 @@ fn more_like_this_text(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_boolean_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -478,7 +473,6 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_uuid_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -517,7 +511,6 @@ fn more_like_this_uuid_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_i64_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -557,7 +550,6 @@ fn more_like_this_i64_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_i32_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -596,7 +588,6 @@ fn more_like_this_i32_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_i16_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -635,7 +626,6 @@ fn more_like_this_i16_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_f32_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -674,7 +664,6 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_f64_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -713,7 +702,6 @@ fn more_like_this_f64_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_numeric_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -752,7 +740,6 @@ fn more_like_this_numeric_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_date_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -790,7 +777,6 @@ fn more_like_this_date_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_time_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -830,7 +816,6 @@ fn more_like_this_time_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_timestamp_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -870,7 +855,6 @@ fn more_like_this_timestamp_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_timestamptz_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (
@@ -910,7 +894,6 @@ fn more_like_this_timestamptz_key(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 fn more_like_this_timetz_key(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_more_like_this_table (

--- a/pg_search/tests/query.rs
+++ b/pg_search/tests/query.rs
@@ -116,7 +116,7 @@ fn single_queries(mut conn: PgConnection) {
     // Boost
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
-    paradedb.boost(paradedb.all(), boost => 1.5)
+    paradedb.boost(query => paradedb.all(), boost => 1.5)
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
@@ -124,7 +124,7 @@ fn single_queries(mut conn: PgConnection) {
     // ConstScore
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM paradedb.bm25_search
-    WHERE bm25_search @@@ paradedb.const_score(paradedb.all(), score => 3.9)
+    WHERE bm25_search @@@ paradedb.const_score(query => paradedb.all(), score => 3.9)
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);

--- a/pg_search/tests/replication.rs
+++ b/pg_search/tests/replication.rs
@@ -167,8 +167,7 @@ impl EphemeralPostgres {
 }
 
 // Test function to test the ephemeral PostgreSQL setup
-#[rstest]
-#[ignore = "@@@"] // Segfaults on PG13.
+#[rstest] // Segfaults on PG13.
 async fn test_ephemeral_postgres() -> Result<()> {
     let config = "
         wal_level = logical
@@ -421,8 +420,7 @@ async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
     Ok(())
 }
 
-#[rstest]
-#[ignore = "@@@"] // Segfaults on PG13.
+#[rstest] // Segfaults on PG13.
 async fn test_replication_with_pg_search_only_on_replica() -> Result<()> {
     let config = "
         wal_level = logical

--- a/pg_search/tests/snapshot.rs
+++ b/pg_search/tests/snapshot.rs
@@ -93,7 +93,6 @@ async fn snippet_after_update(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 async fn score_bm25_after_rollback(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "DELETE FROM paradedb.bm25_search WHERE id = 3".execute(&mut conn);
@@ -116,7 +115,6 @@ async fn score_bm25_after_rollback(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "@@@"]
 async fn snippet_after_rollback(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "DELETE FROM paradedb.bm25_search WHERE id = 3".execute(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This fixes the segfaults that a number of the @@@ tests uncovered.  This was a problem with allocating the "method" structs in a memory context that didn't live long enough.  These structs are supposed to be static consts, but b/c of rust monomorphization we have to allocate, but we do that just one, per generic, in TopMemoryContext so they never go away.

One way this would exhibit is with prepared statements, on the second execute:

```sql
PREPARE crash_on_two AS SELECT * FROM t WHERE field @@@ 'value';
EXECUTE crash_on_two; -- ok
EXECUTE crash_on_two; -- crash!
```

Our test suite uses prepared statements and there's a number of tests that execute the same query multiple times, so I did not add a new test for this specific case.

PR also fixes a bug about how the "rti" (range table index) and "varno" were being confused when detecting and injecting snippets.

## Why

Crashing is bad

## How

## Tests

All the `#[ignore = "@@@"]` tests are now enabled here, and I have 100% test passing on my laptop.