### PR TITLE
fix: docker image tags

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           images: paradedb/paradedb
           tags: |
-            type=raw,value=${{ steps.version.outputs.tag }}
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
 

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -61,9 +61,9 @@ jobs:
         with:
           images: paradedb/paradedb
           tags: |
+            type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
 
       - name: Login to Docker Hub


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Add tags like `v0.11.0` and `0.11.0` only for the default version (PG16).

## Why

Tags without PG version number like `v0.11.0` shouldn't be added to every PG version.

## How

## Tests
