### PR TITLE
docs: Improve "Deploy" sidebar

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -266,17 +266,11 @@
       "pages": [
         "deploy/overview",
         {
-          "group": "Self-Hosted ParadeDB",
+          "group": "ParadeDB Self-Hosted",
           "pages": [
+            "deploy/self-hosted/docker",
             "deploy/self-hosted/kubernetes",
             "deploy/self-hosted/extensions",
-            {
-              "group": "Logical Replication",
-              "pages": [
-                "deploy/self-hosted/logical-replication/getting-started",
-                "deploy/self-hosted/logical-replication/configuration"
-              ]
-            },
             {
               "group": "High Availability",
               "pages": [
@@ -284,7 +278,13 @@
                 "deploy/self-hosted/high-availability/configuration"
               ]
             },
-            "deploy/self-hosted/docker"
+            {
+              "group": "Logical Replication",
+              "pages": [
+                "deploy/self-hosted/logical-replication/getting-started",
+                "deploy/self-hosted/logical-replication/configuration"
+              ]
+            }
           ]
         },
         "deploy/byoc",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Before:
<img width="337" alt="Capture d’écran, le 2025-01-15 à 14 58 28" src="https://github.com/user-attachments/assets/5d45d200-553a-4672-a4b4-a0d9e992ba52" />

After:
<img width="299" alt="Capture d’écran, le 2025-01-15 à 14 58 56" src="https://github.com/user-attachments/assets/ecb79d80-a1d3-4296-82ae-44ea2daa710f" />

I thought this was more cohesive and that the "Docker" section should be with Kubernetes and Extensions rather than after everything.

## Why
QoL

## How
Reorder

## Tests
N/A