### PR TITLE
WIP:  refactor `experiment-block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "libc",
  "memoffset",
  "once_cell",
+ "oneshot",
  "ordered-float",
  "os_info",
  "parking_lot",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -27,6 +27,7 @@ humansize = "2.1.3"
 json5 = "0.4.1"
 libc = "0.2.158"
 memoffset = "0.9.1"
+oneshot = "0.1.8"
 once_cell = "1.19.0"
 os_info = { version = "3", default-features = false }
 parking_lot = "0.12.3"

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -18,7 +18,7 @@
 use pgrx::datum::RangeBound;
 use pgrx::{iter::TableIterator, *};
 
-use crate::postgres::index::open_search_index;
+use crate::index::open_search_reader;
 use crate::postgres::types::TantivyValue;
 use crate::query::{SearchQueryInput, TermInput};
 use crate::schema::AnyEnum;
@@ -59,8 +59,9 @@ pub fn schema(
     // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
     let index = unsafe { PgRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _) };
 
-    let search_index = open_search_index(&index).expect("should be able to open search index");
-    let schema = search_index.schema.schema.clone();
+    let search_reader =
+        open_search_reader(&index).expect("should be able to open a SearchIndexReader");
+    let schema = search_reader.schema.schema.clone();
     let mut field_entries: Vec<_> = schema.fields().collect();
 
     // To ensure consistent ordering of outputs, we'll sort the results by field name.

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -138,7 +138,7 @@ pub(crate) fn estimate_selectivity(
     }
 
     let search_reader =
-        open_search_reader(&indexrel).expect("should be able to open a SearchIndexReader");
+        open_search_reader(indexrel).expect("should be able to open a SearchIndexReader");
     let estimate = search_reader.estimate_docs(search_query_input).unwrap_or(1) as f64;
     let mut selectivity = estimate / reltuples;
     if selectivity > 1.0 {

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -53,7 +53,7 @@ pub fn search_with_query_input(
             &PgRelation::with_lock(index_oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE)
         };
         let search_reader =
-            open_search_reader(&indexrel).expect("should be able to open a SearchIndexReader");
+            open_search_reader(indexrel).expect("should be able to open a SearchIndexReader");
 
         let key_field = search_reader.key_field();
         let key_field_name = key_field.name.0;

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -21,8 +21,7 @@ use super::{
 use crate::api::operator::{estimate_selectivity, find_var_relation, ReturnedNodePointer};
 use crate::gucs::per_tuple_cost;
 use crate::index::fast_fields_helper::FFHelper;
-use crate::index::SearchIndex;
-use crate::postgres::index::open_search_index;
+use crate::index::open_search_reader;
 use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::locate_bm25_index;
 use crate::query::SearchQueryInput;
@@ -53,23 +52,18 @@ pub fn search_with_query_input(
         let indexrel = unsafe {
             &PgRelation::with_lock(index_oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE)
         };
-        let search_index =
-            open_search_index(indexrel).expect("should be able to open search index");
+        let search_reader =
+            open_search_reader(&indexrel).expect("should be able to open a SearchIndexReader");
 
-        let key_field = search_index.key_field_name();
-        let key_field_type = search_index.key_field().type_.into();
-        let search_reader = search_index.get_reader().unwrap();
+        let key_field = search_reader.key_field();
+        let key_field_name = key_field.name.0;
+        let key_field_type = key_field.type_.into();
         let fast_fields = FFHelper::with_fields(
             &search_reader,
-            &[(key_field.clone(), key_field_type).into()],
+            &[(key_field_name.clone(), key_field_type).into()],
         );
-        let top_docs = search_reader.search_via_channel(
-            query.contains_more_like_this(),
-            false,
-            SearchIndex::executor(),
-            &search_index.query(indexrel, &query, &search_reader),
-            None,
-        );
+        let top_docs =
+            search_reader.search_via_channel(query.contains_more_like_this(), false, &query, None);
         let mut hs = FxHashSet::default();
         for (_, doc_address) in top_docs {
             check_for_interrupts!();
@@ -80,7 +74,7 @@ pub fn search_with_query_input(
             );
         }
 
-        (key_field, hs)
+        (key_field_name, hs)
     };
 
     let cached = unsafe { pg_func_extra(fcinfo, default_hash_set) };

--- a/pg_search/src/index/directory/blocking.rs
+++ b/pg_search/src/index/directory/blocking.rs
@@ -251,7 +251,6 @@ impl Directory for BlockingDirectory {
 
             loop {
                 let buffer = cache.get_buffer(current_blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-                let bn = pg_sys::BufferGetBlockNumber(buffer);
                 let page = pg_sys::BufferGetPage(buffer);
                 let item_id = pg_sys::PageGetItemId(page, pg_sys::FirstOffsetNumber);
                 let item = pg_sys::PageGetItem(page, item_id);

--- a/pg_search/src/index/directory/blocking.rs
+++ b/pg_search/src/index/directory/blocking.rs
@@ -174,6 +174,7 @@ impl Directory for BlockingDirectory {
             let mut buffer =
                 cache.get_buffer(TANTIVY_META_BLOCKNO, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
             let mut page = pg_sys::BufferGetPage(buffer);
+            page.init(pg_sys::BufferGetPageSize(buffer));
 
             for (i, chunk) in data.chunks(ITEM_SIZE).enumerate() {
                 if i > 0 {
@@ -250,6 +251,7 @@ impl Directory for BlockingDirectory {
 
             loop {
                 let buffer = cache.get_buffer(current_blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
+                let bn = pg_sys::BufferGetBlockNumber(buffer);
                 let page = pg_sys::BufferGetPage(buffer);
                 let item_id = pg_sys::PageGetItemId(page, pg_sys::FirstOffsetNumber);
                 let item = pg_sys::PageGetItem(page, item_id);

--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 use crossbeam::channel::{Receiver, Sender, TryRecvError};
-use pgrx::check_for_interrupts;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread::{Scope, ScopedJoinHandle};
+use std::thread::ScopedJoinHandle;
 use std::{io, io::Write, ops::Range, result};
 use tantivy::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use tantivy::directory::{

--- a/pg_search/src/index/reader/channel.rs
+++ b/pg_search/src/index/reader/channel.rs
@@ -1,56 +1,47 @@
 use anyhow::Result;
-use crossbeam::channel::{Receiver, Sender};
+use crossbeam::channel::Sender;
 use std::ops::Range;
 use std::path::Path;
 use tantivy::directory::FileHandle;
 use tantivy::directory::OwnedBytes;
 use tantivy::HasLen;
 
-use crate::index::directory::channel::{ChannelRequest, ChannelResponse};
+use crate::index::directory::channel::ChannelRequest;
 use crate::postgres::storage::block::DirectoryEntry;
 
 #[derive(Clone, Debug)]
 pub struct ChannelReader {
     opaque: DirectoryEntry,
     sender: Sender<ChannelRequest>,
-    receiver: Receiver<ChannelResponse>,
 }
 
 impl ChannelReader {
-    pub unsafe fn new(
-        path: &Path,
-        sender: Sender<ChannelRequest>,
-        receiver: Receiver<ChannelResponse>,
-    ) -> Result<Self> {
+    pub unsafe fn new(path: &Path, sender: Sender<ChannelRequest>) -> Result<Self> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         sender
-            .send(ChannelRequest::GetSegmentComponent(path.to_path_buf()))
+            .send(ChannelRequest::GetSegmentComponent(
+                path.to_path_buf(),
+                oneshot_sender,
+            ))
             .unwrap();
-        let opaque = match receiver.recv().unwrap() {
-            ChannelResponse::DirectoryEntry(opaque) => opaque,
-            unexpected => panic!("DirectoryEntry expected, got {:?}", unexpected),
-        };
 
-        Ok(Self {
-            opaque,
-            sender,
-            receiver,
-        })
+        let opaque = oneshot_receiver.recv()?;
+        Ok(Self { opaque, sender })
     }
 }
 
 impl FileHandle for ChannelReader {
     fn read_bytes(&self, range: Range<usize>) -> Result<OwnedBytes, std::io::Error> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
             .send(ChannelRequest::SegmentRead(
                 range.clone(),
                 self.opaque.clone(),
+                oneshot_sender,
             ))
             .unwrap();
-        let data = match self.receiver.recv().unwrap() {
-            ChannelResponse::Bytes(data) => data,
-            unexpected => panic!("Bytes expected, got {:?}", unexpected),
-        };
 
+        let data = oneshot_receiver.recv().unwrap();
         Ok(OwnedBytes::new(data))
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -429,7 +429,7 @@ impl SearchIndexReader {
         });
 
         let blocking_directory = BlockingDirectory::new(self.index_oid);
-        let mut handler = ChannelRequestHandler::open(
+        let handler = ChannelRequestHandler::open(
             blocking_directory,
             self.index_oid,
             response_sender,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -393,7 +393,7 @@ impl SearchIndexReader {
 
         let collector = channel::ChannelCollector::new(need_scores, search_sender);
 
-        let owned_query = self.query(&query);
+        let owned_query = self.query(query);
         std::thread::spawn(move || {
             let channel_directory =
                 ChannelDirectory::new(request_sender.clone(), response_receiver.clone());

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -435,7 +435,7 @@ impl SearchIndexReader {
             response_sender,
             request_receiver,
         );
-        let _ = handler.receive_blocking(Some(|_| false)).unwrap();
+        let _ = handler.receive_blocking().unwrap();
 
         unsafe { pg_sys::UnlockReleaseBuffer(lock) };
         SearchResults::Channel(search_receiver.into_iter())

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -19,9 +19,8 @@ use crate::index::directory::blocking::BlockingDirectory;
 use crate::index::directory::channel::{
     ChannelDirectory, ChannelRequest, ChannelRequestHandler, ChannelResponse,
 };
-use crate::index::SearchIndex;
 use crate::query::SearchQueryInput;
-use crate::schema::{SearchFieldName, SearchIndexSchema};
+use crate::schema::{SearchField, SearchFieldName, SearchIndexSchema};
 use anyhow::Result;
 use pgrx::{pg_sys, PgRelation};
 use std::cmp::Ordering;
@@ -32,8 +31,8 @@ use tantivy::index::Index;
 use tantivy::query::QueryParser;
 use tantivy::schema::FieldType;
 use tantivy::{
-    query::Query, DocAddress, DocId, Order, Score, Searcher, SegmentOrdinal, TantivyDocument,
-    TantivyError,
+    query::Query, DocAddress, DocId, IndexReader, Order, Score, Searcher, SegmentOrdinal,
+    TantivyDocument, TantivyError,
 };
 use tantivy::{snippet::SnippetGenerator, Executor};
 
@@ -206,24 +205,52 @@ pub struct SearchIndexReader {
     pub index_oid: pg_sys::Oid,
     pub searcher: Searcher,
     pub schema: SearchIndexSchema,
-    pub underlying_reader: tantivy::IndexReader,
+    pub underlying_reader: IndexReader,
+    pub underlying_index: Index,
 }
 
 impl SearchIndexReader {
-    pub fn new(search_index: &SearchIndex) -> Result<Self> {
-        let schema = search_index.schema.clone();
-        let reader = search_index
-            .underlying_index
-            .reader_builder()
-            .reload_policy(tantivy::ReloadPolicy::Manual)
-            .try_into()?;
-        let searcher = reader.searcher();
-        Ok(SearchIndexReader {
-            index_oid: search_index.index_oid,
+    pub fn new(
+        index_relation: &PgRelation,
+        index: Index,
+        searcher: Searcher,
+        reader: IndexReader,
+        schema: SearchIndexSchema,
+    ) -> Self {
+        Self {
+            // NB:  holds the relation open with an AccessShareLock, which seems appropriate
+            index_oid: index_relation.oid(),
             searcher,
-            schema: schema.clone(),
+            schema,
             underlying_reader: reader,
-        })
+            underlying_index: index,
+        }
+    }
+
+    pub fn key_field(&self) -> SearchField {
+        self.schema.key_field()
+    }
+
+    pub fn query(&self, search_query_input: &SearchQueryInput) -> Box<dyn Query> {
+        let mut parser = QueryParser::for_index(
+            &self.underlying_index,
+            self.schema
+                .fields
+                .iter()
+                .map(|search_field| search_field.id.0)
+                .collect::<Vec<_>>(),
+        );
+        search_query_input
+            .clone()
+            .into_tantivy_query(
+                &(
+                    unsafe { &PgRelation::with_lock(self.index_oid, pg_sys::AccessShareLock as _) },
+                    &self.schema,
+                ),
+                &mut parser,
+                &self.searcher,
+            )
+            .expect("must be able to parse query")
     }
 
     pub fn get_doc(&self, doc_address: DocAddress) -> tantivy::Result<TantivyDocument> {
@@ -239,7 +266,11 @@ impl SearchIndexReader {
             .map(|space| space.total().get_bytes())?)
     }
 
-    pub fn snippet_generator(&self, field_name: &str, query: &dyn Query) -> SnippetGenerator {
+    pub fn snippet_generator(
+        &self,
+        field_name: &str,
+        query: &SearchQueryInput,
+    ) -> SnippetGenerator {
         let field = self
             .schema
             .get_search_field(&SearchFieldName(field_name.into()))
@@ -247,7 +278,7 @@ impl SearchIndexReader {
 
         match self.schema.schema.get_field_entry(field.into()).field_type() {
             FieldType::Str(_) => {
-                SnippetGenerator::create(&self.searcher, query, field.into())
+                SnippetGenerator::create(&self.searcher, &self.query(query), field.into())
                     .unwrap_or_else(|err| panic!("failed to create snippet generator for field: {field_name}... {err}"))
             }
             _ => panic!("failed to create snippet generator for field: {field_name}... can only highlight text fields")
@@ -265,8 +296,7 @@ impl SearchIndexReader {
         &self,
         need_scores: bool,
         _sort_segments_by_ctid: bool,
-        executor: &'static Executor,
-        query: &dyn Query,
+        query: &SearchQueryInput,
         _estimated_rows: Option<usize>,
     ) -> SearchResults {
         // let estimated_rows = estimated_rows.unwrap_or(0);
@@ -354,8 +384,7 @@ impl SearchIndexReader {
         // }
 
         let cache = unsafe { BM25BufferCache::open(self.index_oid) };
-        let lock =
-            unsafe { cache.get_buffer(METADATA_BLOCKNO, Some(pgrx::pg_sys::BUFFER_LOCK_SHARE)) };
+        let lock = unsafe { cache.get_buffer(METADATA_BLOCKNO, Some(pg_sys::BUFFER_LOCK_SHARE)) };
 
         let (search_sender, search_receiver) = crossbeam::channel::unbounded();
         let (request_sender, request_receiver) = crossbeam::channel::unbounded::<ChannelRequest>();
@@ -364,7 +393,7 @@ impl SearchIndexReader {
 
         let collector = channel::ChannelCollector::new(need_scores, search_sender);
 
-        let owned_query = query.box_clone();
+        let owned_query = self.query(&query);
         std::thread::spawn(move || {
             let channel_directory =
                 ChannelDirectory::new(request_sender.clone(), response_receiver.clone());
@@ -381,7 +410,7 @@ impl SearchIndexReader {
                 .search_with_executor(
                     &owned_query,
                     &collector,
-                    executor,
+                    &Executor::SingleThread,
                     if need_scores {
                         tantivy::query::EnableScoring::Enabled {
                             searcher: &searcher,
@@ -408,7 +437,7 @@ impl SearchIndexReader {
         );
         let _ = handler.receive_blocking(Some(|_| false)).unwrap();
 
-        unsafe { pgrx::pg_sys::UnlockReleaseBuffer(lock) };
+        unsafe { pg_sys::UnlockReleaseBuffer(lock) };
         SearchResults::Channel(search_receiver.into_iter())
     }
 
@@ -422,10 +451,11 @@ impl SearchIndexReader {
         &self,
         need_scores: bool,
         segment_ord: SegmentOrdinal,
-        query: &dyn Query,
+        query: &SearchQueryInput,
     ) -> SearchResults {
         let collector = vec_collector::VecCollector::new(need_scores);
-        let weight = query
+        let weight = self
+            .query(query)
             .weight(if need_scores {
                 tantivy::query::EnableScoring::Enabled {
                     searcher: &self.searcher,
@@ -454,23 +484,21 @@ impl SearchIndexReader {
     /// handle that, if it's necessary.
     pub fn search_top_n(
         &self,
-        executor: &'static Executor,
-        query: &dyn Query,
+        query: &SearchQueryInput,
         sort_field: Option<String>,
         sortdir: SortDirection,
         n: usize,
     ) -> SearchResults {
         if let Some(sort_field) = sort_field {
-            self.top_by_field(executor, query, sort_field, sortdir, n)
+            self.top_by_field(query, sort_field, sortdir, n)
         } else {
-            self.top_by_score(executor, query, sortdir, n)
+            self.top_by_score(query, sortdir, n)
         }
     }
 
     fn top_by_field(
         &self,
-        executor: &Executor,
-        query: &dyn Query,
+        query: &SearchQueryInput,
         sort_field: String,
         sortdir: SortDirection,
         n: usize,
@@ -494,9 +522,9 @@ impl SearchIndexReader {
         let top_docs = self
             .searcher
             .search_with_executor(
-                query,
+                &self.query(query),
                 &collector,
-                executor,
+                &Executor::SingleThread,
                 tantivy::query::EnableScoring::Enabled {
                     searcher: &self.searcher,
                     statistics_provider: &self.searcher,
@@ -525,8 +553,7 @@ impl SearchIndexReader {
 
     fn top_by_score(
         &self,
-        executor: &Executor,
-        query: &dyn Query,
+        query: &SearchQueryInput,
         sortdir: SortDirection,
         n: usize,
     ) -> SearchResults {
@@ -546,9 +573,9 @@ impl SearchIndexReader {
         let top_docs = self
             .searcher
             .search_with_executor(
-                query,
+                &self.query(query),
                 &collector,
-                executor,
+                &Executor::SingleThread,
                 tantivy::query::EnableScoring::Enabled {
                     searcher: &self.searcher,
                     statistics_provider: &self.searcher,
@@ -560,12 +587,7 @@ impl SearchIndexReader {
         SearchResults::TopNByScore(top_docs.len(), top_docs.into_iter())
     }
 
-    pub fn estimate_docs(
-        &self,
-        indexrel: &PgRelation,
-        mut query_parser: QueryParser,
-        search_query_input: SearchQueryInput,
-    ) -> Option<usize> {
+    pub fn estimate_docs(&self, search_query_input: &SearchQueryInput) -> Option<usize> {
         let readers = self.searcher.segment_readers();
         let (ordinal, largest_reader) = readers
             .iter()
@@ -574,10 +596,7 @@ impl SearchIndexReader {
 
         let collector = tantivy::collector::Count;
         let schema = self.schema.schema.clone();
-        let query = &search_query_input
-            .clone()
-            .into_tantivy_query(&(indexrel, &self.schema), &mut query_parser, &self.searcher)
-            .expect("must be able to parse query");
+        let query = self.query(search_query_input);
         let weight = match query.weight(tantivy::query::EnableScoring::Disabled {
             schema: &schema,
             searcher_opt: Some(&self.searcher),

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -120,7 +120,7 @@ mod tests {
         let directory = BlockingDirectory::new(index_oid);
         let (opaque, _, _) = unsafe {
             directory
-                .directory_lookup(&path)
+                .directory_lookup(path)
                 .expect("open segment component opaque should succeed")
         };
         let reader = SegmentComponentReader::new(index_oid, opaque.clone());

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -25,24 +25,16 @@ use crate::postgres::index::get_fields;
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::storage::block::METADATA_BLOCKNO;
 use crate::postgres::storage::utils::BM25BufferCache;
-use crate::query::SearchQueryInput;
-use crate::schema::{
-    SearchDocument, SearchField, SearchFieldConfig, SearchFieldName, SearchFieldType,
-    SearchIndexSchema, SearchIndexSchemaError,
-};
+use crate::schema::{SearchField, SearchFieldConfig, SearchIndexSchema, SearchIndexSchemaError};
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use pgrx::{pg_sys, PgRelation};
-use serde::Serialize;
 use std::num::NonZeroUsize;
 use tantivy::directory::DirectoryClone;
-use tantivy::query::Query;
-use tantivy::schema::Schema;
-use tantivy::{query::QueryParser, Directory, Executor, Index, IndexSettings, ReloadPolicy};
+use tantivy::{Directory, Executor, Index, IndexSettings, ReloadPolicy};
 use thiserror::Error;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager};
 use tracing::trace;
-use url::quirks::search;
 
 /// PostgreSQL operates in a process-per-client model, meaning every client connection
 /// to PostgreSQL results in a new backend process being spawned on the PostgreSQL server.

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -18,8 +18,13 @@
 use super::reader::index::SearchIndexReader;
 use super::writer::index::IndexError;
 use crate::gucs;
+use crate::index::blocking::BlockingDirectory;
+use crate::index::channel::{ChannelDirectory, ChannelRequestHandler};
 use crate::index::writer::index::SearchIndexWriter;
+use crate::postgres::index::get_fields;
 use crate::postgres::options::SearchIndexCreateOptions;
+use crate::postgres::storage::block::METADATA_BLOCKNO;
+use crate::postgres::storage::utils::BM25BufferCache;
 use crate::query::SearchQueryInput;
 use crate::schema::{
     SearchDocument, SearchField, SearchFieldConfig, SearchFieldName, SearchFieldType,
@@ -27,14 +32,17 @@ use crate::schema::{
 };
 use anyhow::Result;
 use once_cell::sync::Lazy;
-use pgrx::PgRelation;
+use pgrx::{pg_sys, PgRelation};
 use serde::Serialize;
 use std::num::NonZeroUsize;
+use tantivy::directory::DirectoryClone;
 use tantivy::query::Query;
-use tantivy::{query::QueryParser, Executor, Index};
+use tantivy::schema::Schema;
+use tantivy::{query::QueryParser, Directory, Executor, Index, IndexSettings, ReloadPolicy};
 use thiserror::Error;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager};
 use tracing::trace;
+use url::quirks::search;
 
 /// PostgreSQL operates in a process-per-client model, meaning every client connection
 /// to PostgreSQL results in a new backend process being spawned on the PostgreSQL server.
@@ -78,44 +86,131 @@ impl WriterResources {
     }
 }
 
-#[derive(Serialize)]
-pub struct SearchIndex {
-    pub schema: SearchIndexSchema,
-    pub index_oid: pgrx::pg_sys::Oid,
-    #[serde(skip_serializing)]
-    pub underlying_index: Index,
+// #[derive(Serialize)]
+struct SearchIndex {
+    schema: SearchIndexSchema,
+    index_oid: pg_sys::Oid,
+    underlying_index: Index,
+    handler: ChannelRequestHandler,
 }
 
 impl SearchIndex {
-    pub fn create_index(
-        index_oid: pgrx::pg_sys::Oid,
-        fields: Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)>,
-        key_field_index: usize,
-    ) -> Result<Self> {
-        SearchIndexWriter::create_index(index_oid, fields, key_field_index)
-    }
-
-    pub fn get_reader(&self) -> Result<SearchIndexReader> {
-        SearchIndexReader::new(self)
-    }
-
-    /// Retrieve an owned writer for a given index. This will block until this process
-    /// can get an exclusive lock on the Tantivy writer. The return type needs to
-    /// be entirely owned by the new process, with no references.
-    pub fn get_writer(
-        &self,
+    fn create_index(
+        index_relation: &PgRelation,
         resources: WriterResources,
-        index_options: &SearchIndexCreateOptions,
     ) -> Result<SearchIndexWriter> {
-        SearchIndexWriter::new(&self.underlying_index, resources, index_options)
+        let schema = make_schema(index_relation)?;
+        let create_options = index_relation.rd_options as *mut SearchIndexCreateOptions;
+
+        let settings = IndexSettings {
+            docstore_compress_dedicated_thread: false,
+            ..IndexSettings::default()
+        };
+        let search_index = Self::prepare_index(index_relation, schema, |directory, schema| {
+            Index::create(directory, schema.schema.clone(), settings)
+        })?;
+
+        SearchIndexWriter::new(
+            search_index.underlying_index,
+            search_index.schema,
+            search_index.handler,
+            resources,
+            unsafe { &*create_options },
+        )
+    }
+
+    fn open_writer(
+        index_relation: &PgRelation,
+        resources: WriterResources,
+    ) -> Result<SearchIndexWriter> {
+        let schema = make_schema(index_relation)?;
+        let create_options = index_relation.rd_options as *mut SearchIndexCreateOptions;
+
+        let search_index = Self::prepare_index(index_relation, schema, |directory, _| {
+            Index::open(directory)
+        })?;
+
+        SearchIndexWriter::new(
+            search_index.underlying_index,
+            search_index.schema,
+            search_index.handler,
+            resources,
+            unsafe { &*create_options },
+        )
+    }
+
+    fn prepare_index<F: FnOnce(Box<dyn Directory>, &SearchIndexSchema) -> tantivy::Result<Index>>(
+        index_relation: &PgRelation,
+        schema: SearchIndexSchema,
+        opener: F,
+    ) -> Result<Self, SearchIndexError>
+    where
+        F: Send + Sync,
+    {
+        let index_oid = index_relation.oid();
+        let cache = unsafe { BM25BufferCache::open(index_oid) };
+        let lock =
+            unsafe { cache.get_buffer(METADATA_BLOCKNO, Some(pgrx::pg_sys::BUFFER_LOCK_SHARE)) };
+
+        let (req_sender, req_receiver) = crossbeam::channel::bounded(1);
+        let (resp_sender, resp_receiver) = crossbeam::channel::bounded(1);
+        let tantivy_dir = BlockingDirectory::new(index_oid);
+        let channel_dir = ChannelDirectory::new(req_sender, resp_receiver);
+        let mut handler =
+            ChannelRequestHandler::open(tantivy_dir, index_oid, resp_sender, req_receiver);
+
+        let underlying_index = handler
+            .wait_for(|| {
+                let mut index = opener(channel_dir.box_clone(), &schema)?;
+                SearchIndex::setup_tokenizers(&mut index, &schema);
+                tantivy::Result::Ok(index)
+            })
+            .expect("scoped thread should not fail")?;
+
+        unsafe { pg_sys::UnlockReleaseBuffer(lock) };
+
+        Ok(SearchIndex {
+            schema,
+            underlying_index,
+            index_oid,
+            handler,
+        })
+    }
+
+    pub fn perform<T, F: FnOnce(&Index) -> T>(&mut self, action: F) -> std::thread::Result<T>
+    where
+        F: Send + Sync,
+        T: Send + Sync,
+    {
+        self.handler.wait_for(|| action(&self.underlying_index))
+    }
+
+    fn open_reader(index_relation: &PgRelation) -> Result<SearchIndexReader> {
+        let directory = BlockingDirectory::new(index_relation.oid());
+        let mut index = Index::open(directory)?;
+        let schema = make_schema(index_relation)?;
+        SearchIndex::setup_tokenizers(&mut index, &schema);
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        let searcher = reader.searcher();
+
+        Ok(SearchIndexReader::new(
+            index_relation,
+            index,
+            searcher,
+            reader,
+            schema,
+        ))
     }
 
     #[allow(static_mut_refs)]
-    pub fn executor() -> &'static Executor {
+    fn executor() -> &'static Executor {
         unsafe { &SEARCH_EXECUTOR }
     }
 
-    pub fn setup_tokenizers(underlying_index: &mut Index, schema: &SearchIndexSchema) {
+    fn setup_tokenizers(underlying_index: &mut Index, schema: &SearchIndexSchema) {
         let tokenizers = schema
             .fields
             .iter()
@@ -135,46 +230,12 @@ impl SearchIndex {
         underlying_index.set_fast_field_tokenizers(create_normalizer_manager());
     }
 
-    pub fn key_field(&self) -> SearchField {
+    fn key_field(&self) -> SearchField {
         self.schema.key_field()
     }
 
-    pub fn key_field_name(&self) -> String {
+    fn key_field_name(&self) -> String {
         self.key_field().name.to_string()
-    }
-
-    pub fn query_parser(&self) -> QueryParser {
-        QueryParser::for_index(
-            &self.underlying_index,
-            self.schema
-                .fields
-                .iter()
-                .map(|search_field| search_field.id.0)
-                .collect::<Vec<_>>(),
-        )
-    }
-
-    pub fn query(
-        &self,
-        indexrel: &PgRelation,
-        search_query_input: &SearchQueryInput,
-        reader: &SearchIndexReader,
-    ) -> Box<dyn Query> {
-        let mut parser = self.query_parser();
-        let searcher = reader.underlying_reader.searcher();
-        search_query_input
-            .clone()
-            .into_tantivy_query(&(indexrel, &self.schema), &mut parser, &searcher)
-            .expect("must be able to parse query")
-    }
-
-    pub fn insert(
-        &self,
-        writer: &mut SearchIndexWriter,
-        document: SearchDocument,
-    ) -> Result<(), SearchIndexError> {
-        writer.insert(document)?;
-        Ok(())
     }
 }
 
@@ -198,4 +259,34 @@ pub enum SearchIndexError {
 
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
+}
+
+fn make_schema(index_relation: &PgRelation) -> Result<SearchIndexSchema> {
+    if index_relation.rd_options.is_null() {
+        panic!("must specify key field")
+    }
+    let (fields, key_field_index) = unsafe { get_fields(index_relation) };
+    let schema = SearchIndexSchema::new(fields, key_field_index)?;
+    Ok(schema)
+}
+
+/// Open a (non-channel-based) [`SearchIndexReader`] for the specified Postgres index relation
+pub fn open_search_reader(index_relation: &PgRelation) -> Result<SearchIndexReader> {
+    SearchIndex::open_reader(index_relation)
+}
+
+/// Open an existing index for writing
+pub fn open_search_writer(
+    index_relation: &PgRelation,
+    resources: WriterResources,
+) -> Result<SearchIndexWriter> {
+    SearchIndex::open_writer(index_relation, resources)
+}
+
+/// Create a new, empty index for the specified Postgres index relation
+pub fn create_new_index(
+    index_relation: &PgRelation,
+    resources: WriterResources,
+) -> Result<SearchIndexWriter> {
+    SearchIndex::create_index(index_relation, resources)
 }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -73,7 +73,6 @@ impl WriterResources {
     }
 }
 
-// #[derive(Serialize)]
 struct SearchIndex {
     schema: SearchIndexSchema,
     underlying_index: Index,

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -51,7 +51,7 @@ impl SearchIndexWriter {
         let memory_budget = memory_budget / parallelism.get();
         let parallelism = NonZeroUsize::new(1).unwrap();
 
-        let (wants_merge, merge_policy) = match resources {
+        let (_wants_merge, merge_policy) = match resources {
             // During a CREATE INDEX we use `target_segment_count` but require twice
             // as many segments before we'll do a merge.
             WriterResources::CreateIndex => {
@@ -129,13 +129,13 @@ impl SearchIndexWriter {
 
     pub fn vacuum(mut self) -> Result<ChannelRequestStats> {
         std::thread::scope(|scope| {
-            let opstampt = scope.spawn(|| {
+            let _opstamp = scope.spawn(|| {
                 let opstamp = self.writer.commit()?;
                 self.writer.wait_merging_threads()?;
                 tantivy::Result::Ok(opstamp)
             });
 
-            self.handler.receive_blocking(Some(|_| false))
+            self.handler.receive_blocking()
         })
     }
 }

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -46,7 +46,7 @@ impl SearchIndexWriter {
         index_options: &SearchIndexCreateOptions,
     ) -> Result<Self> {
         let (parallelism, memory_budget, target_segment_count, merge_on_insert) =
-            resources.resources(&index_options);
+            resources.resources(index_options);
 
         let memory_budget = memory_budget / parallelism.get();
         let parallelism = NonZeroUsize::new(1).unwrap();

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -100,7 +100,6 @@ impl SearchIndexWriter {
             }
         };
 
-        let mut handler = handler.clone();
         let writer = handler
             .wait_for(|| index.writer_with_num_threads(parallelism.get(), memory_budget))
             .expect("scoped thread should not fail")?;

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::writer::index::SearchIndexWriter;
-use crate::index::{create_new_index, open_search_writer, WriterResources};
+use crate::index::{create_new_index, WriterResources};
 use crate::postgres::storage::block::{
     MetaPageData, INDEX_WRITER_LOCK_BLOCKNO, MANAGED_LOCK_BLOCKNO, METADATA_BLOCKNO,
     META_LOCK_BLOCKNO, TANTIVY_META_BLOCKNO,
@@ -109,7 +109,7 @@ fn do_heap_scan<'a>(
     index_relation: &'a PgRelation,
 ) -> usize {
     unsafe {
-        let writer = create_new_index(&index_relation, WriterResources::CreateIndex)
+        let writer = create_new_index(index_relation, WriterResources::CreateIndex)
             .expect("should be able to open a SearchIndexWriter");
 
         let mut state = BuildState::new(index_relation, index_info, writer);
@@ -147,7 +147,7 @@ unsafe extern "C" fn build_callback(
 
     let tupdesc = &build_state.tupdesc;
     let schema = &build_state.schema;
-    let mut writer = &mut build_state.writer;
+    let writer = &mut build_state.writer;
     // In the block below, we switch to the memory context we've defined on our build
     // state, resetting it before and after. We do this because we're looking up a
     // PgTupleDesc... which is supposed to free the corresponding Postgres memory when it

--- a/pg_search/src/postgres/cost.rs
+++ b/pg_search/src/postgres/cost.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::index::open_search_index;
+use crate::index::open_search_reader;
 use crate::{DEFAULT_STARTUP_COST, UNKNOWN_SELECTIVITY};
 use pgrx::*;
 
@@ -48,14 +48,9 @@ pub unsafe extern "C" fn amcostestimate(
         .unwrap_or(1.0) as f64;
     let page_estimate = {
         assert!(!indexrel.rd_options.is_null());
-        let search_index =
-            open_search_index(&indexrel).expect("should be able to open search index");
-        search_index
-            .get_reader()
-            .expect("must be able to initialize index reader in amcostestimate")
-            .byte_size()
-            .unwrap_or(0)
-            / pg_sys::BLCKSZ as u64
+        let search_reader =
+            open_search_reader(&indexrel).expect("should be able to open a SearchIndexReader");
+        search_reader.byte_size().unwrap_or(0) / pg_sys::BLCKSZ as u64
     };
     drop(indexrel);
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -16,7 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::reader::index::SearchResults;
-use crate::index::SearchIndex;
 use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
 use crate::postgres::customscan::pdbscan::is_block_all_visible;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
@@ -122,8 +121,7 @@ impl NormalScanExecState {
         self.search_results = state.search_reader.as_ref().unwrap().search_via_channel(
             state.need_scores(),
             false,
-            SearchIndex::executor(),
-            state.query.as_ref().unwrap(),
+            &state.search_query_input,
             state.limit,
         );
         self.did_query = true;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -21,7 +21,6 @@ use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use crate::query::SearchQueryInput;
 use pgrx::{direct_function_call, pg_sys, IntoDatum};
-use tantivy::query::{Query, QueryClone};
 
 // TODO:  should these be GUCs?  I think yes, probably
 const SUBSEQUENT_RETRY_SCALE_FACTOR: usize = 2;

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -35,7 +35,6 @@ use tantivy::DocAddress;
 pub struct PdbScanState {
     pub rti: pg_sys::Index,
 
-    pub query: Option<Box<dyn Query>>,
     pub search_query_input: SearchQueryInput,
     pub search_reader: Option<SearchIndexReader>,
 

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -27,7 +27,6 @@ use crate::query::SearchQueryInput;
 use pgrx::{name_data_to_str, pg_sys, PgRelation};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use tantivy::query::Query;
 use tantivy::snippet::SnippetGenerator;
 use tantivy::DocAddress;
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -33,7 +33,7 @@ pub extern "C" fn ambulkdelete(
 
     let reader = open_search_reader(&index_relation)
         .expect("ambulkdelete: should be able to open SearchIndexReader");
-    let writer = open_search_writer(&index_relation, WriterResources::Vacuum)
+    let mut writer = open_search_writer(&index_relation, WriterResources::Vacuum)
         .expect("ambulkdelete: should be able to open SearchIndexWriter");
     let ctid_field = reader
         .schema
@@ -52,7 +52,7 @@ pub extern "C" fn ambulkdelete(
                 callback_fn(&mut ipd, callback_state)
                     .then(|| tantivy::Term::from_field_u64(ctid_field, ctid_u64))
             }) {
-                writer.writer.delete_term(ctid);
+                writer.delete_term(ctid);
             }
         }
     }

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -33,7 +33,7 @@ pub extern "C" fn ambulkdelete(
 
     let reader = open_search_reader(&index_relation)
         .expect("ambulkdelete: should be able to open SearchIndexReader");
-    let mut writer = open_search_writer(&index_relation, WriterResources::Vacuum)
+    let writer = open_search_writer(&index_relation, WriterResources::Vacuum)
         .expect("ambulkdelete: should be able to open SearchIndexWriter");
     let ctid_field = reader
         .schema

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -50,7 +50,7 @@ pub extern "C" fn ambulkdelete(
 
                 let callback_fn = callback.as_ref().unwrap();
                 callback_fn(&mut ipd, callback_state)
-                    .then(|| tantivy::Term::from_field_u64(ctid_field.clone(), ctid_u64))
+                    .then(|| tantivy::Term::from_field_u64(ctid_field, ctid_u64))
             }) {
                 writer.writer.delete_term(ctid);
             }

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -15,16 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::index::directory::blocking::BlockingDirectory;
-use crate::index::directory::channel::{
-    ChannelDirectory, ChannelRequest, ChannelRequestHandler, ChannelResponse,
-};
 use crate::index::fast_fields_helper::FFType;
-use crate::index::WriterResources;
-use crate::postgres::options::SearchIndexCreateOptions;
-use pgrx::{pg_sys::ItemPointerData, *};
-use tantivy::index::Index;
-use tantivy::indexer::IndexWriter;
+use crate::index::{open_search_reader, open_search_writer, WriterResources};
+use crate::postgres::utils::u64_to_item_pointer;
+use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn ambulkdelete(
@@ -36,78 +30,45 @@ pub extern "C" fn ambulkdelete(
     let info = unsafe { PgBox::from_pg(info) };
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_relation = unsafe { PgRelation::from_pg(info.index) };
-    let index_oid = index_relation.oid();
-    let options = index_relation.rd_options as *mut SearchIndexCreateOptions;
-    let (parallelism, memory_budget, _, _) =
-        WriterResources::Vacuum.resources(unsafe { options.as_ref().unwrap() });
-    let (request_sender, request_receiver) = crossbeam::channel::unbounded::<ChannelRequest>();
-    let (response_sender, response_receiver) = crossbeam::channel::unbounded::<ChannelResponse>();
 
-    std::thread::scope(|s| {
-        s.spawn(|| {
-            let channel_directory =
-                ChannelDirectory::new(request_sender.clone(), response_receiver.clone());
-            let channel_index = Index::open(channel_directory).expect("channel index should open");
-            let reader = channel_index
-                .reader_builder()
-                .reload_policy(tantivy::ReloadPolicy::Manual)
-                .try_into()
-                .unwrap();
-            let mut writer: IndexWriter = channel_index
-                .writer_with_num_threads(parallelism.into(), memory_budget)
-                .unwrap();
+    let reader = open_search_reader(&index_relation)
+        .expect("ambulkdelete: should be able to open SearchIndexReader");
+    let writer = open_search_writer(&index_relation, WriterResources::Vacuum)
+        .expect("ambulkdelete: should be able to open SearchIndexWriter");
+    let ctid_field = reader
+        .schema
+        .schema
+        .get_field("ctid")
+        .expect("ambulkdelete: ctid field should exist in index schema");
+    for segment_reader in reader.searcher.segment_readers() {
+        let fast_fields = segment_reader.fast_fields();
+        let ctid_ff = FFType::new(fast_fields, "ctid");
+        if let FFType::U64(ff) = ctid_ff {
+            for ctid in ff.iter().filter_map(|ctid_u64| unsafe {
+                let mut ipd = pg_sys::ItemPointerData::default();
+                u64_to_item_pointer(ctid_u64, &mut ipd);
 
-            for segment_reader in reader.searcher().segment_readers() {
-                let fast_fields = segment_reader.fast_fields();
-                let ctid_ff = FFType::new(fast_fields, "ctid");
-                if let FFType::U64(ff) = ctid_ff {
-                    let ctids: Vec<u64> = ff.iter().collect();
-                    request_sender
-                        .send(ChannelRequest::ShouldDeleteCtids(ctids))
-                        .unwrap();
-                    let ctids_to_delete = match response_receiver.recv().unwrap() {
-                        ChannelResponse::ShouldDeleteCtids(ctids) => ctids,
-                        _ => panic!("unexpected response in bulkdelete thread"),
-                    };
-                    for ctid in ctids_to_delete {
-                        let ctid_field = channel_index.schema().get_field("ctid").unwrap();
-                        let ctid_term = tantivy::Term::from_field_u64(ctid_field, ctid);
-                        writer.delete_term(ctid_term);
-                    }
-                }
+                let callback_fn = callback.as_ref().unwrap();
+                callback_fn(&mut ipd, callback_state)
+                    .then(|| tantivy::Term::from_field_u64(ctid_field.clone(), ctid_u64))
+            }) {
+                writer.writer.delete_term(ctid);
             }
-            writer.commit().unwrap();
-            writer.wait_merging_threads().unwrap();
-            request_sender.send(ChannelRequest::Terminate).unwrap();
-        });
-
-        let blocking_directory = BlockingDirectory::new(index_oid);
-        let mut handler = ChannelRequestHandler::open(
-            blocking_directory,
-            index_oid,
-            response_sender,
-            request_receiver,
-        );
-        let should_delete = callback.map(|actual_callback| {
-            move |ctid_val: u64| unsafe {
-                let mut ctid = ItemPointerData::default();
-                crate::postgres::utils::u64_to_item_pointer(ctid_val, &mut ctid);
-                actual_callback(&mut ctid, callback_state)
-            }
-        });
-
-        let blocking_stats = handler.receive_blocking(should_delete).unwrap();
-
-        if stats.is_null() {
-            stats = unsafe {
-                PgBox::from_pg(
-                    pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast(),
-                )
-            };
-            stats.pages_deleted = 0;
         }
+    }
+    let blocking_stats = writer
+        .vacuum()
+        .expect("ambulkdelete: tantivy vacuum should succeed");
 
-        stats.pages_deleted += blocking_stats.deleted_paths.len() as u32;
-        stats.into_pg()
-    })
+    if stats.is_null() {
+        stats = unsafe {
+            PgBox::from_pg(
+                pg_sys::palloc0(std::mem::size_of::<pg_sys::IndexBulkDeleteResult>()).cast(),
+            )
+        };
+        stats.pages_deleted = 0;
+    }
+
+    stats.pages_deleted += blocking_stats.deleted_paths.len() as u32;
+    stats.into_pg()
 }

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -17,9 +17,7 @@
 
 use crate::index::writer::index::SearchIndexWriter;
 use crate::index::{open_search_writer, WriterResources};
-use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::utils::row_to_search_document;
-use anyhow::Result;
 use pgrx::{pg_guard, pg_sys, PgMemoryContexts, PgRelation, PgTupleDesc};
 use std::ffi::CStr;
 use std::panic::{catch_unwind, resume_unwind};

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -16,8 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::writer::index::SearchIndexWriter;
-use crate::index::{SearchIndex, WriterResources};
-use crate::postgres::index::open_search_index;
+use crate::index::{open_search_writer, WriterResources};
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::utils::row_to_search_document;
 use anyhow::Result;
@@ -26,20 +25,9 @@ use std::ffi::CStr;
 use std::panic::{catch_unwind, resume_unwind};
 
 pub struct InsertState {
-    pub index: SearchIndex,
     pub writer: Option<SearchIndexWriter>,
     abort_on_drop: bool,
     committed: bool,
-}
-
-impl InsertState {
-    pub fn try_commit(&mut self) -> Result<()> {
-        if let Some(writer) = self.writer.take() {
-            writer.commit()?;
-            self.committed = true;
-        }
-        Ok(())
-    }
 }
 
 impl Drop for InsertState {
@@ -68,11 +56,8 @@ impl InsertState {
         indexrel: &PgRelation,
         writer_resources: WriterResources,
     ) -> anyhow::Result<Self> {
-        let index = open_search_index(indexrel)?;
-        let options = indexrel.rd_options as *mut SearchIndexCreateOptions;
-        let writer = index.get_writer(writer_resources, options.as_ref().unwrap())?;
+        let writer = open_search_writer(indexrel, writer_resources)?;
         Ok(Self {
-            index,
             writer: Some(writer),
             abort_on_drop: false,
             committed: false,
@@ -148,19 +133,19 @@ unsafe fn aminsert_internal(
     let result = catch_unwind(|| {
         let state = &mut *init_insert_state(index_relation, index_info, WriterResources::Statement);
         let tupdesc = PgTupleDesc::from_pg_unchecked((*index_relation).rd_att);
-        let search_index = &state.index;
         let writer = state.writer.as_mut().expect("writer should not be null");
         let search_document =
-            row_to_search_document(*ctid, &tupdesc, values, isnull, &search_index.schema)
-                .unwrap_or_else(|err| {
+            row_to_search_document(*ctid, &tupdesc, values, isnull, &writer.schema).unwrap_or_else(
+                |err| {
                     panic!(
                         "error creating index entries for index '{}': {err}",
                         CStr::from_ptr((*(*index_relation).rd_rel).relname.data.as_ptr())
                             .to_string_lossy()
                     );
-                });
-        search_index
-            .insert(writer, search_document)
+                },
+            );
+        writer
+            .insert(search_document)
             .expect("insertion into index should succeed");
 
         true

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -142,7 +142,7 @@ pub extern "C" fn amrescan(
                     &[(key_field, key_field_type).into()],
                 ),
                 reader: search_reader,
-                search_query_input: search_query_input,
+                search_query_input,
                 results,
                 itup: (vec![pg_sys::Datum::null(); natts], vec![true; natts]),
                 key_field_oid: PgOid::from(
@@ -154,7 +154,7 @@ pub extern "C" fn amrescan(
                 need_scores,
                 fast_fields: FFHelper::empty(),
                 reader: search_reader,
-                search_query_input: search_query_input,
+                search_query_input,
                 results,
                 itup: (vec![], vec![]),
                 key_field_oid: PgOid::Invalid,

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -213,7 +213,7 @@ mod tests {
         let segment = DirectoryEntry {
             path: PathBuf::from(format!("{}.ext", Uuid::new_v4())),
             start: 0,
-            total_bytes: 100 as usize,
+            total_bytes: 100_usize,
             xid: 0,
         };
         let pg_item: PgItem = segment.clone().into();

--- a/pg_search/src/postgres/storage/linked_list.rs
+++ b/pg_search/src/postgres/storage/linked_list.rs
@@ -343,9 +343,9 @@ mod tests {
         }
     }
 
-    impl Into<PgItem> for PathBuf {
-        fn into(self) -> PgItem {
-            let path_str = self.to_str().expect("file path is not valid UTF-8");
+    impl From<PathBuf> for PgItem {
+        fn from(val: PathBuf) -> Self {
+            let path_str = val.to_str().expect("file path is not valid UTF-8");
             PgItem(
                 path_str.as_pg_cstr() as pg_sys::Item,
                 path_str.as_bytes().len() as pg_sys::Size,

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -16,11 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::blocking::BlockingDirectory;
-use crate::index::channel::{
-    ChannelDirectory, ChannelRequest, ChannelRequestHandler, ChannelResponse,
-};
 use crate::index::{open_search_writer, WriterResources};
-use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::storage::block::{DirectoryEntry, MetaPageData, METADATA_BLOCKNO};
 use crate::postgres::storage::linked_list::LinkedItemList;
 use crate::postgres::storage::utils::{BM25BufferCache, BM25Page};
@@ -28,8 +24,7 @@ use anyhow::Result;
 use pgrx::*;
 use std::path::PathBuf;
 use tantivy::directory::{Lock, MANAGED_LOCK};
-use tantivy::index::Index;
-use tantivy::{Directory, IndexWriter};
+use tantivy::Directory;
 
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
@@ -227,7 +222,7 @@ mod tests {
             let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
             let page = pg_sys::BufferGetPage(buffer);
             let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
-            assert_eq!((*special).deleted, true);
+            assert!((*special).deleted);
             blockno = (*special).next_blockno;
             pg_sys::UnlockReleaseBuffer(buffer);
         }

--- a/tests/tests/fixtures/utils.rs
+++ b/tests/tests/fixtures/utils.rs
@@ -67,20 +67,3 @@ pub fn default_table_path(conn: &mut PgConnection, schema_name: &str, table_name
     let table_oid = table_oid(conn, schema_name, table_name);
     default_schema_path(conn, schema_name).join(table_oid)
 }
-
-pub fn pg_search_index_directory_path(conn: &mut PgConnection, index_name: &str) -> PathBuf {
-    let (relfile_oid, index_oid) = format!(
-        "SELECT relfilenode::int4, oid::int4 FROM pg_class WHERE relname = '{}' AND relkind = 'i'",
-        index_name
-    )
-    .fetch_one::<(i32, i32)>(conn);
-    let (database_oid,) = "SELECT oid::int4 FROM pg_database WHERE datname = current_database();"
-        .fetch_one::<(i32,)>(conn);
-    let data_directory = "SHOW data_directory;".fetch_one::<(String,)>(conn).0;
-
-    PathBuf::from(data_directory)
-        .join("pg_search")
-        .join(database_oid.to_string())
-        .join(index_oid.to_string())
-        .join(relfile_oid.to_string())
-}

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -20,7 +20,6 @@ mod fixtures;
 
 use std::path::PathBuf;
 
-use fixtures::utils::pg_search_index_directory_path;
 use fixtures::*;
 use pretty_assertions::assert_eq;
 use rstest::*;

--- a/tests/tests/parallel.rs
+++ b/tests/tests/parallel.rs
@@ -30,6 +30,7 @@ use tokio::join;
 /// This test targets the locking functionality between Tantivy writers.
 /// With no locking implemented, a high number of concurrent writers will
 /// cause in an error when they all try to commit to the index at once.
+#[ignore = "block-storage: takes a very very long time to complete"]
 #[rstest]
 #[tokio::test]
 async fn test_simultaneous_commits_with_bm25(database: Db) -> Result<()> {


### PR DESCRIPTION
This cleans up internal APIs and always makes a ChannelDirectory-based SearchIndexWriter and a BlockingDirectory-based SearchIndexReader.

I don't expect this to be merged, unless @rebasedming wants the code now.