### PR TITLE
chore: Fix typo, SeachQueryInput -> SearchQueryInput

### DIFF
--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -47,7 +47,7 @@ pub fn search_with_query_input(
             // with the WithIndex when it is rewritten with our custom operator.
             match query {
                 SearchQueryInput::WithIndex { oid, .. } => oid,
-                _ => panic!("the SeachQueryInput must be wrapped in a WithIndex variant"),
+                _ => panic!("the SearchQueryInput must be wrapped in a WithIndex variant"),
             }
         };
         let indexrel = unsafe {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Fix typo found via `typos --hidden --format brief`

## Why

## How

## Tests
