### PR TITLE
fix: bug where we could leak open tantivy file handles

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -111,6 +111,10 @@ jobs:
           cache-targets: true
           cache-all-crates: true
 
+      - name: Install required system tools
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: sudo apt-get update && sudo apt-get install -y lsof
+
       - name: Install & Configure Supported PostgreSQL Version
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         run: |
@@ -233,6 +237,10 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+
+      - name: Install required system tools
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        run: sudo apt-get update && sudo apt-get install -y lsof
 
       - name: Install llvm-tools-preview
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'

--- a/pg_search/src/postgres/visibility_checker.rs
+++ b/pg_search/src/postgres/visibility_checker.rs
@@ -60,6 +60,11 @@ pub struct VisibilityChecker {
 impl Drop for VisibilityChecker {
     fn drop(&mut self) {
         unsafe {
+            if !pg_sys::IsTransactionState() {
+                // we are not in a transaction, so we can't do things like release buffers and close relations
+                return;
+            }
+
             if self.last_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer {
                 pg_sys::ReleaseBuffer(self.last_buffer);
             }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -23,12 +23,13 @@ use fixtures::*;
 use pretty_assertions::assert_eq;
 use rstest::*;
 use sqlx::PgConnection;
+use std::process::Command;
 
 #[rstest]
 fn attribute_1_of_table_has_wrong_type(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    let (id,) = "SELECT id, description FROM paradedb.bm25_search WHERE description @@@ 'keyboard' OR id = 1 ORDER BY id LIMIT 1"
+    let (id, ) = "SELECT id, description FROM paradedb.bm25_search WHERE description @@@ 'keyboard' OR id = 1 ORDER BY id LIMIT 1"
         .fetch_one::<(i32,)>(&mut conn);
     assert_eq!(id, 1);
 }
@@ -95,7 +96,7 @@ fn field_on_left(mut conn: PgConnection) {
 fn table_on_left(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
-    let (id,) =
+    let (id, ) =
         "SELECT id FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id ASC"
             .fetch_one::<(i32,)>(&mut conn);
     assert_eq!(id, 1);
@@ -357,4 +358,44 @@ fn join_issue_1826(mut conn: PgConnection) {
     "#.fetch_result::<(i32, String, String, f32, f32)>(&mut conn).expect("query failed");
 
     assert_eq!(results[0], (3, "Sleek running shoes".into(), "Alice Johnson".into(), 4.921624, 2.4849067));
+}
+
+/// tests that an ERROR raised in the middle of executing a our custom scan doesn't leave open
+/// tantivy file handles
+#[rstest]
+fn leaky_file_handles(mut conn: PgConnection) {
+    let (pid,) = "SELECT pg_backend_pid()".fetch_one::<(i32,)>(&mut conn);
+    r#"
+        CREATE FUNCTION raise_exception(int, int) RETURNS bool LANGUAGE plpgsql AS $$
+        DECLARE
+        BEGIN
+            IF $1 = $2 THEN
+                RAISE EXCEPTION 'error! % = %', $1, $2;
+            END IF;
+            RETURN false;
+        END;
+        $$;
+    "#
+    .execute(&mut conn);
+
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // this will raise an error when it hits id #12
+    let result = "SELECT id, paradedb.score(id), raise_exception(id, 12) FROM paradedb.bm25_search WHERE category @@@ 'electronics' ORDER BY paradedb.score(id) DESC, id LIMIT 10"
+        .execute_result(&mut conn);
+    assert!(result.is_err());
+    assert_eq!(
+        "error returned from database: error! 12 = 12",
+        &format!("{}", result.err().unwrap())
+    );
+
+    let output = Command::new("lsof")
+        .arg("-p")
+        .arg(pid.to_string())
+        .output()
+        .expect("`lsof` command should not fail`");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("stdout: {}", stdout);
+    assert!(!stdout.contains("/tantivy/"));
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -364,9 +364,8 @@ fn join_issue_1826(mut conn: PgConnection) {
 /// tantivy file handles
 #[rstest]
 fn leaky_file_handles(mut conn: PgConnection) {
-    let (pid,) = "SELECT pg_backend_pid()".fetch_one::<(i32,)>(&mut conn);
     r#"
-        CREATE FUNCTION raise_exception(int, int) RETURNS bool LANGUAGE plpgsql AS $$
+        CREATE OR REPLACE FUNCTION raise_exception(int, int) RETURNS bool LANGUAGE plpgsql AS $$
         DECLARE
         BEGIN
             IF $1 = $2 THEN
@@ -378,6 +377,7 @@ fn leaky_file_handles(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
+    let (pid,) = "SELECT pg_backend_pid()".fetch_one::<(i32,)>(&mut conn);
     SimpleProductsTable::setup().execute(&mut conn);
 
     // this will raise an error when it hits id #12


### PR DESCRIPTION
Fix a bug where we could leak open tantivy file handles if an error occurred in the middle of executing our custom scan.
(for testing purposes, adds an operating system dependency on the `lsof` tool.)

# Ticket(s) Closed

- Closes #1835 (maybe?)

## What

It was possible for us to leak open tantivy file handles if an ERROR was raised in the middle of executing our Custom Scan.  This is because the state objects we create weren't being properly dropped in that case.

## Why

## How

## Tests

There's a new test called `leaky_file_handles` that uses the system command `lsof` to see if there's leaky things.