### PR TITLE
fix: Freeze old XIDs in the linked list

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -104,6 +104,9 @@ pub mod pg_test {
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         // return any postgresql.conf settings that are required for your tests
-        vec!["shared_preload_libraries='pg_search'"]
+        vec![
+            "shared_preload_libraries='pg_search'",
+            "vacuum_freeze_min_age=50000000",
+        ]
     }
 }

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -104,9 +104,6 @@ pub mod pg_test {
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         // return any postgresql.conf settings that are required for your tests
-        vec![
-            "shared_preload_libraries='pg_search'",
-            "vacuum_freeze_min_age=50000000",
-        ]
+        vec!["shared_preload_libraries='pg_search'"]
     }
 }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -318,6 +318,7 @@ pub trait MVCCEntry {
     // Required methods
     fn get_xmin(&self) -> pg_sys::TransactionId;
     fn get_xmax(&self) -> pg_sys::TransactionId;
+    fn into_frozen(self, should_freeze_xmin: bool, should_freeze_xmax: bool) -> Self;
 
     // Provided methods
     unsafe fn visible(&self, snapshot: pg_sys::Snapshot) -> bool {
@@ -355,6 +356,16 @@ pub trait MVCCEntry {
             pg_sys::GlobalVisCheckRemovableXid(heap_relation, xmax)
         }
     }
+
+    unsafe fn xmin_needs_freeze(&self, freeze_limit: pg_sys::TransactionId) -> bool {
+        let xmin = self.get_xmin();
+        pg_sys::TransactionIdIsNormal(xmin) && pg_sys::TransactionIdPrecedes(xmin, freeze_limit)
+    }
+
+    unsafe fn xmax_needs_freeze(&self, freeze_limit: pg_sys::TransactionId) -> bool {
+        let xmax = self.get_xmax();
+        pg_sys::TransactionIdIsNormal(xmax) && pg_sys::TransactionIdPrecedes(xmax, freeze_limit)
+    }
 }
 
 impl MVCCEntry for SegmentMetaEntry {
@@ -364,6 +375,21 @@ impl MVCCEntry for SegmentMetaEntry {
     fn get_xmax(&self) -> pg_sys::TransactionId {
         self.xmax
     }
+    fn into_frozen(self, should_freeze_xmin: bool, should_freeze_xmax: bool) -> Self {
+        SegmentMetaEntry {
+            xmin: if should_freeze_xmin {
+                pg_sys::FrozenTransactionId
+            } else {
+                self.xmin
+            },
+            xmax: if should_freeze_xmax {
+                pg_sys::FrozenTransactionId
+            } else {
+                self.xmax
+            },
+            ..self.clone()
+        }
+    }
 }
 
 pub const fn bm25_max_free_space() -> usize {
@@ -371,5 +397,27 @@ pub const fn bm25_max_free_space() -> usize {
         (pg_sys::BLCKSZ as usize)
             - pg_sys::MAXALIGN(size_of::<BM25PageSpecialData>())
             - pg_sys::MAXALIGN(offset_of!(pg_sys::PageHeaderData, pd_linp))
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[pg_test]
+    unsafe fn test_needs_freeze() {
+        let freeze_limit = 100;
+        let segment = SegmentMetaEntry {
+            segment_id: SegmentId::from_uuid_string(&Uuid::new_v4().to_string()).unwrap(),
+            max_doc: 100,
+            opstamp: 0,
+            xmin: 50,
+            xmax: 150,
+        };
+
+        assert_eq!(segment.xmin_needs_freeze(freeze_limit), true);
+        assert_eq!(segment.xmax_needs_freeze(freeze_limit), false);
     }
 }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -145,7 +145,7 @@ pub struct DeleteEntry {
 }
 
 /// Metadata for tracking alive segments
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SegmentMetaEntry {
     pub segment_id: SegmentId,
     pub max_doc: u32,
@@ -161,6 +161,26 @@ pub struct SegmentMetaEntry {
     pub store: Option<FileEntry>,
     pub temp_store: Option<FileEntry>,
     pub delete: Option<DeleteEntry>,
+}
+
+impl Default for SegmentMetaEntry {
+    fn default() -> Self {
+        Self {
+            segment_id: SegmentId::from_uuid_string(&uuid::Uuid::default().to_string()).unwrap(),
+            max_doc: Default::default(),
+            opstamp: Default::default(),
+            xmin: pg_sys::InvalidTransactionId,
+            xmax: pg_sys::InvalidTransactionId,
+            postings: None,
+            positions: None,
+            fast_fields: None,
+            field_norms: None,
+            terms: None,
+            store: None,
+            temp_store: None,
+            delete: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------
@@ -404,7 +424,6 @@ pub const fn bm25_max_free_space() -> usize {
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
-    use uuid::Uuid;
 
     #[pg_test]
     unsafe fn test_needs_freeze() {

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -417,7 +417,7 @@ mod tests {
             xmax: 150,
         };
 
-        assert_eq!(segment.xmin_needs_freeze(freeze_limit), true);
-        assert_eq!(segment.xmax_needs_freeze(freeze_limit), false);
+        assert!(segment.xmin_needs_freeze(freeze_limit));
+        assert!(!segment.xmax_needs_freeze(freeze_limit));
     }
 }

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -18,7 +18,7 @@
 use super::block::{BM25PageSpecialData, LinkedList, LinkedListData, MVCCEntry, PgItem};
 use super::buffer::{BufferManager, BufferMut};
 use super::utils::vacuum_get_freeze_limit;
-use super::NeedWal;
+use crate::postgres::NeedWal;
 use anyhow::Result;
 use pgrx::pg_sys;
 use std::fmt::Debug;
@@ -270,26 +270,6 @@ mod tests {
 
     fn random_segment_id() -> SegmentId {
         SegmentId::from_uuid_string(&Uuid::new_v4().to_string()).unwrap()
-    }
-
-    impl Default for SegmentMetaEntry {
-        fn default() -> Self {
-            Self {
-                segment_id: random_segment_id(),
-                xmin: 0,
-                xmax: 0,
-                opstamp: 0,
-                max_doc: 0,
-                postings: None,
-                positions: None,
-                fast_fields: None,
-                field_norms: None,
-                terms: None,
-                store: None,
-                temp_store: None,
-                delete: None,
-            }
-        }
     }
 
     #[pg_test]

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -127,7 +127,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let snapshot = pg_sys::GetActiveSnapshot();
         let heap_oid = pg_sys::IndexGetRelation(self.relation_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
-        let freeze_limit = vacuum_get_freeze_limit();
+        let freeze_limit = vacuum_get_freeze_limit(heap_relation);
         let start_blockno = self.get_start_blockno();
         let mut blockno = start_blockno;
 

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -17,8 +17,8 @@
 
 use super::block::{BM25PageSpecialData, LinkedList, LinkedListData, MVCCEntry, PgItem};
 use super::buffer::{BufferManager, BufferMut};
-use super::NeedWal;
 use super::utils::vacuum_get_freeze_limit;
+use super::NeedWal;
 use anyhow::Result;
 use pgrx::pg_sys;
 use std::fmt::Debug;
@@ -145,9 +145,10 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
                     } else {
                         let xmin_needs_freeze = entry.xmin_needs_freeze(freeze_limit);
                         let xmax_needs_freeze = entry.xmax_needs_freeze(freeze_limit);
-    
+
                         if xmin_needs_freeze || xmax_needs_freeze {
-                            let frozen_entry = entry.into_frozen(xmin_needs_freeze, xmax_needs_freeze);
+                            let frozen_entry =
+                                entry.into_frozen(xmin_needs_freeze, xmax_needs_freeze);
                             let PgItem(item, size) = frozen_entry.clone().into();
                             let did_replace = page.replace_item(offsetno, item, size);
                             assert!(did_replace);

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -20,7 +20,6 @@ use parking_lot::Mutex;
 use pgrx::pg_sys;
 use pgrx::pg_sys::OffsetNumber;
 use pgrx::PgBox;
-use pgrx::*;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -238,6 +237,7 @@ pub unsafe fn vacuum_get_freeze_limit(heap_relation: pg_sys::Relation) -> pg_sys
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::prelude::*;
 
     #[pg_test]
     unsafe fn test_freeze_limit_relaxed() {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Freezes items in our linked list that are below the vacuum age threshold set in `postgresql.conf`.

## Why

`u32` `TransactionIds` can wrap around. Tuples need to be marked as frozen so that new wrapped transaction values don't conflict with existing ones.

## How

## Tests

Wrote unit tests