### PR TITLE
fix: issue #2067:  vacuum can be cancelled

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -110,7 +110,15 @@ impl Drop for MergeLock {
                 // if we don't have a transaction id (typically from a parallel vacuum)...
                 if current_xid == pg_sys::InvalidTransactionId {
                     // ... then use the next transaction id as ours
-                    current_xid = pg_sys::ReadNextTransactionId();
+                    #[cfg(feature = "pg13")]
+                    {
+                        current_xid = pg_sys::ReadNewTransactionId()
+                    }
+
+                    #[cfg(not(feature = "pg13"))]
+                    {
+                        current_xid = pg_sys::ReadNextTransactionId()
+                    }
                 }
 
                 let mut page = self.0.page_mut();

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -33,7 +33,6 @@ pub extern "C" fn ambulkdelete(
     callback: pg_sys::IndexBulkDeleteCallback,
     callback_state: *mut ::std::os::raw::c_void,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
-    pgrx::warning!("ambulkdelete: called");
     let info = unsafe { PgBox::from_pg(info) };
     let mut stats = unsafe { PgBox::from_pg(stats) };
     let index_relation = unsafe { PgRelation::from_pg(info.index) };

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -27,24 +27,24 @@ use crate::index::{BlockDirectoryType, WriterResources};
 use crate::postgres::storage::buffer::BufferManager;
 
 #[pg_guard]
-pub extern "C" fn ambulkdelete(
+pub unsafe extern "C" fn ambulkdelete(
     info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
     callback: pg_sys::IndexBulkDeleteCallback,
     callback_state: *mut ::std::os::raw::c_void,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
-    let info = unsafe { PgBox::from_pg(info) };
-    let mut stats = unsafe { PgBox::from_pg(stats) };
-    let index_relation = unsafe { PgRelation::from_pg(info.index) };
+    let info = PgBox::from_pg(info);
+    let mut stats = PgBox::from_pg(stats);
+    let index_relation = PgRelation::from_pg(info.index);
     let callback =
         callback.expect("the ambulkdelete() callback should be a valid function pointer");
-    let callback = move |ctid_val: u64| unsafe {
+    let callback = move |ctid_val: u64| {
         let mut ctid = ItemPointerData::default();
         crate::postgres::utils::u64_to_item_pointer(ctid_val, &mut ctid);
         callback(&mut ctid, callback_state)
     };
 
-    let merge_lock = unsafe { MergeLock::acquire_for_delete(index_relation.oid()) };
+    let merge_lock = MergeLock::acquire_for_delete(index_relation.oid());
     let mut writer = SearchIndexWriter::open(
         &index_relation,
         BlockDirectoryType::BulkDelete,
@@ -61,18 +61,24 @@ pub extern "C" fn ambulkdelete(
         let ctid_ff = FFType::new_ctid(segment_reader.fast_fields());
 
         for doc_id in 0..segment_reader.max_doc() {
-            if unsafe { pg_sys::InterruptPending != 0 } {
-                // there's a pending interrupt.  an administrator likely issued a cancel on this
-                // (auto)VACUUM process.  We need to drop our merge_lock and then we're free to have
-                // the interrupt properly handled
-                drop(merge_lock);
-                check_for_interrupts!();
+            if doc_id % 100 == 0 {
+                // NB:  when `IsInParallelMode()` is true, it seems there's always a pending interrupt
+                // so we just don't bother checking for pending interrupts in that situation.  This
+                // is in the case of a parallel vacuum
+                if pg_sys::InterruptPending != 0 && !pg_sys::IsInParallelMode() {
+                    drop(merge_lock);
 
-                // this would indicate that pg_sys::InterruptPending somehow lied to us
-                // or that there's some other lock being held open by this process that we don't know about
-                // which caused `check_for_interrupts!()` to do not do anything
-                unreachable!("ambulkdelete detected a pending interrupt but did not handle it")
+                    // we think there's a pending interrupt, so this should raise a cancel query ERROR
+                    pg_sys::vacuum_delay_point();
+
+                    // if we got here then, ultimately, CHECK_FOR_INTERRUPTS() (which is called via
+                    // vacuum_delay_point()) didn't actually interrupt us, and we're just DOA now
+                    // because we've already dropped our merge_lock
+                    unreachable!("ambulkdelete: detected interrupt but wasn't cancelled");
+                }
+                pg_sys::vacuum_delay_point();
             }
+
             let ctid = ctid_ff.as_u64(doc_id).expect("ctid should be present");
             if callback(ctid) {
                 did_delete = true;

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -39,7 +39,9 @@ pub extern "C" fn amvacuumcleanup(
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
 
         for blockno in 0..nblocks {
-            check_for_interrupts!();
+            if blockno % 100 == 0 {
+                pg_sys::vacuum_delay_point();
+            }
             let buffer = bman.get_buffer(blockno);
             let page = buffer.page();
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2067

## What

This gets a (non-parallel) VACUUM able to respond to cancel query requests.

## Why

It's quite bad to not be able to interrupt things when asked, especially for production systems.

## How

We look to see if there's a pending interrupt, and if there is then we branch to drop our `merge_lock` and then call `vacuum_delay_point()` one last time, which should catch the pending interrupt.  This doesn't happen if the vacuum process `IsInParallelMode()`.

We also now call `vacuum_delay_point()` every 100 docs in `ambulkdelete()` and every 100 blocks in `amvacuumcleanup()`.  We want to be a good citizen here, but we also need our index vacuum to hurry up and finish already.

## Tests

Existing tests pass, along with stressgres, that has now been augmented to allow cancelling jobs during the run.