### PR TITLE
chore: `SegmentMetaEntry` can be `#[derive(Copy)]`

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -262,7 +262,7 @@ pub unsafe fn save_new_metas(
             );
         };
 
-        let PgItem(pg_item, size) = entry.clone().into();
+        let PgItem(pg_item, size) = entry.into();
 
         let did_replace = page.replace_item(offno, pg_item, size);
         assert!(did_replace);
@@ -299,14 +299,14 @@ pub unsafe fn save_new_metas(
             );
         };
 
-        let PgItem(pg_item, size) = entry.clone().into();
+        let PgItem(pg_item, size) = entry.into();
         let did_replace = page.replace_item(offno, pg_item, size);
         if !did_replace {
             // couldn't replace because it doesn't fit in that slot, so delete the item...
             page.delete_item(offno);
 
             // ... and add it to somewhere in the list, starting on this page
-            linked_list.add_items(vec![entry.clone()], Some(buffer))?;
+            linked_list.add_items(vec![entry], Some(buffer))?;
         }
     }
     // chase down the linked lists for any existing deleted entries and mark them as deleted

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -130,14 +130,14 @@ pub trait LinkedList {
 // ---------------------------------------------------------
 
 /// Metadata for tracking where to find a file
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FileEntry {
     pub staring_block: pg_sys::BlockNumber,
     pub total_bytes: usize,
 }
 
 /// Metadata for tracking where to find a ".del" file
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DeleteEntry {
     pub file_entry: FileEntry,
     pub num_deleted_docs: u32,
@@ -145,7 +145,7 @@ pub struct DeleteEntry {
 }
 
 /// Metadata for tracking alive segments
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SegmentMetaEntry {
     pub segment_id: SegmentId,
     pub max_doc: u32,
@@ -163,6 +163,7 @@ pub struct SegmentMetaEntry {
     pub delete: Option<DeleteEntry>,
 }
 
+#[cfg(any(test, feature = "pg_test"))]
 impl Default for SegmentMetaEntry {
     fn default() -> Self {
         Self {
@@ -407,7 +408,7 @@ impl MVCCEntry for SegmentMetaEntry {
             } else {
                 self.xmax
             },
-            ..self.clone()
+            ..self
         }
     }
 }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -441,15 +441,13 @@ mod tests {
         assert!(xmin_needs_freeze);
         assert!(!xmax_needs_freeze);
 
-        let frozen_segment = segment
-            .clone()
-            .into_frozen(xmin_needs_freeze, xmax_needs_freeze);
+        let frozen_segment = segment.into_frozen(xmin_needs_freeze, xmax_needs_freeze);
 
         assert_eq!(
             frozen_segment,
             SegmentMetaEntry {
                 xmin: pg_sys::FrozenTransactionId,
-                ..segment.clone()
+                ..segment
             }
         );
     }

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -313,10 +313,10 @@ mod tests {
         list.garbage_collect(strategy).unwrap();
 
         assert!(list
-            .lookup(|entry| entry.segment_id == entries_to_delete[0].clone().segment_id)
+            .lookup(|entry| entry.segment_id == entries_to_delete[0].segment_id)
             .is_err());
         assert!(list
-            .lookup(|entry| entry.segment_id == entries_to_keep[0].clone().segment_id)
+            .lookup(|entry| entry.segment_id == entries_to_keep[0].segment_id)
             .is_ok());
     }
 
@@ -365,13 +365,9 @@ mod tests {
 
             for entry in entries {
                 if entry.xmax == not_deleted_xid {
-                    assert!(list
-                        .lookup(|el| el.segment_id == entry.clone().segment_id)
-                        .is_ok());
+                    assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_ok());
                 } else {
-                    assert!(list
-                        .lookup(|el| el.segment_id == entry.clone().segment_id)
-                        .is_err());
+                    assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_err());
                 }
             }
         }
@@ -417,13 +413,9 @@ mod tests {
             for entries in [entries_1, entries_2, entries_3] {
                 for entry in entries {
                     if entry.xmax == not_deleted_xid {
-                        assert!(list
-                            .lookup(|el| el.segment_id == entry.clone().segment_id)
-                            .is_ok());
+                        assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_ok());
                     } else {
-                        assert!(list
-                            .lookup(|el| el.segment_id == entry.clone().segment_id)
-                            .is_err());
+                        assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_err());
                     }
                 }
             }


### PR DESCRIPTION
Derive `Copy` for `SegmentMetaEntry` and tighten up the necessary derives for `FileEntry` and `DeleteEntry` while we're here.

Also, the `impl Default for SegmentMetaEntry` is only necessary for tests.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
