### PR TITLE
fix: don't use a buffer to lock merges

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -259,11 +259,9 @@ impl Directory for MVCCDirectory {
             .collect::<FxHashSet<_>>()
             .len();
 
-        if matches!(self.merge_policy, AllowedMergePolicy::None) {
-            return Some(Box::new(NoMergePolicy));
-        }
-
-        if matches!(self.mvcc_style, MvccSatisfies::Any) {
+        if matches!(self.merge_policy, AllowedMergePolicy::None)
+            || matches!(self.mvcc_style, MvccSatisfies::Any)
+        {
             return Some(Box::new(NoMergePolicy));
         }
 

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -304,7 +304,6 @@ pub unsafe fn save_new_metas(
     // add the new entries
     linked_list.add_items(created_entries, None)?;
 
-    // garbage collect the linked list, if no vacuum is going on
     if !deleted_entries.is_empty() {
         linked_list.garbage_collect(pg_sys::GetAccessStrategy(
             pg_sys::BufferAccessStrategyType::BAS_VACUUM,

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -304,6 +304,7 @@ pub unsafe fn save_new_metas(
     // add the new entries
     linked_list.add_items(created_entries, None)?;
 
+    // garbage collect the linked list, if no vacuum is going on
     if !deleted_entries.is_empty() {
         linked_list.garbage_collect(pg_sys::GetAccessStrategy(
             pg_sys::BufferAccessStrategyType::BAS_VACUUM,

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,5 +1,5 @@
 use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
-use crate::postgres::storage::buffer::{BufferManager, BufferMut};
+use crate::postgres::storage::buffer::BufferManager;
 use pgrx::pg_sys;
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::SegmentMeta;
@@ -52,63 +52,78 @@ impl MergePolicy for NPlusOneMergePolicy {
     }
 }
 
-/// Only one merge can happen at a time, so we need to lock the merge process
-#[derive(Debug)]
-pub struct MergeLock(BufferMut);
-
-impl MergeLock {
-    // This lock is acquired by inserts that attempt to merge segments
-    // Merges should only happen if there is no other merge in progress
-    // AND the effects of the previous merge are visible
-    pub unsafe fn acquire_for_merge(relation_oid: pg_sys::Oid) -> Option<Self> {
-        if !pg_sys::IsTransactionState() {
-            return None;
-        }
-
-        let mut bman = BufferManager::new(relation_oid);
-
-        if let Some(mut merge_lock) = bman.get_buffer_conditional(MERGE_LOCK) {
-            let mut page = merge_lock.page_mut();
-            let metadata = page.contents_mut::<MergeLockData>();
-            let last_merge = metadata.last_merge;
-
-            let snapshot = pg_sys::GetActiveSnapshot();
-
-            if pg_sys::XidInMVCCSnapshot(last_merge, snapshot) {
-                None
-            } else {
-                Some(MergeLock(merge_lock))
-            }
-        } else {
-            None
-        }
+// This lock is acquired by inserts if merge_on_insert is true
+// Merges should only happen if there is no other merge in progress
+// AND the effects of the previous merge are visible
+pub unsafe fn acquire_merge_lock(relation_oid: pg_sys::Oid) -> bool {
+    if !pg_sys::IsTransactionState() {
+        return false;
     }
 
-    // This lock must be acquired before ambulkdelete calls commit() on the index
-    // We ask for an exclusive lock because ambulkdelete must delete all dead ctids
-    pub unsafe fn acquire_for_delete(relation_oid: pg_sys::Oid) -> Self {
-        let mut bman = BufferManager::new(relation_oid);
-        let merge_lock = bman.get_buffer_mut(MERGE_LOCK);
-        MergeLock(merge_lock)
-    }
+    let mut bman = BufferManager::new(relation_oid);
 
-    pub unsafe fn num_segments(&mut self) -> u32 {
-        let mut page = self.0.page_mut();
+    if let Some(mut merge_lock) = bman.get_buffer_conditional(MERGE_LOCK) {
+        let mut page = merge_lock.page_mut();
         let metadata = page.contents_mut::<MergeLockData>();
-        metadata.num_segments
+        let last_merge = metadata.last_merge;
+        let last_vacuum = metadata.last_vacuum;
+
+        // a merge has never happened before, so it must be safe to merge
+        if !pg_sys::TransactionIdIsNormal(last_merge) && !pg_sys::TransactionIdIsNormal(last_vacuum)
+        {
+            metadata.last_merge = pg_sys::GetCurrentTransactionId();
+            return true;
+        }
+
+        // allow a merge if the effects of the last merge_on_insert are visible and there is no ongoing vacuum
+        // the effects of vacuums are immediately visible and not subject to mvcc, so we don't do mvcc checks on last_vacuum
+        let snapshot = pg_sys::GetActiveSnapshot();
+        let can_merge = !pg_sys::XidInMVCCSnapshot(last_merge, snapshot)
+            && (pg_sys::TransactionIdDidCommit(last_vacuum)
+                || pg_sys::TransactionIdDidAbort(last_vacuum));
+
+        if can_merge {
+            metadata.last_merge = pg_sys::GetCurrentTransactionId();
+        }
+        can_merge
+    } else {
+        false
     }
 }
 
-impl Drop for MergeLock {
-    fn drop(&mut self) {
-        unsafe {
-            if pg_sys::IsTransactionState() {
-                let mut page = self.0.page_mut();
-                let metadata = page.contents_mut::<MergeLockData>();
-                metadata.last_merge = pg_sys::GetCurrentTransactionId();
-            }
+// This lock must be acquired before ambulkdelete calls commit() on the index
+// We ask for an exclusive lock because ambulkdelete must delete all dead ctids
+pub unsafe fn acquire_delete_lock(relation_oid: pg_sys::Oid) {
+    let mut bman = BufferManager::new(relation_oid);
+
+    {
+        let mut merge_lock = bman.get_buffer_mut(MERGE_LOCK);
+        let mut page = merge_lock.page_mut();
+        let metadata = page.contents_mut::<MergeLockData>();
+        metadata.last_vacuum = pg_sys::GetCurrentTransactionId();
+    }
+
+    // wait for existing merge to finish
+    loop {
+        pgrx::check_for_interrupts!();
+
+        let merge_lock = bman.get_buffer(MERGE_LOCK);
+        let page = merge_lock.page();
+        let metadata = page.contents::<MergeLockData>();
+        let last_merge = metadata.last_merge;
+
+        if !pg_sys::TransactionIdIsInProgress(last_merge) {
+            break;
         }
     }
+}
+
+pub unsafe fn get_num_segments(relation_oid: pg_sys::Oid) -> u32 {
+    let bman = BufferManager::new(relation_oid);
+    let buffer = bman.get_buffer(MERGE_LOCK);
+    let page = buffer.page();
+    let metadata = page.contents::<MergeLockData>();
+    metadata.num_segments
 }
 
 pub unsafe fn set_num_segments(relation_oid: pg_sys::Oid, num_segments: u32) {

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -112,7 +112,10 @@ pub unsafe fn acquire_delete_lock(relation_oid: pg_sys::Oid) {
         let metadata = page.contents::<MergeLockData>();
         let last_merge = metadata.last_merge;
 
-        if !pg_sys::TransactionIdIsInProgress(last_merge) {
+        if pg_sys::TransactionIdDidCommit(last_merge)
+            || pg_sys::TransactionIdDidAbort(last_merge)
+            || !pg_sys::TransactionIdIsNormal(last_merge)
+        {
             break;
         }
     }

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -20,7 +20,7 @@ use tantivy::Term;
 
 use super::storage::block::CLEANUP_LOCK;
 use crate::index::fast_fields_helper::FFType;
-use crate::index::merge_policy::MergeLock;
+use crate::index::merge_policy::acquire_delete_lock;
 use crate::index::reader::index::SearchIndexReader;
 use crate::index::writer::index::SearchIndexWriter;
 use crate::index::{BlockDirectoryType, WriterResources};
@@ -49,7 +49,7 @@ pub extern "C" fn ambulkdelete(
         callback(&mut ctid, callback_state)
     };
 
-    let _merge_lock = unsafe { MergeLock::acquire_for_delete(index_relation.oid()) };
+    unsafe { acquire_delete_lock(index_relation.oid()) };
     let mut writer = SearchIndexWriter::open(
         &index_relation,
         BlockDirectoryType::BulkDelete,

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -46,11 +46,12 @@ pub struct BM25PageSpecialData {
 // Merge lock
 // ---------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {
     pub last_merge: pg_sys::TransactionId,
     pub num_segments: u32,
+    pub last_vacuum: pg_sys::TransactionId,
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2067 

## What

Uses transaction ID evaluation to ensure that only one merge happens at a time. Gets rid of having to hold a buffer LwLock for the duration of the merge.

## Why

Due to concurrency issues, we only allow one merge to happen at a time. In `0.14.0` we relied on a buffer's LwLock to guarantee this. This was hacky and caused issues like sigints not being received while this LwLock was held.

## How

In the first metadata block, we store two `TransactionId`s:

1. `last_merge`: the xid of the last merge 
2. `last_vacuum`: the xid of the last vacuum

A merge is allowed to happen if 

1. the effects of `last_merge` are visible to the active snapshot
2. `last_vacuum` has either committed or aborted

Note that we do NOT check if the effects of `last_vacuum` are MVCC visible. This is because the effects of vacuums are immediately visible and do not adhere to MVCC rules.

If a merge happens, `last_merge` is set to the current XID. 

If a vacuum happens, we acquire an exclusive lock on the metadata block and set `last_vacuum` to the current XID.
## Tests
