### PR TITLE
feat: Optimize writing to be exactly `bm25_max_free_space()` bytes

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -53,7 +53,9 @@ pub fn save_schema(
     let mut schema = LinkedBytesList::open(relation_oid, SCHEMA_START, need_wal);
     if schema.is_empty() {
         let bytes = serde_json::to_vec(tantivy_schema)?;
-        unsafe { schema.write(&bytes)? };
+        unsafe {
+            let _ = schema.write(&bytes)?;
+        }
     }
     Ok(())
 }
@@ -66,7 +68,9 @@ pub fn save_settings(
     let mut settings = LinkedBytesList::open(relation_oid, SETTINGS_START, need_wal);
     if settings.is_empty() {
         let bytes = serde_json::to_vec(tantivy_settings)?;
-        unsafe { settings.write(&bytes)? };
+        unsafe {
+            let _ = settings.write(&bytes)?;
+        }
     }
     Ok(())
 }

--- a/pg_search/src/index/writer/channel.rs
+++ b/pg_search/src/index/writer/channel.rs
@@ -4,7 +4,6 @@ use std::io::{Result, Write};
 use std::path::{Path, PathBuf};
 use tantivy::directory::{AntiCallToken, TerminatingWrite};
 
-#[derive(Clone, Debug)]
 pub struct ChannelWriter {
     path: PathBuf,
     sender: Sender<ChannelRequest>,

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -1,4 +1,4 @@
-use crate::postgres::storage::block::FileEntry;
+use crate::postgres::storage::block::{bm25_max_free_space, FileEntry};
 use crate::postgres::storage::LinkedBytesList;
 use crate::postgres::NeedWal;
 use pgrx::*;
@@ -6,13 +6,11 @@ use std::io::{Result, Write};
 use std::path::{Path, PathBuf};
 use tantivy::directory::{AntiCallToken, TerminatingWrite};
 
-#[derive(Clone, Debug)]
 pub struct SegmentComponentWriter {
-    relation_oid: pg_sys::Oid,
     path: PathBuf,
-    need_wal: NeedWal,
     header_blockno: pg_sys::BlockNumber,
     total_bytes: usize,
+    buffer: ExactBuffer<{ bm25_max_free_space() }, LinkedBytesList>,
 }
 
 impl SegmentComponentWriter {
@@ -20,11 +18,14 @@ impl SegmentComponentWriter {
         let segment_component = LinkedBytesList::create(relation_oid, need_wal);
 
         Self {
-            relation_oid,
             path: path.to_path_buf(),
-            need_wal,
             header_blockno: segment_component.header_blockno,
             total_bytes: 0,
+            buffer: ExactBuffer {
+                writer: segment_component,
+                buffer: [0; bm25_max_free_space()],
+                len: 0,
+            },
         }
     }
 
@@ -42,15 +43,13 @@ impl SegmentComponentWriter {
 
 impl Write for SegmentComponentWriter {
     fn write(&mut self, data: &[u8]) -> Result<usize> {
-        let mut segment_component =
-            LinkedBytesList::open(self.relation_oid, self.header_blockno, self.need_wal);
-        unsafe { segment_component.write(data).expect("write should succeed") };
+        let many = self.buffer.write(data)?;
         self.total_bytes += data.len();
-        Ok(data.len())
+        Ok(many)
     }
 
     fn flush(&mut self) -> Result<()> {
-        Ok(())
+        self.buffer.flush()
     }
 }
 
@@ -58,6 +57,73 @@ impl TerminatingWrite for SegmentComponentWriter {
     fn terminate_ref(&mut self, _: AntiCallToken) -> Result<()> {
         // this is a no-op -- the FileEntry for this segment component
         // is handled through Directory::save_meta()
+        Ok(())
+    }
+}
+
+/// Similar to `[std::io::BufWriter]` except it only writes in increments of the `const CAPACITY: usize`
+/// capacity.  Except on `flush()` where any remaining bytes are written.
+struct ExactBuffer<const CAPACITY: usize, W: Write> {
+    writer: W,
+    buffer: [u8; CAPACITY],
+    len: usize,
+}
+
+impl<const CAPACITY: usize, W: Write> Drop for ExactBuffer<CAPACITY, W> {
+    fn drop(&mut self) {
+        self.flush().ok();
+    }
+}
+
+impl<const CAPACITY: usize, W: Write> Write for ExactBuffer<CAPACITY, W> {
+    fn write(&mut self, mut data: &[u8]) -> Result<usize> {
+        let len = data.len();
+
+        let mut end = len;
+        if self.len < CAPACITY {
+            // fill the buffer with what we can
+            end = (CAPACITY - self.len).min(end);
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    data.as_ptr(),
+                    self.buffer.as_mut_ptr().add(self.len),
+                    end,
+                );
+            }
+            self.len += end;
+            data = &data[end..];
+        }
+
+        if self.len == CAPACITY {
+            // buffer is full -- write it out
+            let _ = self.writer.write(&self.buffer)?;
+            self.len = 0;
+        }
+
+        while data.len() >= CAPACITY {
+            // data has at least as many bytes as our capacity
+            // write it out in chunks of our capacity, to avoid copying it into the buffer
+            end = CAPACITY;
+            let _ = self.writer.write(&data[..end])?;
+            data = &data[end..];
+        }
+
+        if !data.is_empty() {
+            // copy the rest to our buffer -- it'll fit
+            unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), self.buffer.as_mut_ptr(), data.len());
+                self.len = data.len();
+            }
+        }
+
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        if !self.buffer.is_empty() {
+            let _ = self.writer.write(&self.buffer[0..self.len])?;
+            self.len = 0;
+        }
         Ok(())
     }
 }

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -662,7 +662,7 @@ impl From<SearchFieldConfig> for DateOptions {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SearchField {
     /// The id of the field, stored in the index.
     pub id: SearchFieldId,


### PR DESCRIPTION
Writing to block storage would prefer we do it 1 full block at a time, rather than partially filling a block.  Rust's `std::io::BufWriter` is incompatabile with this desire, as it will write everything through if the new set of bytes doesn't fit in the buffer.

We implement our own `ExactBuffer` that keeps a buffer of exactly `bm25_max_free_space()` bytes and will write through only in chunks of that size, if necessary.

Unrelated, during `ambuild()` and `aminsert()`'s initialization, we go walk the `TupleDescriptor` and `SearchIndexSchema` **once** to categorize the fields to be indexed, rather than doing that on every row being inserted.

Combined, these two changes nearly double the indexing records-per-second rate of a large dataset.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
