### PR TITLE
ci: Build Docker Dev

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -129,6 +129,12 @@ jobs:
             exit 1
           fi
 
+      # If we modified the Docker image as part of this PR, we push a test image, 17-0.0.0, to
+      # Docker Hub to enable convenient testing with the ParadeDB Helm Chart.
+      - name: Push `dev` Docker Image to Docker Hub (dev only)
+        if: steps.env.outputs.environment == 'dev'
+        run: docker push paradedb/paradedb:17-0.0.0
+
   # Only run this job on the `main` branch since it requires access to GitHub Secrets, which
   # community contributors don't have access to.
   test-paradedb-helm-chart:

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -130,10 +130,13 @@ jobs:
           fi
 
       # If we modified the Docker image as part of this PR, we push a test image, 17-0.0.0, to
-      # Docker Hub to enable convenient testing with the ParadeDB Helm Chart.
+      # Docker Hub to enable convenient testing with the ParadeDB Helm Chart. We simply re-tag
+      # the image with our test tag and only push that tag.
       - name: Push `dev` Docker Image to Docker Hub (dev only)
         if: steps.env.outputs.environment == 'dev'
-        run: docker push paradedb/paradedb:17-0.0.0
+        run: |
+          docker tag paradedb/paradedb:latest paradedb/paradedb:17-0.0.0
+          docker push paradedb/paradedb:17-0.0.0
 
   # Only run this job on the `main` branch since it requires access to GitHub Secrets, which
   # community contributors don't have access to.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We want to easily test the dev branch with CNPG before pushing to main. This branch makes us push a test tag, 17-0.0.0, so it doesn’t mess with real tags, to Docker Hub as part of arbitrary PRs. This should enable us to easily test dev, and even any PR, with CNPG manually without needing to build the Docker image.

the main caveat is that different PRs will overwrite the tag, so if two people want to test at once it might cause issues, but for now this is fine and we’ll build a more complex test tagging system if it comes to be needed.

## Why
^

## How
^

## Tests
CI :)