### PR TITLE
fix: interrupt holdoff around threads

### DIFF
--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -70,20 +70,7 @@ pub unsafe extern "C" fn ambulkdelete(
 
         for doc_id in 0..segment_reader.max_doc() {
             if doc_id % 100 == 0 {
-                // NB:  when `IsInParallelMode()` is true, it seems there's always a pending interrupt
-                // so we just don't bother checking for pending interrupts in that situation.  This
-                // is in the case of a parallel vacuum
-                if pg_sys::InterruptPending != 0 && !pg_sys::IsInParallelMode() {
-                    drop(merge_lock);
-
-                    // we think there's a pending interrupt, so this should raise a cancel query ERROR
-                    pg_sys::vacuum_delay_point();
-
-                    // if we got here then, ultimately, CHECK_FOR_INTERRUPTS() (which is called via
-                    // vacuum_delay_point()) didn't actually interrupt us, and we're just DOA now
-                    // because we've already dropped our merge_lock
-                    unreachable!("ambulkdelete: detected interrupt but wasn't cancelled");
-                }
+                // we think there's a pending interrupt, so this should raise a cancel query ERROR
                 pg_sys::vacuum_delay_point();
             }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We increment `pg_sys::InterruptHoldoffCount` in our `ChannelRequstHandler` before we send a closure to a background thread to wait for it to finish.  We then decrement it when that closure has returned from the background thread.

## Why

This ensures that Postgres will ignore interrupts while we're essentially blocked on a background tantivy thread doing indexing/commit work.

Also, `ambulkdelete()` no longer inspects the `pg_sys::InterruptPending` state.  We rely on `pg_sys::vacuum_delay_point()` to process interrupts, if it even can.

Because of our open MergeLock, it probably can't.  But that's okay as far as things go.


## How

## Tests

Existing tests, plus stressgres pass.

I did some testing by sending various `kill (1)` signals to random postgres backends as well, and none of them caused any kind of crash.  This kind of thing is a bit hard to test.