### PR TITLE
fix: don't re-create a `SearchIndex` on every indexed row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,7 +3985,6 @@ dependencies = [
  "approx",
  "async-std",
  "bigdecimal 0.4.5",
- "bincode",
  "chrono",
  "cmd_lib",
  "crossbeam",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -20,7 +20,6 @@ icu = ["tokenizers/icu"]
 
 [dependencies]
 anyhow = { version = "1.0.87", features = ["backtrace"] }
-bincode = "1.3.3"
 crossbeam = "0.8.4"
 csv = "1.3.0"
 derive_more = "0.99.18"

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -141,8 +141,8 @@ impl SearchIndex {
     }
 
     pub fn insert(
-        &mut self,
-        writer: &mut SearchIndexWriter,
+        &self,
+        writer: &SearchIndexWriter,
         document: SearchDocument,
     ) -> Result<(), SearchIndexError> {
         // the index is about to change, and that requires our transaction callbacks be registered
@@ -159,9 +159,9 @@ impl SearchIndex {
     /// This function is atomic in that it ensures the underlying changes to the tantivy index
     /// are committed before returning an [`Ok`] response.
     pub fn delete(
-        &mut self,
+        &self,
         reader: &SearchIndexReader,
-        writer: &mut SearchIndexWriter,
+        writer: &SearchIndexWriter,
         should_delete: impl Fn(u64) -> bool,
     ) -> Result<(u32, u32), SearchIndexError> {
         let ctid_field = self.schema.ctid_field().id.0;
@@ -184,7 +184,7 @@ impl SearchIndex {
         Ok(())
     }
 
-    pub fn vacuum(&mut self, writer: &mut SearchIndexWriter) -> Result<(), SearchIndexError> {
+    pub fn vacuum(&self, writer: &SearchIndexWriter) -> Result<(), SearchIndexError> {
         writer.vacuum()?;
         Ok(())
     }

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -141,21 +141,21 @@ impl Drop for SearchIndexWriter {
 }
 
 impl SearchIndexWriter {
-    pub fn insert(&mut self, document: SearchDocument) -> Result<(), IndexError> {
+    pub fn insert(&self, document: SearchDocument) -> Result<(), IndexError> {
         // Add the Tantivy document to the index.
         self.underlying_writer
-            .as_mut()
+            .as_ref()
             .unwrap()
             .add_document(document.into())?;
 
         Ok(())
     }
 
-    pub fn delete(&mut self, ctid_field: &Field, ctid_values: &[u64]) -> Result<(), IndexError> {
+    pub fn delete(&self, ctid_field: &Field, ctid_values: &[u64]) -> Result<(), IndexError> {
         for ctid in ctid_values {
             let ctid_term = tantivy::Term::from_field_u64(*ctid_field, *ctid);
             self.underlying_writer
-                .as_mut()
+                .as_ref()
                 .unwrap()
                 .delete_term(ctid_term);
         }
@@ -177,9 +177,9 @@ impl SearchIndexWriter {
         Ok(())
     }
 
-    pub fn vacuum(&mut self) -> Result<(), IndexError> {
+    pub fn vacuum(&self) -> Result<(), IndexError> {
         self.underlying_writer
-            .as_mut()
+            .as_ref()
             .unwrap()
             .garbage_collect_files()
             .wait()?;

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -29,7 +29,7 @@ pub extern "C" fn ambulkdelete(
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_relation = unsafe { PgRelation::from_pg(info.index) };
 
-    let mut search_index =
+    let search_index =
         open_search_index(&index_relation).expect("should be able to open search index");
     let reader = search_index
         .get_reader()
@@ -52,7 +52,7 @@ pub extern "C" fn ambulkdelete(
             crate::postgres::utils::u64_to_item_pointer(ctid_val, &mut ctid);
             actual_callback(&mut ctid, callback_state)
         };
-        match search_index.delete(&reader, &mut writer, should_delete) {
+        match search_index.delete(&reader, &writer, should_delete) {
             Ok((deleted, not_deleted)) => {
                 stats.pages_deleted += deleted;
                 stats.num_pages += not_deleted;

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -130,10 +130,10 @@ unsafe fn aminsert_internal(
     index_info: *mut pg_sys::IndexInfo,
 ) -> bool {
     let result = catch_unwind(|| {
-        let state = &mut *init_insert_state(index_relation, index_info);
+        let state = &*init_insert_state(index_relation, index_info);
         let tupdesc = PgTupleDesc::from_pg_unchecked((*index_relation).rd_att);
-        let search_index = &mut state.index;
-        let writer = &mut state.writer;
+        let search_index = &state.index;
+        let writer = &state.writer;
         let search_document =
             row_to_search_document(*ctid, &tupdesc, values, isnull, &search_index.schema)
                 .unwrap_or_else(|err| {

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -39,15 +39,15 @@ pub extern "C" fn amvacuumcleanup(
     let index_relation = unsafe { PgRelation::from_pg(info.index) };
     let index_name = index_relation.name();
 
-    let mut search_index =
+    let search_index =
         open_search_index(&index_relation).expect("should be able to open search index");
-    let mut writer = search_index
+    let writer = search_index
         .get_writer()
         .unwrap_or_else(|err| panic!("error loading index writer from directory: {err}"));
 
     // Garbage collect the index and clear the writer cache to free up locks.
     search_index
-        .vacuum(&mut writer)
+        .vacuum(&writer)
         .unwrap_or_else(|err| panic!("error during vacuum on index {index_name}: {err:?}"));
 
     stats

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -679,11 +679,11 @@ impl SearchIndexSchema {
             .clone()
     }
 
+    #[inline(always)]
     pub fn new_document(&self) -> SearchDocument {
-        let doc = tantivy::TantivyDocument::new();
-        let key = self.key_field().id;
-        let ctid = self.ctid_field().id;
-        SearchDocument { doc, key, ctid }
+        SearchDocument {
+            doc: tantivy::TantivyDocument::new(),
+        }
     }
 
     pub fn get_search_field(&self, name: &SearchFieldName) -> Option<&SearchField> {


### PR DESCRIPTION
## What

The "ambuild callback" was creating a new `SearchIndex` instance on every row being indexed, drastically slowing down indexing times.

On a local test dataset of 50M rows (~16G) indexing dropped from 53 minutes to about 21 minutes

## Why

Improve CREATE INDEX times, remove some dead code, and general code cleanup.

This also cleans up the mutability requirements of various methods -- tantivy is mostly atomic, so things like insert and delete don't need mutable references.

## How

## Tests
