### PR TITLE
Introducing ParadeDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [![License](https://img.shields.io/github/license/paradedb/paradedb?color=blue)](https://github.com/paradedb/paradedb?tab=AGPL-3.0-1-ov-file#readme)
 [![Slack URL](https://img.shields.io/badge/Join%20Slack-purple?logo=slack&link=https%3A%2F%2Fjoin.slack.com%2Ft%2Fparadedbcommunity%2Fshared_invite%2Fzt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ)](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ)
 [![X URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Ftwitter.com%2Fparadedb&label=Follow%20%40paradedb)](https://x.com/paradedb)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ParadeDB%20Guru-006BFF)](https://gurubase.io/g/paradedb)
 
 [ParadeDB](https://paradedb.com) is an Elasticsearch alternative built on Postgres. We're modernizing the features of Elasticsearch's product suite, starting with real-time search and analytics.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ParadeDB Guru](https://gurubase.io/g/paradedb) to Gurubase. ParadeDB Guru uses the data from this repo and data from the [docs](https://docs.paradedb.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "ParadeDB Guru", which highlights that ParadeDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ParadeDB Guru in Gurubase, just let me know that's totally fine.
