### PR TITLE
fix: clamp per-thread memory budget allocation to tantivy limits

### DIFF
--- a/docs/documentation/configuration/index.mdx
+++ b/docs/documentation/configuration/index.mdx
@@ -26,8 +26,9 @@ SET paradedb.create_index_parallelism = 8;
 `paradedb.create_index_memory_budget` sets the amount of memory to dedicate **per indexing thread** before the index segment needs to be
 written to disk.
 
-It defaults to Postgres' `maintenance_work_mem` but can be changed to suit the host system's available
-memory. In terms of raw indexing performance, larger is generally better.
+If unset, Postgres' `maintenance_work_mem` value is used, but is first divided by the total parallelism (`paradedb.create_index_parallelism`).
+
+In terms of raw indexing performance, larger is generally better.
 
 The value is measured in megabytes. A value of `1024` is the same as `1GB`.
 
@@ -72,7 +73,7 @@ SET paradedb.statement_parallelism = 1;
 `paradedb.statement_memory_budget` sets the amount of memory to dedicate **per indexing thread** before the index segment needs to be
 written to disk.
 
-Like [indexing memory](#indexing-memory), it defaults to `maintenance_work_mem` and is measured in megabytes.
+Like [indexing memory](#indexing-memory), it defaults to `maintenance_work_mem` divided by the total parallelism, and is measured in megabytes.
 
 If your typical update patterns are single-row atomic INSERTs or UPDATEs, then a value of `15MB` is ideal. If
 your update patterns typically update many thousands of rows, a larger value might be preferred for greater indexing


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1872

## What

When calculating how much memory to allocate to tantivy for index writing, make sure we don't exceed its hard-coded limits, which now become our hard-coded limits.

Our (`pg_search`'s) GUC `paradedb.create_index_memory_budget` is considered to be **per thread**, whereas if it's unset and we fallback to Postgres' `maintenance_work_mem`, we treat that as an overall value, dividing that total by the parallelism value.

From there, we make sure the newly-calculated per-thread memory budget does not exceed tantivy's hardcoded limits, which we adopt in code as our own.

## Why

As pointed out in #1872, it's easy to generally configure Postgres in a way that then becomes incompatible with tantivy.

## How

## Tests
