### PR TITLE
fix: be a little more lenient around problems during DROP INDEX

### DIFF
--- a/pg_search/src/index/directory.rs
+++ b/pg_search/src/index/directory.rs
@@ -148,7 +148,7 @@ impl WriterDirectory {
     /// It's also important to note that this functionis called in contexts that cannot
     /// ask Postgres for the data_dir_path, so we must use the one already initialized
     /// on the WriterDirectory instance.
-    fn search_index_dir_path(
+    pub(crate) fn search_index_dir_path(
         &self,
         ensure_exists: bool,
     ) -> Result<SearchIndexDirPath, SearchDirectoryError> {

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -242,7 +242,8 @@ impl<'de> Deserialize<'de> for SearchIndex {
 
         let tantivy_dir = BlockingDirectory::open(tantivy_dir_path)
             .expect("need a valid path to open a tantivy index");
-        let mut underlying_index = Index::open(tantivy_dir).expect("index should be openable");
+        let mut underlying_index =
+            Index::open(tantivy_dir).map_err(|e| serde::de::Error::custom(e))?;
 
         // We need to setup tokenizers again after retrieving an index from disk.
         Self::setup_tokenizers(&mut underlying_index, &schema);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes # na/

## What

Ran into a problem where a `DROP INDEX` failed complaining about a file not found.  I'm not exactly sure how I got my development database into such a state but haven't been able to reproduce it.

This PR makes errors during DROP INDEX a little more lenient so at least the statement will succeed if there's underlying filesystem issues.  It emits a WARNING now.

## Why

If you can't DROP INDEX then you can't re-create it!

## How

## Tests
