### PR TITLE
feat: parallel top-n queries

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -54,7 +54,7 @@ pub trait ExecMethod {
 
     fn next(&mut self, state: &mut PdbScanState) -> ExecState {
         loop {
-            match self.internal_next() {
+            match self.internal_next(state) {
                 ExecState::Eof => {
                     if !self.query(state) {
                         return ExecState::Eof;
@@ -65,7 +65,7 @@ pub trait ExecMethod {
         }
     }
 
-    fn internal_next(&mut self) -> ExecState;
+    fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState;
 }
 
 struct UnknownScanStyle;
@@ -77,7 +77,7 @@ impl ExecMethod for UnknownScanStyle {
         )
     }
 
-    fn internal_next(&mut self) -> ExecState {
+    fn internal_next(&mut self, _state: &mut PdbScanState) -> ExecState {
         unimplemented!(
             "logic error in pg_search:  `UnknownScanStyle::internal_next()` should never be called"
         )

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -87,7 +87,7 @@ impl ExecMethod for NumericFastFieldExecState {
         }
     }
 
-    fn internal_next(&mut self) -> ExecState {
+    fn internal_next(&mut self, _state: &mut PdbScanState) -> ExecState {
         unsafe {
             match self.inner.search_results.next() {
                 None => ExecState::Eof,

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -98,7 +98,7 @@ impl ExecMethod for StringFastFieldExecState {
         }
     }
 
-    fn internal_next(&mut self) -> ExecState {
+    fn internal_next(&mut self, _state: &mut PdbScanState) -> ExecState {
         if matches!(self.search_results, StringAggResults::None) {
             return ExecState::Eof;
         }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -100,7 +100,7 @@ impl ExecMethod for NormalScanExecState {
         }
     }
 
-    fn internal_next(&mut self) -> ExecState {
+    fn internal_next(&mut self, _state: &mut PdbScanState) -> ExecState {
         match self.search_results.next() {
             // no more rows
             None => ExecState::Eof,

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -193,13 +193,7 @@ impl ExecMethod for TopNScanExecState {
                     .max(self.limit * factor)
                     .min(MAX_CHUNK_SIZE);
 
-                let results = self.query_more_results(state, Some(self.current_segment));
-                let mut results = self.search_reader.as_ref().unwrap().search_top_n(
-                    self.search_query_input.as_ref().unwrap(),
-                    self.sort_field.clone(),
-                    self.sort_direction.into(),
-                    self.chunk_size,
-                );
+                let mut results = self.query_more_results(state, Some(self.current_segment));
 
                 // fast forward and stop on the ctid we last found
                 for (scored, doc_address) in &mut results {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -18,9 +18,11 @@
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::postgres::customscan::builders::custom_path::SortDirection;
 use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
+use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use crate::query::SearchQueryInput;
 use pgrx::{direct_function_call, pg_sys, IntoDatum};
+use tantivy::SegmentOrdinal;
 
 // TODO:  should these be GUCs?  I think yes, probably
 const SUBSEQUENT_RETRY_SCALE_FACTOR: usize = 2;
@@ -39,12 +41,14 @@ pub struct TopNScanExecState {
     search_reader: Option<SearchIndexReader>,
     sort_field: Option<String>,
     search_results: SearchResults,
+    did_query: bool,
 
     // state tracking
     last_ctid: u64,
     found: usize,
     chunk_size: usize,
     retry_count: usize,
+    current_segment: SegmentOrdinal,
 }
 
 impl TopNScanExecState {
@@ -56,36 +60,93 @@ impl TopNScanExecState {
             ..Default::default()
         }
     }
+
+    fn query_more_results(
+        &mut self,
+        state: &mut PdbScanState,
+        current_segment: Option<SegmentOrdinal>,
+    ) -> SearchResults {
+        if let Some(parallel_state) = state.parallel_state {
+            // we're parallel, so either query the provided segment or go get a segment from the parallel state
+            let segment_ord = current_segment
+                .map(Some)
+                .unwrap_or_else(|| unsafe { checkout_segment(parallel_state) });
+
+            if let Some(segment_ord) = segment_ord {
+                self.current_segment = segment_ord;
+
+                let search_reader = state.search_reader.as_ref().unwrap();
+                search_reader.search_top_n_in_segment(
+                    segment_ord,
+                    self.search_query_input.as_ref().unwrap(),
+                    self.sort_field.clone(),
+                    self.sort_direction.into(),
+                    self.limit,
+                )
+            } else {
+                // no more segments to query
+                SearchResults::None
+            }
+        } else if self.did_query {
+            // not parallel, so we're done
+            SearchResults::None
+        } else {
+            // not parallel, first time query
+            let search_reader = state.search_reader.as_ref().unwrap();
+            search_reader.search_top_n(
+                self.search_query_input.as_ref().unwrap(),
+                self.sort_field.clone(),
+                self.sort_direction.into(),
+                self.limit,
+            )
+        }
+    }
+
+    fn reset(&mut self) {
+        self.found = 0;
+        self.last_ctid = 0;
+        self.chunk_size = 0;
+        self.retry_count = 0;
+        self.have_less = false;
+    }
 }
 
 impl ExecMethod for TopNScanExecState {
     fn init(&mut self, state: &mut PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
         let sort_field = state.sort_field.clone();
-        let search_reader = state.search_reader.as_ref().unwrap();
 
         self.search_query_input = Some(state.search_query_input.clone());
         self.sort_field = sort_field;
-        self.search_results = search_reader.search_top_n(
-            self.search_query_input.as_ref().unwrap(),
-            self.sort_field.clone(),
-            self.sort_direction.into(),
-            self.limit,
-        );
-
-        let len = self
-            .search_results
-            .len()
-            .expect("search_results should not be empty");
-
-        self.have_less = len < self.limit;
         self.search_reader = state.search_reader.clone();
     }
 
-    fn internal_next(&mut self) -> ExecState {
+    fn query(&mut self, state: &mut PdbScanState) -> bool {
+        let search_results = self.query_more_results(state, None);
+
+        self.did_query = true;
+
+        if matches!(search_results, SearchResults::None) {
+            false
+        } else {
+            let len = search_results
+                .len()
+                .expect("search_results should not be empty");
+            self.have_less = len < self.limit;
+            self.search_results = search_results;
+            self.reset();
+            true
+        }
+    }
+
+    fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState {
         unsafe {
             let mut next = self.search_results.next();
             loop {
                 match next {
+                    None if !self.did_query => {
+                        // we haven't even done a query yet, so this is our very first time in
+                        return ExecState::Eof;
+                    }
                     None => {
                         if self.found == self.limit || self.have_less {
                             // we found all the matching rows
@@ -97,7 +158,7 @@ impl ExecMethod for TopNScanExecState {
                             ctid: scored.ctid,
                             score: scored.bm25,
                             doc_address,
-                        }
+                        };
                     }
                 }
 
@@ -132,6 +193,7 @@ impl ExecMethod for TopNScanExecState {
                     .max(self.limit * factor)
                     .min(MAX_CHUNK_SIZE);
 
+                let results = self.query_more_results(state, Some(self.current_segment));
                 let mut results = self.search_reader.as_ref().unwrap().search_top_n(
                     self.search_query_input.as_ref().unwrap(),
                     self.sort_field.clone(),

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -184,12 +184,13 @@ impl CustomScan for PdbScan {
 
                 if is_topn {
                     // sorting by a field only works if we're not doing const projections
+                    // the reason for this is that tantivy can't do both scoring and ordering by
+                    // a fast field at the same time.
                     //
                     // and sorting by score always works
                     if !(maybe_needs_const_projections
                         && matches!(&pathkey, Some(OrderByStyle::Field(..))))
                     {
-                        builder = builder.add_path_key(&pathkey);
                         builder.custom_private().set_sort_info(&pathkey);
                     }
                 }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -256,16 +256,7 @@ impl CustomScan for PdbScan {
                     } else {
                         // otherwise we'll do a regular scan and indicate that we're emitting results
                         // sorted by the first pathkey
-                        // let foo = Some(OrderByStyle::Field(
-                        //     PgList::<pg_sys::PathKey>::from_pg(
-                        //         (*builder.args().root).query_pathkeys,
-                        //     )
-                        //     .get_ptr(1)
-                        //     .unwrap(),
-                        //     "whatever".into(),
-                        // ));
                         builder = builder.add_path_key(&pathkey);
-                        // builder = builder.add_path_key(&foo);
                         builder.custom_private().set_sort_info(&pathkey);
                     }
                 } else {

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -85,15 +85,7 @@ fn generates_custom_scan_for_and(mut conn: PgConnection) {
     "SET enable_indexscan TO off;".execute(&mut conn);
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' AND description @@@ 'shoes'".fetch_one::<(Value,)>(&mut conn);
-    let plan = plan
-        .get(0)
-        .unwrap()
-        .as_object()
-        .unwrap()
-        .get("Plan")
-        .unwrap()
-        .as_object()
-        .unwrap();
+    let plan = plan.pointer("/0/Plan/Plans/0").unwrap();
     eprintln!("{plan:#?}");
     assert_eq!(
         plan.get("Custom Plan Provider"),

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -60,7 +60,7 @@ fn sort_by_lower(mut conn: PgConnection) {
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE description @@@ 'keyboard OR shoes' ORDER BY lower(category) LIMIT 5".fetch_one::<(Value,)>(&mut conn);
     let plan = plan
-        .pointer("/0/Plan/Plans/0")
+        .pointer("/0/Plan/Plans/0/Plans/0")
         .unwrap()
         .as_object()
         .unwrap();
@@ -108,7 +108,7 @@ fn sort_by_raw(mut conn: PgConnection) {
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE description @@@ 'keyboard OR shoes' ORDER BY category LIMIT 5".fetch_one::<(Value,)>(&mut conn);
     let plan = plan
-        .pointer("/0/Plan/Plans/0")
+        .pointer("/0/Plan/Plans/0/Plans/0")
         .unwrap()
         .as_object()
         .unwrap();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Transform our existing "Top N" custom scan support into being parallel query capable.

Essentially if the "N" is, say, 10, we kick off parallel workers for each segment (up to num_segments/2) and each segment will return 10 tuples.  Then postgres sorts those and picks the final top 10.

## Why

Significantly faster to find the "top N" docs per segment in parallel than serially.

## How

For example, if the index has 10 segments and the limit is 10, we'll have 5 parallel workers that each return 20 tuples (10 from two different segments, most likely), totaling 100 tuples. Postgres will then sort those and return only the top 10 back to the user.

This works for "Top N" by `paradedb.score()` and also for ordering by a fast field.  In both cases, ascending and descending ordering is supported.

When sorting by `paradedb.score()` we specialize the differences between "Top N ASCending" and "Top N DESCending".  The latter is tantivy's default and is a bit faster over very large segments as it doesn't require any additional per-doc overhead, whereas sorting in ascending order does.

## Tests

No new tests, but some existing tests that examined query plans needed to be updated to account for the new parallel and sort nodes that are now part of the query plan.