### PR TITLE
fix: COPY into a table with bm25 index no longer crashes on Postgres <=16

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -82,6 +82,9 @@ pub unsafe extern "C" fn _PG_init() {
     postgres::options::init();
     gucs::init();
 
+    #[cfg(not(feature = "pg17"))]
+    postgres::fake_aminsertcleanup::register();
+
     setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
 
     // Register our tracing / logging hook, so that we can ensure that the logger

--- a/pg_search/src/postgres/fake_aminsertcleanup.rs
+++ b/pg_search/src/postgres/fake_aminsertcleanup.rs
@@ -1,0 +1,94 @@
+//! This module fakes the behavior of pg17+'s `aminsertcleanup` by hooking the executor's "finish"
+//! hook along with the "process utility hook".
+#![allow(static_mut_refs)]
+
+use crate::postgres::insert::{paradedb_aminsertcleanup, InsertState};
+use pgrx::{pg_guard, pg_sys};
+
+static mut PENDING_TANTIVY_COMMIT: Option<InsertState> = None;
+
+#[inline]
+pub unsafe fn get_pending_insert_state() -> Option<&'static mut InsertState> {
+    PENDING_TANTIVY_COMMIT.as_mut()
+}
+
+#[inline]
+pub unsafe fn set_pending_insert_state(insert_state: InsertState) {
+    assert!(
+        PENDING_TANTIVY_COMMIT.is_none(),
+        "already have a pending tantivy commit state"
+    );
+    PENDING_TANTIVY_COMMIT = Some(insert_state);
+}
+
+#[inline]
+pub unsafe fn reset_pending_insert_state() {
+    PENDING_TANTIVY_COMMIT = None;
+}
+
+pub unsafe fn register() {
+    static mut PREV_PROCESS_UTILITY_HOOK: pg_sys::ProcessUtility_hook_type = None;
+    static mut PREV_EXECUTOR_FINISH_HOOK: pg_sys::ExecutorFinish_hook_type = None;
+
+    PREV_PROCESS_UTILITY_HOOK = pg_sys::ProcessUtility_hook;
+    pg_sys::ProcessUtility_hook = Some(process_utility_hook);
+
+    PREV_EXECUTOR_FINISH_HOOK = pg_sys::ExecutorFinish_hook;
+    pg_sys::ExecutorFinish_hook = Some(executor_finish_hook);
+
+    #[cfg(not(feature = "pg13"))]
+    #[allow(clippy::too_many_arguments)]
+    #[rustfmt::skip]
+    #[pg_guard]
+    unsafe extern "C" fn process_utility_hook(
+        pstmt: *mut pg_sys::PlannedStmt,
+        query_string: *const ::core::ffi::c_char,
+        read_only_tree: bool,
+        context: pg_sys::ProcessUtilityContext::Type,
+        params: pg_sys::ParamListInfo,
+        query_env: *mut pg_sys::QueryEnvironment,
+        dest: *mut pg_sys::DestReceiver,
+        qc: *mut pg_sys::QueryCompletion,
+    ) {
+        if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
+            prev_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
+        } else {
+            pg_sys::standard_ProcessUtility(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc)
+        }
+
+        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
+    }
+
+    #[cfg(feature = "pg13")]
+    #[allow(clippy::too_many_arguments)]
+    #[rustfmt::skip]
+    #[pg_guard]
+    unsafe extern "C" fn process_utility_hook(
+        pstmt: *mut pg_sys::PlannedStmt,
+        query_string: *const ::core::ffi::c_char,
+        context: pg_sys::ProcessUtilityContext::Type,
+        params: pg_sys::ParamListInfo,
+        query_env: *mut pg_sys::QueryEnvironment,
+        dest: *mut pg_sys::DestReceiver,
+        qc: *mut pg_sys::QueryCompletion,
+    ) {
+        if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
+            prev_hook(pstmt, query_string, context, params, query_env, dest, qc);
+        } else {
+            pg_sys::standard_ProcessUtility(pstmt, query_string, context, params, query_env, dest, qc)
+        }
+
+        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
+    }
+
+    #[pg_guard]
+    unsafe extern "C" fn executor_finish_hook(query_desc: *mut pg_sys::QueryDesc) {
+        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
+
+        if let Some(prev_hook) = PREV_EXECUTOR_FINISH_HOOK {
+            prev_hook(query_desc);
+        } else {
+            pg_sys::standard_ExecutorFinish(query_desc);
+        }
+    }
+}

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -29,6 +29,8 @@ mod validate;
 
 pub mod customscan;
 pub mod datetime;
+#[cfg(not(feature = "pg17"))]
+pub mod fake_aminsertcleanup;
 pub mod index;
 mod parallel;
 pub mod storage;

--- a/tests/tests/copy.rs
+++ b/tests/tests/copy.rs
@@ -1,0 +1,26 @@
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+async fn test_copy_to_table(mut conn: PgConnection) {
+    r#"
+        DROP TABLE IF EXISTS test_copy_to_table;
+        CREATE TABLE test_copy_to_table (id SERIAL PRIMARY KEY, name TEXT);
+        CREATE INDEX idx_test_copy_to_table ON test_copy_to_table USING bm25(id, name) WITH (key_field = 'id');
+    "#.execute(&mut conn);
+
+    let mut copyin = conn
+        .copy_in_raw("COPY test_copy_to_table(name) FROM STDIN")
+        .await
+        .unwrap();
+    copyin.send("one\ntwo\nthree".as_bytes()).await.unwrap();
+    copyin.finish().await.unwrap();
+
+    let (count,) = "SELECT COUNT(*) FROM test_copy_to_table WHERE name @@@ 'one'"
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Using `COPY` to copy data into a table with an existing `USING bm25` index would crash on Postgres versions less than 17 due to COPY being considered a utility statement whose memory context cleanup process doesn't exactly match regular DML like INSERT/UPDATE.

COPY works fine on pg17 due to the `aminsertcleanup()` function that was introduced.

For Postgres v13-16 this PR fakes a similar process by hooking the Executor's "end" callback, the process utility hook, and also adding a transient "on abort" transaction callback.

## Why

Crashing is bad and we were missing a test around COPY, so we never caught this.

## How

## Tests

Existing tests pass and also a new test has been added for COPY.