### PR TITLE
chore: remove stored field from index configuration

### DIFF
--- a/docs/documentation/advanced/specialized/more_like_this.mdx
+++ b/docs/documentation/advanced/specialized/more_like_this.mdx
@@ -17,7 +17,8 @@ All other parameters are compatible with both `document_id` and `document_fields
   When querying with the `document_id` parameter, the index fields must be configured with the
   [stored](/documentation/indexing/field_options#all-configuration-options) parameter set to `true`.
 
-  The `key_field` of an index is configured automatically as `stored: true`.
+The `key_field` of an index is configured automatically as `stored: true`.
+
 </Note>
 
 <CodeGroup>

--- a/docs/documentation/advanced/specialized/more_like_this.mdx
+++ b/docs/documentation/advanced/specialized/more_like_this.mdx
@@ -8,10 +8,17 @@ Finds documents similar to a given document or set of field values. This is usef
 
 You must pass either:
 
-- `document_id`, which takes a [`key_field`](/documentation/indexing/create_index#choosing-a-key-field) value to match against the corresponding document.
+- `document_id`, which takes a [key_field](/documentation/indexing/create_index#choosing-a-key-field) value to match against the corresponding document.
 - `document_fields`, which takes a JSON object string to match against.
 
 All other parameters are compatible with both `document_id` and `document_fields`.
+
+<Note>
+  When querying with the `document_id` parameter, the index fields must be configured with the
+  [stored](/documentation/indexing/field_options#all-configuration-options) parameter set to `true`.
+
+  The `key_field` of an index is configured automatically as `stored: true`.
+</Note>
 
 <CodeGroup>
 ```sql Function Syntax

--- a/docs/documentation/indexing/field_options.mdx
+++ b/docs/documentation/indexing/field_options.mdx
@@ -89,7 +89,7 @@ The nested configuration JSON for `text_fields` accepts the following keys.
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
@@ -140,7 +140,7 @@ The nested configuration JSON for `json_fields` accepts the following keys.
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
@@ -176,7 +176,7 @@ WITH (
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
@@ -209,7 +209,7 @@ WITH (
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
@@ -242,7 +242,7 @@ WITH (
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
@@ -272,7 +272,7 @@ WITH (
 `CREATE INDEX` accepts several configuration options for `range_fields`:
 
 <Accordion title="Advanced Options">
-  <ParamField body="stored" default={true}>
+  <ParamField body="stored" default={false}>
     Whether the original value of the field is stored.
     Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>

--- a/docs/documentation/indexing/field_options.mdx
+++ b/docs/documentation/indexing/field_options.mdx
@@ -91,6 +91,7 @@ The nested configuration JSON for `text_fields` accepts the following keys.
   </ParamField>
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
@@ -141,6 +142,7 @@ The nested configuration JSON for `json_fields` accepts the following keys.
   </ParamField>
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
@@ -176,6 +178,7 @@ WITH (
   </ParamField>
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -208,6 +211,7 @@ WITH (
   </ParamField>
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -240,6 +244,7 @@ WITH (
   </ParamField>
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -269,6 +274,7 @@ WITH (
 <Accordion title="Advanced Options">
   <ParamField body="stored" default={true}>
     Whether the original value of the field is stored.
+    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
 </Accordion>
 

--- a/docs/documentation/indexing/field_options.mdx
+++ b/docs/documentation/indexing/field_options.mdx
@@ -90,8 +90,9 @@ The nested configuration JSON for `text_fields` accepts the following keys.
     tokenized and searchable.
   </ParamField>
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
@@ -141,8 +142,9 @@ The nested configuration JSON for `json_fields` accepts the following keys.
     tokenized and searchable.
   </ParamField>
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
@@ -177,8 +179,9 @@ WITH (
     tokenized and searchable.
   </ParamField>
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -210,8 +213,9 @@ WITH (
     tokenized and searchable.
   </ParamField>
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -243,8 +247,9 @@ WITH (
     tokenized and searchable.
   </ParamField>
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -273,8 +278,9 @@ WITH (
 
 <Accordion title="Advanced Options">
   <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored.
-    Required only for use with the [More Like This](/documentation/advanced/specialized/more_like_this) query.
+    Whether the original value of the field is stored. Required only for use
+    with the [More Like
+    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
 </Accordion>
 


### PR DESCRIPTION
## What

Removing the deprecated `stored` field from index configuration in our docs, code, and tests.