### PR TITLE
chore: Remove `bm25_index` suffix

### DIFF
--- a/docs/documentation/full-text/sorting.mdx
+++ b/docs/documentation/full-text/sorting.mdx
@@ -68,7 +68,7 @@ LIMIT 5;
  Limit  (cost=10.00..34.03 rows=5 width=36)
    ->  Custom Scan (ParadeDB Scan) on mock_items  (cost=10.00..34.03 rows=5 width=36)
          Table: mock_items
-         Index: search_idx_bm25_index
+         Index: search_idx
          Scores: false
             Sort Field: rating
             Sort Direction: desc
@@ -110,7 +110,7 @@ LIMIT 5;
  Limit  (cost=10.00..34.05 rows=5 width=584)
    ->  Custom Scan (ParadeDB Scan) on mock_items  (cost=10.00..34.05 rows=5 width=584)
          Table: mock_items
-         Index: search_idx_bm25_index
+         Index: search_idx
          Scores: false
             Sort Field: category
             Sort Direction: desc

--- a/docs/documentation/indexing/delete_index.mdx
+++ b/docs/documentation/indexing/delete_index.mdx
@@ -5,18 +5,7 @@ title: Delete an Index
 ## Basic Usage
 
 The following command deletes a BM25 index.
-It's important to use `paradedb.drop_bm25` instead of `DROP INDEX` to ensure that all index-related resources are cleaned up.
 
 ```sql
-CALL paradedb.drop_bm25(
-  index_name => 'search_idx',
-  schema_name => 'public'
-);
+DROP INDEX search_idx;
 ```
-
-<ParamField body="index_name" required>
-  The name of the index you wish to delete.
-</ParamField>
-<ParamField body="schema_name" default="CURRENT SCHEMA">
-  The name of the schema that the index was created in.
-</ParamField>

--- a/docs/documentation/indexing/inspect_index.mdx
+++ b/docs/documentation/indexing/inspect_index.mdx
@@ -8,10 +8,8 @@ The `schema` function returns a table with information about the index schema. T
 
 The following code block inspects an index called `search_idx`. The argument should be the index name quoted in a string.
 
-Note that Postgres index instance includes a `_bm25_index` suffix on the `index_name` passed to `paradedb.create_bm25()`.
-
 ```sql
-SELECT name, field_type FROM paradedb.schema('search_idx_bm25_index');
+SELECT name, field_type FROM paradedb.schema('search_idx');
 ```
 
 <ParamField body="index" required>
@@ -25,10 +23,8 @@ Because BM25 indexes rely on a custom storage implementation, the built-in Postg
 
 The following code block returns the size of an index called `search_idx`. The argument should be the index name quoted in a string.
 
-Note that Postgres index instance includes a `_bm25_index` suffix on the `index_name` passed to `paradedb.create_bm25()`.
-
 ```sql
-SELECT index_size FROM paradedb.index_size('search_idx_bm25_index');
+SELECT index_size FROM paradedb.index_size('search_idx');
 ```
 
 <ParamField body="index" required>

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -170,7 +170,7 @@ fn text_arrays(mut conn: PgConnection) {
     ('{"another", "array", "of", "texts"}', '{"vtext3", "vtext4", "vtext5"}'),
     ('{"single element"}', '{"single varchar element"}');
     CALL paradedb.create_bm25(
-    	index_name => 'example_table',
+    	index_name => 'example_table_idx',
     	table_name => 'example_table',
     	key_field => 'id',
     	text_fields => paradedb.field('text_array') || paradedb.field('varchar_array')
@@ -207,7 +207,7 @@ fn int_arrays(mut conn: PgConnection) {
     ('{4, 5, 6}', '{300, 400, 500}'),
     ('{7, 8, 9}', '{600, 700, 800, 900}');
     CALL paradedb.create_bm25(
-        index_name => 'example_table',
+        index_name => 'example_table_idx',
         table_name => 'example_table',
         key_field => 'id',
         numeric_fields => paradedb.field('int_array') || paradedb.field('bigint_array')
@@ -238,7 +238,7 @@ fn boolean_arrays(mut conn: PgConnection) {
     ('{false, false, false}'),
     ('{true, true, false}');
     CALL paradedb.create_bm25(
-        index_name => 'example_table',
+        index_name => 'example_table_idx',
         table_name => 'example_table',
         key_field => 'id',
         boolean_fields => paradedb.field('bool_array')
@@ -272,7 +272,7 @@ fn datetime_arrays(mut conn: PgConnection) {
     (ARRAY['2023-03-01'::DATE, '2023-04-01'::DATE], ARRAY['2023-04-01 14:00:00'::TIMESTAMP, '2023-04-01 15:00:00'::TIMESTAMP]),
     (ARRAY['2023-05-01'::DATE, '2023-06-01'::DATE], ARRAY['2023-06-01 16:00:00'::TIMESTAMP, '2023-06-01 17:00:00'::TIMESTAMP]);
     CALL paradedb.create_bm25(
-        index_name => 'example_table',
+        index_name => 'example_table_idx',
         table_name => 'example_table',
         key_field => 'id',
         datetime_fields => paradedb.field('date_array') || paradedb.field('timestamp_array')
@@ -305,7 +305,7 @@ fn json_arrays(mut conn: PgConnection) {
         .execute(&mut conn);
 
     match "CALL paradedb.create_bm25(
-        index_name => 'example_table',
+        index_name => 'example_table_idx',
         table_name => 'example_table',
         key_field => 'id',
         json_fields => paradedb.field('json_array')
@@ -339,7 +339,7 @@ fn uuid(mut conn: PgConnection) {
     
     -- Ensure that indexing works with UUID present on table.
     CALL paradedb.create_bm25(
-    	index_name => 'uuid_table',
+    	index_name => 'uuid_table_bm25_index',
         table_name => 'uuid_table',
         key_field => 'id',
         text_fields => paradedb.field('some_text')
@@ -350,7 +350,7 @@ fn uuid(mut conn: PgConnection) {
 
     r#"
     CALL paradedb.create_bm25(
-        index_name => 'uuid_table',
+        index_name => 'uuid_table_bm25_index',
         table_name => 'uuid_table',
         key_field => 'id',
         text_fields => paradedb.field('some_text') || paradedb.field('random_uuid')
@@ -1144,7 +1144,7 @@ fn json_range(mut conn: PgConnection) {
     "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');"
         .execute(&mut conn);
     "CALL paradedb.create_bm25(
-        index_name => 'bm25_search',
+        index_name => 'bm25_search_idx',
         schema_name => 'paradedb',
         table_name => 'bm25_search',
         key_field => 'id',
@@ -1198,7 +1198,7 @@ fn json_array_term(mut conn: PgConnection) {
     CALL paradedb.create_bm25(
         table_name => 'colors', 
         schema_name => 'public', 
-        index_name => 'colors', 
+        index_name => 'colors_bm25_index', 
         key_field => 'id',
         json_fields => paradedb.field('colors_json') || paradedb.field('colors_jsonb')
     );

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -214,7 +214,7 @@ fn add_scores_across_joins_issue1753(mut conn: PgConnection) {
     r#"
 CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
 CALL paradedb.create_bm25(
-    	index_name => 'mock_items',
+    	index_name => 'search_idx',
         table_name => 'mock_items',
     	schema_name => 'public',
         key_field => 'id',

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -1820,7 +1820,7 @@ fn schema(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('search_idx_bm25_index')".fetch(&mut conn);
+        "SELECT name, field_type FROM paradedb.schema('search_idx')".fetch(&mut conn);
 
     let expected = vec![
         ("category".to_string(), "Str".to_string()),
@@ -1857,7 +1857,7 @@ fn index_size(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    let size: i64 = "SELECT index_size FROM paradedb.index_size('search_idx_bm25_index')"
+    let size: i64 = "SELECT index_size FROM paradedb.index_size('search_idx')"
         .fetch_one::<(i64,)>(&mut conn)
         .0;
 

--- a/tests/tests/find_var_relation.rs
+++ b/tests/tests/find_var_relation.rs
@@ -28,7 +28,7 @@ fn test_subselect(mut conn: PgConnection) {
         CREATE TABLE test_subselect(id serial8, t text);
         INSERT INTO test_subselect(t) VALUES ('this is a test');
         CALL paradedb.create_bm25(
-            index_name => 'test_subselect',
+            index_name => 'test_subselect_idx',
             table_name => 'test_subselect',
             key_field => 'id',
             text_fields => paradedb.field('t')
@@ -50,7 +50,7 @@ fn test_cte(mut conn: PgConnection) {
         INSERT INTO test_cte(t) VALUES ('beer wine cheese');
         INSERT INTO test_cte(t) VALUES ('beer cheese');
         CALL paradedb.create_bm25(
-            index_name => 'test_cte',
+            index_name => 'test_cte_idx',
             table_name => 'test_cte',
             key_field => 'id',
             text_fields => paradedb.field('t')
@@ -73,7 +73,7 @@ fn test_cte2(mut conn: PgConnection) {
         INSERT INTO test_cte(t) VALUES ('beer wine cheese');
         INSERT INTO test_cte(t) VALUES ('beer cheese');
         CALL paradedb.create_bm25(
-            index_name => 'test_cte',
+            index_name => 'test_cte_idx',
             table_name => 'test_cte',
             key_field => 'id',
             text_fields => paradedb.field('t')
@@ -94,7 +94,7 @@ fn test_plain_relation(mut conn: PgConnection) {
         CREATE TABLE test_plain_relation(id serial8, t text);
         INSERT INTO test_plain_relation(t) VALUES ('beer wine cheese');
         CALL paradedb.create_bm25(
-            index_name => 'test_plain_relation',
+            index_name => 'test_plain_relation_idx',
             table_name => 'test_plain_relation',
             key_field => 'id',
             text_fields => paradedb.field('t')

--- a/tests/tests/fixtures/tables/deliveries.rs
+++ b/tests/tests/fixtures/tables/deliveries.rs
@@ -52,7 +52,7 @@ BEGIN;
     );
 
     CALL paradedb.create_bm25(
-        index_name => 'deliveries',
+        index_name => 'deliveries_idx',
         table_name => 'deliveries',
         key_field => '%s',
         range_fields => 

--- a/tests/tests/fixtures/tables/simple_products.rs
+++ b/tests/tests/fixtures/tables/simple_products.rs
@@ -46,7 +46,7 @@ BEGIN;
     CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CALL paradedb.create_bm25(
-    	index_name => 'bm25_search',
+    	index_name => 'bm25_search_bm25_index',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
         key_field => 'id',

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -36,7 +36,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
         .execute(&mut conn);
 
     match "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config'
     )"
     .execute_result(&mut conn)
@@ -46,7 +46,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     };
 
     match "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    key_field => 'id'
     )"
@@ -57,7 +57,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     };
 
     match "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    key_field => 'id',
 	    invalid_field => '{}'		
@@ -69,7 +69,7 @@ fn invalid_create_bm25(mut conn: PgConnection) {
     };
 
     match "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    key_field => 'id',
 	    numeric_fields => paradedb.field('id')		
@@ -87,7 +87,7 @@ fn prevent_duplicate(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -95,7 +95,7 @@ fn prevent_duplicate(mut conn: PgConnection) {
         .execute(&mut conn);
 
     match "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -139,7 +139,7 @@ async fn drop_column(mut conn: PgConnection) {
         text_fields => paradedb.field('fulltext')
     );
 
-    CALL paradedb.drop_bm25('test_index');
+    DROP INDEX test_index CASCADE;
     ALTER TABLE test_table DROP COLUMN fkey;
     "#
     .execute(&mut conn);
@@ -156,7 +156,7 @@ async fn drop_column(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('test_index_bm25_index')".fetch(&mut conn);
+        "SELECT name, field_type FROM paradedb.schema('test_index')".fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
     assert_eq!(rows[1], ("fulltext".into(), "Str".into()));
@@ -169,7 +169,7 @@ fn default_text_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -177,7 +177,7 @@ fn default_text_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -192,7 +192,7 @@ fn text_field_with_options(mut conn: PgConnection) {
 
     r#"
     CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -201,7 +201,7 @@ fn text_field_with_options(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -216,7 +216,7 @@ fn multiple_text_fields(mut conn: PgConnection) {
 
     r#"
     CALL paradedb.create_bm25(
-	index_name => 'index_config',
+	index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -226,7 +226,7 @@ fn multiple_text_fields(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("category".into(), "Str".into()));
@@ -241,7 +241,7 @@ fn default_numeric_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -250,7 +250,7 @@ fn default_numeric_field(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -264,7 +264,7 @@ fn numeric_field_with_options(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -273,7 +273,7 @@ fn numeric_field_with_options(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -287,7 +287,7 @@ fn default_boolean_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -296,7 +296,7 @@ fn default_boolean_field(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -310,7 +310,7 @@ fn boolean_field_with_options(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -319,7 +319,7 @@ fn boolean_field_with_options(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -333,7 +333,7 @@ fn default_json_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -342,7 +342,7 @@ fn default_json_field(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -356,7 +356,7 @@ fn json_field_with_options(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-	    index_name => 'index_config',
+	    index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -365,7 +365,7 @@ fn json_field_with_options(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("ctid".into(), "U64".into()));
@@ -379,7 +379,7 @@ fn default_datetime_field(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -388,7 +388,7 @@ fn default_datetime_field(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("created_at".into(), "Date".into()));
@@ -403,7 +403,7 @@ fn datetime_field_with_options(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -412,7 +412,7 @@ fn datetime_field_with_options(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("created_at".into(), "Date".into()));
@@ -426,7 +426,7 @@ fn multiple_fields(mut conn: PgConnection) {
     "CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb')"
         .execute(&mut conn);
 
-    "CALL paradedb.create_bm25( index_name => 'index_config',
+    "CALL paradedb.create_bm25( index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -438,7 +438,7 @@ fn multiple_fields(mut conn: PgConnection) {
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> =
-        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_bm25_index')"
+        "SELECT name, field_type FROM paradedb.schema('paradedb.index_config_index')"
             .fetch(&mut conn);
 
     assert_eq!(rows[0], ("category".into(), "Str".into()));
@@ -470,7 +470,7 @@ fn null_values(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25( 
-        index_name => 'index_config',
+        index_name => 'index_config_index',
 	    table_name => 'index_config',
 	    schema_name => 'paradedb',
 	    key_field => 'id',
@@ -507,7 +507,7 @@ fn null_key_field_build(mut conn: PgConnection) {
         .execute(&mut conn);
 
     match "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -517,7 +517,7 @@ fn null_key_field_build(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column 'id' cannot be NULL"
+            "error returned from database: error creating index entries for index 'index_config_index': key_field column 'id' cannot be NULL"
         ),
     };
 }
@@ -529,7 +529,7 @@ fn null_key_field_insert(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -542,7 +542,7 @@ fn null_key_field_insert(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with null key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: error creating index entries for index 'index_config_bm25_index': key_field column 'id' cannot be NULL"
+            "error returned from database: error creating index entries for index 'index_config_index': key_field column 'id' cannot be NULL"
         ),
     };
 }
@@ -555,7 +555,7 @@ fn column_name_camelcase(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'IdName',
@@ -576,7 +576,7 @@ fn multi_index_insert_in_transaction(mut conn: PgConnection) {
     "CREATE TABLE paradedb.index_config1(id INTEGER, description TEXT)".execute(&mut conn);
     "CREATE TABLE paradedb.index_config2(id INTEGER, description TEXT)".execute(&mut conn);
     "CALL paradedb.create_bm25(
-        index_name => 'index_config1',
+        index_name => 'index_config1_index',
         table_name => 'index_config1',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -584,7 +584,7 @@ fn multi_index_insert_in_transaction(mut conn: PgConnection) {
     )"
     .execute(&mut conn);
     "CALL paradedb.create_bm25(
-        index_name => 'index_config2',
+        index_name => 'index_config2_index',
         table_name => 'index_config2',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -605,27 +605,6 @@ fn multi_index_insert_in_transaction(mut conn: PgConnection) {
         "SELECT * FROM paradedb.index_config2 WHERE index_config2 @@@ 'description:item'"
             .fetch(&mut conn);
     assert_eq!(rows.len(), 2);
-}
-
-#[rstest]
-fn index_name_too_long(mut conn: PgConnection) {
-    "CREATE TABLE paradedb.index_config(id INTEGER, description TEXT)".execute(&mut conn);
-    "INSERT INTO paradedb.index_config VALUES (1, 'Item 1'), (2, 'Item 2')".execute(&mut conn);
-
-    match "CALL paradedb.create_bm25(
-        index_name => 'index_config_index_name_is_too_long_and_should_be_truncated',
-        table_name => 'index_config',
-        schema_name => 'paradedb',
-        key_field => 'id',
-        text_fields => paradedb.field('description')
-    )"
-    .execute_result(&mut conn) {
-        Ok(_) => panic!("should fail with index name too long"),
-        Err(err) => assert_eq!(
-            err.to_string(),
-            "error returned from database: identifier index_config_index_name_is_too_long_and_should_be_truncated exceeds maximum allowed length of 52 characters"
-        ),
-    };
 }
 
 #[rstest]
@@ -681,7 +660,7 @@ fn delete_index_deletes_tantivy_files(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'public',
         key_field => 'id',
@@ -690,7 +669,7 @@ fn delete_index_deletes_tantivy_files(mut conn: PgConnection) {
     .execute(&mut conn);
 
     // Ensure the expected directory exists.
-    let index_dir = pg_search_index_directory_path(&mut conn, "index_config_bm25_index");
+    let index_dir = pg_search_index_directory_path(&mut conn, "index_config_index");
     assert!(
         index_dir.exists(),
         "expected index directory to exist at: {:?}",
@@ -698,7 +677,7 @@ fn delete_index_deletes_tantivy_files(mut conn: PgConnection) {
     );
 
     // Delete the index.
-    "DROP INDEX index_config_bm25_index CASCADE".execute(&mut conn);
+    "DROP INDEX index_config_index CASCADE".execute(&mut conn);
 
     // Ensure deletion has worked as expected.
     // Tantivy is a little stubborn about deletion. While the contents of the index
@@ -719,7 +698,7 @@ fn delete_index_aborted_maintains_tantivy_files(mut conn: PgConnection) {
         .execute(&mut conn);
 
     "CALL paradedb.create_bm25(
-        index_name => 'index_config',
+        index_name => 'index_config_index',
         table_name => 'index_config',
         schema_name => 'public',
         key_field => 'id',
@@ -728,7 +707,7 @@ fn delete_index_aborted_maintains_tantivy_files(mut conn: PgConnection) {
     .execute(&mut conn);
 
     // Ensure the expected directory exists.
-    let index_dir = pg_search_index_directory_path(&mut conn, "index_config_bm25_index");
+    let index_dir = pg_search_index_directory_path(&mut conn, "index_config_index");
     assert!(
         index_dir.exists(),
         "expected index directory to exist at: {:?}",
@@ -738,7 +717,7 @@ fn delete_index_aborted_maintains_tantivy_files(mut conn: PgConnection) {
     // Delete the index.
     "DO $$ 
     BEGIN
-        DROP INDEX index_config_bm25_index CASCADE;
+        DROP INDEX index_config_index CASCADE;
         RAISE EXCEPTION 'Aborting the transaction intentionally';
     END $$;"
         .execute_result(&mut conn)

--- a/tests/tests/json.rs
+++ b/tests/tests/json.rs
@@ -55,10 +55,7 @@ fn simple_jsonb_string_array_crash(mut conn: PgConnection) {
     // ensure that we can index top-level json arrays that are strings.
     // Prior to 82fb7126ce6d2368cf19dd4dc6e28915afc5cf1e (PR #1618, <=v0.9.4) this didn't work
 
-    r#"
-    call paradedb.drop_bm25('crash');
-    drop table if exists crash cascade;
-    
+    r#"    
     create table crash
     (
         id serial8,
@@ -69,7 +66,7 @@ fn simple_jsonb_string_array_crash(mut conn: PgConnection) {
     
     call paradedb.create_bm25(
             table_name => 'crash',
-            index_name => 'crash',
+            index_name => 'crash_idx',
             key_field => 'id',
             json_fields => paradedb.field('j', indexed => true, fast => true)
          );

--- a/tests/tests/lindera.rs
+++ b/tests/tests/lindera.rs
@@ -39,7 +39,7 @@ async fn lindera_korean_tokenizer(mut conn: PgConnection) {
         ('박지후', '지역 축제 개최 소식', '이번 주말 지역 축제가 열립니다. 다양한 음식과 공연이 준비되어 있어 기대가 됩니다.');
 
     CALL paradedb.create_bm25(
-    	index_name => 'korean',
+    	index_name => 'korean_idx',
     	table_name => 'korean',
     	key_field => 'id',
         text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('korean_lindera'), record => 'position') ||
@@ -75,7 +75,7 @@ async fn lindera_chinese_tokenizer(mut conn: PgConnection) {
         ('张伟', '篮球比赛回顾', '昨日篮球比赛精彩纷呈，尤其是最后时刻的逆转成为了比赛的亮点。'),
         ('王芳', '本地文化节', '本周末将举行一个地方文化节，预计将有各种食物和表演。');
     CALL paradedb.create_bm25(
-    	index_name => 'chinese',
+    	index_name => 'chinese_idx',
     	table_name => 'chinese',
         key_field => 'id',
         text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('chinese_lindera'), record => 'position') ||
@@ -112,7 +112,7 @@ async fn lindera_japenese_tokenizer(mut conn: PgConnection) {
         ('鈴木一郎', 'サッカー試合レビュー', '昨日のサッカー試合では素晴らしいゴールが見られました。終了間際のドラマチックな展開がハイライトでした。'),
         ('高橋花子', '地元の祭り', '今週末に地元で祭りが開催されます。様々な食べ物とパフォーマンスが用意されています。');
     CALL paradedb.create_bm25(
-    	index_name => 'japanese',
+    	index_name => 'japanese_idx',
     	table_name => 'japanese',
         key_field => 'id',
         text_fields => paradedb.field('author', tokenizer => paradedb.tokenizer('japanese_lindera'), record => 'position') ||

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -1016,7 +1016,7 @@ fn range_term(mut conn: PgConnection) {
     );
 
     CALL paradedb.create_bm25(
-        index_name => 'deliveries',
+        index_name => 'deliveries_idx',
         table_name => 'deliveries',
         key_field => 'delivery_id',
         range_fields => 

--- a/tests/tests/query_json.rs
+++ b/tests/tests/query_json.rs
@@ -1178,7 +1178,7 @@ fn range_term(mut conn: PgConnection) {
     );
 
     CALL paradedb.create_bm25(
-        index_name => 'deliveries',
+        index_name => 'deliveries_idx',
         table_name => 'deliveries',
         key_field => 'delivery_id',
         range_fields => 

--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -208,7 +208,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
     // Create the bm25 index on the description field
     "CALL paradedb.create_bm25(
         table_name => 'mock_items',
-        index_name => 'mock_items',
+        index_name => 'search_idx',
         schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')
@@ -216,7 +216,7 @@ async fn test_ephemeral_postgres() -> Result<()> {
     .execute(&mut source_conn);
     "CALL paradedb.create_bm25(
         table_name => 'mock_items',
-        index_name => 'mock_items',
+        index_name => 'search_idx',
         schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')
@@ -365,7 +365,7 @@ async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
 
     "CALL paradedb.create_bm25(
         table_name => 'text_array_table',
-        index_name => 'text_array_table',
+        index_name => 'text_array_table_idx',
         schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('text_array')
@@ -465,7 +465,7 @@ async fn test_replication_with_pg_search_only_on_replica() -> Result<()> {
     // Create the bm25 index on the description field on the replica
     "CALL paradedb.create_bm25(
         table_name => 'mock_items',
-        index_name => 'mock_items',
+        index_name => 'search_idx',
         schema_name => 'public',
         key_field => 'id',
         text_fields => paradedb.field('description')

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -224,7 +224,7 @@ fn default_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-    	index_name => 'tokenizer_config',
+    	index_name => 'tokenizer_config_idx',
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
@@ -246,7 +246,7 @@ fn en_stem_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-    	index_name => 'tokenizer_config',
+    	index_name => 'tokenizer_config_idx',
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
@@ -268,7 +268,7 @@ fn ngram_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-    	index_name => 'tokenizer_config',
+    	index_name => 'tokenizer_config_idx',
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
@@ -292,7 +292,7 @@ fn chinese_compatible_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-    	index_name => 'tokenizer_config',
+    	index_name => 'tokenizer_config_idx',
     	table_name => 'tokenizer_config',
     	schema_name => 'paradedb',
     	key_field => 'id',
@@ -316,7 +316,7 @@ fn whitespace_tokenizer_config(mut conn: PgConnection) {
     CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CALL paradedb.create_bm25(
-    	index_name => 'bm25_search',
+    	index_name => 'bm25_search_idx',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
         key_field => 'id',
@@ -350,7 +350,7 @@ fn lowercase_tokenizer_config(mut conn: PgConnection) {
     CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CALL paradedb.create_bm25(
-    	index_name => 'bm25_search',
+    	index_name => 'bm25_search_idx',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
         key_field => 'id',
@@ -378,7 +378,7 @@ fn raw_tokenizer_config(mut conn: PgConnection) {
     CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
     CALL paradedb.create_bm25(
-    	index_name => 'bm25_search',
+    	index_name => 'bm25_search_idx',
         table_name => 'bm25_search',
     	schema_name => 'paradedb',
         key_field => 'id',
@@ -412,7 +412,7 @@ fn regex_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CALL paradedb.create_bm25(
-        index_name => 'bm25_search',
+        index_name => 'bm25_search_idx',
         table_name => 'bm25_search',
         schema_name => 'paradedb',
         key_field => 'id',
@@ -494,7 +494,7 @@ fn language_stem_tokenizer_deprecated(mut conn: PgConnection) {
         assert_eq!(row.0, 3);
 
         r#"
-        CALL paradedb.drop_bm25('stem_test');
+        DROP INDEX IF EXISTS stem_test;
         DROP TABLE IF EXISTS test_table;
         "#
         .execute(&mut conn);
@@ -553,7 +553,7 @@ fn language_stem_filter(mut conn: PgConnection) {
         assert_eq!(row.0, 3);
 
         r#"
-        CALL paradedb.drop_bm25('stem_test');
+        DROP INDEX IF EXISTS stem_test;
         DROP TABLE IF EXISTS test_table;
         "#
         .execute(&mut conn);

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -31,7 +31,7 @@ fn sort_by_lower(mut conn: PgConnection) {
         CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
         CALL paradedb.create_bm25(
-            index_name => 'bm25_search',
+            index_name => 'bm25_search_idx',
             table_name => 'bm25_search',
             schema_name => 'paradedb',
             key_field => 'id',
@@ -64,7 +64,7 @@ fn sort_by_raw(mut conn: PgConnection) {
         CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
         CALL paradedb.create_bm25(
-            index_name => 'bm25_search',
+            index_name => 'bm25_search_idx',
             table_name => 'bm25_search',
             schema_name => 'paradedb',
             key_field => 'id',
@@ -97,7 +97,7 @@ fn sort_by_row_return_scores(mut conn: PgConnection) {
         CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
 
         CALL paradedb.create_bm25(
-            index_name => 'bm25_search',
+            index_name => 'bm25_search_idx',
             table_name => 'bm25_search',
             schema_name => 'paradedb',
             key_field => 'id',


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Now that the dynamic schemas are gone, we can stop appending `bm25_index` to the Postgres index names, which was a footgun to users trying to run ALTER/DROP/etc. on the index.

This should have no effect to existing indexes.

## Why

## How

- Also removed the unused `uuid` option
- Removed the "max 53 character index name" check. This was necessary because we were manipulating the index name, but now we can let Postgres handle the index name (by default, Postgres truncates at 63 characters).

## Tests
