### PR TITLE
ci: Only save Rust cache on dev

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -67,6 +67,7 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install pgrx & pg_search
         working-directory: pg_search/

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           fetch-depth: 0 # Fetch the entire history
 
+      - name: Extract pgrx Version
+        id: pgrx
+        working-directory: pg_search/
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
+  
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -47,10 +52,9 @@ jobs:
       - name: Install Rust Cache
         uses: ubicloud/rust-cache@v2
         with:
-          prefix-key: "v1"
-          shared-key: ${{ runner.os }}-rust-cache-pg_search-${{ HashFiles('Cargo.lock') }}
+          prefix-key: "v1-rust"
+          key: ${{ env.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
-          cache-on-failure: true
           cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -43,7 +43,7 @@ jobs:
         id: pgrx
         working-directory: pg_search/
         run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
-  
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -48,6 +48,7 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -53,6 +53,7 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install required system tools
         run: sudo apt-get update && sudo apt-get install -y lsof

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -109,6 +109,7 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install required system tools
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
@@ -236,6 +237,7 @@ jobs:
           key: ${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}
           cache-targets: true
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
 
       - name: Install required system tools
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We were saving the Rust cache on every branch, which was busting our maximum 10GB Rust cache, which meant nothing was hit. We only save on `dev`, so feature branches (PRs) see it.

## Why
Make the Rust cache work.

## How
^

## Tests
^