### PR TITLE
chore: fix incorrect collation designations for SearchQueryInput

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -235,7 +235,7 @@ unsafe fn make_search_query_input_opexpr_node(
         let search_query_input_const = pg_sys::makeConst(
             searchqueryinput_typoid(),
             -1,
-            pg_sys::DEFAULT_COLLATION_OID,
+            pg_sys::Oid::INVALID,
             -1,
             wrapped_query.into_datum().unwrap(),
             false,
@@ -293,7 +293,7 @@ unsafe fn make_search_query_input_opexpr_node(
             parse_with_field_procoid(),
             searchqueryinput_typoid(),
             parse_with_field_args.into_pg(),
-            pg_sys::DEFAULT_COLLATION_OID,
+            pg_sys::Oid::INVALID,
             pg_sys::DEFAULT_COLLATION_OID,
             pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
         );
@@ -307,7 +307,7 @@ unsafe fn make_search_query_input_opexpr_node(
     }
 
     newopexpr.opresulttype = pg_sys::BOOLOID;
-    newopexpr.opcollid = pg_sys::DEFAULT_COLLATION_OID;
+    newopexpr.opcollid = pg_sys::Oid::INVALID;
     newopexpr.inputcollid = pg_sys::DEFAULT_COLLATION_OID;
     newopexpr.location = (*(*srs).fcall).location;
 

--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -202,7 +202,7 @@ pub unsafe fn inject_placeholders(
                             let const_ = pg_sys::makeConst(
                                 pg_sys::TEXTOID,
                                 -1,
-                                pg_sys::DEFAULT_COLLATION_OID,
+                                pg_sys::Oid::INVALID,
                                 -1,
                                 pg_sys::Datum::null(),
                                 true,

--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -202,7 +202,7 @@ pub unsafe fn inject_placeholders(
                             let const_ = pg_sys::makeConst(
                                 pg_sys::TEXTOID,
                                 -1,
-                                pg_sys::Oid::INVALID,
+                                pg_sys::DEFAULT_COLLATION_OID,
                                 -1,
                                 pg_sys::Datum::null(),
                                 true,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

There's a few places where we construct `pg_sys::Const` and `pg_sys::FuncExpr` nodes with a `paradedb.searchqueryinput` Datum.  Our `paradedb.searchqueryinput` type is a binary type and as such doesn't have a collation, so using `DEFAULT_COLLATION_ID` is incorrect -- it should just be InvalidOid.

## Why

It's strictly wrong this way and it's likely the cause of a report indicating that pg_search didn't quite work with Citus.

## How

## Tests

Existing tests pass.