### PR TITLE
ci: Add Debian 11

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - phil/deb11 # TODO: Remove this once done testing
   workflow_dispatch:
     inputs:
       version:
@@ -65,6 +67,40 @@ jobs:
             arch: amd64
           - runner: ubicloud-standard-4-arm
             image: debian:12-slim
+            pg_version: 17
+            arch: arm64
+          # Debian 11 (Bullseye)
+          # We build for Debian 11 for compatibility with one of our integration partners
+          - runner: ubicloud-standard-8
+            image: debian:11-slim
+            pg_version: 14
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:11-slim
+            pg_version: 14
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:11-slim
+            pg_version: 15
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:11-slim
+            pg_version: 15
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:11-slim
+            pg_version: 16
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:11-slim
+            pg_version: 16
+            arch: arm64
+          - runner: ubicloud-standard-8
+            image: debian:11-slim
+            pg_version: 17
+            arch: amd64
+          - runner: ubicloud-standard-4-arm
+            image: debian:11-slim
             pg_version: 17
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -9,8 +9,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - phil/deb11 # TODO: Remove this once done testing
   workflow_dispatch:
     inputs:
       version:
@@ -29,7 +27,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on Debian 12 (Bookworm) ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
@@ -37,69 +35,85 @@ jobs:
       matrix:
         include:
           # Debian 12 (Bookworm)
-          - runner: ubicloud-standard-8
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-8
             image: debian:12-slim
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-4-arm
             image: debian:12-slim
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-8
             image: debian:12-slim
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-4-arm
             image: debian:12-slim
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-8
             image: debian:12-slim
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-4-arm
             image: debian:12-slim
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-8
             image: debian:12-slim
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 12 (Bookworm)
+            runner: ubicloud-standard-4-arm
             image: debian:12-slim
             pg_version: 17
             arch: arm64
           # Debian 11 (Bullseye)
           # We build for Debian 11 for compatibility with one of our integration partners
-          - runner: ubicloud-standard-8
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-8
             image: debian:11-slim
             pg_version: 14
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-4-arm
             image: debian:11-slim
             pg_version: 14
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-8
             image: debian:11-slim
             pg_version: 15
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-4-arm
             image: debian:11-slim
             pg_version: 15
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-8
             image: debian:11-slim
             pg_version: 16
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-4-arm
             image: debian:11-slim
             pg_version: 16
             arch: arm64
-          - runner: ubicloud-standard-8
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-8
             image: debian:11-slim
             pg_version: 17
             arch: amd64
-          - runner: ubicloud-standard-4-arm
+          - name: Debian 11 (Bullseye)
+            runner: ubicloud-standard-4-arm
             image: debian:11-slim
             pg_version: 17
             arch: arm64

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.arch }}
+    name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/a

## What
We removed Debian 11 since it was EOL-ed. However, one of our upcoming integration partners require it. This re-adds publishing binaries for Debian 11.

## Why
^

## How
^

## Tests
Tested in CI