### PR TITLE
fix: issue #1951: fail gracefully when the relation oid is unknown

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -774,6 +774,9 @@ unsafe fn pullup_orderby_pathkey<P: Into<*mut pg_sys::List> + Default>(
                 }
             } else if let Some(var) = nodecast!(Var, T_Var, expr) {
                 let (heaprelid, attno, _) = find_var_relation(var, root);
+                if heaprelid == pg_sys::Oid::INVALID {
+                    return None;
+                }
                 let heaprel = PgRelation::with_lock(heaprelid, pg_sys::AccessShareLock as _);
                 let tupdesc = heaprel.tuple_desc();
                 if let Some(att) = tupdesc.get(attno as usize - 1) {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1951

## What

Fixes a bug where we tried to open a relation with a `pg_sys::Oid::INVALID`.  In this case, it's fine if we don't have a heap relation oid and we can just return None.

## Why

## How

## Tests

Yes.