### PR TITLE
fix: deadlocks be gone!

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -275,7 +275,7 @@ impl SearchIndexReader {
         // a pinned but unlocked buffer.
         let cleanup_lock = if needs_cleanup_lock {
             let bman = BufferManager::new(index_relation.oid());
-            Some(bman.get_buffer(CLEANUP_LOCK).unlock())
+            Some(bman.pinned_buffer(CLEANUP_LOCK))
         } else {
             None
         };

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -100,12 +100,10 @@ pub extern "C" fn ambulkdelete(
     // This lock is then immediately released, allowing any queued scans to continue, seeing
     // the new deleted state of the docs we just marked as deleted
     if did_delete {
-        unsafe {
-            let mut bman = BufferManager::new((*(*info).index).rd_id);
-            let cleanup_lock =
-                bman.get_buffer_for_cleanup(CLEANUP_LOCK, pg_sys::ReadBufferMode::RBM_NORMAL as _);
-            drop(cleanup_lock);
-        }
+        let mut bman = BufferManager::new(index_relation.oid());
+        let cleanup_lock =
+            bman.get_buffer_for_cleanup(CLEANUP_LOCK, pg_sys::ReadBufferMode::RBM_NORMAL as _);
+        drop(cleanup_lock);
     }
 
     stats.into_pg()

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -25,6 +25,7 @@ impl Buffer {
         Self { pg_buffer }
     }
 
+    #[allow(dead_code)]
     pub fn unlock(mut self) -> PinnedBuffer {
         unsafe {
             let pg_buffer = self.pg_buffer;
@@ -434,6 +435,10 @@ impl BufferManager {
                 },
             }
         }
+    }
+
+    pub fn pinned_buffer(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {
+        unsafe { PinnedBuffer::new(self.bcache.get_buffer(blockno, None)) }
     }
 
     pub fn get_buffer(&self, blockno: pg_sys::BlockNumber) -> Buffer {

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -18,8 +18,6 @@
 use crate::postgres::storage::buffer::BufferManager;
 use pgrx::*;
 
-use super::delete::BulkDeleteData;
-
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
     info: *mut pg_sys::IndexVacuumInfo,
@@ -28,14 +26,6 @@ pub extern "C" fn amvacuumcleanup(
     let info = unsafe { PgBox::from_pg(info) };
     if info.analyze_only {
         return stats;
-    }
-
-    unsafe {
-        let delete_stats = stats as *mut BulkDeleteData;
-        if !delete_stats.is_null() {
-            let cleanup_lock = (*delete_stats).cleanup_lock;
-            pg_sys::UnlockReleaseBuffer(cleanup_lock);
-        }
     }
 
     // return all recyclable pages to the free space map


### PR DESCRIPTION
# Ticket(s) Closed

Related to #2067.  I don't believe this fixes that issue, but gets us a few steps closer.  Specific investigation into that issue will be in a future PR.

## What

We had a few deadlocks related to block storage.

The first was that `LinkedItemList::garbage_collect()` would travel to the next page and exclusively lock it while it still held an exclusive lock on the current page.  This could cause a lock inversion between concurrent backends that were traversing the linked list at the same time.

The second is that `ambulkdelete()` was simply holding the MERGE_LOCK too long.  Specifically, holding it while we (now temporarily) lock the CLEANUP_LOCK page could cause deadlocks in concurrent backends.

And while not exactly a deadlock issue, via discussions with @rebasedming, we've decided we were holding the CLEANUP_LOCK much longer than we needed to.  So now we simply acquire and release it at the end of `ambulkdelete()`.  This creates a barrier that concurrent scans will queue up against to ensure they see the proper doc deleted statuses, post ambulkdelete.

## Why

## How

see above

## Tests

Stressgres has been running really well with these changes.

https://github.com/user-attachments/assets/50657081-c87e-496f-b0ba-488b50b373a1


