### PR TITLE
fix: Fix macOS binaries install path

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -176,8 +176,11 @@ jobs:
           subject-path: |
             ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
 
+      # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which
+      # is not capable of parsing certain control characters
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -163,12 +163,12 @@ jobs:
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
                   --install-location /opt/homebrew/opt/postgresql@${pg_version} \
-                  postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
+                  pg_search-pg${{ matrix.pg_version }}--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          subject-path: ./pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -189,6 +189,6 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
-          asset_name: postgresql-${{ matrix.pg_version }}-pg_search--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          asset_path: ./pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          asset_name: pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
           overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -142,28 +142,27 @@ jobs:
           package_dir="pg_search-${tag_version}-arm64-pg${pg_version}"
 
           # Define Homebrew PostgreSQL paths
-          brew_pg_path="/opt/homebrew/opt/postgresql@${pg_version}"
-          lib_path="${brew_pg_path}/lib/postgresql"
-          share_path="${brew_pg_path}/share/postgresql@${pg_version}/extension"
+          lib_path="lib/postgresql"
+          share_path="share/postgresql@${pg_version}/extension"
 
           # Create directory structure for Homebrew
-          mkdir -p ${package_dir}${lib_path}
-          mkdir -p ${package_dir}${share_path}
+          mkdir -p ${package_dir}/${lib_path}
+          mkdir -p ${package_dir}/${share_path}
 
           # Copy files into the directory structure. In PostgreSQL 16 onwards, the extension is a .dylib file
           if [[ "${{ matrix.pg_version }}" == "16" || "${{ matrix.pg_version }}" == "17" ]]; then
-            cp archive/*.dylib ${package_dir}${lib_path}
+            cp archive/*.dylib ${package_dir}/${lib_path}
           else
-            cp archive/*.so ${package_dir}${lib_path}
+            cp archive/*.so ${package_dir}/${lib_path}
           fi
-          cp archive/*.control ${package_dir}${share_path}
-          cp archive/*.sql ${package_dir}${share_path}
+          cp archive/*.control ${package_dir}/${share_path}
+          cp archive/*.sql ${package_dir}/${share_path}
 
           # Create the .pkg installer
           pkgbuild --root ${package_dir} \
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
-                  --install-location /opt/homebrew/opt/postgresql${pg_version} \
+                  --install-location /opt/homebrew/opt/postgresql@${pg_version} \
                   postgresql-${{ matrix.pg_version }}-pg_search--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Sign and Attest Build Provenance


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
An extra `/opt/homebrew/opt/` was being prepended to the install path by accident, resulting in Postgres not being able to find the binaries.

## Why
We like when things work.

## How
Fix the installation path to avoid duplicate append.

## Tests
Manual