### PR TITLE
fix: Unbounded number of segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,14 +2799,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "ownedbytes"
-version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2996,8 +2989,8 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "tantivy 0.23.0",
- "tantivy-common 0.7.0",
+ "tantivy",
+ "tantivy-common",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -4474,6 +4467,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4506,63 +4500,13 @@ dependencies = [
  "serde_json",
  "sketches-ddsketch",
  "smallvec",
- "tantivy-bitpacker 0.6.0",
- "tantivy-columnar 0.3.0",
- "tantivy-common 0.7.0",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
  "tantivy-fst",
- "tantivy-query-grammar 0.22.0",
- "tantivy-stacker 0.3.0",
- "tantivy-tokenizer-api 0.3.0",
- "tempfile",
- "thiserror",
- "time",
- "uuid",
- "winapi",
-]
-
-[[package]]
-name = "tantivy"
-version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
-dependencies = [
- "aho-corasick",
- "arc-swap",
- "base64 0.22.1",
- "bitpacking",
- "byteorder",
- "census",
- "crc32fast",
- "crossbeam-channel",
- "downcast-rs",
- "fastdivide",
- "fnv",
- "fs4",
- "htmlescape",
- "hyperloglogplus",
- "itertools 0.13.0",
- "levenshtein_automata",
- "log",
- "lru",
- "lz4_flex",
- "measure_time",
- "memmap2",
- "once_cell",
- "oneshot",
- "rayon",
- "regex",
- "rust-stemmers",
- "rustc-hash",
- "serde",
- "serde_json",
- "sketches-ddsketch",
- "smallvec",
- "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-columnar 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-fst",
- "tantivy-query-grammar 0.22.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-stacker 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-tokenizer-api 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
  "tempfile",
  "thiserror",
  "time",
@@ -4573,14 +4517,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-dependencies = [
- "bitpacking",
-]
-
-[[package]]
-name = "tantivy-bitpacker"
-version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "bitpacking",
 ]
@@ -4588,51 +4525,26 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "downcast-rs",
  "fastdivide",
  "itertools 0.13.0",
  "serde",
- "tantivy-bitpacker 0.6.0",
- "tantivy-common 0.7.0",
- "tantivy-sstable 0.3.0",
- "tantivy-stacker 0.3.0",
-]
-
-[[package]]
-name = "tantivy-columnar"
-version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
-dependencies = [
- "downcast-rs",
- "fastdivide",
- "itertools 0.13.0",
- "serde",
- "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-sstable 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-stacker 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
 ]
 
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "async-trait",
  "byteorder",
- "ownedbytes 0.7.0",
- "serde",
- "time",
-]
-
-[[package]]
-name = "tantivy-common"
-version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
-dependencies = [
- "async-trait",
- "byteorder",
- "ownedbytes 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "ownedbytes",
  "serde",
  "time",
 ]
@@ -4651,14 +4563,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "tantivy-query-grammar"
-version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "nom",
 ]
@@ -4666,20 +4571,10 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
- "tantivy-bitpacker 0.6.0",
- "tantivy-common 0.7.0",
- "tantivy-fst",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "tantivy-sstable"
-version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
-dependencies = [
- "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-bitpacker",
+ "tantivy-common",
  "tantivy-fst",
  "zstd 0.13.2",
 ]
@@ -4687,33 +4582,17 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "murmurhash32",
  "rand_distr",
- "tantivy-common 0.7.0",
-]
-
-[[package]]
-name = "tantivy-stacker"
-version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
-dependencies = [
- "murmurhash32",
- "rand_distr",
- "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-common",
 ]
 
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "tantivy-tokenizer-api"
-version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
 dependencies = [
  "serde",
 ]
@@ -4781,8 +4660,8 @@ dependencies = [
  "sqlx",
  "strum",
  "strum_macros",
- "tantivy 0.23.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
- "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy",
+ "tantivy-common",
  "tempfile",
  "time",
  "tokenizers",
@@ -4904,7 +4783,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tantivy 0.23.0",
+ "tantivy",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "bitpacking",
 ]
@@ -4525,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "nom",
 ]
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84c4b58#84c4b58292afa320590ef7bae81f378029b505c7"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e4e9eb5#e4e9eb52ce8bf2901652e8f9a947f43756f9aa15"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,6 +2799,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.7.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
 dependencies = [
  "stable_deref_trait",
@@ -2989,8 +2996,8 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "tantivy",
- "tantivy-common",
+ "tantivy 0.23.0",
+ "tantivy-common 0.7.0",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -4467,6 +4474,55 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker 0.6.0",
+ "tantivy-columnar 0.3.0",
+ "tantivy-common 0.7.0",
+ "tantivy-fst",
+ "tantivy-query-grammar 0.22.0",
+ "tantivy-stacker 0.3.0",
+ "tantivy-tokenizer-api 0.3.0",
+ "tempfile",
+ "thiserror",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.23.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
 dependencies = [
  "aho-corasick",
@@ -4500,18 +4556,25 @@ dependencies = [
  "serde_json",
  "sketches-ddsketch",
  "smallvec",
- "tantivy-bitpacker",
- "tantivy-columnar",
- "tantivy-common",
+ "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-columnar 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
  "tantivy-fst",
- "tantivy-query-grammar",
- "tantivy-stacker",
- "tantivy-tokenizer-api",
+ "tantivy-query-grammar 0.22.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-stacker 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-tokenizer-api 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
  "tempfile",
  "thiserror",
  "time",
  "uuid",
  "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.6.0"
+dependencies = [
+ "bitpacking",
 ]
 
 [[package]]
@@ -4525,16 +4588,41 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.13.0",
+ "serde",
+ "tantivy-bitpacker 0.6.0",
+ "tantivy-common 0.7.0",
+ "tantivy-sstable 0.3.0",
+ "tantivy-stacker 0.3.0",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.3.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
 dependencies = [
  "downcast-rs",
  "fastdivide",
  "itertools 0.13.0",
  "serde",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-sstable",
- "tantivy-stacker",
+ "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-sstable 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-stacker 0.3.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes 0.7.0",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -4544,7 +4632,7 @@ source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505
 dependencies = [
  "async-trait",
  "byteorder",
- "ownedbytes",
+ "ownedbytes 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
  "serde",
  "time",
 ]
@@ -4563,6 +4651,13 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.22.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
 dependencies = [
  "nom",
@@ -4571,12 +4666,31 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
 dependencies = [
- "tantivy-bitpacker",
- "tantivy-common",
+ "tantivy-bitpacker 0.6.0",
+ "tantivy-common 0.7.0",
  "tantivy-fst",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505e10fc262ac22a9e71f216e45fa"
+dependencies = [
+ "tantivy-bitpacker 0.6.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-fst",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.3.0"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common 0.7.0",
 ]
 
 [[package]]
@@ -4586,7 +4700,14 @@ source = "git+https://github.com/paradedb/tantivy.git?rev=33be46c#33be46c8c68505
 dependencies = [
  "murmurhash32",
  "rand_distr",
- "tantivy-common",
+ "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.3.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4660,8 +4781,8 @@ dependencies = [
  "sqlx",
  "strum",
  "strum_macros",
- "tantivy",
- "tantivy-common",
+ "tantivy 0.23.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
+ "tantivy-common 0.7.0 (git+https://github.com/paradedb/tantivy.git?rev=33be46c)",
  "tempfile",
  "time",
  "tokenizers",
@@ -4783,7 +4904,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "tantivy",
+ "tantivy 0.23.0",
  "tracing",
 ]
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -37,8 +37,8 @@ reqwest = { version = "0.11.27", features = ["blocking"] }
 rustc-hash = "1.1.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { path = "../../tantivy" }
-tantivy-common = { path = "../../tantivy/common" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "84c4b58" }
 thiserror = "1.0.63"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -37,8 +37,8 @@ reqwest = { version = "0.11.27", features = ["blocking"] }
 rustc-hash = "1.1.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "33be46c" }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "33be46c" }
+tantivy = { path = "../../tantivy" }
+tantivy-common = { path = "../../tantivy/common" }
 thiserror = "1.0.63"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -37,8 +37,8 @@ reqwest = { version = "0.11.27", features = ["blocking"] }
 rustc-hash = "1.1.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "84c4b58" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e4e9eb5" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e4e9eb5" }
 thiserror = "1.0.63"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -57,7 +57,7 @@ impl BlockingDirectory {
 
 impl DirectoryClone for BlockingDirectory {
     fn box_clone(&self) -> Box<dyn Directory> {
-        self.0.box_clone()
+        Box::new(BlockingDirectory(self.0.clone()))
     }
 }
 

--- a/pg_search/src/index/writer.rs
+++ b/pg_search/src/index/writer.rs
@@ -29,7 +29,7 @@ use std::{collections::HashSet, path::Path};
 use std::{fs, io, result};
 use tantivy::directory::{
     DirectoryClone, DirectoryLock, FileHandle, FileSlice, Lock, WatchCallback, WatchHandle,
-    WritePtr, INDEX_WRITER_LOCK,
+    WritePtr,
 };
 use tantivy::{
     directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError},
@@ -75,16 +75,10 @@ impl Directory for BlockingDirectory {
     }
 
     fn atomic_write(&self, path: &Path, data: &[u8]) -> io::Result<()> {
-        self.0
-            .acquire_lock(&INDEX_WRITER_LOCK)
-            .expect("must be able to acquire lock");
         self.0.atomic_write(path, data)
     }
 
     fn atomic_read(&self, path: &Path) -> result::Result<Vec<u8>, OpenReadError> {
-        self.0
-            .acquire_lock(&INDEX_WRITER_LOCK)
-            .expect("must be able to acquire lock");
         self.0.atomic_read(path)
     }
 
@@ -100,10 +94,11 @@ impl Directory for BlockingDirectory {
         // This is the only change we actually need to make to the Directory trait impl.
         // We want the acquire_lock behavior to block and wait for a lock to be available,
         // instead of panicking. Internally, Tantivy just polls for its availability.
-        Ok(DirectoryLock::from(Box::new(Lock {
+        let blocking_lock = Lock {
             filepath: lock.filepath.clone(),
             is_blocking: true,
-        })))
+        };
+        self.0.acquire_lock(&blocking_lock)
     }
 
     fn watch(&self, watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -41,7 +41,7 @@ pub extern "C" fn amvacuumcleanup(
 
     let search_index =
         open_search_index(&index_relation).expect("should be able to open search index");
-    let writer = search_index
+    let mut writer = search_index
         .get_writer(WriterResources::Vacuum)
         .unwrap_or_else(|err| panic!("error loading index writer from directory: {err}"));
 
@@ -50,5 +50,18 @@ pub extern "C" fn amvacuumcleanup(
         .vacuum(&writer)
         .unwrap_or_else(|err| panic!("error during vacuum on index {index_name}: {err:?}"));
 
+    // we also need to make sure segments get merged.
+    //
+    // we can force this by doing a .commit(), even tho we don't have changes
+    // then directly taking control of the underlying_writer and waiting for the merge threads
+    // to complete
+    writer.commit().expect("commit should succeed");
+    writer
+        .underlying_writer
+        .take()
+        .unwrap()
+        .wait_merging_threads()
+        .expect("wait_merging_threads() should succeed");
+    pgrx::warning!("HERE");
     stats
 }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -62,6 +62,6 @@ pub extern "C" fn amvacuumcleanup(
         .unwrap()
         .wait_merging_threads()
         .expect("wait_merging_threads() should succeed");
-    pgrx::warning!("HERE");
+
     stats
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -41,8 +41,8 @@ sqlx = { version = "0.7.4", features = [
 ] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "84c4b58" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e4e9eb5" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e4e9eb5" }
 tempfile = "3.12.0"
 time = { version = "0.3.36", features = ["serde"] }
 tokenizers = { path = "../tokenizers" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -41,8 +41,8 @@ sqlx = { version = "0.7.4", features = [
 ] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "33be46c" }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "33be46c" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "84c4b58" }
 tempfile = "3.12.0"
 time = { version = "0.3.36", features = ["serde"] }
 tokenizers = { path = "../tokenizers" }

--- a/tests/tests/vacuum.rs
+++ b/tests/tests/vacuum.rs
@@ -65,12 +65,3 @@ fn manual_vacuum(mut conn: PgConnection) {
     "update sadvac set id = id;".execute(&mut conn);
     assert_eq!(count_func(&mut conn), ROW_COUNT, "post update after vacuum");
 }
-
-#[rstest]
-fn vacuum_cleans_files(mut conn: PgConnection) {
-    SimpleProductsTable::setup().execute(&mut conn);
-
-    "DELETE FROM paradedb.bm25_search".execute(&mut conn);
-    let rows = "SELECT COUNT(*) FROM paradedb.bm25_search".fetch_one::<(i64,)>(&mut conn).0;
-
-}

--- a/tests/tests/vacuum.rs
+++ b/tests/tests/vacuum.rs
@@ -65,3 +65,12 @@ fn manual_vacuum(mut conn: PgConnection) {
     "update sadvac set id = id;".execute(&mut conn);
     assert_eq!(count_func(&mut conn), ROW_COUNT, "post update after vacuum");
 }
+
+#[rstest]
+fn vacuum_cleans_files(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    "DELETE FROM paradedb.bm25_search".execute(&mut conn);
+    let rows = "SELECT COUNT(*) FROM paradedb.bm25_search".fetch_one::<(i64,)>(&mut conn).0;
+
+}

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,7 +21,7 @@ lindera-tokenizer = { version = "0.27.2", features = [
 once_cell = "1.19.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e4e9eb5" }
 tracing = "0.1.40"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,7 +21,7 @@ lindera-tokenizer = { version = "0.27.2", features = [
 once_cell = "1.19.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "33be46c" }
+tantivy = { path = "../../tantivy" }
 tracing = "0.1.40"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,7 +21,7 @@ lindera-tokenizer = { version = "0.27.2", features = [
 once_cell = "1.19.0"
 serde = "1.0.210"
 serde_json = "1.0.128"
-tantivy = { path = "../../tantivy" }
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84c4b58" }
 tracing = "0.1.40"
 strum_macros = "0.26.4"
 strum = { version = "0.26.3", features = ["derive"] }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1835 

## What

Fixes an issue where the number of segments was becoming unbounded.

## Why

User-reported bug.

## How

In the current implementation, every Tantivy `Index` holds onto a `ManagedDirectory`, which stores a snapshot of all segment files present in `managed.json` when initialized. When an `IndexWriter` flushes to disk, the `IndexWriter` appends its new segment paths to that snapshot of segment files and flushes it to `managed.json`.

This does not account for the scenario where the contents of `managed.json` are modified by another processes' `IndexWriter` (now that we allow for concurrent writers) after the snapshot is taken. This causes segments to become lost, which causes them to stay on disk forever (garbage collection doesn't know about them).

In my fork of Tantivy, I fixed this by acquiring a lock on `managed.json` for every read and holding that lock until we write back to `managed.json`.

## Tests

TODO