### PR TITLE
ci: Only run `dev` CI on Rust files and small other fixes

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -23,7 +23,10 @@ on:
       - "tokenizers/Cargo.toml"
   push:
     branches:
-      - dev # Run CI on dev. This is important to fill the GitHub Actions cache in a way that pull requests can see it
+      - dev # Also run on dev to fill the GitHub Actions Rust cache in a way that pull requests can see it
+    paths:
+      - "**/*.rs"
+      - "**/*.toml"
   workflow_dispatch:
 
 concurrency:
@@ -54,21 +57,20 @@ jobs:
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
-      - name: Extract pgrx version
+      - name: Extract pgrx Version
+        id: pgrx
         working-directory: pg_search/
-        run: echo "PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)" >> $GITHUB_ENV
+        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
 
       - name: Install Rust Cache
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: ubicloud/rust-cache@v2
         with:
           prefix-key: "v1-rust"
-          key: ${{ matrix.pg_version }}-${{ env.PGRX_VERSION }}
+          key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
 
       - name: Restore prior criterion output
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         uses: actions/cache/restore@v4
         with:
           path: target/criterion
@@ -106,7 +108,7 @@ jobs:
         run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       - name: Save criterion output, if dev
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/dev'
         uses: actions/cache/save@v4
         with:
           path: target/criterion

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Extract pgrx Version
         id: pgrx
         working-directory: pg_search/
-        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
 
       - name: Install Rust Cache
         uses: ubicloud/rust-cache@v2

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -70,16 +70,10 @@ jobs:
           cache-targets: true
           cache-all-crates: true
 
-      - name: Restore prior criterion output
-        uses: actions/cache/restore@v4
-        with:
-          path: target/criterion
-          key: "pg_search-criterion-benchmark"
-
       - name: Install pgrx & pg_search
         working-directory: pg_search/
         run: |
-          cargo install -j $(nproc) --locked cargo-pgrx --version ${{ env.PGRX_VERSION }} --debug
+          cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
           cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
           cargo pgrx install --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config" --release
 
@@ -106,13 +100,6 @@ jobs:
       - name: Run benchmarks
         working-directory: pg_search/
         run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
-
-      - name: Save criterion output, if dev
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache/save@v4
-        with:
-          path: target/criterion
-          key: "pg_search-criterion-benchmark"
 
       - name: Notify Slack on Failure
         if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"
-  workflow_dispatch:
+    workflow_dispatch:
 
 concurrency:
   group: lint-docker-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"
-    workflow_dispatch:
+  workflow_dispatch:
 
 concurrency:
   group: lint-docker-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -41,11 +41,9 @@ jobs:
             false
           fi
 
-      # We ignore .out and .sql files, which are used by pg_regress for testing
-      # and need a very specific format
       - name: Check for Trailing Whitespaces
         run: |
-          FILES=$(git grep -Ilr '[[:blank:]]$' -- ':(exclude)*.out' ':(exclude)*.sql' ':(exclude)*.rs' || true)
+          FILES=$(git grep -Ilr '[[:blank:]]$' -- ':(exclude)*.sql' ':(exclude)*.rs' || true)
           if [[ ! -z "$FILES" ]]; then
             echo "The following files have trailing whitespaces:"
             echo "$FILES"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Extract pgrx version
+      - name: Extract pgrx Version
+        id: pgrx
         working-directory: pg_search/
-        run: echo "PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv )" >> $GITHUB_ENV
+        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
@@ -44,7 +45,7 @@ jobs:
         uses: ubicloud/rust-cache@v2
         with:
           prefix-key: "v1-lint-rust"
-          key: ${{ matrix.pg_version }}-${{ env.PGRX_VERSION }}
+          key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
 

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -37,14 +37,14 @@ jobs:
       - name: Extract pgrx Version
         id: pgrx
         working-directory: pg_search/
-        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
       - name: Install Rust Cache
         uses: ubicloud/rust-cache@v2
         with:
-          prefix-key: "v1-lint-rust"
+          prefix-key: "v1-rust"
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version ${{ env.PGRX_VERSION }} --debug
+        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx for Current PostgreSQL Version
         run: cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -100,7 +100,6 @@ jobs:
             echo "Error: Invalid branch" && false
           fi
 
-      # We create the GitHub release last in case of failure in previous steps
       - name: Create GitHub Release (prod only)
         if: steps.env.outputs.environment == 'prod'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -52,6 +52,7 @@ jobs:
           fi
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
+      # The pg_version-tag Docker tag syntax is necessary for our K8s CloudNativePG Helm chart
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -78,7 +79,6 @@ jobs:
           endpoint: ${{ secrets.DOCKERHUB_USERNAME }}/paradedb
           install: true
 
-      # The pg_version-tag Docker tag syntax is necessary for our K8s CloudNativePG operator
       - name: Build and Push Docker Image to Docker Hub
         id: build-push
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -342,7 +342,7 @@ jobs:
       - name: Extract pgrx Version
         id: pgrx
         working-directory: pg_search/
-        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
 
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/publish-pg_search.yml
+++ b/.github/workflows/publish-pg_search.yml
@@ -339,12 +339,13 @@ jobs:
           # Install PostgreSQL:
           sudo dnf install -y postgresql${{ matrix.pg_version }} postgresql${{ matrix.pg_version }}-server postgresql${{ matrix.pg_version }}-devel
 
-      - name: Extract pgrx version
+      - name: Extract pgrx Version
+        id: pgrx
         working-directory: pg_search/
-        run: echo "PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)" >> $GITHUB_ENV
+        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
 
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx --version ${{ env.PGRX_VERSION }} --debug
+        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Initialize pgrx for Current PostgreSQL Version

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -37,8 +37,6 @@ jobs:
         working-directory: docs/
         run: |
           output=$(mintlify broken-links)
-
-          # Check if the output contains any broken links
           if [[ "$output" == *"No broken links found."* ]]; then
             echo "No broken links found."
           else

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -20,7 +20,10 @@ on:
       - "!tests/README.md"
   push:
     branches:
-      - dev # Run CI on dev. This is important to fill the GitHub Actions cache in a way that pull requests can see it
+      - dev # Also run on dev to fill the GitHub Actions Rust cache in a way that pull requests can see it
+    paths:
+      - "**/*.rs"
+      - "**/*.toml"
   workflow_dispatch:
     inputs:
       test_upgrade_version:
@@ -91,10 +94,11 @@ jobs:
           fi
           echo "Version check passed!"
 
-      - name: Extract pgrx version
+      - name: Extract pgrx Version
+        id: pgrx
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
-        run: echo "PGRX_VERSION=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)" >> $GITHUB_ENV
+        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
@@ -213,11 +217,11 @@ jobs:
           fi
           echo "Version check passed!"
 
-      - name: Extract pgrx version
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+      - name: Extract pgrx Version
+        id: pgrx
         working-directory: pg_search/
-        run: echo "PGRX_VERSION=$(grep '^pgrx = ' Cargo.toml | sed -E 's/pgrx = "(.*)"/\1/')" >> $GITHUB_ENV
-
+        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+  
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
       - name: Install Rust Cache
@@ -225,7 +229,7 @@ jobs:
         uses: ubicloud/rust-cache@v2
         with:
           prefix-key: "v1-rust"
-          key: ${{ matrix.pg_version }}-${{ env.PGRX_VERSION }}
+          key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -98,7 +98,7 @@ jobs:
         id: pgrx
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
-        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
@@ -219,8 +219,9 @@ jobs:
 
       - name: Extract pgrx Version
         id: pgrx
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
-        run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -107,7 +107,7 @@ jobs:
         uses: ubicloud/rust-cache@v2
         with:
           prefix-key: "v1-rust"
-          key: ${{ matrix.pg_version }}-${{ env.PGRX_VERSION }}
+          key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
 
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install cargo-pgrx
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ env.PGRX_VERSION }} --debug
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize cargo-pgrx environment
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
@@ -221,7 +221,7 @@ jobs:
         id: pgrx
         working-directory: pg_search/
         run: echo "version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)"
-  
+
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.
       - name: Install Rust Cache
@@ -239,7 +239,7 @@ jobs:
 
       - name: Install cargo-pgrx
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ env.PGRX_VERSION }} --debug
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize cargo-pgrx environment
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I was fixing something, and realized two things:

1) We run our `dev` CI to fill the Rust cache, yet we were running it even when no Rust files had changed. Oops? Now we'll only update the Rust cache if it needs to be updating, i.e. if Rust/Toml files changed.
<img width="718" alt="Capture d’écran, le 2024-10-19 à 18 50 15" src="https://github.com/user-attachments/assets/f247f099-f710-4a33-868f-2b8fd983478a">

2) The way we were passing PGRX version is deprecated, using `env.` instead of `outputs.`. I fixed this.

3) The Criteron manual save added by @eeeebbbbrrrr was unfortunately not saving. The cache is 16KB and cannot be overridden. I simply removed it, it should save automatically post-run.
<img width="733" alt="Capture d’écran, le 2024-10-19 à 18 51 09" src="https://github.com/user-attachments/assets/84fcfcae-2bfc-4d0e-b6d9-f8a83c300bca">

4) The `lint-rust.yml` CI had a different key cache, so it wasn't properly taking advantage of the cache.

5) There was a missing run check on a `Extract pgrx Version` step, which meant this step ran unnecessarily when everything else was skipped.

## Why
Accurate CI and lower costs.

## How
^

## Tests
See CI!