### PR TITLE
ci: Split publishing per-OS and add support for macOS and Ubuntu 20.04

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -1,11 +1,11 @@
-# workflows/publish-paradedb.yml
+# workflows/publish-paradedb-docker.yml
 #
-# Publish ParadeDB
+# Publish ParadeDB (Docker)
 # Publish ParadeDB as a Docker image to Docker Hub and as a Helm Chart to paradedb.github.io via our
 # `paradedb/charts` repository. This workflow only runs after a GitHub Release gets created, which
 # happens once we merge to `main`.
 
-name: Publish ParadeDB
+name: Publish ParadeDB (Docker)
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
         default: ""
 
 concurrency:
-  group: publish-paradedb-${{ github.head_ref || github.ref }}
+  group: publish-paradedb-docker-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 # Used by actions/attest-build-provenance to sign the builds

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -27,14 +27,14 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on Debian 12 (Bookworm) ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
     strategy:
       matrix:
         include:
-          # Debian 12
+          # Debian 12 (Bookworm)
           - runner: ubicloud-standard-8
             image: debian:12-slim
             pg_version: 14

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -7,8 +7,6 @@ name: Publish pg_search (Debian)
 
 on:
   push:
-    branches:
-      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -174,12 +172,11 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # TODO: Uncomment once done testing
-      # - name: Upload pg_search .deb to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-      #     asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
-      #     overwrite: true
+      - name: Upload pg_search .deb to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+          overwrite: true

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -7,6 +7,8 @@ name: Publish pg_search
 
 on:
   push:
+    branches:
+      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -103,15 +105,7 @@ jobs:
             DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
             RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
           fi
-          if [ "$DISTRO" = "ubuntu" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "debian" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "rhel" ]; then
-            OS_VERSION="el$RELEASE"
-          else
-            OS_VERSION="$DISTRO-$RELEASE"
-          fi
+          OS_VERSION="$RELEASE"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
@@ -188,11 +182,12 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_search .deb to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
-          overwrite: true
+      # TODO: Uncomment once done testing
+      # - name: Upload pg_search .deb to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      #     asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+      #     overwrite: true

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -1,0 +1,276 @@
+# workflows/publish-pg_search-debian.yml
+#
+# Publish pg_search (Debian/Ubuntu)
+# Build and publish the pg_search extension as .deb to GitHub Releases.
+
+name: Publish pg_search
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to set for the pg_search release. This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
+        required: true
+        default: ""
+
+concurrency:
+  group: publish-pg_search-debian-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  id-token: write
+  attestations: write
+
+jobs:
+  publish-pg_search:
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      matrix:
+        include:
+          # Ubuntu 22.04
+          - runner: ubicloud-standard-8
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:22.04
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:22.04
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:22.04
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:22.04
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:22.04
+            pg_version: 17
+            arch: arm64
+          # Ubuntu 24.04
+          - runner: ubicloud-standard-8
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:24.04
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:24.04
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:24.04
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:24.04
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: ubuntu:24.04
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: ubuntu:24.04
+            pg_version: 17
+            arch: arm64
+          # Debian 12
+          - runner: ubicloud-standard-8
+            image: debian:12-slim
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:12-slim
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:12-slim
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:12-slim
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:12-slim
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:12-slim
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:12-slim
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:12-slim
+            pg_version: 17
+            arch: arm64
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
+      - name: Retrieve OS & GitHub Tag Versions
+        id: version
+        shell: bash
+        run: |
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            if [[ $GITHUB_REF == refs/tags/v* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/v}
+            else
+              # If there is no tag and no provided version, it's a test run and we set a default version
+              VERSION="0.0.0"
+            fi
+          else
+            VERSION=${{ github.event.inputs.version }}
+          fi
+          echo "GitHub Tag Version: $VERSION"
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+
+          if [ -x "$(command -v lsb_release)" ]; then
+            DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+            RELEASE=$(lsb_release -cs)
+          else
+            DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
+            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+          fi
+          if [ "$DISTRO" = "ubuntu" ]; then
+            OS_VERSION="$RELEASE"
+          elif [ "$DISTRO" = "debian" ]; then
+            OS_VERSION="$RELEASE"
+          elif [ "$DISTRO" = "rhel" ]; then
+            OS_VERSION="el$RELEASE"
+          else
+            OS_VERSION="$DISTRO-$RELEASE"
+          fi
+          echo "OS Version: $OS_VERSION"
+          echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
+
+          # RHEL uses different architecture and OS naming conventions when packaging via rpmbuid. We need to
+          # retrieve those as well to programmatically retrieve and upload the correct RPM package
+          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
+            if [ "${{ matrix.arch }}" == "amd64" ]; then
+              ARCH=x86_64
+            else
+              ARCH=aarch64
+            fi
+            echo "RPM Arch: $ARCH"
+            echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install & Configure Supported PostgreSQL Version
+        run: |
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+
+      - name: Extract pgrx Version
+        id: pgrx
+        working-directory: pg_search/
+        run: echo version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv) >> $GITHUB_OUTPUT
+
+      - name: Install pgrx
+        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
+
+      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
+      - name: Initialize pgrx for Current PostgreSQL Version
+        working-directory: pg_search/
+        shell: bash
+        run: |
+          PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+          cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
+
+      - name: Package pg_search Extension with pgrx
+        working-directory: pg_search/
+        run: |
+          PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+          cargo pgrx package --pg-config $PG_CONFIG_PATH --features icu
+
+      - name: Create .deb Package
+        run: |
+          # Create installable package
+          mkdir archive
+          cp `find target/release -type f -name "pg_search*"` archive
+          package_dir=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+
+          # Copy files into directory structure
+          mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
+          mkdir -p ${package_dir}/usr/share/postgresql/${{ matrix.pg_version}}/extension
+          cp archive/*.so ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
+          cp archive/*.control ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
+          cp archive/*.sql ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
+
+          # Create control file (package name cannot have underscore)
+          mkdir -p ${package_dir}/DEBIAN
+          touch ${package_dir}/DEBIAN/control
+          deb_version=${{ steps.version.outputs.tag_version }}
+          CONTROL_FILE="${package_dir}/DEBIAN/control"
+          echo 'Package: postgresql-${{ matrix.pg_version }}-pg-search' >> $CONTROL_FILE
+          echo 'Version:' ${deb_version} >> $CONTROL_FILE
+          echo 'Section: database' >> $CONTROL_FILE
+          echo 'Priority: optional' >> $CONTROL_FILE
+          echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
+          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
+          echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
+          echo 'Description: Full-text search for PostgreSQL using BM25' >> $CONTROL_FILE
+
+          # Create .deb package
+          sudo chown -R root:root ${package_dir}
+          sudo chmod -R 755 ${package_dir}
+          sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+
+      - name: Retrieve GitHub Release Upload URL
+        id: upload_url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+
+      - name: Upload pg_search .deb to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+          overwrite: true

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -3,7 +3,7 @@
 # Publish pg_search (Debian)
 # Build and publish the pg_search extension as .deb to GitHub Releases.
 
-name: Publish pg_search
+name: Publish pg_search (Debian)
 
 on:
   push:
@@ -80,7 +80,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
+      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, since
+      # /bin/sh does not support the `[[` syntax.
       - name: Retrieve OS & GitHub Tag Versions
         id: version
         shell: bash
@@ -98,14 +99,7 @@ jobs:
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
-          if [ -x "$(command -v lsb_release)" ]; then
-            DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-            RELEASE=$(lsb_release -cs)
-          else
-            DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
-            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
-          fi
-          OS_VERSION="$RELEASE"
+          OS_VERSION="$(lsb_release -cs)"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
@@ -125,10 +119,8 @@ jobs:
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
-        shell: bash
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
@@ -165,7 +157,7 @@ jobs:
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Full-text search for PostgreSQL using BM25' >> $CONTROL_FILE
+          echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
 
           # Create .deb package
           sudo chown -R root:root ${package_dir}

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -7,6 +7,8 @@ name: Publish pg_search (macOS)
 
 on:
   push:
+    branches:
+      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -147,11 +149,12 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_search .pkg to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
-          asset_name: pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
-          overwrite: true
+      # TODO: Uncomment once done testing
+      # - name: Upload pg_search .pkg to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+      #     asset_name: pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+      #     overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -146,7 +146,7 @@ jobs:
           mkdir -p ${package_dir}${share_path}
 
           # Copy files into the directory structure. In PostgreSQL 16 onwards, the extension is a .dylib file
-          if [ "${{ matrix.pg_version }}" == "16" || "${{ matrix.pg_version }}" == "17" ]; then
+          if [[ "${{ matrix.pg_version }}" == "16" || "${{ matrix.pg_version }}" == "17" ]]; then
             cp archive/*.dylib ${package_dir}${lib_path}
           else
             cp archive/*.so ${package_dir}${lib_path}

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -1,0 +1,157 @@
+# workflows/publish-pg_search-macos.yml
+#
+# Publish pg_search (macOS)
+# Build and publish the pg_search extension for macOS as .pkg to GitHub Releases.
+
+name: Publish pg_search (macOS)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to set for the pg_search release. This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
+        required: true
+        default: ""
+
+concurrency:
+  group: publish-pg_search-macos-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  id-token: write
+  attestations: write
+
+jobs:
+  publish-pg_search:
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on macOS ${{ matrix.arch }}
+    runs-on: macos-15
+    strategy:
+      matrix:
+        pg_version: [14, 15, 16, 17]
+        arch: [arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install macOS Dependencies
+        run: brew install icu4c
+
+      - name: Retrieve OS & GitHub Tag Versions
+        id: version
+        run: |
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            if [[ $GITHUB_REF == refs/tags/v* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/v}
+            else
+              VERSION="0.0.0"
+            fi
+          else
+            VERSION=${{ github.event.inputs.version }}
+          fi
+          echo "GitHub Tag Version: $VERSION"
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+
+          OS_VERSION=$(sw_vers -productVersion)
+          echo "OS Version: $OS_VERSION"
+          echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install PostgreSQL
+        run: |
+          brew install postgresql@${{ matrix.pg_version }}
+          brew services start postgresql@${{ matrix.pg_version }}
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            echo "/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          else
+            echo "/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+          fi
+
+      - name: Extract pgrx Version
+        id: pgrx
+        working-directory: pg_search/
+        run: |
+          version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)
+          echo "Extracted pgrx version: $version"
+          echo version=$version >> $GITHUB_OUTPUT
+
+      - name: Install pgrx
+        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
+
+      - name: Initialize pgrx for Current PostgreSQL Version
+        working-directory: pg_search/
+        run: |
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
+          else
+            PG_CONFIG_PATH="/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
+          fi
+          cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
+
+      - name: Package pg_search Extension with pgrx
+        working-directory: pg_search/
+        run: |
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
+            export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig"
+            export PATH="/opt/homebrew/bin:$PATH"
+          else
+            PG_CONFIG_PATH="/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
+            export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
+            export PATH="/usr/local/bin:$PATH"
+          fi
+          cargo pgrx package --pg-config $PG_CONFIG_PATH --features icu
+
+      - name: Create .pkg Package
+        run: |
+          # Retrieve the built pg_search extension
+          mkdir archive
+          cp `find target/release -type f -name "pg_search*"` archive
+          ls -l archive
+
+          # Variables for directory structure and versioning
+          pg_version=${{ matrix.pg_version }}
+          tag_version=${{ steps.version.outputs.tag_version }}
+          package_dir="pg_search-${tag_version}-${{ matrix.arch }}-pg${pg_version}"
+
+          # Define Homebrew PostgreSQL paths
+          brew_pg_path="/opt/homebrew/opt/postgresql@${pg_version}"
+          lib_path="${brew_pg_path}/lib/postgresql"
+          share_path="${brew_pg_path}/share/postgresql@${pg_version}/extension"
+
+          # Create directory structure for Homebrew
+          mkdir -p ${package_dir}${lib_path}
+          mkdir -p ${package_dir}${share_path}
+
+          # Copy files into the directory structure
+          cp archive/*.so ${package_dir}${lib_path}
+          cp archive/*.control ${package_dir}${share_path}
+          cp archive/*.sql ${package_dir}${share_path}
+
+          # Create the .pkg installer
+          pkgbuild --root ${package_dir} \
+                  --identifier com.paradedb.pg_search \
+                  --version ${tag_version} \
+                  --install-location /opt/homebrew/opt/postgresql${pg_version} \
+                  pg_search--${tag_version}.${{ matrix.arch }}_sequoia.pkg
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+
+      - name: Retrieve GitHub Release Upload URL
+        id: upload_url
+        run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
+
+      - name: Upload pg_search .pkg to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+          asset_name: pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+          overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} arm64
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} arm64
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -37,27 +37,38 @@ jobs:
           # macOS 14 and 15 are arm-only (M1)
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # macOS 14 (Sonoma)
-          - runner: macos-14
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
             pg_version: 14
-          - runner: macos-14
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
             pg_version: 15
-          - runner: macos-14
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
             pg_version: 16
-          - runner: macos-14
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
             pg_version: 17
           # macOS 15 (Sequoia)
-          - runner: macos-15
+          - name: macOS 15 (Sequoia)
+            runner: macos-15
             pg_version: 14
-          - runner: macos-15
+          - name: macOS 15 (Sequoia)
+            runner: macos-15
             pg_version: 15
-          - runner: macos-15
+          - name: macOS 15 (Sequoia)
+            runner: macos-15
             pg_version: 16
-          - runner: macos-15
+          - name: macOS 15 (Sequoia)
+            runner: macos-15
             pg_version: 17
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: brew install icu4c
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -38,17 +38,26 @@ jobs:
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # macOS 14 (Sonoma)
           - runner: macos-14
-            pg_version: [14, 15, 16, 17]
+            pg_version: 14
+          - runner: macos-14
+            pg_version: 15
+          - runner: macos-14
+            pg_version: 16
+          - runner: macos-14
+            pg_version: 17
           # macOS 15 (Sequoia)
           - runner: macos-15
-            pg_version: [14, 15, 16, 17]
+            pg_version: 14
+          - runner: macos-15
+            pg_version: 15
+          - runner: macos-15
+            pg_version: 16
+          - runner: macos-15
+            pg_version: 17
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        run: brew install icu4c
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -29,18 +29,21 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on macOS ${{ matrix.arch }}
-    runs-on: macos-15
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        pg_version: [14, 15, 16, 17]
-        arch: [arm64]
+        # macOS 14 and 15 are arm-only (M!)
+        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        - runner: [macos-14, macos-15]
+          pg_version: [14, 15, 16, 17]
+          arch: arm64
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install macOS Dependencies
+      - name: Install Dependencies
         run: brew install icu4c
 
       - name: Retrieve OS & GitHub Tag Versions
@@ -66,18 +69,13 @@ jobs:
         run: |
           brew install postgresql@${{ matrix.pg_version }}
           brew services start postgresql@${{ matrix.pg_version }}
-          if [ "${{ matrix.arch }}" == "arm64" ]; then
-            echo "/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
-          else
-            echo "/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
-          fi
+          echo "/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Extract pgrx Version
         id: pgrx
         working-directory: pg_search/
         run: |
           version=$(cargo tree --depth 1 -i pgrx -p pg_search | head -n 1 | cut -f2 -dv)
-          echo "Extracted pgrx version: $version"
           echo version=$version >> $GITHUB_OUTPUT
 
       - name: Install pgrx
@@ -86,25 +84,15 @@ jobs:
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
         run: |
-          if [ "${{ matrix.arch }}" == "arm64" ]; then
-            PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
-          else
-            PG_CONFIG_PATH="/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
-          fi
+          PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
         run: |
-          if [ "${{ matrix.arch }}" == "arm64" ]; then
-            PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
-            export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig"
-            export PATH="/opt/homebrew/bin:$PATH"
-          else
-            PG_CONFIG_PATH="/usr/local/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
-            export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig"
-            export PATH="/usr/local/bin:$PATH"
-          fi
+          PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
+          export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig"
+          export PATH="/opt/homebrew/bin:$PATH"
           cargo pgrx package --pg-config $PG_CONFIG_PATH --features icu
 
       - name: Create .pkg Package
@@ -128,8 +116,15 @@ jobs:
           mkdir -p ${package_dir}${lib_path}
           mkdir -p ${package_dir}${share_path}
 
-          # Copy files into the directory structure
-          cp archive/*.so ${package_dir}${lib_path}
+          # Copy files into the directory structure. In PostgreSQL 16 onwards, the extension is a .dylib file
+          if [ "${{ matrix.pg_version }}" == "16" || "${{ matrix.pg_version }}" == "17" ]; then
+            cp archive/*.dylib ${package_dir}${lib_path}
+          elif [ "${{ matrix.pg_version }}" == "14" || "${{ matrix.pg_version }}" == "15"; then
+            cp archive/*.so ${package_dir}${lib_path}
+          else
+            echo "Unsupported PostgreSQL version: ${{ matrix.pg_version }}"
+            exit 1
+          fi          
           cp archive/*.control ${package_dir}${share_path}
           cp archive/*.sql ${package_dir}${share_path}
 
@@ -138,12 +133,12 @@ jobs:
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
                   --install-location /opt/homebrew/opt/postgresql${pg_version} \
-                  pg_search--${tag_version}.${{ matrix.arch }}_sequoia.pkg
+                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.${{ matrix.arch }}_sequoia.pkg
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -155,6 +150,6 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
       #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
-      #     asset_name: pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
       #     overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ env.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} arm64
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -42,8 +42,6 @@ jobs:
           # macOS 15 (Sequoia)
           - runner: macos-15
             pg_version: [14, 15, 16, 17]
-      env:
-        arch: arm64
 
     steps:
       - name: Checkout code
@@ -116,7 +114,7 @@ jobs:
           # Variables for directory structure and versioning
           pg_version=${{ matrix.pg_version }}
           tag_version=${{ steps.version.outputs.tag_version }}
-          package_dir="pg_search-${tag_version}-${{ env.arch }}-pg${pg_version}"
+          package_dir="pg_search-${tag_version}-arm64-pg${pg_version}"
 
           # Define Homebrew PostgreSQL paths
           brew_pg_path="/opt/homebrew/opt/postgresql@${pg_version}"
@@ -141,12 +139,12 @@ jobs:
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
                   --install-location /opt/homebrew/opt/postgresql${pg_version} \
-                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
+                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
+          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -158,6 +156,6 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
       #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
-      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
+      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
       #     overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -7,8 +7,6 @@ name: Publish pg_search (macOS)
 
 on:
   push:
-    branches:
-      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -170,12 +168,11 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # TODO: Uncomment once done testing
-      # - name: Upload pg_search .pkg to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
-      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
-      #     overwrite: true
+      - name: Upload pg_search .pkg to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -29,15 +29,21 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ env.arch }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        # macOS 14 and 15 are arm-only (M!)
-        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-        - runner: [macos-14, macos-15]
-          pg_version: [14, 15, 16, 17]
-          arch: arm64
+        include:
+          # macOS 14 and 15 are arm-only (M1)
+          # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+          # macOS 14 (Sonoma)
+          - runner: macos-14
+            pg_version: [14, 15, 16, 17]
+          # macOS 15 (Sequoia)
+          - runner: macos-15
+            pg_version: [14, 15, 16, 17]
+      env:
+        arch: arm64
 
     steps:
       - name: Checkout code
@@ -62,8 +68,13 @@ jobs:
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
           OS_VERSION=$(sw_vers -productVersion)
-          echo "OS Version: $OS_VERSION"
-          echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
+          case $OS_VERSION in
+              15.*) OS_NAME="sequoia" ;;
+              14.*) OS_NAME="sonoma" ;;
+              *) exit 1 ;;
+          esac
+          echo "OS Version: $OS_NAME"
+          echo "os_version=$OS_NAME" >> $GITHUB_OUTPUT
 
       - name: Install PostgreSQL
         run: |
@@ -105,7 +116,7 @@ jobs:
           # Variables for directory structure and versioning
           pg_version=${{ matrix.pg_version }}
           tag_version=${{ steps.version.outputs.tag_version }}
-          package_dir="pg_search-${tag_version}-${{ matrix.arch }}-pg${pg_version}"
+          package_dir="pg_search-${tag_version}-${{ env.arch }}-pg${pg_version}"
 
           # Define Homebrew PostgreSQL paths
           brew_pg_path="/opt/homebrew/opt/postgresql@${pg_version}"
@@ -119,12 +130,9 @@ jobs:
           # Copy files into the directory structure. In PostgreSQL 16 onwards, the extension is a .dylib file
           if [ "${{ matrix.pg_version }}" == "16" || "${{ matrix.pg_version }}" == "17" ]; then
             cp archive/*.dylib ${package_dir}${lib_path}
-          elif [ "${{ matrix.pg_version }}" == "14" || "${{ matrix.pg_version }}" == "15"; then
-            cp archive/*.so ${package_dir}${lib_path}
           else
-            echo "Unsupported PostgreSQL version: ${{ matrix.pg_version }}"
-            exit 1
-          fi          
+            cp archive/*.so ${package_dir}${lib_path}
+          fi
           cp archive/*.control ${package_dir}${share_path}
           cp archive/*.sql ${package_dir}${share_path}
 
@@ -133,12 +141,12 @@ jobs:
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
                   --install-location /opt/homebrew/opt/postgresql${pg_version} \
-                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.${{ matrix.arch }}_sequoia.pkg
+                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -150,6 +158,6 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
       #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
-      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ matrix.arch }}_sequoia.pkg
+      #     asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
+      #     asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.${{ env.arch }}_${{ steps.version.outputs.os_version }}.pkg
       #     overwrite: true

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -3,7 +3,7 @@
 # Publish pg_search (Red Hat)
 # Build and publish the pg_search extension as .rpm to GitHub Releases.
 
-name: Publish pg_search
+name: Publish pg_search (Red Hat)
 
 on:
   push:
@@ -43,68 +43,68 @@ jobs:
           - runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 14
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 14
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 15
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 15
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 16
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 16
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 17
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 17
-            arch: arm64
+            arch: aarch64
           # Red Hat Enterprise Linux 9
           - runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 14
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 14
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 15
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 15
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 16
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 16
-            arch: arm64
+            arch: aarch64
           - runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 17
-            arch: amd64
+            arch: x86_64
           - runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 17
-            arch: arm64
+            arch: aarch64
 
     steps:
       - name: Checkout Git Repository
@@ -112,15 +112,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          # Determine RHEL version to retrieve the correct repositories
-          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
-            RHEL_VERSION=8
-          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
-            RHEL_VERSION=9
-          else
-            echo "Unsupported RHEL version"
-            exit 1
-          fi
+          # Extract RHEL version from the image name
+          RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
 
           # Install dependencies
           dnf install -y sudo wget gcc llvm-toolset pkgconf-pkg-config openssl-devel jq rpm-build
@@ -160,10 +153,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Retrieve OS & GitHub Tag Versions
         id: version
-        shell: bash
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
@@ -178,28 +169,9 @@ jobs:
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
-          if [ -x "$(command -v lsb_release)" ]; then
-            DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-            RELEASE=$(lsb_release -cs)
-          else
-            DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
-            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
-          fi
-          OS_VERSION="el$RELEASE"
+          OS_VERSION="el$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
-
-          # RHEL uses different architecture and OS naming conventions when packaging via rpmbuid. We need to
-          # retrieve those as well to programmatically retrieve and upload the correct RPM package
-          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
-            if [ "${{ matrix.arch }}" == "amd64" ]; then
-              ARCH=x86_64
-            else
-              ARCH=aarch64
-            fi
-            echo "RPM Arch: $ARCH"
-            echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
-          fi
 
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         run: |
@@ -214,7 +186,7 @@ jobs:
           fi
 
           # Install the repository RPM:
-          sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-${{ steps.version.outputs.rpm_arch }}/pgdg-redhat-repo-latest.noarch.rpm
+          sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-${{ matrix.arch }}/pgdg-redhat-repo-latest.noarch.rpm
 
           # Disable the built-in PostgreSQL module:
           sudo dnf -qy module disable postgresql
@@ -244,6 +216,9 @@ jobs:
 
       - name: Create .rpm Package
         run: |
+          # Set the current date for the changelog
+          CURRENT_DATE=$(date +"%a %b %d %Y")
+
           echo "Configuring RPM build environment..."
           rpmdev-setuptree
 
@@ -279,8 +254,10 @@ jobs:
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
 
           %changelog
-          * Thu Jun 6 2024 ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
+          * Thu Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
           - Initial RPM Release
+          * $CURRENT_DATE ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
+          - Latest RPM Release
           EOF
 
           echo "Copying pg_search binaries to RPM build directory..."
@@ -293,7 +270,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
+            ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -305,6 +282,6 @@ jobs:
       #   with:
       #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
       #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
-      #     asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
+      #     asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+      #     asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
       #     overwrite: true

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
@@ -38,68 +38,84 @@ jobs:
       matrix:
         include:
           # Red Hat Enterprise Linux 8
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 14
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 14
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 15
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 15
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 16
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 16
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-8
             image: redhat/ubi8:latest
             pg_version: 17
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 8
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi8:latest
             pg_version: 17
             arch: aarch64
           # Red Hat Enterprise Linux 9
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 14
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 14
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 15
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 15
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 16
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 16
             arch: aarch64
-          - runner: ubicloud-standard-8
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-8
             image: redhat/ubi9:latest
             pg_version: 17
             arch: x86_64
-          - runner: ubicloud-standard-4-arm
+          - name: Red Hat Enterprise Linux 9
+            runner: ubicloud-standard-4-arm
             image: redhat/ubi9:latest
             pg_version: 17
             arch: aarch64

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -7,6 +7,8 @@ name: Publish pg_search
 
 on:
   push:
+    branches:
+      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -108,7 +110,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Install RHEL Dependencies
+      - name: Install Dependencies
         run: |
           # Determine RHEL version to retrieve the correct repositories
           if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
@@ -183,15 +185,7 @@ jobs:
             DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
             RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
           fi
-          if [ "$DISTRO" = "ubuntu" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "debian" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "rhel" ]; then
-            OS_VERSION="el$RELEASE"
-          else
-            OS_VERSION="$DISTRO-$RELEASE"
-          fi
+          OS_VERSION="el$RELEASE"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
@@ -305,11 +299,12 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_search .rpm to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
-          asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
-          overwrite: true
+      # TODO: Uncomment once done testing
+      # - name: Upload pg_search .rpm to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
+      #     asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
+      #     overwrite: true

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -1,7 +1,7 @@
-# workflows/publish-pg_search.yml
+# workflows/publish-pg_search-rhel.yml
 #
-# Publish pg_search
-# Build and publish the pg_search extension as .deb and .rpm to GitHub Releases.
+# Publish pg_search (Red Hat)
+# Build and publish the pg_search extension as .rpm to GitHub Releases.
 
 name: Publish pg_search
 
@@ -17,7 +17,7 @@ on:
         default: ""
 
 concurrency:
-  group: publish-pg_search-${{ github.head_ref || github.ref }}
+  group: publish-pg_search-rhel-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 # Used by actions/attest-build-provenance to sign the builds
@@ -37,105 +37,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ubuntu 22.04
-          - runner: ubicloud-standard-8
-            image: ubuntu:22.04
-            pg_version: 14
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:22.04
-            pg_version: 14
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:22.04
-            pg_version: 15
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:22.04
-            pg_version: 15
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:22.04
-            pg_version: 16
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:22.04
-            pg_version: 16
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:22.04
-            pg_version: 17
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:22.04
-            pg_version: 17
-            arch: arm64
-          # Ubuntu 24.04
-          - runner: ubicloud-standard-8
-            image: ubuntu:24.04
-            pg_version: 14
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:24.04
-            pg_version: 14
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:24.04
-            pg_version: 15
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:24.04
-            pg_version: 15
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:24.04
-            pg_version: 16
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:24.04
-            pg_version: 16
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: ubuntu:24.04
-            pg_version: 17
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: ubuntu:24.04
-            pg_version: 17
-            arch: arm64
-          # Debian 12
-          - runner: ubicloud-standard-8
-            image: debian:12-slim
-            pg_version: 14
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
-            pg_version: 14
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: debian:12-slim
-            pg_version: 15
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
-            pg_version: 15
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: debian:12-slim
-            pg_version: 16
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
-            pg_version: 16
-            arch: arm64
-          - runner: ubicloud-standard-8
-            image: debian:12-slim
-            pg_version: 17
-            arch: amd64
-          - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
-            pg_version: 17
-            arch: arm64
           # Red Hat Enterprise Linux 8
           - runner: ubicloud-standard-8
             image: redhat/ubi8:latest
@@ -207,12 +108,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      - name: Install Debian Dependencies
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
-
       - name: Install RHEL Dependencies
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           # Determine RHEL version to retrieve the correct repositories
           if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
@@ -311,17 +207,7 @@ jobs:
             echo "rpm_arch=$ARCH" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install & Configure Supported PostgreSQL Version on Debian
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
-        run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }} debhelper devscripts dput gnupg
-          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
-          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
-
       - name: Install & Configure Supported PostgreSQL Version on RHEL
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           # Determine RHEL version to retrieve the correct repositories
           if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
@@ -350,66 +236,19 @@ jobs:
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
-        shell: bash
         run: |
-          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
-            PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
-          else
-            PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-          fi
+          PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH
 
-      # TODO: Enable --features icu on RHEL
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
         run: |
-          if [[ "${{ matrix.image }}" == "redhat/ubi8:latest" || "${{ matrix.image }}" == "redhat/ubi9:latest" ]]; then
-            PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
-            cargo pgrx package --pg-config $PG_CONFIG_PATH
-          else
-            PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-            cargo pgrx package --pg-config $PG_CONFIG_PATH --features icu
-          fi
-
-      - name: Create .deb Package
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
-        run: |
-          # Create installable package
-          mkdir archive
-          cp `find target/release -type f -name "pg_search*"` archive
-          package_dir=pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
-
-          # Copy files into directory structure
-          mkdir -p ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
-          mkdir -p ${package_dir}/usr/share/postgresql/${{ matrix.pg_version}}/extension
-          cp archive/*.so ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
-          cp archive/*.control ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
-          cp archive/*.sql ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
-
-          # Create control file (package name cannot have underscore)
-          mkdir -p ${package_dir}/DEBIAN
-          touch ${package_dir}/DEBIAN/control
-          deb_version=${{ steps.version.outputs.tag_version }}
-          CONTROL_FILE="${package_dir}/DEBIAN/control"
-          echo 'Package: postgresql-${{ matrix.pg_version }}-pg-search' >> $CONTROL_FILE
-          echo 'Version:' ${deb_version} >> $CONTROL_FILE
-          echo 'Section: database' >> $CONTROL_FILE
-          echo 'Priority: optional' >> $CONTROL_FILE
-          echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
-          echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
-          echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Full-text search for PostgreSQL using BM25' >> $CONTROL_FILE
-
-          # Create .deb package
-          sudo chown -R root:root ${package_dir}
-          sudo chmod -R 755 ${package_dir}
-          sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
+          PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
+          cargo pgrx package --pg-config $PG_CONFIG_PATH
 
       - name: Create .rpm Package
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         run: |
           echo "Configuring RPM build environment..."
           rpmdev-setuptree
@@ -460,25 +299,13 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
             ~/rpmbuild/RPMS/${{ steps.version.outputs.rpm_arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ steps.version.outputs.rpm_arch }}.rpm
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_search .deb to GitHub Release
-        if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
-          overwrite: true
-
       - name: Upload pg_search .rpm to GitHub Release
-        if: ${{ matrix.image == 'redhat/ubi8:latest' || matrix.image == 'redhat/ubi9:latest' }}
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -7,8 +7,6 @@ name: Publish pg_search (Red Hat)
 
 on:
   push:
-    branches:
-      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -251,7 +249,7 @@ jobs:
           %changelog
           * ${{ steps.version.outputs.current_date }} ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
           - Latest RPM Release
-          * Thu Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
+          * Sat Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
           - Initial RPM Release
           EOF
 
@@ -271,12 +269,11 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # TODO: Uncomment once done testing
-      # - name: Upload pg_search .rpm to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
-      #     asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
-      #     overwrite: true
+      - name: Upload pg_search .rpm to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+          asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+          overwrite: true

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -173,17 +173,15 @@ jobs:
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
+          # Retrieve the current date for the changelog
+          CURRENT_DATE=$(LC_TIME=C date +"%a %b %d %Y")
+          echo "Current Date: $CURRENT_DATE"
+          echo "current_date=$CURRENT_DATE" >> $GITHUB_OUTPUT
+
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         run: |
-          # Determine RHEL version to retrieve the correct repositories
-          if [ "${{ matrix.image }}" == "redhat/ubi8:latest" ]; then
-            RHEL_VERSION=8
-          elif [ "${{ matrix.image }}" == "redhat/ubi9:latest" ]; then
-            RHEL_VERSION=9
-          else
-            echo "Unsupported RHEL version"
-            exit 1
-          fi
+          # Extract RHEL version from the image name
+          RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
 
           # Install the repository RPM:
           sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-${{ matrix.arch }}/pgdg-redhat-repo-latest.noarch.rpm
@@ -216,9 +214,6 @@ jobs:
 
       - name: Create .rpm Package
         run: |
-          # Set the current date for the changelog
-          CURRENT_DATE=$(date +"%a %b %d %Y")
-
           echo "Configuring RPM build environment..."
           rpmdev-setuptree
 
@@ -254,7 +249,7 @@ jobs:
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
 
           %changelog
-          * $CURRENT_DATE ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
+          * ${{ steps.version.outputs.current_date }} ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
           - Latest RPM Release
           * Thu Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
           - Initial RPM Release

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -254,10 +254,10 @@ jobs:
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
 
           %changelog
-          * Thu Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
-          - Initial RPM Release
           * $CURRENT_DATE ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}
           - Latest RPM Release
+          * Thu Jun 22 2024 ParadeDB <support@paradedb.com> - 0.7.6
+          - Initial RPM Release
           EOF
 
           echo "Copying pg_search binaries to RPM build directory..."

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -33,50 +33,50 @@ jobs:
       matrix:
         include:
           # Ubuntu 22.04
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 14
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 15
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 17
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 17
             arch: arm64
           # Ubuntu 24.04
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 14
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 15
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-4-arm
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8
+          - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 17
             arch: amd64
           - runner: ubicloud-standard-4-arm

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -32,6 +32,31 @@ jobs:
     strategy:
       matrix:
         include:
+          # Ubuntu 20.04
+          - runner: ubicloud-standard-8-ubuntu-2004
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm-ubuntu-2004
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8-ubuntu-2004
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm-ubuntu-2004
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8-ubuntu-2004
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm-ubuntu-2004
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8-ubuntu-2004
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm-ubuntu-2004
+            pg_version: 17
+            arch: arm64
           # Ubuntu 22.04
           - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 14

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -3,7 +3,7 @@
 # Publish pg_search (Ubuntu)
 # Build and publish the pg_search extension as .deb to GitHub Releases.
 
-name: Publish pg_search
+name: Publish pg_search (Ubuntu)
 
 on:
   push:
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -136,14 +136,7 @@ jobs:
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
-          if [ -x "$(command -v lsb_release)" ]; then
-            DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-            RELEASE=$(lsb_release -cs)
-          else
-            DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
-            RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
-          fi
-          OS_VERSION="$RELEASE"
+          OS_VERSION="$(lsb_release -cs)"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
@@ -201,7 +194,7 @@ jobs:
           echo 'Architecture: ${{ matrix.arch }}' >> $CONTROL_FILE
           echo 'Depends: postgresql-${{ matrix.pg_version }}' >> $CONTROL_FILE
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
-          echo 'Description: Full-text search for PostgreSQL using BM25' >> $CONTROL_FILE
+          echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
 
           # Create .deb package
           sudo chown -R root:root ${package_dir}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -27,84 +27,108 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.runner }} ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
           # Ubuntu 20.04
-          - runner: ubicloud-standard-8-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-8-ubuntu-2004
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-4-arm-ubuntu-2004
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-8-ubuntu-2004
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-4-arm-ubuntu-2004
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-8-ubuntu-2004
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-4-arm-ubuntu-2004
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-8-ubuntu-2004
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2004
+          - name: Ubuntu 20.04 (Focal)
+            runner: ubicloud-standard-4-arm-ubuntu-2004
             pg_version: 17
             arch: arm64
           # Ubuntu 22.04
-          - runner: ubicloud-standard-8-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2204
+          - name: Ubuntu 22.04 (Jammy)
+            runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 17
             arch: arm64
           # Ubuntu 24.04
-          - runner: ubicloud-standard-8-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm-ubuntu-2404
+          - name: Ubuntu 24.04 (Noble)
+            runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 17
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -1,6 +1,6 @@
-# workflows/publish-pg_search-debian.yml
+# workflows/publish-pg_search-ubuntu.yml
 #
-# Publish pg_search (Debian)
+# Publish pg_search (Ubuntu)
 # Build and publish the pg_search extension as .deb to GitHub Releases.
 
 name: Publish pg_search
@@ -17,7 +17,7 @@ on:
         default: ""
 
 concurrency:
-  group: publish-pg_search-debian-${{ github.head_ref || github.ref }}
+  group: publish-pg_search-ubuntu-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 # Used by actions/attest-build-provenance to sign the builds
@@ -27,44 +27,59 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.image }} ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
-    container:
-      image: ${{ matrix.image }}
     strategy:
       matrix:
         include:
-          # Debian 12
+          # Ubuntu 22.04
           - runner: ubicloud-standard-8
-            image: debian:12-slim
             pg_version: 14
             arch: amd64
           - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
             pg_version: 14
             arch: arm64
           - runner: ubicloud-standard-8
-            image: debian:12-slim
             pg_version: 15
             arch: amd64
           - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
             pg_version: 15
             arch: arm64
           - runner: ubicloud-standard-8
-            image: debian:12-slim
             pg_version: 16
             arch: amd64
           - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
             pg_version: 16
             arch: arm64
           - runner: ubicloud-standard-8
-            image: debian:12-slim
             pg_version: 17
             arch: amd64
           - runner: ubicloud-standard-4-arm
-            image: debian:12-slim
+            pg_version: 17
+            arch: arm64
+          # Ubuntu 24.04
+          - runner: ubicloud-standard-8
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
             pg_version: 17
             arch: arm64
 
@@ -78,10 +93,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Retrieve OS & GitHub Tag Versions
         id: version
-        shell: bash
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
@@ -131,10 +144,8 @@ jobs:
       - name: Install pgrx
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
-      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which doesn't support the `[[` syntax
       - name: Initialize pgrx for Current PostgreSQL Version
         working-directory: pg_search/
-        shell: bash
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG_PATH

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -36,50 +36,50 @@ jobs:
           - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 14
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 15
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 16
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2204
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2204
             pg_version: 17
             arch: arm64
           # Ubuntu 24.04
           - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 14
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 15
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 16
             arch: arm64
           - runner: ubicloud-standard-8-ubuntu-2404
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - runner: ubicloud-standard-4-arm-ubuntu-2404
             pg_version: 17
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -7,8 +7,6 @@ name: Publish pg_search (Ubuntu)
 
 on:
   push:
-    branches:
-      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -211,12 +209,11 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      # TODO: Uncomment once done testing
-      # - name: Upload pg_search .deb to GitHub Release
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   with:
-      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      #     asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-      #     asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
-      #     overwrite: true
+      - name: Upload pg_search .deb to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+          overwrite: true

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -7,6 +7,8 @@ name: Publish pg_search
 
 on:
   push:
+    branches:
+      - phil/macos-binaries # TODO: Remove once done testing
     tags:
       - "v*"
   workflow_dispatch:
@@ -141,15 +143,7 @@ jobs:
             DISTRO=$(cat /etc/os-release | grep ^ID= | cut -d= -f2 | tr -d '"')
             RELEASE=$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)
           fi
-          if [ "$DISTRO" = "ubuntu" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "debian" ]; then
-            OS_VERSION="$RELEASE"
-          elif [ "$DISTRO" = "rhel" ]; then
-            OS_VERSION="el$RELEASE"
-          else
-            OS_VERSION="$DISTRO-$RELEASE"
-          fi
+          OS_VERSION="$RELEASE"
           echo "OS Version: $OS_VERSION"
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
@@ -224,11 +218,12 @@ jobs:
         id: upload_url
         run: echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }} | jq .upload_url --raw-output) >> $GITHUB_OUTPUT
 
-      - name: Upload pg_search .deb to GitHub Release
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
-          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
-          overwrite: true
+      # TODO: Uncomment once done testing
+      # - name: Upload pg_search .deb to GitHub Release
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   with:
+      #     github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+      #     upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      #     asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      #     asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+      #     overwrite: true


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1834 

## What
We've had requests for macOS prebuilt binaries. I decided to build for macOS 15 and macOS 14 only, which should be plenty for now. If we need more, we can add later. The benefit of this is that these versions are arm-only, so we save on half of the binaries.

I've also added support for Ubuntu 20.04, which is still requested by some customers.

I've also split up the jobs between 4 files, one per OS. This has the benefit of:
- Not having containers on Ubuntu, which was unnecessary. This speeds up deploys and reduces costs.
- Failures only affect an individual OS, which avoids re-running 40+ jobs.
- Workflow files are shorter and cleaner, since we don't need as many if-statements.

## Why
Easier to use!

## How
^

## Tests
All tested manually up to the publishing step.