### PR TITLE
fix: move merging to foreground on CREATE INDEX

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -6,28 +6,38 @@ use tantivy::SegmentMeta;
 ///
 /// It merges the smallest segments, accounting for deleted docs.
 #[derive(Debug)]
-pub struct NPlusOneMergePolicy(pub usize);
+pub struct NPlusOneMergePolicy {
+    // the number of segments we want to maintain on disk
+    pub n: usize,
+
+    // the minimum number of segments to merge together
+    // if we don't have this many, no merge is performed
+    pub min_num_segments: usize,
+}
 
 impl MergePolicy for NPlusOneMergePolicy {
     fn compute_merge_candidates(&self, segments: &[SegmentMeta]) -> Vec<MergeCandidate> {
-        let n = self.0;
+        let n = self.n;
+        let min_num_segments = self.min_num_segments;
 
-        if segments.len() <= n + 1 {
-            // nothing to merge, we have N+1 or fewer segments
+        if segments.len() < n + min_num_segments {
             return vec![];
         }
 
         // collect a list of the segments and sort them largest-to-smallest, by # of alive docs
-        let mut metas = segments.iter().collect::<Vec<_>>();
-        metas.sort_unstable_by(|a, b| a.num_docs().cmp(&b.num_docs()).reverse());
+        let mut segments = segments.iter().collect::<Vec<_>>();
+        segments.sort_unstable_by(|a, b| a.num_docs().cmp(&b.num_docs()).reverse());
 
         let mut candidate = MergeCandidate(vec![]);
-        while metas.len() > n {
-            let meta = metas.pop().unwrap();
+        while segments.len() > n {
+            let meta = segments.pop().unwrap();
             candidate.0.push(meta.id());
         }
 
-        assert!(candidate.0.len() > 1, "decided to merge only 1 segment");
+        if candidate.0.len() < 2 {
+            // nothing worth merging
+            return vec![];
+        }
 
         vec![candidate]
     }

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -263,7 +263,36 @@ fn do_heap_scan<'a>(
             Some(build_callback),
             &mut state,
         );
+
+        let insert_state = init_insert_state(
+            index_relation.as_ptr(),
+            index_info,
+            WriterResources::CreateIndex,
+        );
+        if let Some(mut writer) = (*insert_state).writer.take() {
+            writer
+                .commit()
+                .unwrap_or_else(|e| panic!("failed to commit new tantivy index: {e}"));
+            pgrx::warning!(
+                "waiting for merge: currently have {} segments",
+                writer
+                    .underlying_writer
+                    .as_ref()
+                    .unwrap()
+                    .index()
+                    .searchable_segments()
+                    .unwrap()
+                    .len()
+            );
+            writer
+                .underlying_writer
+                .take()
+                .unwrap()
+                .wait_merging_threads()
+                .unwrap_or_else(|e| panic!("failed to wait for index merge: {e}"));
+        }
     }
+
     state
 }
 
@@ -299,7 +328,10 @@ unsafe fn build_callback_internal(
         WriterResources::CreateIndex,
     );
     let search_index = &(*insert_state).index;
-    let writer = &(*insert_state).writer;
+    let writer = (*insert_state)
+        .writer
+        .as_ref()
+        .expect("InsertState::writer should be set");
     let schema = &(*insert_state).index.schema;
 
     // In the block below, we switch to the memory context we've defined on our build

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -273,17 +273,6 @@ fn do_heap_scan<'a>(
             writer
                 .commit()
                 .unwrap_or_else(|e| panic!("failed to commit new tantivy index: {e}"));
-            pgrx::warning!(
-                "waiting for merge: currently have {} segments",
-                writer
-                    .underlying_writer
-                    .as_ref()
-                    .unwrap()
-                    .index()
-                    .searchable_segments()
-                    .unwrap()
-                    .len()
-            );
             writer
                 .underlying_writer
                 .take()

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -273,6 +273,7 @@ fn do_heap_scan<'a>(
             writer
                 .commit()
                 .unwrap_or_else(|e| panic!("failed to commit new tantivy index: {e}"));
+
             writer
                 .underlying_writer
                 .take()

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -37,12 +37,12 @@ impl Drop for InsertState {
         unsafe {
             if let Some(mut writer) = self.writer.take() {
                 pgrx_extern_c_guard(|| {
-                    if !pg_sys::IsAbortedTransactionBlockState() && !self.abort_on_drop {
+                    if pg_sys::IsTransactionState() && !self.abort_on_drop {
                         writer
                             .commit()
                             .expect("tantivy index commit should succeed");
                     } else if let Err(e) = writer.abort() {
-                        if pg_sys::IsAbortedTransactionBlockState() {
+                        if !pg_sys::IsTransactionState() {
                             // we're in an aborted state, so the best we can do is warn that our
                             // attempt to abort the tantivy changes failed
                             pgrx::warning!("failed to abort tantivy index changes: {}", e);

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -37,12 +37,12 @@ impl Drop for InsertState {
         unsafe {
             if let Some(mut writer) = self.writer.take() {
                 pgrx_extern_c_guard(|| {
-                    if pg_sys::IsTransactionState() && !self.abort_on_drop {
+                    if !pg_sys::IsAbortedTransactionBlockState() && !self.abort_on_drop {
                         writer
                             .commit()
                             .expect("tantivy index commit should succeed");
                     } else if let Err(e) = writer.abort() {
-                        if !pg_sys::IsTransactionState() {
+                        if pg_sys::IsAbortedTransactionBlockState() {
                             // we're in an aborted state, so the best we can do is warn that our
                             // attempt to abort the tantivy changes failed
                             pgrx::warning!("failed to abort tantivy index changes: {}", e);

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -51,3 +51,36 @@ fn create_and_drop_builtin_index(mut conn: PgConnection) {
 
     "DROP TABLE IF EXISTS test_table CASCADE".execute(&mut conn);
 }
+
+/// Tests that CREATE INDEX and REINDEX and VACUUM merge down to the proper number of segments, based on our
+/// [`NPlusOne`] merge policy
+#[rstest]
+fn segment_count_correct_after_merge(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO test_table (value) SELECT md5(random()::text) FROM generate_series(1, 10000);
+        CALL paradedb.create_bm25(table_name => 'test_table', schema_name => 'public', index_name => 'idxtest_table', key_field => 'id', text_fields => paradedb.field('value'));
+    "#.execute(&mut conn);
+    let nsegments = "SELECT COUNT(*) FROM paradedb.index_info('idxtest_table');"
+        .fetch_one::<(i64,)>(&mut conn)
+        .0 as usize;
+    assert_eq!(nsegments, 8); // '8' is our default value for `paradedb.create_index_parallelism` GUC
+
+    // we now want to target just 2 segments
+    "ALTER INDEX idxtest_table SET (target_segment_count = 2);".execute(&mut conn);
+
+    // reindexing should actually get us 3 segments because our policy is N+1
+    "REINDEX INDEX idxtest_table;".execute(&mut conn);
+    let nsegments = "SELECT COUNT(*) FROM paradedb.index_info('idxtest_table');"
+        .fetch_one::<(i64,)>(&mut conn)
+        .0 as usize;
+    assert_eq!(nsegments, 3);
+
+    // same thing here.  do full table update and then VACUUM should get us back to 2+1 segments
+    "UPDATE test_table SET value = value || ' ';".execute(&mut conn);
+    "VACUUM test_table;".execute(&mut conn);
+    let nsegments = "SELECT COUNT(*) FROM paradedb.index_info('idxtest_table');"
+        .fetch_one::<(i64,)>(&mut conn)
+        .0 as usize;
+    assert_eq!(nsegments, 3);
+}

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -75,12 +75,4 @@ fn segment_count_correct_after_merge(mut conn: PgConnection) {
         .fetch_one::<(i64,)>(&mut conn)
         .0 as usize;
     assert_eq!(nsegments, 3);
-
-    // same thing here.  do full table update and then VACUUM should get us back to 2+1 segments
-    "UPDATE test_table SET value = value || ' ';".execute(&mut conn);
-    "VACUUM test_table;".execute(&mut conn);
-    let nsegments = "SELECT COUNT(*) FROM paradedb.index_info('idxtest_table');"
-        .fetch_one::<(i64,)>(&mut conn)
-        .0 as usize;
-    assert_eq!(nsegments, 3);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This moves the tantivy index commit to the end of `do_heap_scan()` and then immediately asks tantivy to wait for the merge threads, there in the foreground.

## Why

At least during CREATE INDEX or REINDEX, if we don't wait in the foreground for the merge to finish, an index over a large table could have an untenable amount of segments.

## How

## Tests

There's a new test to make sure we get the proper segment count in all cases.
