### PR TITLE
fix: doc example for "phrase" query

### DIFF
--- a/docs/documentation/advanced/phrase/phrase.mdx
+++ b/docs/documentation/advanced/phrase/phrase.mdx
@@ -20,7 +20,7 @@ WHERE id @@@
 '{
     "phrase": {
         "field": "description",
-        "values": ["running", "shoes"]
+        "phrases": ["running", "shoes"]
     }
 }'::jsonb;
 ```
@@ -57,7 +57,7 @@ WHERE id @@@
 '{
     "phrase": {
         "field": "description",
-        "values": ["sleek", "shoes"],
+        "phrases": ["sleek", "shoes"],
         "slop": 1
     }
 }'::jsonb;

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -968,7 +968,46 @@ fn phrase_level_queries(mut conn: PgConnection) {
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
     FROM mock_items
-    WHERE id @@@ paradedb.phrase('description', ARRAY['running', 'shoes'])
+    WHERE id @@@ paradedb.phrase(
+        field => 'description',
+        phrases => ARRAY['running', 'shoes']
+    )"#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+
+    let rows: Vec<(String, i32, String)> = r#"
+    SELECT description, rating, category
+    FROM mock_items
+    WHERE id @@@
+    '{
+        "phrase": {
+            "field": "description",
+            "phrases": ["running", "shoes"]
+        }
+    }'::jsonb;
+    "#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+
+    let rows: Vec<(String, i32, String)> = r#"
+    SELECT description, rating, category
+    FROM mock_items
+    WHERE id @@@ paradedb.phrase('description', ARRAY['sleek', 'shoes'], slop => 1);
+    "#
+    .fetch(&mut conn);
+    assert_eq!(rows.len(), 1);
+
+    let rows: Vec<(String, i32, String)> = r#"
+    SELECT description, rating, category
+    FROM mock_items
+    WHERE id @@@
+    '{
+        "phrase": {
+            "field": "description",
+            "phrases": ["sleek", "shoes"],
+            "slop": 1
+        }
+    }'::jsonb;
     "#
     .fetch(&mut conn);
     assert_eq!(rows.len(), 1);


### PR DESCRIPTION
# Ticket(s) Close

- Closes #2036

## What

Fixed the docs for the `Phrase` query, which incorrectly uses the named parameter `values` in the example (even though the parameter list is correct). Our test was using the positional call style, so it didn't reflect this inconsistency.

## Tests

Added a couple new test cases.
