### PR TITLE
fix: custom scan is better at joins

### DIFF
--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -119,18 +119,8 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
                 PgList::new()
             } else if baseri.is_empty() {
                 joinri
-            } else if joinri.is_empty() {
-                baseri
             } else {
-                // combine them all into one large list of RestrictInfos
-                let mut combinedri = PgList::new();
-                for ri in baseri.iter_ptr() {
-                    combinedri.push(ri);
-                }
-                for ri in joinri.iter_ptr() {
-                    combinedri.push(ri);
-                }
-                combinedri
+                baseri
             }
         }
     }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -121,7 +121,7 @@ impl CustomScan for PdbScan {
             //
             let restrict_info = builder.restrict_info();
             if let Some(quals) =
-                extract_quals(restrict_info.as_ptr().cast(), anyelement_jsonb_opoid())
+                extract_quals(rti, restrict_info.as_ptr().cast(), anyelement_jsonb_opoid())
             {
                 let selectivity = if let Some(limit) = limit {
                     // use the limit

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -97,8 +97,14 @@ impl PrivateData {
 
     pub fn quals(&self) -> Option<Qual> {
         unsafe {
-            self.restrict_info
-                .and_then(|ri| extract_quals(ri.cast(), anyelement_jsonb_opoid()))
+            self.restrict_info.and_then(|ri| {
+                extract_quals(
+                    self.range_table_index()
+                        .expect("rti should be set to get a Qual"),
+                    ri.cast(),
+                    anyelement_jsonb_opoid(),
+                )
+            })
         }
     }
 


### PR DESCRIPTION

# Ticket(s) Closed

- Closes #1776

## What

The custom scan now does a better job of handling joins and figuring out which predicates from the restrict info list are necessary at any given level, and which need to be changed to "give me everything, sorry".

## Why

## How

## Tests

Added an edited version of the test from #1776 and updated an existing test that's now behaving more correctly.