### PR TITLE
chore: make SpinLock public

### DIFF
--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -20,7 +20,7 @@ use std::ptr::addr_of_mut;
 
 #[derive(Debug)]
 #[repr(transparent)]
-struct Spinlock(pg_sys::slock_t);
+pub struct Spinlock(pg_sys::slock_t);
 
 impl Spinlock {
     #[inline(always)]
@@ -30,7 +30,7 @@ impl Spinlock {
 }
 
 #[repr(transparent)]
-struct AcquiredSpinLock(*mut pg_sys::slock_t);
+pub struct AcquiredSpinLock(*mut pg_sys::slock_t);
 
 impl AcquiredSpinLock {
     fn new(lock: &mut Spinlock) -> Self {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Makes our little `SpinLock` wrapper `pub` so it can be used elsewhere.

## Why

To avoid code duplication.

## How

## Tests

n/a