### PR TITLE
feat:  deferred WAL

### DIFF
--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -18,7 +18,8 @@
 use pgrx::datum::RangeBound;
 use pgrx::{iter::TableIterator, *};
 
-use crate::index::open_mvcc_reader;
+use crate::index::reader::index::SearchIndexReader;
+use crate::index::BlockDirectoryType;
 use crate::postgres::types::TantivyValue;
 use crate::query::{SearchQueryInput, TermInput};
 use crate::schema::AnyEnum;
@@ -59,8 +60,8 @@ pub fn schema(
     // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
     let index = unsafe { PgRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _) };
 
-    let search_reader =
-        open_mvcc_reader(&index).expect("should be able to open a SearchIndexReader");
+    let search_reader = SearchIndexReader::open(&index, BlockDirectoryType::Mvcc, false)
+        .expect("could not open search index reader");
     let schema = search_reader.schema().schema.clone();
     let mut field_entries: Vec<_> = schema.fields().collect();
 

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -19,7 +19,8 @@ mod searchqueryinput;
 mod text;
 
 use crate::api::index::{fieldname_typoid, FieldName};
-use crate::index::open_mvcc_reader;
+use crate::index::reader::index::SearchIndexReader;
+use crate::index::BlockDirectoryType;
 use crate::nodecast;
 use crate::postgres::utils::locate_bm25_index;
 use crate::query::SearchQueryInput;
@@ -137,8 +138,8 @@ pub(crate) fn estimate_selectivity(
         return None;
     }
 
-    let search_reader =
-        open_mvcc_reader(indexrel).expect("should be able to open a SearchIndexReader");
+    let search_reader = SearchIndexReader::open(indexrel, BlockDirectoryType::Mvcc, false)
+        .expect("estimate_selectivity: should be able to open a SearchIndexReader");
     let estimate = search_reader.estimate_docs(search_query_input).unwrap_or(1) as f64;
     let mut selectivity = estimate / reltuples;
     if selectivity > 1.0 {

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -21,7 +21,8 @@ use super::{
 use crate::api::operator::{estimate_selectivity, find_var_relation, ReturnedNodePointer};
 use crate::gucs::per_tuple_cost;
 use crate::index::fast_fields_helper::FFHelper;
-use crate::index::open_mvcc_reader;
+use crate::index::reader::index::SearchIndexReader;
+use crate::index::BlockDirectoryType;
 use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::locate_bm25_index;
 use crate::query::SearchQueryInput;
@@ -49,11 +50,12 @@ pub fn search_with_query_input(
                 _ => panic!("the SearchQueryInput must be wrapped in a WithIndex variant"),
             }
         };
-        let indexrel = unsafe {
-            &PgRelation::with_lock(index_oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE)
+        let index_relation = unsafe {
+            PgRelation::with_lock(index_oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE)
         };
         let search_reader =
-            open_mvcc_reader(indexrel).expect("should be able to open a SearchIndexReader");
+            SearchIndexReader::open(&index_relation, BlockDirectoryType::Mvcc, false)
+                .expect("search_with_query_input: should be able to open a SearchIndexReader");
 
         let key_field = search_reader.key_field();
         let key_field_name = key_field.name.0;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -17,7 +17,8 @@
 
 use std::collections::HashMap;
 
-use crate::index::open_mvcc_reader;
+use crate::index::reader::index::SearchIndexReader;
+use crate::index::BlockDirectoryType;
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::schema::IndexRecordOption;
 use crate::schema::SearchFieldConfig;
@@ -299,8 +300,7 @@ fn index_info(
     let index = unsafe { PgRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _) };
 
     // open the specified index
-    let search_reader =
-        open_mvcc_reader(&index).expect("should be able to open a SearchIndexReader");
+    let search_reader = SearchIndexReader::open(&index, BlockDirectoryType::Mvcc, false)?;
     let data = search_reader
         .segment_readers()
         .iter()
@@ -340,8 +340,7 @@ fn validate_checksum(index: PgRelation) -> Result<SetOfIterator<'static, String>
     let index = unsafe { PgRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _) };
 
     // open the specified index
-    let search_reader =
-        open_mvcc_reader(&index).expect("should be able to open a SearchIndexReader");
+    let search_reader = SearchIndexReader::open(&index, BlockDirectoryType::Mvcc, false)?;
 
     let failed = search_reader.validate_checksum()?;
     Ok(SetOfIterator::new(

--- a/pg_search/src/index/directory/bulk_delete.rs
+++ b/pg_search/src/index/directory/bulk_delete.rs
@@ -19,10 +19,10 @@ use super::utils::{
     delete_unused_delete_metas, delete_unused_directory_entries, delete_unused_metas,
     get_deleted_ids, list_managed_files, load_metas, save_delete_metas, DirectoryLookup,
 };
-use crate::index::channel::NeedWal;
 use crate::index::reader::segment_component::SegmentComponentReader;
 use crate::index::writer::segment_component::SegmentComponentWriter;
 use crate::postgres::storage::block::bm25_max_free_space;
+use crate::postgres::NeedWal;
 use anyhow::Result;
 use parking_lot::Mutex;
 use pgrx::pg_sys;

--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -24,7 +24,6 @@ use crate::index::writer::channel::ChannelWriter;
 use crate::index::writer::segment_component::SegmentComponentWriter;
 use crate::postgres::storage::block::{bm25_max_free_space, DirectoryEntry};
 
-pub type NeedWal = bool;
 pub type Overwrite = bool;
 
 pub enum ChannelRequest {

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -20,10 +20,10 @@ use super::utils::{
     get_deleted_ids, list_managed_files, load_metas, save_delete_metas, save_new_metas,
     save_schema, save_settings, DirectoryLookup,
 };
-use crate::index::channel::NeedWal;
 use crate::index::reader::segment_component::SegmentComponentReader;
 use crate::index::writer::segment_component::SegmentComponentWriter;
 use crate::postgres::storage::block::bm25_max_free_space;
+use crate::postgres::NeedWal;
 use anyhow::Result;
 use parking_lot::Mutex;
 use pgrx::pg_sys;

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -1,3 +1,10 @@
+use crate::index::channel::NeedWal;
+use crate::postgres::storage::block::{
+    DeleteMetaEntry, DirectoryEntry, LinkedList, MVCCEntry, PgItem, SegmentMetaEntry,
+    DELETE_METAS_START, DIRECTORY_START, SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
+};
+use crate::postgres::storage::utils::{BM25Buffer, BM25BufferCache};
+use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use anyhow::{anyhow, bail, Result};
 use pgrx::pg_sys;
 #[cfg(any(test, feature = "pg_test"))]
@@ -11,13 +18,6 @@ use tantivy::{
     schema::Schema,
     Directory, IndexMeta, Opstamp,
 };
-
-use crate::postgres::storage::block::{
-    DeleteMetaEntry, DirectoryEntry, LinkedList, MVCCEntry, PgItem, SegmentMetaEntry,
-    DELETE_METAS_START, DIRECTORY_START, SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
-};
-use crate::postgres::storage::utils::{BM25Buffer, BM25BufferCache};
-use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 
 // Converts a SegmentID + SegmentComponent into a PathBuf
 pub struct SegmentComponentPath(pub PathBuf);
@@ -45,13 +45,18 @@ pub trait DirectoryLookup {
     // Required methods
     fn relation_oid(&self) -> pg_sys::Oid;
 
+    fn need_wal(&self) -> NeedWal;
+
     // Provided methods
     unsafe fn directory_lookup(
         &self,
         path: &Path,
     ) -> Result<(DirectoryEntry, pg_sys::BlockNumber, pg_sys::OffsetNumber)> {
-        let directory =
-            LinkedItemList::<DirectoryEntry>::open(self.relation_oid(), DIRECTORY_START);
+        let directory = LinkedItemList::<DirectoryEntry>::open(
+            self.relation_oid(),
+            DIRECTORY_START,
+            self.need_wal(),
+        );
         let result = directory.lookup(path, |opaque, path| opaque.path == *path)?;
         Ok(result)
     }
@@ -72,7 +77,8 @@ where
 
 pub unsafe fn list_managed_files(relation_oid: pg_sys::Oid) -> tantivy::Result<HashSet<PathBuf>> {
     let cache = BM25BufferCache::open(relation_oid);
-    let segment_components = LinkedItemList::<DirectoryEntry>::open(relation_oid, DIRECTORY_START);
+    let segment_components =
+        LinkedItemList::<DirectoryEntry>::open(relation_oid, DIRECTORY_START, false);
     let mut blockno = segment_components.get_start_blockno();
     let mut files = HashSet::new();
 
@@ -99,8 +105,12 @@ pub unsafe fn list_managed_files(relation_oid: pg_sys::Oid) -> tantivy::Result<H
     Ok(files)
 }
 
-pub fn save_schema(relation_oid: pg_sys::Oid, tantivy_schema: &Schema) -> Result<()> {
-    let mut schema = LinkedBytesList::open(relation_oid, SCHEMA_START);
+pub fn save_schema(
+    relation_oid: pg_sys::Oid,
+    tantivy_schema: &Schema,
+    need_wal: NeedWal,
+) -> Result<()> {
+    let mut schema = LinkedBytesList::open(relation_oid, SCHEMA_START, need_wal);
     if schema.is_empty() {
         let bytes = serde_json::to_vec(tantivy_schema)?;
         unsafe { schema.write(&bytes)? };
@@ -108,8 +118,12 @@ pub fn save_schema(relation_oid: pg_sys::Oid, tantivy_schema: &Schema) -> Result
     Ok(())
 }
 
-pub fn save_settings(relation_oid: pg_sys::Oid, tantivy_settings: &IndexSettings) -> Result<()> {
-    let mut settings = LinkedBytesList::open(relation_oid, SETTINGS_START);
+pub fn save_settings(
+    relation_oid: pg_sys::Oid,
+    tantivy_settings: &IndexSettings,
+    need_wal: NeedWal,
+) -> Result<()> {
+    let mut settings = LinkedBytesList::open(relation_oid, SETTINGS_START, need_wal);
     if settings.is_empty() {
         let bytes = serde_json::to_vec(tantivy_settings)?;
         unsafe { settings.write(&bytes)? };
@@ -139,9 +153,10 @@ pub unsafe fn save_delete_metas(
     relation_oid: pg_sys::Oid,
     meta: &IndexMeta,
     opstamp: Opstamp,
+    need_wal: NeedWal,
 ) -> Result<()> {
     let mut delete_metas =
-        LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START);
+        LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START, need_wal);
 
     let new_entries = meta
         .segments
@@ -168,46 +183,37 @@ pub unsafe fn delete_unused_metas(
     relation_oid: pg_sys::Oid,
     deleted_ids: &HashSet<SegmentId>,
     xmax: pg_sys::TransactionId,
+    need_wal: NeedWal,
 ) {
-    let cache = BM25BufferCache::open(relation_oid);
-    let segment_metas = LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
-
+    let mut segment_metas =
+        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START, need_wal);
+    let mut blockno = segment_metas.get_start_blockno();
+    let bman = segment_metas.buffer_manager();
     unsafe {
-        let mut blockno = segment_metas.get_start_blockno();
         while blockno != pg_sys::InvalidBlockNumber {
-            let state = cache.start_xlog();
-            let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-            let page = pg_sys::GenericXLogRegisterBuffer(state, buffer, 0);
-            let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+            let mut buffer = bman.get_buffer_mut(blockno);
+            let mut page = buffer.page_mut();
+            let max_offset = page.max_offset_number();
             let mut offsetno = pg_sys::FirstOffsetNumber;
-            let mut needs_wal = false;
 
             while offsetno <= max_offset {
-                let item_id = pg_sys::PageGetItemId(page, offsetno);
-                let entry = SegmentMetaEntry::from(PgItem(
-                    pg_sys::PageGetItem(page, item_id),
-                    (*item_id).lp_len() as pg_sys::Size,
-                ));
+                let item_id = page.get_item_id(offsetno);
+                let item = page.get_item(item_id);
+                let entry = SegmentMetaEntry::from(PgItem(item, (*item_id).lp_len() as _));
+
                 if deleted_ids.contains(&entry.segment_id) && !entry.deleted() {
                     let entry_with_xmax = SegmentMetaEntry {
                         xmax,
                         ..entry.clone()
                     };
                     let PgItem(item, size) = entry_with_xmax.clone().into();
-                    let overwrite = pg_sys::PageIndexTupleOverwrite(page, offsetno, item, size);
-                    assert!(overwrite);
-                    needs_wal = true;
+                    let did_replace = page.replace_item(offsetno, item, size);
+                    assert!(did_replace);
                 }
                 offsetno += 1;
             }
 
             blockno = buffer.next_blockno();
-            if needs_wal {
-                pg_sys::GenericXLogFinish(state);
-            } else {
-                pg_sys::GenericXLogAbort(state);
-            }
-            pg_sys::UnlockReleaseBuffer(buffer);
         }
     }
 }
@@ -218,6 +224,7 @@ pub unsafe fn save_new_metas(
     previous_meta: &IndexMeta,
     xmin: pg_sys::TransactionId,
     opstamp: Opstamp,
+    need_wal: NeedWal,
 ) -> Result<()> {
     let previous_ids = previous_meta
         .segments
@@ -225,7 +232,7 @@ pub unsafe fn save_new_metas(
         .map(|s| s.id())
         .collect::<HashSet<_>>();
     let mut segment_metas =
-        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
+        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START, need_wal);
 
     let new_entries = meta
         .segments
@@ -247,52 +254,44 @@ pub unsafe fn delete_unused_directory_entries(
     relation_oid: pg_sys::Oid,
     deleted_ids: &HashSet<SegmentId>,
     xmax: pg_sys::TransactionId,
+    need_wal: NeedWal,
 ) {
-    let cache = BM25BufferCache::open(relation_oid);
-    let directory = LinkedItemList::<DirectoryEntry>::open(relation_oid, DIRECTORY_START);
+    let mut directory =
+        LinkedItemList::<DirectoryEntry>::open(relation_oid, DIRECTORY_START, need_wal);
     let mut blockno = directory.get_start_blockno();
+    let bman = directory.buffer_manager();
 
     while blockno != pg_sys::InvalidBlockNumber {
-        let state = cache.start_xlog();
-        let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-        let page = pg_sys::GenericXLogRegisterBuffer(state, buffer, 0);
-        let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+        let mut buffer = bman.get_buffer_mut(blockno);
+        let mut page = buffer.page_mut();
+        let max_offset = page.max_offset_number();
         let mut offsetno = pg_sys::FirstOffsetNumber;
-        let mut needs_wal = false;
 
         while offsetno <= max_offset {
-            let item_id = pg_sys::PageGetItemId(page, offsetno);
-            let entry = DirectoryEntry::from(PgItem(
-                pg_sys::PageGetItem(page, item_id),
-                (*item_id).lp_len() as pg_sys::Size,
-            ));
+            let item_id = page.get_item_id(offsetno);
+            let item = page.get_item(item_id);
+            let entry = DirectoryEntry::from(PgItem(item, (*item_id).lp_len() as _));
             let SegmentComponentId(entry_segment_id) = SegmentComponentPath(entry.path.clone())
                 .try_into()
                 .unwrap_or_else(|_| panic!("{:?} should be valid", entry.path.clone()));
+
             if deleted_ids.contains(&entry_segment_id) && !entry.deleted() {
                 let entry_with_xmax = DirectoryEntry {
                     xmax,
                     ..entry.clone()
                 };
                 let PgItem(item, size) = entry_with_xmax.clone().into();
-                let overwrite = pg_sys::PageIndexTupleOverwrite(page, offsetno, item, size);
-                assert!(overwrite);
+                let did_replace = page.replace_item(offsetno, item, size);
+                assert!(did_replace);
 
                 // Delete the corresponding segment component
-                let segment_component = LinkedBytesList::open(relation_oid, entry.start);
+                let mut segment_component = LinkedBytesList::open(relation_oid, entry.start, true);
                 segment_component.mark_deleted();
-                needs_wal = true;
             }
             offsetno += 1;
         }
 
         blockno = buffer.next_blockno();
-        if needs_wal {
-            pg_sys::GenericXLogFinish(state);
-        } else {
-            pg_sys::GenericXLogAbort(state);
-        }
-        pg_sys::UnlockReleaseBuffer(buffer);
     }
 }
 
@@ -300,46 +299,37 @@ pub unsafe fn delete_unused_delete_metas(
     relation_oid: pg_sys::Oid,
     deleted_ids: &HashSet<SegmentId>,
     xmax: pg_sys::TransactionId,
+    need_wal: NeedWal,
 ) {
-    let cache = BM25BufferCache::open(relation_oid);
-    let delete_metas = LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START);
+    let mut delete_metas =
+        LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START, need_wal);
     let mut blockno = delete_metas.get_start_blockno();
+    let bman = delete_metas.buffer_manager();
 
     while blockno != pg_sys::InvalidBlockNumber {
-        let state = cache.start_xlog();
-        let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-        let page = pg_sys::GenericXLogRegisterBuffer(state, buffer, 0);
-        let max_offset = pg_sys::PageGetMaxOffsetNumber(page);
+        let mut buffer = bman.get_buffer_mut(blockno);
+        let mut page = buffer.page_mut();
+        let max_offset = page.max_offset_number();
         let mut offsetno = pg_sys::FirstOffsetNumber;
-        let mut needs_wal = false;
 
         while offsetno <= max_offset {
-            let item_id = pg_sys::PageGetItemId(page, offsetno);
-            let entry = DeleteMetaEntry::from(PgItem(
-                pg_sys::PageGetItem(page, item_id),
-                (*item_id).lp_len() as pg_sys::Size,
-            ));
+            let item_id = page.get_item_id(offsetno);
+            let item = page.get_item(item_id);
+            let entry = DeleteMetaEntry::from(PgItem(item, (*item_id).lp_len() as _));
+
             if deleted_ids.contains(&entry.segment_id) && !entry.deleted() {
                 let entry_with_xmax = DeleteMetaEntry {
                     xmax,
                     ..entry.clone()
                 };
                 let PgItem(item, size) = entry_with_xmax.clone().into();
-                let overwrite = pg_sys::PageIndexTupleOverwrite(page, offsetno, item, size);
-                assert!(overwrite);
-
-                needs_wal = true;
+                let did_replace = page.replace_item(offsetno, item, size);
+                assert!(did_replace);
             }
             offsetno += 1;
         }
 
         blockno = buffer.next_blockno();
-        if needs_wal {
-            pg_sys::GenericXLogFinish(state);
-        } else {
-            pg_sys::GenericXLogAbort(state);
-        }
-        pg_sys::UnlockReleaseBuffer(buffer);
     }
 }
 
@@ -350,7 +340,8 @@ pub unsafe fn load_metas(
     solve_mvcc: bool,
 ) -> tantivy::Result<IndexMeta> {
     let cache = BM25BufferCache::open(relation_oid);
-    let delete_metas = LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START);
+    let delete_metas =
+        LinkedItemList::<DeleteMetaEntry>::open(relation_oid, DELETE_METAS_START, false);
 
     let mut delete_meta_entries = HashMap::new();
     let mut delete_meta_opstamps = HashMap::new();
@@ -398,7 +389,8 @@ pub unsafe fn load_metas(
         pg_sys::UnlockReleaseBuffer(buffer);
     }
 
-    let segment_metas = LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
+    let segment_metas =
+        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START, false);
 
     let heap_oid = unsafe { pg_sys::IndexGetRelation(relation_oid, false) };
     let heap_relation = unsafe { pg_sys::RelationIdGetRelation(heap_oid) };
@@ -448,8 +440,8 @@ pub unsafe fn load_metas(
 
     pg_sys::RelationClose(heap_relation);
 
-    let schema = LinkedBytesList::open(relation_oid, SCHEMA_START);
-    let settings = LinkedBytesList::open(relation_oid, SETTINGS_START);
+    let schema = LinkedBytesList::open(relation_oid, SCHEMA_START, false);
+    let settings = LinkedBytesList::open(relation_oid, SETTINGS_START, false);
     let deserialized_schema = serde_json::from_slice(&schema.read_all())?;
     let deserialized_settings = serde_json::from_slice(&settings.read_all())?;
 

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -1,9 +1,9 @@
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{
     DeleteMetaEntry, DirectoryEntry, LinkedList, MVCCEntry, PgItem, SegmentMetaEntry,
     DELETE_METAS_START, DIRECTORY_START, SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
 };
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
+use crate::postgres::NeedWal;
 use anyhow::{anyhow, bail, Result};
 use pgrx::pg_sys;
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -373,7 +373,6 @@ pub unsafe fn load_metas(
 
     let segment_metas =
         LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START, false);
-
     let heap_oid = unsafe { pg_sys::IndexGetRelation(relation_oid, false) };
     let heap_relation = unsafe { pg_sys::RelationIdGetRelation(heap_oid) };
     let mut alive_segments = vec![];

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -274,7 +274,8 @@ pub unsafe fn delete_unused_directory_entries(
                 assert!(did_replace);
 
                 // Delete the corresponding segment component
-                let mut segment_component = LinkedBytesList::open(relation_oid, entry.start, true);
+                let mut segment_component =
+                    LinkedBytesList::open(relation_oid, entry.start, need_wal);
                 segment_component.mark_deleted();
             }
             offsetno += 1;

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,9 +1,9 @@
+use crate::index::channel::NeedWal;
+use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
+use crate::postgres::storage::buffer::{BufferManager, BufferMut};
 use pgrx::pg_sys;
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::SegmentMeta;
-
-use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
-use crate::postgres::storage::utils::BM25BufferCache;
 
 /// A tantivy [`MergePolicy`] that endeavours to keep a maximum number of segments "N", plus
 /// one extra for leftovers.
@@ -48,50 +48,36 @@ impl MergePolicy for NPlusOneMergePolicy {
 }
 
 /// Only one merge can happen at a time, so we need to lock the merge process
-pub struct MergeLock {
-    relation_oid: pg_sys::Oid,
-    buffer: pg_sys::Buffer,
-}
+pub struct MergeLock(BufferMut);
 
 impl MergeLock {
     // This lock is acquired by inserts if merge_on_insert is true
     // Merges should only happen if there is no other merge in progress
     // AND the effects of the previous merge are visible
-    pub unsafe fn acquire_for_merge(relation_oid: pg_sys::Oid) -> Option<Self> {
-        let cache = BM25BufferCache::open(relation_oid);
-        let merge_lock = cache.get_buffer(MERGE_LOCK, None);
+    pub unsafe fn acquire_for_merge(relation_oid: pg_sys::Oid, need_wal: NeedWal) -> Option<Self> {
         let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+        let mut bman = BufferManager::new(relation_oid, need_wal);
 
-        if pg_sys::ConditionalLockBuffer(merge_lock) {
-            let page = pg_sys::BufferGetPage(merge_lock);
-            let metadata = pg_sys::PageGetContents(page) as *mut MergeLockData;
-            let last_merge = (*metadata).last_merge;
-            if pg_sys::XidInMVCCSnapshot(last_merge, snapshot)
-                && last_merge != pg_sys::InvalidTransactionId
-            {
-                pg_sys::UnlockReleaseBuffer(merge_lock);
+        if let Some(mut merge_lock) = bman.get_buffer_mut_conditional(MERGE_LOCK) {
+            let mut page = merge_lock.page_mut();
+            let metadata = page.contents_mut::<MergeLockData>();
+            let last_merge = metadata.last_merge;
+            if pg_sys::XidInMVCCSnapshot(last_merge, snapshot) {
                 None
             } else {
-                Some(MergeLock {
-                    relation_oid,
-                    buffer: merge_lock,
-                })
+                Some(MergeLock(merge_lock))
             }
         } else {
-            pg_sys::ReleaseBuffer(merge_lock);
             None
         }
     }
 
     // This lock must be acquired before ambulkdelete calls commit() on the index
     // We ask for an exclusive lock because ambulkdelete must delete all dead ctids
-    pub unsafe fn acquire_for_delete(relation_oid: pg_sys::Oid) -> Self {
-        let cache = BM25BufferCache::open(relation_oid);
-        let buffer = cache.get_buffer(MERGE_LOCK, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-        MergeLock {
-            relation_oid,
-            buffer,
-        }
+    pub unsafe fn acquire_for_delete(relation_oid: pg_sys::Oid, need_wal: NeedWal) -> Self {
+        let mut bman = BufferManager::new(relation_oid, need_wal);
+        let merge_lock = bman.get_buffer_mut(MERGE_LOCK);
+        MergeLock(merge_lock)
     }
 }
 
@@ -99,13 +85,9 @@ impl Drop for MergeLock {
     fn drop(&mut self) {
         unsafe {
             if pg_sys::IsTransactionState() {
-                let cache = BM25BufferCache::open(self.relation_oid);
-                let state = cache.start_xlog();
-                let page = pg_sys::GenericXLogRegisterBuffer(state, self.buffer, 0);
-                let metadata = pg_sys::PageGetContents(page) as *mut MergeLockData;
-                (*metadata).last_merge = pg_sys::GetCurrentTransactionId();
-                pg_sys::GenericXLogFinish(state);
-                pg_sys::UnlockReleaseBuffer(self.buffer);
+                let mut page = self.0.page_mut();
+                let metadata = page.contents_mut::<MergeLockData>();
+                metadata.last_merge = pg_sys::GetCurrentTransactionId();
             }
         }
     }

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -74,13 +74,14 @@ impl MergeLock {
     // Merges should only happen if there is no other merge in progress
     // AND the effects of the previous merge are visible
     pub unsafe fn acquire_for_merge(relation_oid: pg_sys::Oid, need_wal: NeedWal) -> Option<Self> {
-        let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
         let mut bman = BufferManager::new(relation_oid, need_wal);
 
         if let Some(mut merge_lock) = bman.get_buffer_conditional(MERGE_LOCK) {
             let mut page = merge_lock.page_mut();
             let metadata = page.contents_mut::<MergeLockData>();
             let last_merge = metadata.last_merge;
+            let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+
             if pg_sys::XidInMVCCSnapshot(last_merge, snapshot) {
                 None
             } else {

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,6 +1,6 @@
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
 use crate::postgres::storage::buffer::{BufferManager, BufferMut};
+use crate::postgres::NeedWal;
 use pgrx::pg_sys;
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::merge_policy::NoMergePolicy;

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -24,24 +24,6 @@ impl From<AllowedMergePolicy> for Box<dyn MergePolicy> {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum AllowedMergePolicy {
-    None,
-    NPlusOne(usize),
-}
-
-impl From<AllowedMergePolicy> for Box<dyn MergePolicy> {
-    fn from(policy: AllowedMergePolicy) -> Self {
-        match policy {
-            AllowedMergePolicy::None => Box::new(NoMergePolicy),
-            AllowedMergePolicy::NPlusOne(n) => Box::new(NPlusOneMergePolicy {
-                n,
-                min_num_segments: 2,
-            }),
-        }
-    }
-}
-
 /// A tantivy [`MergePolicy`] that endeavours to keep a maximum number of segments "N", plus
 /// one extra for leftovers.
 ///

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -232,7 +232,7 @@ impl SearchIndexReader {
         directory_type: BlockDirectoryType,
         needs_cleanup_lock: bool,
     ) -> Result<Self> {
-        let schema = get_index_schema(&index_relation)?;
+        let schema = get_index_schema(index_relation)?;
 
         // It is possible for index only scans and custom scans, which only check the visibility map
         // and do not fetch tuples from the heap, to suffer from the concurrent TID recycling problem.

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -221,7 +221,8 @@ pub struct SearchIndexReader {
     underlying_index: Index,
 
     // [`Buffer`] has a Drop impl, so we hold onto the lock, but don't otherwise use it
-    // and it's an Arc b/c if we're clone'd (we do derive it, afterall), we only want this
+    //
+    // also, it's an Arc b/c if we're clone'd (we do derive it, after all), we only want this
     // buffer dropped once
     _cleanup_lock: Arc<Option<Buffer>>,
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -364,7 +364,6 @@ impl SearchIndexReader {
         query: &SearchQueryInput,
         _estimated_rows: Option<usize>,
     ) -> SearchResults {
-        // let need_scores = true;
         let collector = vec_collector::VecCollector::new(need_scores);
         let results = self.collect(query, collector, need_scores);
         SearchResults::AllSegments(results.into_iter().flatten())

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -1,3 +1,4 @@
+use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{bm25_max_free_space, DirectoryEntry, LinkedList};
 use crate::postgres::storage::linked_bytes::RangeData;
 use crate::postgres::storage::LinkedBytesList;
@@ -22,8 +23,8 @@ pub struct SegmentComponentReader {
 }
 
 impl SegmentComponentReader {
-    pub unsafe fn new(relation_oid: pg_sys::Oid, entry: DirectoryEntry) -> Self {
-        let block_list = LinkedBytesList::open(relation_oid, entry.start);
+    pub unsafe fn new(relation_oid: pg_sys::Oid, entry: DirectoryEntry, need_wal: NeedWal) -> Self {
+        let block_list = LinkedBytesList::open(relation_oid, entry.start, need_wal);
 
         Self {
             block_list,

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -137,17 +137,17 @@ mod tests {
         let segment = format!("{}.term", uuid::Uuid::new_v4());
         let path = Path::new(segment.as_str());
 
-        let mut writer = unsafe { SegmentComponentWriter::new(relation_oid, path) };
+        let mut writer = unsafe { SegmentComponentWriter::new(relation_oid, path, false) };
         writer.write_all(&bytes).unwrap();
         writer.terminate().unwrap();
 
-        let directory = MVCCDirectory::new(relation_oid);
+        let directory = MVCCDirectory::new(relation_oid, false);
         let (entry, _, _) = unsafe {
             directory
                 .directory_lookup(path)
                 .expect("open directory entry should succeed")
         };
-        let reader = SegmentComponentReader::new(relation_oid, entry.clone());
+        let reader = SegmentComponentReader::new(relation_oid, entry.clone(), false);
 
         assert_eq!(reader.len(), 100_000);
         assert_eq!(

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -1,7 +1,7 @@
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{bm25_max_free_space, DirectoryEntry, LinkedList};
 use crate::postgres::storage::linked_bytes::RangeData;
 use crate::postgres::storage::LinkedBytesList;
+use crate::postgres::NeedWal;
 use anyhow::Result;
 use parking_lot::Mutex;
 use pgrx::*;

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -15,21 +15,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::reader::index::SearchIndexReader;
-use super::writer::index::IndexError;
 use crate::gucs;
-use crate::index::bulk_delete::BulkDeleteDirectory;
-use crate::index::channel::{ChannelDirectory, ChannelRequestHandler, NeedWal};
-use crate::index::mvcc::MVCCDirectory;
-use crate::index::writer::index::SearchIndexWriter;
+use crate::index::channel::NeedWal;
+use crate::index::merge_policy::AllowedMergePolicy;
 use crate::postgres::index::get_fields;
 use crate::postgres::options::SearchIndexCreateOptions;
-use crate::schema::{SearchFieldConfig, SearchIndexSchema, SearchIndexSchemaError};
+use crate::schema::{SearchFieldConfig, SearchIndexSchema};
 use anyhow::Result;
 use pgrx::PgRelation;
 use std::num::NonZeroUsize;
-use tantivy::{Index, IndexSettings, ReloadPolicy};
-use thiserror::Error;
+use tantivy::Index;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager};
 use tracing::trace;
 
@@ -40,231 +35,60 @@ pub enum WriterResources {
 }
 pub type Parallelism = NonZeroUsize;
 pub type MemoryBudget = usize;
-pub type TargetSegmentCount = usize;
 pub type DoMerging = bool;
+pub type IndexConfig = (
+    Parallelism,
+    MemoryBudget,
+    DoMerging,
+    AllowedMergePolicy,
+    NeedWal,
+);
 
-enum BlockDirectoryType {
+pub enum BlockDirectoryType {
     Mvcc,
     BulkDelete,
 }
 
 impl WriterResources {
-    pub fn resources(
-        &self,
-        index_options: &SearchIndexCreateOptions,
-    ) -> (
-        Parallelism,
-        MemoryBudget,
-        TargetSegmentCount,
-        DoMerging,
-        NeedWal,
-    ) {
+    pub fn resources(&self, index_options: &SearchIndexCreateOptions) -> IndexConfig {
+        let target_segment_count = index_options.target_segment_count();
+        let merge_on_insert = index_options.merge_on_insert();
+
         match self {
-            WriterResources::CreateIndex => (
-                gucs::create_index_parallelism(),
-                gucs::create_index_memory_budget(),
-                index_options.target_segment_count(),
-                true,  // we always want a merge on CREATE INDEX
-                false, // we don't need direct WAL support during CREATE INDEX
-            ),
-            WriterResources::Statement => (
-                gucs::statement_parallelism(),
-                gucs::statement_memory_budget(),
-                index_options.target_segment_count(),
-                index_options.merge_on_insert(), // user/index decides if we merge for INSERT/UPDATE statements
-                true,                            // regular statements do need WAL support
-            ),
-            WriterResources::Vacuum => (
-                gucs::statement_parallelism(),
-                gucs::statement_memory_budget(),
-                index_options.target_segment_count(),
-                true, // we always want a merge on (auto)VACUUM
-                true, // VACUUM always needs WAL support
-            ),
+            WriterResources::CreateIndex => {
+                (
+                    gucs::create_index_parallelism(),
+                    gucs::create_index_memory_budget(),
+                    true, // we always want a merge on CREATE INDEX
+                    AllowedMergePolicy::NPlusOne(target_segment_count),
+                    false, // we don't need direct WAL support during CREATE INDEX
+                )
+            }
+            WriterResources::Statement => {
+                let policy = if merge_on_insert {
+                    AllowedMergePolicy::NPlusOne(target_segment_count)
+                } else {
+                    AllowedMergePolicy::None
+                };
+                (
+                    gucs::statement_parallelism(),
+                    gucs::statement_memory_budget(),
+                    merge_on_insert, // user/index decides if we merge for INSERT/UPDATE statements
+                    policy,
+                    true, // regular statements do need WAL support
+                )
+            }
+            WriterResources::Vacuum => {
+                (
+                    gucs::statement_parallelism(),
+                    gucs::statement_memory_budget(),
+                    true, // we always want a merge on (auto)VACUUM
+                    AllowedMergePolicy::NPlusOne(target_segment_count),
+                    true, // VACUUM always needs WAL support
+                )
+            }
         }
     }
-}
-
-/// How many messages should we buffer between the channels?
-const CHANNEL_QUEUE_LEN: usize = 1000;
-
-struct SearchIndex {
-    schema: SearchIndexSchema,
-    underlying_index: Index,
-    handler: ChannelRequestHandler,
-}
-
-impl SearchIndex {
-    fn create_index(
-        index_relation: &PgRelation,
-        resources: WriterResources,
-    ) -> Result<SearchIndexWriter> {
-        let schema = get_index_schema(index_relation)?;
-        let create_options = index_relation.rd_options as *mut SearchIndexCreateOptions;
-
-        let settings = IndexSettings {
-            docstore_compress_dedicated_thread: false,
-            ..IndexSettings::default()
-        };
-        let search_index = Self::prepare_index(
-            index_relation,
-            schema,
-            BlockDirectoryType::Mvcc,
-            false,
-            |directory, schema| Index::create(directory, schema.schema.clone(), settings),
-        )?;
-
-        SearchIndexWriter::new(
-            index_relation.oid(),
-            search_index.underlying_index,
-            search_index.schema,
-            search_index.handler,
-            resources,
-            unsafe { &*create_options },
-        )
-    }
-
-    fn open_writer(
-        index_relation: &PgRelation,
-        resources: WriterResources,
-        directory_type: BlockDirectoryType,
-    ) -> Result<SearchIndexWriter> {
-        let schema = get_index_schema(index_relation)?;
-        let create_options = index_relation.rd_options as *mut SearchIndexCreateOptions;
-        let search_index = Self::prepare_index(
-            index_relation,
-            schema,
-            directory_type,
-            true,
-            |directory, _| Index::open(directory),
-        )?;
-
-        SearchIndexWriter::new(
-            index_relation.oid(),
-            search_index.underlying_index,
-            search_index.schema,
-            search_index.handler,
-            resources,
-            unsafe { &*create_options },
-        )
-    }
-
-    fn prepare_index<
-        F: FnOnce(ChannelDirectory, &SearchIndexSchema) -> tantivy::Result<Index>
-            + Send
-            + Sync
-            + 'static,
-    >(
-        index_relation: &PgRelation,
-        schema: SearchIndexSchema,
-        directory_type: BlockDirectoryType,
-        need_wal: NeedWal,
-        opener: F,
-    ) -> Result<Self, SearchIndexError> {
-        let index_oid = index_relation.oid();
-
-        let (req_sender, req_receiver) = crossbeam::channel::bounded(CHANNEL_QUEUE_LEN);
-        let channel_dir = ChannelDirectory::new(req_sender);
-        let mut handler = match directory_type {
-            BlockDirectoryType::Mvcc => ChannelRequestHandler::open(
-                &MVCCDirectory::new(index_oid, need_wal),
-                index_oid,
-                req_receiver,
-            ),
-            BlockDirectoryType::BulkDelete => ChannelRequestHandler::open(
-                &BulkDeleteDirectory::new(index_oid),
-                index_oid,
-                req_receiver,
-            ),
-        };
-
-        let underlying_index = {
-            let schema = schema.clone();
-            handler
-                .wait_for(move || {
-                    let mut index = opener(channel_dir, &schema)?;
-                    SearchIndex::setup_tokenizers(&mut index, &schema);
-                    tantivy::Result::Ok(index)
-                })
-                .expect("scoped thread should not fail")?
-        };
-
-        Ok(SearchIndex {
-            schema,
-            underlying_index,
-            handler,
-        })
-    }
-
-    fn open_reader(
-        index_relation: &PgRelation,
-        directory_type: BlockDirectoryType,
-    ) -> Result<SearchIndexReader> {
-        let mut index = match directory_type {
-            BlockDirectoryType::Mvcc => {
-                Index::open(MVCCDirectory::new(index_relation.oid(), false))?
-            }
-            BlockDirectoryType::BulkDelete => {
-                Index::open(BulkDeleteDirectory::new(index_relation.oid()))?
-            }
-        };
-        let schema = get_index_schema(index_relation)?;
-        SearchIndex::setup_tokenizers(&mut index, &schema);
-        let reader = index
-            .reader_builder()
-            .reload_policy(ReloadPolicy::Manual)
-            .try_into()?;
-        let searcher = reader.searcher();
-        Ok(SearchIndexReader::new(
-            index_relation,
-            index,
-            searcher,
-            reader,
-            schema,
-        ))
-    }
-
-    fn setup_tokenizers(underlying_index: &mut Index, schema: &SearchIndexSchema) {
-        let tokenizers = schema
-            .fields
-            .iter()
-            .filter_map(|field| {
-                let field_config = &field.config;
-                let field_name: &str = field.name.as_ref();
-                trace!(field_name, "attempting to create tokenizer");
-                match field_config {
-                    SearchFieldConfig::Text { tokenizer, .. }
-                    | SearchFieldConfig::Json { tokenizer, .. } => Some(tokenizer),
-                    _ => None,
-                }
-            })
-            .collect();
-
-        underlying_index.set_tokenizers(create_tokenizer_manager(tokenizers));
-        underlying_index.set_fast_field_tokenizers(create_normalizer_manager());
-    }
-}
-
-#[derive(Error, Debug)]
-#[allow(clippy::enum_variant_names)]
-pub enum SearchIndexError {
-    #[error(transparent)]
-    SchemaError(#[from] SearchIndexSchemaError),
-
-    #[error(transparent)]
-    WriterIndexError(#[from] IndexError),
-
-    #[error(transparent)]
-    TantivyError(#[from] tantivy::error::TantivyError),
-
-    #[error(transparent)]
-    IOError(#[from] std::io::Error),
-
-    #[error(transparent)]
-    SerdeError(#[from] serde_json::Error),
-
-    #[error(transparent)]
-    AnyhowError(#[from] anyhow::Error),
 }
 
 pub fn get_index_schema(index_relation: &PgRelation) -> Result<SearchIndexSchema> {
@@ -276,34 +100,22 @@ pub fn get_index_schema(index_relation: &PgRelation) -> Result<SearchIndexSchema
     Ok(schema)
 }
 
-/// Open a (non-channel-based) [`SearchIndexReader`] for the specified Postgres index relation
-pub fn open_mvcc_reader(index_relation: &PgRelation) -> Result<SearchIndexReader> {
-    SearchIndex::open_reader(index_relation, BlockDirectoryType::Mvcc)
-}
+pub fn setup_tokenizers(underlying_index: &mut Index, schema: &SearchIndexSchema) {
+    let tokenizers = schema
+        .fields
+        .iter()
+        .filter_map(|field| {
+            let field_config = &field.config;
+            let field_name: &str = field.name.as_ref();
+            trace!(field_name, "attempting to create tokenizer");
+            match field_config {
+                SearchFieldConfig::Text { tokenizer, .. }
+                | SearchFieldConfig::Json { tokenizer, .. } => Some(tokenizer),
+                _ => None,
+            }
+        })
+        .collect();
 
-pub fn open_bulk_delete_reader(index_relation: &PgRelation) -> Result<SearchIndexReader> {
-    SearchIndex::open_reader(index_relation, BlockDirectoryType::BulkDelete)
-}
-
-/// Open an existing index for writing
-pub fn open_mvcc_writer(
-    index_relation: &PgRelation,
-    resources: WriterResources,
-) -> Result<SearchIndexWriter> {
-    SearchIndex::open_writer(index_relation, resources, BlockDirectoryType::Mvcc)
-}
-
-pub fn open_bulk_delete_writer(
-    index_relation: &PgRelation,
-    resources: WriterResources,
-) -> Result<SearchIndexWriter> {
-    SearchIndex::open_writer(index_relation, resources, BlockDirectoryType::BulkDelete)
-}
-
-/// Create a new, empty index for the specified Postgres index relation
-pub fn create_new_index(
-    index_relation: &PgRelation,
-    resources: WriterResources,
-) -> Result<SearchIndexWriter> {
-    SearchIndex::create_index(index_relation, resources)
+    underlying_index.set_tokenizers(create_tokenizer_manager(tokenizers));
+    underlying_index.set_fast_field_tokenizers(create_normalizer_manager());
 }

--- a/pg_search/src/index/writer/channel.rs
+++ b/pg_search/src/index/writer/channel.rs
@@ -1,9 +1,8 @@
+use crate::index::directory::channel::ChannelRequest;
 use crossbeam::channel::Sender;
 use std::io::{Result, Write};
 use std::path::{Path, PathBuf};
 use tantivy::directory::{AntiCallToken, TerminatingWrite};
-
-use crate::index::directory::channel::ChannelRequest;
 
 #[derive(Clone, Debug)]
 pub struct ChannelWriter {
@@ -27,7 +26,7 @@ impl Write for ChannelWriter {
                 self.path.clone(),
                 data.to_vec(),
             ))
-            .unwrap();
+            .unwrap_or_else(|e| panic!("got send error: {e}"));
         Ok(data.len())
     }
 

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -93,9 +93,6 @@ impl SearchIndexWriter {
                 .expect("scoped thread should not fail")?
         };
 
-        let create_options = index_relation.rd_options as *mut SearchIndexCreateOptions;
-        let (parallelism, memory_budget, wants_merge, merge_policy) =
-            resources.resources(unsafe { &*create_options });
         let writer = handler
             .wait_for(move || {
                 let writer = index.writer_with_num_threads(parallelism.get(), memory_budget)?;

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -1,26 +1,28 @@
+use crate::index::channel::NeedWal;
+use crate::postgres::storage::block::{DirectoryEntry, DIRECTORY_START};
+use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use pgrx::*;
 use std::io::{Result, Write};
 use std::path::{Path, PathBuf};
 use tantivy::directory::{AntiCallToken, TerminatingWrite};
 
-use crate::postgres::storage::block::{DirectoryEntry, DIRECTORY_START};
-use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
-
 #[derive(Clone, Debug)]
 pub struct SegmentComponentWriter {
     relation_oid: pg_sys::Oid,
     path: PathBuf,
+    need_wal: NeedWal,
     header_blockno: pg_sys::BlockNumber,
     total_bytes: usize,
 }
 
 impl SegmentComponentWriter {
-    pub unsafe fn new(relation_oid: pg_sys::Oid, path: &Path) -> Self {
-        let segment_component = LinkedBytesList::create(relation_oid);
+    pub unsafe fn new(relation_oid: pg_sys::Oid, path: &Path, need_wal: NeedWal) -> Self {
+        let segment_component = LinkedBytesList::create(relation_oid, need_wal);
 
         Self {
             relation_oid,
             path: path.to_path_buf(),
+            need_wal,
             header_blockno: segment_component.header_blockno,
             total_bytes: 0,
         }
@@ -29,7 +31,8 @@ impl SegmentComponentWriter {
 
 impl Write for SegmentComponentWriter {
     fn write(&mut self, data: &[u8]) -> Result<usize> {
-        let mut segment_component = LinkedBytesList::open(self.relation_oid, self.header_blockno);
+        let mut segment_component =
+            LinkedBytesList::open(self.relation_oid, self.header_blockno, self.need_wal);
         unsafe { segment_component.write(data).expect("write should succeed") };
         self.total_bytes += data.len();
         Ok(data.len())
@@ -43,8 +46,11 @@ impl Write for SegmentComponentWriter {
 impl TerminatingWrite for SegmentComponentWriter {
     fn terminate_ref(&mut self, _: AntiCallToken) -> Result<()> {
         unsafe {
-            let mut directory =
-                LinkedItemList::<DirectoryEntry>::open(self.relation_oid, DIRECTORY_START);
+            let mut directory = LinkedItemList::<DirectoryEntry>::open(
+                self.relation_oid,
+                DIRECTORY_START,
+                self.need_wal,
+            );
             let entry = DirectoryEntry {
                 path: self.path.clone(),
                 total_bytes: self.total_bytes,

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -1,6 +1,6 @@
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{DirectoryEntry, DIRECTORY_START};
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
+use crate::postgres::NeedWal;
 use pgrx::*;
 use std::io::{Result, Write};
 use std::path::{Path, PathBuf};

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -199,11 +199,11 @@ unsafe fn create_metadata(relation_oid: pg_sys::Oid, need_wal: NeedWal) {
     let mut bman = BufferManager::new(relation_oid, need_wal);
     let mut merge_lock = bman.new_buffer();
     assert_eq!(merge_lock.number(), MERGE_LOCK);
-
     let mut page = merge_lock.init_page();
     let metadata = page.contents_mut::<MergeLockData>();
     metadata.last_merge = pg_sys::InvalidTransactionId;
 
+    // initialize all the other required buffers
     let schema = LinkedBytesList::create(relation_oid, need_wal);
     let settings = LinkedBytesList::create(relation_oid, need_wal);
     let directory = LinkedItemList::<DirectoryEntry>::create(relation_oid, need_wal);

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -41,7 +41,7 @@ impl Default for Box<dyn ExecMethod> {
 }
 
 pub trait ExecMethod {
-    fn init(&mut self, state: &PdbScanState, cstate: *mut pg_sys::CustomScanState);
+    fn init(&mut self, state: &mut PdbScanState, cstate: *mut pg_sys::CustomScanState);
 
     fn query(&mut self, state: &PdbScanState) -> bool {
         false
@@ -66,7 +66,7 @@ pub trait ExecMethod {
 struct UnknownScanStyle;
 
 impl ExecMethod for UnknownScanStyle {
-    fn init(&mut self, _state: &PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
+    fn init(&mut self, _state: &mut PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
         unimplemented!(
             "logic error in pg_search:  `UnknownScanStyle::init()` should never be called"
         )

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -58,7 +58,7 @@ impl Drop for NormalScanExecState {
     }
 }
 impl ExecMethod for NormalScanExecState {
-    fn init(&mut self, state: &PdbScanState, cstate: *mut pg_sys::CustomScanState) {
+    fn init(&mut self, state: &mut PdbScanState, cstate: *mut pg_sys::CustomScanState) {
         unsafe {
             self.heaprel = state.heaprel.unwrap();
             self.slot = pg_sys::MakeTupleTableSlot(

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -59,7 +59,7 @@ impl TopNScanExecState {
 }
 
 impl ExecMethod for TopNScanExecState {
-    fn init(&mut self, state: &PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
+    fn init(&mut self, state: &mut PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
         let sort_field = state.sort_field.clone();
         let search_reader = state.search_reader.as_ref().unwrap();
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -26,7 +26,8 @@ use crate::api::operator::{
     anyelement_query_input_opoid, attname_from_var, estimate_selectivity, find_var_relation,
 };
 use crate::api::{AsCStr, AsInt, Cardinality};
-use crate::index::{get_index_schema, open_mvcc_reader};
+use crate::index::reader::index::SearchIndexReader;
+use crate::index::{get_index_schema, BlockDirectoryType};
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags, OrderByStyle};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
@@ -518,8 +519,8 @@ impl CustomScan for PdbScan {
             .map(|indexrel| unsafe { PgRelation::from_pg(*indexrel) })
             .expect("custom_state.indexrel should already be open");
 
-        let search_reader =
-            open_mvcc_reader(&indexrel).expect("should be able to open a SearchIndexReader");
+        let search_reader = SearchIndexReader::open(&indexrel, BlockDirectoryType::Mvcc, true)
+            .expect("should be able to open the search index reader");
         state.custom_state_mut().search_reader = Some(search_reader);
 
         let csstate = addr_of_mut!(state.csstate);

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -40,7 +40,7 @@ pub extern "C" fn ambulkdelete(
         callback(&mut ctid, callback_state)
     };
 
-    let _merge_lock = unsafe { MergeLock::acquire_for_delete(index_relation.oid()) };
+    let _merge_lock = unsafe { MergeLock::acquire_for_delete(index_relation.oid(), true) };
     let mut writer = open_bulk_delete_writer(&index_relation, WriterResources::Vacuum)
         .expect("ambulkdelete: should be able to open a SearchIndexWriter");
     let reader = open_bulk_delete_reader(&index_relation)

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::writer::index::SearchIndexWriter;
-use crate::index::{open_mvcc_writer, WriterResources};
+use crate::index::{BlockDirectoryType, WriterResources};
 use crate::postgres::utils::row_to_search_document;
 use pgrx::itemptr::item_pointer_get_both;
 use pgrx::{pg_guard, pg_sys, PgMemoryContexts, PgRelation, PgTupleDesc};
@@ -55,7 +55,7 @@ impl InsertState {
         indexrel: &PgRelation,
         writer_resources: WriterResources,
     ) -> anyhow::Result<Self> {
-        let writer = open_mvcc_writer(indexrel, writer_resources)?;
+        let writer = SearchIndexWriter::open(indexrel, BlockDirectoryType::Mvcc, writer_resources)?;
         Ok(Self {
             writer: Some(writer),
             abort_on_drop: false,

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -107,3 +107,5 @@ pub fn rel_get_bm25_index(relid: pg_sys::Oid) -> Option<(PgRelation, PgRelation)
         None
     }
 }
+
+pub type NeedWal = bool;

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -16,8 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::fast_fields_helper::FFHelper;
-use crate::index::open_mvcc_reader;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
+use crate::index::BlockDirectoryType;
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::{parallel, ScanStrategy};
 use crate::query::SearchQueryInput;
@@ -104,8 +104,10 @@ pub extern "C" fn amrescan(
     }
 
     // Create the index and scan state
-    let search_reader =
-        open_mvcc_reader(&indexrel).expect("should be able to open a SearchIndexReader");
+    let search_reader = SearchIndexReader::open(&indexrel, BlockDirectoryType::Mvcc, unsafe {
+        (*scan).xs_want_itup
+    })
+    .expect("amrescan: should be able to open a SearchIndexReader");
     unsafe {
         parallel::maybe_init_parallel_scan(scan, search_reader.searcher());
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -26,11 +26,12 @@ use std::slice::from_raw_parts;
 use tantivy::index::SegmentId;
 
 pub const MERGE_LOCK: pg_sys::BlockNumber = 0;
-pub const SCHEMA_START: pg_sys::BlockNumber = 1;
-pub const SETTINGS_START: pg_sys::BlockNumber = 3;
-pub const DIRECTORY_START: pg_sys::BlockNumber = 5;
-pub const SEGMENT_METAS_START: pg_sys::BlockNumber = 7;
-pub const DELETE_METAS_START: pg_sys::BlockNumber = 9;
+pub const CLEANUP_LOCK: pg_sys::BlockNumber = 1;
+pub const SCHEMA_START: pg_sys::BlockNumber = 2;
+pub const SETTINGS_START: pg_sys::BlockNumber = 4;
+pub const DIRECTORY_START: pg_sys::BlockNumber = 6;
+pub const SEGMENT_METAS_START: pg_sys::BlockNumber = 8;
+pub const DELETE_METAS_START: pg_sys::BlockNumber = 10;
 
 // ---------------------------------------------------------
 // BM25 page special data

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::utils::BM25BufferCache;
+use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::SKIPLIST_FREQ;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
@@ -123,15 +123,10 @@ pub trait LinkedList {
     }
 
     unsafe fn get_linked_list_data(&self) -> LinkedListData {
-        let cache = BM25BufferCache::open(self.get_relation_oid());
-        let header_buffer =
-            cache.get_buffer(self.get_header_blockno(), Some(pg_sys::BUFFER_LOCK_SHARE));
-        let page = pg_sys::BufferGetPage(header_buffer);
-        let metadata = pg_sys::PageGetContents(page) as *mut LinkedListData;
-        let data = metadata.read_unaligned();
-
-        pg_sys::UnlockReleaseBuffer(header_buffer);
-        data
+        let bman = BufferManager::new(self.get_relation_oid(), false);
+        let header_buffer = bman.get_buffer(self.get_header_blockno());
+        let page = header_buffer.page();
+        page.contents::<LinkedListData>()
     }
 }
 

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -1,6 +1,6 @@
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::block::{BM25PageSpecialData, PgItem};
 use crate::postgres::storage::utils::{BM25Buffer, BM25BufferCache, BM25Page};
+use crate::postgres::NeedWal;
 use pgrx::pg_sys;
 use std::marker::PhantomData;
 use std::ptr::NonNull;

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -417,9 +417,15 @@ impl BufferManager {
         }
     }
 
-    pub fn get_buffer_for_cleanup(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
+    pub fn get_buffer_for_cleanup(
+        &mut self,
+        blockno: pg_sys::BlockNumber,
+        strategy: pg_sys::BufferAccessStrategy,
+    ) -> BufferMut {
         unsafe {
-            let buffer = self.bcache.get_buffer(blockno, None);
+            let buffer = self
+                .bcache
+                .get_buffer_with_strategy(blockno, strategy, None);
             pg_sys::LockBufferForCleanup(buffer);
             BufferMut {
                 style: self.style(XlogFlag::ExistingBuffer),

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -1,0 +1,430 @@
+use crate::index::channel::NeedWal;
+use crate::postgres::storage::block::BM25PageSpecialData;
+use crate::postgres::storage::utils::{BM25Buffer, BM25BufferCache, BM25Page};
+use pgrx::pg_sys;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+#[derive(Debug, Copy, Clone, Default)]
+#[repr(i32)]
+enum XlogFlag {
+    #[default]
+    ExistingBuffer = 0,
+    NewBuffer = pg_sys::GENERIC_XLOG_FULL_IMAGE as i32,
+}
+#[derive(Copy, Clone, Default)]
+enum XlogStyle {
+    #[default]
+    Unlogged,
+    Logged(NonNull<pg_sys::GenericXLogState>, XlogFlag),
+}
+
+impl XlogStyle {
+    fn get_page(&self, buffer: pg_sys::Buffer) -> pg_sys::Page {
+        unsafe {
+            match self {
+                XlogStyle::Logged(state, flag) => {
+                    pg_sys::GenericXLogRegisterBuffer(state.as_ptr(), buffer, *flag as i32)
+                }
+                XlogStyle::Unlogged => pg_sys::BufferGetPage(buffer),
+            }
+        }
+    }
+}
+
+pub struct Buffer {
+    pg_buffer: pg_sys::Buffer,
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        unsafe {
+            if pg_sys::IsTransactionState() {
+                pg_sys::UnlockReleaseBuffer(self.pg_buffer);
+            }
+        }
+    }
+}
+
+impl Buffer {
+    pub fn page(&self) -> Page {
+        let pg_page = unsafe { pg_sys::BufferGetPage(self.pg_buffer) };
+        Page {
+            pg_page,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn page_contents<T: Copy>(&self) -> T {
+        self.page().contents()
+    }
+
+    pub fn number(&self) -> pg_sys::BlockNumber {
+        unsafe { pg_sys::BufferGetBlockNumber(self.pg_buffer) }
+    }
+
+    pub fn page_size(&self) -> pg_sys::Size {
+        unsafe { pg_sys::BufferGetPageSize(self.pg_buffer) }
+    }
+
+    pub fn next_blockno(&self) -> pg_sys::BlockNumber {
+        unsafe { self.pg_buffer.next_blockno() }
+    }
+}
+
+pub struct BufferMut {
+    style: XlogStyle,
+    dirty: bool,
+    inner: Buffer,
+}
+
+impl Drop for BufferMut {
+    fn drop(&mut self) {
+        if self.dirty {
+            unsafe {
+                match self.style {
+                    XlogStyle::Logged(state, _) => {
+                        pg_sys::GenericXLogFinish(state.as_ptr());
+                    }
+                    XlogStyle::Unlogged => {
+                        pg_sys::MarkBufferDirty(self.inner.pg_buffer);
+                    }
+                }
+            }
+        } else {
+            unsafe {
+                match self.style {
+                    XlogStyle::Logged(state, _) => {
+                        pg_sys::GenericXLogAbort(state.as_ptr());
+                    }
+                    XlogStyle::Unlogged => {
+                        // noop
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl BufferMut {
+    pub fn init_page(&mut self) -> PageMut {
+        let page_size = self.page_size();
+        let page = self.page_mut();
+        page.buffer.dirty = true;
+        unsafe {
+            pg_sys::PageInit(page.pg_page, page_size, size_of::<BM25PageSpecialData>());
+
+            let special = pg_sys::PageGetSpecialPointer(page.pg_page) as *mut BM25PageSpecialData;
+            (*special).next_blockno = pg_sys::InvalidBlockNumber;
+            (*special).xmax = pg_sys::InvalidTransactionId;
+        }
+        page
+    }
+
+    pub fn page(&self) -> Page {
+        unsafe {
+            Page {
+                pg_page: pg_sys::BufferGetPage(self.inner.pg_buffer),
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    pub fn page_mut(&mut self) -> PageMut {
+        let pg_page = self.style.get_page(self.inner.pg_buffer);
+        PageMut {
+            buffer: self,
+            pg_page,
+        }
+    }
+
+    pub fn number(&self) -> pg_sys::BlockNumber {
+        self.inner.number()
+    }
+
+    pub fn page_size(&self) -> pg_sys::Size {
+        self.inner.page_size()
+    }
+
+    pub fn next_blockno(&self) -> pg_sys::BlockNumber {
+        self.inner.next_blockno()
+    }
+}
+
+pub struct Page<'a> {
+    pg_page: pg_sys::Page,
+    _marker: PhantomData<&'a Buffer>,
+}
+
+impl<'a> Page<'a> {
+    pub fn free_space(&self) -> usize {
+        unsafe { pg_sys::PageGetFreeSpace(self.pg_page) }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        unsafe { pg_sys::PageIsEmpty(self.pg_page) }
+    }
+
+    pub fn max_offset_number(&self) -> pg_sys::OffsetNumber {
+        unsafe { pg_sys::PageGetMaxOffsetNumber(self.pg_page) }
+    }
+
+    pub fn get_item_id(&self, offno: pg_sys::OffsetNumber) -> pg_sys::ItemId {
+        unsafe { pg_sys::PageGetItemId(self.pg_page, offno) }
+    }
+
+    pub fn get_item(&self, item_id: pg_sys::ItemId) -> pg_sys::Item {
+        unsafe { pg_sys::PageGetItem(self.pg_page, item_id) }
+    }
+
+    pub fn header(&self) -> &pg_sys::PageHeaderData {
+        unsafe { &*(self.pg_page as *const pg_sys::PageHeaderData) }
+    }
+
+    pub fn special<T>(&self) -> &T {
+        unsafe { &*(pg_sys::PageGetSpecialPointer(self.pg_page) as *const T) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe {
+            let header_size = std::mem::offset_of!(pg_sys::PageHeaderData, pd_linp);
+            let slice_len = self.header().pd_lower as usize - header_size;
+            std::slice::from_raw_parts((self.pg_page as *const u8).add(header_size), slice_len)
+        }
+    }
+
+    pub fn as_slice_range(&self, offset: usize, len: usize) -> &[u8] {
+        unsafe {
+            let header_size = std::mem::offset_of!(pg_sys::PageHeaderData, pd_linp);
+            std::slice::from_raw_parts((self.pg_page as *const u8).add(header_size + offset), len)
+        }
+    }
+
+    pub fn contents<T: Copy>(&self) -> T {
+        unsafe { (pg_sys::PageGetContents(self.pg_page) as *const T).read_unaligned() }
+    }
+}
+
+pub struct PageMut<'a> {
+    buffer: &'a mut BufferMut,
+    pg_page: pg_sys::Page,
+}
+
+impl<'a> PageMut<'a> {
+    pub fn mark_deleted(self) {
+        unsafe { self.pg_page.mark_deleted() }
+    }
+
+    pub fn max_offset_number(&self) -> pg_sys::OffsetNumber {
+        unsafe { pg_sys::PageGetMaxOffsetNumber(self.pg_page) }
+    }
+
+    pub fn get_item_id(&self, offno: pg_sys::OffsetNumber) -> pg_sys::ItemId {
+        unsafe { pg_sys::PageGetItemId(self.pg_page, offno) }
+    }
+
+    pub fn get_item(&self, item_id: pg_sys::ItemId) -> pg_sys::Item {
+        unsafe { pg_sys::PageGetItem(self.pg_page, item_id) }
+    }
+
+    #[track_caller]
+    pub fn append_item(
+        &mut self,
+        item: pg_sys::Item,
+        size: pg_sys::Size,
+        flags: i32,
+    ) -> pg_sys::OffsetNumber {
+        let offno = unsafe {
+            pg_sys::PageAddItemExtended(
+                self.pg_page,
+                item,
+                size,
+                pg_sys::InvalidOffsetNumber,
+                flags,
+            )
+        };
+        self.buffer.dirty = true;
+        offno
+    }
+
+    pub fn replace_item(
+        &mut self,
+        offno: pg_sys::OffsetNumber,
+        item: pg_sys::Item,
+        size: pg_sys::Size,
+    ) -> bool {
+        let did_replace =
+            unsafe { pg_sys::PageIndexTupleOverwrite(self.pg_page, offno, item, size) };
+        self.buffer.dirty = true;
+        did_replace
+    }
+
+    pub fn delete_items(&mut self, item_offsets: &mut [pg_sys::OffsetNumber]) {
+        unsafe {
+            pg_sys::PageIndexMultiDelete(
+                self.pg_page,
+                item_offsets.as_mut_ptr(),
+                item_offsets.len() as i32,
+            );
+            self.buffer.dirty = true;
+        }
+    }
+
+    pub fn header(&self) -> &pg_sys::PageHeaderData {
+        unsafe { &*(self.pg_page as *mut pg_sys::PageHeaderData) }
+    }
+
+    pub fn header_mut(&mut self) -> &mut pg_sys::PageHeaderData {
+        let header = unsafe { &mut *(self.pg_page as *mut pg_sys::PageHeaderData) };
+        self.buffer.dirty = true;
+        header
+    }
+
+    pub fn special<T>(&self) -> &T {
+        unsafe { &*(pg_sys::PageGetSpecialPointer(self.pg_page) as *mut T) }
+    }
+
+    pub fn special_mut<T>(&mut self) -> &mut T {
+        let special = unsafe { &mut *(pg_sys::PageGetSpecialPointer(self.pg_page) as *mut T) };
+        self.buffer.dirty = true;
+        special
+    }
+
+    pub fn free_space_slice_mut(&mut self, len: usize) -> &mut [u8] {
+        let slice = unsafe {
+            std::slice::from_raw_parts_mut(
+                (self.pg_page as *mut u8).add(self.header_mut().pd_lower as usize),
+                len,
+            )
+        };
+        self.buffer.dirty = true;
+        slice
+    }
+
+    pub fn contents_mut<T>(&mut self) -> &mut T {
+        let contents = unsafe {
+            let contents = pg_sys::PageGetContents(self.pg_page) as *mut T;
+
+            // adjust pd_lower at the same time
+            let header = self.pg_page as *mut pg_sys::PageHeaderData;
+            (*header).pd_lower = (contents.add(1) as usize - header as usize)
+                .try_into()
+                .expect("pd_lower overflowed");
+
+            &mut *contents
+        };
+        self.buffer.dirty = true;
+        contents
+    }
+}
+
+pub trait PageHeaderMethods {
+    fn free_space(&self) -> usize;
+}
+
+impl PageHeaderMethods for pg_sys::PageHeaderData {
+    fn free_space(&self) -> usize {
+        self.pd_upper as usize - self.pd_lower as usize
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BufferManager {
+    logged: bool,
+    bcache: Arc<BM25BufferCache>,
+}
+
+impl BufferManager {
+    pub fn new(indexrelid: pg_sys::Oid, need_wal: NeedWal) -> Self {
+        if need_wal {
+            Self::logged(indexrelid)
+        } else {
+            Self::unlogged(indexrelid)
+        }
+    }
+
+    pub fn logged(indexrelid: pg_sys::Oid) -> Self {
+        Self {
+            logged: true,
+            bcache: BM25BufferCache::open(indexrelid),
+        }
+    }
+
+    pub fn unlogged(indexrelid: pg_sys::Oid) -> Self {
+        Self {
+            logged: false,
+            bcache: BM25BufferCache::open(indexrelid),
+        }
+    }
+
+    pub fn bm25cache(&self) -> &BM25BufferCache {
+        &self.bcache
+    }
+
+    fn style(&self, flag: XlogFlag) -> XlogStyle {
+        if self.logged {
+            unsafe { XlogStyle::Logged(NonNull::new_unchecked(self.bcache.start_xlog()), flag) }
+        } else {
+            XlogStyle::Unlogged
+        }
+    }
+
+    pub fn new_buffer(&mut self) -> BufferMut {
+        unsafe {
+            BufferMut {
+                style: self.style(XlogFlag::NewBuffer),
+                dirty: false,
+                inner: Buffer {
+                    pg_buffer: self.bcache.new_buffer(),
+                },
+            }
+        }
+    }
+
+    pub fn get_buffer(&self, blockno: pg_sys::BlockNumber) -> Buffer {
+        unsafe {
+            Buffer {
+                pg_buffer: self
+                    .bcache
+                    .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE)),
+            }
+        }
+    }
+
+    pub fn get_buffer_mut(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
+        unsafe {
+            BufferMut {
+                style: self.style(XlogFlag::ExistingBuffer),
+                dirty: false,
+                inner: Buffer {
+                    pg_buffer: self
+                        .bcache
+                        .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE)),
+                },
+            }
+        }
+    }
+
+    pub fn get_buffer_mut_conditional(
+        &mut self,
+        blockno: pg_sys::BlockNumber,
+    ) -> Option<BufferMut> {
+        unsafe {
+            let buffer = self.bcache.get_buffer(blockno, None);
+            if pg_sys::ConditionalLockBuffer(buffer) {
+                Some(BufferMut {
+                    style: self.style(XlogFlag::ExistingBuffer),
+                    dirty: false,
+                    inner: Buffer { pg_buffer: buffer },
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn page_is_empty(&self, blockno: pg_sys::BlockNumber) -> bool {
+        self.get_buffer(blockno).page().is_empty()
+    }
+}

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -224,8 +224,12 @@ pub struct PageMut<'a> {
 }
 
 impl<'a> PageMut<'a> {
-    pub fn mark_deleted(self) {
-        unsafe { self.inner.pg_page.mark_deleted() }
+    pub fn mark_deleted(mut self) {
+        unsafe {
+            self.special_mut::<BM25PageSpecialData>().xmax =
+                pg_sys::ReadNextFullTransactionId().value as pg_sys::TransactionId;
+        }
+        self.buffer.dirty = true;
     }
 
     pub fn max_offset_number(&self) -> pg_sys::OffsetNumber {

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -16,9 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::block::{bm25_max_free_space, BM25PageSpecialData, LinkedList, LinkedListData};
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::buffer::{BufferManager, PageHeaderMethods};
 use crate::postgres::storage::SKIPLIST_FREQ;
+use crate::postgres::NeedWal;
 use anyhow::Result;
 use parking_lot::Mutex;
 use pgrx::pg_sys;

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -16,7 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::block::{bm25_max_free_space, BM25PageSpecialData, LinkedList, LinkedListData};
-use super::utils::{BM25BufferCache, BM25Page};
+use crate::index::channel::NeedWal;
+use crate::postgres::storage::buffer::{BufferManager, PageHeaderMethods};
 use crate::postgres::storage::SKIPLIST_FREQ;
 use anyhow::Result;
 use parking_lot::Mutex;
@@ -26,9 +27,7 @@ use std::cmp::min;
 use std::collections::hash_map::Entry;
 use std::io::{Cursor, Read};
 use std::ops::{Deref, Range};
-use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::Arc;
-
 // ---------------------------------------------------------------
 // Linked list implementation over block storage,
 // where each node is a page filled with bm25_max_free_space()
@@ -66,7 +65,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct LinkedBytesList {
-    cache: Arc<BM25BufferCache>,
+    bman: BufferManager,
     relation_oid: pg_sys::Oid,
     pub header_blockno: pg_sys::BlockNumber,
     metadata: LinkedListData,
@@ -132,18 +131,18 @@ impl Deref for RangeData {
 }
 
 impl LinkedBytesList {
-    pub fn open(relation_oid: pg_sys::Oid, header_blockno: pg_sys::BlockNumber) -> Self {
-        let cache = unsafe { BM25BufferCache::open(relation_oid) };
-        let metadata = unsafe {
-            let header_buffer = cache.get_buffer(header_blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-            let page = pg_sys::BufferGetPage(header_buffer);
-            let metadata = pg_sys::PageGetContents(page) as *mut LinkedListData;
-            let metadata = metadata.read_unaligned();
-            pg_sys::UnlockReleaseBuffer(header_buffer);
-            metadata
-        };
+    pub fn open(
+        relation_oid: pg_sys::Oid,
+        header_blockno: pg_sys::BlockNumber,
+        need_wal: NeedWal,
+    ) -> Self {
+        let bman = BufferManager::new(relation_oid, need_wal);
+        let metadata = bman
+            .get_buffer(header_blockno)
+            .page_contents::<LinkedListData>();
+
         Self {
-            cache,
+            bman,
             relation_oid,
             header_blockno,
             metadata,
@@ -151,45 +150,24 @@ impl LinkedBytesList {
         }
     }
 
-    pub unsafe fn create(relation_oid: pg_sys::Oid) -> Self {
-        let cache = BM25BufferCache::open(relation_oid);
-        let state = cache.start_xlog();
+    pub unsafe fn create(relation_oid: pg_sys::Oid, need_wal: NeedWal) -> Self {
+        let mut bman = BufferManager::new(relation_oid, need_wal);
 
-        let header_buffer = cache.new_buffer();
-        let header_blockno = pg_sys::BufferGetBlockNumber(header_buffer);
-        let start_buffer = cache.new_buffer();
-        let start_blockno = pg_sys::BufferGetBlockNumber(start_buffer);
+        let mut header_buffer = bman.new_buffer();
+        let header_blockno = header_buffer.number();
+        let mut start_buffer = bman.new_buffer();
+        let start_blockno = start_buffer.number();
 
-        let header_page = pg_sys::GenericXLogRegisterBuffer(
-            state,
-            header_buffer,
-            pg_sys::GENERIC_XLOG_FULL_IMAGE as i32,
-        );
-        header_page.init(pg_sys::BufferGetPageSize(header_buffer));
+        let mut header_page = header_buffer.init_page();
+        start_buffer.init_page();
 
-        let start_page = pg_sys::GenericXLogRegisterBuffer(
-            state,
-            start_buffer,
-            pg_sys::GENERIC_XLOG_FULL_IMAGE as i32,
-        );
-        start_page.init(pg_sys::BufferGetPageSize(start_buffer));
-
-        let metadata = pg_sys::PageGetContents(header_page) as *mut LinkedListData;
-        (*metadata).skip_list[0] = start_blockno;
-        (*metadata).inner.last_blockno = start_blockno;
-        (*metadata).inner.npages = 1;
-
-        // Set pd_lower to the end of the metadata
-        // Without doing so, metadata will be lost if xlog.c compresses the page
-        let page_header = header_page as *mut pg_sys::PageHeaderData;
-        (*page_header).pd_lower = (metadata.add(1) as usize - header_page as usize) as u16;
-
-        pg_sys::GenericXLogFinish(state);
-        pg_sys::UnlockReleaseBuffer(header_buffer);
-        pg_sys::UnlockReleaseBuffer(start_buffer);
+        let metadata = header_page.contents_mut::<LinkedListData>();
+        metadata.skip_list[0] = start_blockno;
+        metadata.inner.last_blockno = start_blockno;
+        metadata.inner.npages = 1;
 
         Self {
-            cache,
+            bman,
             relation_oid,
             header_blockno,
             metadata: *metadata,
@@ -198,134 +176,94 @@ impl LinkedBytesList {
     }
 
     pub unsafe fn write(&mut self, bytes: &[u8]) -> Result<()> {
-        let cache = &self.cache;
         let mut data_cursor = Cursor::new(bytes);
         let mut bytes_written = 0;
 
         while bytes_written < bytes.len() {
-            unsafe {
-                let insert_blockno = self.get_last_blockno();
-                let buffer = cache.get_buffer(insert_blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-                let state = cache.start_xlog();
-                let page = pg_sys::GenericXLogRegisterBuffer(state, buffer, 0);
-                let header = page as *mut pg_sys::PageHeaderData;
-                let free_space = ((*header).pd_upper - (*header).pd_lower) as usize;
-                assert!(free_space <= bm25_max_free_space());
+            let insert_blockno = self.get_last_blockno();
+            let mut buffer = self.bman.get_buffer_mut(insert_blockno);
+            let mut page = buffer.page_mut();
+            let free_space = page.header().free_space();
+            assert!(free_space <= bm25_max_free_space());
 
-                let bytes_to_write = min(free_space, bytes.len() - bytes_written);
-                if bytes_to_write == 0 {
-                    let new_buffer = cache.new_buffer();
-                    // Set next blockno
-                    let new_blockno = pg_sys::BufferGetBlockNumber(new_buffer);
-                    let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
-                    (*special).next_blockno = new_blockno;
-                    // Initialize new page
-                    let new_page = pg_sys::GenericXLogRegisterBuffer(
-                        state,
-                        new_buffer,
-                        pg_sys::GENERIC_XLOG_FULL_IMAGE as i32,
-                    );
-                    new_page.init(pg_sys::BufferGetPageSize(new_buffer));
-                    // Set last blockno to new blockno
-                    let header_buffer = cache.get_buffer(
-                        self.get_header_blockno(),
-                        Some(pg_sys::BUFFER_LOCK_EXCLUSIVE),
-                    );
+            let bytes_to_write = min(free_space, bytes.len() - bytes_written);
+            if bytes_to_write == 0 {
+                let mut new_buffer = self.bman.new_buffer();
 
-                    let page = pg_sys::GenericXLogRegisterBuffer(state, header_buffer, 0);
-                    let metadata = pg_sys::PageGetContents(page) as *mut LinkedListData;
-                    (*metadata).inner.last_blockno = new_blockno;
-                    (*metadata).inner.npages += 1;
-                    if (*metadata).inner.npages as usize % SKIPLIST_FREQ == 0 {
-                        let idx = (*metadata).inner.npages as usize / SKIPLIST_FREQ;
-                        (*metadata).skip_list[idx] = new_blockno;
-                    }
-                    self.metadata = *metadata;
+                // Set next blockno
+                let new_blockno = new_buffer.number();
+                let special = page.special_mut::<BM25PageSpecialData>();
+                special.next_blockno = new_blockno;
 
-                    pg_sys::GenericXLogFinish(state);
-                    pg_sys::UnlockReleaseBuffer(buffer);
-                    pg_sys::UnlockReleaseBuffer(new_buffer);
-                    pg_sys::UnlockReleaseBuffer(header_buffer);
-                    continue;
+                // Initialize new page
+                new_buffer.init_page();
+
+                // Set last blockno to new blockno
+                let mut header_buffer = self.bman.get_buffer_mut(self.get_header_blockno());
+
+                let mut page = header_buffer.page_mut();
+                let metadata = page.contents_mut::<LinkedListData>();
+                metadata.inner.last_blockno = new_blockno;
+                metadata.inner.npages += 1;
+                if metadata.inner.npages as usize % SKIPLIST_FREQ == 0 {
+                    let idx = metadata.inner.npages as usize / SKIPLIST_FREQ;
+                    metadata.skip_list[idx] = new_blockno;
                 }
-
-                let page_slice = from_raw_parts_mut(
-                    (page as *mut u8).add((*header).pd_lower as usize),
-                    bytes_to_write,
-                );
-                data_cursor.read_exact(page_slice)?;
-                bytes_written += bytes_to_write;
-                (*header).pd_lower += bytes_to_write as u16;
-                pg_sys::GenericXLogFinish(state);
-                pg_sys::UnlockReleaseBuffer(buffer);
+                self.metadata = *metadata;
+                continue;
             }
+
+            let page_slice = page.free_space_slice_mut(bytes_to_write);
+            data_cursor.read_exact(page_slice)?;
+            bytes_written += bytes_to_write;
+
+            page.header_mut().pd_lower += bytes_to_write as u16;
         }
 
         Ok(())
     }
 
     pub unsafe fn read_all(&self) -> Vec<u8> {
-        let cache = &self.cache;
         let mut blockno = self.get_start_blockno();
         let mut bytes: Vec<u8> = vec![];
 
         while blockno != pg_sys::InvalidBlockNumber {
-            let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-            let page = pg_sys::BufferGetPage(buffer);
-            let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
-            let header = page as *mut pg_sys::PageHeaderData;
-            let header_size = std::mem::offset_of!(pg_sys::PageHeaderData, pd_linp) as u16;
-            let slice_len = (*header).pd_lower - header_size;
-            let slice = from_raw_parts((page as *mut u8).add(header_size.into()), slice_len.into());
+            let buffer = self.bman.get_buffer(blockno);
+            let page = buffer.page();
+            let special = page.special::<BM25PageSpecialData>();
+            let slice = page.as_slice();
 
             bytes.extend_from_slice(slice);
-            blockno = (*special).next_blockno;
-            pg_sys::UnlockReleaseBuffer(buffer);
+            blockno = special.next_blockno;
         }
 
         bytes
     }
 
-    pub unsafe fn mark_deleted(&self) {
-        let cache = &self.cache;
+    pub unsafe fn mark_deleted(&mut self) {
         let mut blockno = self.get_start_blockno();
         while blockno != pg_sys::InvalidBlockNumber {
-            let state = cache.start_xlog();
-            let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-            let page = pg_sys::GenericXLogRegisterBuffer(state, buffer, 0);
-            let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
-            blockno = (*special).next_blockno;
-            page.mark_deleted();
+            let mut buffer = self.bman.get_buffer_mut(blockno);
+            let page = buffer.page_mut();
+            let special = page.special::<BM25PageSpecialData>();
 
-            pg_sys::GenericXLogFinish(state);
-            pg_sys::UnlockReleaseBuffer(buffer);
+            blockno = special.next_blockno;
+            page.mark_deleted();
         }
 
-        let state = cache.start_xlog();
-        let header_buffer =
-            cache.get_buffer(self.header_blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-        let lock_page = pg_sys::GenericXLogRegisterBuffer(state, header_buffer, 0);
+        let mut header_buffer = self.bman.get_buffer_mut(self.header_blockno);
+        let lock_page = header_buffer.page_mut();
         lock_page.mark_deleted();
-
-        pg_sys::GenericXLogFinish(state);
-        pg_sys::UnlockReleaseBuffer(header_buffer);
     }
 
     pub fn is_empty(&self) -> bool {
-        unsafe {
-            let cache = &self.cache;
-            let start_blockno = self.get_start_blockno();
-            let start_buffer = cache.get_buffer(start_blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-            let start_page = pg_sys::BufferGetPage(start_buffer);
-            let is_empty = pg_sys::PageIsEmpty(start_page);
-            pg_sys::UnlockReleaseBuffer(start_buffer);
-            is_empty
-        }
+        self.bman.page_is_empty(self.get_start_blockno())
     }
 
     #[inline]
     pub unsafe fn get_cached_page_slice(&self, blockno: pg_sys::BlockNumber) -> &[u8] {
-        self.cache
+        self.bman
+            .bm25cache()
             .get_page_slice(blockno, Some(pg_sys::BUFFER_LOCK_SHARE))
     }
 
@@ -352,7 +290,6 @@ impl LinkedBytesList {
         const ITEM_SIZE: usize = bm25_max_free_space();
 
         // find the closest block in the linked list to where `range` begins
-        let cache = &self.cache;
         let start_block_ord = range.start / ITEM_SIZE;
         let (nearest_block, nearest_ord) = self.nearest_block_by_ord(start_block_ord);
         let mut blockno = nearest_block;
@@ -365,11 +302,11 @@ impl LinkedBytesList {
                 // scan forward from that block skipping those that appear before our range begins
                 let mut skip = start_block_ord - nearest_ord.saturating_sub(1);
                 while skip != 0 && blockno != pg_sys::InvalidBlockNumber {
-                    let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-                    let page = pg_sys::BufferGetPage(buffer);
-                    let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
-                    blockno = (*special).next_blockno;
-                    pg_sys::UnlockReleaseBuffer(buffer);
+                    let buffer = self.bman.get_buffer(blockno);
+                    let page = buffer.page();
+                    let special = page.special::<BM25PageSpecialData>();
+
+                    blockno = special.next_blockno;
                     skip -= 1;
                 }
 
@@ -386,23 +323,19 @@ impl LinkedBytesList {
             let mut data = Vec::with_capacity(range.len());
             let mut remaining = range.len();
             while data.len() != range.len() && blockno != pg_sys::InvalidBlockNumber {
-                let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-                let page = pg_sys::BufferGetPage(buffer);
-                let special = pg_sys::PageGetSpecialPointer(page) as *mut BM25PageSpecialData;
+                let buffer = self.bman.get_buffer(blockno);
+                let page = buffer.page();
+                let special = page.special::<BM25PageSpecialData>();
                 let slice_start = if data.is_empty() {
                     range.start % ITEM_SIZE
                 } else {
                     0
                 };
                 let slice_len = (ITEM_SIZE - slice_start).min(remaining);
-                let header_size = std::mem::offset_of!(pg_sys::PageHeaderData, pd_linp);
-                let slice =
-                    from_raw_parts((page as *mut u8).add(slice_start + header_size), slice_len);
+                let slice = page.as_slice_range(slice_start, slice_len);
+
                 data.extend_from_slice(slice);
-
-                blockno = (*special).next_blockno;
-                pg_sys::UnlockReleaseBuffer(buffer);
-
+                blockno = special.next_blockno;
                 remaining -= slice_len;
             }
 
@@ -416,6 +349,7 @@ impl LinkedBytesList {
 mod tests {
     use super::*;
     use crate::postgres::storage::block::BM25PageSpecialData;
+    use crate::postgres::storage::utils::BM25BufferCache;
     use pgrx::prelude::*;
 
     #[pg_test]
@@ -430,7 +364,7 @@ mod tests {
         // Test read/write from newly created linked list
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
         let start_blockno = {
-            let mut linked_list = LinkedBytesList::create(relation_oid);
+            let mut linked_list = LinkedBytesList::create(relation_oid, true);
             linked_list.write(&bytes).unwrap();
             let read_bytes = linked_list.read_all();
             assert_eq!(bytes, read_bytes);
@@ -439,7 +373,7 @@ mod tests {
         };
 
         // Test read from already created linked list
-        let linked_list = LinkedBytesList::open(relation_oid, start_blockno);
+        let linked_list = LinkedBytesList::open(relation_oid, start_blockno, true);
         let read_bytes = linked_list.read_all();
         assert_eq!(bytes, read_bytes);
     }
@@ -453,7 +387,7 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let mut linked_list = LinkedBytesList::create(relation_oid);
+        let mut linked_list = LinkedBytesList::create(relation_oid, true);
         assert!(linked_list.is_empty());
 
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
@@ -470,7 +404,7 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let mut linked_list = LinkedBytesList::create(relation_oid);
+        let mut linked_list = LinkedBytesList::create(relation_oid, true);
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
         linked_list.write(&bytes).unwrap();
         linked_list.mark_deleted();

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -130,7 +130,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let mut blockno = start_blockno;
 
         while blockno != pg_sys::InvalidBlockNumber {
-            let mut buffer = self.bman.get_buffer_mut(blockno);
+            let mut buffer = self.bman.get_buffer_for_cleanup(blockno);
             let mut page = buffer.page_mut();
             let mut offsetno = pg_sys::FirstOffsetNumber;
             let max_offset = page.max_offset_number();

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -120,8 +120,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
     }
 
     pub unsafe fn garbage_collect(&mut self, strategy: pg_sys::BufferAccessStrategy) -> Result<()> {
-        // let cache = &self.cache;
-
         // Delete all items that are definitely dead
         let snapshot = pg_sys::GetActiveSnapshot();
         let heap_oid = unsafe { pg_sys::IndexGetRelation(self.relation_oid, false) };

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -155,8 +155,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
     }
 
     pub unsafe fn add_items(&mut self, items: Vec<T>) -> Result<()> {
-        // let cache = &self.cache;
-
         for item in items {
             let PgItem(pg_item, size) = item.into();
 

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -16,8 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::block::{BM25PageSpecialData, LinkedList, LinkedListData, MVCCEntry, PgItem};
-use crate::index::channel::NeedWal;
 use crate::postgres::storage::buffer::BufferManager;
+use crate::postgres::NeedWal;
 use anyhow::{bail, Result};
 use pgrx::pg_sys;
 use std::fmt::Debug;

--- a/pg_search/src/postgres/storage/mod.rs
+++ b/pg_search/src/postgres/storage/mod.rs
@@ -86,6 +86,7 @@
 // +-------------------------------------------------------------+
 
 pub mod block;
+pub mod buffer;
 pub mod linked_bytes;
 pub mod linked_items;
 pub mod utils;

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -130,6 +130,25 @@ impl BM25BufferCache {
         buffer
     }
 
+    pub unsafe fn get_buffer_with_strategy(
+        &self,
+        blockno: pg_sys::BlockNumber,
+        strategy: pg_sys::BufferAccessStrategy,
+        lock: Option<u32>,
+    ) -> pg_sys::Buffer {
+        let buffer = pg_sys::ReadBufferExtended(
+            self.indexrel.as_ptr(),
+            pg_sys::ForkNumber::MAIN_FORKNUM,
+            blockno,
+            pg_sys::ReadBufferMode::RBM_NORMAL,
+            strategy,
+        );
+        if let Some(lock) = lock {
+            pg_sys::LockBuffer(buffer, lock as i32);
+        }
+        buffer
+    }
+
     pub unsafe fn get_page_slice(&self, blockno: pg_sys::BlockNumber, lock: Option<u32>) -> &[u8] {
         let mut cache = self.cache.lock();
         let slice = cache.entry(blockno).or_insert_with(|| {

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -42,8 +42,6 @@ impl BM25Page for pg_sys::Page {
             return false;
         }
 
-        pgrx::warning!("   xmax={}", (*special).xmax);
-
         pg_sys::GlobalVisCheckRemovableXid(heap_relation, (*special).xmax)
     }
 }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,7 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::index::{open_mvcc_writer, WriterResources};
+use crate::index::writer::index::SearchIndexWriter;
+use crate::index::{BlockDirectoryType, WriterResources};
 use crate::postgres::storage::block::{
     DeleteMetaEntry, DirectoryEntry, SegmentMetaEntry, DELETE_METAS_START, DIRECTORY_START,
     SEGMENT_METAS_START,
@@ -37,10 +38,14 @@ pub extern "C" fn amvacuumcleanup(
     let index_relation = unsafe { PgRelation::from_pg(info.index) };
 
     // vacuum the index, which is effectively just a forced commit() plus a wait_merging_threads()
-    open_mvcc_writer(&index_relation, WriterResources::Vacuum)
-        .expect("amvacuumcleanup: should be able to open a SearchIndexWriter")
-        .vacuum()
-        .expect("amvacuumcleanup: SearchIndexWriter.vacuum() should succeed");
+    SearchIndexWriter::open(
+        &index_relation,
+        BlockDirectoryType::Mvcc,
+        WriterResources::Vacuum,
+    )
+    .expect("amvacuumcleanup: should be able to open a SearchIndexWriter")
+    .vacuum()
+    .expect("amvacuumcleanup: SearchIndexWriter.vacuum() should succeed");
 
     unsafe {
         // Garbage collect linked lists

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -54,17 +54,17 @@ pub extern "C" fn amvacuumcleanup(
         let mut directory =
             LinkedItemList::<DirectoryEntry>::open(index_oid, DIRECTORY_START, true);
         directory
-            .garbage_collect()
+            .garbage_collect(info.strategy)
             .expect("garbage collection should succeed");
         let mut segment_metas =
             LinkedItemList::<SegmentMetaEntry>::open(index_oid, SEGMENT_METAS_START, true);
         segment_metas
-            .garbage_collect()
+            .garbage_collect(info.strategy)
             .expect("garbage collection should succeed");
         let mut delete_metas =
             LinkedItemList::<DeleteMetaEntry>::open(index_oid, DELETE_METAS_START, true);
         delete_metas
-            .garbage_collect()
+            .garbage_collect(info.strategy)
             .expect("garbage collection should succeed");
 
         // Return all recyclable pages to the free space map
@@ -78,8 +78,6 @@ pub extern "C" fn amvacuumcleanup(
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();
 
-            // let buffer = cache.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
-            // let page = pg_sys::BufferGetPage(buffer);
             if page.is_recyclable(heap_relation) {
                 bman.record_free_index_page(buffer);
             }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -75,10 +75,12 @@ pub extern "C" fn amvacuumcleanup(
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
         for blockno in 0..nblocks {
+            pgrx::warning!("checking block {}", blockno);
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();
 
             if page.is_recyclable(heap_relation) {
+                pgrx::warning!("   can be recycled!");
                 bman.record_free_index_page(buffer);
             }
         }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -46,17 +46,18 @@ pub extern "C" fn amvacuumcleanup(
         // Garbage collect linked lists
         // If new LinkedItemLists are created they should be garbage collected here
         let index_oid = index_relation.oid();
-        let mut directory = LinkedItemList::<DirectoryEntry>::open(index_oid, DIRECTORY_START);
+        let mut directory =
+            LinkedItemList::<DirectoryEntry>::open(index_oid, DIRECTORY_START, true);
         directory
             .garbage_collect()
             .expect("garbage collection should succeed");
         let mut segment_metas =
-            LinkedItemList::<SegmentMetaEntry>::open(index_oid, SEGMENT_METAS_START);
+            LinkedItemList::<SegmentMetaEntry>::open(index_oid, SEGMENT_METAS_START, true);
         segment_metas
             .garbage_collect()
             .expect("garbage collection should succeed");
         let mut delete_metas =
-            LinkedItemList::<DeleteMetaEntry>::open(index_oid, DELETE_METAS_START);
+            LinkedItemList::<DeleteMetaEntry>::open(index_oid, DELETE_METAS_START, true);
         delete_metas
             .garbage_collect()
             .expect("garbage collection should succeed");

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -75,12 +75,10 @@ pub extern "C" fn amvacuumcleanup(
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
         for blockno in 0..nblocks {
-            pgrx::warning!("checking block {}", blockno);
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();
 
             if page.is_recyclable(heap_relation) {
-                pgrx::warning!("   can be recycled!");
                 bman.record_free_index_page(buffer);
             }
         }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -888,7 +888,7 @@ mod tests {
     use rstest::rstest;
     use tantivy::schema::{JsonObjectOptions, NumericOptions, TextOptions};
 
-    use crate::schema::{SearchFieldConfig, SearchFieldName, SearchFieldType, SearchIndexSchema};
+    use crate::schema::SearchFieldConfig;
 
     #[rstest]
     fn test_search_text_options() {


### PR DESCRIPTION
This defers WAL logging for CREATE INDEX/REINDEX to the end of the statement.

This is actually a gigantic refactor of how we handle Buffers and Pages along with passing down a `needs_wal: bool` flag, which originates from `WriterResources`