### PR TITLE
chore: overload `FFType::new()` for the `ctid` field

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -110,6 +110,12 @@ pub enum FFType {
 }
 
 impl FFType {
+    /// Construct the proper [`FFType`] for the internal `ctid` field, which
+    /// should be a known field name in the Tantivy index
+    pub fn new_ctid(ffr: &FastFieldReaders) -> Self {
+        Self::U64(ffr.u64("ctid").expect("ctid should be a u64 fast field"))
+    }
+
     /// Construct the proper [`FFType`] for the specified `field_name`, which
     /// should be a known field name in the Tantivy index
     #[track_caller]

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -150,7 +150,7 @@ impl Iterator for SearchResults {
             SearchResults::SingleSegment(searcher, segment_ord, fftype, iter) => {
                 let (score, doc_address) = iter.next()?;
                 let ctid_ff = fftype.get_or_insert_with(|| {
-                    FFType::new(searcher.segment_reader(*segment_ord).fast_fields(), "ctid")
+                    FFType::new_ctid(searcher.segment_reader(*segment_ord).fast_fields())
                 });
                 let scored = SearchIndexScore {
                     ctid: ctid_ff
@@ -165,11 +165,10 @@ impl Iterator for SearchResults {
                 match last.next() {
                     Some((score, doc_address)) => {
                         let ctid_ff = fftype.get_or_insert_with(|| {
-                            FFType::new(
+                            FFType::new_ctid(
                                 searcher
                                     .segment_reader(doc_address.segment_ord)
                                     .fast_fields(),
-                                "ctid",
                             )
                         });
                         let scored = SearchIndexScore {
@@ -192,11 +191,10 @@ impl Iterator for SearchResults {
         };
 
         let ctid_ff = ff_lookup.entry(doc_address.segment_ord).or_insert_with(|| {
-            FFType::new(
+            FFType::new_ctid(
                 searcher
                     .segment_reader(doc_address.segment_ord)
                     .fast_fields(),
-                "ctid",
             )
         });
         let scored = SearchIndexScore {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -392,7 +392,7 @@ mod term_ord_collector {
                 segment_ord: segment_local_id,
                 results: Default::default(),
                 ff: ff.str(&self.field)?.expect("ff should be a str field"),
-                ctid_ff: FFType::new(ff, "ctid"),
+                ctid_ff: FFType::new_ctid(ff),
             })
         }
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -63,7 +63,7 @@ pub extern "C" fn ambulkdelete(
     let mut did_delete = false;
 
     for segment_reader in reader.searcher().segment_readers() {
-        let ctid_ff = FFType::new(segment_reader.fast_fields(), "ctid");
+        let ctid_ff = FFType::new_ctid(segment_reader.fast_fields());
 
         for doc_id in 0..segment_reader.max_doc() {
             check_for_interrupts!();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We know that the `ctid` field is a `FFType::U64` so we can directly construct it as such, rather than surfing the various types until we find the one that works.

This cleans up a tiny bit of overhead when first iterating a segment's search results.

## Why

Just some general code cleanup with a _minor_ performance improvement.

## How

## Tests

Existing tests pass.