### PR TITLE
fix: don't hold a lock during merge

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -276,7 +276,7 @@ impl Directory for MVCCDirectory {
         }
 
         // try to acquire merge lock and do merge
-        if let Some(mut merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
+        if let Some(merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
             if matches!(&self.merge_policy, &AllowedMergePolicy::NPlusOne) {
                 let num_segments = merge_lock.num_segments();
                 let parallelism = std::thread::available_parallelism()

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -278,7 +278,7 @@ impl Directory for MVCCDirectory {
         // try to acquire merge lock and do merge
         if let Some(mut merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
             if matches!(&self.merge_policy, &AllowedMergePolicy::NPlusOne) {
-                let num_segments = unsafe { merge_lock.num_segments() };
+                let num_segments = merge_lock.num_segments();
                 let parallelism = std::thread::available_parallelism()
                     .expect("failed to get available_parallelism")
                     .get();

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -72,7 +72,7 @@ impl MergeLock {
 
         if let Some(mut merge_lock) = bman.get_buffer_for_cleanup_conditional(
             MERGE_LOCK,
-            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_NORMAL),
         ) {
             let mut page = merge_lock.page_mut();
             let metadata = page.contents_mut::<MergeLockData>();
@@ -101,7 +101,7 @@ impl MergeLock {
         let mut bman = BufferManager::new(relation_oid);
         let merge_lock = bman.get_buffer_for_cleanup(
             MERGE_LOCK,
-            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_NORMAL),
         );
         let page = merge_lock.page();
         let metadata = page.contents::<MergeLockData>();

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,5 +1,5 @@
 use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
-use crate::postgres::storage::buffer::{BufferManager, BufferMut, PinnedBuffer};
+use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use pgrx::pg_sys;
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::SegmentMeta;
@@ -56,7 +56,7 @@ impl MergePolicy for NPlusOneMergePolicy {
 #[derive(Debug)]
 pub struct MergeLock {
     num_segments: u32,
-    buffer: PinnedBuffer,
+    _buffer: PinnedBuffer,
 }
 
 impl MergeLock {
@@ -78,17 +78,17 @@ impl MergeLock {
             let metadata = page.contents_mut::<MergeLockData>();
             let last_merge = metadata.last_merge;
             let snapshot = pg_sys::GetActiveSnapshot();
+            let last_merge_visible = pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
+                || !pg_sys::XidInMVCCSnapshot(last_merge, snapshot);
 
-            if pg_sys::XidInMVCCSnapshot(last_merge, snapshot) {
-                None
-            } else {
-                crate::log_message(&format!("MERGE STARTING, LAST MERGE {:?}", last_merge));
-
+            if last_merge_visible {
                 metadata.last_merge = pg_sys::GetCurrentTransactionId();
                 Some(MergeLock {
                     num_segments: metadata.num_segments,
-                    buffer: merge_lock.unlock(),
+                    _buffer: merge_lock.unlock(),
                 })
+            } else {
+                None
             }
         } else {
             None
@@ -108,7 +108,7 @@ impl MergeLock {
 
         MergeLock {
             num_segments: metadata.num_segments,
-            buffer: merge_lock.unlock(),
+            _buffer: merge_lock.unlock(),
         }
     }
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -46,7 +46,7 @@ pub struct BM25PageSpecialData {
 // Merge lock
 // ---------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {
     pub last_merge: pg_sys::TransactionId,

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -31,6 +31,9 @@ pub const SCHEMA_START: pg_sys::BlockNumber = 2;
 pub const SETTINGS_START: pg_sys::BlockNumber = 4;
 pub const SEGMENT_METAS_START: pg_sys::BlockNumber = 6;
 
+// Blocks before this cutoff are not considered for being returned to the FSM
+pub const VACUUM_START: pg_sys::BlockNumber = 2;
+
 // ---------------------------------------------------------
 // BM25 page special data
 // ---------------------------------------------------------

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -98,7 +98,9 @@ impl BufferMut {
             self.inner.pg_buffer = pg_sys::InvalidBuffer as pg_sys::Buffer;
 
             // unlock this buffer and convert to a PinnedBuffer
-            pg_sys::MarkBufferDirty(pg_buffer);
+            if self.dirty {
+                pg_sys::MarkBufferDirty(pg_buffer);
+            }
             pg_sys::LockBuffer(pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as _);
             PinnedBuffer::new(pg_buffer)
         }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -474,6 +474,7 @@ impl BufferManager {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get_buffer_conditional(&mut self, blockno: pg_sys::BlockNumber) -> Option<BufferMut> {
         unsafe {
             let pg_buffer = self.bcache.get_buffer(blockno, None);

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -35,6 +35,9 @@ pub extern "C" fn amvacuumcleanup(
         if !delete_stats.is_null() {
             let cleanup_lock = (*delete_stats).cleanup_lock;
             pg_sys::UnlockReleaseBuffer(cleanup_lock);
+
+            crate::log_message(&format!("VACUUM CLEANUP {}", pg_sys::GetCurrentTransactionId()));
+            let _ = (*delete_stats).merge_lock.take();
         }
     }
 

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -35,9 +35,6 @@ pub extern "C" fn amvacuumcleanup(
         if !delete_stats.is_null() {
             let cleanup_lock = (*delete_stats).cleanup_lock;
             pg_sys::UnlockReleaseBuffer(cleanup_lock);
-
-            crate::log_message(&format!("VACUUM CLEANUP {}", pg_sys::GetCurrentTransactionId()));
-            let _ = (*delete_stats).merge_lock.take();
         }
     }
 
@@ -51,7 +48,7 @@ pub extern "C" fn amvacuumcleanup(
         let heap_oid = pg_sys::IndexGetRelation(index_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
-        for blockno in 0..nblocks {
+        for blockno in 2..nblocks {
             check_for_interrupts!();
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::postgres::storage::block::VACUUM_START;
 use crate::postgres::storage::buffer::BufferManager;
 use pgrx::*;
 
@@ -48,7 +49,7 @@ pub extern "C" fn amvacuumcleanup(
         let heap_oid = pg_sys::IndexGetRelation(index_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
-        for blockno in 2..nblocks {
+        for blockno in VACUUM_START..nblocks {
             check_for_interrupts!();
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2112 
- Closes #2067 

## What

- Uses pins instead of locks to ensure that only one merge happens at a time, which allows the merge process to receive sigints
- Allows multiple merges to happen within the same transaction

## Why

For MVCC correctness, we only allow one merge to happen at a time. In `0.14.0` we relied on a buffer's LwLock to guarantee this. This was hacky and caused issues like sigints not being received while this LwLock was held.

## How

Instead of holding a lock on the "merge block" while the merge is happening, we just hold a pin. The `LockBufferForCleanup` function checks that no other backends are holding a pin on the buffer, guaranteeing that only one merge can happen at once.

## Tests
