### PR TITLE
perf: don't `.collect()` search results anymore

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -28,22 +28,22 @@ use pgrx::{pg_sys, PgRelation};
 use rustc_hash::FxHashMap;
 use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::iter::Flatten;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tantivy::collector::{Collector, TopDocs};
 use tantivy::index::Index;
-use tantivy::query::{EnableScoring, QueryClone, QueryParser, Weight};
+use tantivy::query::{EnableScoring, QueryParser, Weight};
 use tantivy::schema::FieldType;
 use tantivy::termdict::TermOrdinal;
 use tantivy::{
-    query::Query, DocAddress, DocId, IndexReader, Order, ReloadPolicy, Score, Searcher,
-    SegmentOrdinal, SegmentReader, TantivyDocument, TantivyError,
+    query::Query, DocAddress, DocId, DocSet, IndexReader, Order, ReloadPolicy, Score, Searcher,
+    SegmentOrdinal, SegmentReader, TantivyDocument,
 };
 use tantivy::{snippet::SnippetGenerator, Executor};
 
-/// Represents a matching document from a tantivy search.  Typically it is returned as an Iterator
+/// Represents a matching document from a tantivy search.  Typically, it is returned as an Iterator
 /// Item alongside the originating tantivy [`DocAddress`]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SearchIndexScore {
@@ -71,7 +71,7 @@ pub enum SortDirection {
     None,
 }
 
-impl From<SortDirection> for tantivy::Order {
+impl From<SortDirection> for Order {
     fn from(value: SortDirection) -> Self {
         match value {
             SortDirection::Asc => Order::Asc,
@@ -88,34 +88,29 @@ pub enum SearchResults {
     #[default]
     None,
     TopNByScore(
-        usize,
         Searcher,
         FxHashMap<SegmentOrdinal, FFType>,
         std::vec::IntoIter<(Score, DocAddress)>,
     ),
     TopNByTweakedScore(
-        usize,
         Searcher,
         FxHashMap<SegmentOrdinal, FFType>,
         std::vec::IntoIter<(TweakedScore, DocAddress)>,
     ),
     TopNByField(
-        usize,
         Searcher,
         FxHashMap<SegmentOrdinal, FFType>,
         std::vec::IntoIter<(TermOrdinal, DocAddress)>,
     ),
     SingleSegment(
-        usize,
         Searcher,
         FxHashMap<SegmentOrdinal, FFType>,
-        vec_collector::FruitStyle,
+        scorer_iter::ScorerIter,
     ),
     AllSegments(
-        usize,
         Searcher,
         FxHashMap<SegmentOrdinal, FFType>,
-        Flatten<std::vec::IntoIter<vec_collector::FruitStyle>>,
+        Flatten<std::vec::IntoIter<scorer_iter::ScorerIter>>,
     ),
 }
 
@@ -141,127 +136,67 @@ impl Iterator for SearchResults {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            SearchResults::None => None,
-            SearchResults::TopNByScore(_, searcher, ff_lookup, iter) => {
-                let (score, doc_address) = iter.next()?;
+        let (searcher, ff_lookup, (score, doc_address)) = match self {
+            SearchResults::None => return None,
+            SearchResults::TopNByScore(searcher, ff_lookup, iter) => {
+                (searcher, ff_lookup, iter.next()?)
+            }
+            SearchResults::TopNByTweakedScore(searcher, ff_lookup, iter) => {
+                let (score, doc_id) = iter.next()?;
+                (searcher, ff_lookup, (score.score, doc_id))
+            }
+            SearchResults::TopNByField(searcher, ff_lookup, iter) => {
+                let (_, doc_id) = iter.next()?;
+                (searcher, ff_lookup, (1.0, doc_id))
+            }
+            SearchResults::SingleSegment(searcher, ff_lookup, iter) => {
+                (searcher, ff_lookup, iter.next()?)
+            }
+            SearchResults::AllSegments(searcher, ff_lookup, iter) => {
+                (searcher, ff_lookup, iter.next()?)
+            }
+        };
 
-                let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-                    FFType::new(
-                        searcher
-                            .segment_reader(doc_address.segment_ord)
-                            .fast_fields(),
-                        "ctid",
-                    )
-                });
-                let scored = SearchIndexScore {
-                    ctid: ctid_ff
-                        .as_u64(doc_address.doc_id)
-                        .expect("ctid should be present"),
-                    bm25: score,
-                };
-                Some((scored, doc_address))
-            }
-            SearchResults::TopNByTweakedScore(_, searcher, ff_lookup, iter) => {
-                let (scored, doc_address) = iter.next()?;
-
-                let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-                    FFType::new(
-                        searcher
-                            .segment_reader(doc_address.segment_ord)
-                            .fast_fields(),
-                        "ctid",
-                    )
-                });
-                let scored = SearchIndexScore {
-                    ctid: ctid_ff
-                        .as_u64(doc_address.doc_id)
-                        .expect("ctid should be present"),
-                    bm25: scored.score,
-                };
-                Some((scored, doc_address))
-            }
-            SearchResults::TopNByField(_, searcher, ff_lookup, iter) => {
-                let (_, doc_address) = iter.next()?;
-                let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-                    FFType::new(
-                        searcher
-                            .segment_reader(doc_address.segment_ord)
-                            .fast_fields(),
-                        "ctid",
-                    )
-                });
-                let scored = SearchIndexScore {
-                    ctid: ctid_ff
-                        .as_u64(doc_address.doc_id)
-                        .expect("ctid should be present"),
-                    bm25: 1.0,
-                };
-                Some((scored, doc_address))
-            }
-            SearchResults::SingleSegment(_, searcher, ff_lookup, iter) => {
-                let (score, doc_address) = iter.next()?;
-
-                let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-                    FFType::new(
-                        searcher
-                            .segment_reader(doc_address.segment_ord)
-                            .fast_fields(),
-                        "ctid",
-                    )
-                });
-                let scored = SearchIndexScore {
-                    ctid: ctid_ff
-                        .as_u64(doc_address.doc_id)
-                        .expect("ctid should be present"),
-                    bm25: score,
-                };
-                Some((scored, doc_address))
-            }
-            SearchResults::AllSegments(_, searcher, ff_lookup, iter) => {
-                let (score, doc_address) = iter.next()?;
-
-                let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-                    FFType::new(
-                        searcher
-                            .segment_reader(doc_address.segment_ord)
-                            .fast_fields(),
-                        "ctid",
-                    )
-                });
-                let scored = SearchIndexScore {
-                    ctid: ctid_ff
-                        .as_u64(doc_address.doc_id)
-                        .expect("ctid should be present"),
-                    bm25: score,
-                };
-                Some((scored, doc_address))
-            }
-        }
+        let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
+            FFType::new(
+                searcher
+                    .segment_reader(doc_address.segment_ord)
+                    .fast_fields(),
+                "ctid",
+            )
+        });
+        let scored = SearchIndexScore {
+            ctid: ctid_ff
+                .as_u64(doc_address.doc_id)
+                .expect("ctid should be present"),
+            bm25: score,
+        };
+        Some((scored, doc_address))
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             SearchResults::None => (0, Some(0)),
-            SearchResults::TopNByScore(_, _, _, iter) => iter.size_hint(),
-            SearchResults::TopNByTweakedScore(_, _, _, iter) => iter.size_hint(),
-            SearchResults::TopNByField(_, _, _, iter) => iter.size_hint(),
-            SearchResults::SingleSegment(_, _, _, iter) => iter.size_hint(),
-            SearchResults::AllSegments(_, _, _, iter) => iter.size_hint(),
+            SearchResults::TopNByScore(_, _, iter) => iter.size_hint(),
+            SearchResults::TopNByTweakedScore(_, _, iter) => iter.size_hint(),
+            SearchResults::TopNByField(_, _, iter) => iter.size_hint(),
+            SearchResults::SingleSegment(_, _, iter) => iter.size_hint(),
+            SearchResults::AllSegments(_, _, iter) => iter.size_hint(),
         }
     }
-}
 
-impl SearchResults {
-    pub fn len(&self) -> Option<usize> {
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
         match self {
-            SearchResults::None => Some(0),
-            SearchResults::TopNByScore(count, ..) => Some(*count),
-            SearchResults::TopNByTweakedScore(count, ..) => Some(*count),
-            SearchResults::TopNByField(count, ..) => Some(*count),
-            SearchResults::SingleSegment(count, ..) => Some(*count),
-            SearchResults::AllSegments(count, ..) => Some(*count),
+            SearchResults::None => 0,
+            SearchResults::TopNByScore(_, _, iter) => iter.count(),
+            SearchResults::TopNByTweakedScore(_, _, iter) => iter.count(),
+            SearchResults::TopNByField(_, _, iter) => iter.count(),
+            SearchResults::SingleSegment(_, _, iter) => iter.count(),
+            SearchResults::AllSegments(_, _, iter) => iter.count(),
         }
     }
 }
@@ -351,6 +286,12 @@ impl SearchIndexReader {
             .expect("must be able to parse query")
     }
 
+    fn weight(&self, need_scores: bool, search_query_input: &SearchQueryInput) -> Box<dyn Weight> {
+        self.query(search_query_input)
+            .weight(self.enable_scoring(need_scores))
+            .expect("weight should be constructable")
+    }
+
     pub fn get_doc(&self, doc_address: DocAddress) -> tantivy::Result<TantivyDocument> {
         self.searcher.doc(doc_address)
     }
@@ -414,14 +355,29 @@ impl SearchIndexReader {
         query: &SearchQueryInput,
         _estimated_rows: Option<usize>,
     ) -> SearchResults {
-        let collector = vec_collector::VecCollector::new(None, need_scores);
-        let results = self.collect(query, collector, need_scores);
-        let len = results.iter().map(|iter| iter.len()).sum();
+        let weight = self.weight(need_scores, query);
+
+        let iters = self
+            .searcher()
+            .segment_readers()
+            .iter()
+            .enumerate()
+            .map(|(segment_ord, segment_reader)| {
+                let scorer = weight
+                    .scorer(segment_reader, 1.0)
+                    .expect("scorer should be constructable");
+                scorer_iter::ScorerIter::new(
+                    scorer,
+                    segment_ord as SegmentOrdinal,
+                    segment_reader.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
         SearchResults::AllSegments(
-            len,
             self.searcher.clone(),
             Default::default(),
-            results.into_iter().flatten(),
+            iters.into_iter().flatten(),
         )
     }
 
@@ -437,31 +393,13 @@ impl SearchIndexReader {
         segment_ord: SegmentOrdinal,
         query: &SearchQueryInput,
     ) -> SearchResults {
-        let collector = vec_collector::VecCollector::new(None, need_scores);
-        let weight = self
-            .query(query)
-            .weight(if need_scores {
-                tantivy::query::EnableScoring::Enabled {
-                    searcher: &self.searcher,
-                    statistics_provider: &self.searcher,
-                }
-            } else {
-                tantivy::query::EnableScoring::Disabled {
-                    schema: &self.schema.schema,
-                    searcher_opt: Some(&self.searcher),
-                }
-            })
-            .expect("weight should be constructable");
+        let weight = self.weight(need_scores, query);
         let segment_reader = self.searcher.segment_reader(segment_ord);
-        let results = collector
-            .collect_segment(weight.as_ref(), segment_ord, segment_reader)
-            .expect("single segment collection should succeed");
-        SearchResults::SingleSegment(
-            results.len(),
-            self.searcher.clone(),
-            Default::default(),
-            results.into_iter(),
-        )
+        let scorer = weight
+            .scorer(segment_reader, 1.0)
+            .expect("scorer should be constructable");
+        let iter = scorer_iter::ScorerIter::new(scorer, segment_ord, segment_reader.clone());
+        SearchResults::SingleSegment(self.searcher.clone(), Default::default(), iter)
     }
 
     /// Search the Tantivy index for the "top N" matching documents.
@@ -529,7 +467,6 @@ impl SearchIndexReader {
             TopDocs::with_limit(n).order_by_u64_field(sort_field.name.0.clone(), sortdir.into());
         let top_docs = self.collect(query, collector, true);
         SearchResults::TopNByField(
-            top_docs.len(),
             self.searcher.clone(),
             Default::default(),
             top_docs.into_iter(),
@@ -556,7 +493,6 @@ impl SearchIndexReader {
                 );
                 let top_docs = self.collect(query, collector, true);
                 SearchResults::TopNByTweakedScore(
-                    top_docs.len(),
                     self.searcher.clone(),
                     Default::default(),
                     top_docs.into_iter(),
@@ -568,7 +504,6 @@ impl SearchIndexReader {
                 let collector = TopDocs::with_limit(n);
                 let top_docs = self.collect(query, collector, true);
                 SearchResults::TopNByScore(
-                    top_docs.len(),
                     self.searcher.clone(),
                     Default::default(),
                     top_docs.into_iter(),
@@ -576,70 +511,25 @@ impl SearchIndexReader {
             }
 
             SortDirection::None => {
-                let enabled_scoring = if need_scores {
-                    tantivy::query::EnableScoring::Enabled {
-                        searcher: &self.searcher,
-                        statistics_provider: &self.searcher,
-                    }
-                } else {
-                    tantivy::query::EnableScoring::Disabled {
-                        schema: self.searcher.schema(),
-                        searcher_opt: Some(&self.searcher),
-                    }
-                };
-
-                struct WeightLimitQuery {
-                    query: Box<dyn Query>,
-                    weight: limit::WeightLimit,
-                }
-                impl Debug for WeightLimitQuery {
-                    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
-                        Ok(())
-                    }
-                }
-
-                impl QueryClone for WeightLimitQuery {
-                    fn box_clone(&self) -> Box<dyn Query> {
-                        Box::new(WeightLimitQuery {
-                            query: self.query.box_clone(),
-                            weight: self.weight.clone(),
-                        })
-                    }
-                }
-
-                impl Query for WeightLimitQuery {
-                    fn weight(
-                        &self,
-                        _enable_scoring: EnableScoring<'_>,
-                    ) -> tantivy::Result<Box<dyn Weight>> {
-                        Ok(Box::new(self.weight.clone()))
-                    }
-                }
-
-                let query = self.query(query);
-                let weight = query
-                    .weight(enabled_scoring)
-                    .expect("creating a Weight from a Query should not fail");
-                let query: Box<dyn Query> = Box::new(WeightLimitQuery {
-                    query,
-                    weight: limit::WeightLimit::new(n, weight),
-                });
-                let collector = vec_collector::VecCollector::new(Some(n), need_scores);
-                let results = self
-                    .searcher
-                    .search_with_executor(
-                        &query,
-                        &collector,
-                        &Executor::SingleThread,
-                        enabled_scoring,
-                    )
-                    .expect("should be able to collect top-n");
-                let len = results.iter().map(|iter| iter.len()).sum();
+                let iters = self
+                    .searcher()
+                    .segment_readers()
+                    .iter()
+                    .enumerate()
+                    .map(|(segment_ord, segment_reader)| {
+                        scorer_iter::ScorerIter::new(
+                            self.weight(need_scores, query)
+                                .scorer(segment_reader, 1.0)
+                                .expect("scorer should be constructable"),
+                            segment_ord as SegmentOrdinal,
+                            segment_reader.clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
                 SearchResults::AllSegments(
-                    len,
                     self.searcher.clone(),
                     Default::default(),
-                    results.into_iter().flatten(),
+                    iters.into_iter().flatten(),
                 )
             }
         }
@@ -685,7 +575,6 @@ impl SearchIndexReader {
             .merge_fruits(vec![top_docs])
             .expect("should be able to merge top-n in segment");
         SearchResults::TopNByField(
-            top_docs.len(),
             self.searcher.clone(),
             Default::default(),
             top_docs.into_iter(),
@@ -705,7 +594,7 @@ impl SearchIndexReader {
         query: &SearchQueryInput,
         sortdir: SortDirection,
         n: usize,
-        need_scores: bool,
+        _need_scores: bool,
     ) -> SearchResults {
         let query = self.query(query);
         let weight = query
@@ -739,7 +628,6 @@ impl SearchIndexReader {
                     .expect("should be able to merge top-n in segment");
 
                 SearchResults::TopNByTweakedScore(
-                    top_docs.len(),
                     self.searcher.clone(),
                     Default::default(),
                     top_docs.into_iter(),
@@ -762,7 +650,6 @@ impl SearchIndexReader {
                     .expect("should be able to merge top-n in segment");
 
                 SearchResults::TopNByScore(
-                    top_docs.len(),
                     self.searcher.clone(),
                     Default::default(),
                     top_docs.into_iter(),
@@ -770,68 +657,38 @@ impl SearchIndexReader {
             }
 
             SortDirection::None => {
-                let collector = vec_collector::VecCollector::new(Some(n), need_scores);
-                let weight = limit::WeightLimit::new(n, weight);
                 let segment_reader = self.searcher.segment_reader(segment_ord);
-                let results = collector
-                    .collect_segment(&weight, segment_ord, segment_reader)
-                    .expect("single segment collection should succeed");
-                SearchResults::SingleSegment(
-                    results.len(),
-                    self.searcher.clone(),
-                    Default::default(),
-                    results.into_iter(),
-                )
+                let scorer = weight
+                    .scorer(segment_reader, 1.0)
+                    .expect("scorer should be constructable");
+                let iter =
+                    scorer_iter::ScorerIter::new(scorer, segment_ord, segment_reader.clone());
+                SearchResults::SingleSegment(self.searcher.clone(), Default::default(), iter)
             }
         }
     }
 
     pub fn estimate_docs(&self, search_query_input: &SearchQueryInput) -> Option<usize> {
-        let readers = self.searcher.segment_readers();
-        let (ordinal, largest_reader) = readers
+        let largest_reader = self
+            .searcher
+            .segment_readers()
             .iter()
-            .enumerate()
-            .max_by_key(|(_, reader)| reader.num_docs())?;
-
-        let collector = tantivy::collector::Count;
-        let schema = self.schema.schema.clone();
-        let query = self.query(search_query_input);
-        let weight = match query.weight(tantivy::query::EnableScoring::Disabled {
-            schema: &schema,
-            searcher_opt: Some(&self.searcher),
-        }) {
-            // created the Weight, no problem
-            Ok(weight) => weight,
-
-            // got an error trying to create the weight.  This *likely* means
-            // the query requires scoring, so try again with scoring enabled.
-            // I've seen this with the `MoreLikeThis` query type.
-            //
-            // NB:  we could just return `None` here and let the caller deal with it?
-            //      a deciding factor might be if users complain that query planning
-            //      is too slow when they use constructs like `MoreLikeThis`
-            Err(TantivyError::InvalidArgument(_)) => query
-                .weight(tantivy::query::EnableScoring::Enabled {
-                    searcher: &self.searcher,
-                    statistics_provider: &self.searcher,
-                })
-                .expect("creating a Weight from a Query should not fail"),
-
-            // something completely unexpected happen, so just panic
-            Err(e) => panic!("{:?}", e),
-        };
-
-        let count = collector
-            .collect_segment(weight.as_ref(), ordinal as SegmentOrdinal, largest_reader)
+            .max_by_key(|reader| reader.num_docs())?;
+        let weight = self.weight(
+            search_query_input.contains_more_like_this(),
+            search_query_input,
+        );
+        let count = weight
+            .scorer(largest_reader, 1.0)
             .expect("counting docs in the largest segment should not fail")
-            .max(1); // want to assume at least 1 matching document
+            .size_hint() as usize;
         let segment_doc_proportion =
             largest_reader.num_docs() as f64 / self.searcher.num_docs() as f64;
 
         Some((count as f64 / segment_doc_proportion).ceil() as usize)
     }
 
-    pub fn collect<C: Collector + 'static>(
+    fn collect<C: Collector + 'static>(
         &self,
         query: &SearchQueryInput,
         collector: C,
@@ -843,271 +700,86 @@ impl SearchIndexReader {
                 &owned_query,
                 &collector,
                 &Executor::SingleThread,
-                if need_scores {
-                    tantivy::query::EnableScoring::Enabled {
-                        searcher: &self.searcher,
-                        statistics_provider: &self.searcher,
-                    }
-                } else {
-                    tantivy::query::EnableScoring::Disabled {
-                        schema: &self.schema.schema,
-                        searcher_opt: Some(&self.searcher),
-                    }
-                },
+                self.enable_scoring(need_scores),
             )
             .expect("search should not fail")
     }
+
+    fn enable_scoring(&self, need_scores: bool) -> EnableScoring {
+        if need_scores {
+            tantivy::query::EnableScoring::Enabled {
+                searcher: &self.searcher,
+                statistics_provider: &self.searcher,
+            }
+        } else {
+            tantivy::query::EnableScoring::Disabled {
+                schema: &self.schema.schema,
+                searcher_opt: Some(&self.searcher),
+            }
+        }
+    }
 }
 
-mod limit {
-    use std::sync::Arc;
-    use tantivy::query::{Explanation, Scorer, Weight};
-    use tantivy::{DocId, DocSet, Score, SegmentReader, TERMINATED};
+mod scorer_iter {
+    use tantivy::query::Scorer;
+    use tantivy::{DocAddress, DocSet, Score, SegmentOrdinal, SegmentReader};
 
-    struct LimitingScorer {
-        limit: u32,
-        inner: Box<dyn Scorer>,
-        cnt: u32,
+    pub struct ScorerIter {
+        scorer: Box<dyn Scorer>,
+        segment_ord: SegmentOrdinal,
+        segment_reader: SegmentReader,
     }
 
-    impl DocSet for LimitingScorer {
-        fn advance(&mut self) -> DocId {
-            self.cnt += 1;
-            if self.cnt >= self.limit {
-                return TERMINATED;
-            }
-            self.inner.advance()
-        }
-
-        fn doc(&self) -> DocId {
-            self.inner.doc()
-        }
-
-        fn size_hint(&self) -> u32 {
-            self.limit
-        }
-    }
-
-    impl Scorer for LimitingScorer {
-        fn score(&mut self) -> Score {
-            self.inner.score()
-        }
-    }
-
-    #[derive(Clone)]
-    pub struct WeightLimit {
-        limit: u32,
-        inner: Arc<Box<dyn Weight>>,
-    }
-
-    impl WeightLimit {
-        pub fn new(limit: usize, inner: Box<dyn Weight>) -> Self {
+    impl ScorerIter {
+        pub fn new(
+            scorer: Box<dyn Scorer>,
+            segment_ord: SegmentOrdinal,
+            segment_reader: SegmentReader,
+        ) -> Self {
             Self {
-                limit: limit.try_into().expect("limit should not exceed u32::MAX"),
-                inner: Arc::new(inner),
+                scorer,
+                segment_ord,
+                segment_reader,
             }
         }
     }
 
-    impl Weight for WeightLimit {
-        fn scorer(&self, reader: &SegmentReader, boost: Score) -> tantivy::Result<Box<dyn Scorer>> {
-            let scorer = self.inner.scorer(reader, boost)?;
-            Ok(Box::new(LimitingScorer {
-                limit: self.limit,
-                inner: scorer,
-                cnt: 0,
-            }))
-        }
-
-        fn explain(&self, reader: &SegmentReader, doc: DocId) -> tantivy::Result<Explanation> {
-            self.inner.explain(reader, doc)
-        }
-    }
-}
-
-mod vec_collector {
-
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use tantivy::collector::{Collector, SegmentCollector};
-    use tantivy::query::Weight;
-    use tantivy::{DocAddress, DocId, Score, SegmentOrdinal, SegmentReader};
-
-    #[derive(Default)]
-    pub enum FruitStyle {
-        #[default]
-        Empty,
-        Scored(
-            SegmentOrdinal,
-            std::vec::IntoIter<Score>,
-            std::vec::IntoIter<DocId>,
-        ),
-        Blocks(
-            usize,
-            SegmentOrdinal,
-            std::iter::Flatten<std::vec::IntoIter<std::vec::IntoIter<DocId>>>,
-        ),
-    }
-
-    impl FruitStyle {
-        pub fn len(&self) -> usize {
-            match self {
-                FruitStyle::Empty => 0,
-                FruitStyle::Scored(_, iter, ..) => iter.len(),
-                FruitStyle::Blocks(count, ..) => *count,
-            }
-        }
-    }
-
-    impl Iterator for FruitStyle {
+    impl Iterator for ScorerIter {
         type Item = (Score, DocAddress);
 
         fn next(&mut self) -> Option<Self::Item> {
-            match self {
-                FruitStyle::Empty => None,
-                FruitStyle::Scored(segment_ord, score, doc) => {
-                    let doc = doc.next()?;
-                    let score = score.next()?;
-                    let doc_address = DocAddress::new(*segment_ord, doc);
-                    Some((score, doc_address))
+            loop {
+                let doc_id = self.scorer.doc();
+
+                if doc_id == tantivy::TERMINATED {
+                    // we've read all the docs
+                    return None;
+                } else if !self
+                    .segment_reader
+                    .alive_bitset()
+                    .map(|alive_bitset| alive_bitset.is_alive(doc_id))
+                    // if there's no alive_bitset, the doc is alive
+                    .unwrap_or(true)
+                {
+                    // this doc isn't alive, move to the next doc and loop around
+                    self.scorer.advance();
+                    continue;
                 }
-                FruitStyle::Blocks(_, segment_ord, doc) => {
-                    let doc = doc.next()?;
-                    Some((0.0, DocAddress::new(*segment_ord, doc)))
-                }
+
+                // this doc is alive
+                let score = self.scorer.score();
+                let next = Some((score, DocAddress::new(self.segment_ord, doc_id)));
+
+                // move to the next doc for the next iteration
+                self.scorer.advance();
+
+                // return the live doc
+                return next;
             }
         }
-    }
 
-    /// A [`Collector`] that collects all matching documents into a [`Vec`].
-    pub struct VecCollector {
-        limit: Option<usize>,
-        need_scores: bool,
-        count: AtomicUsize,
-    }
-
-    impl VecCollector {
-        pub fn new(limit: Option<usize>, need_scores: bool) -> Self {
-            Self {
-                limit,
-                need_scores,
-                count: Default::default(),
-            }
-        }
-    }
-
-    impl Collector for VecCollector {
-        type Fruit = Vec<FruitStyle>;
-        type Child = VecSegmentCollector;
-
-        fn for_segment(
-            &self,
-            segment_local_id: SegmentOrdinal,
-            _segment_reader: &SegmentReader,
-        ) -> tantivy::Result<Self::Child> {
-            Ok(VecSegmentCollector {
-                segment_ord: segment_local_id,
-                scored: (vec![], vec![]),
-                doc_blocks: vec![],
-            })
-        }
-
-        fn requires_scoring(&self) -> bool {
-            self.need_scores
-        }
-
-        fn merge_fruits(
-            &self,
-            segment_fruits: Vec<<Self::Child as SegmentCollector>::Fruit>,
-        ) -> tantivy::Result<Self::Fruit> {
-            // NB:  we never call this function, but best to implement it anyways
-            Ok(segment_fruits)
-        }
-
-        fn collect_segment(
-            &self,
-            weight: &dyn Weight,
-            segment_ord: u32,
-            reader: &SegmentReader,
-        ) -> tantivy::Result<<Self::Child as SegmentCollector>::Fruit> {
-            let mut segment_collector = self.for_segment(segment_ord, reader)?;
-
-            if self.limit.is_none() || self.count.load(Ordering::Relaxed) < self.limit.unwrap_or(0)
-            {
-                match (reader.alive_bitset(), self.requires_scoring()) {
-                    (Some(alive_bitset), true) => {
-                        weight.for_each(reader, &mut |doc, score| {
-                            if alive_bitset.is_alive(doc) {
-                                self.count.fetch_add(1, Ordering::Relaxed);
-                                segment_collector.collect(doc, score);
-                            }
-                        })?;
-                    }
-                    (Some(alive_bitset), false) => {
-                        weight.for_each_no_score(reader, &mut |docs| {
-                            for doc in docs.iter().cloned() {
-                                if alive_bitset.is_alive(doc) {
-                                    self.count.fetch_add(1, Ordering::Relaxed);
-                                    segment_collector.collect(doc, 0.0);
-                                }
-                            }
-                        })?;
-                    }
-                    (None, true) => {
-                        weight.for_each(reader, &mut |doc, score| {
-                            self.count.fetch_add(1, Ordering::Relaxed);
-                            segment_collector.collect(doc, score);
-                        })?;
-                    }
-                    (None, false) => {
-                        weight.for_each_no_score(reader, &mut |docs| {
-                            self.count.fetch_add(docs.len(), Ordering::Relaxed);
-                            segment_collector.collect_block(docs);
-                        })?;
-                    }
-                }
-            }
-
-            Ok(segment_collector.harvest())
-        }
-    }
-
-    pub struct VecSegmentCollector {
-        segment_ord: SegmentOrdinal,
-        scored: (Vec<DocId>, Vec<Score>),
-        doc_blocks: Vec<std::vec::IntoIter<DocId>>,
-    }
-
-    impl SegmentCollector for VecSegmentCollector {
-        type Fruit = FruitStyle;
-
-        fn collect(&mut self, doc: DocId, score: Score) {
-            self.scored.0.push(doc);
-            self.scored.1.push(score);
-        }
-
-        #[allow(clippy::unnecessary_to_owned)]
-        fn collect_block(&mut self, docs: &[DocId]) {
-            self.doc_blocks.push(docs.to_vec().into_iter());
-        }
-
-        fn harvest(mut self) -> Self::Fruit {
-            if !self.doc_blocks.is_empty() {
-                if !self.scored.0.is_empty() {
-                    self.doc_blocks.push(self.scored.0.into_iter());
-                }
-                FruitStyle::Blocks(
-                    self.doc_blocks.iter().map(|i| i.len()).sum(),
-                    self.segment_ord,
-                    self.doc_blocks.into_iter().flatten(),
-                )
-            } else {
-                FruitStyle::Scored(
-                    self.segment_ord,
-                    self.scored.1.into_iter(),
-                    self.scored.0.into_iter(),
-                )
-            }
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, Some(self.scorer.size_hint() as usize))
         }
     }
 }


### PR DESCRIPTION
In the general cases of querying a segment (or even all segments) we no longer go through tantivy's `Collector` APIs and instead map the underlying `Scorer` as an `Iterator`.

This allows us to completely eliminate the need to first collect all the `(Score, DocAddress)` matches into `Vec`s.

Additionally, it allows for `SearchIndexReader::estimate_docs()` to avoid a lot of overhead and just use the `::size_hint()`, which is good enough for our query planning purposes.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
