### PR TITLE
docs: Tweak special characters section

### DIFF
--- a/docs/documentation/full-text/phrase.mdx
+++ b/docs/documentation/full-text/phrase.mdx
@@ -42,4 +42,5 @@ WHERE description @@@ '"plastic keyb"*';
 
 ## Special Characters
 
-The special characters `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `\*`, and `SPACE` must be escaped by a`\` inside the query term.
+The special characters `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `<`, `>`, `~`, `!`, `\\`, `\*` must be
+escaped by a `\` inside the query term.

--- a/docs/documentation/full-text/term.mdx
+++ b/docs/documentation/full-text/term.mdx
@@ -46,4 +46,5 @@ WHERE description @@@ '(shoes running -white)';
 
 ## Special Characters
 
-The special characters `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `~`, `!`, `\\`, `\*`, and `SPACE` must be escaped by a`\` inside the query term.
+The special characters `+` , `^`, `` ` ``, `:`, `{`, `}`, `"`, `[`, `]`, `(`, `)`, `<`, `>`,`~`, `!`, `\\`, `\*`, and `SPACE` must
+be escaped by a `\` inside the query term.


### PR DESCRIPTION
# Ticket(s) Closed
 * Closes #N/A

## What

- Removes `SPACE` from special characters list in the doc for phrase search.
- Adds `<` and `>` to the special characters list in term and phrase search docs.

## Why

https://github.com/paradedb/paradedb/pull/1819#discussion_r1807090826

1. `SPACE` should not be listed among the special characters in phrase search. It's the point of phrase search to contain multiple terms separated by spaces `"word1 word2"`. Adding a `\` character in front of a whitespace doesn't appear to give it any different meaning and thus would be just redundant.

2. The and `>` and `<` characters should be added to the list, as they have special meaning, at least when used in term search as the first character in a term - e.g. `category:<footwear`.

Example illustrating (2):
```sql
=> CALL paradedb.create_bm25(
  index_name => 'search_idx',
  table_name => 'mock_items',
  schema_name => 'public',
  key_field => 'id',
  text_fields => paradedb.field('description', tokenizer =>
  paradedb.tokenizer('en_stem')) || paradedb.field('category', tokenizer
  => paradedb.tokenizer('en_stem')),
  numeric_fields => paradedb.field('rating')
);

=> INSERT INTO mock_items (description, rating, category, in_stock, metadata, created_at, last_updated_date, latest_available_time)
VALUES ('Strange category item', 5, '<footwear', true, '{"color": "red", "size": 42}', NOW(), CURRENT_DATE, '10:00:00');

=> SELECT description, rating, category
FROM mock_items
WHERE id @@@ paradedb.parse('category:<footwear') order by id desc limit 4;
       description        | rating |  category
--------------------------+--------+------------
 Warm woolen sweater      |      3 | Apparel
 Handcrafted wooden frame |      5 | Home Decor
 Historical fiction book  |      3 | Books
 Moisturizing lip balm    |      4 | Beauty
(4 rows)

=> SELECT description, rating, category
FROM mock_items
WHERE id @@@ paradedb.parse('category:\<footwear') order by id desc limit 4;
      description      | rating | category
-----------------------+--------+-----------
 Strange category item |      5 | <footwear
 Winter woolen socks   |      5 | Footwear
 Comfortable slippers  |      3 | Footwear
 Sturdy hiking boots   |      4 | Footwear
(4 rows)
```

Analogical thing can be demonstrated for the `>` character.

## How

N/A

## Tests

N/A
