### PR TITLE
fix: raise an error when score() and snippet() are called on non-custom scan

### DIFF
--- a/docs/documentation/guides/hybrid.mdx
+++ b/docs/documentation/guides/hybrid.mdx
@@ -23,14 +23,14 @@ calculated against the vector `[1,2,3]`.
 
 ```sql
 WITH bm25_candidates AS (
-    SELECT id
+    SELECT id, paradedb.score(id)
     FROM mock_items
     WHERE description @@@ 'keyboard'
     ORDER BY paradedb.score(id) DESC
     LIMIT 20
 ),
 bm25_ranked AS (
-    SELECT id, RANK() OVER (ORDER BY paradedb.score(id) DESC) AS rank
+    SELECT id, RANK() OVER (ORDER BY score DESC) AS rank
     FROM bm25_candidates
 ),
 semantic_search AS (

--- a/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
@@ -23,8 +23,8 @@ use pgrx::{
 use std::ptr::addr_of_mut;
 
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
-fn score_from_relation(_relation_reference: AnyElement) -> Option<f32> {
-    None
+fn score_from_relation(_relation_reference: AnyElement) -> f32 {
+    panic!("`paradedb.score()` function called in unsupported context.");
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
@@ -41,8 +41,8 @@ fn snippet_from_relation(
     start_tag: default!(String, "'<b>'"),
     end_tag: default!(String, "'</b>'"),
     max_num_chars: default!(i32, "150"),
-) -> Option<String> {
-    None
+) -> String {
+    panic!("`paradedb.snippet()` function called in unsupported context.");
 }
 
 extension_sql!(

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -733,7 +733,6 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
         SELECT id, RANK () OVER (ORDER BY paradedb.score(id) DESC) AS rank
         FROM mock_items
         WHERE mock_items @@@ 'rating:>1'
-        AND category = 'Electronics'
         LIMIT 20
     )
     SELECT
@@ -780,7 +779,6 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
         SELECT id, RANK () OVER (ORDER BY paradedb.score(id) DESC) AS rank
         FROM mock_items
         WHERE mock_items @@@ 'rating:>1'
-        AND category = 'Electronics'
         LIMIT 20
     )
     SELECT

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -344,6 +344,34 @@ fn scores_survive_joins(mut conn: PgConnection) {
     );
 }
 
+#[rstest]
+fn scores_error_when_non_custom_scan(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let result =
+      "SELECT id, paradedb.score(id) FROM paradedb.bm25_search WHERE description @@@ 'keyboard' AND paradedb.score(id) > 0"
+        .fetch_result::<(i32, f32)>(&mut conn);
+    assert!(result.is_err());
+    assert_eq!(
+        "error returned from database: `paradedb.score()` function called in unsupported context.",
+        &format!("{}", result.err().unwrap())
+    );
+}
+
+#[rstest]
+fn snippets_error_when_non_custom_scan(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+
+    let result =
+      "SELECT id, paradedb.snippet(description) FROM paradedb.bm25_search WHERE description @@@ 'keyboard' AND paradedb.snippet(description) LIKE 'Ergonomic%'"
+        .fetch_result::<(i32, String)>(&mut conn);
+    assert!(result.is_err());
+    assert_eq!(
+        "error returned from database: `paradedb.snippet()` function called in unsupported context.",
+        &format!("{}", result.err().unwrap())
+    );
+}
+
 #[rustfmt::skip]
 #[rstest]
 fn join_issue_1776(mut conn: PgConnection) {

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -1884,14 +1884,14 @@ fn hybrid_search(mut conn: PgConnection) {
 
     let rows: Vec<(i32, BigDecimal, String, Vector)> = r#"
     WITH bm25_candidates AS (
-        SELECT id
+        SELECT id, paradedb.score(id)
         FROM mock_items
         WHERE description @@@ 'keyboard'
         ORDER BY paradedb.score(id) DESC
         LIMIT 20
     ),
     bm25_ranked AS (
-        SELECT id, RANK() OVER (ORDER BY paradedb.score(id) DESC) AS rank
+        SELECT id, RANK() OVER (ORDER BY score DESC) AS rank
         FROM bm25_candidates
     ),
     semantic_search AS (


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2038 

## What

- `paradedb.score()` and `paradedb.snippet()` now raise an error when called outside a Custom Scan context.

## Why

- Returning an error instead of NULL might be more user-friendly and helps clarify unsupported usage.


## How

- Invoke a panic in `score_from_relation` and `snippet_from_relation`.

## Tests

- Added unit tests.
