### PR TITLE
ci: Cache benchmark performance, and compare across runs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Order is important. The last matching pattern has the most precedence.
+# Order is important. The last matching pattern has the most precedence
 
 /.cargo/                                                       @philippemnoel @rebasedming
 /.github/                                                      @philippemnoel @rebasedming

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Index benchmark data
         working-directory: pg_search/
-        run: cargo paradedb bench eslogs build-search-index --url postgresql://localhost:28817/postgres
+        run: cargo paradedb bench eslogs build-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       - name: Run search benchmarks
         working-directory: pg_search/

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -103,14 +103,8 @@ jobs:
 
       - name: Export Criterion benchmark results
         run: |
-          cargo install critcmp
-
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-
-      - name: Export Criterion benchmark results
-        run: |
-          critcmp --export target/criterion/new > output.txt
+          cargo install-j $(nproc) --locked critcmp --debug
+          critcmp --export new
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
       - name: Store benchmarks result

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Export Criterion benchmark results
         run: |
           cargo install-j $(nproc) --locked critcmp --debug
-          critcmp --export new
+          critcmp --export new > output.json
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
       - name: Store benchmarks result
@@ -112,7 +112,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-pg_search-criterion-dev
-          path: output.txt
+          path: output.json
 
       - name: Download benchmarks baseline
         if: github.event_name == 'pull_request'
@@ -126,7 +126,7 @@ jobs:
         id: compare
         run: |
           if [ -f ./previous/output.txt ]; then
-            result=$(critcmp ./previous/output.txt output.txt)
+            result=$(critcmp ./previous/output.json output.json)
             echo "comparison_result<<EOF" >> $GITHUB_OUTPUT
             echo "$result" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
-    runs-on: ubuntu-latest # Temporarily, to be able to SSH
+    runs-on: ubicloud-standard-8
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -114,15 +114,23 @@ jobs:
           name: benchmark-pg_search-criterion-dev
           path: output.json
 
+      - name: Check if baseline exists
+        id: check_artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: benchmark-pg_search-criterion-dev
+          path: previous/
+
       - name: Download benchmarks baseline
-        if: github.event_name == 'pull_request'
+        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
         uses: actions/download-artifact@v4
         with:
           name: benchmark-pg_search-criterion-dev
           path: previous/
 
       - name: Compare benchmarks results
-        if: github.event_name == 'pull_request'
+        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
         id: compare
         run: |
           if [ -f ./previous/output.txt ]; then
@@ -135,6 +143,7 @@ jobs:
           fi
 
       - name: Generate Commit Message
+        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
         run: |
           echo "Generating GitHub comment message"
           {
@@ -147,6 +156,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Attach Performance Comparison to PR
+        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -99,7 +99,80 @@ jobs:
 
       - name: Run benchmarks
         working-directory: pg_search/
-        run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
+        run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres -- --output-format bencher | tee output.txt
+
+      # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
+      - name: Store benchmarks result
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-pg_search-criterion-dev
+          path: output.txt
+
+      - name: Download benchmarks baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-pg_search-criterion-dev
+          path: previous/
+
+      - name: Compare benchmarks results
+        if: github.event_name == 'pull_request'
+        id: compare
+        run: |
+          if [ -f ./previous/output.txt ]; then
+            cargo install critcmp
+            result=$(critcmp ./previous/output.txt output.txt)
+            echo "comparison_result<<EOF" >> $GITHUB_OUTPUT
+            echo "$result" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "No previous benchmark result found"
+          fi
+
+      - name: Generate Commit Message
+        run: |
+          echo "Generating GitHub comment message"
+          {
+            echo 'DIFF<<EOF'
+            echo 'Performance comparison (latest commit) with `dev`:'
+            echo
+            echo 'A suggested "upgrade.sql" script entry might be:'
+            echo
+            cat ${{ steps.compare.outputs.comparison_result }}
+            echo
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - name: Attach Schema Diff to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+
+            const botComment = comments.data.find(comment => comment.user.type === 'Bot' && comment.body.includes('A schema difference was detected.'));
+
+            if (botComment) {
+              // Update the existing comment
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.DIFF
+              });
+            } else {
+              // Create a new comment if none exists
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.DIFF
+              });
+            }
 
       - name: Notify Slack on Failure
         if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -137,8 +137,6 @@ jobs:
             echo 'DIFF<<EOF'
             echo 'Performance comparison (latest commit) with `dev`:'
             echo
-            echo 'A suggested "upgrade.sql" script entry might be:'
-            echo
             cat ${{ steps.compare.outputs.comparison_result }}
             echo
             echo EOF

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
-    runs-on: ubicloud-standard-8
+    runs-on: ubuntu-latest # Temporarily, to be able to SSH
     if: github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -112,11 +112,14 @@ jobs:
           echo "duration_min=$min" >> $GITHUB_OUTPUT
           echo "duration_hours=$hours" >> $GITHUB_OUTPUT
 
-      # TODO: Modify `cargo paradedb bench` to output Criterion results to a file
       - name: Run search benchmarks
-        id: search_benchmark
         working-directory: pg_search/
         run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
+
+      - name: Export Criterion benchmark results
+        run: |
+          cargo install critcmp
+          critcmp --export target/criterion/new > output.txt
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
       - name: Store benchmarks result
@@ -138,7 +141,6 @@ jobs:
         id: compare
         run: |
           if [ -f ./previous/output.txt ]; then
-            cargo install critcmp
             result=$(critcmp ./previous/output.txt output.txt)
             echo "comparison_result<<EOF" >> $GITHUB_OUTPUT
             echo "$result" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Export Criterion benchmark results
         run: |
           cargo install critcmp
+
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+
+      - name: Export Criterion benchmark results
+        run: |
           critcmp --export target/criterion/new > output.txt
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -94,12 +94,29 @@ jobs:
         run: cargo paradedb bench eslogs generate --events 5000000 --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       - name: Index benchmark data
+        id: index_benchmark
         working-directory: pg_search/
-        run: cargo paradedb bench eslogs build-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
+        run: |
+          output=$(cargo paradedb bench eslogs build-search-index --url postgresql://localhost:28817/postgres)
+          echo "$output"
 
-      - name: Run benchmarks
+          # Extract the duration values using grep and sed
+          ms=$(echo "$output" | grep "Duration:" | grep "milliseconds" | sed 's/.*: \([0-9]*\) .*/\1/')
+          sec=$(echo "$output" | grep "Duration:" | grep "seconds" | sed 's/.*: \([0-9.]*\) .*/\1/')
+          min=$(echo "$output" | grep "Duration:" | grep "minutes" | sed 's/.*: \([0-9.]*\) .*/\1/')
+          hours=$(echo "$output" | grep "Duration:" | grep "hours" | sed 's/.*: \([0-9.]*\) .*/\1/')
+
+          # Save to GitHub output
+          echo "duration_ms=$ms" >> $GITHUB_OUTPUT
+          echo "duration_sec=$sec" >> $GITHUB_OUTPUT
+          echo "duration_min=$min" >> $GITHUB_OUTPUT
+          echo "duration_hours=$hours" >> $GITHUB_OUTPUT
+
+      # TODO: Modify `cargo paradedb bench` to output Criterion results to a file
+      - name: Run search benchmarks
+        id: search_benchmark
         working-directory: pg_search/
-        run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres -- --output-format bencher | tee output.txt
+        run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
       - name: Store benchmarks result
@@ -142,7 +159,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
 
-      - name: Attach Schema Diff to PR
+      - name: Attach Performance Comparison to PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -152,7 +169,7 @@ jobs:
               repo: context.repo.repo
             });
 
-            const botComment = comments.data.find(comment => comment.user.type === 'Bot' && comment.body.includes('A schema difference was detected.'));
+            const botComment = comments.data.find(comment => comment.user.type === 'Bot' && comment.body.includes('Performance comparison (latest commit) with `dev`:'));
 
             if (botComment) {
               // Update the existing comment

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Export Criterion benchmark results
         run: |
-          cargo install-j $(nproc) --locked critcmp --debug
+          cargo install -j $(nproc) --locked critcmp --debug
           critcmp --export new > output.json
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -94,23 +94,8 @@ jobs:
         run: cargo paradedb bench eslogs generate --events 5000000 --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       - name: Index benchmark data
-        id: index_benchmark
         working-directory: pg_search/
-        run: |
-          output=$(cargo paradedb bench eslogs build-search-index --url postgresql://localhost:28817/postgres)
-          echo "$output"
-
-          # Extract the duration values using grep and sed
-          ms=$(echo "$output" | grep "Duration:" | grep "milliseconds" | sed 's/.*: \([0-9]*\) .*/\1/')
-          sec=$(echo "$output" | grep "Duration:" | grep "seconds" | sed 's/.*: \([0-9.]*\) .*/\1/')
-          min=$(echo "$output" | grep "Duration:" | grep "minutes" | sed 's/.*: \([0-9.]*\) .*/\1/')
-          hours=$(echo "$output" | grep "Duration:" | grep "hours" | sed 's/.*: \([0-9.]*\) .*/\1/')
-
-          # Save to GitHub output
-          echo "duration_ms=$ms" >> $GITHUB_OUTPUT
-          echo "duration_sec=$sec" >> $GITHUB_OUTPUT
-          echo "duration_min=$min" >> $GITHUB_OUTPUT
-          echo "duration_hours=$hours" >> $GITHUB_OUTPUT
+        run: cargo paradedb bench eslogs build-search-index --url postgresql://localhost:28817/postgres
 
       - name: Run search benchmarks
         working-directory: pg_search/

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"
-  workflow_dispatch:
+    workflow_dispatch:
 
 concurrency:
   group: lint-docker-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"
-    workflow_dispatch:
+  workflow_dispatch:
 
 concurrency:
   group: lint-docker-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
More CI anthills... Requested by @eeeebbbbrrrr. This stores the results of benchmark runs as GitHub artifact, which gets compared and printed on PRs.

## Why
^

## How
^

## Tests
CI