### PR TITLE
chore: undo "ctids in postings"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,7 +2998,6 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4843,7 +4842,6 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4892,7 +4890,6 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "bitpacking",
 ]
@@ -4900,7 +4897,6 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4915,7 +4911,6 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4938,7 +4933,6 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "nom",
 ]
@@ -4946,7 +4940,6 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -4957,7 +4950,6 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4967,7 +4959,6 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735#e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4842,6 +4843,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4890,6 +4892,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "bitpacking",
 ]
@@ -4897,6 +4900,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4911,6 +4915,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4933,6 +4938,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "nom",
 ]
@@ -4940,6 +4946,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -4950,6 +4957,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4959,6 +4967,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,16 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735", features = [
+#tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735", features = [
+#  "quickwit",        # for sstable support
+#  "stopwords",
+#  "lz4-compression",
+#], default-features = false }
+#tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735" }
+
+tantivy = { path = "/home/zombodb/_work/tantivy", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735" }
+tantivy-common = { path = "/home/zombodb/_work/tantivy/common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-#tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735", features = [
-#  "quickwit",        # for sstable support
-#  "stopwords",
-#  "lz4-compression",
-#], default-features = false }
-#tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "e22ad2b9f2f8ce8fc1dfe197c7e980b53f73e735" }
-
-tantivy = { path = "/home/zombodb/_work/tantivy", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "83efdfa3879921a478afe098dcc1fd9835d2b52d", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { path = "/home/zombodb/_work/tantivy/common" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "83efdfa3879921a478afe098dcc1fd9835d2b52d" }

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -227,6 +227,18 @@ impl FFType {
             None
         }
     }
+
+    /// Given a [`DocId`], what is its u64 "fast field" value?
+    ///
+    /// If this [`FFType`] isn't [`FFType::U64`], this function returns [`None`].
+    #[inline(always)]
+    pub fn as_u64(&self, doc: DocId) -> Option<u64> {
+        if let FFType::U64(ff) = self {
+            ff.first(doc)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn _PG_init() {
     // is initialized for all connections.
     #[allow(static_mut_refs)]
     #[allow(deprecated)]
-    // pgrx::hooks::register_hook(&mut TRACE_HOOK);
+    pgrx::hooks::register_hook(&mut TRACE_HOOK);
     customscan::register_rel_pathlist(customscan::pdbscan::PdbScan);
 }
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn _PG_init() {
     // is initialized for all connections.
     #[allow(static_mut_refs)]
     #[allow(deprecated)]
-    pgrx::hooks::register_hook(&mut TRACE_HOOK);
+    // pgrx::hooks::register_hook(&mut TRACE_HOOK);
     customscan::register_rel_pathlist(customscan::pdbscan::PdbScan);
 }
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -22,9 +22,10 @@ use crate::postgres::storage::block::{
 };
 use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
-use crate::postgres::utils::{categorize_fields, row_to_search_document, CategorizedFieldData};
+use crate::postgres::utils::{
+    categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
+};
 use crate::schema::SearchField;
-use pgrx::itemptr::item_pointer_get_both;
 use pgrx::*;
 use std::ffi::CStr;
 use std::time::Instant;
@@ -167,7 +168,7 @@ unsafe extern "C" fn build_callback(
                 );
             });
             writer
-                .insert(search_document, item_pointer_get_both(*ctid))
+                .insert(search_document, item_pointer_to_u64(*ctid))
                 .unwrap_or_else(|err| {
                     panic!("error inserting document during build callback.  See Postgres log for more information: {err:?}")
                 });

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -66,6 +66,7 @@ pub extern "C" fn ambulkdelete(
         let ctid_ff = FFType::new(segment_reader.fast_fields(), "ctid");
 
         for doc_id in 0..segment_reader.max_doc() {
+            check_for_interrupts!();
             let ctid = ctid_ff.as_u64(doc_id).expect("ctid should be present");
             if callback(ctid) {
                 did_delete = true;

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -16,11 +16,10 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use pgrx::{pg_sys::ItemPointerData, *};
-use tantivy::postings::Postings;
-use tantivy::schema::IndexRecordOption;
-use tantivy::{DocSet, Term};
+use tantivy::Term;
 
 use super::storage::block::CLEANUP_LOCK;
+use crate::index::fast_fields_helper::FFType;
 use crate::index::merge_policy::MergeLock;
 use crate::index::reader::index::SearchIndexReader;
 use crate::index::writer::index::SearchIndexWriter;
@@ -64,29 +63,15 @@ pub extern "C" fn ambulkdelete(
     let mut did_delete = false;
 
     for segment_reader in reader.searcher().segment_readers() {
-        let inverted_index = segment_reader
-            .inverted_index(ctid_field)
-            .expect("tantivy inverted index should contain the ctid field");
-        let termdict = inverted_index.terms();
-        let mut allterms = termdict
-            .stream()
-            .expect("should be able to stream all terms from the inverted index");
-        while let Some((term_bytes, term_info)) = allterms.next() {
-            let mut postings = inverted_index
-                .read_postings_from_terminfo(term_info, IndexRecordOption::Basic)
-                .expect("should be able to retrieve postings for TermInfo");
-            loop {
-                let ctid = postings.ctid_value();
-                let ctid = ((ctid.0 as u64) << 16) | ctid.1 as u64;
-                if callback(ctid) {
-                    did_delete = true;
-                    writer
-                        .delete_term(Term::from_field_bytes(ctid_field, term_bytes))
-                        .expect("ambulkdelete: deleting ctid Term should succeed");
-                }
-                if postings.advance() == tantivy::TERMINATED {
-                    break;
-                }
+        let ctid_ff = FFType::new(segment_reader.fast_fields(), "ctid");
+
+        for doc_id in 0..segment_reader.max_doc() {
+            let ctid = ctid_ff.as_u64(doc_id).expect("ctid should be present");
+            if callback(ctid) {
+                did_delete = true;
+                writer
+                    .delete_term(Term::from_field_u64(ctid_field, ctid))
+                    .expect("ambulkdelete: deleting ctid Term should succeed");
             }
         }
     }

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -17,9 +17,10 @@
 
 use crate::index::writer::index::SearchIndexWriter;
 use crate::index::{BlockDirectoryType, WriterResources};
-use crate::postgres::utils::{categorize_fields, row_to_search_document, CategorizedFieldData};
+use crate::postgres::utils::{
+    categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
+};
 use crate::schema::SearchField;
-use pgrx::itemptr::item_pointer_get_both;
 use pgrx::{pg_guard, pg_sys, PgMemoryContexts, PgRelation, PgTupleDesc};
 use std::ffi::CStr;
 use std::panic::{catch_unwind, resume_unwind};
@@ -169,7 +170,7 @@ unsafe fn aminsert_internal(
             );
         });
         writer
-            .insert(search_document, item_pointer_get_both(*ctid))
+            .insert(search_document, item_pointer_to_u64(*ctid))
             .expect("insertion into index should succeed");
 
         true

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -59,11 +59,6 @@ pub fn item_pointer_to_u64(ctid: pg_sys::ItemPointerData) -> u64 {
     (blockno << 16) | offno
 }
 
-pub fn ctid_to_u64(ctid: tantivy::Ctid) -> u64 {
-    let (blockno, offno) = (ctid.0 as u64, ctid.1 as u64);
-    (blockno << 16) | offno
-}
-
 /// Rather than using pgrx' version of this function, we use our own, which doesn't leave 2
 /// empty bytes in the middle of the 64bit representation.  A ctid being only 48bits means
 /// if we leave the upper 16 bits (2 bytes) empty, tantivy will have a better chance of

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -62,6 +62,7 @@ pub extern "C" fn amvacuumcleanup(
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
         for blockno in 0..nblocks {
+            check_for_interrupts!();
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -878,15 +878,7 @@ impl SearchQueryInput {
                     Bound::Unbounded => Bound::Unbounded,
                 };
 
-                if let Some(path) = path {
-                    Ok(Box::new(RangeQuery::with_path(
-                        lower_bound,
-                        upper_bound,
-                        Some(path),
-                    )))
-                } else {
-                    Ok(Box::new(RangeQuery::new(lower_bound, upper_bound)))
-                }
+                Ok(Box::new(RangeQuery::new(lower_bound, upper_bound)))
             }
             Self::RangeContains {
                 field,

--- a/pg_search/src/query/range.rs
+++ b/pg_search/src/query/range.rs
@@ -88,25 +88,21 @@ impl RangeField {
         comparison: Comparison,
     ) -> Result<RangeQuery, Box<dyn std::error::Error>> {
         let query = match comparison {
-            Comparison::LessThan => RangeQuery::with_path(
+            Comparison::LessThan => RangeQuery::new(
                 Bound::Excluded(Self::as_range_term(self, owned, Some(LOWER_KEY))?),
                 Bound::Unbounded,
-                Some(LOWER_KEY.to_owned()),
             ),
-            Comparison::LessThanOrEqual => RangeQuery::with_path(
+            Comparison::LessThanOrEqual => RangeQuery::new(
                 Bound::Included(Self::as_range_term(self, owned, Some(LOWER_KEY))?),
                 Bound::Unbounded,
-                Some(LOWER_KEY.to_owned()),
             ),
-            Comparison::GreaterThan => RangeQuery::with_path(
+            Comparison::GreaterThan => RangeQuery::new(
                 Bound::Unbounded,
                 Bound::Excluded(Self::as_range_term(self, owned, Some(LOWER_KEY))?),
-                Some(LOWER_KEY.to_owned()),
             ),
-            Comparison::GreaterThanOrEqual => RangeQuery::with_path(
+            Comparison::GreaterThanOrEqual => RangeQuery::new(
                 Bound::Unbounded,
                 Bound::Included(Self::as_range_term(self, owned, Some(LOWER_KEY))?),
-                Some(LOWER_KEY.to_owned()),
             ),
         };
 
@@ -119,25 +115,21 @@ impl RangeField {
         comparison: Comparison,
     ) -> Result<RangeQuery, Box<dyn std::error::Error>> {
         let query = match comparison {
-            Comparison::LessThan => RangeQuery::with_path(
+            Comparison::LessThan => RangeQuery::new(
                 Bound::Excluded(Self::as_range_term(self, owned, Some(UPPER_KEY))?),
                 Bound::Unbounded,
-                Some(UPPER_KEY.to_owned()),
             ),
-            Comparison::LessThanOrEqual => RangeQuery::with_path(
+            Comparison::LessThanOrEqual => RangeQuery::new(
                 Bound::Included(Self::as_range_term(self, owned, Some(UPPER_KEY))?),
                 Bound::Unbounded,
-                Some(UPPER_KEY.to_owned()),
             ),
-            Comparison::GreaterThan => RangeQuery::with_path(
+            Comparison::GreaterThan => RangeQuery::new(
                 Bound::Unbounded,
                 Bound::Excluded(Self::as_range_term(self, owned, Some(UPPER_KEY))?),
-                Some(UPPER_KEY.to_owned()),
             ),
-            Comparison::GreaterThanOrEqual => RangeQuery::with_path(
+            Comparison::GreaterThanOrEqual => RangeQuery::new(
                 Bound::Unbounded,
                 Bound::Included(Self::as_range_term(self, owned, Some(UPPER_KEY))?),
-                Some(UPPER_KEY.to_owned()),
             ),
         };
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -702,8 +702,6 @@ impl SearchIndexSchema {
         let mut builder = Schema::builder();
         let mut search_fields = vec![];
 
-        let key_field_name = fields[key_index].0 .0.clone();
-
         for (name, config, field_type) in fields {
             let id: SearchFieldId = match field_type {
                 SearchFieldType::Text => builder.add_text_field(name.as_ref(), config.clone()),
@@ -727,13 +725,11 @@ impl SearchIndexSchema {
 
         // hardcode the ctid field into the schema.  "ctid" is a reserved Postgres attribute name
         // so we don't need to worry about name conflicts
-        builder.add_u64_field("ctid", tantivy::schema::INDEXED);
-
-        let schema = builder.build_with_key_field(&key_field_name);
+        builder.add_u64_field("ctid", tantivy::schema::INDEXED | tantivy::schema::FAST);
 
         Ok(Self {
             key: key_index,
-            schema,
+            schema: builder.build(),
             lookup: Self::build_lookup(&search_fields).into(),
             fields: search_fields,
         })


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

For short while we modified our tantivy fork to allow for pushing Postgres "ctid" values directly into the tantivy postings file, inline with its `DocId`s so that we could get the ctid values as quickly as possible, avoiding fast fields.

Well, as of a commit to https://github.com/paradedb/paradedb/pull/2065, our "fast fields is quite slow" drama is gone, so we're able to undo this "ctids in postings" business.

I've updated our tantivy fork in https://github.com/paradedb/tantivy/commit/83efdfa3879921a478afe098dcc1fd9835d2b52d to revert that particular (huge!) changeset and this PR against pg_search undoes our side of that change.

Now that we're using fast fields correctly, the performance numbers are essentially identical, which isn't necessarily surprising as we're still reading/decoding about the same number of bytes in essentially the same manner.

## Why

Less changes to tantivy is great.  This will also make our indexes much smaller as we're no longer duplicating ctids in every postings list.

## How

## Tests

All existing tests pass.  Local perf testing looks good too