### PR TITLE
feat: new `NPlusOneMergePolicy` that targets that many segments

### DIFF
--- a/docs/documentation/configuration/index.mdx
+++ b/docs/documentation/configuration/index.mdx
@@ -2,9 +2,10 @@
 title: Indexing
 ---
 
-## Index Creation
+## System Configuration Settings
 
-These settings affect the `paradedb.create_bm25` statement.
+These settings can be set in `postgresql.conf` and affect system resources used by the `paradedb.create_bm25()` function
+and normal INSERT/UPDATE/COPY statements.
 
 ### Indexing Threads
 
@@ -46,10 +47,6 @@ This can be useful to monitor the progress of a long-running `CREATE INDEX` stat
 SET paradedb.log_create_index_progress = true;
 ```
 
-## Index Upsert
-
-These settings affect `INSERT`, `UPDATE`, and `COPY` statements to tables with a BM25 index.
-
 ### Statement Parallelism
 
 <Note>This setting requires superuser privileges.</Note>
@@ -84,4 +81,22 @@ longer-term search overhead of having many additional index segments until (auto
 
 ```sql
 SET paradedb.statement_memory_budget = 15;
+```
+
+## Index Configuration Settings
+
+These settings can be applied to an existing `USING bm25` index with `ALTER INDEX <idxname> SET (...)` and affect runtime
+operations around how the underlying tantivy index segments are merged, and when.
+
+`target_segment_count` is an integer value that indicates the number of tantivy index segments that are preferred for
+the index. If unspecified, the default is the number of available CPUs. The actual number of index segments may be
+different, depending on runtime operations, but should generally be close to this value.
+
+`merge_on_insert` is a boolean that indicates if pg_search should merge segments whenever a tuple is inserted into the index.
+This includes INSERT/UPDATE/COPY statements. The default is `true`. Setting this to `false` can improve INSERT/UPDATE/COPY
+throughput at the expense of creating more segments that will be later merged by (auto)VACUUM.
+
+```sql
+ALTER INDEX idxfoo_bm25_index SET (target_segment_count = 8);
+ALTER INDEX idxfoo_bm25_index SET (merge_on_insert = true);
 ```

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -143,8 +143,6 @@ pub fn init() {
         GucContext::Suset,
         GucFlags::UNIT_MB,
     );
-
-    pgrx::warning!("GUCS initialized");
 }
 
 pub fn telemetry_enabled() -> bool {

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,0 +1,34 @@
+use tantivy::indexer::{MergeCandidate, MergePolicy};
+use tantivy::SegmentMeta;
+
+/// A tantivy [`MergePolicy`] that endeavours to keep a maximum number of segments "N", plus
+/// one extra for leftovers.
+///
+/// It merges the smallest segments, accounting for deleted docs.
+#[derive(Debug)]
+pub struct NPlusOneMergePolicy(pub usize);
+
+impl MergePolicy for NPlusOneMergePolicy {
+    fn compute_merge_candidates(&self, segments: &[SegmentMeta]) -> Vec<MergeCandidate> {
+        let n = self.0;
+
+        if segments.len() <= n + 1 {
+            // nothing to merge, we have N+1 or fewer segments
+            return vec![];
+        }
+
+        // collect a list of the segments and sort them largest-to-smallest, by # of alive docs
+        let mut metas = segments.iter().collect::<Vec<_>>();
+        metas.sort_unstable_by(|a, b| a.num_docs().cmp(&b.num_docs()).reverse());
+
+        let mut candidate = MergeCandidate(vec![]);
+        while metas.len() > n {
+            let meta = metas.pop().unwrap();
+            candidate.0.push(meta.id());
+        }
+
+        assert!(candidate.0.len() > 1, "decided to merge only 1 segment");
+
+        vec![candidate]
+    }
+}

--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod directory;
 pub mod fast_fields_helper;
+mod merge_policy;
 pub mod reader;
 pub mod search;
 pub mod writer;

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -131,15 +131,19 @@ impl SearchIndex {
             .underlying_index
             .writer_with_num_threads(parallelism.get(), memory_budget)?;
 
+        let wants_merge;
         let merge_policy: Box<dyn MergePolicy> = if merge_on_insert {
+            wants_merge = true;
             Box::new(NPlusOneMergePolicy(target_segment_count))
         } else {
+            wants_merge = false;
             Box::new(NoMergePolicy)
         };
         underlying_writer.set_merge_policy(merge_policy);
 
         Ok(SearchIndexWriter {
             underlying_writer: Some(underlying_writer),
+            wants_merge,
         })
     }
 

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -18,10 +18,12 @@
 use super::reader::SearchIndexReader;
 use super::IndexError;
 use crate::gucs;
+use crate::index::merge_policy::NPlusOneMergePolicy;
 use crate::index::SearchIndexWriter;
 use crate::index::{
     BlockingDirectory, SearchDirectoryError, SearchFs, TantivyDirPath, WriterDirectory,
 };
+use crate::postgres::options::SearchIndexCreateOptions;
 use crate::query::SearchQueryInput;
 use crate::schema::{
     SearchDocument, SearchField, SearchFieldConfig, SearchFieldName, SearchFieldType,
@@ -32,6 +34,8 @@ use once_cell::sync::Lazy;
 use pgrx::PgRelation;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::num::NonZeroUsize;
+use tantivy::indexer::NoMergePolicy;
+use tantivy::merge_policy::MergePolicy;
 use tantivy::query::Query;
 use tantivy::{query::QueryParser, Executor, Index};
 use thiserror::Error;
@@ -54,21 +58,32 @@ pub enum WriterResources {
 }
 pub type Parallelism = NonZeroUsize;
 pub type MemoryBudget = usize;
+pub type TargetSegmentCount = usize;
+pub type DoMerging = bool;
 
 impl WriterResources {
-    pub fn resources(&self) -> (Parallelism, MemoryBudget) {
+    pub fn resources(
+        &self,
+        index_options: &SearchIndexCreateOptions,
+    ) -> (Parallelism, MemoryBudget, TargetSegmentCount, DoMerging) {
         match self {
             WriterResources::CreateIndex => (
                 gucs::create_index_parallelism(),
                 gucs::create_index_memory_budget(),
+                index_options.target_segment_count(),
+                true, // we always want a merge on CREATE INDEX
             ),
             WriterResources::Statement => (
                 gucs::statement_parallelism(),
                 gucs::statement_memory_budget(),
+                index_options.target_segment_count(),
+                index_options.merge_on_insert(), // user/index decides if we merge for INSERT/UPDATE statements
             ),
             WriterResources::Vacuum => (
                 gucs::statement_parallelism(),
                 gucs::statement_memory_budget(),
+                index_options.target_segment_count(),
+                true, // we always want a merge on (auto)VACUUM
             ),
         }
     }
@@ -105,11 +120,24 @@ impl SearchIndex {
     /// Retrieve an owned writer for a given index. This will block until this process
     /// can get an exclusive lock on the Tantivy writer. The return type needs to
     /// be entirely owned by the new process, with no references.
-    pub fn get_writer(&self, resources: WriterResources) -> Result<SearchIndexWriter> {
-        let (parallelism, memory_budget) = resources.resources();
+    pub fn get_writer(
+        &self,
+        resources: WriterResources,
+        index_options: &SearchIndexCreateOptions,
+    ) -> Result<SearchIndexWriter> {
+        let (parallelism, memory_budget, target_segment_count, merge_on_insert) =
+            resources.resources(index_options);
         let underlying_writer = self
             .underlying_index
             .writer_with_num_threads(parallelism.get(), memory_budget)?;
+
+        let merge_policy: Box<dyn MergePolicy> = if merge_on_insert {
+            Box::new(NPlusOneMergePolicy(target_segment_count))
+        } else {
+            Box::new(NoMergePolicy)
+        };
+        underlying_writer.set_merge_policy(merge_policy);
+
         Ok(SearchIndexWriter {
             underlying_writer: Some(underlying_writer),
         })


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Introduce a new merge policy that will merge the smallest segments in order to keep at least "N" segments, and there could be a "plus one" segment for leftovers.  The idea is that we can roughly keep a minimum number of segments while merging together the smallest segments.

We also add two new index `WITH` options, `target_segment_count = integer` which provides the "N" for the above and a `merge_on_insert = boolean` which dictates if we perform a merge after INSERT/UPDATE/COPY statements.

CREATE INDEX and (auto)VACUUM will always do a merge, using our new policy.

## Why

To give users a bit more flexibility and provide a default that allows for better parallelism during search.

## How

## Tests

Existing tests pass along with a run of our internal stressgres tool.