### PR TITLE
feat: Garbage collection TPS optimizations

### DIFF
--- a/pg_search/sql/pg_search--0.13.2--0.13.3.sql
+++ b/pg_search/sql/pg_search--0.13.2--0.13.3.sql
@@ -1,0 +1,30 @@
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/bootstrap/create_bm25.rs:389
+-- pg_search::bootstrap::create_bm25::page_info
+CREATE  FUNCTION "page_info"(
+	"index" regclass, /* pgrx::rel::PgRelation */
+	"blockno" bigint /* i64 */
+) RETURNS TABLE (
+	"offsetno" INT,  /* i32 */
+	"size" INT,  /* i32 */
+	"visible" bool,  /* bool */
+	"recyclable" bool,  /* bool */
+	"contents" jsonb  /* pgrx::datum::json::JsonB */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'page_info_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/bootstrap/create_bm25.rs:367
+-- pg_search::bootstrap::create_bm25::storage_info
+CREATE  FUNCTION "storage_info"(
+	"index" regclass /* pgrx::rel::PgRelation */
+) RETURNS TABLE (
+	"block" bigint,  /* i64 */
+	"max_offset" INT  /* i32 */
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'storage_info_wrapper';

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -420,11 +420,10 @@ fn page_info(
 
     for offsetno in pg_sys::FirstOffsetNumber..=max_offset {
         unsafe {
-            if let Some(pg_item) = page.read_pg_item(offsetno) {
-                let entry = SegmentMetaEntry::from(pg_item.clone());
+            if let Some((entry, size)) = page.read_item::<SegmentMetaEntry>(offsetno) {
                 data.push((
                     offsetno as i32,
-                    pg_item.1 as i32,
+                    size as i32,
                     entry.visible(snapshot),
                     entry.recyclable(snapshot, heap_relation),
                     JsonB(serde_json::to_value(entry)?),

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -33,7 +33,7 @@ pub unsafe fn list_managed_files(relation_oid: pg_sys::Oid) -> tantivy::Result<H
         let mut offsetno = pg_sys::FirstOffsetNumber;
 
         while offsetno <= max_offset {
-            if let Some(entry) = page.read_item::<SegmentMetaEntry>(offsetno) {
+            if let Some((entry, _)) = page.read_item::<SegmentMetaEntry>(offsetno) {
                 files.extend(entry.get_component_paths());
             }
             offsetno += 1;
@@ -348,7 +348,7 @@ pub unsafe fn load_metas(
         let mut offsetno = pg_sys::FirstOffsetNumber;
 
         while offsetno <= max_offset {
-            if let Some(entry) = page.read_item::<SegmentMetaEntry>(offsetno) {
+            if let Some((entry, _)) = page.read_item::<SegmentMetaEntry>(offsetno) {
                 if (solve_mvcc == MvccSatisfies::Any && !entry.recyclable(snapshot, heap_relation))
                     || entry.visible(snapshot)
                 {

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -188,6 +188,7 @@ impl Default for SegmentMetaEntry {
 // ---------------------------------------------------------
 
 /// Wrapper for pg_sys::Item that also stores its size
+#[derive(Clone)]
 pub struct PgItem(pub pg_sys::Item, pub pg_sys::Size);
 
 impl From<SegmentMetaEntry> for PgItem {

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -170,6 +170,10 @@ impl Page<'_> {
         unsafe { self.pg_page.read_item(offno) }
     }
 
+    pub fn read_pg_item(&self, offno: pg_sys::OffsetNumber) -> Option<PgItem> {
+        unsafe { self.pg_page.read_pg_item(offno) }
+    }
+
     pub fn header(&self) -> &pg_sys::PageHeaderData {
         unsafe { &*(self.pg_page as *const pg_sys::PageHeaderData) }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -166,12 +166,11 @@ impl Page<'_> {
         unsafe { pg_sys::PageGetMaxOffsetNumber(self.pg_page) }
     }
 
-    pub fn read_item<T: From<PgItem>>(&self, offno: pg_sys::OffsetNumber) -> Option<T> {
+    pub fn read_item<T: From<PgItem>>(
+        &self,
+        offno: pg_sys::OffsetNumber,
+    ) -> Option<(T, pg_sys::Size)> {
         unsafe { self.pg_page.read_item(offno) }
-    }
-
-    pub fn read_pg_item(&self, offno: pg_sys::OffsetNumber) -> Option<PgItem> {
-        unsafe { self.pg_page.read_pg_item(offno) }
     }
 
     pub fn header(&self) -> &pg_sys::PageHeaderData {
@@ -231,7 +230,10 @@ impl PageMut<'_> {
         unsafe { pg_sys::PageGetMaxOffsetNumber(self.pg_page) }
     }
 
-    pub fn read_item<T: From<PgItem>>(&self, offno: pg_sys::OffsetNumber) -> Option<T> {
+    pub fn read_item<T: From<PgItem>>(
+        &self,
+        offno: pg_sys::OffsetNumber,
+    ) -> Option<(T, pg_sys::Size)> {
         unsafe { self.pg_page.read_item(offno) }
     }
 
@@ -241,7 +243,7 @@ impl PageMut<'_> {
     ) -> Option<pg_sys::OffsetNumber> {
         let max = self.max_offset_number();
         for offno in pg_sys::FirstOffsetNumber as pg_sys::OffsetNumber..=max {
-            let item = self.read_item::<T>(offno)?;
+            let (item, _) = self.read_item::<T>(offno)?;
             if cmp(item) {
                 return Some(offno);
             }

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -140,7 +140,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
             let mut delete_offsets = vec![];
 
             while offsetno <= max_offset {
-                if let Some(entry) = page.read_item::<T>(offsetno) {
+                if let Some((entry, _)) = page.read_item::<T>(offsetno) {
                     if entry.recyclable(snapshot, heap_relation) {
                         delete_offsets.push(offsetno);
                     } else {
@@ -267,7 +267,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
             let max_offset = page.max_offset_number();
 
             while offsetno <= max_offset {
-                if let Some(deserialized) = page.read_item::<T>(offsetno) {
+                if let Some((deserialized, _)) = page.read_item::<T>(offsetno) {
                     if cmp(&deserialized) {
                         return Ok((deserialized, blockno, offsetno));
                     }

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -24,13 +24,15 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 pub trait BM25Page {
-    unsafe fn read_item<T: From<PgItem>>(&self, offsetno: pg_sys::OffsetNumber) -> Option<T>;
-    unsafe fn read_pg_item(&self, offsetno: pg_sys::OffsetNumber) -> Option<PgItem>;
+    unsafe fn read_item<T: From<PgItem>>(
+        &self,
+        offsetno: pg_sys::OffsetNumber,
+    ) -> Option<(T, pg_sys::Size)>;
     unsafe fn recyclable(self, heap_relation: pg_sys::Relation) -> bool;
 }
 
 impl BM25Page for pg_sys::Page {
-    unsafe fn read_item<T: From<PgItem>>(&self, offno: OffsetNumber) -> Option<T> {
+    unsafe fn read_item<T: From<PgItem>>(&self, offno: OffsetNumber) -> Option<(T, pg_sys::Size)> {
         let item_id = pg_sys::PageGetItemId(*self, offno);
 
         if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
@@ -38,18 +40,8 @@ impl BM25Page for pg_sys::Page {
         }
 
         let item = pg_sys::PageGetItem(*self, item_id);
-        Some(T::from(PgItem(item, (*item_id).lp_len() as pg_sys::Size)))
-    }
-
-    unsafe fn read_pg_item(&self, offno: OffsetNumber) -> Option<PgItem> {
-        let item_id = pg_sys::PageGetItemId(*self, offno);
-
-        if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
-            return None;
-        }
-
-        let item = pg_sys::PageGetItem(*self, item_id);
-        Some(PgItem(item, (*item_id).lp_len() as pg_sys::Size))
+        let size = (*item_id).lp_len() as pg_sys::Size;
+        Some((T::from(PgItem(item, size)), size))
     }
 
     unsafe fn recyclable(self, heap_relation: pg_sys::Relation) -> bool {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Some optimizations around `garbage_collect` in high insert/update scenarios:

1. **Compaction**: If `garbage_collect` renders entire pages in the linked list empty, they should be removed from the linked list (provided it's not the first page in the list). The pointer of the previous node then needs to be rewritten to point to the next non-empty page.
2. **Merge on insert**: Garbage collection now attempts to run during `merge_on_insert` (if a lock can be acquired).

Also introduces `paradedb.storage_info` and `paradedb.page_info`. `storage_info` returns all the blocks in the segment meta linked list and the max offset of each page. `page_info` returns information about every item for a particular block number.

In Stressgres, I'm seeing the linked list never growing beyond one page, and I'm also seeing 500+ TPS for SELECTs on my laptop (before it was around 200 TPS).

## Why

Prevents the linked list size from growing unbounded and decreasing throughput over time.

## How

## Tests
