### PR TITLE
feat: bring parallel custom scans to community

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,6 +3174,7 @@ dependencies = [
  "derive_more",
  "fixture",
  "humansize",
+ "itertools 0.14.0",
  "json5",
  "libc",
  "memoffset",
@@ -3175,6 +3185,7 @@ dependencies = [
  "parking_lot",
  "pgrx",
  "pgrx-tests",
+ "rayon",
  "reqwest 0.11.27",
  "rstest 0.23.0",
  "rustc-hash",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4.38"
 crossbeam = "0.8.4"
 derive_more = "0.99.18"
 humansize = "2.1.3"
+itertools = "0.14.0"
 json5 = "0.4.1"
 libc = "0.2.158"
 memoffset = "0.9.1"
@@ -33,6 +34,7 @@ os_info = { version = "3", default-features = false }
 parking_lot = "0.12.3"
 tokenizers = { path = "../tokenizers" }
 pgrx = { git = "https://github.com/paradedb/pgrx.git", rev = "f251f1e" }
+rayon = "1.10.0"
 reqwest = { version = "0.11.27", features = ["blocking"] }
 rustc-hash = "1.1.0"
 serde = "1.0.210"

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -279,6 +279,34 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
         self
     }
 
+    pub fn set_parallel(
+        mut self,
+        is_topn: bool,
+        row_estimate: Cardinality,
+        limit: Option<Cardinality>,
+        segment_count: usize,
+    ) -> Self {
+        unsafe {
+            // all non-topN/limit queries can do parallel
+            if !is_topn && limit.is_none() {
+                // we will try to parallelize based on the number of index segments
+                let nworkers = segment_count.min(pg_sys::max_parallel_workers as usize);
+
+                if nworkers > 0
+                    && row_estimate > (nworkers * nworkers) as f64
+                    && (*self.args.rel).consider_parallel
+                {
+                    self.custom_path_node.path.parallel_aware = true;
+                    self.custom_path_node.path.parallel_safe = true;
+                    self.custom_path_node.path.parallel_workers =
+                        nworkers.try_into().expect("nworkers should be a valid i32");
+                }
+            }
+
+            self
+        }
+    }
+
     pub fn build(mut self) -> pg_sys::CustomPath {
         self.custom_path_node.custom_paths = self.custom_paths.into_pg();
         self.custom_path_node.custom_private = self.custom_private.into();

--- a/pg_search/src/postgres/customscan/dsm.rs
+++ b/pg_search/src/postgres/customscan/dsm.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
+use crate::postgres::customscan::exec::{
+    begin_custom_scan, end_custom_scan, exec_custom_scan, explain_custom_scan, rescan_custom_scan,
+    shutdown_custom_scan,
+};
+use crate::postgres::customscan::{wrap_custom_scan_state, CustomScan, ExecMethod};
+use pgrx::{pg_guard, pg_sys, PgMemoryContexts};
+
+pub trait ParallelQueryCapable: ExecMethod
+where
+    Self: CustomScan,
+{
+    fn exec_methods() -> *const pg_sys::CustomExecMethods {
+        unsafe {
+            static mut METHODS: *mut pg_sys::CustomExecMethods = std::ptr::null_mut();
+
+            if METHODS.is_null() {
+                METHODS = PgMemoryContexts::TopMemoryContext.leak_and_drop_on_delete(
+                    pg_sys::CustomExecMethods {
+                        CustomName: Self::NAME.as_ptr(),
+                        BeginCustomScan: Some(begin_custom_scan::<Self>),
+                        ExecCustomScan: Some(exec_custom_scan::<Self>),
+                        EndCustomScan: Some(end_custom_scan::<Self>),
+                        ReScanCustomScan: Some(rescan_custom_scan::<Self>),
+                        MarkPosCustomScan: None,
+                        RestrPosCustomScan: None,
+                        EstimateDSMCustomScan: Some(estimate_dsm_custom_scan::<Self>),
+                        InitializeDSMCustomScan: Some(initialize_dsm_custom_scan::<Self>),
+                        ReInitializeDSMCustomScan: Some(reinitialize_dsm_custom_scan::<Self>),
+                        InitializeWorkerCustomScan: Some(initialize_worker_custom_scan::<Self>),
+                        ShutdownCustomScan: Some(shutdown_custom_scan::<Self>),
+                        ExplainCustomScan: Some(explain_custom_scan::<Self>),
+                    },
+                );
+            }
+            METHODS
+        }
+    }
+
+    fn estimate_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+    ) -> pg_sys::Size;
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut std::os::raw::c_void,
+    );
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut std::os::raw::c_void,
+    );
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        toc: *mut pg_sys::shm_toc,
+        coordinate: *mut std::os::raw::c_void,
+    );
+}
+
+/// Estimate the amount of dynamic shared memory that will be required for parallel operation. This
+/// may be higher than the amount that will actually be used, but it must not be lower. The return
+/// value is in bytes. This callback is optional, and need only be supplied if this custom scan
+/// provider supports parallel execution.
+#[pg_guard]
+pub extern "C" fn estimate_dsm_custom_scan<CS: CustomScan + ParallelQueryCapable>(
+    node: *mut pg_sys::CustomScanState,
+    pcxt: *mut pg_sys::ParallelContext,
+) -> pg_sys::Size {
+    let mut custom_state = wrap_custom_scan_state::<CS>(node);
+    unsafe { CS::estimate_dsm_custom_scan(custom_state.as_mut(), pcxt) }
+}
+
+/// Initialize the dynamic shared memory that will be required for parallel operation. coordinate
+/// points to a shared memory area of size equal to the return value of EstimateDSMCustomScan. This
+/// callback is optional, and need only be supplied if this custom scan provider supports parallel
+/// execution.
+#[pg_guard]
+pub extern "C" fn initialize_dsm_custom_scan<CS: CustomScan + ParallelQueryCapable>(
+    node: *mut pg_sys::CustomScanState,
+    pcxt: *mut pg_sys::ParallelContext,
+    coordinate: *mut std::os::raw::c_void,
+) {
+    let mut custom_state = wrap_custom_scan_state::<CS>(node);
+    unsafe { CS::initialize_dsm_custom_scan(custom_state.as_mut(), pcxt, coordinate) }
+}
+
+/// Re-initialize the dynamic shared memory required for parallel operation when the custom-scan
+/// plan node is about to be re-scanned. This callback is optional, and need only be supplied if
+/// this custom scan provider supports parallel execution. Recommended practice is that this callback
+/// reset only shared state, while the ReScanCustomScan callback resets only local state. Currently,
+/// this callback will be called before ReScanCustomScan, but it's best not to rely on that ordering.
+#[pg_guard]
+pub extern "C" fn reinitialize_dsm_custom_scan<CS: CustomScan + ParallelQueryCapable>(
+    node: *mut pg_sys::CustomScanState,
+    pcxt: *mut pg_sys::ParallelContext,
+    coordinate: *mut std::os::raw::c_void,
+) {
+    let mut custom_state = wrap_custom_scan_state::<CS>(node);
+    unsafe { CS::reinitialize_dsm_custom_scan(custom_state.as_mut(), pcxt, coordinate) }
+}
+
+/// Initialize a parallel worker's local state based on the shared state set up by the leader during
+/// InitializeDSMCustomScan. This callback is optional, and need only be supplied if this custom scan
+/// provider supports parallel execution.
+#[pg_guard]
+pub extern "C" fn initialize_worker_custom_scan<CS: CustomScan + ParallelQueryCapable>(
+    node: *mut pg_sys::CustomScanState,
+    toc: *mut pg_sys::shm_toc,
+    coordinate: *mut std::os::raw::c_void,
+) {
+    let mut custom_state = wrap_custom_scan_state::<CS>(node);
+    unsafe { CS::initialize_worker_custom_scan(custom_state.as_mut(), toc, coordinate) }
+}

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -24,6 +24,7 @@ use pgrx::{pg_sys, PgMemoryContexts};
 use std::ffi::CStr;
 
 mod builders;
+mod dsm;
 mod exec;
 mod hook;
 mod path;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+pub(crate) mod fast_fields;
 pub(crate) mod normal;
 pub(crate) mod top_n;
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -1,0 +1,355 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+pub mod numeric;
+pub mod string;
+
+use crate::index::fast_fields_helper::{FFHelper, FastFieldType, WhichFastField};
+use crate::index::reader::index::{SearchIndexReader, SearchResults};
+use crate::index::BlockDirectoryType;
+use crate::nodecast;
+use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
+use crate::postgres::customscan::builders::custom_state::{
+    CustomScanStateBuilder, CustomScanStateWrapper,
+};
+use crate::postgres::customscan::explainer::Explainer;
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::numeric::NumericFastFieldExecState;
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::string::StringFastFieldExecState;
+use crate::postgres::customscan::pdbscan::exec_methods::normal::NormalScanExecState;
+use crate::postgres::customscan::pdbscan::privdat::PrivateData;
+use crate::postgres::customscan::pdbscan::projections::score::{score_funcoid, uses_scores};
+use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
+use crate::postgres::customscan::pdbscan::PdbScan;
+use crate::postgres::customscan::CustomScanState;
+use crate::schema::SearchIndexSchema;
+use itertools::Itertools;
+use pgrx::{pg_sys, IntoDatum, PgList, PgOid, PgRelation, PgTupleDesc};
+use tantivy::DocAddress;
+
+pub struct FastFieldExecState {
+    heaprel: pg_sys::Relation,
+    tupdesc: Option<PgTupleDesc<'static>>,
+
+    ffhelper: FFHelper,
+
+    slot: *mut pg_sys::TupleTableSlot,
+    strbuf: String,
+    vmbuff: pg_sys::Buffer,
+    which_fast_fields: Vec<WhichFastField>,
+    search_results: SearchResults,
+
+    did_query: bool,
+}
+
+impl Drop for FastFieldExecState {
+    fn drop(&mut self) {
+        unsafe {
+            if pg_sys::IsTransactionState()
+                && self.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
+            {
+                pg_sys::ReleaseBuffer(self.vmbuff);
+            }
+        }
+    }
+}
+
+impl FastFieldExecState {
+    pub fn new(which_fast_fields: Vec<WhichFastField>) -> Self {
+        Self {
+            heaprel: std::ptr::null_mut(),
+            tupdesc: None,
+
+            ffhelper: Default::default(),
+            slot: std::ptr::null_mut(),
+            strbuf: String::with_capacity(256),
+            vmbuff: pg_sys::InvalidBuffer as pg_sys::Buffer,
+            which_fast_fields,
+            search_results: Default::default(),
+            did_query: false,
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn ff_to_datum(
+    which_fast_field: (&WhichFastField, usize),
+    typid: pg_sys::Oid,
+    score: f32,
+    doc_address: DocAddress,
+    ff_helper: &mut FFHelper,
+    strbuf: &mut String,
+    slot: *const pg_sys::TupleTableSlot,
+) -> Option<pg_sys::Datum> {
+    let field_index = which_fast_field.1;
+    let which_fast_field = which_fast_field.0;
+
+    if typid == pg_sys::INT2OID || typid == pg_sys::INT4OID || typid == pg_sys::INT8OID {
+        match ff_helper.i64(field_index, doc_address) {
+            None => None,
+            Some(v) => v.into_datum(),
+        }
+    } else if matches!(which_fast_field, WhichFastField::Ctid) {
+        (*slot).tts_tid.into_datum()
+    } else if matches!(which_fast_field, WhichFastField::TableOid) {
+        (*slot).tts_tableOid.into_datum()
+    } else if matches!(which_fast_field, WhichFastField::Score) {
+        score.into_datum()
+    } else if matches!(
+        which_fast_field,
+        WhichFastField::Named(_, FastFieldType::String)
+    ) {
+        strbuf.as_str().into_datum()
+    } else if typid == pg_sys::TEXTOID || typid == pg_sys::VARCHAROID {
+        // NB:  we don't actually support text-based fast fields... yet
+        // but if we did, we'd want to do it this way
+        ff_helper
+            .string(field_index, doc_address, strbuf)
+            .and_then(|s| strbuf.as_str().into_datum())
+    } else {
+        match ff_helper.value(field_index, doc_address) {
+            None => None,
+            Some(value) => value
+                .try_into_datum(PgOid::from_untagged(typid))
+                .expect("value should be convertible to Datum"),
+        }
+    }
+}
+
+/// Count how many "fast fields" are requested to be used by the query, as described by the `builder` argument.
+pub unsafe fn count(
+    builder: &mut CustomPathBuilder<PrivateData>,
+    rti: pg_sys::Index,
+    table: &PgRelation,
+    schema: &SearchIndexSchema,
+    target_list: *mut pg_sys::List,
+) -> f64 {
+    let ff = pullup_fast_fields(target_list, schema, table, rti).unwrap_or_default();
+
+    builder.custom_private().set_maybe_ff(!ff.is_empty());
+    ff.iter().sorted().dedup().count() as f64
+}
+
+/// Find all the fields that can be as "fast fields", categorize them as [`WhichFastField`]s, and
+/// return the list.  If there are none, or one or more of the fields can't be used as a "fast field",
+/// we return [`None`].
+pub unsafe fn collect(
+    maybe_ff: bool,
+    target_list: *mut pg_sys::List,
+    rti: pg_sys::Index,
+    schema: &SearchIndexSchema,
+    heaprel: &PgRelation,
+) -> Option<Vec<WhichFastField>> {
+    if maybe_ff {
+        pullup_fast_fields(target_list, schema, heaprel, rti)
+    } else {
+        None
+    }
+}
+
+pub unsafe fn pullup_fast_fields(
+    node: *mut pg_sys::List,
+    schema: &SearchIndexSchema,
+    heaprel: &PgRelation,
+    rti: pg_sys::Index,
+) -> Option<Vec<WhichFastField>> {
+    let mut matches = Vec::new();
+
+    let tupdesc = heaprel.tuple_desc();
+    let targetlist = PgList::<pg_sys::TargetEntry>::from_pg(node);
+    for te in targetlist.iter_ptr() {
+        if (*te).resorigtbl != pg_sys::Oid::INVALID && (*te).resorigtbl != heaprel.oid() {
+            continue;
+        }
+        if let Some(var) = nodecast!(Var, T_Var, (*te).expr) {
+            match (*var).varattno as i32 {
+                // any of these mean we can't use fast fields
+                pg_sys::MinTransactionIdAttributeNumber
+                | pg_sys::MaxTransactionIdAttributeNumber
+                | pg_sys::MinCommandIdAttributeNumber
+                | pg_sys::MaxCommandIdAttributeNumber => return None,
+
+                // these aren't _exactly_ fast fields, but we do have the information
+                // readily available during the scan, so we'll pretend
+                pg_sys::SelfItemPointerAttributeNumber => {
+                    // okay, "ctid" is a fast field but it's secret
+                    matches.push(WhichFastField::Ctid);
+                    continue;
+                }
+
+                pg_sys::TableOidAttributeNumber => {
+                    matches.push(WhichFastField::TableOid);
+                    continue;
+                }
+
+                attno => {
+                    let att = tupdesc
+                        .get((attno - 1) as usize)
+                        .expect("attnum should exist in tupdesc");
+                    if schema.is_fast_field(att.name()) {
+                        let ff_type = if (*var).vartype == pg_sys::TEXTOID
+                            || (*var).vartype == pg_sys::VARCHAROID
+                        {
+                            FastFieldType::String
+                        } else {
+                            FastFieldType::Numeric
+                        };
+
+                        matches.push(WhichFastField::Named(att.name().to_string(), ff_type));
+                        continue;
+                    }
+                }
+            }
+        } else if uses_scores((*te).expr.cast(), score_funcoid(), rti) {
+            matches.push(WhichFastField::Score);
+            continue;
+        } else if pgrx::is_a((*te).expr.cast(), pg_sys::NodeTag::T_Aggref) {
+            matches.push(WhichFastField::Junk("agg".into()));
+            continue;
+        } else if nodecast!(Const, T_Const, (*te).expr).is_some() {
+            matches.push(WhichFastField::Junk("const".into()));
+            continue;
+        } else if nodecast!(WindowFunc, T_WindowFunc, (*te).expr).is_some() {
+            matches.push(WhichFastField::Junk("window".into()));
+            continue;
+        }
+
+        // we only support Vars or our score function in the target list
+        return None;
+    }
+
+    if matches
+        .iter()
+        .sorted()
+        .dedup()
+        .filter(|ff| matches!(ff, WhichFastField::Named(_, FastFieldType::String)))
+        .count()
+        > 1
+    {
+        // we cannot support more than 1 different String fast field
+        return None;
+    }
+
+    Some(matches)
+}
+
+/// If the query can return "fast fields", make that determination here, falling back to the
+/// [`NormalScanExecState`] if not.
+///
+/// We support [`StringFastFieldExecState`] when there's 1 fast field and it's a string, or
+/// [`NumericFastFieldExecState`] when there's one or more numeric fast fields
+///
+/// `paradedb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
+/// these specialized [`ExecMethod`]s.
+pub fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
+    if let Some(field) = is_string_agg_capable(builder.custom_state()) {
+        let which_fast_fields = builder.custom_state().which_fast_fields.clone().unwrap();
+        builder
+            .custom_state()
+            .assign_exec_method(StringFastFieldExecState::new(field, which_fast_fields));
+    } else if is_numeric_fast_field_capable(builder.custom_state()) {
+        let which_fast_fields = builder.custom_state().which_fast_fields.clone().unwrap();
+        builder
+            .custom_state()
+            .assign_exec_method(NumericFastFieldExecState::new(which_fast_fields));
+    } else {
+        builder
+            .custom_state()
+            .assign_exec_method(NormalScanExecState::default());
+    }
+}
+
+fn is_string_agg_capable(state: &PdbScanState) -> Option<String> {
+    is_string_agg_capable_ex(state.limit, &state.which_fast_fields)
+}
+
+pub fn is_string_agg_capable_ex(
+    limit: Option<usize>,
+    which_fast_fields: &Option<Vec<WhichFastField>>,
+) -> Option<String> {
+    if limit.is_some() {
+        // doing a string_agg when there's a limit is always a loss, performance-wise
+        return None;
+    }
+    let mut string_field = None;
+    for ff in which_fast_fields.iter().flatten() {
+        match ff {
+            WhichFastField::Named(_, FastFieldType::String) if string_field.is_none() => {
+                string_field = Some(ff.name())
+            }
+            WhichFastField::Named(_, FastFieldType::String) => {
+                // too many string fields for us to be capable of doing a string_agg
+                return None;
+            }
+            _ => {
+                // noop
+            }
+        }
+    }
+    string_field
+}
+
+fn is_numeric_fast_field_capable(state: &PdbScanState) -> bool {
+    if state.which_fast_fields.is_none() || state.targetlist_len == 0 {
+        return false;
+    }
+
+    for ff in state.which_fast_fields.iter().flatten() {
+        if matches!(ff, WhichFastField::Named(_, FastFieldType::String)) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Add nodes to `EXPLAIN` output to describe the "fast fields" being used by the query, if any
+pub fn explain(state: &CustomScanStateWrapper<PdbScan>, explainer: &mut Explainer) {
+    if state.custom_state().is_top_n_capable().is_none() {
+        if let Some(fast_fields) = state.custom_state().which_fast_fields.as_ref() {
+            explainer.add_text(
+                "Fast Fields",
+                fast_fields
+                    .iter()
+                    .map(|field| field.name())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+            if let Some(string_agg_field) = is_string_agg_capable(state.custom_state()) {
+                explainer.add_text("String Agg Field", string_agg_field);
+            }
+        }
+    }
+}
+
+pub fn estimate_cardinality(indexrel: &PgRelation, field: &str) -> Option<usize> {
+    let reader = SearchIndexReader::open(indexrel, BlockDirectoryType::Mvcc, false)
+        .expect("estimate_cardinality: should be able to open SearchIndexReader");
+    let searcher = reader.searcher();
+    let largest_segment_reader = searcher
+        .segment_readers()
+        .iter()
+        .max_by_key(|sr| sr.num_docs())
+        .unwrap();
+
+    Some(
+        largest_segment_reader
+            .fast_fields()
+            .str(field)
+            .ok()
+            .flatten()?
+            .num_terms(),
+    )
+}

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::index::fast_fields_helper::{FFHelper, WhichFastField};
+use crate::index::reader::index::SearchResults;
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
+    ff_to_datum, FastFieldExecState,
+};
+use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
+use crate::postgres::customscan::pdbscan::is_block_all_visible;
+use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
+use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
+use pgrx::pg_sys::CustomScanState;
+use pgrx::{pg_sys, PgTupleDesc};
+
+pub struct NumericFastFieldExecState {
+    inner: FastFieldExecState,
+}
+
+impl NumericFastFieldExecState {
+    pub fn new(which_fast_fields: Vec<WhichFastField>) -> Self {
+        Self {
+            inner: FastFieldExecState::new(which_fast_fields),
+        }
+    }
+}
+
+impl ExecMethod for NumericFastFieldExecState {
+    fn init(&mut self, state: &mut PdbScanState, cstate: *mut CustomScanState) {
+        unsafe {
+            self.inner.heaprel = state.heaprel();
+            self.inner.tupdesc = Some(PgTupleDesc::from_pg_unchecked(
+                (*cstate).ss.ps.ps_ResultTupleDesc,
+            ));
+            self.inner.slot = pg_sys::MakeTupleTableSlot(
+                (*cstate).ss.ps.ps_ResultTupleDesc,
+                &pg_sys::TTSOpsVirtual,
+            );
+            self.inner.ffhelper = FFHelper::with_fields(
+                state.search_reader.as_ref().unwrap(),
+                &self.inner.which_fast_fields,
+            );
+        }
+    }
+
+    fn query(&mut self, state: &PdbScanState) -> bool {
+        if let Some(parallel_state) = state.parallel_state {
+            if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
+                self.inner.search_results = state.search_reader.as_ref().unwrap().search_segment(
+                    state.need_scores(),
+                    segment_ord,
+                    &state.search_query_input,
+                );
+                return true;
+            }
+
+            // no more segments to query
+            self.inner.search_results = SearchResults::None;
+            false
+        } else if self.inner.did_query {
+            // not parallel, so we're done
+            false
+        } else {
+            // not parallel, first time query
+            self.inner.search_results = state.search_reader.as_ref().unwrap().search(
+                state.need_scores(),
+                false,
+                &state.search_query_input,
+                state.limit,
+            );
+            self.inner.did_query = true;
+            true
+        }
+    }
+
+    fn internal_next(&mut self) -> ExecState {
+        unsafe {
+            match self.inner.search_results.next() {
+                None => ExecState::Eof,
+                Some((scored, doc_address)) => {
+                    let slot = self.inner.slot;
+                    let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
+
+                    crate::postgres::utils::u64_to_item_pointer(scored.ctid, &mut (*slot).tts_tid);
+                    (*slot).tts_tableOid = (*self.inner.heaprel).rd_id;
+
+                    if is_block_all_visible(
+                        self.inner.heaprel,
+                        &mut self.inner.vmbuff,
+                        (*slot).tts_tid,
+                        (*slot).tts_tableOid,
+                    ) {
+                        (*slot).tts_flags &= !pg_sys::TTS_FLAG_EMPTY as u16;
+                        (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
+                        (*slot).tts_nvalid = natts as _;
+
+                        let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
+                        let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
+
+                        #[rustfmt::skip]
+                        debug_assert!(natts == self.inner.which_fast_fields.len());
+
+                        let fast_fields = &mut self.inner.ffhelper;
+                        let which_fast_fields = &self.inner.which_fast_fields;
+                        for (i, att) in self.inner.tupdesc.as_ref().unwrap().iter().enumerate() {
+                            let which_fast_field = &which_fast_fields[i];
+
+                            match ff_to_datum(
+                                (which_fast_field, i),
+                                att.atttypid,
+                                scored.bm25,
+                                doc_address,
+                                fast_fields,
+                                &mut self.inner.strbuf,
+                                slot,
+                            ) {
+                                None => {
+                                    datums[i] = pg_sys::Datum::null();
+                                    isnull[i] = true;
+                                }
+                                Some(datum) => {
+                                    datums[i] = datum;
+                                    isnull[i] = false;
+                                }
+                            }
+                        }
+
+                        ExecState::Virtual { slot }
+                    } else {
+                        ExecState::RequiresVisibilityCheck {
+                            ctid: scored.ctid,
+                            score: scored.bm25,
+                            doc_address,
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -1,0 +1,424 @@
+// Copyright (c) 2023-2024 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::index::fast_fields_helper::{FFHelper, WhichFastField};
+use crate::index::reader::index::{SearchIndexReader, SearchIndexScore, SearchResults};
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
+    ff_to_datum, FastFieldExecState,
+};
+use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
+use crate::postgres::customscan::pdbscan::is_block_all_visible;
+use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
+use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
+use crate::query::SearchQueryInput;
+use parking_lot::Mutex;
+use pgrx::pg_sys::CustomScanState;
+use pgrx::{pg_sys, PgTupleDesc};
+use rayon::prelude::*;
+use rustc_hash::FxHashMap;
+use std::collections::BTreeMap;
+use tantivy::collector::Collector;
+use tantivy::query::Query;
+use tantivy::{DocAddress, Executor, SegmentOrdinal};
+
+pub struct StringFastFieldExecState {
+    inner: FastFieldExecState,
+    search_results: StringAggResults,
+    field: String,
+}
+
+impl StringFastFieldExecState {
+    pub fn new(field: String, which_fast_fields: Vec<WhichFastField>) -> Self {
+        Self {
+            inner: FastFieldExecState::new(which_fast_fields),
+            search_results: StringAggResults::None,
+            field,
+        }
+    }
+}
+
+impl ExecMethod for StringFastFieldExecState {
+    fn init(&mut self, state: &mut PdbScanState, cstate: *mut CustomScanState) {
+        unsafe {
+            self.inner.heaprel = state.heaprel();
+            self.inner.tupdesc = Some(PgTupleDesc::from_pg_unchecked(
+                (*cstate).ss.ps.ps_ResultTupleDesc,
+            ));
+            self.inner.slot = pg_sys::MakeTupleTableSlot(
+                (*cstate).ss.ps.ps_ResultTupleDesc,
+                &pg_sys::TTSOpsVirtual,
+            );
+            self.inner.ffhelper = FFHelper::with_fields(
+                state.search_reader.as_ref().unwrap(),
+                &self.inner.which_fast_fields,
+            );
+        }
+    }
+
+    fn query(&mut self, state: &PdbScanState) -> bool {
+        if let Some(parallel_state) = state.parallel_state {
+            if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
+                let searcher = StringAggSearcher(state.search_reader.as_ref().unwrap().clone());
+                self.search_results = searcher.string_agg_by_segment(
+                    state.need_scores(),
+                    &state.search_query_input,
+                    &self.field,
+                    segment_ord,
+                );
+                return true;
+            }
+
+            // no more segments to query
+            self.inner.search_results = SearchResults::None;
+            false
+        } else if self.inner.did_query {
+            // not parallel, so we're done
+            false
+        } else {
+            // not parallel, first time query
+            let searcher = StringAggSearcher(state.search_reader.as_ref().unwrap().clone());
+            self.search_results =
+                searcher.string_agg(state.need_scores(), &state.search_query_input, &self.field);
+            self.inner.did_query = true;
+            true
+        }
+    }
+
+    fn internal_next(&mut self) -> ExecState {
+        if matches!(self.search_results, StringAggResults::None) {
+            return ExecState::Eof;
+        }
+
+        unsafe {
+            // SAFETY:  .next() can't be called with self.search_results being set to Some(...)
+            match self.search_results.next() {
+                None => ExecState::Eof,
+                Some((scored, doc_address, mut term)) => {
+                    let slot = self.inner.slot;
+                    let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
+
+                    crate::postgres::utils::u64_to_item_pointer(scored.ctid, &mut (*slot).tts_tid);
+                    (*slot).tts_tableOid = (*self.inner.heaprel).rd_id;
+
+                    if is_block_all_visible(
+                        self.inner.heaprel,
+                        &mut self.inner.vmbuff,
+                        (*slot).tts_tid,
+                        (*slot).tts_tableOid,
+                    ) {
+                        (*slot).tts_flags &= !pg_sys::TTS_FLAG_EMPTY as u16;
+                        (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
+                        (*slot).tts_nvalid = natts as _;
+
+                        let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
+                        let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
+
+                        #[rustfmt::skip]
+                        debug_assert!(natts == self.inner.which_fast_fields.len());
+
+                        let fast_fields = &mut self.inner.ffhelper;
+                        let which_fast_fields = &self.inner.which_fast_fields;
+                        for (i, att) in self.inner.tupdesc.as_ref().unwrap().iter().enumerate() {
+                            let which_fast_field = &which_fast_fields[i];
+
+                            match ff_to_datum(
+                                (which_fast_field, i),
+                                att.atttypid,
+                                scored.bm25,
+                                doc_address,
+                                fast_fields,
+                                &mut term,
+                                slot,
+                            ) {
+                                None => {
+                                    datums[i] = pg_sys::Datum::null();
+                                    isnull[i] = true;
+                                }
+                                Some(datum) => {
+                                    datums[i] = datum;
+                                    isnull[i] = false;
+                                }
+                            }
+                        }
+
+                        ExecState::Virtual { slot }
+                    } else {
+                        ExecState::RequiresVisibilityCheck {
+                            ctid: scored.ctid,
+                            score: scored.bm25,
+                            doc_address,
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+enum StringAggResults {
+    #[default]
+    None,
+    Batched {
+        current: (String, std::vec::IntoIter<(SearchIndexScore, DocAddress)>),
+        set: std::vec::IntoIter<(String, std::vec::IntoIter<(SearchIndexScore, DocAddress)>)>,
+    },
+    SingleSegment(crossbeam::channel::IntoIter<(SearchIndexScore, DocAddress, String)>),
+}
+
+impl Iterator for StringAggResults {
+    type Item = (SearchIndexScore, DocAddress, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            StringAggResults::None => None,
+            StringAggResults::Batched { current, set } => loop {
+                if let Some(next) = current.1.next() {
+                    return Some((next.0, next.1, current.0.clone()));
+                } else if let Some(next_set) = set.next() {
+                    *current = next_set;
+                } else {
+                    return None;
+                }
+            },
+            StringAggResults::SingleSegment(iter) => iter.next(),
+        }
+    }
+}
+
+struct StringAggSearcher(SearchIndexReader);
+
+impl StringAggSearcher {
+    pub fn string_agg(
+        &self,
+        need_scores: bool,
+        query: &SearchQueryInput,
+        field: &str,
+    ) -> StringAggResults {
+        let collector = term_ord_collector::TermOrdCollector {
+            need_scores,
+            field: field.into(),
+        };
+
+        let query = self.0.query(query);
+        let results = self
+            .0
+            .searcher()
+            .search_with_executor(
+                &query,
+                &collector,
+                &Executor::SingleThread,
+                if need_scores {
+                    tantivy::query::EnableScoring::Enabled {
+                        searcher: self.0.searcher(),
+                        statistics_provider: self.0.searcher(),
+                    }
+                } else {
+                    tantivy::query::EnableScoring::Disabled {
+                        schema: &self.0.schema().schema,
+                        searcher_opt: Some(self.0.searcher()),
+                    }
+                },
+            )
+            .expect("failed to search");
+
+        let field = field.to_string();
+        let searcher = self.0.searcher().clone();
+
+        let merged: Mutex<BTreeMap<String, Vec<(SearchIndexScore, DocAddress)>>> =
+            Mutex::new(BTreeMap::new());
+
+        results
+            .into_par_iter()
+            .for_each(|(str_ff, segment_results)| {
+                let keys = segment_results.keys().cloned().collect::<Vec<_>>();
+                let mut values = segment_results.into_iter();
+                let mut resolved = FxHashMap::default();
+                str_ff
+                    .dictionary()
+                    .sorted_ords_to_term_cb(keys.into_iter(), |bytes| {
+                        let term = std::str::from_utf8(bytes)
+                            .expect("term should be valid utf8")
+                            .to_string();
+
+                        resolved.insert(
+                            term,
+                            values.next().unwrap_or_else(|| panic!("internal error: don't have the same number of TermOrd keys and values")).1,
+                        );
+
+                        Ok(())
+                    })
+                    .expect("term ord resolution should succeed");
+
+                let mut guard = merged.lock();
+                for (term, mut results) in resolved {
+                    guard.entry(term).or_default().append(&mut results);
+                }
+            });
+
+        let set = merged
+            .into_inner()
+            .into_iter()
+            .map(|(term, docs)| (term, docs.into_iter()))
+            .collect::<Vec<_>>()
+            .into_iter();
+        StringAggResults::Batched {
+            current: (String::default(), vec![].into_iter()),
+            set,
+        }
+    }
+
+    pub fn string_agg_by_segment(
+        &self,
+        need_scores: bool,
+        query: &SearchQueryInput,
+        field: &str,
+        segment_ord: SegmentOrdinal,
+    ) -> StringAggResults {
+        let (sender, receiver) = crossbeam::channel::unbounded();
+
+        let segment_reader = self.0.searcher().segment_reader(segment_ord);
+        let collector = term_ord_collector::TermOrdCollector {
+            need_scores,
+            field: field.into(),
+        };
+
+        let weight = self
+            .0
+            .query(query)
+            .weight(if need_scores {
+                tantivy::query::EnableScoring::Enabled {
+                    searcher: self.0.searcher(),
+                    statistics_provider: self.0.searcher(),
+                }
+            } else {
+                tantivy::query::EnableScoring::Disabled {
+                    schema: &self.0.schema().schema,
+                    searcher_opt: Some(self.0.searcher()),
+                }
+            })
+            .expect("weight should be constructable");
+
+        let (str_ff, results) = collector
+            .collect_segment(weight.as_ref(), segment_ord, segment_reader)
+            .expect("single segment collection should succeed");
+
+        let field = field.to_string();
+        let searcher = self.0.searcher().clone();
+        let dictionary = str_ff.dictionary();
+        let term_ords = results.keys().cloned().collect::<Vec<_>>();
+        let mut results = results.into_iter();
+        dictionary
+            .sorted_ords_to_term_cb(term_ords.into_iter(), |bytes| {
+                let term = std::str::from_utf8(bytes)
+                    .expect("term should be valid utf8")
+                    .to_string();
+
+                let (_, values) = results.next().unwrap_or_else(|| {
+                    panic!("internal error: don't have the same number of TermOrd keys and values")
+                });
+                for (scored, doc_address) in values {
+                    sender
+                        .send((scored, doc_address, term.clone()))
+                        .map_err(|_| {
+                            std::io::Error::new(std::io::ErrorKind::Other, "failed to send term")
+                        })?;
+                }
+
+                Ok(())
+            })
+            .expect("term ord lookup should succeed");
+
+        StringAggResults::SingleSegment(receiver.into_iter())
+    }
+}
+
+mod term_ord_collector {
+    use crate::index::reader::index::SearchIndexScore;
+    use std::collections::BTreeMap;
+    use tantivy::collector::{Collector, SegmentCollector};
+    use tantivy::columnar::StrColumn;
+
+    use tantivy::termdict::TermOrdinal;
+    use tantivy::{Ctid, DocAddress, DocId, Score, SegmentOrdinal, SegmentReader};
+
+    pub struct TermOrdCollector {
+        pub need_scores: bool,
+        pub field: String,
+    }
+
+    impl Collector for TermOrdCollector {
+        type Fruit = Vec<(
+            StrColumn,
+            BTreeMap<TermOrdinal, Vec<(SearchIndexScore, DocAddress)>>,
+        )>;
+        type Child = TermOrdSegmentCollector;
+
+        fn for_segment(
+            &self,
+            segment_local_id: SegmentOrdinal,
+            segment_reader: &SegmentReader,
+        ) -> tantivy::Result<Self::Child> {
+            let ff = segment_reader.fast_fields();
+            Ok(TermOrdSegmentCollector {
+                segment_ord: segment_local_id,
+                results: Default::default(),
+                ff: ff.str(&self.field)?.expect("ff should be a str field"),
+            })
+        }
+
+        fn requires_scoring(&self) -> bool {
+            self.need_scores
+        }
+
+        fn merge_fruits(
+            &self,
+            segment_fruits: Vec<<Self::Child as SegmentCollector>::Fruit>,
+        ) -> tantivy::Result<Self::Fruit> {
+            Ok(segment_fruits)
+        }
+    }
+
+    pub struct TermOrdSegmentCollector {
+        pub ff: StrColumn,
+        pub results: BTreeMap<TermOrdinal, Vec<(SearchIndexScore, DocAddress)>>,
+        pub segment_ord: SegmentOrdinal,
+    }
+
+    impl SegmentCollector for TermOrdSegmentCollector {
+        type Fruit = (
+            StrColumn,
+            BTreeMap<TermOrdinal, Vec<(SearchIndexScore, DocAddress)>>,
+        );
+
+        fn collect(&mut self, doc: DocId, score: Score, ctid: Ctid) {
+            if let Some(term_ord) = self.ff.term_ords(doc).next() {
+                let doc_address = DocAddress::new(self.segment_ord, doc);
+                let scored = SearchIndexScore::new(ctid, score);
+
+                self.results
+                    .entry(term_ord)
+                    .or_default()
+                    .push((scored, doc_address));
+            }
+        }
+
+        fn harvest(self) -> Self::Fruit {
+            (self.ff, self.results)
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -18,6 +18,7 @@
 use crate::index::reader::index::SearchResults;
 use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
 use crate::postgres::customscan::pdbscan::is_block_all_visible;
+use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use crate::postgres::utils::u64_to_item_pointer;
 use pgrx::pg_sys;
@@ -70,7 +71,28 @@ impl ExecMethod for NormalScanExecState {
     }
 
     fn query(&mut self, state: &PdbScanState) -> bool {
-        self.do_query(state)
+        if let Some(parallel_state) = state.parallel_state {
+            if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
+                self.search_results = state.search_reader.as_ref().unwrap().search_segment(
+                    state.need_scores(),
+                    segment_ord,
+                    &state.search_query_input,
+                );
+                return true;
+            }
+
+            // no more segments to query
+            self.search_results = SearchResults::None;
+            false
+        } else if self.did_query {
+            // not parallel, so we're done
+            false
+        } else {
+            // not parallel, first time query
+            self.do_query(state);
+            self.did_query = true;
+            true
+        }
     }
 
     fn internal_next(&mut self) -> ExecState {

--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -1,0 +1,126 @@
+use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
+use crate::postgres::customscan::dsm::ParallelQueryCapable;
+use crate::postgres::customscan::pdbscan::PdbScan;
+use pgrx::pg_sys::{shm_toc, ParallelContext, Size};
+use std::os::raw::c_void;
+use tantivy::SegmentOrdinal;
+
+// TODO:  get rid of this after community-dev merge
+pub mod spinlock {
+    use pgrx::pg_sys;
+    use std::ptr::addr_of_mut;
+
+    #[derive(Debug)]
+    #[repr(transparent)]
+    pub struct Spinlock(pub pg_sys::slock_t);
+
+    impl Spinlock {
+        #[inline(always)]
+        pub fn init(&mut self) {
+            unsafe {
+                // SAFETY:  `unsafe` due to normal FFI
+                pg_sys::SpinLockInit(addr_of_mut!(self.0));
+            }
+        }
+
+        #[must_use]
+        #[inline(always)]
+        pub fn acquire(&mut self) -> impl Drop {
+            AcquiredSpinLock::new(self)
+        }
+    }
+
+    #[repr(transparent)]
+    pub struct AcquiredSpinLock(*mut pg_sys::slock_t);
+
+    impl AcquiredSpinLock {
+        fn new(lock: &mut Spinlock) -> Self {
+            unsafe {
+                let addr = addr_of_mut!(lock.0);
+                pg_sys::SpinLockAcquire(addr);
+                Self(addr)
+            }
+        }
+    }
+
+    impl Drop for AcquiredSpinLock {
+        #[inline(always)]
+        fn drop(&mut self) {
+            unsafe {
+                pg_sys::SpinLockRelease(self.0);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct PdbParallelScanState {
+    mutex: spinlock::Spinlock,
+    segment_count: SegmentOrdinal,
+    remaining_segments: SegmentOrdinal,
+}
+
+impl ParallelQueryCapable for PdbScan {
+    fn estimate_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut ParallelContext,
+    ) -> Size {
+        size_of::<PdbParallelScanState>()
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        let pscan_state = coordinate.cast::<PdbParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+
+        unsafe {
+            (*pscan_state).mutex.init();
+            (*pscan_state).segment_count = state
+                .custom_state()
+                .search_reader
+                .as_ref()
+                .expect("SearchReader should be set")
+                .searcher()
+                .segment_readers()
+                .len()
+                .try_into()
+                .expect("should not have more than u32 segments");
+            (*pscan_state).remaining_segments = (*pscan_state).segment_count;
+            state.custom_state_mut().parallel_state = Some(pscan_state);
+        }
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        let pscan_state = coordinate.cast::<PdbParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        toc: *mut shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        let pscan_state = coordinate.cast::<PdbParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+
+        state.custom_state_mut().parallel_state = Some(pscan_state);
+    }
+}
+
+pub unsafe fn checkout_segment(pscan_state: *mut PdbParallelScanState) -> Option<SegmentOrdinal> {
+    let mutex = (*pscan_state).mutex.acquire();
+    if (*pscan_state).remaining_segments > 0 {
+        (*pscan_state).remaining_segments -= 1;
+        Some((*pscan_state).remaining_segments)
+    } else {
+        None
+    }
+}

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -19,6 +19,7 @@ use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::postgres::customscan::builders::custom_path::SortDirection;
 use crate::postgres::customscan::pdbscan::exec_methods::ExecMethod;
+use crate::postgres::customscan::pdbscan::parallel::PdbParallelScanState;
 use crate::postgres::customscan::pdbscan::projections::snippet::SnippetInfo;
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::options::SearchIndexCreateOptions;
@@ -34,6 +35,8 @@ use tantivy::snippet::SnippetGenerator;
 
 #[derive(Default)]
 pub struct PdbScanState {
+    pub parallel_state: Option<*mut PdbParallelScanState>,
+
     pub rti: pg_sys::Index,
 
     pub search_query_input: SearchQueryInput,

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -59,6 +59,11 @@ pub fn item_pointer_to_u64(ctid: pg_sys::ItemPointerData) -> u64 {
     (blockno << 16) | offno
 }
 
+pub fn ctid_to_u64(ctid: tantivy::Ctid) -> u64 {
+    let (blockno, offno) = (ctid.0 as u64, ctid.1 as u64);
+    (blockno << 16) | offno
+}
+
 /// Rather than using pgrx' version of this function, we use our own, which doesn't leave 2
 /// empty bytes in the middle of the 64bit representation.  A ctid being only 48bits means
 /// if we leave the upper 16 bits (2 bytes) empty, tantivy will have a better chance of

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -54,6 +54,7 @@ fn generates_custom_scan_for_or(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' OR description @@@ 'shoes'".fetch_one::<(Value,)>(&mut conn);
+
     let plan = plan
         .get(0)
         .unwrap()
@@ -62,7 +63,12 @@ fn generates_custom_scan_for_or(mut conn: PgConnection) {
         .get("Plan")
         .unwrap()
         .as_object()
+        .unwrap()
+        .get("Plans")
+        .unwrap()
+        .get(0)
         .unwrap();
+
     eprintln!("{plan:#?}");
     assert_eq!(
         plan.get("Custom Plan Provider"),

--- a/tests/tests/parallel_index_scan.rs
+++ b/tests/tests/parallel_index_scan.rs
@@ -57,7 +57,7 @@ fn dont_do_parallel_index_scan(mut conn: PgConnection) {
     "set enable_indexscan to off;".execute(&mut conn);
     let (plan, ) = "EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON) select count(*) from paradedb.bm25_search where description @@@ 'shoes';".fetch_one::<(Value,)>(&mut conn);
     let plan = plan
-        .pointer("/0/Plan/Plans/0")
+        .pointer("/0/Plan/Plans/0/Plans/0/Plans/0")
         .unwrap()
         .as_object()
         .unwrap();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This brings our previously enterprise-only Parallel Custom Scan support to the community version.

## Why

Block storage basically requires this in order to maintain excellent search performance.

## How

## Tests
