### PR TITLE
ci: Only run Docker Scout on PRs to `main`

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -41,7 +41,10 @@ jobs:
             echo "Using dev configuration..."
           fi
 
+      # Only login to Docker Hub on PRs to `main` since this is only used
+      # for comparing upcoming release Docker images via Docker Scout.
       - name: Login to Docker Hub
+        if: steps.env.outputs.environment == 'prod'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -60,17 +63,6 @@ jobs:
         if: steps.env.outputs.environment == 'dev'
         working-directory: docker/
         run: docker build --file Dockerfile --tag paradedb/paradedb:latest ..
-
-      - name: Compare the ParadeDB Docker Image to the ParadeDB Docker Image in Docker Hub via Docker Scout
-        uses: docker/scout-action@v1
-        with:
-          command: compare
-          image: paradedb/paradedb:latest # Local ParadeDB Docker Image
-          to-env: production # Docker Hub ParadeDB Docker Image
-          organization: paradedb
-          ignore-unchanged: true
-          only-severities: critical,high
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Sleep 10 seconds to give time for Postgres to start inside the container. The docker-compose.yml file
       # will use the local ParadeDB image that we just built.
@@ -102,6 +94,20 @@ jobs:
             echo "Error: ParadeDB Docker container logs contain an error"
             exit 1
           fi
+
+      # On PRs to `main`, we compare the Docker image built from the PR to the last official
+      # ParadeDB Docker image in Docker Hub to check for security regressions.
+      - name: Compare the ParadeDB Docker Image to the ParadeDB Docker Image in Docker Hub via Docker Scout
+        if: steps.env.outputs.environment == 'prod'
+        uses: docker/scout-action@v1
+        with:
+          command: compare
+          image: paradedb/paradedb:latest # Local ParadeDB Docker Image
+          to-env: production # Docker Hub ParadeDB Docker Image
+          organization: paradedb
+          ignore-unchanged: true
+          only-severities: critical,high
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Only run this job on the `main` branch since it requires access to GitHub Secrets, which
   # community contributors don't have access to.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We only run Docker Scout on PRs to `main`, to avoid permission issues with community contributors.

## Why
^

## How
^

## Tests
^