### PR TITLE
fix: issue #1895: joins+scores now work correctly

### DIFF
--- a/pg_search/sql/pg_search--0.12.2--0.13.0.sql
+++ b/pg_search/sql/pg_search--0.12.2--0.13.0.sql
@@ -22,3 +22,24 @@ LANGUAGE c AS 'MODULE_PATHNAME', 'format_create_index_wrapper';
 
 DROP FUNCTION IF EXISTS boost(boost pg_catalog.float4, query searchqueryinput);
 CREATE OR REPLACE FUNCTION boost(factor pg_catalog.float4, query searchqueryinput) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boost_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE STRICT;
+
+-- pg_search/src/postgres/customscan/pdbscan/projections/mod.rs:31
+-- pg_search::postgres::customscan::pdbscan::projections::placeholder_support
+CREATE  FUNCTION "placeholder_support"(
+    "arg" internal /* pgrx::datum::internal::Internal */
+) RETURNS internal /* pg_search::api::operator::ReturnedNodePointer */
+    IMMUTABLE PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'placeholder_support_wrapper';
+
+-- pg_search/src/postgres/customscan/pdbscan/projections/score.rs:30
+-- requires:
+--   score_from_relation
+--   placeholder_support
+ALTER FUNCTION score SUPPORT placeholder_support;
+
+-- pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs:48
+-- requires:
+--   snippet_from_relation
+--   placeholder_support
+ALTER FUNCTION snippet SUPPORT placeholder_support;

--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -52,7 +52,7 @@ pub unsafe fn placeholder_support(arg: Internal) -> ReturnedNodePointer {
         assert!(vars.len() == 1, "function is improperly defined or called");
         let var = vars.pop().unwrap();
 
-        let phrels = pg_sys::bms_make_singleton((*var).varno);
+        let phrels = pg_sys::bms_make_singleton((*var).varno as _);
         let phv = pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| {
             #[allow(improper_ctypes)]
             #[rustfmt::skip]
@@ -69,7 +69,10 @@ pub unsafe fn placeholder_support(arg: Internal) -> ReturnedNodePointer {
 
         // copy these properties up from the Var to its placeholder
         (*phv).phlevelsup = (*var).varlevelsup;
-        (*phv).phnullingrels = (*var).varnullingrels;
+        #[cfg(not(any(feature = "pg13", feature = "pg14", feature = "pg15")))]
+        {
+            (*phv).phnullingrels = (*var).varnullingrels;
+        }
 
         return ReturnedNodePointer(NonNull::new(phv.cast()));
     }

--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -18,14 +18,64 @@
 pub mod score;
 pub mod snippet;
 
+use crate::api::operator::{find_vars, ReturnedNodePointer};
 use crate::nodecast;
 use crate::postgres::customscan::pdbscan::projections::score::score_funcoid;
 use crate::postgres::customscan::pdbscan::projections::snippet::{snippet_funcoid, SnippetInfo};
 use pgrx::pg_sys::expression_tree_walker;
-use pgrx::{pg_guard, pg_sys, PgList};
+use pgrx::{pg_extern, pg_guard, pg_sys, Internal, PgList};
 use std::collections::HashMap;
-use std::ptr::addr_of_mut;
+use std::ptr::{addr_of_mut, NonNull};
 use tantivy::snippet::SnippetGenerator;
+
+#[pg_extern(immutable, parallel_safe)]
+pub unsafe fn placeholder_support(arg: Internal) -> ReturnedNodePointer {
+    // we will "simply" calls to `paradedb.score(<anyelement>)` by wrapping (a copy of) its `FuncExpr`
+    // node in a `PlaceHolderVar`.  This ensures that Postgres won't lose the scores when they're
+    // emitted by our custom scan from underneath JOIN nodes (Hash Join, Merge Join, etc).
+    if let Some(srs) = nodecast!(
+        SupportRequestSimplify,
+        T_SupportRequestSimplify,
+        arg.unwrap().unwrap().cast_mut_ptr::<pg_sys::Node>()
+    ) {
+        if (*srs).root.is_null() {
+            return ReturnedNodePointer(None);
+        }
+
+        if !(*(*srs).root).hasJoinRTEs {
+            // however, if the query does not do joins, then using a `PlaceHolderVar` will lead
+            // to a crash -- it wouldn't provide any additional value anyways
+            return ReturnedNodePointer(None);
+        }
+
+        let mut vars = find_vars((*srs).fcall.cast());
+        assert!(vars.len() == 1, "function is improperly defined or called");
+        let var = vars.pop().unwrap();
+
+        let phrels = pg_sys::bms_make_singleton((*var).varno);
+        let phv = pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| {
+            #[allow(improper_ctypes)]
+            #[rustfmt::skip]
+            extern "C" {
+                fn make_placeholder_expr(root: *mut pg_sys::PlannerInfo, expr: *mut pg_sys::Expr, phrels: pg_sys::Relids) -> *mut pg_sys::PlaceHolderVar;
+            }
+
+            make_placeholder_expr(
+                (*srs).root,
+                pg_sys::copyObjectImpl((*srs).fcall.cast()).cast(),
+                phrels,
+            )
+        });
+
+        // copy these properties up from the Var to its placeholder
+        (*phv).phlevelsup = (*var).varlevelsup;
+        (*phv).phnullingrels = (*var).varnullingrels;
+
+        return ReturnedNodePointer(NonNull::new(phv.cast()));
+    }
+
+    ReturnedNodePointer(None)
+}
 
 pub unsafe fn maybe_needs_const_projections(node: *mut pg_sys::Node) -> bool {
     #[pg_guard]

--- a/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
@@ -17,13 +17,23 @@
 
 use crate::nodecast;
 use pgrx::pg_sys::expression_tree_walker;
-use pgrx::{direct_function_call, pg_extern, pg_guard, pg_sys, AnyElement, IntoDatum, PgList};
+use pgrx::{
+    direct_function_call, extension_sql, pg_extern, pg_guard, pg_sys, AnyElement, IntoDatum, PgList,
+};
 use std::ptr::addr_of_mut;
 
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn score_from_relation(_relation_reference: AnyElement) -> Option<f32> {
     None
 }
+
+extension_sql!(
+    r#"
+ALTER FUNCTION score SUPPORT placeholder_support;
+"#,
+    name = "score_placeholder",
+    requires = [score_from_relation, placeholder_support]
+);
 
 pub fn score_funcoid() -> pg_sys::Oid {
     unsafe {

--- a/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
@@ -18,8 +18,8 @@
 use crate::nodecast;
 use pgrx::pg_sys::expression_tree_walker;
 use pgrx::{
-    default, direct_function_call, pg_extern, pg_guard, pg_sys, AnyElement, FromDatum, IntoDatum,
-    PgList,
+    default, direct_function_call, extension_sql, pg_extern, pg_guard, pg_sys, AnyElement,
+    FromDatum, IntoDatum, PgList,
 };
 use std::collections::HashMap;
 use std::ptr::addr_of_mut;
@@ -44,6 +44,14 @@ fn snippet_from_relation(
 ) -> Option<String> {
     None
 }
+
+extension_sql!(
+    r#"
+ALTER FUNCTION snippet SUPPORT placeholder_support;
+"#,
+    name = "snippet_placeholder",
+    requires = [snippet_from_relation, placeholder_support]
+);
 
 pub fn snippet_funcoid() -> pg_sys::Oid {
     unsafe {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1895

## What

We now tell Postgres, in the case of a query with JOINs, that calls to `paradedb.score()` and `paradedb.snippet()` need to be wrapped in a proper `PlaceHolderVar` so that their values are not lost during query planning/execution -- specifically through nodes like HashJoin and MergeJoin.

## Why

Our intent is to support generating (and properly tracking) scores/snippets from either/both sides of a join.

## How

Using the Postgres `PlaceHolderVar` node when the query is a join.

## Tests

Yes.