### PR TITLE
fix: don't hold merge lock

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -276,7 +276,7 @@ impl Directory for MVCCDirectory {
         }
 
         // try to acquire merge lock and do merge
-        if let Some(mut merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
+        if let Some(merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
             if matches!(&self.merge_policy, &AllowedMergePolicy::NPlusOne) {
                 let num_segments = merge_lock.num_segments();
                 let parallelism = std::thread::available_parallelism()

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -278,7 +278,7 @@ impl Directory for MVCCDirectory {
         // try to acquire merge lock and do merge
         if let Some(mut merge_lock) = unsafe { MergeLock::acquire_for_merge(self.relation_oid) } {
             if matches!(&self.merge_policy, &AllowedMergePolicy::NPlusOne) {
-                let num_segments = unsafe { merge_lock.num_segments() };
+                let num_segments = merge_lock.num_segments();
                 let parallelism = std::thread::available_parallelism()
                     .expect("failed to get available_parallelism")
                     .get();

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -46,7 +46,7 @@ const MIN_NUM_SEGMENTS: usize = 2;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MvccSatisfies {
     Snapshot,
-    Any,
+    Vacuum,
 }
 
 /// Tantivy Directory trait implementation over block storage
@@ -80,7 +80,7 @@ impl MVCCDirectory {
         Self {
             relation_oid,
             merge_policy,
-            mvcc_style: MvccSatisfies::Any,
+            mvcc_style: MvccSatisfies::Vacuum,
             readers: Arc::new(Mutex::new(FxHashMap::default())),
             merge_lock: Default::default(),
         }

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -116,6 +116,28 @@ pub unsafe fn save_new_metas(
     modified_ids.retain(|id| new_files.contains_key(id));
 
     //
+    // process the deleted segments
+    //
+    // find the deleted segment entries and set their `xmax` to this transaction id
+    // and for each file in each deleted segment, locate its LinkedBytesList and .mark_deleted()
+    //
+    let deleted_entries = deleted_ids
+        .into_iter()
+        .map(|id| {
+            let (mut meta_entry, blockno, _) = linked_list
+                .lookup_ex(|entry| entry.segment_id == *id)
+                .unwrap_or_else(|e| {
+                    panic!("segment id `{id}` should be in the segment meta linked list: {e}")
+                });
+
+            meta_entry.xmax = pg_sys::GetCurrentTransactionId();
+            (meta_entry, blockno)
+        })
+        .collect::<Vec<_>>();
+
+    let merge_happened = !deleted_entries.is_empty();
+
+    //
     // process the new segments
     //
     // these are added to the linked list as new items
@@ -129,6 +151,7 @@ pub unsafe fn save_new_metas(
             let mut files = new_files.remove(id)?;
 
             let meta_entry = SegmentMetaEntry {
+                merge_happened,
                 segment_id: *id,
                 max_doc: created_segment.max_doc(),
                 xmin: pg_sys::GetCurrentTransactionId(),
@@ -191,26 +214,6 @@ pub unsafe fn save_new_metas(
             });
 
             Some((meta_entry, blockno))
-        })
-        .collect::<Vec<_>>();
-
-    //
-    // process the deleted segments
-    //
-    // find the deleted segment entries and set their `xmax` to this transaction id
-    // and for each file in each deleted segment, locate its LinkedBytesList and .mark_deleted()
-    //
-    let deleted_entries = deleted_ids
-        .into_iter()
-        .map(|id| {
-            let (mut meta_entry, blockno, _) = linked_list
-                .lookup_ex(|entry| entry.segment_id == *id)
-                .unwrap_or_else(|e| {
-                    panic!("segment id `{id}` should be in the segment meta linked list: {e}")
-                });
-
-            meta_entry.xmax = pg_sys::GetCurrentTransactionId();
-            (meta_entry, blockno)
         })
         .collect::<Vec<_>>();
 
@@ -304,7 +307,7 @@ pub unsafe fn save_new_metas(
     // add the new entries
     linked_list.add_items(created_entries, None)?;
 
-    if !deleted_entries.is_empty() {
+    if merge_happened {
         linked_list.garbage_collect(pg_sys::GetAccessStrategy(
             pg_sys::BufferAccessStrategyType::BAS_VACUUM,
         ))?;
@@ -338,11 +341,18 @@ pub unsafe fn load_metas(
             if let Some((entry, _)) = page.read_item::<SegmentMetaEntry>(offsetno) {
                 let visible = match solve_mvcc {
                     MvccSatisfies::Vacuum => {
-                        !entry.recyclable(snapshot, heap_relation)
-                            && pg_sys::TransactionIdPrecedes(
-                                entry.get_xmin(),
-                                pg_sys::ReadNextFullTransactionId().value as pg_sys::TransactionId,
-                            )
+                        // we should be inside a vacuum, so any segment with an xid that is greater than
+                        // or equal to the next xid is not visible to us
+                        let before_latest_vacuum = pg_sys::TransactionIdPrecedes(
+                            entry.get_xmin(),
+                            pg_sys::ReadNextFullTransactionId().value as pg_sys::TransactionId,
+                        );
+
+                        // the exception being if a segment is a merged segment, in which case it should be considered
+                        // because it's comprised of segments that were visible before the vacuum
+                        (before_latest_vacuum || entry.merge_happened)
+                        // also don't bother considering recyclable segments
+                        && !entry.recyclable(snapshot, heap_relation)
                     }
                     MvccSatisfies::Snapshot => entry.visible(snapshot),
                 };

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -72,7 +72,7 @@ impl MergeLock {
 
         if let Some(mut merge_lock) = bman.get_buffer_for_cleanup_conditional(
             MERGE_LOCK,
-            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_NORMAL),
         ) {
             let mut page = merge_lock.page_mut();
             let metadata = page.contents_mut::<MergeLockData>();
@@ -101,7 +101,7 @@ impl MergeLock {
         let mut bman = BufferManager::new(relation_oid);
         let merge_lock = bman.get_buffer_for_cleanup(
             MERGE_LOCK,
-            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_NORMAL),
         );
         let page = merge_lock.page();
         let metadata = page.contents::<MergeLockData>();

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -1,5 +1,5 @@
 use crate::postgres::storage::block::{MergeLockData, MERGE_LOCK};
-use crate::postgres::storage::buffer::{BufferManager, BufferMut};
+use crate::postgres::storage::buffer::{BufferManager, BufferMut, PinnedBuffer};
 use pgrx::pg_sys;
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::SegmentMeta;
@@ -54,7 +54,10 @@ impl MergePolicy for NPlusOneMergePolicy {
 
 /// Only one merge can happen at a time, so we need to lock the merge process
 #[derive(Debug)]
-pub struct MergeLock(BufferMut);
+pub struct MergeLock {
+    num_segments: u32,
+    buffer: PinnedBuffer,
+}
 
 impl MergeLock {
     // This lock is acquired by inserts that attempt to merge segments
@@ -67,7 +70,10 @@ impl MergeLock {
 
         let mut bman = BufferManager::new(relation_oid);
 
-        if let Some(mut merge_lock) = bman.get_buffer_conditional(MERGE_LOCK) {
+        if let Some(mut merge_lock) = bman.get_buffer_for_cleanup_conditional(
+            MERGE_LOCK,
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+        ) {
             let mut page = merge_lock.page_mut();
             let metadata = page.contents_mut::<MergeLockData>();
             let last_merge = metadata.last_merge;
@@ -75,11 +81,14 @@ impl MergeLock {
             let last_merge_visible = pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
                 || !pg_sys::XidInMVCCSnapshot(last_merge, snapshot);
 
-            if last_merge_visible {
-                metadata.last_merge = pg_sys::GetCurrentTransactionId();
-                Some(MergeLock(merge_lock))
-            } else {
+            if pg_sys::XidInMVCCSnapshot(last_merge, snapshot) {
                 None
+            } else {
+                metadata.last_merge = pg_sys::GetCurrentTransactionId();
+                Some(MergeLock {
+                    num_segments: metadata.num_segments,
+                    buffer: merge_lock.unlock(),
+                })
             }
         } else {
             None
@@ -90,26 +99,21 @@ impl MergeLock {
     // We ask for an exclusive lock because ambulkdelete must delete all dead ctids
     pub unsafe fn acquire_for_delete(relation_oid: pg_sys::Oid) -> Self {
         let mut bman = BufferManager::new(relation_oid);
-        let merge_lock = bman.get_buffer_mut(MERGE_LOCK);
-        MergeLock(merge_lock)
-    }
+        let merge_lock = bman.get_buffer_for_cleanup(
+            MERGE_LOCK,
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM),
+        );
+        let page = merge_lock.page();
+        let metadata = page.contents::<MergeLockData>();
 
-    pub unsafe fn num_segments(&mut self) -> u32 {
-        let mut page = self.0.page_mut();
-        let metadata = page.contents_mut::<MergeLockData>();
-        metadata.num_segments
-    }
-}
-
-impl Drop for MergeLock {
-    fn drop(&mut self) {
-        unsafe {
-            if pg_sys::IsTransactionState() {
-                let mut page = self.0.page_mut();
-                let metadata = page.contents_mut::<MergeLockData>();
-                metadata.last_merge = pg_sys::GetCurrentTransactionId();
-            }
+        MergeLock {
+            num_segments: metadata.num_segments,
+            buffer: merge_lock.unlock(),
         }
+    }
+
+    pub fn num_segments(&self) -> u32 {
+        self.num_segments
     }
 }
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -28,7 +28,6 @@ use crate::index::{BlockDirectoryType, WriterResources};
 #[repr(C)]
 pub struct BulkDeleteData {
     stats: pg_sys::IndexBulkDeleteResult,
-    pub cleanup_lock: pg_sys::Buffer,
     pub merge_lock: Option<MergeLock>,
 }
 
@@ -107,10 +106,11 @@ pub extern "C" fn ambulkdelete(
                 info.strategy,
             );
             pg_sys::LockBufferForCleanup(cleanup_buffer);
+            pg_sys::UnlockReleaseBuffer(cleanup_buffer);
 
             let mut opaque = PgBox::<BulkDeleteData>::alloc0();
             opaque.stats = *stats;
-            opaque.cleanup_lock = cleanup_buffer;
+            // opaque.cleanup_lock = cleanup_buffer;
             // A merge cannot kick off while vacuum is running
             // To prevent this, we keep the merge lock in the IndexBulkDeleteResult state
             // Its Drop impl will be invoked when Postgres cleans up after vacuum

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -142,6 +142,7 @@ pub struct DeleteEntry {
 /// Metadata for tracking alive segments
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SegmentMetaEntry {
+    pub merge_happened: bool,
     pub segment_id: SegmentId,
     pub max_doc: u32,
     pub xmin: pg_sys::TransactionId,

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -46,7 +46,7 @@ pub struct BM25PageSpecialData {
 // Merge lock
 // ---------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {
     pub last_merge: pg_sys::TransactionId,

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -49,11 +49,12 @@ pub struct BM25PageSpecialData {
 // Merge lock
 // ---------------------------------------------------------
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {
     pub last_merge: pg_sys::TransactionId,
     pub num_segments: u32,
+    pub last_vacuum: pg_sys::TransactionId,
 }
 
 // ---------------------------------------------------------

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -31,6 +31,9 @@ pub const SCHEMA_START: pg_sys::BlockNumber = 2;
 pub const SETTINGS_START: pg_sys::BlockNumber = 4;
 pub const SEGMENT_METAS_START: pg_sys::BlockNumber = 6;
 
+// Blocks before this cutoff are not considered for being returned to the FSM
+pub const VACUUM_START: pg_sys::BlockNumber = 2;
+
 // ---------------------------------------------------------
 // BM25 page special data
 // ---------------------------------------------------------

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -97,7 +97,9 @@ impl BufferMut {
             self.inner.pg_buffer = pg_sys::InvalidBuffer as pg_sys::Buffer;
 
             // unlock this buffer and convert to a PinnedBuffer
-            pg_sys::MarkBufferDirty(pg_buffer);
+            if self.dirty {
+                pg_sys::MarkBufferDirty(pg_buffer);
+            }
             pg_sys::LockBuffer(pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as _);
             PinnedBuffer::new(pg_buffer)
         }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -66,7 +66,10 @@ pub struct BufferMut {
 impl Drop for BufferMut {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() && self.dirty {
+            if pg_sys::IsTransactionState()
+                && self.dirty
+                && self.inner.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer
+            {
                 pg_sys::MarkBufferDirty(self.inner.pg_buffer);
             }
         }
@@ -86,6 +89,18 @@ impl BufferMut {
             (*special).xmax = pg_sys::InvalidTransactionId;
         }
         page
+    }
+
+    pub fn unlock(mut self) -> PinnedBuffer {
+        unsafe {
+            let pg_buffer = self.inner.pg_buffer;
+            self.inner.pg_buffer = pg_sys::InvalidBuffer as pg_sys::Buffer;
+
+            // unlock this buffer and convert to a PinnedBuffer
+            pg_sys::MarkBufferDirty(pg_buffer);
+            pg_sys::LockBuffer(pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as _);
+            PinnedBuffer::new(pg_buffer)
+        }
     }
 
     #[allow(dead_code)]
@@ -115,6 +130,7 @@ impl BufferMut {
     }
 }
 
+#[derive(Debug)]
 pub struct PinnedBuffer {
     pg_buffer: pg_sys::Buffer,
 }
@@ -485,6 +501,27 @@ impl BufferManager {
             BufferMut {
                 dirty: false,
                 inner: Buffer::new(buffer),
+            }
+        }
+    }
+
+    pub fn get_buffer_for_cleanup_conditional(
+        &mut self,
+        blockno: pg_sys::BlockNumber,
+        strategy: pg_sys::BufferAccessStrategy,
+    ) -> Option<BufferMut> {
+        unsafe {
+            let buffer = self
+                .bcache
+                .get_buffer_with_strategy(blockno, strategy, None);
+            if pg_sys::ConditionalLockBufferForCleanup(buffer) {
+                Some(BufferMut {
+                    dirty: false,
+                    inner: Buffer::new(buffer),
+                })
+            } else {
+                pg_sys::ReleaseBuffer(buffer);
+                None
             }
         }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -473,6 +473,7 @@ impl BufferManager {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get_buffer_conditional(&mut self, blockno: pg_sys::BlockNumber) -> Option<BufferMut> {
         unsafe {
             let pg_buffer = self.bcache.get_buffer(blockno, None);

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -19,8 +19,6 @@ use crate::postgres::storage::block::VACUUM_START;
 use crate::postgres::storage::buffer::BufferManager;
 use pgrx::*;
 
-use super::delete::BulkDeleteData;
-
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
     info: *mut pg_sys::IndexVacuumInfo,
@@ -29,14 +27,6 @@ pub extern "C" fn amvacuumcleanup(
     let info = unsafe { PgBox::from_pg(info) };
     if info.analyze_only {
         return stats;
-    }
-
-    unsafe {
-        let delete_stats = stats as *mut BulkDeleteData;
-        if !delete_stats.is_null() {
-            let cleanup_lock = (*delete_stats).cleanup_lock;
-            pg_sys::UnlockReleaseBuffer(cleanup_lock);
-        }
     }
 
     // return all recyclable pages to the free space map

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -35,6 +35,9 @@ pub extern "C" fn amvacuumcleanup(
         if !delete_stats.is_null() {
             let cleanup_lock = (*delete_stats).cleanup_lock;
             pg_sys::UnlockReleaseBuffer(cleanup_lock);
+
+            crate::log_message(&format!("VACUUM CLEANUP {}", pg_sys::GetCurrentTransactionId()));
+            let _ = (*delete_stats).merge_lock.take();
         }
     }
 

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -35,9 +35,6 @@ pub extern "C" fn amvacuumcleanup(
         if !delete_stats.is_null() {
             let cleanup_lock = (*delete_stats).cleanup_lock;
             pg_sys::UnlockReleaseBuffer(cleanup_lock);
-
-            crate::log_message(&format!("VACUUM CLEANUP {}", pg_sys::GetCurrentTransactionId()));
-            let _ = (*delete_stats).merge_lock.take();
         }
     }
 
@@ -51,7 +48,7 @@ pub extern "C" fn amvacuumcleanup(
         let heap_oid = pg_sys::IndexGetRelation(index_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
-        for blockno in 0..nblocks {
+        for blockno in 2..nblocks {
             check_for_interrupts!();
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::postgres::storage::block::VACUUM_START;
 use crate::postgres::storage::buffer::BufferManager;
 use pgrx::*;
 
@@ -48,7 +49,7 @@ pub extern "C" fn amvacuumcleanup(
         let heap_oid = pg_sys::IndexGetRelation(index_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
-        for blockno in 2..nblocks {
+        for blockno in VACUUM_START..nblocks {
             check_for_interrupts!();
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2067 

## What

- Uses pins instead of locks to ensure that only one merge happens at a time, which allows the merge process to receive sigints

## Why

For MVCC correctness, we only allow one merge to happen at a time. In `0.14.0` we relied on a buffer's LwLock to guarantee this. This was hacky and caused issues like sigints not being received while this LwLock was held.

## How

Instead of holding a lock on the "merge block" while the merge is happening, we just hold a pin. The `LockBufferForCleanup` function checks that no other backends are holding a pin on the buffer, guaranteeing that only one merge can happen at once.

## Tests