### PR TITLE
ci: Fix extension upgrade test workflow

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -140,12 +140,20 @@ jobs:
           VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
           psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
 
-      - name: Run pg_search test suite
+      - name: Run pg_search Integration Tests
+        working-directory: tests/
         run: |
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
           export PARADEDB_TELEMETRY=false
-          RUST_BACKTRACE=1 cargo test --features pg${{ matrix.pg_version }},icu --no-default-features
+          RUST_BACKTRACE=1 cargo test --features icu
+
+      - name: Run pg_search Unit Tests
+        working-directory: pg_search/
+        run: |
+          export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
+          export PARADEDB_TELEMETRY=false
+          RUST_BACKTRACE=1 cargo test --features pg${{ matrix.pg_version }} --no-default-features
 
       - name: Print the Postgres Logs
         if: always()

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -159,7 +159,7 @@ jobs:
           # Necessary for the ephemeral Postgres test to have proper permissions
           sudo chown -R $(whoami) /var/run/postgresql/
 
-      - name: Run integration tests
+      - name: Run pg_search Integration Tests
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: tests/
         run: |
@@ -168,7 +168,7 @@ jobs:
           export PARADEDB_TELEMETRY=false
           RUST_BACKTRACE=1 cargo test --features icu
 
-      - name: Run pgrx tests
+      - name: Run pg_search Unit Tests
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: pg_search/
         run: |
@@ -279,7 +279,7 @@ jobs:
           RUST_BACKTRACE=1 cargo pgrx start pg${{ matrix.pg_version }}
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
 
-      - name: Run pg_search test suite against pgrx-managed Postgres
+      - name: Run pg_search Integration Tests Against pgrx-managed Postgres
         if: steps.check_skip.outputs.skip_remaining_steps != 'true'
         working-directory: tests/
         run: RUST_BACKTRACE=1 DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --no-default-features --features=icu -- --skip replication --skip ephemeral


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
v0.14 brought unit tests and we didn't update the extension upgrade workflow to follow the same framework.

## Why
^

## How
^

## Tests
^