### PR TITLE
feat: Expose the position of highlights in snippets

### DIFF
--- a/docs/documentation/full-text/highlighting.mdx
+++ b/docs/documentation/full-text/highlighting.mdx
@@ -46,3 +46,24 @@ FROM mock_items
 WHERE description @@@ 'shoes'
 LIMIT 5;
 ```
+
+## Snippet Positions
+
+`paradedb.snippet_positions(<column>)` is used to return the start position and length of the highlighted snippet.
+
+```sql
+SELECT id, paradedb.snippet_positions(description)
+FROM mock_items
+WHERE description @@@ 'shoes'
+LIMIT 5;
+```
+
+<ParamField body="start_tag" default="<b>">
+  The leading indicator around the highlighted region.
+</ParamField>
+<ParamField body="end_tag" default="</b>">
+  The trailing indicator around the highlighted region.
+</ParamField>
+<ParamField body="max_num_chars" default={150}>
+  Max number of characters for a highlighted fragment.
+</ParamField>

--- a/docs/documentation/full-text/highlighting.mdx
+++ b/docs/documentation/full-text/highlighting.mdx
@@ -58,12 +58,6 @@ WHERE description @@@ 'shoes'
 LIMIT 5;
 ```
 
-<ParamField body="start_tag" default="<b>">
-  The leading indicator around the highlighted region.
-</ParamField>
-<ParamField body="end_tag" default="</b>">
-  The trailing indicator around the highlighted region.
-</ParamField>
 <ParamField body="max_num_chars" default={150}>
   Max number of characters for a highlighted fragment.
 </ParamField>

--- a/pg_search/sql/pg_search--0.10.3--0.11.0.sql
+++ b/pg_search/sql/pg_search--0.10.3--0.11.0.sql
@@ -83,6 +83,19 @@ CREATE  FUNCTION "snippet"(
     STRICT STABLE PARALLEL SAFE
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'snippet_from_relation_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs:58
+-- pg_search::postgres::customscan::pdbscan::projections::snippet::snippet_positions
+CREATE  FUNCTION \\"snippet_positions\\"(
+    "field\\" anyelement, /* pgrx::datum::anyelement::AnyElement */
+		"start_tag\\" TEXT DEFAULT \'<b>\', /* alloc::string::String */
+    "end_tag\\" TEXT DEFAULT \'</b>\', /* alloc::string::String */
+    "max_num_chars\\" INT DEFAULT 150 /* i32 */
+) RETURNS INT[] /* core::option::Option<alloc::vec::Vec<i32>> */
+    STRICT STABLE PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'snippet_position_from_relation_wrapper';
 DROP FUNCTION IF EXISTS term(field text, value anyarray);
 CREATE OR REPLACE FUNCTION term(field fieldname, value anyarray DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'anyarray_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS term(field text, value date);

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -657,7 +657,7 @@ impl CustomScan for PdbScan {
                                     {
                                         if let Some(snippet) = state
                                             .custom_state()
-                                            .make_snippet(doc_address, snippet_info)
+                                            .make_snippet_positions(doc_address, snippet_info)
                                         {
                                             (**const_snippet_positions_nodes).constvalue =
                                                 snippet.into_datum().unwrap();

--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -24,6 +24,7 @@ use crate::postgres::customscan::pdbscan::projections::score::score_funcoid;
 use crate::postgres::customscan::pdbscan::projections::snippet::{snippet_funcoid, SnippetInfo};
 use pgrx::pg_sys::expression_tree_walker;
 use pgrx::{pg_extern, pg_guard, pg_sys, Internal, PgList};
+use snippet::snippet_positions_funcoid;
 use std::collections::HashMap;
 use std::ptr::{addr_of_mut, NonNull};
 use tantivy::snippet::SnippetGenerator;
@@ -91,6 +92,7 @@ pub unsafe fn maybe_needs_const_projections(node: *mut pg_sys::Node) -> bool {
             let data = &*data.cast::<Data>();
             if (*funcexpr).funcid == data.score_funcoid
                 || (*funcexpr).funcid == data.snipped_funcoid
+                || (*funcexpr).funcid == data.snipped_positions_funcoid
             {
                 return true;
             }
@@ -102,11 +104,13 @@ pub unsafe fn maybe_needs_const_projections(node: *mut pg_sys::Node) -> bool {
     struct Data {
         score_funcoid: pg_sys::Oid,
         snipped_funcoid: pg_sys::Oid,
+        snipped_positions_funcoid: pg_sys::Oid,
     }
 
     let mut data = Data {
         score_funcoid: score_funcoid(),
         snipped_funcoid: snippet_funcoid(),
+        snipped_positions_funcoid: snippet_positions_funcoid(),
     };
 
     let data = addr_of_mut!(data).cast();

--- a/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
@@ -143,7 +143,7 @@ pub unsafe fn uses_snippets(
                         max_num_chars: max_num_chars_arg as usize,
                     });
                 } else {
-                    panic!("`paradedb.snippet()`' or `paradedb.snippet_positions()`' arguments must be literals");
+                    panic!("`paradedb.snippet()` or `paradedb.snippet_positions()`'s arguments must be literals");
                 }
             }
         }

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -443,6 +443,17 @@ fn full_text_search(mut conn: PgConnection) {
     assert!(rows[0].1.contains("<i>"));
     assert!(rows[0].1.contains("</i>"));
 
+    let rows: Vec<(i32, [i32; 2])> = r#"
+    SELECT id, paradedb.snippet_positions(description, start_tag => '<i>', end_tag => '</i>')
+    FROM mock_items
+    WHERE description @@@ 'shoes'
+    LIMIT 5
+    "#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].1, [14, 5]);
+    assert_eq!(rows[1].1, [8, 5]);
+
     // Order by score
     let rows: Vec<(String, i32, String, f32)> = r#"
         SELECT description, rating, category, paradedb.score(id)

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -444,7 +444,7 @@ fn full_text_search(mut conn: PgConnection) {
     assert!(rows[0].1.contains("</i>"));
 
     let rows: Vec<(i32, [i32; 2])> = r#"
-    SELECT id, paradedb.snippet_positions(description, start_tag => '<i>', end_tag => '</i>')
+    SELECT id, paradedb.snippet_positions(description)
     FROM mock_items
     WHERE description @@@ 'shoes'
     ORDER BY id

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -447,12 +447,14 @@ fn full_text_search(mut conn: PgConnection) {
     SELECT id, paradedb.snippet_positions(description, start_tag => '<i>', end_tag => '</i>')
     FROM mock_items
     WHERE description @@@ 'shoes'
+    ORDER BY id
     LIMIT 5
     "#
     .fetch(&mut conn);
     assert_eq!(rows.len(), 3);
     assert_eq!(rows[0].1, [14, 5]);
-    assert_eq!(rows[1].1, [8, 5]);
+    assert_eq!(rows[1].1, [14, 5]);
+    assert_eq!(rows[2].1, [8, 5]);
 
     // Order by score
     let rows: Vec<(String, i32, String, f32)> = r#"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1778

## What
```sql
pg_search=# 
SELECT id, paradedb.snippet_positions(description)
    FROM mock_items
    WHERE description @@@ 'shoes'
    LIMIT 5;
 id | snippet_positions 
----+-------------------
  4 | {14,5}
  3 | {14,5}
  5 | {8,5}
(3 rows)
```
## Why

## How

## Tests
Yes
