### PR TITLE
perf: do not do expensive merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,7 +2998,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "bitpacking",
 ]
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4938,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "nom",
 ]
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=83efdfa3879921a478afe098dcc1fd9835d2b52d#83efdfa3879921a478afe098dcc1fd9835d2b52d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,7 +2998,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "bitpacking",
 ]
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4938,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "nom",
 ]
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "tantivy-bitpacker",
  "tantivy-common",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1367db73e2405093283b9e1ab85d85eb87721af9#1367db73e2405093283b9e1ab85d85eb87721af9"
+source = "git+https://github.com/paradedb/tantivy.git?rev=25b895b15c620ab7ed1869bc8994587b718cd57f#25b895b15c620ab7ed1869bc8994587b718cd57f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "83efdfa3879921a478afe098dcc1fd9835d2b52d", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "25b895b15c620ab7ed1869bc8994587b718cd57f", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "83efdfa3879921a478afe098dcc1fd9835d2b52d" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "25b895b15c620ab7ed1869bc8994587b718cd57f" }

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -16,6 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use super::utils::{list_managed_files, load_metas, save_new_metas, save_schema, save_settings};
+use crate::index::merge_policy::{
+    set_num_segments, AllowedMergePolicy, MergeLock, NPlusOneMergePolicy,
+};
 use crate::index::reader::segment_component::SegmentComponentReader;
 use crate::postgres::storage::block::{
     FileEntry, SegmentFileDetails, SegmentMetaEntry, SEGMENT_METAS_START,
@@ -24,7 +27,7 @@ use crate::postgres::storage::LinkedItemList;
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
 use pgrx::pg_sys;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::any::Any;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
@@ -34,7 +37,11 @@ use std::sync::Arc;
 use std::{io, result};
 use tantivy::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use tantivy::directory::{DirectoryLock, FileHandle, Lock, WatchCallback, WatchHandle, WritePtr};
+use tantivy::merge_policy::{MergePolicy, NoMergePolicy};
 use tantivy::{index::SegmentMetaInventory, Directory, IndexMeta};
+
+// Minimum number of segments for the NPlusOneMergePolicy to maintain
+const MIN_NUM_SEGMENTS: usize = 2;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MvccSatisfies {
@@ -49,6 +56,8 @@ pub enum MvccSatisfies {
 pub struct MVCCDirectory {
     relation_oid: pg_sys::Oid,
     mvcc_style: MvccSatisfies,
+    merge_policy: AllowedMergePolicy,
+    merge_lock: Arc<Mutex<Option<MergeLock>>>,
 
     // keep a cache of readers behind an Arc<Mutex<_>> so that if/when this MVCCDirectory is
     // cloned, we don't lose all the work we did originally creating the FileHandler impls.  And
@@ -57,19 +66,23 @@ pub struct MVCCDirectory {
 }
 
 impl MVCCDirectory {
-    pub fn snapshot(relation_oid: pg_sys::Oid) -> Self {
+    pub fn snapshot(relation_oid: pg_sys::Oid, merge_policy: AllowedMergePolicy) -> Self {
         Self {
             relation_oid,
+            merge_policy,
             mvcc_style: MvccSatisfies::Snapshot,
             readers: Arc::new(Mutex::new(FxHashMap::default())),
+            merge_lock: Default::default(),
         }
     }
 
-    pub fn any(relation_oid: pg_sys::Oid) -> Self {
+    pub fn any(relation_oid: pg_sys::Oid, merge_policy: AllowedMergePolicy) -> Self {
         Self {
             relation_oid,
+            merge_policy,
             mvcc_style: MvccSatisfies::Any,
             readers: Arc::new(Mutex::new(FxHashMap::default())),
+            merge_lock: Default::default(),
         }
     }
 
@@ -228,12 +241,66 @@ impl Directory for MVCCDirectory {
             )
         }
     }
+
+    fn reconsider_merge_policy(
+        &self,
+        meta: &IndexMeta,
+        previous_meta: &IndexMeta,
+    ) -> Option<Box<dyn MergePolicy>> {
+        let new_ids = meta
+            .segments
+            .iter()
+            .map(|s| s.id())
+            .collect::<FxHashSet<_>>();
+        let previous_ids = previous_meta
+            .segments
+            .iter()
+            .map(|s| s.id())
+            .collect::<FxHashSet<_>>();
+        let segments_created = new_ids
+            .difference(&previous_ids)
+            .collect::<FxHashSet<_>>()
+            .len();
+
+        if matches!(self.merge_policy, AllowedMergePolicy::None) {
+            return Some(Box::new(NoMergePolicy));
+        }
+
+        //
+        // if more than 1 segment was created, that means a bulk insert occurred
+        // we should not merge these new segments because that would be a very expensive operation
+        // instead, we should just increase the target segment count for the next merge
+        if segments_created > 1 {
+            unsafe { set_num_segments(self.relation_oid, new_ids.len() as u32 - 1) };
+            return Some(Box::new(NoMergePolicy));
+        }
+
+        // try to acquire merge lock and do merge
+        if let Some(mut merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
+            if let AllowedMergePolicy::NPlusOne(n) = self.merge_policy {
+                let num_segments = unsafe { merge_lock.num_segments() };
+                let target_segments = std::cmp::max(n, num_segments as usize);
+                let merge_policy: Box<dyn MergePolicy> = Box::new(NPlusOneMergePolicy {
+                    n: target_segments,
+                    min_num_segments: MIN_NUM_SEGMENTS,
+                });
+
+                let mut lock = self.merge_lock.lock();
+                *lock = Some(merge_lock);
+
+                return Some(merge_policy);
+            }
+        }
+
+        Some(Box::new(NoMergePolicy))
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use crate::index::merge_policy::AllowedMergePolicy;
     use pgrx::prelude::*;
 
     #[pg_test]
@@ -246,7 +313,7 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let directory = MVCCDirectory::snapshot(relation_oid);
+        let directory = MVCCDirectory::snapshot(relation_oid, AllowedMergePolicy::None);
         let listed_files = directory.list_managed_files().unwrap();
         assert_eq!(listed_files.len(), 6);
     }

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -234,10 +234,10 @@ pub unsafe fn save_new_metas(
     //
 
     // delete old entries and their corresponding files
-    for (entry, blockno) in deleted_entries {
+    for (entry, blockno) in &deleted_entries {
         assert!(entry.xmax == current_xid);
 
-        let mut buffer = linked_list.bman_mut().get_buffer_mut(blockno);
+        let mut buffer = linked_list.bman_mut().get_buffer_mut(*blockno);
         let mut page = buffer.page_mut();
 
         let Some(offno) =
@@ -249,7 +249,7 @@ pub unsafe fn save_new_metas(
             );
         };
 
-        let PgItem(pg_item, size) = entry.into();
+        let PgItem(pg_item, size) = (*entry).into();
 
         let did_replace = page.replace_item(offno, pg_item, size);
         assert!(did_replace);
@@ -304,6 +304,12 @@ pub unsafe fn save_new_metas(
 
     // add the new entries
     linked_list.add_items(created_entries, None)?;
+
+    if !deleted_entries.is_empty() {
+        linked_list.garbage_collect(pg_sys::GetAccessStrategy(
+            pg_sys::BufferAccessStrategyType::BAS_VACUUM,
+        ))?;
+    }
 
     Ok(())
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::fast_fields_helper::FFType;
+use crate::index::merge_policy::AllowedMergePolicy;
 use crate::index::{setup_tokenizers, BlockDirectoryType};
 use crate::postgres::storage::block::CLEANUP_LOCK;
 use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -260,7 +260,7 @@ impl SearchIndexReader {
             None
         };
 
-        let directory = directory_type.directory(index_relation);
+        let directory = directory_type.directory(index_relation, AllowedMergePolicy::None);
         let mut index = Index::open(directory)?;
         let schema = SearchIndexSchema::open(index.schema(), index_relation);
 

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -37,8 +37,7 @@ pub enum WriterResources {
 }
 pub type Parallelism = NonZeroUsize;
 pub type MemoryBudget = usize;
-pub type DoMerging = bool;
-pub type IndexConfig = (Parallelism, MemoryBudget, DoMerging, AllowedMergePolicy);
+pub type IndexConfig = (Parallelism, MemoryBudget, AllowedMergePolicy);
 
 pub enum BlockDirectoryType {
     Mvcc,
@@ -46,10 +45,16 @@ pub enum BlockDirectoryType {
 }
 
 impl BlockDirectoryType {
-    pub fn directory(self, index_relation: &PgRelation) -> MVCCDirectory {
+    pub fn directory(
+        self,
+        index_relation: &PgRelation,
+        merge_policy: AllowedMergePolicy,
+    ) -> MVCCDirectory {
         match self {
-            BlockDirectoryType::Mvcc => MVCCDirectory::snapshot(index_relation.oid()),
-            BlockDirectoryType::BulkDelete => MVCCDirectory::any(index_relation.oid()),
+            BlockDirectoryType::Mvcc => MVCCDirectory::snapshot(index_relation.oid(), merge_policy),
+            BlockDirectoryType::BulkDelete => {
+                MVCCDirectory::any(index_relation.oid(), merge_policy)
+            }
         }
     }
 
@@ -57,9 +62,10 @@ impl BlockDirectoryType {
         self,
         index_relation: &PgRelation,
         receiver: Receiver<ChannelRequest>,
+        merge_policy: AllowedMergePolicy,
     ) -> ChannelRequestHandler {
         ChannelRequestHandler::open(
-            self.directory(index_relation),
+            self.directory(index_relation, merge_policy),
             index_relation.oid(),
             receiver,
         )
@@ -77,14 +83,11 @@ impl WriterResources {
         let merge_on_insert = options.merge_on_insert();
 
         match self {
-            WriterResources::CreateIndex => {
-                (
-                    gucs::create_index_parallelism(),
-                    gucs::create_index_memory_budget(),
-                    true, // we always want a merge on CREATE INDEX
-                    AllowedMergePolicy::NPlusOne(target_segment_count),
-                )
-            }
+            WriterResources::CreateIndex => (
+                gucs::create_index_parallelism(),
+                gucs::create_index_memory_budget(),
+                AllowedMergePolicy::None,
+            ),
             WriterResources::Statement => {
                 let policy = if merge_on_insert {
                     AllowedMergePolicy::NPlusOne(target_segment_count)
@@ -94,18 +97,14 @@ impl WriterResources {
                 (
                     gucs::statement_parallelism(),
                     gucs::statement_memory_budget(),
-                    merge_on_insert, // user/index decides if we merge for INSERT/UPDATE statements
                     policy,
                 )
             }
-            WriterResources::Vacuum => {
-                (
-                    gucs::statement_parallelism(),
-                    gucs::statement_memory_budget(),
-                    true, // we always want a merge on (auto)VACUUM
-                    AllowedMergePolicy::NPlusOne(target_segment_count),
-                )
-            }
+            WriterResources::Vacuum => (
+                gucs::statement_parallelism(),
+                gucs::statement_memory_budget(),
+                AllowedMergePolicy::NPlusOne(target_segment_count),
+            ),
         }
     }
 }

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -16,19 +16,15 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::Result;
-use pgrx::{pg_sys, PgRelation};
+use pgrx::PgRelation;
 use std::sync::Arc;
-use tantivy::indexer::{MergePolicy, NoMergePolicy, UserOperation};
+use tantivy::indexer::UserOperation;
 use tantivy::schema::Field;
 use tantivy::{Index, IndexSettings, IndexWriter, Opstamp, TantivyDocument, TantivyError, Term};
 use thiserror::Error;
 
 use crate::index::channel::{ChannelDirectory, ChannelRequestHandler};
-use crate::index::merge_policy::MergeLock;
-use crate::index::mvcc::MVCCDirectory;
 use crate::index::{get_index_schema, setup_tokenizers, BlockDirectoryType, WriterResources};
-use crate::postgres::storage::block::{SegmentMetaEntry, SEGMENT_METAS_START};
-use crate::postgres::storage::LinkedItemList;
 use crate::{
     postgres::types::TantivyValueError,
     schema::{SearchDocument, SearchIndexSchema},
@@ -48,9 +44,7 @@ pub struct SearchIndexWriter {
     // mis-use the IndexWriter in particular.
     writer: Arc<IndexWriter>,
     handler: ChannelRequestHandler,
-    wants_merge: bool,
     insert_queue: Vec<UserOperation>,
-    relation_oid: pg_sys::Oid,
 }
 
 impl SearchIndexWriter {
@@ -59,12 +53,12 @@ impl SearchIndexWriter {
         directory_type: BlockDirectoryType,
         resources: WriterResources,
     ) -> Result<Self> {
-        let (parallelism, memory_budget, wants_merge, merge_policy) =
-            resources.resources(index_relation);
+        let (parallelism, memory_budget, merge_policy) = resources.resources(index_relation);
 
         let (req_sender, req_receiver) = crossbeam::channel::bounded(CHANNEL_QUEUE_LEN);
         let channel_dir = ChannelDirectory::new(req_sender);
-        let mut handler = directory_type.channel_request_handler(index_relation, req_receiver);
+        let mut handler =
+            directory_type.channel_request_handler(index_relation, req_receiver, merge_policy);
 
         let mut index = {
             handler
@@ -81,7 +75,6 @@ impl SearchIndexWriter {
             .wait_for(move || {
                 let writer =
                     index_clone.writer_with_num_threads(parallelism.get(), memory_budget)?;
-                writer.set_merge_policy(merge_policy.into());
                 tantivy::Result::Ok(writer)
             })
             .expect("scoped thread should not fail")?;
@@ -90,11 +83,9 @@ impl SearchIndexWriter {
         let ctid_field = schema.schema.get_field("ctid")?;
 
         Ok(Self {
-            relation_oid: index_relation.oid(),
             writer: Arc::new(writer),
             schema,
             handler,
-            wants_merge,
             ctid_field,
             insert_queue: Vec::with_capacity(MAX_INSERT_QUEUE_SIZE),
         })
@@ -102,15 +93,15 @@ impl SearchIndexWriter {
 
     pub fn create_index(index_relation: &PgRelation) -> Result<Self> {
         let schema = get_index_schema(index_relation)?;
-        let (parallelism, memory_budget, wants_merge, merge_policy) =
+        let (parallelism, memory_budget, merge_policy) =
             WriterResources::CreateIndex.resources(index_relation);
 
         let (req_sender, req_receiver) = crossbeam::channel::bounded(CHANNEL_QUEUE_LEN);
         let channel_dir = ChannelDirectory::new(req_sender);
-        let mut handler = ChannelRequestHandler::open(
-            MVCCDirectory::snapshot(index_relation.oid()),
-            index_relation.oid(),
+        let mut handler = BlockDirectoryType::Mvcc.channel_request_handler(
+            index_relation,
             req_receiver,
+            merge_policy,
         );
 
         let mut index = {
@@ -132,19 +123,16 @@ impl SearchIndexWriter {
         let writer = handler
             .wait_for(move || {
                 let writer = index.writer_with_num_threads(parallelism.get(), memory_budget)?;
-                writer.set_merge_policy(merge_policy.into());
                 tantivy::Result::Ok(writer)
             })
             .expect("scoped thread should not fail")?;
         let ctid_field = schema.schema.get_field("ctid")?;
 
         Ok(Self {
-            relation_oid: index_relation.oid(),
             writer: Arc::new(writer),
             schema,
             ctid_field,
             handler,
-            wants_merge,
             insert_queue: Vec::with_capacity(MAX_INSERT_QUEUE_SIZE),
         })
     }
@@ -174,63 +162,25 @@ impl SearchIndexWriter {
         Ok(())
     }
 
-    pub fn commit(mut self, should_merge: bool) -> Result<()> {
+    pub fn commit(mut self) -> Result<()> {
         self.drain_insert_queue()?;
         let mut writer =
             Arc::into_inner(self.writer).expect("should not have an outstanding Arc<IndexWriter>");
 
-        if should_merge {
-            let _opstamp = self
-                .handler
-                .wait_for(move || {
-                    let opstamp = writer.commit()?;
-                    writer.wait_merging_threads()?;
-                    tantivy::Result::Ok(opstamp)
-                })
-                .expect("spawned thread should not fail")?;
-        } else {
-            self.handler
-                .wait_for(move || {
-                    let policy: Box<dyn MergePolicy> = Box::new(NoMergePolicy);
-                    writer.set_merge_policy(policy);
-                    let opstamp = writer.commit()?;
-                    tantivy::Result::Ok(opstamp)
-                })
-                .expect("spawned thread should not fail")?;
-        };
-        Ok(())
-    }
+        self.handler
+            .wait_for(move || {
+                let opstamp = writer.commit()?;
+                writer.wait_merging_threads()?;
+                tantivy::Result::Ok(opstamp)
+            })
+            .expect("spawned thread should not fail")?;
 
-    pub fn commit_inserts(self) -> Result<()> {
-        let index_oid = self.relation_oid;
-        let merge_lock = if self.wants_merge {
-            unsafe { MergeLock::acquire_for_merge(self.relation_oid) }
-        } else {
-            None
-        };
-        self.commit(merge_lock.is_some())?;
-
-        if merge_lock.is_some() {
-            unsafe {
-                garbage_collect_metas(index_oid)?;
-            }
-        }
         Ok(())
     }
 
     pub fn vacuum(self) -> Result<()> {
         assert!(self.insert_queue.is_empty());
-
-        let index_oid = self.relation_oid;
-        let merge_lock = unsafe { MergeLock::acquire_for_merge(self.relation_oid) };
-        self.commit(merge_lock.is_some())?;
-
-        if merge_lock.is_some() {
-            unsafe {
-                garbage_collect_metas(index_oid)?;
-            }
-        }
-        Ok(())
+        self.commit()
     }
 
     fn drain_insert_queue(&mut self) -> Result<Opstamp, TantivyError> {
@@ -240,14 +190,6 @@ impl SearchIndexWriter {
             .wait_for(move || writer.run(insert_queue))
             .expect("spawned thread should not fail")
     }
-}
-
-unsafe fn garbage_collect_metas(index_oid: pg_sys::Oid) -> Result<()> {
-    let mut segment_metas =
-        LinkedItemList::<SegmentMetaEntry>::open(index_oid, SEGMENT_METAS_START);
-    segment_metas.garbage_collect(pg_sys::GetAccessStrategy(
-        pg_sys::BufferAccessStrategyType::BAS_VACUUM,
-    ))
 }
 
 #[derive(Error, Debug)]

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -15,7 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::index::merge_policy::set_num_segments;
+use crate::index::reader::index::SearchIndexReader;
 use crate::index::writer::index::SearchIndexWriter;
+use crate::index::BlockDirectoryType;
 use crate::postgres::storage::block::{
     MergeLockData, SegmentMetaEntry, CLEANUP_LOCK, MERGE_LOCK, SCHEMA_START, SEGMENT_METAS_START,
     SETTINGS_START,
@@ -123,8 +126,17 @@ fn do_heap_scan<'a>(
 
         state
             .writer
-            .commit_inserts()
+            .commit()
             .unwrap_or_else(|e| panic!("failed to commit new tantivy index: {e}"));
+
+        // store number of segments created in metadata
+        let search_reader =
+            SearchIndexReader::open(index_relation, BlockDirectoryType::Mvcc, false)
+                .expect("do_heap_scan: should be able to open a SearchIndexReader");
+        set_num_segments(
+            index_relation.oid(),
+            search_reader.segment_readers().len() as u32,
+        );
 
         state.count
     }
@@ -207,6 +219,7 @@ unsafe fn create_metadata(index_relation: &PgRelation) {
     let mut page = merge_lock.init_page();
     let metadata = page.contents_mut::<MergeLockData>();
     metadata.last_merge = pg_sys::InvalidTransactionId;
+    metadata.num_segments = 0;
 
     // Init cleanup lock buffer
     let mut cleanup_lock = bman.new_buffer();

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -27,6 +27,7 @@ use crate::api::operator::{
     anyelement_query_input_opoid, attname_from_var, estimate_selectivity, find_var_relation,
 };
 use crate::api::{AsCStr, AsInt, Cardinality};
+use crate::index::merge_policy::AllowedMergePolicy;
 use crate::index::mvcc::MVCCDirectory;
 use crate::index::reader::index::SearchIndexReader;
 use crate::index::BlockDirectoryType;
@@ -112,7 +113,7 @@ impl CustomScan for PdbScan {
 
             let root = builder.args().root;
 
-            let directory = MVCCDirectory::snapshot(bm25_index.oid());
+            let directory = MVCCDirectory::snapshot(bm25_index.oid(), AllowedMergePolicy::None);
             let index = Index::open(directory).expect("custom_scan: should be able to open index");
             let schema = SearchIndexSchema::open(index.schema(), &bm25_index);
             let pathkey = pullup_orderby_pathkey(&mut builder, rti, &schema, root);
@@ -355,7 +356,7 @@ impl CustomScan for PdbScan {
                 let heaprel = indexrel
                     .heap_relation()
                     .expect("index should belong to a table");
-                let directory = MVCCDirectory::snapshot(indexrel.oid());
+                let directory = MVCCDirectory::snapshot(indexrel.oid(), AllowedMergePolicy::None);
                 let index = Index::open(directory)
                     .expect("create_custom_scan_state: should be able to open index");
                 let schema = SearchIndexSchema::open(index.schema(), &indexrel);

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -79,7 +79,7 @@ pub extern "C" fn ambulkdelete(
 
     // Don't merge here, amvacuumcleanup will merge
     writer
-        .commit(false)
+        .commit()
         .expect("ambulkdelete: commit should succeed");
 
     if stats.is_null() {

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -47,7 +47,7 @@ impl Drop for InsertState {
             if pg_sys::IsTransactionState() && !self.abort_on_drop && !self.committed {
                 if let Some(writer) = self.writer.take() {
                     writer
-                        .commit_inserts()
+                        .commit()
                         .expect("tantivy index commit should succeed");
                 }
                 self.committed = true;
@@ -172,7 +172,6 @@ unsafe fn aminsert_internal(
         writer
             .insert(search_document, item_pointer_to_u64(*ctid))
             .expect("insertion into index should succeed");
-
         true
     });
 
@@ -208,7 +207,7 @@ pub unsafe extern "C" fn aminsertcleanup(
 
     if let Some(writer) = (*state).writer.take() {
         writer
-            .commit_inserts()
+            .commit()
             .expect("must be able to commit inserts in aminsertcleanup");
     };
 }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -47,8 +47,10 @@ pub struct BM25PageSpecialData {
 // ---------------------------------------------------------
 
 #[derive(Debug)]
+#[repr(C, packed)]
 pub struct MergeLockData {
     pub last_merge: pg_sys::TransactionId,
+    pub num_segments: u32,
 }
 
 // ---------------------------------------------------------

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -3,6 +3,7 @@ use crate::postgres::storage::utils::{BM25BufferCache, BM25Page};
 use pgrx::pg_sys;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct Buffer {
     pg_buffer: pg_sys::Buffer,
 }
@@ -57,6 +58,7 @@ impl Buffer {
     }
 }
 
+#[derive(Debug)]
 pub struct BufferMut {
     dirty: bool,
     inner: Buffer,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Fixes a problem where `CREATE INDEX` and large bulk inserts could be significantly slowed down by merge if the `target_segment_count` does not match the number of segments that exist. This problem manifests itself in two places:

1. In `CREATE INDEX`: Over very large tables, the number of segments can exceed the target segment count if the segment doesn't fit in memory. Merging the index down to the target segment count at the end is a bad idea because you're essentially rewriting the entire index.

2. In bulk inserts: If, say, a million rows are inserted at once, several new segments will appear. The n plus one merge policy will try to merge those new segments down into one segment, which is again very expensive and probably not optimal.

## Why

Significant improvements to write throughout and indexing times of large datasets.

## How

We have implemented a new merge strategy:

1. At the end of `CREATE INDEX`, do not merge. If `maintenance_work_mem` is set to a reasonably large value, the index should already be configured to have an optimal number of segments.
2. At the end of an insert statement, check how many segments were created. If only one segment was created, then this was a small insert, and we should try and merge this segment to maintain the target segment count. However, if more than one segment was created, this was a large insert. We shouldn't try to merge these segments together; instead, we should increment the target segment count to be one less than the new number of segments.

In order to detect whether more than one segment was created by an insert, I had to modify the Tantivy `Directory` trait to give us a new function `reconsider_merge_policy` that tells us how many segments were created and allows us to set a new merge policy.

## Tests

See new added tests.