### PR TITLE
fix: allow subsecond precision for datetime queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "bitpacking",
 ]
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "nom",
 ]
@@ -5025,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=552cceee87eadce2fa7366a65e8b232295f24d04#552cceee87eadce2fa7366a65e8b232295f24d04"
+source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "552cceee87eadce2fa7366a65e8b232295f24d04", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "9da1bef5b3456430ec59d2da8b5a03c78df8bb75", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "552cceee87eadce2fa7366a65e8b232295f24d04" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "9da1bef5b3456430ec59d2da8b5a03c78df8bb75" }

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -245,7 +245,7 @@ pub fn convert_pg_date_string(typeoid: PgOid, date_string: &str) -> tantivy::Dat
                 NaiveDate::from_ymd_opt(twtz.year(), twtz.month().into(), twtz.day().into())
                     .expect("must be able to convert timestamp with timezone")
                     .and_hms_micro_opt(twtz.hour().into(), twtz.minute().into(), seconds, micros)
-                    .expect("must be able to parse timestamp format")
+                    .expect("must be able to parse timestamp with timezone")
                     .and_utc()
                     .timestamp_micros();
             tantivy::DateTime::from_timestamp_micros(micros)

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -224,12 +224,12 @@ pub fn convert_pg_date_string(typeoid: PgOid, date_string: &str) -> tantivy::Dat
             let t = pgrx::datum::Timestamp::from_str(date_string)
                 .expect("must be a valid postgres timestamp");
             let twtz: datum::TimestampWithTimeZone = t.into();
-            let (seconds, _micros, _nanos) = convert_pgrx_seconds_to_chrono(twtz.second())
+            let (seconds, micros, _nanos) = convert_pgrx_seconds_to_chrono(twtz.second())
                 .expect("must not overflow converting pgrx seconds");
             let micros =
                 NaiveDate::from_ymd_opt(twtz.year(), twtz.month().into(), twtz.day().into())
                     .expect("must be able to convert date timestamp")
-                    .and_hms_opt(twtz.hour().into(), twtz.minute().into(), seconds)
+                    .and_hms_micro_opt(twtz.hour().into(), twtz.minute().into(), seconds, micros)
                     .expect("must be able to parse timestamp format")
                     .and_utc()
                     .timestamp_micros();
@@ -239,13 +239,13 @@ pub fn convert_pg_date_string(typeoid: PgOid, date_string: &str) -> tantivy::Dat
             let twtz = pgrx::datum::TimestampWithTimeZone::from_str(date_string)
                 .expect("must be a valid postgres timestamp with time zone")
                 .to_utc();
-            let (seconds, _micros, _nanos) = convert_pgrx_seconds_to_chrono(twtz.second())
+            let (seconds, micros, _nanos) = convert_pgrx_seconds_to_chrono(twtz.second())
                 .expect("must not overflow converting pgrx seconds");
             let micros =
                 NaiveDate::from_ymd_opt(twtz.year(), twtz.month().into(), twtz.day().into())
                     .expect("must be able to convert timestamp with timezone")
-                    .and_hms_opt(twtz.hour().into(), twtz.minute().into(), seconds)
-                    .expect("must be able to parse timestamp with timezone")
+                    .and_hms_micro_opt(twtz.hour().into(), twtz.minute().into(), seconds, micros)
+                    .expect("must be able to parse timestamp format")
                     .and_utc()
                     .timestamp_micros();
             tantivy::DateTime::from_timestamp_micros(micros)

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -28,7 +28,8 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use tantivy::schema::{
-    DateOptions, Field, JsonObjectOptions, NumericOptions, Schema, TextFieldIndexing, TextOptions,
+    DateOptions, DateTimePrecision, Field, JsonObjectOptions, NumericOptions, Schema,
+    TextFieldIndexing, TextOptions,
 };
 use thiserror::Error;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
@@ -648,7 +649,10 @@ impl From<SearchFieldConfig> for DateOptions {
                     date_options = date_options.set_stored();
                 }
                 if fast {
-                    date_options = date_options.set_fast();
+                    date_options = date_options
+                        .set_fast()
+                        // Match Postgres' maximum allowed precision of microseconds
+                        .set_precision(DateTimePrecision::Microseconds);
                 }
                 if indexed {
                     date_options = date_options.set_indexed();

--- a/tests/tests/datetime.rs
+++ b/tests/tests/datetime.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2023-2025 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn datetime_microsecond(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE ts (id SERIAL, t TIMESTAMP);
+    CREATE INDEX ts_idx on ts using bm25 (id, t) with (key_field = 'id');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.079776Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.079777Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.079778Z');
+    "#
+    .execute(&mut conn);
+
+    // Term queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.079777Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.term('t', '2025-01-28T18:19:14.079777Z'::timestamp)".fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.079777Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM ts WHERE t @@@ '"2025-01-28T18:19:14.079777Z"'"#.fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    // Range queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t > '2025-01-28T18:19:14.079777Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.range('t', tsrange('2025-01-28T18:19:14.079777Z'::timestamp, NULL, '(]')) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+}
+
+#[rstest]
+fn datetime_term_millisecond(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE ts (id SERIAL, t TIMESTAMP(3));
+    CREATE INDEX ts_idx on ts using bm25 (id, t) with (key_field = 'id');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.078Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.079Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.08Z');
+    "#
+    .execute(&mut conn);
+
+    // Term queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.079Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE id @@@ paradedb.term('t', '2025-01-28T18:19:14.079Z'::timestamp)"
+            .fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.079Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM ts WHERE t @@@ '"2025-01-28T18:19:14.079Z"'"#.fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM ts WHERE t @@@ '"2025-01-28T18:19:14Z"'"#.fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.078001Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM ts WHERE t @@@ '"2025-01-28T18:19:14.078001Z"'"#.fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    // Range queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t > '2025-01-28T18:19:14.079Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.range('t', tsrange('2025-01-28T18:19:14.079Z'::timestamp, NULL, '(]')) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t > '2025-01-28T18:19:14.07Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.range('t', tsrange('2025-01-28T18:19:14.07Z'::timestamp, NULL, '(]')) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+}
+
+#[rstest]
+fn datetime_term_second(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE ts (id SERIAL, t TIMESTAMP(0));
+    CREATE INDEX ts_idx on ts using bm25 (id, t) with (key_field = 'id');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:14.1Z');
+    INSERT INTO ts (t) values ('2025-01-28T18:19:15Z');
+    "#
+    .execute(&mut conn);
+
+    // Term queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.term('t', '2025-01-28T18:19:14Z'::timestamp) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t = '2025-01-28T18:19:14.1Z'::timestamp".fetch(&mut conn);
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM ts WHERE t @@@ '"2025-01-28T18:19:14.1Z"'"#.fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    // Range queries
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t > '2025-01-28T18:19:14Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.range('t', tsrange('2025-01-28T18:19:14Z'::timestamp, NULL, '(]')) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+
+    let expected: Vec<(i32,)> =
+        "SELECT id FROM ts WHERE t > '2025-01-28T18:19:14.001Z'::timestamp ORDER BY id"
+            .fetch(&mut conn);
+    let rows: Vec<(i32,)> = "SELECT id FROM ts WHERE id @@@ paradedb.range('t', tsrange('2025-01-28T18:19:14.001Z'::timestamp, NULL, '(]')) ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows, expected);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2139 

## What

Allows term and range queries with subsecond precision.

## Why

See GH issue.

## How

By default, Tantivy truncates datetime terms in the index and in fast fields to second precision. Postgres defaults to microsecond precision - this PR stores everything with microsecond precision. Also fixed a conversion issue on our end where we were truncating to seconds.

Needs https://github.com/paradedb/tantivy/pull/27 to be merged.

## Tests
