### PR TITLE
feat: improve general CustomScan performance

### DIFF
--- a/pg_search/src/api/operator/text.rs
+++ b/pg_search/src/api/operator/text.rs
@@ -50,6 +50,9 @@ fn text_support_request_simplify(arg: Internal) -> Option<ReturnedNodePointer> {
             T_SupportRequestSimplify,
             arg.unwrap()?.cast_mut_ptr::<pg_sys::Node>()
         )?;
+        if (*srs).root.is_null() {
+            return None;
+        }
         let mut input_args = PgList::<pg_sys::Node>::from_pg((*(*srs).fcall).args);
 
         let lhs = input_args.get_ptr(0)?;

--- a/pg_search/src/postgres/visibility_checker.rs
+++ b/pg_search/src/postgres/visibility_checker.rs
@@ -16,45 +16,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::postgres::utils;
-use pgrx::itemptr::item_pointer_get_block_number;
 use pgrx::pg_sys;
-use pgrx::pg_sys::Buffer;
-
-//
-// we redeclare these functions so we can use the directly without pgrx' "#[pg_guard]" overhead.
-//
-// Instead, when we call these, we make sure we've created our own ffi boundary guard and run all
-// these functions within the same guard
-//
-#[allow(improper_ctypes)]
-#[allow(non_snake_case)]
-extern "C" {
-    fn ReleaseAndReadBuffer(
-        buffer: Buffer,
-        relation: pg_sys::Relation,
-        blockNum: pg_sys::BlockNumber,
-    ) -> Buffer;
-
-    fn LockBuffer(buffer: Buffer, mode: ::core::ffi::c_int);
-    fn heap_hot_search_buffer(
-        tid: pg_sys::ItemPointer,
-        relation: pg_sys::Relation,
-        buffer: Buffer,
-        snapshot: pg_sys::Snapshot,
-        heapTuple: pg_sys::HeapTuple,
-        all_dead: *mut bool,
-        first_call: bool,
-    ) -> bool;
-}
 
 /// Helper to manage the information necessary to validate that a "ctid" is currently visible to
 /// a snapshot
 pub struct VisibilityChecker {
-    relation: pg_sys::Relation,
-    need_close: bool,
+    scan: *mut pg_sys::IndexFetchTableData,
     snapshot: pg_sys::Snapshot,
-    last_buffer: pg_sys::Buffer,
-    ipd: pg_sys::ItemPointerData,
+    tid: pg_sys::ItemPointerData,
 }
 
 impl Drop for VisibilityChecker {
@@ -65,14 +34,7 @@ impl Drop for VisibilityChecker {
                 return;
             }
 
-            if self.last_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer {
-                pg_sys::ReleaseBuffer(self.last_buffer);
-            }
-
-            if self.need_close {
-                // SAFETY:  `self.relation` is always a valid, open relation, created via `pg_sys::RelationGetRelation`
-                pg_sys::RelationClose(self.relation);
-            }
+            pg_sys::table_index_fetch_end(self.scan);
         }
     }
 }
@@ -80,64 +42,43 @@ impl Drop for VisibilityChecker {
 impl VisibilityChecker {
     /// Construct a new [`VisibilityChecker`] that can validate ctid visibility against the specified
     /// `relation` and `snapshot`
-    pub fn with_rel_and_snap(relation: pg_sys::Relation, snapshot: pg_sys::Snapshot) -> Self {
-        Self {
-            relation,
-            need_close: false,
-            snapshot,
-            last_buffer: pg_sys::InvalidBuffer as pg_sys::Buffer,
-            ipd: pg_sys::ItemPointerData::default(),
+    pub fn with_rel_and_snap(heaprel: pg_sys::Relation, snapshot: pg_sys::Snapshot) -> Self {
+        unsafe {
+            Self {
+                scan: pg_sys::table_index_fetch_begin(heaprel),
+                snapshot,
+                tid: pg_sys::ItemPointerData::default(),
+            }
         }
     }
 
     /// If the specified `ctid` is visible in the heap, run the provided closure and return its
     /// result as `Some(T)`.  If it's not visible, return `None` without running the provided closure
-    pub fn exec_if_visible<T, F: FnMut(pg_sys::Oid, pg_sys::HeapTupleData, pg_sys::Buffer) -> T>(
+    pub fn exec_if_visible<T, F: FnMut(pg_sys::Relation) -> T>(
         &mut self,
         ctid: u64,
+        slot: *mut pg_sys::TupleTableSlot,
         mut func: F,
     ) -> Option<T> {
         unsafe {
-            // Using ctid, get itempointer => buffer => page => heaptuple
-            utils::u64_to_item_pointer(ctid, &mut self.ipd);
+            utils::u64_to_item_pointer(ctid, &mut self.tid);
 
-            let blockno = item_pointer_get_block_number(&self.ipd);
-
-            // SAFETY:  in order for us to properly handle possible ERRORs we need to create
-            // our own ffi guard boundary.  The ReleaseAndReadBuffer, LockBuffer, and heap_hot_search_buffer (see below)
-            // functions are internal to postgres and the ffi boundary needs to be guarded, but we
-            // don't want to incur the overhead of guarding each one individually.
-            //
-            // This also create a requirement that we cannot raise a rust panic!() while in the
-            // `pg_guard_ffi_boundary()` closure.
-            pg_sys::ffi::pg_guard_ffi_boundary(|| {
-                self.last_buffer = ReleaseAndReadBuffer(self.last_buffer, self.relation, blockno);
-
-                LockBuffer(self.last_buffer, pg_sys::BUFFER_LOCK_SHARE as _);
-                let (found, htup) = self.check_page_vis(self.last_buffer);
-                let result = found.then(|| func((*self.relation).rd_id, htup, self.last_buffer));
-                LockBuffer(self.last_buffer, pg_sys::BUFFER_LOCK_UNLOCK as _);
-                result
-            })
-        }
-    }
-
-    unsafe fn check_page_vis(&mut self, buffer: pg_sys::Buffer) -> (bool, pg_sys::HeapTupleData) {
-        unsafe {
-            let mut heap_tuple = pg_sys::HeapTupleData::default();
-
-            // Check if heaptuple is visible
-            // In Postgres, the indexam `amgettuple` calls `heap_hot_search_buffer` for its visibility check
-            let found = heap_hot_search_buffer(
-                &mut self.ipd,
-                self.relation,
-                buffer,
+            let mut call_again = false;
+            let mut all_dead = false;
+            let found = pg_sys::table_index_fetch_tuple(
+                self.scan,
+                &mut self.tid,
                 self.snapshot,
-                &mut heap_tuple,
-                std::ptr::null_mut(),
-                true,
+                slot,
+                &mut call_again,
+                &mut all_dead,
             );
-            (found, heap_tuple)
+
+            if found {
+                Some(func((*self.scan).rel))
+            } else {
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Seeing a nearly 2x performance improvement in selecting large number of rows from queries such as:

```sql
SELECT * FROM t WHERE ... @@@ ...; -- selects millions of rows
```


## Why

Getting rid of some low-hanging per-tuple evaluation overhead.

## How

We cleanup the VisibilityChecker to do it the same way Postgres' `nodeIndexscan.c` does it, which saves a little bit of overhead.

We cleanup our `BufferedChannelCollector` to immediately send blocks of matched documents (as a `Vec<T>`) over the channel.  We also switch to using a bounded channel (bound to the # of CPUs) -- this is where the big performance improvement came from.

And as a drive-by, fix a possible segfault in our `SupportRequestSimplify` processing.

## Tests

Existing tests pass.