### PR TITLE
fix: use `heap_fetch` instead of `Spi` for snippets

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -105,7 +105,7 @@ impl WriterResources {
                     gucs::statement_memory_budget(),
                     merge_on_insert, // user/index decides if we merge for INSERT/UPDATE statements
                     policy,
-                    true, // regular statements do need WAL support
+                    false, // regular statements do need WAL support
                 )
             }
             WriterResources::Vacuum => {
@@ -114,7 +114,7 @@ impl WriterResources {
                     gucs::statement_memory_budget(),
                     true, // we always want a merge on (auto)VACUUM
                     AllowedMergePolicy::NPlusOne(target_segment_count),
-                    true, // VACUUM always needs WAL support
+                    false, // VACUUM always needs WAL support
                 )
             }
         }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -631,12 +631,9 @@ impl CustomScan for PdbScan {
                                     for (snippet_info, const_snippet_node) in
                                         &state.custom_state().const_snippet_nodes
                                     {
-                                        if let Some(snippet) = state.custom_state().make_snippet(
-                                            state.custom_state().heaprel_namespace(),
-                                            state.custom_state().heaprelname(),
-                                            ctid,
-                                            snippet_info,
-                                        ) {
+                                        if let Some(snippet) =
+                                            state.custom_state().make_snippet(ctid, snippet_info)
+                                        {
                                             (**const_snippet_node).constvalue =
                                                 snippet.into_datum().unwrap();
                                             (**const_snippet_node).constisnull = false;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Fixes an edge case where `Spi` will fail if called from a parallel worker.

## Why

## How

## Tests
