### PR TITLE
perf: bypass `pg_sys::IsTransactionState()`, directly linking to the function

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -61,7 +61,7 @@ impl MergeLock {
     // Merges should only happen if there is no other merge in progress
     // AND the effects of the previous merge are visible
     pub unsafe fn acquire_for_merge(relation_oid: pg_sys::Oid) -> Option<Self> {
-        if !pg_sys::IsTransactionState() {
+        if !crate::postgres::utils::IsTransactionState() {
             return None;
         }
 
@@ -104,7 +104,7 @@ impl MergeLock {
 impl Drop for MergeLock {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() {
+            if crate::postgres::utils::IsTransactionState() {
                 let mut page = self.0.page_mut();
                 let metadata = page.contents_mut::<MergeLockData>();
                 metadata.last_merge = pg_sys::GetCurrentTransactionId();

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -61,7 +61,7 @@ pub struct FastFieldExecState {
 impl Drop for FastFieldExecState {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState()
+            if crate::postgres::utils::IsTransactionState()
                 && self.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
             {
                 pg_sys::ReleaseBuffer(self.vmbuff);

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -55,7 +55,7 @@ impl Default for NormalScanExecState {
 impl Drop for NormalScanExecState {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState()
+            if crate::postgres::utils::IsTransactionState()
                 && self.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
             {
                 pg_sys::ReleaseBuffer(self.vmbuff);

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -11,7 +11,7 @@ impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
             if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer
-                && pg_sys::IsTransactionState()
+                && crate::postgres::utils::IsTransactionState()
             {
                 pg_sys::UnlockReleaseBuffer(self.pg_buffer);
             }
@@ -66,7 +66,7 @@ pub struct BufferMut {
 impl Drop for BufferMut {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() && self.dirty {
+            if crate::postgres::utils::IsTransactionState() && self.dirty {
                 pg_sys::MarkBufferDirty(self.inner.pg_buffer);
             }
         }
@@ -122,7 +122,7 @@ pub struct PinnedBuffer {
 impl Drop for PinnedBuffer {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() {
+            if crate::postgres::utils::IsTransactionState() {
                 pg_sys::ReleaseBuffer(self.pg_buffer);
             }
         }

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -180,7 +180,7 @@ impl BM25BufferCache {
 impl Drop for BM25BufferCache {
     fn drop(&mut self) {
         unsafe {
-            if pg_sys::IsTransactionState() {
+            if crate::postgres::utils::IsTransactionState() {
                 pg_sys::RelationClose(self.indexrel.as_ptr());
                 pg_sys::RelationClose(self.heaprel.as_ptr());
             }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -24,6 +24,12 @@ use pgrx::itemptr::{item_pointer_get_both, item_pointer_set_all};
 use pgrx::*;
 use std::str::FromStr;
 
+extern "C" {
+    // SAFETY: `IsTransactionState()` doesn't raise an ERROR.  As such, we can avoid the pgrx
+    // sigsetjmp overhead by linking to the function directly.
+    pub fn IsTransactionState() -> bool;
+}
+
 /// Finds and returns the `USING bm25` index on the specified relation with the
 /// highest OID, or [`None`] if there aren't any.
 pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgRelation> {

--- a/pg_search/src/postgres/visibility_checker.rs
+++ b/pg_search/src/postgres/visibility_checker.rs
@@ -29,7 +29,7 @@ pub struct VisibilityChecker {
 impl Drop for VisibilityChecker {
     fn drop(&mut self) {
         unsafe {
-            if !pg_sys::IsTransactionState() {
+            if !crate::postgres::utils::IsTransactionState() {
                 // we are not in a transaction, so we can't do things like release buffers and close relations
                 return;
             }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This changes our use of `pg_sys::IsTransactionState()` to directly link to the function so that we can bypass the sigsetjmp overhead pgrx introduces.

This function, as written in Postgres, does not call `ereport()` so we don't have to worry about the FFI boundary.

## Why

Calling `pg_sys::IsTransactionState()` showed up as about 3% of the 66% of the time pg_search spends reading Buffers during a simple query.

With this, it's no longer in the profile at all.

## How

## Tests

Existing tests pass.
