### PR TITLE
fix: better support prepared statements in the form of `field @@@ $1::text`

### DIFF
--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -137,6 +137,7 @@ fn query_input_support_request_simplify(arg: pg_sys::Datum) -> Option<ReturnedNo
             &mut input_args,
             var,
             query,
+            None,
             anyelement_query_input_opoid(),
             anyelement_query_input_procoid(),
         ))


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1841

## What

Postgres might decide to re-plan a PREPAREd statement, and when the rhs of our `@@@` operator is TEXT, it may replace it with a `Param` node instead of the `Const` node we've been assuming up to this point.

In that case, we transform the operator expression from `field @@@ $1::text` into `key_field @@@ paradedb.parse_with_field('field', $1::text)`, which then gets properly paramterized through the normal IndexScan machinery.

## Why

## How

## Tests

There's a few new tests here to make sure that when Postgres replans a prepared statement that it still executes, even if the plan is a little different.