### PR TITLE
fix: in upgrade.sql, CURRENT_SCHEMA should not be quoted

### DIFF
--- a/pg_search/sql/pg_search--0.10.3--0.10.4.sql
+++ b/pg_search/sql/pg_search--0.10.3--0.10.4.sql
@@ -180,7 +180,7 @@ AS 'MODULE_PATHNAME', 'index_info_wrapper';
 ALTER TYPE paradedb.TestTable ADD VALUE 'Deliveries';
 
 DROP PROCEDURE IF EXISTS paradedb.create_bm25(index_name text, table_name text, key_field text, schema_name text, text_fields jsonb, numeric_fields jsonb, boolean_fields jsonb, json_fields jsonb, datetime_fields jsonb, predicates text);
-CREATE OR REPLACE PROCEDURE paradedb.create_bm25(index_name text DEFAULT '', table_name text DEFAULT '', key_field text DEFAULT '', schema_name text DEFAULT 'current_schema', text_fields jsonb DEFAULT '{}', numeric_fields jsonb DEFAULT '{}', boolean_fields jsonb DEFAULT '{}', json_fields jsonb DEFAULT '{}', range_fields jsonb DEFAULT '{}', datetime_fields jsonb DEFAULT '{}', predicates text DEFAULT '') AS 'MODULE_PATHNAME', 'create_bm25_jsonb_wrapper' LANGUAGE c;
+CREATE OR REPLACE PROCEDURE paradedb.create_bm25(index_name text DEFAULT '', table_name text DEFAULT '', key_field text DEFAULT '', schema_name text DEFAULT CURRENT_SCHEMA, text_fields jsonb DEFAULT '{}', numeric_fields jsonb DEFAULT '{}', boolean_fields jsonb DEFAULT '{}', json_fields jsonb DEFAULT '{}', range_fields jsonb DEFAULT '{}', datetime_fields jsonb DEFAULT '{}', predicates text DEFAULT '') AS 'MODULE_PATHNAME', 'create_bm25_jsonb_wrapper' LANGUAGE c;
 /* </end connected objects> */
 /* <begin connected objects> */
 -- pg_search/src/api/index.rs:670


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In the upgrade script, it quoted (and transformed to lowercase) the default value for the `paradedb.create_bm25()` procedures's `schema_name =>` argument to be `'current_schema'` when in fact it should be `CURRENT_SCHEMA`.

## Why

## How

## Tests
