### PR TITLE
fix: concurrency bug related to VACUUM deleting segments it shouldn't

### DIFF
--- a/pg_search/sql/pg_search--0.14.1--0.14.2.sql
+++ b/pg_search/sql/pg_search--0.14.1--0.14.2.sql
@@ -1,0 +1,15 @@
+-- pg_search/src/bootstrap/create_bm25.rs:404
+-- pg_search::bootstrap::create_bm25::find_ctid
+CREATE  FUNCTION "find_ctid"(
+    "index" regclass, /* pgrx::rel::PgRelation */
+    "ctid" tid /* pgrx_pg_sys::include::pg13::ItemPointerData */
+) RETURNS TEXT[] /* core::result::Result<core::option::Option<alloc::vec::Vec<alloc::string::String>>, anyhow::Error> */
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'find_ctid_wrapper';
+
+DROP FUNCTION IF EXISTS index_info(index regclass);
+CREATE OR REPLACE FUNCTION index_info(index regclass, show_invisible bool DEFAULT false)
+    RETURNS TABLE(visible bool, recyclable bool, xmin pg_catalog."numeric", xmax pg_catalog."numeric", segno text, byte_size pg_catalog."numeric", num_docs pg_catalog."numeric", num_deleted pg_catalog."numeric", termdict_bytes pg_catalog."numeric", postings_bytes pg_catalog."numeric", positions_bytes pg_catalog."numeric", fast_fields_bytes pg_catalog."numeric", fieldnorms_bytes pg_catalog."numeric", store_bytes pg_catalog."numeric", deletes_bytes pg_catalog."numeric")
+    AS 'MODULE_PATHNAME', 'index_info_wrapper'
+    LANGUAGE c STRICT;

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -301,6 +301,14 @@ impl SearchIndexReader {
         })
     }
 
+    pub fn segment_ids(&self) -> HashSet<SegmentId> {
+        self.searcher
+            .segment_readers()
+            .iter()
+            .map(|r| r.segment_id())
+            .collect()
+    }
+
     pub fn key_field(&self) -> SearchField {
         self.schema.key_field()
     }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -173,6 +173,64 @@ impl Default for SegmentMetaEntry {
     }
 }
 
+impl SegmentMetaEntry {
+    pub fn num_docs(&self) -> usize {
+        self.max_doc as usize - self.num_deleted_docs()
+    }
+
+    pub fn num_deleted_docs(&self) -> usize {
+        self.delete
+            .map(|entry| entry.num_deleted_docs as usize)
+            .unwrap_or(0)
+    }
+
+    pub fn byte_size(&self) -> u64 {
+        let mut size = 0;
+
+        size += self
+            .postings
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .positions
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .fast_fields
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .field_norms
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .terms
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .store
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .temp_store
+            .as_ref()
+            .map(|entry| entry.total_bytes as u64)
+            .unwrap_or(0);
+        size += self
+            .delete
+            .as_ref()
+            .map(|entry| entry.file_entry.total_bytes as u64)
+            .unwrap_or(0);
+        size
+    }
+}
+
 // ---------------------------------------------------------
 // Linked list entry <-> PgItem
 // ---------------------------------------------------------

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -727,10 +727,6 @@ impl SearchIndexSchema {
             });
         }
 
-        // hardcode the ctid field into the schema.  "ctid" is a reserved Postgres attribute name
-        // so we don't need to worry about name conflicts
-        builder.add_u64_field("ctid", tantivy::schema::INDEXED | tantivy::schema::FAST);
-
         Ok(Self {
             key: key_index,
             schema: builder.build(),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Primarily, this PR fixes a concurrency bug with VACCUM where it could delete segments it shouldn't.  The reason this could happen is that, eventually, tantivy reloads the IndexMeta from the Directory and we use that information to compare with the previous version to see if any segments had been deleted.

The nature of MVCC is such that the reloading phase could see different entries b/c of concurrent transactions, causing us to mark a segment as deleted when it was not. 

## Why

Spurious instances of records temporarily disappearing from the index are bad!  They also take literal days to track down and fix.  Big ups to @rebasedming for his help with this.

## How

The solution is for our [`MVCCDirectory`] to locally cache the results of `load_metas()` and always return that, ensuring tantivy always sees a consistent view of the underlying index structure throughout its updating/commit process.

This PR also introduces a new UDF called `paradedb.find_ctid(regclass, tid)` that will find the segment containing the specified ctid.  It also expands the number of columns returned from `paradedb.index_info()` to indicate the segment visibility.

We also centralize the logic for "list_managed_files()" into `LinkedItemList` as it's now used in a few places.

## Tests

Existing tests pass and stressgres ran for over 35m before I got bored.

![screenshot_2025-01-30_at_10 35 48___am_720](https://github.com/user-attachments/assets/fff692a1-dfc3-461e-ada6-cfdca3b5d321)

