### PR TITLE
chore: Add more Docker tags

### DIFF
--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -91,7 +91,9 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest-pg${{ matrix.pg_version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -92,14 +92,10 @@ jobs:
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
-            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -95,6 +95,7 @@ jobs:
             type=raw,value=latest-pg${{ matrix.pg_version }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
+            type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -93,10 +93,10 @@ jobs:
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=postgres${{ matrix.pg_version }}
-            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
+            type=raw,value=latest-pg${{ matrix.pg_version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -90,12 +90,11 @@ jobs:
           images: paradedb/paradedb
           tags: |
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
+            type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
+            type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
+            type=raw,value=latest-pg${{ matrix.pg_version }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=latest-pg${{ matrix.pg_version }}
-            type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
-            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -93,6 +93,10 @@ jobs:
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
+            type=raw,value=postgres${{ matrix.pg_version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},suffix=-postgres${{ matrix.pg_version }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-paradedb.yml
+++ b/.github/workflows/publish-paradedb.yml
@@ -90,12 +90,13 @@ jobs:
           images: paradedb/paradedb
           tags: |
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
             type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == 16 }}
-            type=raw,value=latest,enable=${{ matrix.pg_version == 16 }}
             type=raw,value=latest-pg${{ matrix.pg_version }}
+            type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}
             type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.version.outputs.tag }},suffix=-pg${{ matrix.pg_version }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

Proposed by me in https://github.com/paradedb/paradedb/issues/1718#issuecomment-2436551477

## Why

Currently whoever wants to use the project's docker image has to stick to either one of the following:
- `latest`, ofc, subject to breaking changes both form this project as well from upstream.
- stick to a specific PradeDB version, subject to upstream breaking changes.
- stick to a specifc PradeDB and Postgres upstream dep.

## How

By introducing more granular tagging we let developers chose how to follow updated with the following options:
- `{{major}}.{{minor}}.{{path}}-postgres{{version}}`: sticks to a specific project version and pg version
- `{{major}}.{{minor}}-postgres{{version}}`: sticks to a specific project major+minor and pg version
- `{{major}}-postgres{{version}}`: sticks to a specific project major and pg version (ensuring no breaking changes from both sources, but keeping both up to date)
- `postgres{{version}}`: sticks to this project latest release but sticks to a specific pg version

## Tests
