### PR TITLE
ci: Display schema diff in GHA logs

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           (pg-schema-diff diff ~/old.sql ~/this.sql | grep -v "^$" > ~/diff.sql) || true
           (diff ~/old.sql ~/this.sql > ~/diff.patch) || true
+          cat ~/diff.sql
 
       - name: Generate Commit Message
         id: generate_commit_message


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This way external contributors can now what schema diff to add, even if it's not commented on the PR.

## Why

## How

## Tests
