### PR TITLE
fix: mis-aligned params for building ES index in cargo-paradedb

### DIFF
--- a/cargo-paradedb/src/main.rs
+++ b/cargo-paradedb/src/main.rs
@@ -80,9 +80,9 @@ fn main() -> Result<()> {
                     url,
                     elastic_url,
                 } => block_on(subcommand::bench_eslogs_build_elastic_table(
+                    elastic_url,
                     url,
                     table,
-                    elastic_url,
                 )),
                 EsLogsCommand::QueryElasticIndex {
                     elastic_url,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

```rust
pub async fn bench_eslogs_build_elastic_table(
    elastic_url: String,
    postgres_url: String,
    table: String,
) -> Result<()> {
```

However, the caller is:

```rust
EsLogsCommand::BuildElasticIndex {
    table,
    url,
    elastic_url,
} => block_on(subcommand::bench_eslogs_build_elastic_table(
    url,
    table,
    elastic_url,
)),
```

## How

## Tests
