### PR TITLE
feat: Support indexing enums

### DIFF
--- a/docs/documentation/advanced/compound/parse.mdx
+++ b/docs/documentation/advanced/compound/parse.mdx
@@ -188,3 +188,28 @@ WHERE id @@@
 }'::jsonb;
 ```
 </CodeGroup>
+
+## Enumerated Types
+
+To query a custom [enum](/documentation/indexing/create_index#enumerated-types) with `paradedb.parse`, the
+underlying ordinal value must be used.
+
+<CodeGroup>
+```sql Function Syntax
+-- Assume we have indexed an enum called color and 'red' has an ordinal of 1.0
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@ paradedb.parse('color:1.0');
+```
+```sql JSON Syntax
+-- Assume we have indexed an enum called color and 'red' has an ordinal of 1.0
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@
+'{
+    "parse": {
+        "query_string": "color:1.0"
+    }
+}'::jsonb;
+```
+</CodeGroup>

--- a/docs/documentation/advanced/term/term.mdx
+++ b/docs/documentation/advanced/term/term.mdx
@@ -55,3 +55,29 @@ WHERE id @@@
 }'::jsonb;
 ```
 </CodeGroup>
+
+## Enumerated Types
+
+`term` can be used to filter over custom Postgres [enums](/documentation/indexing/create_index#enumerated-types)
+if the query term is explicitly cast to the enum type. If JSON syntax is used, the underlying ordinal value of the enum must be used.
+
+<CodeGroup>
+```sql Function Syntax
+-- Assume we have indexed an enum called color
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@ paradedb.term('color', 'red'::color);
+```
+```sql JSON Syntax
+-- Assume we have indexed an enum called color and 'red' has an ordinal of 1.0
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@
+'{
+    "term": {
+        "field": "color",
+        "value": 1.0
+    }
+}'::jsonb;
+```
+</CodeGroup>

--- a/docs/documentation/indexing/create_index.mdx
+++ b/docs/documentation/indexing/create_index.mdx
@@ -268,6 +268,30 @@ CALL paradedb.create_bm25(
   Whether the original value of the field is stored.
 </ParamField>
 
+### Enumerated Types
+
+Custom Postgres [enums](https://www.postgresql.org/docs/current/datatype-enum.html) should be indexed as `numeric_fields`.
+This is because enums are stored as float values in Postgres.
+
+```sql
+CREATE TYPE color AS ENUM ('red', 'green', 'blue');
+ALTER TABLE mock_items ADD COLUMN color color;
+
+CALL paradedb.create_bm25(
+  index_name => 'search_idx',
+  table_name => 'mock_items',
+  key_field => 'id',
+  numeric_fields => paradedb.field('color')
+);
+```
+
+Enums should be queried with [term queries](/documentation/advanced/term/term).
+
+<Note>
+If the ordering of the enum is changed with `ADD VALUE ... [ BEFORE | AFTER ]`, the BM25 index should be dropped
+and recreated to account for the new enum ordinal values.
+</Note>
+
 ### Multiple Fields
 
 The `||` operator can be used to index multiple fields.

--- a/pg_search/sql/pg_search--0.12.0--0.12.1.sql
+++ b/pg_search/sql/pg_search--0.12.0--0.12.1.sql
@@ -1,1 +1,11 @@
 ALTER TYPE TestTable ADD VALUE 'Customers';
+
+-- pg_search/src/api/index.rs:580
+-- pg_search::api::index::term
+CREATE  FUNCTION "term"(
+	"field" FieldName, /* pg_search::api::index::FieldName */
+	"value" anyenum /* pg_search::schema::anyenum::AnyEnum */
+) RETURNS SearchQueryInput /* pg_search::query::SearchQueryInput */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'term_anyenum_wrapper';

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -582,7 +582,6 @@ pub fn term_anyenum(field: FieldName, value: AnyEnum) -> SearchQueryInput {
     let tantivy_value = TantivyValue::try_from(value)
         .expect("value should be a valid TantivyValue representation")
         .tantivy_schema_value();
-    pgrx::info!("TantivyValue: {:?}", tantivy_value);
     let is_datetime = matches!(tantivy_value, OwnedValue::Date(_));
 
     SearchQueryInput::Term {
@@ -626,7 +625,6 @@ term_fn!(time_with_time_zone, pgrx::datum::TimeWithTimeZone);
 term_fn!(timestamp_with_time_zome, pgrx::datum::TimestampWithTimeZone);
 term_fn!(numeric, pgrx::AnyNumeric);
 term_fn!(uuid, pgrx::Uuid);
-// term_fn!(anyenum, AnyEnum);
 term_fn_unsupported!(json, pgrx::Json, "json");
 term_fn_unsupported!(jsonb, pgrx::JsonB, "jsonb");
 term_fn_unsupported!(anyarray, pgrx::AnyArray, "array");

--- a/pg_search/src/schema/anyenum.rs
+++ b/pg_search/src/schema/anyenum.rs
@@ -1,0 +1,69 @@
+use crate::pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+use pgrx::*;
+use std::ffi::CStr;
+use std::fmt::{Display, Formatter};
+
+pub struct AnyEnum {
+    datum: pg_sys::Datum,
+    typoid: pg_sys::Oid,
+}
+
+impl FromDatum for AnyEnum {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        typoid: pg_sys::Oid,
+    ) -> Option<Self> {
+        if is_null {
+            None
+        } else {
+            Some(AnyEnum { datum, typoid })
+        }
+    }
+}
+
+unsafe impl SqlTranslatable for AnyEnum {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::As("anyenum".into()))
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("anyenum")))
+    }
+}
+
+unsafe impl<'fcx> callconv::ArgAbi<'fcx> for AnyEnum
+where
+    Self: 'fcx,
+{
+    unsafe fn unbox_arg_unchecked(arg: callconv::Arg<'_, 'fcx>) -> Self {
+        let index = arg.index();
+        unsafe {
+            arg.unbox_arg_using_from_datum()
+                .unwrap_or_else(|| panic!("argument {index} must not be null"))
+        }
+    }
+}
+
+impl Display for AnyEnum {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        unsafe {
+            let strval = pg_sys::OidOutputFunctionCall(self.typoid, self.datum);
+            CStr::from_ptr(strval).to_str().unwrap().fmt(f)
+        }
+    }
+}
+
+impl AnyEnum {
+    pub fn ordinal(&self) -> Option<f32> {
+        match unsafe { pg_sys::Oid::from_datum(self.datum, self.datum.is_null()) } {
+            Some(oid) => {
+                let (_, _, ordinal) = enum_helper::lookup_enum_by_oid(oid);
+                Some(ordinal)
+            }
+            None => None,
+        }
+    }
+}

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -91,6 +91,13 @@ impl TryFrom<&PgOid> for SearchFieldType {
                 | PgBuiltInOids::TIMETZOID => Ok(SearchFieldType::Date),
                 _ => Err(SearchIndexSchemaError::InvalidPgOid(*pg_oid)),
             },
+            PgOid::Custom(custom) => {
+                if unsafe { pgrx::pg_sys::type_is_enum(*custom) } {
+                    Ok(SearchFieldType::Text)
+                } else {
+                    Err(SearchIndexSchemaError::InvalidPgOid(*pg_oid))
+                }
+            }
             _ => Err(SearchIndexSchemaError::InvalidPgOid(*pg_oid)),
         }
     }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod anyenum;
 mod document;
 pub mod range;
 
@@ -34,6 +35,7 @@ use thiserror::Error;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 
 use crate::query::AsFieldType;
+pub use anyenum::AnyEnum;
 
 /// The id of a field, stored in the index.
 #[derive(Debug, Clone, Display, From, AsRef, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -93,7 +95,7 @@ impl TryFrom<&PgOid> for SearchFieldType {
             },
             PgOid::Custom(custom) => {
                 if unsafe { pgrx::pg_sys::type_is_enum(*custom) } {
-                    Ok(SearchFieldType::Text)
+                    Ok(SearchFieldType::F64)
                 } else {
                     Err(SearchIndexSchemaError::InvalidPgOid(*pg_oid))
                 }

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -746,13 +746,14 @@ fn custom_enum(mut conn: PgConnection) {
         table_name => 'index_config',
         schema_name => 'paradedb',
         key_field => 'id',
-        text_fields => paradedb.field('description') || paradedb.field('color')
+        text_fields => paradedb.field('description'),
+        numeric_fields => paradedb.field('color')
     )
     "#
     .execute(&mut conn);
 
     let rows: Vec<(i32, String)> =
-        "SELECT id, description FROM paradedb.index_config WHERE color @@@ 'red'".fetch(&mut conn);
+        "SELECT id, description FROM paradedb.index_config WHERE id @@@ paradedb.term('color', 'red'::color)".fetch(&mut conn);
 
     assert_eq!(rows, vec![(1, "Item 1".into())]);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Supports indexing enums as `numeric_fields`.

## Why

Enums can be used as filter conditions.

## How

We extract and index the enum ordinal value.

## Tests

See `custom_enum` test.