### PR TITLE
feat: Set PG17 as the default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 /docker/                                                       @philippemnoel @rebasedming
 /docs/                                                         @rebasedming @neilyio
 /pg_search/                                                    @rebasedming @neilyio
-/shared/                                                       @rebasedming @neilyio
+/tests/                                                        @rebasedming @neilyio
 /tokenizers/                                                   @rebasedming @neilyio

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [17]
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -34,6 +34,8 @@ jobs:
     strategy:
       matrix:
         pg_version: [13, 14, 15, 16, 17]
+    env:
+      default_pg_version: 17
 
     steps:
       - name: Checkout Git Repository
@@ -66,9 +68,9 @@ jobs:
             type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=latest-pg${{ matrix.pg_version }}
-            type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == 17 }}
+            type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 17 }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 17 }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -106,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [16]
+        pg_version: [17]
 
     steps:
       - name: Retrieve GitHub Release Version

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -68,9 +68,9 @@ jobs:
             type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=latest-pg${{ matrix.pg_version }}
-            type=raw,value=latest,enable=${{ matrix.pg_version == 17 }}
-            type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 17 }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 17 }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version }}
+            type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # The default Postgres major version ParadeDB ships with. In CI, this gets updated to ship builds for all official PGDG versions.
-ARG PG_VERSION_MAJOR=16
+ARG PG_VERSION_MAJOR=17
 
 ###############################################
 # First Stage: Builder

--- a/docs/deploy/extensions.mdx
+++ b/docs/deploy/extensions.mdx
@@ -47,7 +47,7 @@ Most popular Postgres extensions can be installed with `apt-get install`.
 
 ```bash
 apt-get update
-apt-get install -y --no-install-recommends postgresql-16-partman
+apt-get install -y --no-install-recommends postgresql-17-partman
 ```
 
 <Note>

--- a/docs/deploy/replication/self-hosted.mdx
+++ b/docs/deploy/replication/self-hosted.mdx
@@ -128,10 +128,10 @@ replication consists of two steps:
 You should run `pg_basebackup` on your standby server to create a physical byte-for-byte replica of your primary cluster. The `--pgdata` directory specifies the where the standby cluster will be created. The directory must exist, and must be empty.
 
 ```bash
-mkdir -p /var/lib/postgresql/16/main
+mkdir -p /var/lib/postgresql/17/main
 
-pg_basebackup --create-slot --slot standby1 --host 192.168.0.30 --pgdata /var/lib/postgresql/16/main --progress --username replicator --write-recovery-conf
-pg_basebackup --create-slot --slot standby2 --host 192.168.0.30 --pgdata /var/lib/postgresql/16/main --progress --username replicator --write-recovery-conf
+pg_basebackup --create-slot --slot standby1 --host 192.168.0.30 --pgdata /var/lib/postgresql/17/main --progress --username replicator --write-recovery-conf
+pg_basebackup --create-slot --slot standby2 --host 192.168.0.30 --pgdata /var/lib/postgresql/17/main --progress --username replicator --write-recovery-conf
 ```
 
 ### Start PostgreSQL on Standby Server

--- a/docs/deploy/self-hosted/docker.mdx
+++ b/docs/deploy/self-hosted/docker.mdx
@@ -5,11 +5,7 @@ title: Docker
 To deploy ParadeDB via Docker, pull and run the `paradedb/paradedb` image locally. This is the recommended deployment method for
 testing and development.
 
-<Note>
-  ParadeDB supports Postgres 13+, and the `latest` tag ships with Postgres 16.
-  To specify a different Postgres version, please refer to the available tags on
-  [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
-</Note>
+**Note**: ParadeDB supports Postgres 13+, and the `latest` tag ships with Postgres 17. To specify a different Postgres version, please refer to the available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
 docker run \

--- a/docs/deploy/self-hosted/extensions.mdx
+++ b/docs/deploy/self-hosted/extensions.mdx
@@ -35,7 +35,7 @@ ParadeDB provides prebuilt binaries for our extensions on
 - Ubuntu 22.04 and 24.04
 - Red Hat Enterprise Linux 8 and 9
 
-Postgres 14, 15 and 16 on both `amd64 (x86_64)` and `arm64` are available. If you are using a different version of Postgres or a different operating system, you will need to build the extensions from source.
+Postgres 14, 15, 16, and 17 on both `amd64 (x86_64)` and `arm64` are available. If you are using a different version of Postgres or a different operating system, you will need to build the extensions from source.
 
 ### pg_search
 
@@ -43,38 +43,38 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 <Note>
   You can replace `0.12.2` with the `pg_search` version you wish to install and
-  `16` with the version of Postgres you are using.
+  `17` with the version of Postgres you are using.
 </Note>
 
 <CodeGroup>
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-16-pg-search_0.12.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-17-pg-search_0.12.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-16-pg-search_0.12.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-17-pg-search_0.12.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-16-pg-search_0.12.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/postgresql-17-pg-search_0.12.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/pg_search_16-0.12.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/pg_search_17-0.12.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/pg_search_16-0.12.2-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.12.2/pg_search_17-0.12.2-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
@@ -86,38 +86,38 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 <Note>
   You can replace `0.2.3` with the `pg_analytics` version you wish to install
-  and `16` with the version of Postgres you are using.
+  and `17` with the version of Postgres you are using.
 </Note>
 
 <CodeGroup>
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-16-pg-analytics_0.2.3-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-17-pg-analytics_0.2.3-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-16-pg-analytics_0.2.3-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-17-pg-analytics_0.2.3-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-16-pg-analytics_0.2.3-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/postgresql-17-pg-analytics_0.2.3-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/pg_analytics_16-0.2.3-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/pg_analytics_17-0.2.3-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/pg_analytics_16-0.2.3-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.2.3/pg_analytics_17-0.2.3-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 

--- a/docs/documentation/getting-started/install.mdx
+++ b/docs/documentation/getting-started/install.mdx
@@ -7,11 +7,7 @@ your primary Postgres is in a virtual private cloud (VPC), we recommend deployin
 instance within your VPC to avoid exposing public IP addresses and needing to provision traffic routing
 rules.
 
-<Note>
-  ParadeDB supports Postgres 13+, and the `latest` tag ships with Postgres 16.
-  To specify a different Postgres version, please refer to the available tags on
-  [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
-</Note>
+**Note**: ParadeDB supports Postgres 13+, and the `latest` tag ships with Postgres 17. To specify a different Postgres version, please refer to the available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
 docker run \

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -8,7 +8,7 @@ ParadeDB is an Elasticsearch alternative built on Postgres. We're modernizing th
 starting with real-time search and analytics.
 
 ParadeDB is not a fork of Postgres but regular Postgres with custom extensions installed. ParadeDB itself
-supports Postgres 13+ and ships with Postgres 16 by default.
+ships with Postgres 17 by default and supports Postgres 13+.
 
 ## Why ParadeDB
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["pg16"]
+default = ["pg17"]
 pg13 = ["pgrx/pg13"]
 pg14 = ["pgrx/pg14"]
 pg15 = ["pgrx/pg15"]

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -50,7 +50,7 @@ This enables the extension to spawn a background worker process that performs wr
 
 #### Debian/Ubuntu
 
-We provide prebuilt binaries for Debian-based Linux for Postgres 17, 16, 15 and 14. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+We provide prebuilt binaries for Debian-based Linux for Postgres 14, 15, 16, and 17. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
 Our prebuilt binaries come with the ICU tokenizer enabled, which requires the `libicu` library. If you don't have it installed, you can do so with:
 
@@ -99,12 +99,12 @@ Then, install the PostgreSQL version of your choice using your system package ma
 
 ```bash
 # macOS
-brew install postgresql@16
+brew install postgresql@17
 
 # Ubuntu
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-sudo apt-get update && sudo apt-get install -y postgresql-16 postgresql-server-dev-16
+sudo apt-get update && sudo apt-get install -y postgresql-17 postgresql-server-dev-17
 
 # Arch Linux
 sudo pacman -S extra/postgresql
@@ -119,20 +119,20 @@ export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
 Then, install and initialize `pgrx`:
 
 ```bash
-# Note: Replace --pg16 with your version of Postgres, if different (i.e. --pg15, --pg14, etc.)
+# Note: Replace --pg17 with your version of Postgres, if different (i.e. --pg16, etc.)
 cargo install --locked cargo-pgrx --version 0.12.7
 
 # macOS arm64
-cargo pgrx init --pg16=/opt/homebrew/opt/postgresql@16/bin/pg_config
+cargo pgrx init --pg17=/opt/homebrew/opt/postgresql@17/bin/pg_config
 
 # macOS amd64
-cargo pgrx init --pg16=/usr/local/opt/postgresql@16/bin/pg_config
+cargo pgrx init --pg17=/usr/local/opt/postgresql@17/bin/pg_config
 
 # Ubuntu
-cargo pgrx init --pg16=/usr/lib/postgresql/16/bin/pg_config
+cargo pgrx init --pg17=/usr/lib/postgresql/17/bin/pg_config
 
 # Arch Linux
-cargo pgrx init --pg16=/usr/bin/pg_config
+cargo pgrx init --pg17=/usr/bin/pg_config
 ```
 
 If you prefer to use a different version of Postgres, update the `--pg` flag accordingly.
@@ -154,21 +154,21 @@ sudo pacman -S extra/clang
 `pgvector` needed for hybrid search unit tests.
 
 ```bash
-# Note: Replace 16 with your version of Postgres
+# Note: Replace 17 with your version of Postgres
 git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
 # macOS arm64
-PG_CONFIG=/opt/homebrew/opt/postgresql@16/bin/pg_config make
-sudo PG_CONFIG=/opt/homebrew/opt/postgresql@16/bin/pg_config make install # may need sudo
+PG_CONFIG=/opt/homebrew/opt/postgresql@17/bin/pg_config make
+sudo PG_CONFIG=/opt/homebrew/opt/postgresql@17/bin/pg_config make install # may need sudo
 
 # macOS amd64
-PG_CONFIG=/usr/local/opt/postgresql@16/bin/pg_config make
-sudo PG_CONFIG=/usr/local/opt/postgresql@16/bin/pg_config make install # may need sudo
+PG_CONFIG=/usr/local/opt/postgresql@17/bin/pg_config make
+sudo PG_CONFIG=/usr/local/opt/postgresql@17/bin/pg_config make install # may need sudo
 
 # Ubuntu
-PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config make
-sudo PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config make install # may need sudo
+PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config make
+sudo PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config make install # may need sudo
 
 # Arch Linux
 PG_CONFIG=/usr/bin/pg_config make
@@ -252,7 +252,7 @@ DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
 
 USER_NAME should be replaced with your system user name. (eg: output of `whoami`)
 
-PORT should be replaced with 28800 + your postgres version. (eg: 28816 for postgres 16)
+PORT should be replaced with 28800 + your postgres version. (eg: 28817 for Postgres 17)
 
 ## License
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,10 +8,10 @@ An example of doing all that's necessary to run the tests is, from the root of t
 #! /bin/sh
 
 set -x
-export DATABASE_URL=postgresql://localhost:28816/pg_search
+export DATABASE_URL=postgresql://localhost:28817/pg_search
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
-cargo pgrx install --package pg_search --features=icu --pg-config ~/.pgrx/16.4/pgrx-install/bin/pg_config
+cargo pgrx install --package pg_search --features=icu --pg-config ~/.pgrx/17.0/pgrx-install/bin/pg_config
 cargo pgrx start --package pg_search
 
 cargo test --package tests --features=icu


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1718

## What
PG17 is the new latest Postgres.

## Why
Keep up.

## How
Updated all the references to PG16. We already added support before.

## Tests
CI!