### PR TITLE
feat: enable multiple tokenizers through aliased fields configs

### DIFF
--- a/docs/documentation/indexing/tokenizers.mdx
+++ b/docs/documentation/indexing/tokenizers.mdx
@@ -242,8 +242,8 @@ WITH (
     key_field='id',
     text_fields='{
         "description": {"tokenizer": {"type": "whitespace"}},
-        "description_ngram": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 3, "prefix_only": false} "column": "description"},
-        "description_stem": {"tokenizer": {"type": "default", "stemmer": "English"}, "column": "description"}}
+        "description_ngram": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 3, "prefix_only": false}, "column": "description"},
+        "description_stem": {"tokenizer": {"type": "default", "stemmer": "English"}, "column": "description"}
     }'
 );
 

--- a/docs/documentation/indexing/tokenizers.mdx
+++ b/docs/documentation/indexing/tokenizers.mdx
@@ -237,7 +237,7 @@ Here's an example of how to create a BM25 index with multiple tokenizers for the
 
 ```sql
 CREATE INDEX search_idx ON public.mock_items
-USING bm25 (id, description, description_ngram, description_stem)
+USING bm25 (id, description)
 WITH (
     key_field='id',
     text_fields='{

--- a/docs/documentation/indexing/tokenizers.mdx
+++ b/docs/documentation/indexing/tokenizers.mdx
@@ -229,12 +229,9 @@ SELECT * FROM paradedb.tokenize(
 
 ## Multiple Tokenizers
 
-<Info>
-  Multiple tokenizers are a ParadeDB enterprise feature. [Contact
-  us](mailto:sales@paradedb.com) for access.
-</Info>
-
 ParadeDB supports using multiple tokenizers for the same field within a single BM25 index. This feature allows for more flexible and powerful querying capabilities, enabling you to employ various strategies to match against an index term.
+
+To setup a field with multiple tokenizers, you should configure it with an alias in the `WITH` options to `CREATE INDEX`. The configuration should contain a `"column"` key that points to the table column containing the data for that field.
 
 Here's an example of how to create a BM25 index with multiple tokenizers for the same field:
 

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -242,6 +242,7 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
                 indexed: true,
                 fast: true,
                 stored: true,
+                column: None,
             }
         }
         SearchFieldType::Text => SearchFieldConfig::Text {
@@ -252,6 +253,7 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
             tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
+            column: None,
         },
         SearchFieldType::Json => SearchFieldConfig::Json {
             indexed: true,
@@ -262,17 +264,23 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
             fieldnorms: true,
+            column: None,
         },
-        SearchFieldType::Range => SearchFieldConfig::Range { stored: true },
+        SearchFieldType::Range => SearchFieldConfig::Range {
+            stored: true,
+            column: None,
+        },
         SearchFieldType::Bool => SearchFieldConfig::Boolean {
             indexed: true,
             fast: true,
             stored: true,
+            column: None,
         },
         SearchFieldType::Date => SearchFieldConfig::Date {
             indexed: true,
             fast: true,
             stored: true,
+            column: None,
         },
     };
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -112,7 +112,7 @@ pub extern "C" fn ambuild(
         })
         .collect();
 
-    for (name, _) in rdopts.get_text_fields() {
+    for (name, _config) in rdopts.get_text_fields() {
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Text)) {
             panic!("'{name}' cannot be indexed as a text field");
         }
@@ -162,6 +162,7 @@ pub extern "C" fn ambuild(
                 indexed: true,
                 fast: true,
                 stored: true,
+                column: None,
             }
         }
         SearchFieldType::Text => SearchFieldConfig::Text {
@@ -172,6 +173,7 @@ pub extern "C" fn ambuild(
             tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
+            column: None,
         },
         SearchFieldType::Json => SearchFieldConfig::Json {
             indexed: true,
@@ -182,17 +184,23 @@ pub extern "C" fn ambuild(
             tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
+            column: None,
         },
-        SearchFieldType::Range => SearchFieldConfig::Range { stored: true },
+        SearchFieldType::Range => SearchFieldConfig::Range {
+            stored: true,
+            column: None,
+        },
         SearchFieldType::Bool => SearchFieldConfig::Boolean {
             indexed: true,
             fast: true,
             stored: true,
+            column: None,
         },
         SearchFieldType::Date => SearchFieldConfig::Date {
             indexed: true,
             fast: true,
             stored: true,
+            column: None,
         },
     };
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -21,13 +21,11 @@ use crate::postgres::index::relfilenode_from_pg_relation;
 use crate::postgres::insert::init_insert_state;
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::utils::row_to_search_document;
-use crate::schema::{IndexRecordOption, SearchFieldConfig, SearchFieldName, SearchFieldType};
+use crate::schema::{SearchFieldConfig, SearchFieldName, SearchFieldType};
 use pgrx::*;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::time::Instant;
-use tokenizers::manager::SearchTokenizerFilters;
-use tokenizers::{SearchNormalizer, SearchTokenizer};
 
 // For now just pass the count on the build callback state
 struct BuildState {
@@ -89,6 +87,7 @@ pub extern "C" fn ambuild(
         let ops = unsafe { PgBox::<SearchIndexCreateOptions>::alloc0() };
         ops.into_pg_boxed()
     };
+    let key_field = rdopts.get_key_field().expect("must specify a key_field");
 
     // Create a map from column name to column type. We'll use this to verify that index
     // configurations passed by the user reference the correct types for each column.
@@ -112,13 +111,17 @@ pub extern "C" fn ambuild(
         })
         .collect();
 
-    for (name, _config) in rdopts.get_text_fields() {
+    for (name, config) in rdopts.get_text_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Text)) {
             panic!("'{name}' cannot be indexed as a text field");
         }
     }
 
-    for (name, _) in rdopts.get_numeric_fields() {
+    for (name, config) in rdopts.get_numeric_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(
             name_type_map.get(&name),
             Some(SearchFieldType::U64 | SearchFieldType::I64 | SearchFieldType::F64)
@@ -127,93 +130,42 @@ pub extern "C" fn ambuild(
         }
     }
 
-    for (name, _) in rdopts.get_boolean_fields() {
+    for (name, config) in rdopts.get_boolean_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Bool)) {
             panic!("'{name}' cannot be indexed as a boolean field");
         }
     }
 
-    for (name, _) in rdopts.get_json_fields() {
+    for (name, config) in rdopts.get_json_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Json)) {
             panic!("'{name}' cannot be indexed as a JSON field");
         }
     }
 
-    for (name, _) in rdopts.get_range_fields() {
+    for (name, config) in rdopts.get_range_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Range)) {
             panic!("'{name}' cannot be indexed as a range field");
         }
     }
 
-    for (name, _) in rdopts.get_datetime_fields() {
+    for (name, config) in rdopts.get_datetime_fields() {
+        // (multi-tokenizers) check if field config specifies its source column
+        let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
         if !matches!(name_type_map.get(&name), Some(SearchFieldType::Date)) {
             panic!("'{name}' cannot be indexed as a datetime field");
         }
     }
 
-    let key_field = rdopts.get_key_field().expect("must specify key field");
-    let key_field_type = match name_type_map.get(&key_field) {
-        Some(field_type) => field_type,
-        None => panic!("key field does not exist"),
-    };
-    let key_config = match key_field_type {
-        SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => {
-            SearchFieldConfig::Numeric {
-                indexed: true,
-                fast: true,
-                stored: true,
-                column: None,
-            }
-        }
-        SearchFieldType::Text => SearchFieldConfig::Text {
-            indexed: true,
-            fast: true,
-            stored: true,
-            fieldnorms: false,
-            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
-            record: IndexRecordOption::Basic,
-            normalizer: SearchNormalizer::Raw,
-            column: None,
-        },
-        SearchFieldType::Json => SearchFieldConfig::Json {
-            indexed: true,
-            fast: true,
-            stored: true,
-            fieldnorms: false,
-            expand_dots: false,
-            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
-            record: IndexRecordOption::Basic,
-            normalizer: SearchNormalizer::Raw,
-            column: None,
-        },
-        SearchFieldType::Range => SearchFieldConfig::Range {
-            stored: true,
-            column: None,
-        },
-        SearchFieldType::Bool => SearchFieldConfig::Boolean {
-            indexed: true,
-            fast: true,
-            stored: true,
-            column: None,
-        },
-        SearchFieldType::Date => SearchFieldConfig::Date {
-            indexed: true,
-            fast: true,
-            stored: true,
-            column: None,
-        },
-    };
-
     // Concatenate the separate lists of fields.
     let fields: Vec<_> = rdopts
         .get_fields(&heap_relation, index_info)
         .into_iter()
-        .filter(|(name, _, _)| name != &key_field) // Process key_field separately.
-        .chain(std::iter::once((
-            key_field.clone(),
-            key_config,
-            *key_field_type,
-        )))
         // "ctid" is a reserved column name in Postgres, so we don't need to worry about
         // creating a name conflict with a user-named column.
         .chain(std::iter::once((

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -22,8 +22,9 @@ use pgrx::*;
 use serde_json::json;
 use std::collections::HashMap;
 use std::ffi::CStr;
+use tokenizers::{manager::SearchTokenizerFilters, SearchNormalizer, SearchTokenizer};
 
-use crate::schema::{SearchFieldConfig, SearchFieldName, SearchFieldType};
+use crate::schema::{IndexRecordOption, SearchFieldConfig, SearchFieldName, SearchFieldType};
 
 /* ADDING OPTIONS
  * in init(), call pg_sys::add_{type}_reloption (check postgres docs for what args you need)
@@ -308,13 +309,120 @@ impl SearchIndexCreateOptions {
         Self::deserialize_config_fields(config, &SearchFieldConfig::date_from_json)
     }
 
-    #[allow(unused)]
+    fn json_value_to_search_field_config(
+        field_type: &SearchFieldType,
+        field_config: serde_json::Value,
+    ) -> SearchFieldConfig {
+        match field_type {
+            SearchFieldType::Text => SearchFieldConfig::text_from_json(field_config),
+            SearchFieldType::I64 => SearchFieldConfig::numeric_from_json(field_config),
+            SearchFieldType::F64 => SearchFieldConfig::numeric_from_json(field_config),
+            SearchFieldType::U64 => SearchFieldConfig::numeric_from_json(field_config),
+            SearchFieldType::Bool => SearchFieldConfig::boolean_from_json(field_config),
+            SearchFieldType::Json => SearchFieldConfig::json_from_json(field_config),
+            SearchFieldType::Date => SearchFieldConfig::date_from_json(field_config),
+            SearchFieldType::Range => SearchFieldConfig::range_from_json(field_config),
+        }
+        .expect("field config should be valid for SearchFieldConfig::{field_name}")
+    }
+
+    pub fn get_key_field(&self) -> Option<SearchFieldName> {
+        let key_field_name = self.get_str(self.key_field_offset, "".to_string());
+        if key_field_name.is_empty() {
+            return None;
+        }
+        Some(SearchFieldName(key_field_name))
+    }
+
+    fn get_key_field_config(
+        &self,
+        heaprel: &PgRelation,
+    ) -> (SearchFieldName, SearchFieldConfig, SearchFieldType) {
+        // Create a map from column name to column type. We'll use this to verify that index
+        // configurations passed by the user reference the correct types for each column.
+        let name_type_map: HashMap<SearchFieldName, SearchFieldType> = heaprel
+            .tuple_desc()
+            .into_iter()
+            .filter_map(|attribute| {
+                let attname = attribute.name();
+                let attribute_type_oid = attribute.type_oid();
+                let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
+                let base_oid = if array_type != pg_sys::InvalidOid {
+                    PgOid::from(array_type)
+                } else {
+                    attribute_type_oid
+                };
+                if let Ok(search_field_type) = SearchFieldType::try_from(&base_oid) {
+                    Some((attname.into(), search_field_type))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let key_field_name = self.get_key_field().expect("must specfiy key_field");
+        let key_field_type = match name_type_map.get(&key_field_name) {
+            Some(field_type) => field_type,
+            None => panic!("key field does not exist"),
+        };
+        let key_field_config = match key_field_type {
+            SearchFieldType::I64 | SearchFieldType::U64 | SearchFieldType::F64 => {
+                SearchFieldConfig::Numeric {
+                    indexed: true,
+                    fast: true,
+                    stored: true,
+                    column: None,
+                }
+            }
+            SearchFieldType::Text => SearchFieldConfig::Text {
+                indexed: true,
+                fast: true,
+                stored: true,
+                fieldnorms: false,
+                tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+                record: IndexRecordOption::Basic,
+                normalizer: SearchNormalizer::Raw,
+                column: None,
+            },
+            SearchFieldType::Json => SearchFieldConfig::Json {
+                indexed: true,
+                fast: true,
+                stored: true,
+                fieldnorms: false,
+                expand_dots: false,
+                tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+                record: IndexRecordOption::Basic,
+                normalizer: SearchNormalizer::Raw,
+                column: None,
+            },
+            SearchFieldType::Range => SearchFieldConfig::Range {
+                stored: true,
+                column: None,
+            },
+            SearchFieldType::Bool => SearchFieldConfig::Boolean {
+                indexed: true,
+                fast: true,
+                stored: true,
+                column: None,
+            },
+            SearchFieldType::Date => SearchFieldConfig::Date {
+                indexed: true,
+                fast: true,
+                stored: true,
+                column: None,
+            },
+        };
+
+        (key_field_name.into(), key_field_config, *key_field_type)
+    }
+
     pub fn get_fields(
         &self,
         heaprel: &PgRelation,
         index_info: *mut pg_sys::IndexInfo,
     ) -> Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)> {
         let tupdesc = heaprel.tuple_desc();
+        let (key_field_name, key_field_config, key_field_type) = self.get_key_field_config(heaprel);
 
         let mut config_by_name = [
             self.text_fields_offset,
@@ -334,23 +442,8 @@ impl SearchIndexCreateOptions {
         })
         .collect::<HashMap<_, _>>();
 
-        let _ = unsafe {
-            let num_attrs = (*index_info).ii_NumIndexAttrs;
-            (0..num_attrs)
-                .map(|i| {
-                    let attr_number = (*index_info).ii_IndexAttrNumbers[i as usize];
-                    let attribute = tupdesc
-                        .get((attr_number - 1) as usize)
-                        .expect("attribute should exist");
-                    let column_name = attribute.name();
-                    let column_type_oid = attribute.type_oid();
-                    (column_name, column_type_oid)
-                })
-                .collect::<Vec<_>>()
-        };
-
         let num_index_attrs = unsafe { (*index_info).ii_NumIndexAttrs };
-        (0..num_index_attrs)
+        let mut fields_by_name = (0..num_index_attrs)
             .map(|i| {
                 let attr_number = unsafe { (*index_info).ii_IndexAttrNumbers[i as usize] };
                 let attribute = tupdesc
@@ -370,36 +463,55 @@ impl SearchIndexCreateOptions {
                     panic!("cannot index column '{column_name}' with type {base_oid:?}: {err}")
                 });
 
-                let field_config = config_by_name
+                if column_name == key_field_name.0 && config_by_name.contains_key(column_name){
+                    panic!("cannot override BM25 configuration for key_field '{column_name}', you must use an aliased field name and 'column' configuration key");
+                }
+
+                let json_config = config_by_name
                     .remove(column_name)
                     .unwrap_or_else(|| json!({}));
 
                 (
-                    column_name.into(),
-                    match field_type {
-                        SearchFieldType::Text => SearchFieldConfig::text_from_json(field_config),
-                        SearchFieldType::I64 => SearchFieldConfig::numeric_from_json(field_config),
-                        SearchFieldType::F64 => SearchFieldConfig::numeric_from_json(field_config),
-                        SearchFieldType::U64 => SearchFieldConfig::numeric_from_json(field_config),
-                        SearchFieldType::Bool => SearchFieldConfig::boolean_from_json(field_config),
-                        SearchFieldType::Json => SearchFieldConfig::json_from_json(field_config),
-                        SearchFieldType::Date => SearchFieldConfig::date_from_json(field_config),
-                        SearchFieldType::Range => SearchFieldConfig::range_from_json(field_config),
-                    }
-                    .expect("field config should be valid for SearchFieldConfig::{field_name}"),
-                    field_type,
+                    column_name.to_string(),
+                    (
+                        column_name.into(),
+                        Self::json_value_to_search_field_config(&field_type, json_config),
+                        field_type,
+                    ),
                 )
             })
-            .collect()
-    }
+            .collect::<HashMap<_, _>>();
 
-    pub fn get_key_field(&self) -> Option<SearchFieldName> {
-        let key_field = self.get_str(self.key_field_offset, "".to_string());
-        if key_field.is_empty() {
-            None
-        } else {
-            Some(key_field.into())
+        // Ensure the key_field entry has the correct default values.
+        fields_by_name.insert(
+            key_field_name.0.clone(),
+            (key_field_name, key_field_config, key_field_type),
+        );
+
+        // Iterate through all the configured fields to check for fields configured that don't
+        // have a matching Postgres column (for features like multiple tokenizers).
+        // Above, we've mutated config_by_name and removed entries that have a matching
+        // Postgres column, so all the entries below are aliases.
+        for (name, json_config) in config_by_name {
+            // A field not corresponding to a Postgres table column MUST have a 'column' key
+            // on the configuration, telling us which column contains the data to index.
+            if let Some(column) = json_config.get("column").and_then(|c| c.as_str()) {
+                if let Some((_, _, field_type)) = fields_by_name.get(column) {
+                    fields_by_name.insert(
+                        name.to_string(),
+                        (
+                            SearchFieldName(name.to_string()),
+                            Self::json_value_to_search_field_config(&field_type, json_config),
+                            field_type.clone(),
+                        ),
+                    );
+                }
+            } else {
+                panic!("Field '{name}' does not match any column, and has no 'column' key")
+            }
         }
+
+        fields_by_name.into_values().collect()
     }
 
     pub fn target_segment_count(&self) -> usize {

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -413,7 +413,7 @@ impl SearchIndexCreateOptions {
             },
         };
 
-        (key_field_name.into(), key_field_config, *key_field_type)
+        (key_field_name, key_field_config, *key_field_type)
     }
 
     pub fn get_fields(
@@ -501,8 +501,8 @@ impl SearchIndexCreateOptions {
                         name.to_string(),
                         (
                             SearchFieldName(name.to_string()),
-                            Self::json_value_to_search_field_config(&field_type, json_config),
-                            field_type.clone(),
+                            Self::json_value_to_search_field_config(field_type, json_config),
+                            *field_type,
                         ),
                     );
                 }

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -360,7 +360,7 @@ impl SearchIndexCreateOptions {
             })
             .collect();
 
-        let key_field_name = self.get_key_field().expect("must specfiy key_field");
+        let key_field_name = self.get_key_field().expect("must specify key_field");
         let key_field_type = match name_type_map.get(&key_field_name) {
             Some(field_type) => field_type,
             None => panic!("key field does not exist"),

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -80,58 +80,60 @@ pub unsafe fn row_to_search_document(
     schema: &SearchIndexSchema,
 ) -> Result<SearchDocument, IndexError> {
     let mut document = schema.new_document();
+    let mut alias_lookup = schema.alias_lookup();
 
     // Create a vector of index entries from the postgres row.
     for (attno, attribute) in tupdesc.iter().enumerate() {
         let attname = attribute.name().to_string();
         let attribute_type_oid = attribute.type_oid();
 
-        // If we can't lookup the attribute name in the field_lookup parameter,
-        // it means that this field is not part of the index. We should skip it.
-        let search_field =
-            if let Some(index_field) = schema.get_search_field(&attname.clone().into()) {
-                index_field
-            } else {
-                continue;
-            };
+        // List any indexed fields that use this column as source data.
+        let mut search_fields = alias_lookup.remove(&attname).unwrap_or_default();
 
-        let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
-        let (base_oid, is_array) = if array_type != pg_sys::InvalidOid {
-            (PgOid::from(array_type), true)
-        } else {
-            (attribute_type_oid, false)
+        // If there's an indexed field with the same name as a this column, add it to the list.
+        if let Some(index_field) = schema.get_search_field(&attname.clone().into()) {
+            search_fields.push(index_field)
         };
 
-        let is_json = matches!(
-            base_oid,
-            PgOid::BuiltIn(pg_sys::BuiltinOid::JSONBOID | pg_sys::BuiltinOid::JSONOID)
-        );
+        for search_field in search_fields {
+            let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
+            let (base_oid, is_array) = if array_type != pg_sys::InvalidOid {
+                (PgOid::from(array_type), true)
+            } else {
+                (attribute_type_oid, false)
+            };
 
-        let datum = *values.add(attno);
-        let isnull = *isnull.add(attno);
-
-        let SearchFieldName(key_field_name) = schema.key_field().name;
-        if key_field_name == attname && isnull {
-            return Err(IndexError::KeyIdNull(key_field_name));
-        }
-
-        if isnull {
-            continue;
-        }
-
-        if is_array {
-            for value in TantivyValue::try_from_datum_array(datum, base_oid)? {
-                document.insert(search_field.id, value.tantivy_schema_value());
-            }
-        } else if is_json {
-            for value in TantivyValue::try_from_datum_json(datum, base_oid)? {
-                document.insert(search_field.id, value.tantivy_schema_value());
-            }
-        } else {
-            document.insert(
-                search_field.id,
-                TantivyValue::try_from_datum(datum, base_oid)?.tantivy_schema_value(),
+            let is_json = matches!(
+                base_oid,
+                PgOid::BuiltIn(pg_sys::BuiltinOid::JSONBOID | pg_sys::BuiltinOid::JSONOID)
             );
+
+            let datum = *values.add(attno);
+            let isnull = *isnull.add(attno);
+
+            let SearchFieldName(key_field_name) = schema.key_field().name;
+            if key_field_name == attname && isnull {
+                return Err(IndexError::KeyIdNull(key_field_name));
+            }
+
+            if isnull {
+                continue;
+            }
+
+            if is_array {
+                for value in TantivyValue::try_from_datum_array(datum, base_oid)? {
+                    document.insert(search_field.id, value.tantivy_schema_value());
+                }
+            } else if is_json {
+                for value in TantivyValue::try_from_datum_json(datum, base_oid)? {
+                    document.insert(search_field.id, value.tantivy_schema_value());
+                }
+            } else {
+                document.insert(
+                    search_field.id,
+                    TantivyValue::try_from_datum(datum, base_oid)?.tantivy_schema_value(),
+                );
+            }
         }
     }
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -233,6 +233,14 @@ impl SearchFieldConfig {
             None => Ok(SearchNormalizer::Raw),
         }?;
 
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
         Ok(SearchFieldConfig::Text {
             indexed,
             fast,
@@ -241,7 +249,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
-            column: None,
+            column,
         })
     }
 
@@ -300,6 +308,14 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
         Ok(SearchFieldConfig::Json {
             indexed,
             fast,
@@ -309,7 +325,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
-            column: None,
+            column,
         })
     }
 
@@ -325,10 +341,15 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
-        Ok(SearchFieldConfig::Range {
-            stored,
-            column: None,
-        })
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
+        Ok(SearchFieldConfig::Range { stored, column })
     }
 
     pub fn numeric_from_json(value: serde_json::Value) -> Result<Self> {
@@ -357,11 +378,19 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
         Ok(SearchFieldConfig::Numeric {
             indexed,
             fast,
             stored,
-            column: None,
+            column,
         })
     }
 
@@ -391,11 +420,19 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
         Ok(SearchFieldConfig::Boolean {
             indexed,
             fast,
             stored,
-            column: None,
+            column,
         })
     }
 
@@ -425,12 +462,32 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
+        let column = match obj.get("column") {
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'column' field should be a string"))
+                .map(|s| Some(s.to_string())),
+            None => Ok(None),
+        }?;
+
         Ok(SearchFieldConfig::Date {
             indexed,
             fast,
             stored,
-            column: None,
+            column,
         })
+    }
+
+    pub fn column(&self) -> Option<&String> {
+        match self {
+            Self::Text { column, .. }
+            | Self::Json { column, .. }
+            | Self::Range { column, .. }
+            | Self::Numeric { column, .. }
+            | Self::Boolean { column, .. }
+            | Self::Date { column, .. } => column.as_ref(),
+            _ => None,
+        }
     }
 }
 
@@ -784,6 +841,21 @@ impl SearchIndexSchema {
             _ => None,
         }
     }
+
+    /// A lookup from a Postgres column name to search fields that have
+    /// marked it as their source column with the 'column' key.
+    pub fn alias_lookup(&self) -> HashMap<String, Vec<&SearchField>> {
+        let mut lookup = HashMap::new();
+        for field in &self.fields {
+            if let Some(column) = field.config.column() {
+                lookup
+                    .entry(column.to_string())
+                    .or_insert_with(Vec::new)
+                    .push(field);
+            }
+        }
+        lookup
+    }
 }
 
 // Index record schema
@@ -865,6 +937,11 @@ impl AsTypeOid for (&PgRelation, &SearchIndexSchema) {
             let attname = attribute.name().to_string();
             let typeoid = attribute.type_oid();
             if search_field.name.0 == attname {
+                return typeoid;
+            }
+            // If the field was aliased, return the column
+            // it points to.
+            if search_field.config.column() == Some(&attname) {
                 return typeoid;
             }
         }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -122,6 +122,8 @@ pub enum SearchFieldConfig {
         record: IndexRecordOption,
         #[serde(default)]
         normalizer: SearchNormalizer,
+        #[serde(default)]
+        column: Option<String>,
     },
     Json {
         #[serde(default = "default_as_true")]
@@ -140,10 +142,14 @@ pub enum SearchFieldConfig {
         record: IndexRecordOption,
         #[serde(default)]
         normalizer: SearchNormalizer,
+        #[serde(default)]
+        column: Option<String>,
     },
     Range {
         #[serde(default = "default_as_true")]
         stored: bool,
+        #[serde(default)]
+        column: Option<String>,
     },
     Numeric {
         #[serde(default = "default_as_true")]
@@ -152,6 +158,8 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        #[serde(default)]
+        column: Option<String>,
     },
     Boolean {
         #[serde(default = "default_as_true")]
@@ -160,6 +168,8 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        #[serde(default)]
+        column: Option<String>,
     },
     Date {
         #[serde(default = "default_as_true")]
@@ -168,6 +178,8 @@ pub enum SearchFieldConfig {
         fast: bool,
         #[serde(default = "default_as_true")]
         stored: bool,
+        #[serde(default)]
+        column: Option<String>,
     },
     Ctid,
 }
@@ -229,6 +241,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
+            column: None,
         })
     }
 
@@ -296,6 +309,7 @@ impl SearchFieldConfig {
             tokenizer,
             record,
             normalizer,
+            column: None,
         })
     }
 
@@ -311,7 +325,10 @@ impl SearchFieldConfig {
             None => Ok(true),
         }?;
 
-        Ok(SearchFieldConfig::Range { stored })
+        Ok(SearchFieldConfig::Range {
+            stored,
+            column: None,
+        })
     }
 
     pub fn numeric_from_json(value: serde_json::Value) -> Result<Self> {
@@ -344,6 +361,7 @@ impl SearchFieldConfig {
             indexed,
             fast,
             stored,
+            column: None,
         })
     }
 
@@ -377,6 +395,7 @@ impl SearchFieldConfig {
             indexed,
             fast,
             stored,
+            column: None,
         })
     }
 
@@ -410,6 +429,7 @@ impl SearchFieldConfig {
             indexed,
             fast,
             stored,
+            column: None,
         })
     }
 }
@@ -453,6 +473,7 @@ impl From<SearchFieldConfig> for TextOptions {
                 tokenizer,
                 record,
                 normalizer,
+                ..
             } => {
                 if stored {
                     text_options = text_options.set_stored();
@@ -483,9 +504,10 @@ impl From<SearchFieldConfig> for NumericOptions {
                 indexed,
                 fast,
                 stored,
+                ..
             }
             // Following the example of Quickwit, which uses NumericOptions for boolean options.
-            | SearchFieldConfig::Boolean { indexed, fast, stored } => {
+            | SearchFieldConfig::Boolean { indexed, fast, stored, .. } => {
                 if stored {
                     numeric_options = numeric_options.set_stored();
                 }
@@ -519,6 +541,7 @@ impl From<SearchFieldConfig> for JsonObjectOptions {
                 tokenizer,
                 record,
                 normalizer,
+                ..
             } => {
                 if stored {
                     json_options = json_options.set_stored();
@@ -538,7 +561,7 @@ impl From<SearchFieldConfig> for JsonObjectOptions {
                     json_options = json_options.set_indexing_options(text_field_indexing);
                 }
             }
-            SearchFieldConfig::Range { stored } => {
+            SearchFieldConfig::Range { stored, .. } => {
                 if stored {
                     json_options = json_options.set_stored();
                 }
@@ -564,6 +587,7 @@ impl From<SearchFieldConfig> for DateOptions {
                 indexed,
                 fast,
                 stored,
+                ..
             } => {
                 if stored {
                     date_options = date_options.set_stored();
@@ -915,6 +939,7 @@ mod tests {
                 indexed: true,
                 fast: true,
                 stored: true,
+                column: None,
             },
             SearchFieldType::U64,
         )];

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -1404,7 +1404,6 @@ fn alias_cannot_be_key_field(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore = "figure out multiple tokenizers"]
 fn multiple_tokenizers_same_field_in_query(mut conn: PgConnection) {
     // Create the table
     "CREATE TABLE product_reviews (

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -1544,3 +1544,190 @@ fn more_like_this_with_alias(mut conn: PgConnection) {
     assert!(rows.iter().any(|(_, flavour, _)| flavour == "banana"));
     assert!(rows.iter().any(|(_, flavour, _)| flavour == "banana split"));
 }
+
+#[rstest]
+fn multiple_aliases_same_column(mut conn: PgConnection) {
+    // Test multiple aliases pointing to the same column with different tokenizers
+    "CREATE TABLE multi_alias (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );"
+    .execute(&mut conn);
+
+    "INSERT INTO multi_alias (content) VALUES 
+    ('running and jumping'),
+    ('ran and jumped'),
+    ('runner jumper athlete');"
+        .execute(&mut conn);
+
+    // Create index with multiple aliases for same column
+    r#"CREATE INDEX multi_alias_idx ON multi_alias
+    USING bm25 (id, content)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "content": {
+                "tokenizer": {"type": "default"}
+            },
+            "content_stem": {
+                "column": "content",
+                "tokenizer": {"type": "default", "stemmer": "English"}
+            },
+            "content_ngram": {
+                "column": "content", 
+                "tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 3, "prefix_only": false}
+            }
+        }'
+    );"#
+    .execute(&mut conn);
+
+    // Test each alias configuration
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM multi_alias WHERE multi_alias @@@ 'content:running'".fetch(&mut conn);
+    assert_eq!(rows, vec![(1,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM multi_alias WHERE multi_alias @@@ 'content_stem:running'".fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM multi_alias WHERE multi_alias @@@ 'content_ngram:run'".fetch(&mut conn);
+    assert_eq!(rows.len(), 2);
+}
+
+#[rstest]
+fn missing_source_column(mut conn: PgConnection) {
+    "CREATE TABLE missing_source (
+        id SERIAL PRIMARY KEY,
+        text_field TEXT
+    );"
+    .execute(&mut conn);
+
+    // Attempt to create index with alias pointing to non-existent column
+    let result = r#"CREATE INDEX missing_source_idx ON missing_source
+    USING bm25 (id, text_field)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "alias": {
+                "column": "nonexistent_column",
+                "tokenizer": {"type": "default"}
+            }
+        }'
+    );"#
+    .execute_result(&mut conn);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "error returned from database: 'nonexistent_column' cannot be indexed as a text field"
+    );
+}
+
+#[rstest]
+fn alias_type_mismatch(mut conn: PgConnection) {
+    "CREATE TABLE type_mismatch (
+        id SERIAL PRIMARY KEY,
+        numeric_field INTEGER,
+        text_field TEXT
+    );"
+    .execute(&mut conn);
+
+    // Try to create text alias pointing to numeric column
+    let result = r#"CREATE INDEX type_mismatch_idx ON type_mismatch
+    USING bm25 (id, numeric_field, text_field)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "wrong_type": {
+                "column": "numeric_field",
+                "tokenizer": {"type": "default"}
+            }
+        }'
+    );"#
+    .execute_result(&mut conn);
+
+    assert!(result.is_err());
+}
+
+#[rstest]
+fn alias_chain_validation(mut conn: PgConnection) {
+    // Test that we can't create an alias that points to another alias
+    "CREATE TABLE alias_chain (
+        id SERIAL PRIMARY KEY,
+        base_field TEXT
+    );"
+    .execute(&mut conn);
+
+    let result = r#"CREATE INDEX alias_chain_idx ON alias_chain
+    USING bm25 (id, base_field)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "first_alias": {
+                "column": "base_field",
+                "tokenizer": {"type": "default"}
+            },
+            "second_alias": {
+                "column": "first_alias",
+                "tokenizer": {"type": "default"}
+            }
+        }'
+    );"#
+    .execute_result(&mut conn);
+
+    assert!(result.is_err());
+}
+
+#[rstest]
+fn mixed_field_types_with_aliases(mut conn: PgConnection) {
+    // Test mixing different field types with aliases
+    "CREATE TABLE mixed_fields (
+        id SERIAL PRIMARY KEY,
+        text_content TEXT,
+        num_value INTEGER,
+        bool_flag BOOLEAN
+    );"
+    .execute(&mut conn);
+
+    "INSERT INTO mixed_fields (text_content, num_value, bool_flag) VALUES 
+    ('test content', 42, true),
+    ('another test', 100, false);"
+        .execute(&mut conn);
+
+    r#"CREATE INDEX mixed_fields_idx ON mixed_fields
+    USING bm25 (id, text_content, num_value, bool_flag)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "text_alias": {
+                "column": "text_content",
+                "tokenizer": {"type": "default"}
+            }
+        }',
+        numeric_fields='{
+            "num_alias": {
+                "column": "num_value"
+            }
+        }',
+        boolean_fields='{
+            "bool_alias": {
+                "column": "bool_flag"
+            }
+        }'
+    );"#
+    .execute(&mut conn);
+
+    // Test each type of alias
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM mixed_fields WHERE mixed_fields @@@ 'text_alias:test'".fetch(&mut conn);
+    assert_eq!(rows.len(), 2);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM mixed_fields WHERE mixed_fields @@@ 'num_alias:42'".fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM mixed_fields WHERE mixed_fields @@@ 'bool_alias:true'".fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+}

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -2248,6 +2248,8 @@ fn available_tokenizers(mut conn: PgConnection) {
     "#
     .fetch(&mut conn);
     assert_eq!(rows.len(), 2);
+    assert!(rows.iter().any(|r| r.0.contains("cotton")));
+    assert!(rows.iter().any(|r| r.0.contains("shirt")));
 
     r#"DROP INDEX search_idx;"#.execute(&mut conn);
 }

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -2215,7 +2215,7 @@ fn available_tokenizers(mut conn: PgConnection) {
     // Test multiple tokenizers for the same field
     r#"
     CREATE INDEX search_idx ON mock_items
-    USING bm25 (id, description, description_ngram, description_stem)
+    USING bm25 (id, description)
     WITH (
         key_field='id',
         text_fields='{
@@ -2247,11 +2247,9 @@ fn available_tokenizers(mut conn: PgConnection) {
     LIMIT 5;
     "#
     .fetch(&mut conn);
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 1);
     assert!(rows.iter().any(|r| r.0.contains("cotton")));
     assert!(rows.iter().any(|r| r.0.contains("shirt")));
-
-    r#"DROP INDEX search_idx;"#.execute(&mut conn);
 }
 
 #[rstest]
@@ -2316,7 +2314,7 @@ fn fast_fields(mut conn: PgConnection) {
 
     r#"
     CREATE INDEX search_idx ON mock_items
-    USING bm25 (id, rating)
+    USING bm25 (id, description, rating)
     WITH (
         key_field = 'id',
         text_fields ='{

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -2211,6 +2211,45 @@ fn available_tokenizers(mut conn: PgConnection) {
     );
     "#
     .execute(&mut conn);
+
+    // Test multiple tokenizers for the same field
+    r#"
+    CREATE INDEX search_idx ON mock_items
+    USING bm25 (id, description, description_ngram, description_stem)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "description": {"tokenizer": {"type": "whitespace"}},
+            "description_ngram": {"tokenizer": {"type": "ngram", "min_gram": 3, "max_gram": 3, "prefix_only": false}, "column": "description"},
+            "description_stem": {"tokenizer": {"type": "default", "stemmer": "English"}, "column": "description"}
+        }'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(String, i32, String)> = r#"
+    SELECT description, rating, category
+    FROM mock_items
+    WHERE id @@@ paradedb.parse('description_ngram:cam AND description_stem:digitally')
+    ORDER BY rating DESC
+    LIMIT 5;
+    "#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].0.contains("camera"));
+    assert!(rows[0].0.contains("digital"));
+
+    let rows: Vec<(String, i32, String)> = r#"
+    SELECT description, rating, category
+    FROM mock_items
+    WHERE id @@@ paradedb.parse('description:"Soft cotton" OR description_stem:shirts')
+    ORDER BY rating DESC
+    LIMIT 5;
+    "#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 2);
+
+    r#"DROP INDEX search_idx;"#.execute(&mut conn);
 }
 
 #[rstest]

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -42,7 +42,7 @@ fn invalid_create_index(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with no key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: must specify key field"
+            "error returned from database: must specify a key_field"
         ),
     };
 


### PR DESCRIPTION
## What
Adds support for multiple tokenizers on a single field in BM25 indexes by allowing aliased fields to reference source columns.

## Why
Enables more flexible text search by allowing different tokenization strategies (e.g. exact match, stemming, n-grams) to be applied to the same text content without duplicating data.

## How
- Added optional column field to SearchFieldConfig to specify source column
- Modified field validation to handle aliased fields referencing source columns
- Updated schema and index building logic to support field aliasing
- Prevented key fields from being used as aliases to maintain index integrity

## Tests
Added comprehensive test cases covering:

- Basic multi-tokenizer functionality with stemming and n-grams
- More-like-this queries with aliased fields
- Multiple aliases pointing to same column
- Field type validation and error handling
- Mixed field types with aliases
- Integration with existing BM25 features