### PR TITLE
fix: guard against concurrent file deletions

### DIFF
--- a/pg_search/src/index/directory.rs
+++ b/pg_search/src/index/directory.rs
@@ -64,10 +64,11 @@ pub trait SearchFs {
         let path = self.tantivy_dir_path(false)?;
         let mut total_size = 0;
 
-        for entry_result in WalkDir::new(path) {
-            let entry = entry_result?;
+        for entry in WalkDir::new(path).into_iter().flatten() {
             if entry.path().is_file() {
-                total_size += entry.metadata()?.len();
+                if let Ok(metadata) = entry.metadata() {
+                    total_size += metadata.len();
+                }
             }
         }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Makes our `SearchFs::total_size()` impl resilient to filesystem changes while we're calculating the directory size.  This came up as a failure in CI once.

## Why

The directory _could_ be being modified concurrently... especially by a background merge process.

## How

## Tests
