### PR TITLE
feat: GUCs to control resource usage during CREATE INDEX and INSERT/UPDATE/COPY

### DIFF
--- a/docs/documentation/configuration.mdx
+++ b/docs/documentation/configuration.mdx
@@ -29,7 +29,7 @@ automatically detect "available parallelism" of the host computer.
 
 For best performance it is recommended to use one less than the total number of host computer cores.
 
-This GUC can oly be changed by the superuser.
+This GUC can only be changed by the superuser.
 
 ### `paradedb.create_index_memory_budget`
 
@@ -42,7 +42,7 @@ memory. In terms of raw indexing performance, generally larger is better. Keep i
 The value follows Postgres' rules for GUCs that specify byte values. It is measured in megabytes. As such, an
 qualified value of `1024` is the same as `1GB`.
 
-This GUC can oly be changed by the superuser.
+This GUC can only be changed by the superuser.
 
 ### `paradedb.statement_parallelism`
 
@@ -53,7 +53,7 @@ If your typical update patterns are single-record atomic INSERTs or UPDATEs, the
 your update patterns typically update many thousands of rows, a larger value might be preferred for greater indexing
 concurrency.
 
-This GUC can oly be changed by the superuser.
+This GUC can only be changed by the superuser.
 
 ### `paradedb.statement_memory_budget`
 
@@ -74,7 +74,7 @@ Generally speaking, for statement level indexing, the parallelism value dictates
 segments that will be created, so there's a trade-off between finishing the INSERT/UPDATE statement quickly and the
 longer-term search overhead of having many additional index segments until (auto)VACUUM runs.
 
-This GUC can oly be changed by the superuser.
+This GUC can only be changed by the superuser.
 
 ### `paradedb.log_create_index_progress`
 

--- a/docs/documentation/configuration.mdx
+++ b/docs/documentation/configuration.mdx
@@ -14,6 +14,76 @@ SET paradedb.enable_custom_scan = true;
 Custom scans should only be disabled for debugging purposes. They must be enabled for scoring, highlighting,
 and various predicate pushdowns to work.
 
+## Indexing Resource Usage
+
+ParadeDB offers a number of `postgresql.conf` settings, which can only be changed by a superuser, to control the number
+of concurrent indexing threads and the amount of memory each thread should use.
+
+These settings are split between `CREATE INDEX` and regular `INSERT/UPDATE/COPY` statements as it seems logical that
+more resources might be desired for `CREATE INDEX`, which typically only needs to happen once.
+
+### `paradedb.create_index_parallelism`
+
+This is the number of indexing threads to use during `CREATE INDEX`. The default is `8`. A value of zero will
+automatically detect "available parallelism" of the host computer.
+
+For best performance it is recommended to use one less than the total number of host computer cores.
+
+This GUC can oly be changed by the superuser.
+
+### `paradedb.create_index_memory_budget`
+
+This is the amount of memory to dedicate, **per indexing thread** (see above), before the index segment needs to be
+written to disk.
+
+It defaults to whatever the Postgres `maintenance_work_mem` is, but can be changed to suit the host system's available
+memory. In terms of raw indexing performance, generally larger is better. Keep in mind that this
+
+The value follows Postgres' rules for GUCs that specify byte values. It is measured in megabytes. As such, an
+qualified value of `1024` is the same as `1GB`.
+
+This GUC can oly be changed by the superuser.
+
+### `paradedb.statement_parallelism`
+
+This is the number of indexing threads to use during `INSERT/UPDATE/COPY` statements. The default is `8`. A value of
+zero will automatically detect "available parallelism" of the host computer.
+
+If your typical update patterns are single-record atomic INSERTs or UPDATEs, then a value of `1` is ideal. If
+your update patterns typically update many thousands of rows, a larger value might be preferred for greater indexing
+concurrency.
+
+This GUC can oly be changed by the superuser.
+
+### `paradedb.statement_memory_budget`
+
+This is the amount of memory to dedicate, **per indexing thread** (see above), before the index segment needs to be
+written to disk.
+
+It defaults to whatever the Postgres `maintenance_work_mem` is, but can be changed to suit the host system's available
+memory. In terms of raw indexing performance, generally larger is better. Keep in mind that this
+
+The value follows Postgres' rules for GUCs that specify byte values. It is measured in megabytes. As such, an
+qualified value of `1024` is the same as `1GB`.
+
+If your typical update patterns are single-record atomic INSERTs or UPDATEs, then a value of `15MB` is ideal. If
+your update patterns typically update many thousands of rows, a larger value might be preferred for greater indexing
+concurrency.
+
+Generally speaking, for statement level indexing, the parallelism value dictates the number of new Tantivy index
+segments that will be created, so there's a trade-off between finishing the INSERT/UPDATE statement quickly and the
+longer-term search overhead of having many additional index segments until (auto)VACUUM runs.
+
+This GUC can oly be changed by the superuser.
+
+### `paradedb.log_create_index_progress`
+
+A boolean setting, defaulting to `false`, which will create Postgres `LOG:` entries every 100,000 rows which include
+the indexing rate (rows per second).
+
+This can be useful to monitor the progress of a long-running `CREATE INDEX` statement. The GUC can be changed by
+any user.
+
 ## Telemetry
 
 By default, ParadeDB collects anonymous telemetry to better understand how many people are

--- a/docs/documentation/indexing/create_index.mdx
+++ b/docs/documentation/indexing/create_index.mdx
@@ -34,6 +34,11 @@ CALL paradedb.create_bm25(
   The name of the schema, or namespace, of the table.
 </ParamField>
 
+## Resource Management GUCs
+
+A [set of GUCs](/documentation/configuration) exist to control the amount of resources to allocate during index creation.  While they have sensible
+defaults, overall indexing performance can be drastically improved if configured for the host system.
+
 ## Field Types
 
 In addition to text fields, numeric, datetime, boolean, and JSON fields can also be indexed. For optimal performance, we recommend indexing all fields

--- a/pg_search/src/api/operator/searchconfig.rs
+++ b/pg_search/src/api/operator/searchconfig.rs
@@ -18,13 +18,12 @@
 use crate::api::operator::{
     anyelement_jsonb_opoid, estimate_selectivity, find_var_relation, ReturnedNodePointer,
 };
-use crate::gucs::GlobalGucSettings;
 use crate::index::SearchIndex;
 use crate::postgres::index::open_search_index;
 use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::locate_bm25_index;
 use crate::schema::SearchConfig;
-use crate::{nodecast, GUCS, UNKNOWN_SELECTIVITY};
+use crate::{gucs, nodecast, UNKNOWN_SELECTIVITY};
 use pgrx::{
     check_for_interrupts, pg_extern, pg_func_extra, pg_sys, AnyElement, FromDatum, Internal, JsonB,
     PgList, PgOid, PgRelation,
@@ -103,12 +102,12 @@ fn search_config_support_request_cost(arg: Internal) -> Option<ReturnedNodePoint
         // ultimately we have to hash all the resulting ctids in memory.  For lack of a better
         // value, we say it costs as much as the `GUCS.per_tuple_cost()`.  This is an arbitrary
         // number that we've documented as needing to be big.
-        (*src).startup = GUCS.per_tuple_cost();
+        (*src).startup = gucs::per_tuple_cost();
 
         // similarly, use the same GUC here.  Postgres will then add this into its per-tuple
         // cost evaluations for whatever scan it's considering using for the `@@@` operator.
         // our IAM provides more intelligent costs for the IndexScan situation.
-        (*src).per_tuple = GUCS.per_tuple_cost();
+        (*src).per_tuple = gucs::per_tuple_cost();
 
         Some(ReturnedNodePointer(NonNull::new(src.cast())))
     }

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -15,101 +15,200 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
+use crate::index::Parallelism;
+use pgrx::{pg_sys, GucContext, GucFlags, GucRegistry, GucSetting};
+use std::num::NonZeroUsize;
 
-pub trait GlobalGucSettings {
-    fn telemetry_enabled(&self) -> bool;
+/// Is our telemetry tracking enabled?  Default is `true`.
+static TELEMETRY: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-    /// Allows the user to toggle the use of our "ParadeDB Custom Scan".  The default is `true`.
-    fn enable_custom_scan(&self) -> bool;
+/// Allows the user to toggle the use of our "ParadeDB Custom Scan".  The default is `true`.
+static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-    /// The `per_tuple_cost` is an arbitrary value that needs to be really high.  In fact, we default
-    /// to one hundred million.
-    ///
-    /// The reason for this is we really do not want Postgres to choose a plan where the `@@@` operator
-    /// is used in a sequential scan, filter, or recheck condition... unless of course there's no
-    /// other way to solve the query.
-    ///
-    /// This value is a multiplier that Postgres applies to the estimated row count any given `@@@`
-    /// query clause will return.  In our case, higher is better.
-    ///
-    /// Our IAM impl has its own costing functions that don't use this GUC and provide sensible estimates
-    /// for the overall IndexScan.  That plus this help to persuade Postgres to use our IAM whenever
-    /// it logically can.
-    fn per_tuple_cost(&self) -> f64;
+/// The `PER_TUPLE_COST` is an arbitrary value that needs to be really high.  In fact, we default
+/// to one hundred million.
+///
+/// The reason for this is we really do not want Postgres to choose a plan where the `@@@` operator
+/// is used in a sequential scan, filter, or recheck condition... unless of course there's no
+/// other way to solve the query.
+///
+/// This value is a multiplier that Postgres applies to the estimated row count any given `@@@`
+/// query clause will return.  In our case, higher is better.
+///
+/// Our IAM impl has its own costing functions that don't use this GUC and provide sensible estimates
+/// for the overall IndexScan.  That plus this help to persuade Postgres to use our IAM whenever
+/// it logically can.
+static PER_TUPLE_COST: GucSetting<f64> = GucSetting::<f64>::new(100_000_000.0);
+
+/// Should we log the progress of the CREATE INDEX operation?  Default is `false`.
+static LOG_CREATE_INDEX_PROGRESS: GucSetting<bool> = GucSetting::<bool>::new(false);
+
+/// How many threads should tantivy use during CREATE INDEX?
+static CREATE_INDEX_PARALLELISM: GucSetting<i32> = GucSetting::<i32>::new(8);
+
+/// How much memory should tantivy use during CREATE INDEX.  This value is decided to each indexing
+/// thread.  So if there's 10 threads and this value is 100MB, then a total of 1GB will be allocated.
+static CREATE_INDEX_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(0);
+
+/// How many threads should tantivy use during a regular INSERT/UPDATE/COPY statement?
+static STATEMENT_PARALLELISM: GucSetting<i32> = GucSetting::<i32>::new(8);
+
+/// How much memory should tantivy use during a regular INSERT/UPDATE/COPY statement?  This value is decided to each indexing
+/// thread.  So if there's 10 threads and this value is 100MB, then a total of 1GB will be allocated.
+static STATEMENT_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(0);
+
+pub fn init() {
+    // Note that Postgres is very specific about the naming convention of variables.
+    // They must be namespaced... we use 'paradedb.<variable>' below.
+    // They cannot have more than one '.' - paradedb.pg_search.telemetry will not work.
+
+    GucRegistry::define_bool_guc(
+        "paradedb.pg_search_telemetry",
+        "Enable telemetry on the ParadeDB pg_search extension.",
+        "Enable telemetry on the ParadeDB pg_search extension.",
+        &TELEMETRY,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        "paradedb.enable_custom_scan",
+        "Enable ParadeDB's custom scan",
+        "Enable ParadeDB's custom scan",
+        &ENABLE_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_float_guc(
+        "paradedb.per_tuple_cost",
+        "Arbitrary multiplier for the cost of retrieving a tuple from a USING bm25 index outside of an IndexScan",
+        "Default is 100,000,000.0.  It is very expensive to use a USING bm25 index in the wrong query plan",
+        &PER_TUPLE_COST,
+        0.0,
+        f64::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        "paradedb.log_create_index_progress",
+        "Log CREATE INDEX progress every 100,000 rows",
+        "",
+        &LOG_CREATE_INDEX_PROGRESS,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        "paradedb.create_index_parallelism",
+        "The number of threads to use when creating an index",
+        "Default is 8.  Recommended value is roughly the number of cores in the machine.  Value of zero means a thread for as many cores in the machine",
+        &CREATE_INDEX_PARALLELISM,
+        0,
+        std::thread::available_parallelism().expect("your computer should have at least one core").get().try_into().expect("your computer has too many cores"),
+        GucContext::Suset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        "paradedb.create_index_memory_budget",
+        "The amount of memory to allocate to 1 thread during indexing",
+        "Default is `maintenance_work_mem`",
+        &CREATE_INDEX_MEMORY_BUDGET,
+        0,
+        i32::MAX,
+        GucContext::Suset,
+        GucFlags::UNIT_MB,
+    );
+
+    GucRegistry::define_int_guc(
+        "paradedb.statement_parallelism",
+        "The number of threads to use when indexing during an INSERT/UPDATE/COPY statement",
+        "Default is 8.  Recommended value is roughly the number of cores in the machine.  Value of zero means a thread for as many cores in the machine",
+        &STATEMENT_PARALLELISM,
+        0,
+        std::thread::available_parallelism().expect("your computer should have at least one core").get().try_into().expect("your computer has too many cores"),
+        GucContext::Suset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        "paradedb.statement_memory_budget",
+        "The amount of memory to allocate to 1 thread during an INSERT/UPDATE/COPY statement",
+        "Default is `maintenance_work_mem`",
+        &STATEMENT_MEMORY_BUDGET,
+        0,
+        i32::MAX,
+        GucContext::Suset,
+        GucFlags::UNIT_MB,
+    );
+
+    pgrx::warning!("GUCS initialized");
 }
 
-pub struct PostgresGlobalGucSettings {
-    telemetry: GucSetting<bool>,
-    enable_custom_scan: GucSetting<bool>,
-    per_tuple_cost: GucSetting<f64>,
+pub fn telemetry_enabled() -> bool {
+    // If PARADEDB_TELEMETRY is not 'true' at compile time, then we will never enable.
+    // This is useful for test builds and CI.
+    option_env!("PARADEDB_TELEMETRY") == Some("true") && TELEMETRY.get()
 }
 
-impl PostgresGlobalGucSettings {
-    pub const fn new() -> Self {
-        Self {
-            telemetry: GucSetting::<bool>::new(true),
-            enable_custom_scan: GucSetting::<bool>::new(true),
-            per_tuple_cost: GucSetting::<f64>::new(100_000_000.0),
+pub fn enable_custom_scan() -> bool {
+    ENABLE_CUSTOM_SCAN.get()
+}
+
+pub fn per_tuple_cost() -> f64 {
+    PER_TUPLE_COST.get()
+}
+
+pub fn log_create_index_progress() -> bool {
+    LOG_CREATE_INDEX_PROGRESS.get()
+}
+
+pub fn create_index_parallelism() -> NonZeroUsize {
+    adjust_nthreads(CREATE_INDEX_PARALLELISM.get())
+}
+
+pub fn create_index_memory_budget() -> usize {
+    adjust_budget(CREATE_INDEX_MEMORY_BUDGET.get(), create_index_parallelism())
+}
+
+pub fn statement_parallelism() -> NonZeroUsize {
+    adjust_nthreads(STATEMENT_PARALLELISM.get())
+}
+
+pub fn statement_memory_budget() -> usize {
+    adjust_budget(STATEMENT_MEMORY_BUDGET.get(), statement_parallelism())
+}
+
+fn adjust_nthreads(nthreads: i32) -> NonZeroUsize {
+    let nthreads = if nthreads <= 0 {
+        std::thread::available_parallelism()
+            .expect("your computer should have at least one core")
+            .get()
+    } else {
+        nthreads as usize
+    };
+
+    unsafe {
+        // SAFETY:  we ensured above that nthreads is > 0
+        NonZeroUsize::new_unchecked(nthreads)
+    }
+}
+
+fn adjust_budget(budget: i32, parallelism: Parallelism) -> usize {
+    let adjusted_budget = if budget <= 0 {
+        // value is unset, so we'll use the maintenance_work_mem
+        unsafe {
+            // SAFETY:  Postgres sets maintenance_work_mem when it starts up
+            pg_sys::maintenance_work_mem as usize * 1024 // convert from kilobytes to bytes
         }
-    }
+    } else {
+        budget as usize * 1024 * 1024 // convert from megabytes to bytes
+    };
 
-    pub fn init(&self, extension_name: &str) {
-        // Note that Postgres is very specific about the naming convention of variables.
-        // They must be namespaced... we use 'paradedb.<variable>' below.
-        // They cannot have more than one '.' - paradedb.pg_search.telemetry will not work.
+    let total_budget = adjusted_budget * parallelism.get();
 
-        // telemetry
-        GucRegistry::define_bool_guc(
-            &format!("paradedb.{extension_name}_telemetry"),
-            &format!("Enable telemetry on the ParadeDB {extension_name} extension.",),
-            &format!("Enable telemetry on the ParadeDB {extension_name} extension.",),
-            &self.telemetry,
-            GucContext::Userset,
-            GucFlags::default(),
-        );
-
-        GucRegistry::define_bool_guc(
-            "paradedb.enable_custom_scan",
-            "Enable ParadeDB's custom scan",
-            "Enable ParadeDB's custom scan",
-            &self.enable_custom_scan,
-            GucContext::Userset,
-            GucFlags::default(),
-        );
-
-        // per_tuple_cost
-        GucRegistry::define_float_guc(
-            "paradedb.per_tuple_cost",
-            "Arbitrary multiplier for the cost of retrieving a tuple from a USING bm25 index outside of an IndexScan",
-            "Default is 100,000,000.0.  It is very expensive to use a USING bm25 index in the wrong query plan",
-            &self.per_tuple_cost,
-            0.0,
-            f64::MAX,
-            GucContext::Userset,
-            GucFlags::default(),
-        )
-    }
-}
-
-impl Default for PostgresGlobalGucSettings {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GlobalGucSettings for PostgresGlobalGucSettings {
-    fn telemetry_enabled(&self) -> bool {
-        // If PARADEDB_TELEMETRY is not 'true' at compile time, then we will never enable.
-        // This is useful for test builds and CI.
-        option_env!("PARADEDB_TELEMETRY") == Some("true") && self.telemetry.get()
-    }
-
-    fn enable_custom_scan(&self) -> bool {
-        self.enable_custom_scan.get()
-    }
-
-    fn per_tuple_cost(&self) -> f64 {
-        self.per_tuple_cost.get()
-    }
+    // tantivy will panic if we give it less than 15 meg
+    total_budget.max(15_000_000)
 }

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -31,12 +31,8 @@ pub mod telemetry;
 pub mod trace;
 
 use self::postgres::customscan;
-use gucs::PostgresGlobalGucSettings;
 use pgrx::*;
 use telemetry::setup_telemetry_background_worker;
-
-// A static variable is required to host grand unified configuration settings.
-pub static GUCS: PostgresGlobalGucSettings = PostgresGlobalGucSettings::new();
 
 // A hardcoded value when we can't figure out a good selectivity value
 const UNKNOWN_SELECTIVITY: f64 = 0.00001;
@@ -77,7 +73,7 @@ pub unsafe extern "C" fn _PG_init() {
     }
 
     postgres::options::init();
-    GUCS.init("pg_search");
+    gucs::init();
 
     setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
 

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -15,10 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::gucs::GlobalGucSettings;
+use crate::gucs;
 use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
 use crate::postgres::customscan::CustomScan;
-use crate::GUCS;
 use once_cell::sync::Lazy;
 use pgrx::{pg_guard, pg_sys, PgMemoryContexts};
 use rustc_hash::FxHashMap;
@@ -67,7 +66,7 @@ pub extern "C" fn paradedb_rel_pathlist_callback<CS: CustomScan>(
     rte: *mut pg_sys::RangeTblEntry,
 ) {
     unsafe {
-        if !GUCS.enable_custom_scan() {
+        if !gucs::enable_custom_scan() {
             return;
         }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -24,7 +24,6 @@ mod scan_state;
 
 use crate::api::operator::{anyelement_jsonb_opoid, attname_from_var, estimate_selectivity};
 use crate::api::{AsCStr, AsInt, Cardinality};
-use crate::gucs::GlobalGucSettings;
 use crate::index::score::SearchIndexScore;
 use crate::index::SearchIndex;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
@@ -54,7 +53,7 @@ use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::schema::SearchConfig;
-use crate::{DEFAULT_STARTUP_COST, GUCS, UNKNOWN_SELECTIVITY};
+use crate::{DEFAULT_STARTUP_COST, UNKNOWN_SELECTIVITY};
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgRelation};
 use scan_state::SortDirection;
@@ -73,10 +72,6 @@ impl CustomScan for PdbScan {
     type PrivateData = PrivateData;
 
     fn callback(mut builder: CustomPathBuilder<Self::PrivateData>) -> Option<pg_sys::CustomPath> {
-        if !GUCS.enable_custom_scan() {
-            return None;
-        }
-
         unsafe {
             if builder.restrict_info().is_empty() {
                 return None;

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::index::WriterResources;
 use crate::postgres::index::open_search_index;
 use pgrx::{pg_sys::ItemPointerData, *};
 
@@ -35,7 +36,7 @@ pub extern "C" fn ambulkdelete(
         .get_reader()
         .unwrap_or_else(|err| panic!("error loading index reader in bulkdelete: {err}"));
     let mut writer = search_index
-        .get_writer()
+        .get_writer(WriterResources::Vacuum)
         .unwrap_or_else(|err| panic!("error loading index writer in bulkdelete: {err}"));
 
     if stats.is_null() {

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::*;
-
+use crate::index::WriterResources;
 use crate::postgres::index::open_search_index;
+use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
@@ -42,7 +42,7 @@ pub extern "C" fn amvacuumcleanup(
     let search_index =
         open_search_index(&index_relation).expect("should be able to open search index");
     let writer = search_index
-        .get_writer()
+        .get_writer(WriterResources::Vacuum)
         .unwrap_or_else(|err| panic!("error loading index writer from directory: {err}"));
 
     // Garbage collect the index and clear the writer cache to free up locks.


### PR DESCRIPTION
Introduce a set of GUCs, and documentation, to allow configuration of system resources dedicated to tantivy during its indexing processes.

As a followup to #1803, which reduced indexing time from ~53 minutes to ~21 minutes on a local database, this PR allows resource configuration such that that same data now indexes locally in 9m 42s.

# Ticket(s) Closed

- Closes #

## What

Add a series of GUCs to let the superuser decide how many threads and how much memory per thread to dedicate to tantivy during indexing.

Also, this rejiggers how we manage our GUC state.  The trait and impl was just too much boilerplate to be easily extensible.

## Why

On a big computer, fully utilizing its hardware resources can **drastically** improve indexing performance.

## How

## Tests

Existing tests pass.