### PR TITLE
feat: Add support for indexing domain types (#2009)

### DIFF
--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -587,3 +587,167 @@ fn custom_enum_parse(mut conn: PgConnection) {
 
     assert_eq!(rows, vec![(1, "Item 1".into())]);
 }
+
+#[rstest]
+fn domain_types(mut conn: PgConnection) {
+    // Create domain types for all of the built-in types pg_search supports.
+    r#"
+    CREATE DOMAIN nonemptytext AS text CHECK (VALUE <> '');
+    CREATE DOMAIN nonemptyvarchar AS varchar CHECK (VALUE <> '');
+    CREATE DOMAIN nonemptyuuid AS uuid CHECK (VALUE IS NOT NULL);
+    CREATE DOMAIN possmallint AS smallint CHECK (VALUE > 0);
+    CREATE DOMAIN posint AS integer CHECK (VALUE > 0);
+    CREATE DOMAIN posbigint AS bigint CHECK (VALUE > 0);
+    CREATE DOMAIN posreal AS real CHECK (VALUE > 0);
+    CREATE DOMAIN posdouble AS double precision CHECK (VALUE > 0);
+    CREATE DOMAIN posnumeric AS numeric CHECK (VALUE > 0);
+    CREATE DOMAIN trueboolean AS boolean CHECK (VALUE = TRUE);
+    CREATE DOMAIN nonemptyjsonbarray AS jsonb CHECK (jsonb_typeof(VALUE) = 'array' AND jsonb_array_length(VALUE) > 0);
+    CREATE DOMAIN nonemptyjsonarray AS json CHECK (json_typeof(VALUE) = 'array' AND json_array_length(VALUE) > 0);
+    CREATE DOMAIN posint4range AS int4range CHECK (lower(VALUE) > 0);
+    CREATE DOMAIN posint8range AS int8range CHECK (lower(VALUE) > 0);
+    CREATE DOMAIN posnumrange as numrange CHECK (lower(VALUE) > 0.0);
+    CREATE DOMAIN daterange2025 as daterange CHECK (date_part('year', lower(VALUE)) = 2025 and date_part('year', upper(VALUE)) = 2025);
+    CREATE DOMAIN tsrange2025 as tsrange CHECK (date_part('year', lower(VALUE)) = 2025 and date_part('year', upper(VALUE)) = 2025);
+    CREATE DOMAIN tstzrange2025 as tstzrange CHECK (date_part('year', lower(VALUE)) = 2025 and date_part('year', upper(VALUE)) = 2025);
+    CREATE DOMAIN date2025 as date CHECK (date_part('year', VALUE) = 2025 and date_part('year', VALUE) = 2025);
+    CREATE DOMAIN ts2025 as timestamp CHECK (date_part('year', VALUE) = 2025 and date_part('year', VALUE) = 2025);
+    CREATE DOMAIN tstz2025 as timestamptz CHECK (date_part('year', VALUE) = 2025 and date_part('year', VALUE) = 2025);
+    CREATE DOMAIN noon as time CHECK (date_part('hour', VALUE) = 12);
+    CREATE DOMAIN noontz as timetz CHECK (date_part('hour', VALUE) = 12);
+    "#
+    .execute(&mut conn);
+
+    // Create a table containing all of the domain types in its schema and index them all.
+    r#"
+    CREATE TABLE paradedb.index_config(
+        id INTEGER,
+        n1 nonemptytext,
+        n2 nonemptyvarchar,
+        n3 nonemptyuuid,
+        n4 possmallint,
+        n5 posint,
+        n6 posbigint,
+        n7 posreal,
+        n8 posdouble,
+        n9 posnumeric,
+        n10 trueboolean,
+        n11 nonemptyjsonbarray,
+        n12 nonemptyjsonarray,
+        n13 posint4range,
+        n14 posint8range,
+        n15 posnumrange,
+        n16 daterange2025,
+        n17 tsrange2025,
+        n18 tstzrange2025,
+        n19 date2025,
+        n20 ts2025,
+        n21 tstz2025,
+        n22 noon,
+        n23 noontz
+    );
+
+    INSERT INTO paradedb.index_config VALUES
+    (1, 'Item 1', 'Item 1', '11111111-1111-1111-1111-111111111111', 1, 1, 1, 1, 1, 1, TRUE, '[1, 2, 3]'::json, '[1, 2, 3]'::jsonb, '[1, 3]'::int4range, '[1, 3]'::int8range, '[1.0, 3.0]'::numrange, '[2025-01-01, 2025-01-31]'::daterange, '[2025-01-01, 2025-01-31]'::tsrange, '[2025-01-01, 2025-01-31]'::tstzrange, '2025-01-01'::date, '2025-01-01'::timestamp, '2025-01-01'::timestamptz, '12:01:00'::time, '12:01:00'::timetz),
+    (2, 'Item 2', 'Item 2', '22222222-2222-2222-2222-222222222222', 2, 2, 2, 2, 2, 2, TRUE, '[2, 3, 4]'::json, '[2, 3, 4]'::jsonb, '[2, 4]'::int4range, '[2, 4]'::int8range, '[2.0, 4.0]'::numrange, '[2025-02-01, 2025-02-28]'::daterange, '[2025-02-01, 2025-02-28]'::tsrange, '[2025-02-01, 2025-02-28]'::tstzrange, '2025-02-01'::date, '2025-02-01'::timestamp, '2025-02-01'::timestamptz, '12:02:00'::time, '12:02:00'::timetz),
+    (3, 'Item 3', 'Item 3', '33333333-3333-3333-3333-333333333333', 3, 3, 3, 3, 3, 3, TRUE, '[3, 4, 5]'::json, '[3, 4, 5]'::jsonb, '[3, 5]'::int4range, '[3, 5]'::int8range, '[3.0, 5.0]'::numrange, '[2025-03-01, 2025-03-31]'::daterange, '[2025-03-01, 2025-03-31]'::tsrange, '[2025-03-01, 2025-03-31]'::tstzrange, '2025-03-01'::date, '2025-03-01'::timestamp, '2025-03-01'::timestamptz, '12:03:00'::time, '12:03:00'::timetz);
+
+    CREATE INDEX index_config_index ON paradedb.index_config
+    USING bm25 (id, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, n16, n17, n18, n19, n20, n21, n22, n23)
+    WITH (key_field='id');
+    "#
+    .execute(&mut conn);
+
+    // Ensure all domain type values are indexed and queryable as expected.
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n1 @@@ 'Item 2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n2 @@@ 'Item 2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n3 @@@ '22222222' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n4 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n5 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n6 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n7 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n8 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n9 @@@ '2' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(2,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n10 @@@ 'true' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(1,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n11 @@@ '5' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n12 @@@ '5' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n13', 5) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n14', 5) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n15', 5.0) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n16', '2025-03-01'::date) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n17', '2025-03-01'::timestamp) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE id @@@ paradedb.range_term('n18', '2025-03-01'::timestamptz) ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n19 @@@ '\"2025-03-01T00:00:00Z\"' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n20 @@@ '\"2025-03-01T00:00:00Z\"' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n21 @@@ '\"2025-03-01T00:00:00Z\"' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n22 @@@ '\"1970-01-01T12:03:00Z\"' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM paradedb.index_config WHERE n23 @@@ '\"1970-01-01T12:03:00Z\"' ORDER BY paradedb.score(id) DESC LIMIT 1".fetch(&mut conn);
+    assert_eq!(rows, vec![(3,)]);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2009

## What

Adding support for indexing user-defined domain types.

## Why

Feature request in #2009. So users can create domain types with their own constraints defined at the type-level, and have those types be able to participate in pg_search's capabilities, as long as the underlying type is one pg_search supports.

## How

Both during schema validation and converting to underlying tantivy values, we check custom OIDs to see if they are compatible/coercible to a supported built-in type, and if so, treat the custom type as if it were the built-in type accordingly.

## Tests

Extended the index_config tests with a test that explores all of the pg_search supported types and ensures an equivalent domain type can both be indexed and queried.
