### PR TITLE
fix: memory leak & perf problem during custom scan execution

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -58,6 +58,8 @@ pub struct PdbScanState {
     pub visibility_checker: Option<VisibilityChecker>,
 
     pub need_scores: bool,
+    pub score_funcoid: pg_sys::Oid,
+    pub snippet_funcoid: pg_sys::Oid,
     pub snippet_generators: HashMap<SnippetInfo, Option<SnippetGenerator>>,
     pub var_attname_lookup: HashMap<(i32, pg_sys::AttrNumber), String>,
 


### PR DESCRIPTION
We were calling the `score_funcoid()` and `snippet_funcoid()` functions for every tuple returned from our Custom Scan, which leaked per-tuple memory and also introduced a tremendous amount of overhead.

Now we determine those function oids once when we setup the scan.

# Ticket(s) Closed

- Closes #

## What

Fix a bad memory leak and performance regression with CustomScan execution

## Why

## How

## Tests

Existing tests pass