### PR TITLE
ci: Fix issue with external contributors unable to create PR comments

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -20,6 +20,7 @@ on:
 # Required to post a comment to the PR
 permissions:
   pull-requests: write
+  issues: write
 
 concurrency:
   group: check-pg_search-schema-upgrade-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
As per: https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-issues

PRs are considered a type of issue, and we needed to enable `issue` write permissions for creating comments. This does that!

## Why
Enable external contributors to post schema upgrade comments to the PR.

## How
^

## Tests
^