### PR TITLE
fix: bug where parallel workers that don't have anything to do would instead just query the whole index

### DIFF
--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -128,6 +128,8 @@ pub extern "C" fn amrescan(
                 segment_number,
                 &query,
             )
+        } else if pg_sys::ParallelWorkerNumber > -1 {
+            SearchResults::None
         } else {
             search_reader.search_via_channel(
                 need_scores,

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -156,7 +156,7 @@ async fn test_statement_level_locking(database: Db) -> Result<()> {
     // Run both tasks concurrently
     join!(task_a, task_b);
 
-    // Stop the timer and ssert that the duration is close to 3 seconds
+    // Stop the timer and assert that the duration is close to 5 seconds
     let duration = start_time.elapsed();
     assert!(
         duration.as_secs() >= 3 && duration.as_secs() < 5,

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -159,7 +159,7 @@ async fn test_statement_level_locking(database: Db) -> Result<()> {
     // Stop the timer and ssert that the duration is close to 3 seconds
     let duration = start_time.elapsed();
     assert!(
-        duration.as_secs() >= 3 && duration.as_secs() < 4,
+        duration.as_secs() >= 3 && duration.as_secs() < 5,
         "Expected duration to be around 3 seconds, but it took {:?}",
         duration
     );


### PR DESCRIPTION


# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
