### PR TITLE
fix: Fix macOS install

### DIFF
--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -162,7 +162,7 @@ jobs:
 
           # Create postinstall script
           mkdir -p ~/tmp/pg_search_postinstall_script/
-          postinstall_file=~/tmp/pg_search_postinstall_script/postinstall.sh
+          postinstall_file=~/tmp/pg_search_postinstall_script/postinstall
           cat <<EOF > $postinstall_file
           #!/bin/bash
           # Define paths
@@ -174,7 +174,7 @@ jobs:
           ln -s ${share_path}/* /opt/homebrew/share/
           ln -s ${share_path}/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/share/
           EOF
-          chmod +x ~/tmp/pg_search_postinstall_script/postinstall.sh
+          chmod +x ~/tmp/pg_search_postinstall_script/postinstall
 
           # Create the .pkg installer
           pkgbuild --root ${package_dir} \

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -165,14 +165,16 @@ jobs:
           postinstall_file=~/tmp/pg_search_postinstall_script/postinstall
           cat <<EOF > $postinstall_file
           #!/bin/bash
-          # Define paths
-          lib_path="/opt/homebrew/opt/paradedb/lib/postgresql"
-          share_path="/opt/homebrew/opt/paradedb/share/postgresql@${{ matrix.pg_version }}/extension"
-          # Create symlinks in other folders
-          ln -s ${lib_path}/* /opt/homebrew/lib/
-          ln -s ${lib_path}/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/lib/
-          ln -s ${share_path}/* /opt/homebrew/share/
-          ln -s ${share_path}/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/share/
+          # Top-level Homebrew, used by the default Homebrew PostgreSQL formula
+          mkdir -p /opt/homebrew/lib/postgresql@15/
+          mkdir -p /opt/homebrew/share/postgresql@15/extension/
+          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/lib/postgresql@15/
+          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@15/extension/* /opt/homebrew/share/postgresql@15/extension/
+          # Opt-level Homebrew, used by the other Homebrew PostgreSQL formulas
+          mkdir -p /opt/homebrew/opt/postgresql@15/lib/postgresql/
+          mkdir -p /opt/homebrew/opt/postgresql@15/share/postgresql@15/extension/
+          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/opt/postgresql@15/lib/postgresql/
+          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@15/extension/* /opt/homebrew/opt/postgresql@15/share/postgresql@15/extension/
           EOF
           chmod +x ~/tmp/pg_search_postinstall_script/postinstall
 

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -158,17 +158,34 @@ jobs:
           cp archive/*.control ${package_dir}/${share_path}
           cp archive/*.sql ${package_dir}/${share_path}
 
+          # Create postinstall script
+          mkdir -p ~/tmp/pg_search_postinstall_script/
+          postinstall_file=~/tmp/pg_search_postinstall_script/postinstall.sh
+          cat <<EOF > $postinstall_file
+          #!/bin/bash
+          # Define paths
+          lib_path="/opt/homebrew/opt/paradedb/lib/postgresql"
+          share_path="/opt/homebrew/opt/paradedb/share/postgresql@${{ matrix.pg_version }}/extension"
+          # Create symlinks in other folders
+          ln -s ${lib_path}/* /opt/homebrew/lib/
+          ln -s ${lib_path}/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/lib/
+          ln -s ${share_path}/* /opt/homebrew/share/
+          ln -s ${share_path}/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/share/
+          EOF
+          chmod +x ~/tmp/pg_search_postinstall_script/postinstall.sh
+
           # Create the .pkg installer
           pkgbuild --root ${package_dir} \
                   --identifier com.paradedb.pg_search \
                   --version ${tag_version} \
-                  --install-location /opt/homebrew/opt/postgresql@${pg_version} \
-                  pg_search-pg${{ matrix.pg_version }}--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
+                  --install-location /opt/homebrew/opt/paradedb \
+                  --scripts ~/tmp/pg_search_postinstall_script/ \
+                  pg_search@${{ matrix.pg_version }}--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ./pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          subject-path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -189,6 +206,6 @@ jobs:
         with:
           github_token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
-          asset_path: ./pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
-          asset_name: pg_search-pg${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          asset_path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          asset_name: pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
           overwrite: true

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -9,8 +9,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - phil/fix-macos
   workflow_dispatch:
     inputs:
       version:
@@ -37,18 +35,18 @@ jobs:
           # macOS 14 and 15 are arm-only (M1)
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # macOS 14 (Sonoma)
-          # - name: macOS 14 (Sonoma)
-          #   runner: macos-14
-          #   pg_version: 14
-          # - name: macOS 14 (Sonoma)
-          #   runner: macos-14
-          #   pg_version: 15
-          # - name: macOS 14 (Sonoma)
-          #   runner: macos-14
-          #   pg_version: 16
-          # - name: macOS 14 (Sonoma)
-          #   runner: macos-14
-          #   pg_version: 17
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
+            pg_version: 14
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
+            pg_version: 15
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
+            pg_version: 16
+          - name: macOS 14 (Sonoma)
+            runner: macos-14
+            pg_version: 17
           # macOS 15 (Sequoia)
           - name: macOS 15 (Sequoia)
             runner: macos-15

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -166,15 +166,15 @@ jobs:
           cat <<EOF > $postinstall_file
           #!/bin/bash
           # Top-level Homebrew, used by the default Homebrew PostgreSQL formula
-          mkdir -p /opt/homebrew/lib/postgresql@15/
-          mkdir -p /opt/homebrew/share/postgresql@15/extension/
-          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/lib/postgresql@15/
-          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@15/extension/* /opt/homebrew/share/postgresql@15/extension/
+          mkdir -p /opt/homebrew/lib/postgresql@${{ matrix.pg_version }}/
+          mkdir -p /opt/homebrew/share/postgresql@${{ matrix.pg_version }}/extension/
+          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/lib/postgresql@${{ matrix.pg_version }}/
+          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@${{ matrix.pg_version }}/extension/* /opt/homebrew/share/postgresql@${{ matrix.pg_version }}/extension/
           # Opt-level Homebrew, used by the other Homebrew PostgreSQL formulas
-          mkdir -p /opt/homebrew/opt/postgresql@15/lib/postgresql/
-          mkdir -p /opt/homebrew/opt/postgresql@15/share/postgresql@15/extension/
-          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/opt/postgresql@15/lib/postgresql/
-          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@15/extension/* /opt/homebrew/opt/postgresql@15/share/postgresql@15/extension/
+          mkdir -p /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/lib/postgresql/
+          mkdir -p /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/share/postgresql@${{ matrix.pg_version }}/extension/
+          ln -sf /opt/homebrew/opt/paradedb/lib/postgresql/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/lib/postgresql/
+          ln -sf /opt/homebrew/opt/paradedb/share/postgresql@${{ matrix.pg_version }}/extension/* /opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/share/postgresql@${{ matrix.pg_version }}/extension/
           EOF
           chmod +x ~/tmp/pg_search_postinstall_script/postinstall
 

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - phil/fix-macos
   workflow_dispatch:
     inputs:
       version:
@@ -35,18 +37,18 @@ jobs:
           # macOS 14 and 15 are arm-only (M1)
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           # macOS 14 (Sonoma)
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 14
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 15
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 16
-          - name: macOS 14 (Sonoma)
-            runner: macos-14
-            pg_version: 17
+          # - name: macOS 14 (Sonoma)
+          #   runner: macos-14
+          #   pg_version: 14
+          # - name: macOS 14 (Sonoma)
+          #   runner: macos-14
+          #   pg_version: 15
+          # - name: macOS 14 (Sonoma)
+          #   runner: macos-14
+          #   pg_version: 16
+          # - name: macOS 14 (Sonoma)
+          #   runner: macos-14
+          #   pg_version: 17
           # macOS 15 (Sequoia)
           - name: macOS 15 (Sequoia)
             runner: macos-15


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We had a report of missing symlinks in our macOS binary installation. This PR fixes it! Instead of installing our extension within a symlink directory, we install it in a standalone directly, `opt/paradedb`, similar to what `pgvector` does, and add symlinks to both Postgres directories.

References:
- https://www.unix.com/man-page/osx/1/pkgbuild/

```
--scripts scripts-path
		 Archive the entire contents of scripts-path as the package scripts. If this directory contains scripts named preinstall and/or
		 postinstall, these will be run as the top-level scripts of the package. If you want to run scripts for specific bundles, you must
		 specify those in a component property list; see more at COMPONENT PROPERTY LIST.  Any other files under scripts-path will be used
		 only if the top-level or component-specific scripts invoke them.
```

I also fixed the naming scheme to follow the official Homebrew naming scheme.

## Why
User does not need to manually move the files.

## How
^

## Tests
- [x] Do a final manual test