### PR TITLE
feat: enable concurrent index creation + reindex on BM25

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -35,6 +35,7 @@ pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgRelation> {
         // Find all bm25 indexes and keep the one with highest OID
         indices
             .into_iter()
+            .filter(|index| pg_sys::get_index_isvalid(index.oid()))
             .filter(|index| {
                 !index.rd_indam.is_null()
                     && (*index.rd_indam).ambuild == Some(crate::postgres::build::ambuild)

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -25,19 +25,21 @@ use chrono::{NaiveDate, NaiveTime};
 use pgrx::itemptr::{item_pointer_get_both, item_pointer_set_all};
 use pgrx::*;
 
-/// Finds and returns the first `USING bm25` index on the specified relation, or [`None`] if there
-/// aren't any
+/// Finds and returns the `USING bm25` index on the specified relation with the
+/// highest OID, or [`None`] if there aren't any.
 pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgRelation> {
     unsafe {
         let heaprel = PgRelation::open(heaprelid);
-        for index in heaprel.indices(pg_sys::AccessShareLock as _) {
-            if !index.rd_indam.is_null()
-                && (*index.rd_indam).ambuild == Some(crate::postgres::build::ambuild)
-            {
-                return Some(index);
-            }
-        }
-        None
+        let indices = heaprel.indices(pg_sys::AccessShareLock as _);
+
+        // Find all bm25 indexes and keep the one with highest OID
+        indices
+            .into_iter()
+            .filter(|index| {
+                !index.rd_indam.is_null()
+                    && (*index.rd_indam).ambuild == Some(crate::postgres::build::ambuild)
+            })
+            .max_by_key(|index| index.oid().as_u32())
     }
 }
 

--- a/tests/tests/reindex.rs
+++ b/tests/tests/reindex.rs
@@ -261,12 +261,12 @@ async fn concurrent_index_creation(mut conn: PgConnection) -> Result<()> {
         numeric_fields='{"rating": {}}',
         boolean_fields='{"in_stock": {}}',
         json_fields='{"metadata": {}}',
-        fast_fields='{"created_at": {}, "last_updated_date": {}}'
+        datetime_fields='{"created_at": {}, "last_updated_date": {}}'
     )"#.execute(&mut conn);
 
     // Query using the new index
     let columns: SimpleProductsTableVec =
-        "SELECT * FROM paradedb.bm25_search WHERE bm25_search_bm25_index_2 @@@ 'description:keyboard' ORDER BY id"
+        "SELECT * FROM paradedb.bm25_search WHERE id @@@ 'description:keyboard' ORDER BY id"
             .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![1, 2]);
 
@@ -275,7 +275,7 @@ async fn concurrent_index_creation(mut conn: PgConnection) -> Result<()> {
 
     // Verify the new index still works
     let columns: SimpleProductsTableVec =
-        "SELECT * FROM paradedb.bm25_search WHERE bm25_search_bm25_index_2 @@@ 'description:keyboard' ORDER BY id"
+        "SELECT * FROM paradedb.bm25_search WHERE id @@@ 'description:keyboard' ORDER BY id"
             .fetch_collect(&mut conn);
     assert_eq!(columns.id, vec![1, 2]);
 

--- a/tests/tests/reindex.rs
+++ b/tests/tests/reindex.rs
@@ -1,0 +1,267 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use crate::fixtures::utils::pg_search_index_directory_path;
+use anyhow::Result;
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+use std::path::PathBuf;
+use tantivy::Index;
+
+#[rstest]
+async fn basic_reindex(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Get initial index directory path and verify it exists
+    let index_dir = pg_search_index_directory_path(&mut conn, "bm25_search_bm25_index");
+    assert!(index_dir.exists());
+
+    // Verify initial search works
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Perform REINDEX
+    "REINDEX INDEX paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Verify index directory still exists
+    assert!(index_dir.exists());
+
+    // Verify search still works after reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn concurrent_reindex(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Get initial index directory path
+    let index_dir = pg_search_index_directory_path(&mut conn, "bm25_search_bm25_index");
+    assert!(index_dir.exists());
+
+    // Verify initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Perform concurrent REINDEX
+    "REINDEX INDEX CONCURRENTLY paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Verify search still works after concurrent reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_with_updates(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Make some updates
+    "UPDATE paradedb.bm25_search SET description = 'Mechanical keyboard' WHERE id = 1".execute(&mut conn);
+    "INSERT INTO paradedb.bm25_search (description, category, rating, in_stock, metadata, created_at, last_updated_date) VALUES ('Wireless keyboard', 'Electronics', 4, true, '{\"color\": \"black\"}', now(), current_date)".execute(&mut conn);
+
+    // Verify updates are searchable
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2, 42]);
+
+    // Perform REINDEX
+    "REINDEX INDEX paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Verify all updates are still searchable after reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2, 42]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_with_deletes(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Delete some records
+    "DELETE FROM paradedb.bm25_search WHERE id = 1".execute(&mut conn);
+
+    // Verify delete is reflected in search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![2]);
+
+    // Perform REINDEX
+    "REINDEX INDEX paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Verify deleted records are still not searchable after reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![2]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_schema_validation(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Get initial schema
+    let initial_schema: Vec<(String, String)> =
+        "SELECT name, field_type FROM paradedb.schema('paradedb.bm25_search_bm25_index') ORDER BY name"
+            .fetch(&mut conn);
+
+    // Perform REINDEX
+    "REINDEX INDEX paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Get schema after reindex
+    let reindexed_schema: Vec<(String, String)> =
+        "SELECT name, field_type FROM paradedb.schema('paradedb.bm25_search_bm25_index') ORDER BY name"
+            .fetch(&mut conn);
+
+    // Verify schema hasn't changed
+    assert_eq!(initial_schema, reindexed_schema);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_partial_index(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Create a partial index
+    r#"CREATE INDEX partial_idx ON paradedb.bm25_search
+    USING bm25 (id, description, category)
+    WITH (key_field='id')
+    WHERE category = 'Electronics'"#
+        .execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Perform REINDEX
+    "REINDEX INDEX paradedb.partial_idx".execute(&mut conn);
+
+    // Verify partial index still works correctly after reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn concurrent_reindex_with_updates(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Start concurrent reindex
+    "REINDEX INDEX CONCURRENTLY paradedb.bm25_search_bm25_index".execute(&mut conn);
+
+    // Make updates during reindex
+    "UPDATE paradedb.bm25_search SET description = 'Mechanical keyboard' WHERE id = 1".execute(&mut conn);
+    "INSERT INTO paradedb.bm25_search (description, category, rating, in_stock, metadata, created_at, last_updated_date) VALUES ('Wireless keyboard', 'Electronics', 4, true, '{\"color\": \"black\"}', now(), current_date)".execute(&mut conn);
+
+    // Verify all updates are searchable after concurrent reindex
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2, 42]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_table(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Reindex entire table
+    "REINDEX TABLE paradedb.bm25_search".execute(&mut conn);
+
+    // Verify search still works
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    Ok(())
+}
+
+#[rstest]
+async fn reindex_database(mut conn: PgConnection) -> Result<()> {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    // Initial search
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    // Reindex entire database
+    "REINDEX DATABASE postgres".execute(&mut conn);
+
+    // Verify search still works
+    let columns: SimpleProductsTableVec =
+        "SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id"
+            .fetch_collect(&mut conn);
+    assert_eq!(columns.id, vec![1, 2]);
+
+    Ok(())
+}


### PR DESCRIPTION
## What
This PR adjusts some of the verification logic in our `ambuild` method to support `REINDEX` and `CREATE INDEX CONCURRENTLY`.

## Why
Now that we've entirely adopted `CREATE INDEX` syntax for creating BM25 indexes, its much easier for users to take advantage of `CONCURRENTLY` so they can build new indexes in the background.

## Tests
I've added a new set of tests to `reindex.rs` that covers some basic scenarios for both `REINDEX` and `CREATE INDEX`. 