### PR TITLE
chore: don't rebuild schema every time a reader or writer is opened

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -130,14 +130,12 @@ pub fn get_index_schema(index_relation: &PgRelation) -> Result<SearchIndexSchema
     Ok(schema)
 }
 
-pub fn setup_tokenizers(underlying_index: &mut Index, schema: &SearchIndexSchema) {
-    let tokenizers = schema
-        .fields
+pub fn setup_tokenizers(underlying_index: &mut Index, index_relation: &PgRelation) {
+    let (fields, _) = unsafe { get_fields(index_relation) };
+    let tokenizers = fields
         .iter()
-        .filter_map(|field| {
-            let field_config = &field.config;
-            let field_name: &str = field.name.as_ref();
-            trace!(field_name, "attempting to create tokenizer");
+        .filter_map(|(field_name, field_config, _)| {
+            trace!("{} {}", field_name.0, "attempting to create tokenizer");
             match field_config {
                 SearchFieldConfig::Text { tokenizer, .. }
                 | SearchFieldConfig::Json { tokenizer, .. } => Some(tokenizer),

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -26,8 +26,9 @@ use crate::api::operator::{
     anyelement_query_input_opoid, attname_from_var, estimate_selectivity, find_var_relation,
 };
 use crate::api::{AsCStr, AsInt, Cardinality};
+use crate::index::mvcc::MVCCDirectory;
 use crate::index::reader::index::SearchIndexReader;
-use crate::index::{get_index_schema, BlockDirectoryType};
+use crate::index::BlockDirectoryType;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags, OrderByStyle};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
@@ -62,6 +63,7 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ptr::addr_of_mut;
 use tantivy::snippet::SnippetGenerator;
+use tantivy::Index;
 
 #[derive(Default)]
 pub struct PdbScan;
@@ -107,8 +109,10 @@ impl CustomScan for PdbScan {
             };
 
             let root = builder.args().root;
-            let schema =
-                get_index_schema(&bm25_index).expect("should be able to get the index schema");
+
+            let directory = MVCCDirectory::snapshot(bm25_index.oid(), false);
+            let index = Index::open(directory).expect("custom_scan: should be able to open index");
+            let schema = SearchIndexSchema::open(index.schema(), &bm25_index);
             let pathkey = pullup_orderby_pathkey(&mut builder, rti, &schema, root);
 
             #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The existing code constructs a new Tantivy `Schema` from scratch every time a reader or writer is opened. Instead, we can just read the schema from disk since `save_metas` already saves the schema.

## Why

Rebuilding the schema every time introduces surface area for bugs -- the schema is strict, and if we accidentally rebuild the fields in the wrong order it will break search. This hasn't presented a problem yet but was creating issues in the open PR #1982 -- merging this in will make that PR easier.

## How

## Tests
