### PR TITLE
fix: parallel scans now work correctly on block storage

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -189,7 +189,7 @@ pub struct SearchIndexReader {
     underlying_reader: IndexReader,
     underlying_index: Index,
 
-    // [`PinnedBuffer`] has a Drop impl, so we hold onto the lock, but don't otherwise use it
+    // [`PinnedBuffer`] has a Drop impl, so we hold onto it but don't otherwise use it
     //
     // also, it's an Arc b/c if we're clone'd (we do derive it, after all), we only want this
     // buffer dropped once
@@ -214,7 +214,7 @@ impl SearchIndexReader {
         // a pinned but unlocked buffer.
         let cleanup_lock = if needs_cleanup_lock {
             let bman = BufferManager::new(index_relation.oid());
-            Some(bman.get_buffer_pinned(CLEANUP_LOCK))
+            Some(bman.get_buffer(CLEANUP_LOCK).unlock())
         } else {
             None
         };

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -44,11 +44,15 @@ impl Default for Box<dyn ExecMethod> {
 pub trait ExecMethod {
     fn init(&mut self, state: &mut PdbScanState, cstate: *mut pg_sys::CustomScanState);
 
-    fn query(&mut self, state: &PdbScanState) -> bool {
+    fn uses_visibility_map(&self, state: &PdbScanState) -> bool {
+        true
+    }
+
+    fn query(&mut self, state: &mut PdbScanState) -> bool {
         false
     }
 
-    fn next(&mut self, state: &PdbScanState) -> ExecState {
+    fn next(&mut self, state: &mut PdbScanState) -> ExecState {
         loop {
             match self.internal_next() {
                 ExecState::Eof => {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -57,7 +57,7 @@ impl ExecMethod for NumericFastFieldExecState {
         }
     }
 
-    fn query(&mut self, state: &PdbScanState) -> bool {
+    fn query(&mut self, state: &mut PdbScanState) -> bool {
         if let Some(parallel_state) = state.parallel_state {
             if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
                 self.inner.search_results = state.search_reader.as_ref().unwrap().search_segment(

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -69,7 +69,7 @@ impl ExecMethod for StringFastFieldExecState {
         }
     }
 
-    fn query(&mut self, state: &PdbScanState) -> bool {
+    fn query(&mut self, state: &mut PdbScanState) -> bool {
         if let Some(parallel_state) = state.parallel_state {
             if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
                 let searcher = StringAggSearcher(state.search_reader.as_ref().unwrap().clone());

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -70,7 +70,12 @@ impl ExecMethod for NormalScanExecState {
         }
     }
 
-    fn query(&mut self, state: &PdbScanState) -> bool {
+    fn uses_visibility_map(&self, state: &PdbScanState) -> bool {
+        // if we don't return any actual fields, then we'll use the visibility map
+        state.targetlist_len == 0
+    }
+
+    fn query(&mut self, state: &mut PdbScanState) -> bool {
         if let Some(parallel_state) = state.parallel_state {
             if let Some(segment_ord) = unsafe { checkout_segment(parallel_state) } {
                 self.search_results = state.search_reader.as_ref().unwrap().search_segment(

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -105,10 +105,10 @@ impl PdbScanState {
     }
 
     #[inline(always)]
-    pub fn exec_method<'a>(&self) -> &'a Box<dyn ExecMethod> {
+    pub fn exec_method<'a>(&self) -> &'a dyn ExecMethod {
         let ptr = self.exec_method.get();
         assert!(!ptr.is_null());
-        unsafe { ptr.as_ref().unwrap_unchecked() }
+        unsafe { ptr.as_ref().unwrap_unchecked().as_ref() }
     }
 
     #[inline(always)]

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -105,7 +105,14 @@ impl PdbScanState {
     }
 
     #[inline(always)]
-    pub fn exec_method<'a>(&mut self) -> &'a mut Box<dyn ExecMethod> {
+    pub fn exec_method<'a>(&self) -> &'a Box<dyn ExecMethod> {
+        let ptr = self.exec_method.get();
+        assert!(!ptr.is_null());
+        unsafe { ptr.as_ref().unwrap_unchecked() }
+    }
+
+    #[inline(always)]
+    pub fn exec_method_mut<'a>(&mut self) -> &'a mut Box<dyn ExecMethod> {
         let ptr = self.exec_method.get();
         assert!(!ptr.is_null());
         unsafe { ptr.as_mut().unwrap_unchecked() }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -10,10 +10,10 @@ pub struct Buffer {
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
-            if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer {
-                if pg_sys::IsTransactionState() {
-                    pg_sys::UnlockReleaseBuffer(self.pg_buffer);
-                }
+            if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer
+                && pg_sys::IsTransactionState()
+            {
+                pg_sys::UnlockReleaseBuffer(self.pg_buffer);
             }
         }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -10,8 +10,10 @@ pub struct Buffer {
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() {
-                pg_sys::UnlockReleaseBuffer(self.pg_buffer);
+            if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer {
+                if pg_sys::IsTransactionState() {
+                    pg_sys::UnlockReleaseBuffer(self.pg_buffer);
+                }
             }
         }
     }
@@ -21,6 +23,17 @@ impl Buffer {
     fn new(pg_buffer: pg_sys::Buffer) -> Self {
         assert!(pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer);
         Self { pg_buffer }
+    }
+
+    pub fn unlock(mut self) -> PinnedBuffer {
+        unsafe {
+            let pg_buffer = self.pg_buffer;
+            self.pg_buffer = pg_sys::InvalidBuffer as pg_sys::Buffer;
+
+            // unlock this buffer and convert to a PinnedBuffer
+            pg_sys::LockBuffer(pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as _);
+            PinnedBuffer::new(pg_buffer)
+        }
     }
 
     pub fn page(&self) -> Page {
@@ -400,10 +413,6 @@ impl BufferManager {
                 ),
             }
         }
-    }
-
-    pub fn get_buffer_pinned(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {
-        unsafe { PinnedBuffer::new(self.bcache.get_buffer(blockno, None)) }
     }
 
     pub fn get_buffer_conditional(&mut self, blockno: pg_sys::BlockNumber) -> Option<BufferMut> {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This fixes parallel index/custom scans to work correctly on block storage.

The primary fix here is that `SearchIndexReader::open()` now only holds onto a *pinned* `CLEANUP_LOCK` buffer, instead of a pinned&locked version.

## Why

This is necessary to ensure that buffer LWLocks aren't held longer than they should be.  Doing so can cause Postgres to fail to empty the parallel worker message queues because ProcessInterrupts doesn't do anything if there's an outstanding LWLock.

## How

## Tests

All existing tests, plus stressgres, pass.