### PR TITLE
feat: add a top-level feature for pgrx' `unsafe-postgres` feature

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -17,6 +17,7 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 icu = ["tokenizers/icu"]
+unsafe-postgres = ["pgrx/unsafe-postgres"]
 
 [dependencies]
 anyhow = { version = "1.0.87", features = ["backtrace"] }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2092

## What

We now expose pgrx' `unsafe-postgres` feature flag as one of our own, allowing those building pg_search against a Postgres fork that claims to not be compatible to easily build pg_search.

## Why

Building pg_search against a Postgres fork is cumbersome b/c it requires hand-editing our `Cargo.toml` to add the `unsafe-postgres` feature to our pgrx dependency line.

This will let thse folks build pg_search with:

```shell
$ cargo pgrx package pgXX --features icu,unsafe-postgres
```

## How

## Tests
