### PR TITLE
feat: add index_fields() and format_create_bm25 functions to support CREATE INDEX

### DIFF
--- a/docs/documentation/indexing/create_index.mdx
+++ b/docs/documentation/indexing/create_index.mdx
@@ -70,7 +70,7 @@ WITH (
 );
 ```
 
-`paradedb.field` accepts the following configuration options for text fields:
+`CREATE INDEX` accepts the following configuration options for `text_fields`:
 
 <ParamField body="indexed" default={true}>
   Whether the field is indexed. Must be `true` in order for the field to be
@@ -119,7 +119,7 @@ WITH (
 );
 ```
 
-`paradedb.field` accepts the following configuration options numeric fields:
+`CREATE INDEX` accepts the following configuration options `numeric_fields`:
 
 <ParamField body="indexed" default={true}>
   Whether the field is indexed. Must be `true` in order for the field to be
@@ -145,7 +145,7 @@ USING bm25 (id, in_stock)
 WITH (key_field = 'id');
 ```
 
-`paradedb.field` accepts several configuration options for boolean fields:
+`CREATE_INDEX` accepts several configuration options for `boolean_fields`:
 
 <ParamField body="indexed" default={true}>
   Whether the field is indexed. Must be `true` in order for the field to be
@@ -171,7 +171,7 @@ USING bm25 (id, metadata)
 WITH (key_field = 'id');
 ```
 
-`paradedb.field` accepts several configuration options for JSON fields:
+`CREATE INDEX` accepts several configuration options for `json_fields`:
 
 <ParamField body="indexed" default={true}>
   Whether the field is indexed. Must be `true` in order for the field to be tokenized and
@@ -216,7 +216,7 @@ USING bm25 (id, created_at)
 WITH (key_field = 'id');
 ```
 
-`paradedb.field` accepts several configuration options for boolean fields:
+`CREATE INDEX` accepts several configuration options for `boolean_fields`:
 
 <ParamField body="indexed" default={true}>
   Whether the field is indexed. Must be `true` in order for the field to be

--- a/docs/documentation/indexing/tokenizers.mdx
+++ b/docs/documentation/indexing/tokenizers.mdx
@@ -171,7 +171,7 @@ SELECT * FROM paradedb.tokenize(
   us](mailto:sales@paradedb.com) for access.
 </Info>
 
-ParadeDB supports using multiple tokenizers for the same field within a single BM25 index. This feature allows for more flexible and powerful querying capabilities, enabling you to employ various strategies to match against an index term. You can apply different tokenizers to the same field by using the `column` parameter in the `paradedb.field` function.
+ParadeDB supports using multiple tokenizers for the same field within a single BM25 index. This feature allows for more flexible and powerful querying capabilities, enabling you to employ various strategies to match against an index term.
 
 Here's an example of how to create a BM25 index with multiple tokenizers for the same field:
 

--- a/pg_search/sql/pg_search--0.12.2--0.13.0.sql
+++ b/pg_search/sql/pg_search--0.12.2--0.13.0.sql
@@ -43,3 +43,34 @@ ALTER FUNCTION score SUPPORT placeholder_support;
 --   snippet_from_relation
 --   placeholder_support
 ALTER FUNCTION snippet SUPPORT placeholder_support;
+
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/bootstrap/create_bm25.rs:39
+-- pg_search::bootstrap::create_bm25::format_create_bm25
+CREATE  FUNCTION "format_create_bm25"(
+	"index_name" TEXT, /* &str */
+	"table_name" TEXT, /* &str */
+	"key_field" TEXT, /* &str */
+	"schema_name" TEXT DEFAULT '', /* &str */
+	"text_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"numeric_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"boolean_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"json_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"range_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"datetime_fields" jsonb DEFAULT '{}'::jsonb, /* pgrx::datum::json::JsonB */
+	"predicates" TEXT DEFAULT '' /* &str */
+) RETURNS TEXT /* core::result::Result<alloc::string::String, anyhow::Error> */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'format_create_bm25_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/bootstrap/create_bm25.rs:134
+-- pg_search::bootstrap::create_bm25::index_fields
+CREATE  FUNCTION "index_fields"(
+	"index" regclass /* pgrx::rel::PgRelation */
+) RETURNS jsonb /* pgrx::datum::json::JsonB */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'index_fields_wrapper';

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -15,12 +15,89 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
+
+use anyhow::bail;
 use anyhow::Result;
 use pgrx::prelude::*;
+use pgrx::JsonB;
 use pgrx::PgRelation;
+use serde_json::Map;
+use serde_json::Value;
+use tokenizers::manager::SearchTokenizerFilters;
+use tokenizers::SearchNormalizer;
+use tokenizers::SearchTokenizer;
 
 use crate::index::{SearchFs, SearchIndex, WriterDirectory};
 use crate::postgres::index::{open_search_index, relfilenode_from_pg_relation};
+use crate::postgres::options::SearchIndexCreateOptions;
+use crate::schema::IndexRecordOption;
+use crate::schema::SearchFieldConfig;
+use crate::schema::SearchFieldName;
+use crate::schema::SearchFieldType;
+
+#[pg_extern]
+fn format_create_bm25(
+    index_name: &str,
+    table_name: &str,
+    key_field: &str,
+    schema_name: default!(&str, "''"),
+    text_fields: default!(JsonB, "'{}'::jsonb"),
+    numeric_fields: default!(JsonB, "'{}'::jsonb"),
+    boolean_fields: default!(JsonB, "'{}'::jsonb"),
+    json_fields: default!(JsonB, "'{}'::jsonb"),
+    range_fields: default!(JsonB, "'{}'::jsonb"),
+    datetime_fields: default!(JsonB, "'{}'::jsonb"),
+    predicates: default!(&str, "''"),
+) -> Result<String> {
+    let mut column_names = vec![key_field.to_string()];
+    for fields in [
+        &text_fields,
+        &numeric_fields,
+        &boolean_fields,
+        &json_fields,
+        &range_fields,
+        &datetime_fields,
+    ] {
+        if let Value::Object(ref map) = fields.0 {
+            for key in map.keys() {
+                if key != key_field {
+                    column_names.push(spi::quote_identifier(key.clone()));
+                }
+            }
+        } else {
+            bail!("Expected a JSON object, received: {}", fields.0);
+        }
+    }
+
+    let column_names_csv = column_names
+        .clone()
+        .into_iter()
+        .collect::<Vec<String>>()
+        .join(", ");
+
+    let predicate_where = if !predicates.is_empty() {
+        format!("WHERE {}", predicates)
+    } else {
+        "".to_string()
+    };
+
+    Ok(format!(
+        "CREATE INDEX {} ON {}.{} USING bm25 ({}, {}) WITH (key_field={}, text_fields={}, numeric_fields={}, boolean_fields={}, json_fields={}, range_fields={}, datetime_fields={}) {};",
+        spi::quote_identifier(index_name),
+        spi::quote_identifier(schema_name),
+        spi::quote_identifier(table_name),
+        spi::quote_identifier(key_field),
+        column_names_csv,
+        spi::quote_literal(key_field),
+        spi::quote_literal(&serde_json::to_string(&text_fields)?),
+        spi::quote_literal(&serde_json::to_string(&numeric_fields)?),
+        spi::quote_literal(&serde_json::to_string(&boolean_fields)?),
+        spi::quote_literal(&serde_json::to_string(&json_fields)?),
+        spi::quote_literal(&serde_json::to_string(&range_fields)?),
+        spi::quote_literal(&serde_json::to_string(&datetime_fields)?),
+        predicate_where))
+}
 
 #[pg_extern(sql = "
 CREATE OR REPLACE PROCEDURE paradedb.delete_bm25_index_by_oid(
@@ -52,6 +129,165 @@ unsafe fn delete_bm25_index_by_oid(index_oid: pg_sys::Oid) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[pg_extern]
+pub unsafe fn index_fields(index: PgRelation) -> JsonB {
+    let rdopts: PgBox<SearchIndexCreateOptions> = if !index.rd_options.is_null() {
+        unsafe { PgBox::from_pg(index.rd_options as *mut SearchIndexCreateOptions) }
+    } else {
+        let ops = unsafe { PgBox::<SearchIndexCreateOptions>::alloc0() };
+        ops.into_pg_boxed()
+    };
+
+    // Create a map from column name to column type. We'll use this to verify that index
+    // configurations passed by the user reference the correct types for each column.
+    let name_type_map: HashMap<SearchFieldName, SearchFieldType> = index
+        .tuple_desc()
+        .into_iter()
+        .filter_map(|attribute| {
+            let attname = attribute.name();
+            let attribute_type_oid = attribute.type_oid();
+            let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
+            let base_oid = if array_type != pg_sys::InvalidOid {
+                PgOid::from(array_type)
+            } else {
+                attribute_type_oid
+            };
+            if let Ok(search_field_type) = SearchFieldType::try_from(&base_oid) {
+                Some((attname.into(), search_field_type))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Parse and validate the index configurations for each column.
+    let text_fields =
+        rdopts
+            .get_text_fields()
+            .into_iter()
+            .map(|(name, config)| match name_type_map.get(&name) {
+                Some(field_type @ SearchFieldType::Text) => (name, config, *field_type),
+                _ => panic!("'{name}' cannot be indexed as a text field"),
+            });
+
+    let numeric_fields = rdopts
+        .get_numeric_fields()
+        .into_iter()
+        .map(|(name, config)| match name_type_map.get(&name) {
+            Some(field_type @ SearchFieldType::U64)
+            | Some(field_type @ SearchFieldType::I64)
+            | Some(field_type @ SearchFieldType::F64) => (name, config, *field_type),
+            _ => panic!("'{name}' cannot be indexed as a numeric field"),
+        });
+
+    let boolean_fields = rdopts
+        .get_boolean_fields()
+        .into_iter()
+        .map(|(name, config)| match name_type_map.get(&name) {
+            Some(field_type @ SearchFieldType::Bool) => (name, config, *field_type),
+            _ => panic!("'{name}' cannot be indexed as a boolean field"),
+        });
+
+    let json_fields =
+        rdopts
+            .get_json_fields()
+            .into_iter()
+            .map(|(name, config)| match name_type_map.get(&name) {
+                Some(field_type @ SearchFieldType::Json) => (name, config, *field_type),
+                _ => panic!("'{name}' cannot be indexed as a JSON field"),
+            });
+
+    let range_fields = rdopts.get_range_fields().into_iter().map(|(name, config)| {
+        match name_type_map.get(&name) {
+            Some(field_type @ SearchFieldType::Range) => (name, config, *field_type),
+            _ => panic!("'{name}' cannot be indexed as a range field"),
+        }
+    });
+
+    let datetime_fields = rdopts
+        .get_datetime_fields()
+        .into_iter()
+        .map(|(name, config)| match name_type_map.get(&name) {
+            Some(field_type @ SearchFieldType::Date) => (name, config, *field_type),
+            _ => panic!("'{name}' cannot be indexed as a datetime field"),
+        });
+
+    let key_field = rdopts.get_key_field().expect("must specify key field");
+    let key_field_type = match name_type_map.get(&key_field) {
+        Some(field_type) => field_type,
+        None => panic!("key field does not exist"),
+    };
+    let key_config = match key_field_type {
+        SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => {
+            SearchFieldConfig::Numeric {
+                indexed: true,
+                fast: true,
+                stored: true,
+            }
+        }
+        SearchFieldType::Text => SearchFieldConfig::Text {
+            indexed: true,
+            fast: true,
+            stored: true,
+            fieldnorms: false,
+            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+            record: IndexRecordOption::Basic,
+            normalizer: SearchNormalizer::Raw,
+        },
+        SearchFieldType::Json => SearchFieldConfig::Json {
+            indexed: true,
+            fast: true,
+            stored: true,
+            expand_dots: false,
+            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+            record: IndexRecordOption::Basic,
+            normalizer: SearchNormalizer::Raw,
+            fieldnorms: true,
+        },
+        SearchFieldType::Range => SearchFieldConfig::Range { stored: true },
+        SearchFieldType::Bool => SearchFieldConfig::Boolean {
+            indexed: true,
+            fast: true,
+            stored: true,
+        },
+        SearchFieldType::Date => SearchFieldConfig::Date {
+            indexed: true,
+            fast: true,
+            stored: true,
+        },
+    };
+
+    // Concatenate the separate lists of fields.
+    let fields = text_fields
+        .chain(numeric_fields)
+        .chain(boolean_fields)
+        .chain(json_fields)
+        .chain(range_fields)
+        .chain(datetime_fields)
+        .chain(std::iter::once((
+            key_field.clone(),
+            key_config,
+            *key_field_type,
+        )))
+        // "ctid" is a reserved column name in Postgres, so we don't need to worry about
+        // creating a name conflict with a user-named column.
+        .chain(std::iter::once((
+            "ctid".into(),
+            SearchFieldConfig::Ctid,
+            SearchFieldType::U64,
+        )))
+        .map(|(name, config, _)| {
+            (
+                name.0,
+                serde_json::to_value(config)
+                    .expect("must be able to convert search field config to JSON"),
+            )
+        })
+        .collect::<Map<_, _>>();
+
+    JsonB(serde_json::Value::from(fields))
 }
 
 #[pg_extern]

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -36,6 +36,7 @@ use crate::schema::SearchFieldConfig;
 use crate::schema::SearchFieldName;
 use crate::schema::SearchFieldType;
 
+#[allow(clippy::too_many_arguments)]
 #[pg_extern]
 fn format_create_bm25(
     index_name: &str,


### PR DESCRIPTION
## What
Introduces `paradedb.index_fields` as well as `paradedb.format_create_bm25` functions as helpers for creating and inspecting indexes.

Also some final doc changes around `CREATE INDEX`, removing outstanding references to `paradedb.field`.

## Why
Typing out the JSON that is now required for `CREATE INDEX` is cumbersome, so `format_create_bm25` will return a SQL string that can be evaluated.

`paradedb.index_fields` lets us inspect the field configuration that was used to create an index.

## Tests
New tests for each function.