### PR TITLE
fix: correct docs for disjunction_max and phrase_prefex

### DIFF
--- a/docs/documentation/advanced/compound/disjunction_max.mdx
+++ b/docs/documentation/advanced/compound/disjunction_max.mdx
@@ -21,7 +21,7 @@ FROM mock_items
 WHERE id @@@
 '{
     "disjunction_max": {
-        "queries": [
+        "disjuncts": [
             {"term": {"field": "description", "value": "shoes"}},
             {"term": {"field": "description", "value": "running"}}
         ]

--- a/docs/documentation/advanced/phrase/phrase_prefix.mdx
+++ b/docs/documentation/advanced/phrase/phrase_prefix.mdx
@@ -20,7 +20,7 @@ WHERE id @@@
 '{
     "phrase_prefix": {
         "field": "description",
-        "values": ["running", "sh"]
+        "phrases": ["running", "sh"]
     }
 }'::jsonb;
 ```


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1953 
- Closes #1954

## What
A couple mistakes in our docs from when we introduced JSON syntax. Thank you @Traverso!

## Tests
Tests added for each query.
