### PR TITLE
fix: dedup key_field in format_create_bm25 

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -74,6 +74,7 @@ fn format_create_bm25(
     let column_names_csv = column_names
         .clone()
         .into_iter()
+        .filter(|name| name != key_field)
         .collect::<Vec<String>>()
         .join(", ");
 

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -148,7 +148,7 @@ fn test_format_create_bm25_basic(mut conn: PgConnection) {
     "#
     .fetch_one::<(String,)>(&mut conn);
 
-    let expected = r##"CREATE INDEX my_index ON public.my_table USING bm25 (id, id, title, price, is_available, details, price_range, published_date) WITH (key_field='id', text_fields='{"title":true}', numeric_fields='{"price":true}', boolean_fields='{"is_available":true}', json_fields='{"details":true}', range_fields='{"price_range":true}', datetime_fields='{"published_date":true}') WHERE price > 0;"##;
+    let expected = r##"CREATE INDEX my_index ON public.my_table USING bm25 (id, title, price, is_available, details, price_range, published_date) WITH (key_field='id', text_fields='{"title":true}', numeric_fields='{"price":true}', boolean_fields='{"is_available":true}', json_fields='{"details":true}', range_fields='{"price_range":true}', datetime_fields='{"published_date":true}') WHERE price > 0;"##;
 
     assert_eq!(row.0, expected);
 }
@@ -172,7 +172,7 @@ fn test_format_create_index_no_predicate(mut conn: PgConnection) {
     "#
     .fetch_one::<(String,)>(&mut conn);
 
-    let expected = r##"CREATE INDEX another_index ON inventory.products USING bm25 (product_id, product_id, name) WITH (key_field='product_id', text_fields='{"name":true}', numeric_fields='{}', boolean_fields='{}', json_fields='{}', range_fields='{}', datetime_fields='{}') ;"##;
+    let expected = r##"CREATE INDEX another_index ON inventory.products USING bm25 (product_id, name) WITH (key_field='product_id', text_fields='{"name":true}', numeric_fields='{}', boolean_fields='{}', json_fields='{}', range_fields='{}', datetime_fields='{}') ;"##;
 
     assert_eq!(row.0, expected);
 }
@@ -196,7 +196,7 @@ fn test_format_bm25_basic(mut conn: PgConnection) {
     "#
     .fetch_one::<(String,)>(&mut conn);
 
-    let expected = r##"CREATE INDEX my_search_idx ON public.articles USING bm25 (id, id, content, title, rating, published, metadata, price_range, created_at) WITH (key_field='id', text_fields='{"content":true,"title":true}', numeric_fields='{"rating":true}', boolean_fields='{"published":true}', json_fields='{"metadata":true}', range_fields='{"price_range":true}', datetime_fields='{"created_at":true}') WHERE rating > 3;"##;
+    let expected = r##"CREATE INDEX my_search_idx ON public.articles USING bm25 (id, content, title, rating, published, metadata, price_range, created_at) WITH (key_field='id', text_fields='{"content":true,"title":true}', numeric_fields='{"rating":true}', boolean_fields='{"published":true}', json_fields='{"metadata":true}', range_fields='{"price_range":true}', datetime_fields='{"created_at":true}') WHERE rating > 3;"##;
 
     assert_eq!(row.0, expected);
 }
@@ -220,7 +220,7 @@ fn test_format_bm25_empty_fields(mut conn: PgConnection) {
     "#
     .fetch_one::<(String,)>(&mut conn);
 
-    let expected = r#"CREATE INDEX minimal_idx ON public.simple_table USING bm25 (id, id, title) WITH (key_field='id', text_fields='{"title":true}', numeric_fields='{}', boolean_fields='{}', json_fields='{}', range_fields='{}', datetime_fields='{}') ;"#;
+    let expected = r#"CREATE INDEX minimal_idx ON public.simple_table USING bm25 (id, title) WITH (key_field='id', text_fields='{"title":true}', numeric_fields='{}', boolean_fields='{}', json_fields='{}', range_fields='{}', datetime_fields='{}') ;"#;
 
     assert_eq!(row.0, expected);
 }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -228,7 +228,7 @@ fn test_format_bm25_empty_fields(mut conn: PgConnection) {
 #[rstest]
 fn test_format_bm25_invalid_json(mut conn: PgConnection) {
     let res = r#"
-        SELECT paradedb.format_bm25(
+        SELECT paradedb.format_create_bm25(
             'bad_idx',
             'test_table',
             'id',

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -143,8 +143,7 @@ fn test_format_create_bm25_basic(mut conn: PgConnection) {
             published_date TIMESTAMP
         );
     "#
-    .execute_result(&mut conn)
-    .unwrap();
+    .execute(&mut conn);
 
     // Get the CREATE INDEX statement
     let sql = r#"
@@ -153,20 +152,19 @@ fn test_format_create_bm25_basic(mut conn: PgConnection) {
             'my_table'::text, 
             'id'::text, 
             'public'::text, 
-            '{"title": true}'::jsonb, 
-            '{"price": true}'::jsonb, 
-            '{"is_available": true}'::jsonb, 
-            '{"details": true}'::jsonb, 
-            '{"price_range": true}'::jsonb, 
-            '{"published_date": true}'::jsonb, 
+            '{"title": {}}'::jsonb, 
+            '{"price": {}}'::jsonb, 
+            '{"is_available": {}}'::jsonb, 
+            '{"details": {}}'::jsonb, 
+            '{"price_range": {}}'::jsonb, 
+            '{"published_date": {}}'::jsonb, 
             'price > 0'::text
         );
     "#
-    .fetch_one::<(String,)>(&mut conn)
-    .unwrap();
+    .fetch_one::<(String,)>(&mut conn);
 
     // Execute the CREATE INDEX statement
-    sql.0.execute_result(&mut conn).unwrap();
+    sql.0.execute(&mut conn);
 
     // Cleanup
     r#"DROP TABLE public.my_table CASCADE;"#.execute_result(&mut conn).unwrap();
@@ -176,7 +174,7 @@ fn test_format_create_bm25_basic(mut conn: PgConnection) {
 fn test_format_create_index_no_predicate(mut conn: PgConnection) {
     // Create schema and test table
     r#"CREATE SCHEMA IF NOT EXISTS inventory;"#.execute_result(&mut conn).unwrap();
-    
+
     r#"
         CREATE TABLE inventory.products (
             product_id INTEGER PRIMARY KEY,
@@ -193,7 +191,7 @@ fn test_format_create_index_no_predicate(mut conn: PgConnection) {
             'products', 
             'product_id', 
             'inventory', 
-            '{"name": true}'::jsonb, 
+            '{"name": {}}'::jsonb, 
             '{}'::jsonb, 
             '{}'::jsonb, 
             '{}'::jsonb, 
@@ -202,10 +200,9 @@ fn test_format_create_index_no_predicate(mut conn: PgConnection) {
             ''
         );
     "#
-    .fetch_one::<(String,)>(&mut conn)
-    .unwrap();
+    .fetch_one::<(String,)>(&mut conn);
 
-    sql.0.execute_result(&mut conn).unwrap();
+    sql.0.execute(&mut conn);
 
     // Cleanup
     r#"DROP TABLE inventory.products CASCADE;"#.execute_result(&mut conn).unwrap();
@@ -237,17 +234,16 @@ fn test_format_bm25_basic(mut conn: PgConnection) {
             'articles',
             'id',
             'public',
-            '{"title": true, "content": true}'::jsonb,
-            '{"rating": true}'::jsonb,
-            '{"published": true}'::jsonb,
-            '{"metadata": true}'::jsonb,
-            '{"price_range": true}'::jsonb,
-            '{"created_at": true}'::jsonb,
+            '{"title": {}, "content": {}}'::jsonb,
+            '{"rating": {}}'::jsonb,
+            '{"published": {}}'::jsonb,
+            '{"metadata": {}}'::jsonb,
+            '{"price_range": {}}'::jsonb,
+            '{"created_at": {}}'::jsonb,
             'rating > 3'
         );
     "#
-    .fetch_one::<(String,)>(&mut conn)
-    .unwrap();
+    .fetch_one::<(String,)>(&mut conn);
 
     sql.0.execute_result(&mut conn).unwrap();
 
@@ -264,8 +260,7 @@ fn test_format_bm25_empty_fields(mut conn: PgConnection) {
             title TEXT
         );
     "#
-    .execute_result(&mut conn)
-    .unwrap();
+    .execute(&mut conn);
 
     // Get and execute CREATE INDEX statement
     let sql = r#"
@@ -274,7 +269,7 @@ fn test_format_bm25_empty_fields(mut conn: PgConnection) {
             'simple_table',
             'id',
             'public',
-            '{"title": true}'::jsonb,
+            '{"title": {}}'::jsonb,
             '{}'::jsonb,
             '{}'::jsonb,
             '{}'::jsonb,
@@ -283,13 +278,13 @@ fn test_format_bm25_empty_fields(mut conn: PgConnection) {
             ''
         );
     "#
-    .fetch_one::<(String,)>(&mut conn)
-    .unwrap();
+    .fetch_one::<(String,)>(&mut conn);
 
-    sql.0.execute_result(&mut conn).unwrap();
+    // Ensure the result can be executed.
+    sql.0.execute(&mut conn);
 
     // Cleanup
-    r#"DROP TABLE public.simple_table CASCADE;"#.execute_result(&mut conn).unwrap();
+    r#"DROP TABLE public.simple_table CASCADE;"#.execute(&mut conn);
 }
 
 #[rstest]
@@ -333,8 +328,7 @@ fn test_index_fields(mut conn: PgConnection) {
             created_at TIMESTAMP
         );
     "#
-    .execute_result(&mut conn)
-    .unwrap();
+    .execute(&mut conn);
 
     r#"
         CREATE INDEX idx_test_fields ON test_fields USING bm25 (
@@ -349,8 +343,7 @@ fn test_index_fields(mut conn: PgConnection) {
             datetime_fields='{"created_at": {}}'
         );
     "#
-    .execute_result(&mut conn)
-    .unwrap();
+    .execute(&mut conn);
 
     // Get the index fields
     let row: (serde_json::Value,) = r#"
@@ -470,5 +463,5 @@ fn test_index_fields(mut conn: PgConnection) {
     assert!(fields.contains_key("ctid"));
 
     // Cleanup
-    r#"DROP TABLE test_fields CASCADE;"#.execute_result(&mut conn).unwrap();
+    r#"DROP TABLE test_fields CASCADE;"#.execute(&mut conn);
 }


### PR DESCRIPTION
## What
The new `format_create_bm25` function needs to de-deuplicate they key_field in the CSV column.

## Tests
Added an execution step to each test to ensure validity.
