### PR TITLE
perf: improve query planning times by loading `BlockList`s on demand and update tantivy rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "bitpacking",
 ]
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "nom",
 ]
@@ -5025,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=b42a45dd4aa29ce880864c95f2b6e69ad26cdc06#b42a45dd4aa29ce880864c95f2b6e69ad26cdc06"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7f86b472c262d90c506c75aea645050f290fa3e8#7f86b472c262d90c506c75aea645050f290fa3e8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "b42a45dd4aa29ce880864c95f2b6e69ad26cdc06", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7f86b472c262d90c506c75aea645050f290fa3e8", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "b42a45dd4aa29ce880864c95f2b6e69ad26cdc06" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "7f86b472c262d90c506c75aea645050f290fa3e8" }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We defer loading a `LinkedBytesList`'s `BlockList` until needed.  This eliminates quite some overhead during query planning.

Additionally, we update our tantivy dependency rev to pick up the recent lazy loading changes from https://github.com/paradedb/tantivy/pull/20

## Why

In a test here, these two changes combined drop query planning time, for a simple query, from about 1.4ms to about 0.436ms.

## How

## Tests

Existing tests pass