### PR TITLE
feat: allow pg_search to not be in shared_preload_libraries on PG 17

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -70,6 +70,7 @@ jobs:
           cargo pgrx install --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config" --release
 
       - name: Add pg_search to shared_preload_libraries
+        if: matrix.pg_version < 17
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -77,6 +77,7 @@ jobs:
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
 
       - name: Add pg_search to shared_preload_libraries
+        if: matrix.pg_version < 17
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -87,6 +87,7 @@ jobs:
         run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
       - name: Add pg_search to shared_preload_libraries
+        if: matrix.pg_version < 17
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -142,7 +142,7 @@ jobs:
         run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
       - name: Add pg_search to shared_preload_libraries
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version < 17
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 
@@ -258,7 +258,7 @@ jobs:
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make install -j
 
       - name: Add pg_search to shared_preload_libraries
-        if: steps.check_skip.outputs.skip_remaining_steps != 'true'
+        if: steps.check_skip.outputs.skip_remaining_steps != 'true' && matrix.pg_version < 17
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
         run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -227,7 +227,7 @@ RUN apt-get update \
 # The `postgres` database is the default database that exists in every Postgres installation. The pg_cron
 # extension requires a database to store its metadata tables. By using `postgres`, we ensure that it has a
 # stable, always-available database for its operations, no matter what other databases are created or deleted.
-RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_search,pg_analytics,pg_cron'/" /usr/share/postgresql/postgresql.conf.sample && \
+RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_analytics,pg_cron'/" /usr/share/postgresql/postgresql.conf.sample && \
     echo "cron.database_name = 'postgres'" >> /usr/share/postgresql/postgresql.conf.sample
 
 # In order for a user to manually install third party Postgres extensions (e.g. PostGIS, pg_partman, etc.) that ParadeDB does not

--- a/docs/deploy/self-hosted/extensions.mdx
+++ b/docs/deploy/self-hosted/extensions.mdx
@@ -152,7 +152,7 @@ If you are a [ParadeDB Enterprise](/deploy/enterprise) user, you should have rec
 
 ## Update `postgresql.conf`
 
-Next, add the extension(s) to `shared_preload_libraries` in `postgresql.conf`.
+Next, add the extension(s) to `shared_preload_libraries` in `postgresql.conf`. Adding `pg_search` to `shared_preload_libraries` is unnecessary if your Postgres version 17 or higher.
 
 ```ini
 shared_preload_libraries = 'pg_search,pg_analytics'

--- a/docs/deploy/self-hosted/extensions.mdx
+++ b/docs/deploy/self-hosted/extensions.mdx
@@ -152,7 +152,7 @@ If you are a [ParadeDB Enterprise](/deploy/enterprise) user, you should have rec
 
 ## Update `postgresql.conf`
 
-Next, add the extension(s) to `shared_preload_libraries` in `postgresql.conf`. Adding `pg_search` to `shared_preload_libraries` is unnecessary if your Postgres version 17 or higher.
+Next, add the extension(s) to `shared_preload_libraries` in `postgresql.conf`. Adding `pg_search` to `shared_preload_libraries` is unnecessary if your Postgres version is 17 or higher.
 
 ```ini
 shared_preload_libraries = 'pg_search,pg_analytics'

--- a/docs/deploy/self-hosted/logical-replication/getting-started.mdx
+++ b/docs/deploy/self-hosted/logical-replication/getting-started.mdx
@@ -75,7 +75,7 @@ max_wal_senders = 10
 - `listen_addresses` specifies the IP addresses on which PostgreSQL listens for connections. By default, PostgreSQL only listens on `localhost`. To allow other servers (like your standby servers) to connect for replication, you need to include their IP addresses.
 - `max_wal_senders` determines the maximum number of concurrent connections that can send WAL (Write-Ahead Log) data.
 
-If you are running `pg_search` on the primary server, make sure to add it to `shared_preload_libraries`. If you are installing it only on the standby server as a search replica,
+If you are running `pg_search` on the primary server, make sure to add it to `shared_preload_libraries` if your Postgres version is less than 17. If you are installing it only on the standby server as a search replica,
 you should skip this step.
 
 ```ini

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -40,7 +40,7 @@ This will spin up a Postgres instance with `pg_search` preinstalled.
 
 If you are self-hosting Postgres and would like to use the extension within your existing Postgres, follow the steps below.
 
-It's **very important** to make the following change to your `postgresql.conf` configuration file. `pg_search` must be in the list of `shared_preload_libraries`:
+It's **very important** to make the following change to your `postgresql.conf` configuration file. `pg_search` must be in the list of `shared_preload_libraries` if your Postgres version is less than 17:
 
 ```c
 shared_preload_libraries = 'pg_search'

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -75,7 +75,7 @@ pub fn MyDatabaseId() -> u32 {
 #[allow(non_snake_case)]
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
-    if !pg_sys::process_shared_preload_libraries_in_progress {
+    if cfg!(not(feature = "pg17")) && !pg_sys::process_shared_preload_libraries_in_progress {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }
 
@@ -104,6 +104,13 @@ pub mod pg_test {
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         // return any postgresql.conf settings that are required for your tests
-        vec!["shared_preload_libraries='pg_search'"]
+
+        let mut options: Vec<&'static str> = Vec::new();
+
+        if cfg!(not(feature = "pg17")) {
+            options.push("shared_preload_libraries='pg_search'");
+        }
+
+        options
     }
 }

--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -178,6 +178,8 @@ async fn test_ephemeral_postgres_with_pg_basebackup() -> Result<()> {
         wal_level = logical
         max_replication_slots = 4
         max_wal_senders = 4
+        # Adding pg_search to shared_preload_libraries in 17 doesn't do anything
+        # but simplifies testing
         shared_preload_libraries = 'pg_search'
     ";
 
@@ -274,6 +276,8 @@ async fn test_replication_with_pg_search_only_on_replica() -> Result<()> {
         wal_level = logical
         max_replication_slots = 4
         max_wal_senders = 4
+        # Adding pg_search to shared_preload_libraries in 17 doesn't do anything
+        # but simplifies testing
         shared_preload_libraries = 'pg_search'
     ";
 
@@ -358,6 +362,8 @@ async fn test_physical_streaming_replication() -> Result<()> {
         archive_command = 'cp %p {}/%f'
         max_wal_senders = 3
         wal_keep_size = '160MB'
+        # Adding pg_search to shared_preload_libraries in 17 doesn't do anything
+        # but simplifies testing
         shared_preload_libraries = 'pg_search'
         ",
         archive_dir.path().display()
@@ -404,6 +410,8 @@ async fn test_physical_streaming_replication() -> Result<()> {
     .expect("Failed to run pg_basebackup for standby setup");
 
     let standby_config = "
+        # Adding pg_search to shared_preload_libraries in 17 doesn't do anything
+        # but simplifies testing
         shared_preload_libraries = 'pg_search'
         hot_standby = on
     ";


### PR DESCRIPTION
There doesn't seem to be any reason why pg_search has to be in shared_preload_libraries on PG 17.