### PR TITLE
ci: Only run schema bot on PRs to `main`

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -9,8 +9,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - dev
-      - main
+      - main # We only run the extension upgrade test on PRs to `main`, since it's when we do the release
     paths:
       - ".github/workflows/check-pg_search-schema-upgrade.yml"
       - "pg_search/**"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
It doesn't work with external contributions. Running it against `main` only will ensure we see the diff before promotions, and will ensure it doesn't block external contributors.

## Why
^

## How
^

## Tests
^