### PR TITLE
fix: rm user postgres in dockerfile

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -140,6 +140,7 @@ jobs:
           VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
           psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
 
+      # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
       - name: Run pg_search Integration Tests
         working-directory: tests/
         run: |
@@ -147,13 +148,6 @@ jobs:
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
           export PARADEDB_TELEMETRY=false
           RUST_BACKTRACE=1 cargo test --features icu
-
-      - name: Run pg_search Unit Tests
-        working-directory: pg_search/
-        run: |
-          export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
-          export PARADEDB_TELEMETRY=false
-          RUST_BACKTRACE=1 cargo test --features pg${{ matrix.pg_version }} --no-default-features
 
       - name: Print the Postgres Logs
         if: always()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,8 +185,6 @@ COPY --from=builder-pg_search /tmp/target/release/pg_search-pg${PG_VERSION_MAJOR
 COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
 COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 
-# Switch to root for configuring runtime dependencies
-USER root
 
 # Required for pg_analytics and pg_cron
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -247,8 +247,5 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# Switch back to the postgres user, with the new uid
-USER postgres
-
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
 COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh


### PR DESCRIPTION
# Ticket(s) Closed

- Closes (partially) #2020
- Closes #2030 

## What
Issue created by setting user postgres in docker file
## Why
When trying to run paradedb docker image with --tmpfs parameter it fails with folder permission issue.

## How
By removing user postgres, the container starts with root container and switches to postgres user after creating in $PGDATA dir in postgres([entrypoint.sh](https://github.com/docker-library/postgres/blob/0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0/17/bookworm/docker-entrypoint.sh#L310))

## Tests
Test instructions are mentioned in the attached issue
