### PR TITLE
feat: optimize queries with a `LIMIT` but no `ORDER BY`

### DIFF
--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -55,6 +55,10 @@ pub trait CustomScanState: Default {
     fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
         None
     }
+
+    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
+        None
+    }
 }
 
 pub trait CustomScan: ExecMethod + Default + Sized {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -34,6 +34,7 @@ pub struct TopNScanExecState {
     heaprelid: pg_sys::Oid,
     limit: usize,
     sort_direction: SortDirection,
+    need_scores: bool,
 
     // set during init
     have_less: bool,
@@ -52,11 +53,17 @@ pub struct TopNScanExecState {
 }
 
 impl TopNScanExecState {
-    pub fn new(heaprelid: pg_sys::Oid, limit: usize, sort_direction: SortDirection) -> Self {
+    pub fn new(
+        heaprelid: pg_sys::Oid,
+        limit: usize,
+        sort_direction: SortDirection,
+        need_scores: bool,
+    ) -> Self {
         Self {
             heaprelid,
             limit,
             sort_direction,
+            need_scores,
             ..Default::default()
         }
     }
@@ -82,6 +89,7 @@ impl TopNScanExecState {
                     self.sort_field.clone(),
                     self.sort_direction.into(),
                     self.limit,
+                    self.need_scores,
                 )
             } else {
                 // no more segments to query
@@ -98,6 +106,7 @@ impl TopNScanExecState {
                 self.sort_field.clone(),
                 self.sort_direction.into(),
                 self.limit,
+                self.need_scores,
             )
         }
     }

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -72,6 +72,10 @@ impl PrivateData {
         self.limit = limit.map(|l| l.round() as usize);
     }
 
+    pub fn set_sort_direction(&mut self, sort_direction: Option<SortDirection>) {
+        self.sort_direction = sort_direction;
+    }
+
     pub fn set_sort_info(&mut self, pathkey: &Option<OrderByStyle>) {
         if let Some(style) = pathkey {
             match style {
@@ -193,21 +197,18 @@ pub mod serialize {
 
     impl AsValueNode for SortDirection {
         fn as_value_node(&self) -> *mut Node {
-            unsafe {
-                match self {
-                    SortDirection::Asc => makeInteger(Some(0)),
-                    SortDirection::Desc => makeInteger(Some(1)),
-                }
-            }
+            unsafe { makeInteger(Some(*self as i32)) }
         }
 
         fn from_value_node(node: *mut Node) -> Option<Self> {
             unsafe {
-                let integer = node.as_int()?;
-                if integer == 0 {
+                let integer = node.as_int()? as i32;
+                if integer == SortDirection::Asc as i32 {
                     Some(Self::Asc)
-                } else if integer == 1 {
+                } else if integer == SortDirection::Desc as i32 {
                     Some(Self::Desc)
+                } else if integer == SortDirection::None as i32 {
+                    Some(Self::None)
                 } else {
                     None
                 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -95,6 +95,13 @@ impl CustomScanState for PdbScanState {
             _ => None,
         }
     }
+
+    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
+        match (self.limit, self.sort_direction) {
+            (Some(limit), Some(SortDirection::None)) => Some(limit),
+            _ => None,
+        }
+    }
 }
 
 impl PdbScanState {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

If a query has a LIMIT but no ORDER BY, we can run this through our custom scan's "top n" machinery, but essentially picking a random document.

We endeavor to *avoid* parallel custom scans here, but we will generate one if the LIMIT happens to be greater than num_segments cubed -- needed some kind of heuristic and this seems to roughly be the breaking point on my computer.  We can always tweak this logic in the future

## Why

Our prior implementation was a pretty big regression relative to non-block-storage tantivy.

## How

We distinguish between queries with only a LIMIT and queries with both a LIMIT and ORDER BY, and pass through the proper information to make different decisions at the point we query tantivy.

## Tests

Existing, plus new tests, all pass.