### PR TITLE
chore: fix v1.84.0 clippy complaints

### DIFF
--- a/cargo-paradedb/src/subcommand.rs
+++ b/cargo-paradedb/src/subcommand.rs
@@ -46,7 +46,7 @@ pub fn install() -> Result<()> {
 
     // Using `exec` will replace the terminate the current process and replace it
     // with the command we've defined, as opposed to running it as a subprocess.
-    command.exec();
+    let _ = command.exec();
     Ok(())
 }
 

--- a/pg_search/src/bin/pgrx_embed.rs
+++ b/pg_search/src/bin/pgrx_embed.rs
@@ -1,1 +1,2 @@
+#![allow(unexpected_cfgs)]
 ::pgrx::pgrx_embed!();

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -14,6 +14,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
+#![allow(unexpected_cfgs)]
 
 mod api;
 mod bootstrap;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Rust v1.84 introduced some new clippy lint warnings, which this PR addresses.

As a result, our MSRV is now v1.84.0

## Why

## How

## Tests
