### PR TITLE
feat: replace LinkedBytes skiplist with bitpacked block numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ version = "0.13.2"
 dependencies = [
  "anyhow",
  "bincode",
+ "bitpacking",
  "chrono",
  "crossbeam",
  "derive_more",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -20,6 +20,7 @@ icu = ["tokenizers/icu"]
 
 [dependencies]
 anyhow = { version = "1.0.87", features = ["backtrace"] }
+bitpacking = "0.9.2"
 chrono = "0.4.38"
 crossbeam = "0.8.4"
 derive_more = "0.99.18"

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -15,7 +15,7 @@ use tantivy_common::StableDeref;
 
 #[derive(Clone, Debug)]
 pub struct SegmentComponentReader {
-    block_list: LinkedBytesList,
+    block_list: Arc<LinkedBytesList>,
     npages: Arc<AtomicU32>,
     last_blockno: Arc<AtomicU32>,
     entry: FileEntry,
@@ -26,7 +26,7 @@ impl SegmentComponentReader {
         let block_list = LinkedBytesList::open(relation_oid, entry.staring_block);
 
         Self {
-            block_list,
+            block_list: Arc::new(block_list),
             entry,
             npages: Arc::new(AtomicU32::new(0)),
             last_blockno: Arc::new(AtomicU32::new(pg_sys::InvalidBlockNumber)),

--- a/pg_search/src/index/writer/channel.rs
+++ b/pg_search/src/index/writer/channel.rs
@@ -37,7 +37,7 @@ impl Write for ChannelWriter {
     }
 
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        self.write(buf)?;
+        let _ = self.write(buf)?;
         Ok(())
     }
 }

--- a/pg_search/src/index/writer/channel.rs
+++ b/pg_search/src/index/writer/channel.rs
@@ -25,11 +25,19 @@ impl Write for ChannelWriter {
                 self.path.clone(),
                 data.to_vec(),
             ))
-            .unwrap_or_else(|e| panic!("got send error: {e}"));
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))?;
         Ok(data.len())
     }
 
     fn flush(&mut self) -> Result<()> {
+        self.sender
+            .send(ChannelRequest::SegmentFlush(self.path.clone()))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))?;
+        Ok(())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.write(buf)?;
         Ok(())
     }
 }
@@ -38,7 +46,6 @@ impl TerminatingWrite for ChannelWriter {
     fn terminate_ref(&mut self, _: AntiCallToken) -> Result<()> {
         self.sender
             .send(ChannelRequest::SegmentWriteTerminate(self.path.clone()))
-            .unwrap();
-        Ok(())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))
     }
 }

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -54,9 +54,8 @@ impl Write for SegmentComponentWriter {
 
 impl TerminatingWrite for SegmentComponentWriter {
     fn terminate_ref(&mut self, _: AntiCallToken) -> Result<()> {
-        // this is a no-op -- the FileEntry for this segment component
-        // is handled through Directory::save_meta()
-        Ok(())
+        self.buffer.flush()?;
+        self.buffer.writer.flush()
     }
 }
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn _PG_init() {
     // is initialized for all connections.
     #[allow(static_mut_refs)]
     #[allow(deprecated)]
-    // pgrx::hooks::register_hook(&mut TRACE_HOOK);
+    pgrx::hooks::register_hook(&mut TRACE_HOOK);
     customscan::register_rel_pathlist(customscan::pdbscan::PdbScan);
 }
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn _PG_init() {
     // is initialized for all connections.
     #[allow(static_mut_refs)]
     #[allow(deprecated)]
-    pgrx::hooks::register_hook(&mut TRACE_HOOK);
+    // pgrx::hooks::register_hook(&mut TRACE_HOOK);
     customscan::register_rel_pathlist(customscan::pdbscan::PdbScan);
 }
 

--- a/pg_search/src/postgres/storage/blocklist.rs
+++ b/pg_search/src/postgres/storage/blocklist.rs
@@ -498,6 +498,11 @@ pub mod reader {
             Self { blocks }
         }
 
+        #[allow(dead_code)]
+        pub fn len(&self) -> usize {
+            self.blocks.len()
+        }
+
         pub fn get(&self, i: usize) -> Option<pg_sys::BlockNumber> {
             self.blocks.get(i).cloned()
         }

--- a/pg_search/src/postgres/storage/blocklist.rs
+++ b/pg_search/src/postgres/storage/blocklist.rs
@@ -205,9 +205,9 @@ pub mod builder {
                 }
             }
 
-            if self.queue.len() == BitPacker8x::BLOCK_LEN {
+            if self.queue.len() == BitPacker1x::BLOCK_LEN {
                 self.chunks
-                    .push(self.pack_8x(&self.queue, self.last_chunked_blockno));
+                    .push(self.pack_1x(&self.queue, self.last_chunked_blockno));
 
                 let last = self.queue.last().cloned();
                 self.queue.clear();

--- a/pg_search/src/postgres/storage/blocklist.rs
+++ b/pg_search/src/postgres/storage/blocklist.rs
@@ -73,6 +73,7 @@ pub mod builder {
             }
         }
 
+        #[allow(dead_code)]
         pub fn len(&self) -> usize {
             match self {
                 ChunkStyle::Sorted1x { .. } => BitPacker1x::BLOCK_LEN,
@@ -101,7 +102,7 @@ pub mod builder {
                 ChunkStyle::Uncompressed(values) => {
                     size_of::<u8>() // tag
                         + size_of::<u8>() // len
-                        + values.len() * std::mem::size_of::<pg_sys::BlockNumber>()
+                        + values.len() * size_of::<pg_sys::BlockNumber>()
                 }
             }
         }
@@ -189,6 +190,7 @@ pub mod builder {
     }
 
     impl BlockList {
+        #[allow(dead_code)]
         pub fn is_empty(&self) -> bool {
             self.chunks.is_empty() && self.queue.is_empty()
         }
@@ -400,7 +402,7 @@ pub mod reader {
                         | tag @ ChunkSyleTag::StrictlySorted1x
                         | tag @ ChunkSyleTag::StrictlySorted4x
                         | tag @ ChunkSyleTag::StrictlySorted8x => {
-                            let num_bits = slice[offset] as u8;
+                            let num_bits = slice[offset];
                             offset += 1;
                             let initial = u32::from_le_bytes(
                                 slice[offset..offset + size_of::<pg_sys::BlockNumber>()]

--- a/pg_search/src/postgres/storage/blocklist.rs
+++ b/pg_search/src/postgres/storage/blocklist.rs
@@ -1,0 +1,503 @@
+#[derive(Debug)]
+#[repr(u8)]
+enum ChunkSyleTag {
+    Sorted1x = 0,
+    Sorted4x = 1,
+    Sorted8x = 2,
+    StrictlySorted1x = 3,
+    StrictlySorted4x = 4,
+    StrictlySorted8x = 5,
+    Uncompressed = 6,
+}
+
+impl From<u8> for ChunkSyleTag {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => ChunkSyleTag::Sorted1x,
+            1 => ChunkSyleTag::Sorted4x,
+            2 => ChunkSyleTag::Sorted8x,
+            3 => ChunkSyleTag::StrictlySorted1x,
+            4 => ChunkSyleTag::StrictlySorted4x,
+            5 => ChunkSyleTag::StrictlySorted8x,
+            6 => ChunkSyleTag::Uncompressed,
+            other => panic!("invalid chunk style tag: {}", other),
+        }
+    }
+}
+
+impl From<ChunkSyleTag> for u8 {
+    fn from(value: ChunkSyleTag) -> Self {
+        value as u8
+    }
+}
+
+pub mod builder {
+    use crate::postgres::storage::block::BM25PageSpecialData;
+    use crate::postgres::storage::blocklist::ChunkSyleTag;
+    use crate::postgres::storage::buffer::BufferManager;
+    use bitpacking::{BitPacker, BitPacker1x, BitPacker4x, BitPacker8x};
+    use pgrx::pg_sys;
+    use std::fmt::{Debug, Formatter};
+
+    #[rustfmt::skip]
+    enum ChunkStyle {
+        Sorted1x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        Sorted4x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        Sorted8x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        StrictlySorted1x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        StrictlySorted4x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        StrictlySorted8x { num_bits: u8, initial: pg_sys::BlockNumber, bytes: Vec<u8> },
+        Uncompressed(Vec<pg_sys::BlockNumber>),
+    }
+
+    impl Debug for ChunkStyle {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ChunkStyle")
+                .field("tag", &self.tag())
+                .field("num_bits", &self.num_bits())
+                .field("byte_len", &self.byte_len())
+                .finish()
+        }
+    }
+
+    impl ChunkStyle {
+        pub fn tag(&self) -> ChunkSyleTag {
+            match self {
+                ChunkStyle::Sorted1x { .. } => ChunkSyleTag::Sorted1x,
+                ChunkStyle::Sorted4x { .. } => ChunkSyleTag::Sorted4x,
+                ChunkStyle::Sorted8x { .. } => ChunkSyleTag::Sorted8x,
+                ChunkStyle::StrictlySorted1x { .. } => ChunkSyleTag::StrictlySorted1x,
+                ChunkStyle::StrictlySorted4x { .. } => ChunkSyleTag::StrictlySorted4x,
+                ChunkStyle::StrictlySorted8x { .. } => ChunkSyleTag::StrictlySorted8x,
+                ChunkStyle::Uncompressed(_) => ChunkSyleTag::Uncompressed,
+            }
+        }
+
+        pub fn len(&self) -> usize {
+            match self {
+                ChunkStyle::Sorted1x { .. } => BitPacker1x::BLOCK_LEN,
+                ChunkStyle::Sorted4x { .. } => BitPacker4x::BLOCK_LEN,
+                ChunkStyle::Sorted8x { .. } => BitPacker8x::BLOCK_LEN,
+                ChunkStyle::StrictlySorted1x { .. } => BitPacker1x::BLOCK_LEN,
+                ChunkStyle::StrictlySorted4x { .. } => BitPacker4x::BLOCK_LEN,
+                ChunkStyle::StrictlySorted8x { .. } => BitPacker8x::BLOCK_LEN,
+                ChunkStyle::Uncompressed(values) => values.len(),
+            }
+        }
+
+        pub fn byte_len(&self) -> usize {
+            match self {
+                ChunkStyle::Sorted1x { bytes, .. }
+                | ChunkStyle::Sorted4x { bytes, .. }
+                | ChunkStyle::Sorted8x { bytes, .. }
+                | ChunkStyle::StrictlySorted1x { bytes, .. }
+                | ChunkStyle::StrictlySorted4x { bytes, .. }
+                | ChunkStyle::StrictlySorted8x { bytes, .. } => {
+                    size_of::<u8>() // tag
+                        + size_of::<u8>()   // num_bits
+                        + size_of::<pg_sys::BlockNumber>()   // initial
+                        + bytes.len()
+                }
+                ChunkStyle::Uncompressed(values) => {
+                    size_of::<u8>() // tag
+                        + size_of::<u8>() // len
+                        + values.len() * std::mem::size_of::<pg_sys::BlockNumber>()
+                }
+            }
+        }
+
+        pub fn num_bits(&self) -> u8 {
+            match self {
+                ChunkStyle::Sorted1x { num_bits, .. } => *num_bits,
+                ChunkStyle::Sorted4x { num_bits, .. } => *num_bits,
+                ChunkStyle::Sorted8x { num_bits, .. } => *num_bits,
+                ChunkStyle::StrictlySorted1x { num_bits, .. } => *num_bits,
+                ChunkStyle::StrictlySorted4x { num_bits, .. } => *num_bits,
+                ChunkStyle::StrictlySorted8x { num_bits, .. } => *num_bits,
+                ChunkStyle::Uncompressed(_) => u8::MAX,
+            }
+        }
+
+        pub fn into_bytes(self) -> Vec<u8> {
+            let tag = self.tag();
+            match self {
+                ChunkStyle::Sorted1x {
+                    num_bits,
+                    initial,
+                    bytes,
+                }
+                | ChunkStyle::Sorted4x {
+                    num_bits,
+                    initial,
+                    bytes,
+                }
+                | ChunkStyle::Sorted8x {
+                    num_bits,
+                    initial,
+                    bytes,
+                }
+                | ChunkStyle::StrictlySorted1x {
+                    num_bits,
+                    initial,
+                    bytes,
+                }
+                | ChunkStyle::StrictlySorted4x {
+                    num_bits,
+                    initial,
+                    bytes,
+                }
+                | ChunkStyle::StrictlySorted8x {
+                    num_bits,
+                    initial,
+                    bytes,
+                } => std::iter::once(tag as u8)
+                    .chain(std::iter::once(num_bits))
+                    .chain(initial.to_le_bytes())
+                    .chain(bytes)
+                    .collect(),
+                ChunkStyle::Uncompressed(values) => std::iter::once(tag as u8)
+                    .chain((values.len() as u8).to_le_bytes())
+                    .chain(values.into_iter().map(|bn| bn.to_le_bytes()).flatten())
+                    .collect(),
+            }
+        }
+    }
+
+    pub struct BlockList {
+        chunks: Vec<ChunkStyle>,
+        queue: Vec<pg_sys::BlockNumber>,
+        last_chunked_blockno: Option<pg_sys::BlockNumber>,
+    }
+
+    impl Default for BlockList {
+        fn default() -> Self {
+            Self {
+                chunks: Default::default(),
+                queue: Vec::with_capacity(BitPacker8x::BLOCK_LEN),
+                last_chunked_blockno: None,
+            }
+        }
+    }
+
+    impl Debug for BlockList {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BlockList")
+                .field("chunks", &self.chunks)
+                .field("queue", &format!("len={}", self.queue.len()))
+                .finish()
+        }
+    }
+
+    impl BlockList {
+        pub fn is_empty(&self) -> bool {
+            self.chunks.is_empty() && self.queue.is_empty()
+        }
+
+        pub fn push(&mut self, block_number: pg_sys::BlockNumber) {
+            assert!(block_number != 0, "cannot add block 0 to the blocklist");
+
+            if let Some(last) = self.queue.last() {
+                if last == &block_number {
+                    // we just added this block
+                    return;
+                }
+            }
+
+            if self.queue.len() == BitPacker8x::BLOCK_LEN {
+                self.chunks
+                    .push(self.pack_8x(&self.queue, self.last_chunked_blockno));
+
+                let last = self.queue.last().cloned();
+                self.queue.clear();
+                self.last_chunked_blockno = last;
+            }
+
+            self.queue.push(block_number);
+        }
+
+        pub fn finish(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
+            let mut queue = &self.queue[..];
+            let mut last = self.last_chunked_blockno;
+            while !queue.is_empty() {
+                if queue.len() >= BitPacker8x::BLOCK_LEN {
+                    let (head, tail) = queue.split_at(BitPacker8x::BLOCK_LEN);
+                    self.chunks.push(self.pack_8x(&head, last));
+
+                    last = head.last().cloned();
+                    queue = tail;
+                } else if queue.len() >= BitPacker4x::BLOCK_LEN {
+                    let (head, tail) = queue.split_at(BitPacker4x::BLOCK_LEN);
+                    self.chunks.push(self.pack_4x(&head, last));
+
+                    last = head.last().cloned();
+                    queue = tail;
+                } else if queue.len() >= BitPacker1x::BLOCK_LEN {
+                    let (head, tail) = queue.split_at(BitPacker1x::BLOCK_LEN);
+                    self.chunks.push(self.pack_1x(&head, last));
+
+                    last = head.last().cloned();
+                    queue = tail;
+                } else {
+                    self.chunks.push(ChunkStyle::Uncompressed(queue.to_vec()));
+                    self.queue.clear();
+                    break;
+                }
+            }
+
+            let mut chunks = std::mem::take(&mut self.chunks).into_iter();
+            let mut chunk = chunks.next()?;
+            let mut block = bman.new_buffer();
+            block.init_page();
+
+            let starting_blockno = block.number();
+            loop {
+                let mut page = block.page_mut();
+
+                if page.can_fit(chunk.byte_len()) {
+                    // this chunk fits on this page, so write it there
+                    // TODO:  can probably write directly to the slice rather than going through a Vec<u8>
+                    let bytes = chunk.into_bytes();
+                    page.append_bytes(&bytes);
+
+                    chunk = match chunks.next() {
+                        Some(chunk) => chunk,
+                        None => break,
+                    }
+                } else {
+                    // this chunk doesn't fit on this page, so allocate another page
+                    let mut next_block = bman.new_buffer();
+                    next_block.init_page();
+
+                    // and link it to this one
+                    page.special_mut::<BM25PageSpecialData>().next_blockno = next_block.number();
+
+                    // and loop back around to write this chunk to the new page
+                    block = next_block;
+                }
+            }
+
+            Some(starting_blockno)
+        }
+
+        fn pack_8x(
+            &self,
+            slice: &[pg_sys::BlockNumber],
+            initial: Option<pg_sys::BlockNumber>,
+        ) -> ChunkStyle {
+            let packer = BitPacker8x::new();
+            if slice.is_sorted() {
+                let num_bits = packer.num_bits_strictly_sorted(initial, slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker8x::BLOCK_LEN / 8];
+                packer.compress_strictly_sorted(initial, &slice, &mut bytes, num_bits);
+                ChunkStyle::StrictlySorted8x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            } else {
+                let num_bits = packer.num_bits_sorted(initial.unwrap_or(0), slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker8x::BLOCK_LEN / 8];
+                packer.compress_sorted(initial.unwrap_or(0), &slice, &mut bytes, num_bits);
+                ChunkStyle::Sorted8x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            }
+        }
+
+        fn pack_4x(
+            &self,
+            slice: &[pg_sys::BlockNumber],
+            initial: Option<pg_sys::BlockNumber>,
+        ) -> ChunkStyle {
+            let packer = BitPacker4x::new();
+            if slice.is_sorted() {
+                let num_bits = packer.num_bits_strictly_sorted(initial, slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker4x::BLOCK_LEN / 8];
+                packer.compress_strictly_sorted(initial, &slice, &mut bytes, num_bits);
+                ChunkStyle::StrictlySorted4x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            } else {
+                let num_bits = packer.num_bits_sorted(initial.unwrap_or(0), slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker4x::BLOCK_LEN / 8];
+                packer.compress_sorted(initial.unwrap_or(0), &slice, &mut bytes, num_bits);
+                ChunkStyle::Sorted4x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            }
+        }
+
+        fn pack_1x(
+            &self,
+            slice: &[pg_sys::BlockNumber],
+            initial: Option<pg_sys::BlockNumber>,
+        ) -> ChunkStyle {
+            let packer = BitPacker1x::new();
+            if slice.is_sorted() {
+                let num_bits = packer.num_bits_strictly_sorted(initial, slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker1x::BLOCK_LEN / 8];
+                packer.compress_strictly_sorted(initial, &slice, &mut bytes, num_bits);
+                ChunkStyle::StrictlySorted1x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            } else {
+                let num_bits = packer.num_bits_sorted(initial.unwrap_or(0), slice);
+                let mut bytes = vec![0u8; num_bits as usize * BitPacker1x::BLOCK_LEN / 8];
+                packer.compress_sorted(initial.unwrap_or(0), &slice, &mut bytes, num_bits);
+                ChunkStyle::Sorted1x {
+                    num_bits,
+                    initial: initial.unwrap_or(0),
+                    bytes,
+                }
+            }
+        }
+    }
+}
+
+pub mod reader {
+    use crate::postgres::storage::block::BM25PageSpecialData;
+    use crate::postgres::storage::blocklist::ChunkSyleTag;
+    use crate::postgres::storage::buffer::BufferManager;
+    use bitpacking::{BitPacker, BitPacker1x, BitPacker4x, BitPacker8x};
+    use pgrx::pg_sys;
+
+    #[derive(Default, Debug)]
+    pub struct BlockList {
+        blocks: Vec<pg_sys::BlockNumber>,
+    }
+
+    impl BlockList {
+        pub fn new(bman: &BufferManager, starting_block: pg_sys::BlockNumber) -> Self {
+            if starting_block == pg_sys::InvalidBlockNumber {
+                return Self::default();
+            }
+
+            let mut blocks = Vec::new();
+            let mut blockno = starting_block;
+            loop {
+                let block = bman.get_buffer(blockno);
+                let page = block.page();
+
+                let mut offset = 0;
+                let slice = page.as_slice();
+
+                loop {
+                    let tag = ChunkSyleTag::from(slice[offset]);
+                    offset += 1;
+
+                    match tag {
+                        tag @ ChunkSyleTag::Sorted1x
+                        | tag @ ChunkSyleTag::Sorted4x
+                        | tag @ ChunkSyleTag::Sorted8x
+                        | tag @ ChunkSyleTag::StrictlySorted1x
+                        | tag @ ChunkSyleTag::StrictlySorted4x
+                        | tag @ ChunkSyleTag::StrictlySorted8x => {
+                            let num_bits = slice[offset] as u8;
+                            offset += 1;
+                            let initial = u32::from_le_bytes(
+                                slice[offset..offset + size_of::<pg_sys::BlockNumber>()]
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                            offset += size_of::<pg_sys::BlockNumber>();
+                            let end = blocks.len();
+                            match tag {
+                                ChunkSyleTag::Sorted1x => {
+                                    blocks.extend_from_slice(&[0; BitPacker1x::BLOCK_LEN]);
+                                    offset += BitPacker1x::new().decompress_sorted(
+                                        initial,
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                ChunkSyleTag::Sorted4x => {
+                                    blocks.extend_from_slice(&[0; BitPacker4x::BLOCK_LEN]);
+                                    offset += BitPacker4x::new().decompress_sorted(
+                                        initial,
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                ChunkSyleTag::Sorted8x => {
+                                    blocks.extend_from_slice(&[0; BitPacker8x::BLOCK_LEN]);
+                                    offset += BitPacker8x::new().decompress_sorted(
+                                        initial,
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                ChunkSyleTag::StrictlySorted1x => {
+                                    blocks.extend_from_slice(&[0; BitPacker1x::BLOCK_LEN]);
+                                    offset += BitPacker1x::new().decompress_strictly_sorted(
+                                        (initial != 0).then_some(initial),
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                ChunkSyleTag::StrictlySorted4x => {
+                                    blocks.extend_from_slice(&[0; BitPacker4x::BLOCK_LEN]);
+                                    offset += BitPacker4x::new().decompress_strictly_sorted(
+                                        (initial != 0).then_some(initial),
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                ChunkSyleTag::StrictlySorted8x => {
+                                    blocks.extend_from_slice(&[0; BitPacker8x::BLOCK_LEN]);
+                                    offset += BitPacker8x::new().decompress_strictly_sorted(
+                                        (initial != 0).then_some(initial),
+                                        &slice[offset..],
+                                        &mut blocks[end..],
+                                        num_bits,
+                                    );
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        ChunkSyleTag::Uncompressed => {
+                            let len = slice[offset] as usize;
+                            offset += 1;
+                            let mut tmp = [0u8; size_of::<pg_sys::BlockNumber>()];
+                            for _ in 0..len {
+                                tmp.copy_from_slice(
+                                    &slice[offset..offset + size_of::<pg_sys::BlockNumber>()],
+                                );
+                                offset += size_of::<pg_sys::BlockNumber>();
+                                let value = u32::from_le_bytes(tmp);
+                                blocks.push(value);
+                            }
+                        }
+                    }
+
+                    if offset >= slice.len() {
+                        break;
+                    }
+                }
+
+                blockno = page.special::<BM25PageSpecialData>().next_blockno;
+                if blockno == pg_sys::InvalidBlockNumber {
+                    break;
+                }
+            }
+
+            Self { blocks }
+        }
+
+        pub fn get(&self, i: usize) -> Option<pg_sys::BlockNumber> {
+            self.blocks.get(i).cloned()
+        }
+    }
+}

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -16,17 +16,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::block::{bm25_max_free_space, BM25PageSpecialData, LinkedList, LinkedListData};
+use crate::postgres::storage::blocklist;
 use crate::postgres::storage::buffer::{BufferManager, PageHeaderMethods};
-use crate::postgres::storage::SKIPLIST_FREQ;
 use anyhow::Result;
-use parking_lot::Mutex;
 use pgrx::pg_sys;
-use rustc_hash::FxHashMap;
+use pgrx::pg_sys::BlockNumber;
 use std::cmp::min;
-use std::collections::hash_map::Entry;
 use std::io::{Cursor, Read, Write};
 use std::ops::{Deref, Range};
-use std::sync::Arc;
 // ---------------------------------------------------------------
 // Linked list implementation over block storage,
 // where each node is a page filled with bm25_max_free_space()
@@ -62,12 +59,13 @@ use std::sync::Arc;
 // | [next_blockno: BlockNumber, xmax: TransactionId]            |
 // +-------------------------------------------------------------+
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LinkedBytesList {
     bman: BufferManager,
     pub header_blockno: pg_sys::BlockNumber,
     metadata: LinkedListData,
-    skipcache: Arc<Mutex<FxHashMap<usize, pg_sys::BlockNumber>>>,
+    blocklist_builder: blocklist::builder::BlockList,
+    blocklist_reader: blocklist::reader::BlockList,
 }
 
 impl Write for LinkedBytesList {
@@ -79,6 +77,12 @@ impl Write for LinkedBytesList {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
+        if let Some(blockno) = self.blocklist_builder.finish(&mut self.bman) {
+            let mut header_block = self.bman.get_buffer_mut(self.header_blockno);
+            let mut page = header_block.page_mut();
+            let metadata = page.contents_mut::<LinkedListData>();
+            metadata.blocklist_start = blockno;
+        }
         Ok(())
     }
 }
@@ -86,6 +90,10 @@ impl Write for LinkedBytesList {
 impl LinkedList for LinkedBytesList {
     fn get_header_blockno(&self) -> pg_sys::BlockNumber {
         self.header_blockno
+    }
+
+    fn block_for_ord(&self, ord: usize) -> Option<BlockNumber> {
+        self.blocklist_reader.get(ord)
     }
 
     unsafe fn get_linked_list_data(&self) -> LinkedListData {
@@ -144,11 +152,13 @@ impl LinkedBytesList {
             .get_buffer(header_blockno)
             .page_contents::<LinkedListData>();
 
+        let blocklist_reader = blocklist::reader::BlockList::new(&bman, metadata.blocklist_start);
         Self {
             bman,
             header_blockno,
             metadata,
-            skipcache: Default::default(),
+            blocklist_builder: Default::default(),
+            blocklist_reader,
         }
     }
 
@@ -164,15 +174,17 @@ impl LinkedBytesList {
         start_buffer.init_page();
 
         let metadata = header_page.contents_mut::<LinkedListData>();
-        metadata.skip_list[0] = start_blockno;
-        metadata.inner.last_blockno = start_blockno;
-        metadata.inner.npages = 1;
+        metadata.start_blockno = start_blockno;
+        metadata.last_blockno = start_blockno;
+        metadata.npages = 1;
+        metadata.blocklist_start = pg_sys::InvalidBlockNumber;
 
         Self {
             bman,
             header_blockno,
             metadata: *metadata,
-            skipcache: Default::default(),
+            blocklist_builder: Default::default(),
+            blocklist_reader: Default::default(),
         }
     }
 
@@ -182,6 +194,8 @@ impl LinkedBytesList {
 
         let mut insert_blockno = self.get_last_blockno();
         while bytes_written < bytes.len() {
+            self.blocklist_builder.push(insert_blockno);
+
             let mut buffer = self.bman.get_buffer_mut(insert_blockno);
             let mut page = buffer.page_mut();
             let free_space = page.header().free_space();
@@ -204,19 +218,17 @@ impl LinkedBytesList {
 
                 let mut page = header_buffer.page_mut();
                 let metadata = page.contents_mut::<LinkedListData>();
-                metadata.inner.last_blockno = new_blockno;
-                metadata.inner.npages += 1;
-                if metadata.inner.npages as usize % SKIPLIST_FREQ == 0 {
-                    let idx = metadata.inner.npages as usize / SKIPLIST_FREQ;
-                    metadata.skip_list[idx] = new_blockno;
-                }
+                metadata.last_blockno = new_blockno;
+                metadata.npages += 1;
                 self.metadata = *metadata;
 
                 insert_blockno = new_blockno;
                 continue;
             }
 
-            let page_slice = page.free_space_slice_mut(bytes_to_write);
+            let page_slice = page
+                .free_space_slice_mut(bytes_to_write)
+                .expect("page is full");
             data_cursor.read_exact(page_slice)?;
             bytes_written += bytes_to_write;
 
@@ -294,28 +306,9 @@ impl LinkedBytesList {
 
         // find the closest block in the linked list to where `range` begins
         let start_block_ord = range.start / ITEM_SIZE;
-        let (nearest_block, nearest_ord) = self.nearest_block_by_ord(start_block_ord);
-        let mut blockno = nearest_block;
-
-        match self.skipcache.lock().entry(start_block_ord) {
-            Entry::Occupied(entry) => {
-                blockno = *entry.get();
-            }
-            Entry::Vacant(entry) => {
-                // scan forward from that block skipping those that appear before our range begins
-                let mut skip = start_block_ord - nearest_ord.saturating_sub(1);
-                while skip != 0 && blockno != pg_sys::InvalidBlockNumber {
-                    let buffer = self.bman.get_buffer(blockno);
-                    let page = buffer.page();
-                    let special = page.special::<BM25PageSpecialData>();
-
-                    blockno = special.next_blockno;
-                    skip -= 1;
-                }
-
-                entry.insert(blockno);
-            }
-        }
+        let mut blockno = self
+            .block_for_ord(start_block_ord)
+            .expect("block not found");
 
         if range.start % ITEM_SIZE + range.len() < ITEM_SIZE {
             // fits on one page -- use our page cache.  many individual pages are read multiple

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -69,7 +69,9 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedList for 
     }
 
     fn block_for_ord(&self, ord: usize) -> Option<BlockNumber> {
-        unimplemented!("block_for_ord is not implemented for LinkedItemList")
+        unimplemented!(
+            "block_for_ord is not implemented for LinkedItemList.  caller requested ord: {ord}"
+        )
     }
 
     unsafe fn get_linked_list_data(&self) -> LinkedListData {

--- a/pg_search/src/postgres/storage/mod.rs
+++ b/pg_search/src/postgres/storage/mod.rs
@@ -91,6 +91,7 @@
 // +-------------------------------------------------------------+
 
 pub mod block;
+mod blocklist;
 pub mod buffer;
 pub mod linked_bytes;
 pub mod linked_items;
@@ -98,6 +99,3 @@ pub mod utils;
 
 pub use self::linked_bytes::LinkedBytesList;
 pub use self::linked_items::LinkedItemList;
-
-/// How often should a linked list make a skip list entry?
-pub const SKIPLIST_FREQ: usize = 500;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This removes our "skiplist" and replaces it with a scheme that tightly bitpacks every `BlockNumber` used in one of our `LinkedBytesList`s.  

The skiplist was slow due to forward scanning and could have also ended up being too small for a very large tantivy file.

There's a small performance improvement with this on isolated queries... around 2-3%.

Additionally, we had an issue where panics during `ChannelRequestHandler::wait_for(|| ...)` wouldn't be reported and would end up crashing Postgres.  This fixes that too.

## Why

## How

## Tests

Existing tests pass and stresgres' TPS rate for SELECT statements has improved by roughly 20%.