### PR TITLE
fix: upgrade path from 0.10.2 to 0.10.3

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -77,11 +77,11 @@ jobs:
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
-      # This is the pgrx version compatible with ParadeDB v0.11.0
-      - name: Install cargo-pgrx for ParadeDB v0.11.0
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.12.6 --debug
+      # This is the pgrx version compatible with ParadeDB v0.10.0
+      - name: Install cargo-pgrx for ParadeDB v0.10.0
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.12.4 --debug
 
-      - name: Initialize cargo-pgrx environment for ParadeDB v0.11.0
+      - name: Initialize cargo-pgrx environment for ParadeDB v0.10.0
         run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
       - name: Add pg_search to shared_preload_libraries

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -89,10 +89,10 @@ jobs:
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 
       # This is the first version at which we started supporting upgrading via ALTER EXTENSION
-      - name: Checkout ParadeDB v0.11.0
-        run: git checkout v0.11.0
+      - name: Checkout ParadeDB v0.10.0
+        run: git checkout v0.10.0
 
-      - name: Compile & install pg_search v0.11.0
+      - name: Compile & install pg_search v0.10.0
         working-directory: pg_search/
         run: cargo pgrx install --features icu --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 

--- a/pg_search/sql/pg_search--0.10.2--0.10.3.sql
+++ b/pg_search/sql/pg_search--0.10.2--0.10.3.sql
@@ -3,5 +3,5 @@ CREATE TYPE TestTable AS ENUM (
 	'Orders',
 	'Parts'
 );
-DROP FUNCTION IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar");
+DROP PROCEDURE IF EXISTS paradedb.create_bm25_test_table(table_name pg_catalog."varchar", schema_name pg_catalog."varchar");
 CREATE OR REPLACE PROCEDURE paradedb.create_bm25_test_table(table_name pg_catalog."varchar" DEFAULT 'bm25_test_table', schema_name pg_catalog."varchar" DEFAULT 'paradedb', table_type paradedb.testtable DEFAULT 'Items') AS 'MODULE_PATHNAME', 'create_bm25_test_table_wrapper' LANGUAGE c;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1850

## What

This fixes the extension upgrade script from v0.10.2 to v0.10.3.

## Why

Is the cause of upgrade failures from "v0.10" to "v0.11".

## How

## Tests
