### PR TITLE
chore: point to paradedb/tantivy main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,7 +3070,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5019,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "bitpacking",
 ]
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "nom",
 ]
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=cc0f329a1df02c21085d520a07f92665cbe4ceee#cc0f329a1df02c21085d520a07f92665cbe4ceee"
+source = "git+https://github.com/paradedb/tantivy.git?branch=main#656e9fa2fe6fe564ab09d4b34fd78fed725224f8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "cc0f329a1df02c21085d520a07f92665cbe4ceee", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "main", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "cc0f329a1df02c21085d520a07f92665cbe4ceee" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", branch = "main" }


### PR DESCRIPTION
# Ticket(s) Closed

## What
Now that we've stabilized the changes to our Tantivy fork, we can point at main branch again.