### PR TITLE
docs: ParadeDB in CI

### DIFF
--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -57,22 +57,33 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      # On any branch other than `main`, we build the ParadeDB Docker Image using Docker Compose so that community
-      # contributors can trigger the workflow without needing access to GitHub Secrets.
-      #
-      # In this environment, PARADEDB_TELEMETRY is set to false to avoid sending misleading telemetry data to PostHog.
-      - name: Build the ParadeDB Docker Image via Docker Compose (dev only)
-        if: steps.env.outputs.environment == 'dev'
+      - name: Build the ParadeDB Docker Image via Docker Compose
         working-directory: docker/
         run: docker compose -f docker-compose.dev.yml build
 
-      # Sleep 10 seconds to give time for Postgres to start inside the container. The docker-compose.yml file
-      # will use the local ParadeDB image that we just built since we tagged it with `latest` in docker-compose.dev.yml.
-      #
-      # We add a --tmpfs mount as a test of compatibility with the upstream `postgres` image.
-      - name: Start the ParadeDB Docker Image
+      # On PRs to `dev`, we start the ParadeDB Docker image using Docker Compose to test the
+      # compose file. The docker-compose.yml file will use the local ParadeDB image that we
+      # just built since we tagged it with `latest` in docker-compose.dev.yml.
+      - name: Start the ParadeDB Docker Image via Docker Compose (dev only)
+        if: steps.env.outputs.environment == 'dev'
         working-directory: docker/
-        run: docker compose -f docker-compose.yml up -d --tmpfs /tmp && sleep 10
+        run: PARADEDB_TELEMETRY=false docker compose -f docker-compose.yml up -d && sleep 10
+
+      # On PRs to `main`, we start the ParadeDB Docker image using `docker run` to test the
+      # standalone Docker image. We add a --tmpfs mount as a test of compatibility with the
+      # upstream `postgres` image.
+      - name: Start the ParadeDB Docker Image via Docker Run (prod only)
+        if: steps.env.outputs.environment == 'dev'
+        working-directory: docker/
+        run: |
+          docker run -d \
+            --name paradedb \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            -p 5432:5432 \
+            --tmpfs /tmp \
+            paradedb/paradedb:latest
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
       - name: Check for Errors in the ParadeDB Docker Image

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -71,9 +71,10 @@ jobs:
 
       # On PRs to `main`, we start the ParadeDB Docker image using `docker run` to test the
       # standalone Docker image. We add a --tmpfs mount as a test of compatibility with the
-      # upstream `postgres` image.
+      # upstream `postgres` image. The `docker run` command will use the local ParadeDB image
+      # that we just built since we tagged it with `latest` in docker-compose.dev.yml.
       - name: Start the ParadeDB Docker Image via Docker Run (prod only)
-        if: steps.env.outputs.environment == 'dev'
+        if: steps.env.outputs.environment == 'prod'
         working-directory: docker/
         run: |
           docker run -d \

--- a/.github/workflows/test-paradedb.yml
+++ b/.github/workflows/test-paradedb.yml
@@ -64,13 +64,15 @@ jobs:
       - name: Build the ParadeDB Docker Image via Docker Compose (dev only)
         if: steps.env.outputs.environment == 'dev'
         working-directory: docker/
-        run: docker build --file Dockerfile --tag paradedb/paradedb:latest ..
+        run: docker compose -f docker-compose.dev.yml build
 
       # Sleep 10 seconds to give time for Postgres to start inside the container. The docker-compose.yml file
-      # will use the local ParadeDB image that we just built.
+      # will use the local ParadeDB image that we just built since we tagged it with `latest` in docker-compose.dev.yml.
+      #
+      # We add a --tmpfs mount as a test of compatibility with the upstream `postgres` image.
       - name: Start the ParadeDB Docker Image
         working-directory: docker/
-        run: docker compose -f docker-compose.yml up -d && sleep 10
+        run: docker compose -f docker-compose.yml up -d --tmpfs /tmp && sleep 10
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly
       - name: Check for Errors in the ParadeDB Docker Image

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       cache_to:
         - type=local,dest=./.docker_cache_dev
     container_name: paradedb-dev
+    image: paradedb/paradedb:latest # Tag the image with `latest` to make it run in the `docker-compose.yml` file
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -1,0 +1,65 @@
+---
+title: GitHub Actions
+---
+
+## Overview
+
+ParadeDB can be added to a GitHub Actions workflow as a [service container](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers) in the job definition. Service containers are additional
+containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers
+run alongside the job container or the runner (e.g., `ubuntu-latest`) and can be connected to on localhost.
+
+## Sample GitHub Actions Workflow
+
+```yaml
+name: ParadeDB in GitHub Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  paradedb-in-github-actions:
+    name: ParadeDB in GitHub Actions
+    runs-on: ubuntu-latest
+
+    # All
+    services:
+      paradedb:
+        image: paradedb/paradedb:latest
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Wait for PostgreSQL to be ready
+        run: |
+          for i in {1..10}; do
+            if psql -h localhost -U testuser -d testdb -c "SELECT 1;" > /dev/null 2>&1; then
+              echo "Database is ready!"
+              break
+            fi
+            echo "Waiting for database..."
+            sleep 5
+          done
+
+      - name: Run ParadeDB example queries
+        run: |
+          psql -h localhost -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+          psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
+          psql -h localhost -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
+          psql -h localhost -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
+```

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -25,7 +25,6 @@ jobs:
     name: ParadeDB in GitHub Actions
     runs-on: ubuntu-latest
 
-    # All
     services:
       paradedb:
         # The list of available tags can be found at https://hub.docker.com/r/paradedb/paradedb/tags

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -28,6 +28,7 @@ jobs:
     # All
     services:
       paradedb:
+        # The list of available tags can be found at https://hub.docker.com/r/paradedb/paradedb/tags
         image: paradedb/paradedb:latest
         env:
           POSTGRES_USER: testuser

--- a/docs/deploy/ci/github-actions.mdx
+++ b/docs/deploy/ci/github-actions.mdx
@@ -2,12 +2,6 @@
 title: GitHub Actions
 ---
 
-## Overview
-
-ParadeDB can be added to a GitHub Actions workflow as a [service container](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers) in the job definition. Service containers are additional
-containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers
-run alongside the job container or the runner (e.g., `ubuntu-latest`) and can be connected to on localhost.
-
 ## Sample GitHub Actions Workflow
 
 ```yaml

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -2,12 +2,6 @@
 title: GitLab CI
 ---
 
-## Overview
-
-ParadeDB can be added to a GitLab CI workflow as a [service container](https://docs.gitlab.com/ee/ci/services/) in the job definition. Service containers are additional
-containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers
-run alongside the job container and can be connected to over their service name.
-
 ## Sample GitLab CI Workflow
 
 ```yaml

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -8,10 +8,11 @@ ParadeDB can be added to a GitLab CI workflow as a [service container](https://d
 containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers
 run alongside the job container and can be connected to over their service name.
 
-## Sample GitHub Actions Workflow
+## Sample GitLab CI Workflow
 
 ```yaml
 paradedb-in-gitlab-ci:
+  # The list of available tags can be found at https://hub.docker.com/r/paradedb/paradedb/tags
   image: paradedb/paradedb:latest
   services:
     - postgres

--- a/docs/deploy/ci/gitlab-ci.mdx
+++ b/docs/deploy/ci/gitlab-ci.mdx
@@ -1,0 +1,27 @@
+---
+title: GitLab CI
+---
+
+## Overview
+
+ParadeDB can be added to a GitLab CI workflow as a [service container](https://docs.gitlab.com/ee/ci/services/) in the job definition. Service containers are additional
+containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers
+run alongside the job container and can be connected to over their service name.
+
+## Sample GitHub Actions Workflow
+
+```yaml
+paradedb-in-gitlab-ci:
+  image: paradedb/paradedb:latest
+  services:
+    - postgres
+  variables:
+    POSTGRES_USER: testuser
+    POSTGRES_DB: testdb
+    POSTGRES_HOST_AUTH_METHOD: trust
+  script:
+    - psql -h "postgres" -U testuser -d testdb -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+    - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
+    - psql -h "postgres" -U testuser -d testdb -c "CREATE INDEX search_idx ON mock_items USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
+    - psql -h "postgres" -U testuser -d testdb -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
+```

--- a/docs/deploy/ci/overview.mdx
+++ b/docs/deploy/ci/overview.mdx
@@ -1,0 +1,7 @@
+---
+title: Overview
+---
+
+ParadeDB can be added to a GitHub Actions workflow as a [service container](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers) in the job
+definition. Service containers are additional containers started in a workflow to provide necessary services (like databases) that a job depends on. These containers run alongside the job container or
+the runner (e.g., `ubuntu-latest`) and can be connected to on localhost.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -230,7 +230,7 @@
                 "pages": [
                   "deploy/overview",
                   {
-                    "group": "Self-Hosted ParadeDB",
+                    "group": "ParadeDB Self-Hosted",
                     "pages": [
                       "deploy/self-hosted/kubernetes",
                       "deploy/self-hosted/extensions",
@@ -254,7 +254,14 @@
                   "deploy/byoc",
                   "deploy/enterprise",
                   "deploy/upgrading",
-                  "deploy/third-party-extensions"
+                  "deploy/third-party-extensions",
+                  {
+                    "group": "Continuous Integration",
+                    "pages": [
+                      "deploy/ci/github-actions",
+                      "deploy/ci/gitlab-ci"
+                    ]
+                  }
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -258,6 +258,7 @@
                   {
                     "group": "Continuous Integration",
                     "pages": [
+                      "deploy/ci/overview",
                       "deploy/ci/github-actions",
                       "deploy/ci/gitlab-ci"
                     ]

--- a/docs/welcome/support.mdx
+++ b/docs/welcome/support.mdx
@@ -2,7 +2,7 @@
 title: Help and Support
 ---
 
-For questions regarding enterprise support or commercial licensing, please [contact the sales](mailto:sales@paradedb.com).
+For questions regarding enterprise support or commercial licensing, please [contact sales](mailto:sales@paradedb.com).
 For community support and general questions, please join the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ).
 
 Alternatively, you can create GitHub Discussions directly from within ParadeDB via the `paradedb.help` function.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2020

## What
This PR adds documentation for running ParadeDB in CI and a test for `tmpfs` for upstream `postgres` compatibility.

## Why
Customers are asking

## How
- For GitLab, followed their official Postgres template: https://gitlab.com/gitlab-examples/postgres/-/blob/master/.gitlab-ci.yml?ref_type=heads

## Tests
CI