### PR TITLE
ci: Retrieve the correct GitHub artifact to compare benchmark runs

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -124,10 +124,12 @@ jobs:
           LATEST_RUN_ID=$(gh api \
             repos/paradedb/paradedb/actions/runs \
             --jq '.workflow_runs | map(select(.head_branch == "dev" and .conclusion == "success")) | .[0].id')
+          echo "Latest `dev` benchmark-pg_search run ID: $LATEST_RUN_ID"
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Check if baseline exists
-        id: check_artifact
+      - name: Download benchmarks baseline
+        if: github.event_name == 'pull_request'
+        id: download_baseline
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -136,15 +138,8 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get_latest_dev_run.outputs.run_id }}
 
-      - name: Download benchmarks baseline
-        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-pg_search-criterion-dev
-          path: previous/
-
       - name: Compare benchmarks results
-        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
         id: compare
         run: |
           if [ -f ./previous/output.txt ]; then
@@ -157,7 +152,7 @@ jobs:
           fi
 
       - name: Generate Commit Message
-        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
         run: |
           echo "Generating GitHub comment message"
           {
@@ -170,7 +165,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Attach Performance Comparison to PR
-        if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           cargo install -j $(nproc) --locked critcmp --debug
           critcmp --export new > output.json
+          cat output.json
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
       - name: Store benchmarks result
@@ -123,8 +124,9 @@ jobs:
         run: |
           LATEST_RUN_ID=$(gh api \
             repos/paradedb/paradedb/actions/workflows/benchmark-pg_search.yml/runs \
-            --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' | head -n 1
-          echo "Latest `dev` benchmark-pg_search run ID: $LATEST_RUN_ID"
+            --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' \
+            | head -n 1)
+          echo "Latest \`dev\` benchmark-pg_search run ID: $LATEST_RUN_ID"
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Download benchmarks baseline

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -131,6 +131,8 @@ jobs:
 
       - name: Compare benchmarks results (PRs only)
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
+        id: compare_benchmarks
+        continue-on-error: true # TODO: Remove this line once we have baseline data
         run: |
           cargo install -j $(nproc) --locked critcmp --debug
           result=$(critcmp ./previous/ target/criterion/)
@@ -145,6 +147,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Attach Performance Comparison to PR (PRs only)
+        if: steps.compare_benchmarks.outcome == 'success' && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -115,40 +115,21 @@ jobs:
           name: benchmark-pg_search-criterion-dev
           path: output.json
 
-      # We need to retrieve the latest successful benchmark run ID on `dev`
-      # to know which GitHub Artifact to download
-      - name: Get latest successful benchmark run ID from `dev`
+      - name: Download benchmarks baseline
         if: github.event_name == 'pull_request'
-        id: get_latest_dev_run
+        id: download_baseline
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # We retrieve the latest successful benchmark run ID on `dev` to know which GitHub Artifact to download
           LATEST_RUN_ID=$(gh api \
             repos/paradedb/paradedb/actions/workflows/benchmark-pg_search.yml/runs \
             --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' \
             | head -n 1)
           echo "Latest \`dev\` benchmark-pg_search run ID: $LATEST_RUN_ID"
-          echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Echo Run ID
-        run: |
-          echo "Run ID: ${{ steps.get_latest_dev_run.outputs.run_id }}"
-
-      # TODO: Fails here
-      - name: Download benchmarks baseline
-        if: github.event_name == 'pull_request'
-        id: download_baseline
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-pg_search-criterion-dev
-          path: previous/
-          run-id: ${{ steps.get_latest_dev_run.outputs.run_id }}
-
-      # TODO: remove
-      - name: Download benchmarks baseline using GitHub CLI
-        working-directory: pg_search/
-        run: |
-          gh run download ${{ steps.get_latest_dev_run.outputs.run_id }} \
+          # This automatically unzips the downloaded artifact, which extracts the output.json file
+          gh run download $LATEST_RUN_ID \
             --repo paradedb/paradedb \
             --name benchmark-pg_search-criterion-dev \
             --dir ./previous

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -118,6 +118,7 @@ jobs:
       # We need to retrieve the latest successful benchmark run ID on `dev`
       # to know which GitHub Artifact to download
       - name: Get latest successful benchmark run ID from `dev`
+        if: github.event_name == 'pull_request'
         id: get_latest_dev_run
         env:
           GH_TOKEN: ${{ github.token }}
@@ -129,16 +130,28 @@ jobs:
           echo "Latest \`dev\` benchmark-pg_search run ID: $LATEST_RUN_ID"
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Echo Run ID
+        run: |
+          echo "Run ID: ${{ steps.get_latest_dev_run.outputs.run_id }}"
+
+      # TODO: Fails here
       - name: Download benchmarks baseline
         if: github.event_name == 'pull_request'
         id: download_baseline
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: benchmark-pg_search-criterion-dev
           path: previous/
-          repository: ${{ github.repository }}
           run-id: ${{ steps.get_latest_dev_run.outputs.run_id }}
+
+      # TODO: remove
+      - name: Download benchmarks baseline using GitHub CLI
+        working-directory: pg_search/
+        run: |
+          gh run download ${{ steps.get_latest_dev_run.outputs.run_id }} \
+            --repo paradedb/paradedb \
+            --name benchmark-pg_search-criterion-dev \
+            --dir ./previous
 
       - name: Compare benchmarks results
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -122,8 +122,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           LATEST_RUN_ID=$(gh api \
-            repos/paradedb/paradedb/actions/runs \
-            --jq '.workflow_runs | map(select(.head_branch == "dev" and .conclusion == "success")) | .[0].id')
+            repos/paradedb/paradedb/actions/workflows/benchmark-pg_search.yml/runs \
+            --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' | head -n 1
           echo "Latest `dev` benchmark-pg_search run ID: $LATEST_RUN_ID"
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -122,9 +122,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           LATEST_RUN_ID=$(gh api \
-            repos/${{ github.repository }}/actions/runs \
-            --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' \
-            --limit 1)
+            repos/paradedb/paradedb/actions/runs \
+            --jq '.workflow_runs | map(select(.head_branch == "dev" and .conclusion == "success")) | .[0].id')
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Check if baseline exists

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -112,8 +112,6 @@ jobs:
       - name: Download benchmarks baseline (PRs only)
         if: github.event_name == 'pull_request'
         id: download_baseline
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           # We retrieve the latest successful benchmark run ID on `dev` to know which GitHub Artifact to download
           LATEST_RUN_ID=$(gh api \

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -101,20 +101,13 @@ jobs:
         working-directory: pg_search/
         run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
-      - name: Export Criterion benchmark results
-        run: |
-          cargo install -j $(nproc) --locked critcmp --debug
-          critcmp --export new > output.json
-          echo "Current benchmarks results:"
-          cat output.json
-
-      # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
+      # On dev, we store the benchmark results as artifacts to serve as a comparison point for PRs
       - name: Store benchmarks result
         if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-pg_search-criterion-dev
-          path: output.json
+          path: target/criterion/
 
       - name: Download benchmarks baseline
         if: github.event_name == 'pull_request'
@@ -133,33 +126,25 @@ jobs:
           gh run download $LATEST_RUN_ID \
             --repo paradedb/paradedb \
             --name benchmark-pg_search-criterion-dev \
-            --dir ./previous
-          echo "Previous benchmarks results:"
-          cat ./previous/output.json
+            --dir ./previous/
+          ls -l ./previous/
 
-      - name: Compare benchmarks results and generate commit message
+      - name: Compare benchmarks results
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
-        id: compare_and_generate_commit_message
         run: |
-          if [ -f ./previous/output.json ]; then
-            result=$(critcmp ./previous/output.json output.json)
-            echo "comparison_found=true" >> $GITHUB_OUTPUT
-            echo "Generating GitHub comment message"
-            {
-              echo 'DIFF<<EOF'
-              echo 'Performance comparison (latest commit) with `dev`:'
-              echo
-              echo "$result"
-              echo
-              echo 'EOF'
-            } >> "$GITHUB_ENV"
-          else
-            echo "No previous benchmark result found"
-            echo "comparison_found=false" >> $GITHUB_OUTPUT
-          fi
+          cargo install -j $(nproc) --locked critcmp --debug
+          result=$(critcmp ./previous/ target/criterion)
+          echo "Generating GitHub comment message"
+          {
+            echo 'DIFF<<EOF'
+            echo 'Performance comparison (latest commit) with `dev`:'
+            echo
+            echo "$result"
+            echo
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
 
       - name: Attach Performance Comparison to PR
-        if: steps.compare_and_generate_commit_message.outputs.comparison_found == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -102,14 +102,14 @@ jobs:
         run: cargo paradedb bench eslogs query-search-index --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for PRs
-      - name: Store benchmarks result
+      - name: Store benchmarks result (dev only)
         if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-pg_search-criterion-dev
           path: target/criterion/
 
-      - name: Download benchmarks baseline
+      - name: Download benchmarks baseline (PRs only)
         if: github.event_name == 'pull_request'
         id: download_baseline
         env:
@@ -129,11 +129,11 @@ jobs:
             --dir ./previous/
           ls -l ./previous/
 
-      - name: Compare benchmarks results
+      - name: Compare benchmarks results (PRs only)
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
         run: |
           cargo install -j $(nproc) --locked critcmp --debug
-          result=$(critcmp ./previous/ target/criterion)
+          result=$(critcmp ./previous/ target/criterion/)
           echo "Generating GitHub comment message"
           {
             echo 'DIFF<<EOF'
@@ -144,7 +144,7 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
-      - name: Attach Performance Comparison to PR
+      - name: Attach Performance Comparison to PR (PRs only)
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           cargo install -j $(nproc) --locked critcmp --debug
           critcmp --export new > output.json
+          echo "Current benchmarks results:"
           cat output.json
 
       # On dev, we store the benchmark results as artifacts to serve as a comparison point for feature branches
@@ -133,22 +134,27 @@ jobs:
             --repo paradedb/paradedb \
             --name benchmark-pg_search-criterion-dev \
             --dir ./previous
+          echo "Previous benchmarks results:"
+          cat ./previous/output.json
 
       - name: Compare benchmarks results
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
         id: compare
         run: |
-          if [ -f ./previous/output.txt ]; then
+          if [ -f ./previous/output.json ]; then
             result=$(critcmp ./previous/output.json output.json)
             echo "comparison_result<<EOF" >> $GITHUB_OUTPUT
             echo "$result" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+            echo "comparison_found=true" >> $GITHUB_OUTPUT
           else
             echo "No previous benchmark result found"
+            echo "comparison_found=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate Commit Message
-        if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.compare.outputs.comparison_found == 'true'
+        id: generate_commit_message
         run: |
           echo "Generating GitHub comment message"
           {
@@ -161,7 +167,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Attach Performance Comparison to PR
-        if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
+        if: steps.generate_commit_message.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -137,37 +137,29 @@ jobs:
           echo "Previous benchmarks results:"
           cat ./previous/output.json
 
-      - name: Compare benchmarks results
+      - name: Compare benchmarks results and generate commit message
         if: steps.download_baseline.outcome == 'success' && github.event_name == 'pull_request'
-        id: compare
+        id: compare_and_generate_commit_message
         run: |
           if [ -f ./previous/output.json ]; then
             result=$(critcmp ./previous/output.json output.json)
-            echo "comparison_result<<EOF" >> $GITHUB_OUTPUT
-            echo "$result" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
             echo "comparison_found=true" >> $GITHUB_OUTPUT
+            echo "Generating GitHub comment message"
+            {
+              echo 'DIFF<<EOF'
+              echo 'Performance comparison (latest commit) with `dev`:'
+              echo
+              echo "$result"
+              echo
+              echo 'EOF'
+            } >> "$GITHUB_ENV"
           else
             echo "No previous benchmark result found"
             echo "comparison_found=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate Commit Message
-        if: steps.compare.outputs.comparison_found == 'true'
-        id: generate_commit_message
-        run: |
-          echo "Generating GitHub comment message"
-          {
-            echo 'DIFF<<EOF'
-            echo 'Performance comparison (latest commit) with `dev`:'
-            echo
-            cat ${{ steps.compare.outputs.comparison_result }}
-            echo
-            echo EOF
-          } >> "$GITHUB_ENV"
-
       - name: Attach Performance Comparison to PR
-        if: steps.generate_commit_message.outcome == 'success'
+        if: steps.compare_and_generate_commit_message.outputs.comparison_found == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Download benchmarks baseline (PRs only)
         if: github.event_name == 'pull_request'
         id: download_baseline
+        env:
+          GH_TOKEN: ${{ github.token }} # Required by `gh`
         run: |
           # We retrieve the latest successful benchmark run ID on `dev` to know which GitHub Artifact to download
           LATEST_RUN_ID=$(gh api \

--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -114,6 +114,19 @@ jobs:
           name: benchmark-pg_search-criterion-dev
           path: output.json
 
+      # We need to retrieve the latest successful benchmark run ID on `dev`
+      # to know which GitHub Artifact to download
+      - name: Get latest successful benchmark run ID from `dev`
+        id: get_latest_dev_run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST_RUN_ID=$(gh api \
+            repos/${{ github.repository }}/actions/runs \
+            --jq '.workflow_runs[] | select(.head_branch == "dev" and .conclusion == "success") | .id' \
+            --limit 1)
+          echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
+
       - name: Check if baseline exists
         id: check_artifact
         uses: actions/download-artifact@v4
@@ -121,6 +134,8 @@ jobs:
         with:
           name: benchmark-pg_search-criterion-dev
           path: previous/
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get_latest_dev_run.outputs.run_id }}
 
       - name: Download benchmarks baseline
         if: steps.check_artifact.outcome == 'success' && github.event_name == 'pull_request'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We were previously defaulting to retrieving the artifact for the PR branch, which none existed, rather than from the `dev` branch. This should fix that, and finally make our benchmark comparison code work (famous last words).

## Why
Code that works is better than one that doesn't.

## How
Retrieve the latest `dev` run ID and pass that to the artifact download step.

## Tests
See CI