### PR TITLE
chore: Switch to Docker Build Cloud

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -69,14 +69,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx with Build Cloud
         uses: docker/setup-buildx-action@v3
         with:
-          version: "lab:latest"
-          driver: cloud
-          endpoint: "${{ secrets.DOCKERHUB_USERNAME }}/paradedb"
-          install: true
           platforms: linux/amd64,linux/arm64
+          version: lab:latest
+          driver: cloud
+          endpoint: ${{ secrets.DOCKERHUB_USERNAME }}/paradedb
+          install: true
 
       # The pg_version-tag Docker tag syntax is necessary for our K8s CloudNativePG operator
       - name: Build and Push Docker Image to Docker Hub

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   publish-paradedb-container-image:
-    name: Publish ParadeDB Container Image for PostgreSQL ${{ matrix.pg_version }}
+    name: Publish ParadeDB Docker Image for PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubicloud-standard-2
     strategy:
       matrix:
@@ -69,17 +69,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          version: "lab:latest"
+          driver: cloud
+          endpoint: "${{ secrets.DOCKERHUB_USERNAME }}/paradedb"
+          install: true
+          platforms: linux/amd64,linux/arm64
 
       # The pg_version-tag Docker tag syntax is necessary for our K8s CloudNativePG operator
       - name: Build and Push Docker Image to Docker Hub
         id: build-push
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: |
@@ -91,8 +93,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           push: true
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Sign and Attest Build Provenance

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -52,9 +52,6 @@ jobs:
           fi
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Configure Depot CLI
-        uses: depot/setup-action@v1
-
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -50,17 +50,28 @@ jobs:
             echo "Using dev configuration..."
           fi
 
-      - name: Configure Depot CLI
+      - name: Login to Docker Hub
         if: steps.env.outputs.environment == 'prod'
-        uses: depot/setup-action@v1
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      # We only build with Depot when promoting to `main` as doing so requires access to GitHub Secrets,
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: "lab:latest"
+          driver: cloud
+          install: true
+          platforms: linux/${{ matrix.arch }}
+
+      # We only build with Docker Buildcloud when promoting to `main` as doing so requires access to GitHub Secrets,
       # which community contributors don't have access to.
       #
       # We keep PARADEDB_TELEMETRY=true to test the telemetry feature, even though this isn't real usage.
-      - name: Build the ParadeDB Docker Image via Depot (prod only)
+      - name: Build the ParadeDB Docker Image (prod only)
         if: steps.env.outputs.environment == 'prod'
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: |
@@ -72,9 +83,8 @@ jobs:
           file: docker/Dockerfile
           push: false # Don't push to Docker Hub
           load: true # Load the image into the Docker daemon of the runner
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
           tags: paradedb/paradedb:latest # Tag the local image as latest so it gets picked up by Docker Compose
+          outputs: "type=cacheonly" # Export results to the build cache
 
       # On any branch other than `main`, we build the ParadeDB Docker Image using Docker Compose so that community
       # contributors can trigger the workflow without needing access to GitHub Secrets.

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -22,18 +22,9 @@ concurrency:
 
 jobs:
   test-paradedb:
-    name: Test ParadeDB on PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    name: Test ParadeDB Docker Image
+    runs-on: depot-ubuntu-latest-8
     if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        include:
-          - runner: ubicloud-standard-8
-            pg_version: 16
-            arch: amd64
-          - runner: ubicloud-standard-8-arm
-            pg_version: 16
-            arch: arm64
 
     steps:
       - name: Checkout Git Repository
@@ -46,7 +37,7 @@ jobs:
             echo "environment=prod" >> $GITHUB_OUTPUT
             echo "Using prod configuration..."
           else
-            echo "environment=prod" >> $GITHUB_OUTPUT
+            echo "environment=dev" >> $GITHUB_OUTPUT
             echo "Using dev configuration..."
           fi
 
@@ -58,13 +49,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
+        if: steps.env.outputs.environment == 'prod'
         uses: docker/setup-buildx-action@v3
         with:
           version: "lab:latest"
           driver: cloud
           endpoint: "${{ secrets.DOCKERHUB_USERNAME }}/paradedb"
           install: true
-          platforms: linux/${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64
 
       # We only build with Docker Buildcloud when promoting to `main` as doing so requires access to GitHub Secrets,
       # which community contributors don't have access to.
@@ -80,7 +72,7 @@ jobs:
             POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
             COMMIT_SHA=testcommitsha
             PARADEDB_TELEMETRY=true
-          platforms: linux/${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           push: false # Don't push to Docker Hub
           load: true # Load the image into the Docker daemon of the runner

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -46,7 +46,7 @@ jobs:
             echo "environment=prod" >> $GITHUB_OUTPUT
             echo "Using prod configuration..."
           else
-            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "environment=prod" >> $GITHUB_OUTPUT
             echo "Using dev configuration..."
           fi
 
@@ -62,7 +62,7 @@ jobs:
         with:
           version: "lab:latest"
           driver: cloud
-          endpoint: "ORG/default"
+          endpoint: "${{ secrets.DOCKERHUB_USERNAME }}/paradedb"
           install: true
           platforms: linux/${{ matrix.arch }}
 

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           version: "lab:latest"
           driver: cloud
+          endpoint: "ORG/default"
           install: true
           platforms: linux/${{ matrix.arch }}
 

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -48,17 +48,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx with Build Cloud
         if: steps.env.outputs.environment == 'prod'
         uses: docker/setup-buildx-action@v3
         with:
-          version: "lab:latest"
-          driver: cloud
-          endpoint: "${{ secrets.DOCKERHUB_USERNAME }}/paradedb"
-          install: true
           platforms: linux/amd64,linux/arm64
+          version: lab:latest
+          driver: cloud
+          endpoint: ${{ secrets.DOCKERHUB_USERNAME }}/paradedb
+          install: true
 
-      # We only build with Docker Buildcloud when promoting to `main` as doing so requires access to GitHub Secrets,
+      # We only build with Docker Build Cloud when promoting to `main` as doing so requires access to GitHub Secrets,
       # which community contributors don't have access to.
       #
       # We keep PARADEDB_TELEMETRY=true to test the telemetry feature, even though this isn't real usage.

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Set Environment
+      - name: Set up Environment
         id: env
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This PR:

- Moves our container build for test and publish from Depot, which costs 200$/mo, to Docker Build Cloud, which costs 6$/mo
- Combines the two Docker test jobs we had for arm/amd onto a single job, to reduce CI minutes by half
- Only runs the Docker test on changes to the `docker/` folder, to significantly reduce Docker build minutes (by 90%+ here)
- Rename the Docker workflow to say Docker in the name, so it's easier to understand what it tests

## Why
Depot is starting to charge us A LOT, and our CI was super wasteful.

## How
^

## Tests
Manually tested. You can see it here: https://app.docker.com/build/accounts/paradedb/builds