### PR TITLE
fix: Use the primary postgres pg_ctl path rather than the system pg_ctl path in replication test

### DIFF
--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -529,8 +529,9 @@ async fn test_physical_streaming_replication() -> Result<()> {
     // Reconfigure primary to require synchronous replication
     // This ensures commits wait for replication confirmation.
     "ALTER SYSTEM SET synchronous_standby_names = '*';".execute(&mut primary_conn);
+    let pg_ctl_path = primary_postgres.pg_ctl_path.clone();
     let tempdir_path = primary_postgres.tempdir_path.clone();
-    run_cmd!(pg_ctl -D $tempdir_path restart &> /dev/null)
+    run_cmd!($pg_ctl_path -D $tempdir_path restart &> /dev/null)
         .expect("Failed to restart primary with sync config");
 
     // Reconnect after restart


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2044 

## What

Fixing the newly added physical streaming replication test to use the environment's appropriate `pg_ctl` binary and not relying on one being available in the system PATH.

## Why

Portable tests, and it's clear that the intention was to do this when the tests were written.

## How

Use the primary ephemeral postgres instance's `pg_ctl` path instead of one in the system PATH.

## Tests

This is fixing a broken test.