### PR TITLE
docs: fix parallel scan docs

### DIFF
--- a/docs/documentation/aggregates/overview.mdx
+++ b/docs/documentation/aggregates/overview.mdx
@@ -112,9 +112,25 @@ GROUP BY description LIMIT 5;
 ```
 </Accordion>
 
-## Caveats
+## Performance Tuning
 
 In addition to configuring fast fields, there are several other important factors that optimize aggregate performance.
+
+### Parallel Workers
+
+If the table is large enough, ParadeDB can invoke a parallel scan for certain aggregate queries.
+
+```sql
+-- This will invoke a parallel scan if mock_items becomes very large
+SELECT COUNT(*) FROM mock_items
+WHERE description @@@ 'shoes';
+```
+
+If a parallel scan was invoked, a `Parallel Index Only Scan` will appear in the query's `EXPLAIN` output.
+
+By default, Postgres allows `2` workers per parallel query. Increasing the number of [parallel workers](/documentation/configuration/parallel)
+allows parallel queries to use all of the available hardware on the host machine and can deliver significant
+speedups.
 
 ### Predicates
 
@@ -148,24 +164,6 @@ Running `VACUUM` over the table updates its visibility map. This can be automate
 ```sql
 VACUUM mock_items;
 ```
-
-### Parallel Scan Workers
-
-If the table is large enough, ParadeDB can invoke a parallel index-only scan for queries that return only a `COUNT(*)`.
-
-```sql
--- This will invoke a parallel scan if mock_items becomes very large
-SELECT COUNT(*) FROM mock_items
-WHERE description @@@ 'shoes';
-
--- This will not invoke a parallel scan
-SELECT rating, COUNT(*) FROM mock_items
-WHERE description @@@ 'shoes'
-GROUP BY rating LIMIT 5;
-```
-
-If a parallel scan was invoked, a `Parallel Index Only Scan` will appear in the query's `EXPLAIN` output. Tuning Postgres' [parallel worker settings](/documentation/configuration/parallel)
-can further accelerate parallel scans.
 
 ### Text Fast Fields
 

--- a/docs/documentation/configuration/parallel.mdx
+++ b/docs/documentation/configuration/parallel.mdx
@@ -3,20 +3,26 @@ title: Parallel Scans
 ---
 
 The BM25 index supports parallel scans. You can check if the Postgres query planner chose a parallel scan by running `EXPLAIN` on a query.
-There are a few Postgres settings that can tune the performance of parallel scans.
+The following Postgres settings must be configured to increase the number of parallel workers.
 
-## Max Worker Processes
+## Max Parallel Workers
 
-`max_worker_processes` is a global limit for the number of available background workers across all connections. The default is `8`.
-This setting must be changed inside `postgresql.conf`, and Postgres needs to be restarted afterward.
+`max_parallel_workers` and `max_worker_processes` control how many workers are available to parallel scans.
+`max_worker_processes` is a global limit for the number of available workers across all connections, and
+`max_parallel_workers` specifies how many of those workers can be used for parallel scans.
+
+These settings must be changed inside `postgresql.conf`, and Postgres needs to be restarted afterward.
 
 ```init postgresql.conf
 max_worker_processes = 16;
+max_parallel_workers = 16;
 ```
 
 ## Max Parallel Workers per Gather
 
 `max_parallel_workers_per_gather` is a limit for the number of parallel workers that a single parallel query can use. The default is `2`.
+This setting can be set in `postgresql.conf` to apply to all connections, or within a connection to apply to a single
+session.
 
 ```sql
 SET max_parallel_workers_per_gather = 16;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The docs failed to mention that users also need to set `max_parallel_workers` to increase query parallelism.

## Why

## How

## Tests
