### PR TITLE
feat: rename `boost` parameter to BoostQuery as `factor`

### DIFF
--- a/docs/documentation/advanced/compound/boost.mdx
+++ b/docs/documentation/advanced/compound/boost.mdx
@@ -25,7 +25,7 @@ WHERE id @@@
     "boolean": {
         "should": [
             {"term": {"field": "description", "value": "shoes"}},
-            {"boost": {"boost": 2.0, "query": {"term": {"field": "description", "value": "running"}}}}
+            {"boost": {"factor": 2.0, "query": {"term": {"field": "description", "value": "running"}}}}
         ]
     }
 }'::jsonb;
@@ -34,7 +34,7 @@ WHERE id @@@
 
 <div className="mt-8" />
 
-<ParamField body="boost" required>
+<ParamField body="factor" required>
   The factor by which to multiply the score of each result.
 </ParamField>
 <ParamField body="query" required>

--- a/docs/documentation/advanced/compound/overview.mdx
+++ b/docs/documentation/advanced/compound/overview.mdx
@@ -10,7 +10,7 @@ SELECT description, rating, category
 FROM mock_items
 WHERE id @@@ paradedb.boolean(
     should => ARRAY[
-        paradedb.boost(query => paradedb.term('description', 'shoes'), boost => 2.0),
+        paradedb.boost(query => paradedb.term('description', 'shoes'), factor => 2.0),
         paradedb.term('description', 'running')
     ]
 );
@@ -22,7 +22,7 @@ WHERE id @@@
 '{
     "boolean": {
         "should": [
-            {"boost": {"query": {"term": {"field": "description", "value": "shoes"}}, "boost": 2.0}},
+            {"boost": {"query": {"term": {"field": "description", "value": "shoes"}}, "factor": 2.0}},
             {"term": {"field": "description", "value": "running"}}
         ]
     }

--- a/pg_search/sql/pg_search--0.12.0--0.12.1.sql
+++ b/pg_search/sql/pg_search--0.12.0--0.12.1.sql
@@ -9,25 +9,3 @@ CREATE  FUNCTION "term"(
 IMMUTABLE STRICT PARALLEL SAFE 
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'term_anyenum_wrapper';
-
-DROP PROCEDURE IF EXISTS paradedb.create_bm25(index_name text, table_name text, key_field text, schema_name text, text_fields jsonb, numeric_fields jsonb, boolean_fields jsonb, json_fields jsonb, range_fields jsonb, datetime_fields jsonb, predicates text);
-DROP PROCEDURE IF EXISTS paradedb.drop_bm25(index_name text, schema_name text);
-/* </end connected objects> */
-/* <begin connected objects> */
--- pg_search/src/api/config.rs:84
--- pg_search::api::config::format_create_index
-CREATE OR REPLACE FUNCTION paradedb.format_create_index(
-    index_name text DEFAULT '',
-    table_name text DEFAULT '',
-    key_field text DEFAULT '',
-    schema_name text DEFAULT CURRENT_SCHEMA,
-    text_fields jsonb DEFAULT '{}',
-    numeric_fields jsonb DEFAULT '{}',
-    boolean_fields jsonb DEFAULT '{}',
-    json_fields jsonb DEFAULT '{}',
-    range_fields jsonb DEFAULT '{}',
-    datetime_fields jsonb DEFAULT '{}',
-    predicates text DEFAULT ''
-)
-RETURNS text
-LANGUAGE c AS 'MODULE_PATHNAME', 'format_create_index_wrapper';

--- a/pg_search/sql/pg_search--0.12.2--0.12.3.sql
+++ b/pg_search/sql/pg_search--0.12.2--0.12.3.sql
@@ -1,0 +1,24 @@
+DROP PROCEDURE IF EXISTS paradedb.create_bm25(index_name text, table_name text, key_field text, schema_name text, text_fields jsonb, numeric_fields jsonb, boolean_fields jsonb, json_fields jsonb, range_fields jsonb, datetime_fields jsonb, predicates text);
+DROP PROCEDURE IF EXISTS paradedb.drop_bm25(index_name text, schema_name text);
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/config.rs:84
+-- pg_search::api::config::format_create_index
+CREATE OR REPLACE FUNCTION paradedb.format_create_index(
+    index_name text DEFAULT '',
+    table_name text DEFAULT '',
+    key_field text DEFAULT '',
+    schema_name text DEFAULT CURRENT_SCHEMA,
+    text_fields jsonb DEFAULT '{}',
+    numeric_fields jsonb DEFAULT '{}',
+    boolean_fields jsonb DEFAULT '{}',
+    json_fields jsonb DEFAULT '{}',
+    range_fields jsonb DEFAULT '{}',
+    datetime_fields jsonb DEFAULT '{}',
+    predicates text DEFAULT ''
+)
+RETURNS text
+LANGUAGE c AS 'MODULE_PATHNAME', 'format_create_index_wrapper';
+
+DROP FUNCTION IF EXISTS boost(boost pg_catalog.float4, query searchqueryinput);
+CREATE OR REPLACE FUNCTION boost(factor pg_catalog.float4, query searchqueryinput) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boost_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE STRICT;

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -160,10 +160,10 @@ pub fn boolean_singles(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn boost(boost: f32, query: SearchQueryInput) -> SearchQueryInput {
+pub fn boost(factor: f32, query: SearchQueryInput) -> SearchQueryInput {
     SearchQueryInput::Boost {
         query: Box::new(query),
-        boost,
+        factor,
     }
 }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -60,7 +60,7 @@ pub enum SearchQueryInput {
     },
     Boost {
         query: Box<SearchQueryInput>,
-        boost: f32,
+        factor: f32,
     },
     ConstScore {
         query: Box<SearchQueryInput>,
@@ -520,9 +520,9 @@ impl SearchQueryInput {
                 }
                 Ok(Box::new(BooleanQuery::new(subqueries)))
             }
-            Self::Boost { query, boost } => Ok(Box::new(BoostQuery::new(
+            Self::Boost { query, factor } => Ok(Box::new(BoostQuery::new(
                 query.into_tantivy_query(field_lookup, parser, searcher)?,
-                boost,
+                factor,
             ))),
             Self::ConstScore { query, score } => Ok(Box::new(ConstScoreQuery::new(
                 query.into_tantivy_query(field_lookup, parser, searcher)?,

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -1128,7 +1128,7 @@ fn compound_queries(mut conn: PgConnection) {
     FROM mock_items
     WHERE id @@@ paradedb.boolean(
         should => ARRAY[
-            paradedb.boost(query => paradedb.term('description', 'shoes'), boost => 2.0),
+            paradedb.boost(query => paradedb.term('description', 'shoes'), factor => 2.0),
             paradedb.term('description', 'running')
         ]
     );
@@ -1143,7 +1143,7 @@ fn compound_queries(mut conn: PgConnection) {
     '{
         "boolean": {
             "should": [
-                {"boost": {"query": {"term": {"field": "description", "value": "shoes"}}, "boost": 2.0}},
+                {"boost": {"query": {"term": {"field": "description", "value": "shoes"}}, "factor": 2.0}},
                 {"term": {"field": "description", "value": "running"}}
             ]
         }
@@ -1239,7 +1239,7 @@ fn compound_queries(mut conn: PgConnection) {
         "boolean": {
             "should": [
                 {"term": {"field": "description", "value": "shoes"}},
-                {"boost": {"boost": 2.0, "query": {"term": {"field": "description", "value": "running"}}}}
+                {"boost": {"factor": 2.0, "query": {"term": {"field": "description", "value": "running"}}}}
             ]
         }
     }'::jsonb;

--- a/tests/tests/mlt.rs
+++ b/tests/tests/mlt.rs
@@ -92,7 +92,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     SELECT * FROM paradedb.bm25_search
     WHERE id @@@ 
     paradedb.boost(
-        boost => 1.5,
+        factor => 1.5,
         query => paradedb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
@@ -153,7 +153,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
         should => paradedb.disjunction_max(
             disjuncts => ARRAY[
                 paradedb.boost(
-                    boost => 3,
+                    factor => 3,
                     query => paradedb.more_like_this(
                         min_doc_frequency => 2,
                         min_term_frequency => 1,

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -116,7 +116,7 @@ fn single_queries(mut conn: PgConnection) {
     // Boost
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
-    paradedb.boost(query => paradedb.all(), boost => 1.5)
+    paradedb.boost(query => paradedb.all(), factor => 1.5)
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);

--- a/tests/tests/query_json.rs
+++ b/tests/tests/query_json.rs
@@ -121,7 +121,7 @@ fn single_queries(mut conn: PgConnection) {
     // Boost
     let columns: SimpleProductsTableVec = r#"
     SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
-    '{"boost": {"query": {"all": null}, "boost": 1.5}}'::jsonb
+    '{"boost": {"query": {"all": null}, "factor": 1.5}}'::jsonb
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
@@ -273,7 +273,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
     SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
     jsonb_build_object('boost', jsonb_build_object(
         'query', jsonb_build_object('all', null),
-        'boost', 1.5)) ORDER BY id"#
+        'factor', 1.5)) ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
 


### PR DESCRIPTION
## What
Changes the `boost` parameter to `factor` everywhere.

## Why
This is more consistent with naming for other interfaces (like `boost_factor` in MoreLikeThis), and is a decision we made based on feedback from ORM integrators.