### PR TITLE
fix: incorrect json arrays test

### DIFF
--- a/docs/documentation/advanced/json/arrays.mdx
+++ b/docs/documentation/advanced/json/arrays.mdx
@@ -4,7 +4,10 @@ title: JSON Arrays
 
 ## Basic Usage
 
-When dealing with JSON arrays, the array elements are “flattened” so that each element can be searched individually. This means that if a JSON array is encountered, each element in the array is treated as a separate value and indexed accordingly. For example, given the following JSON structure:
+When dealing with JSON arrays, the array elements are “flattened” so that each
+element can be searched individually. This means that if a JSON array is
+encountered, each element in the array is treated as a separate value and
+indexed accordingly. For example, given the following JSON structure:
 
 ```json
 {
@@ -14,14 +17,15 @@ When dealing with JSON arrays, the array elements are “flattened” so that ea
 }
 ```
 
-The JSON array in the colors field is flattened to emit separate terms for each color. This allows for individual search queries like:
+The JSON array in the colors field is flattened to emit separate terms for each
+color. This allows for individual search queries like:
 
 <CodeGroup>
 ```sql Function Syntax
 SELECT description, metadata
 FROM mock_items
-WHERE id @@@ paradedb.term('metadata.colors:blue')
-OR id @@@ paradedb.term('metadata.colors:red');
+WHERE id @@@ paradedb.term('metadata.colors' , 'blue')
+OR id @@@ paradedb.term('metadata.colors', 'red');
 ```
 ```sql JSON Syntax
 SELECT description, metadata


### PR DESCRIPTION
Closes #2129 

`paradedb.term` should take two separate arguments.