### PR TITLE
feat: implement new `tantivy::Directory::supports_garbage_collection()` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "bitpacking",
 ]
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "nom",
 ]
@@ -5025,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=9da1bef5b3456430ec59d2da8b5a03c78df8bb75#9da1bef5b3456430ec59d2da8b5a03c78df8bb75"
+source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "9da1bef5b3456430ec59d2da8b5a03c78df8bb75", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "46488b5ca649d5e08dcebe18b7c1fbb1fb204a78", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "9da1bef5b3456430ec59d2da8b5a03c78df8bb75" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "46488b5ca649d5e08dcebe18b7c1fbb1fb204a78" }

--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -28,7 +28,6 @@ use tantivy::{Directory, IndexMeta};
 pub type Overwrite = bool;
 
 pub enum ChannelRequest {
-    ListManagedFiles(oneshot::Sender<HashSet<PathBuf>>),
     RegisterFilesAsManaged(Vec<PathBuf>, Overwrite),
     SegmentRead(Range<usize>, FileEntry, oneshot::Sender<OwnedBytes>),
     SegmentWrite(PathBuf, Vec<u8>),
@@ -119,15 +118,8 @@ impl Directory for ChannelDirectory {
     }
 
     fn list_managed_files(&self) -> tantivy::Result<HashSet<PathBuf>> {
-        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
-        self.sender
-            .send(ChannelRequest::ListManagedFiles(oneshot_sender))
-            .unwrap();
-
-        match oneshot_receiver.recv() {
-            Ok(result) => Ok(result),
-            Err(e) => Err(tantivy::TantivyError::InternalError(e.to_string())),
-        }
+        // because we don't support garbage collection
+        unimplemented!("list_managed_files should not be called");
     }
 
     fn register_files_as_managed(
@@ -182,6 +174,10 @@ impl Directory for ChannelDirectory {
             .unwrap();
 
         oneshot_receiver.recv().unwrap()
+    }
+
+    fn supports_garbage_collection(&self) -> bool {
+        false
     }
 }
 
@@ -285,10 +281,6 @@ impl ChannelRequestHandler {
 
     fn process_message(&mut self, message: ChannelRequest) -> Result<ShouldTerminate> {
         match message {
-            ChannelRequest::ListManagedFiles(sender) => {
-                let managed_files = self.directory.list_managed_files()?;
-                sender.send(managed_files)?;
-            }
             ChannelRequest::RegisterFilesAsManaged(files, overwrite) => {
                 self.directory.register_files_as_managed(files, overwrite)?;
             }

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::utils::{list_managed_files, load_metas, save_new_metas, save_schema, save_settings};
+use super::utils::{load_metas, save_new_metas, save_schema, save_settings};
 use crate::index::merge_policy::{
     set_num_segments, AllowedMergePolicy, MergeLock, NPlusOneMergePolicy,
 };
@@ -191,7 +191,8 @@ impl Directory for MVCCDirectory {
     /// Returns a list of all segment components to Tantivy,
     /// identified by <uuid>.<ext> PathBufs
     fn list_managed_files(&self) -> tantivy::Result<HashSet<PathBuf>> {
-        unsafe { list_managed_files(self.relation_oid) }
+        // because we don't support garbage collection
+        unimplemented!("list_managed_files should not be called");
     }
 
     // This is intentionally a no-op
@@ -305,6 +306,10 @@ impl Directory for MVCCDirectory {
         }
 
         Some(Box::new(NoMergePolicy))
+    }
+
+    fn supports_garbage_collection(&self) -> bool {
+        false
     }
 }
 

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -7,7 +7,6 @@ use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use anyhow::Result;
 use pgrx::pg_sys;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -17,17 +16,6 @@ use tantivy::{
     schema::Schema,
     IndexMeta,
 };
-
-pub unsafe fn list_managed_files(relation_oid: pg_sys::Oid) -> tantivy::Result<HashSet<PathBuf>> {
-    let segment_components =
-        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
-
-    Ok(segment_components
-        .list()
-        .into_iter()
-        .flat_map(|entry| entry.get_component_paths())
-        .collect())
-}
 
 pub fn save_schema(relation_oid: pg_sys::Oid, tantivy_schema: &Schema) -> Result<()> {
     let mut schema = LinkedBytesList::open(relation_oid, SCHEMA_START);

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::mem::{offset_of, size_of};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::slice::from_raw_parts;
 use tantivy::index::{SegmentComponent, SegmentId};
 use tantivy::Opstamp;
@@ -279,70 +279,6 @@ impl SegmentMetaEntry {
             SegmentComponent::TempStore => self.temp_store,
             SegmentComponent::Delete => self.delete.map(|entry| entry.file_entry),
         }
-    }
-
-    pub fn get_component_paths(&self) -> Vec<PathBuf> {
-        let mut paths = Vec::with_capacity(8);
-
-        let uuid = self.segment_id.uuid_string();
-        if self.postings.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::Postings
-            )));
-        }
-        if self.positions.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::Positions
-            )));
-        }
-        if self.fast_fields.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::FastFields
-            )));
-        }
-        if self.field_norms.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::FieldNorms
-            )));
-        }
-        if self.terms.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::Terms
-            )));
-        }
-        if self.store.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::Store
-            )));
-        }
-        if self.temp_store.is_some() {
-            paths.push(PathBuf::from(format!(
-                "{}.{}",
-                uuid,
-                SegmentComponent::TempStore
-            )));
-        }
-        if let Some(_entry) = &self.delete {
-            paths.push(PathBuf::from(format!(
-                "{}.0.{}", // we can hardcode zero as the opstamp component of the path as it's not used by anyone
-                uuid,
-                SegmentComponent::Delete
-            )));
-        }
-
-        paths
     }
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This overrides the default implementation of
`Directory::supports_garbage_collection()` to return false, and then removes all the code that might have been called if it were to return true.

It also moves our tantivy dependency rev forward to the commit from https://github.com/paradedb/tantivy/pull/28. 

## Why

Explictly opting out of garbage collection, which
https://github.com/paradedb/tantivy/pull/28 now allows us to do, a) removes all calls to `Directory::list_managed_files()` through normal operations and b) gives us some peace of mind that tantivy won't do something we don't expect.

This idea came about when researching the concurrency issue fixed by PR #2142.

## How

## Tests

Existing tests pass, and so does stressgres