### PR TITLE
chore: Upgrade to `pg_analytics` 0.3.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,16 +185,6 @@ COPY --from=builder-pg_search /tmp/target/release/pg_search-pg${PG_VERSION_MAJOR
 COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
 COPY --from=builder-pg_analytics /tmp/pg_analytics/target/release/pg_analytics-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 
-
-# Required for pg_analytics and pg_cron
-#
-# If a user connects to ParadeDB with the superuser, the DuckDB folder will be created in the user's home directory. If
-# the user connects with the postgres user, the DuckDB folder will be created in the /var/lib/postgresql directory. We
-# chmod both directories to ensure that DuckDB can write to them no matter which user is used to connect to the database.
-RUN mkdir .duckdb/ && chmod -R a+rwX .duckdb/ && \
-    mkdir /var/lib/postgresql/.duckdb/ && \
-    chmod -R a+rwX /var/lib/postgresql/.duckdb/
-
 # Install Barman Cloud and its dependencies for Azure, Google, and AWS via `pip`, and clean up after the installation to
 # minimize the size of the image. These are required for enabling Postgres backups in our CloudNativePG deployments.
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,7 +93,7 @@ ENV POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     PARADEDB_VERSION=${PARADEDB_VERSION} \
     PARADEDB_TELEMETRY=${PARADEDB_TELEMETRY}
 
-RUN git clone --branch v0.3.0 https://github.com/paradedb/pg_analytics.git /tmp/pg_analytics/
+RUN git clone --branch v0.3.1 https://github.com/paradedb/pg_analytics.git /tmp/pg_analytics/
 
 # Build the extension
 WORKDIR /tmp/pg_analytics

--- a/docs/deploy/self-hosted/extensions.mdx
+++ b/docs/deploy/self-hosted/extensions.mdx
@@ -108,7 +108,7 @@ sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/pg_analytics/releases/latest).
 
 <Note>
-  You can replace `0.3.0` with the `pg_analytics` version you wish to install
+  You can replace `0.3.1` with the `pg_analytics` version you wish to install
   and `17` with the version of Postgres you are using.
 </Note>
 
@@ -116,31 +116,31 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.0/postgresql-17-pg-analytics_0.3.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.1/postgresql-17-pg-analytics_0.3.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.0/postgresql-17-pg-analytics_0.3.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.1/postgresql-17-pg-analytics_0.3.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.0/postgresql-17-pg-analytics_0.3.0-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.1/postgresql-17-pg-analytics_0.3.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_analytics.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.0/pg_analytics_17-0.3.0-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.1/pg_analytics_17-0.3.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.0/pg_analytics_17-0.3.0-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
+curl -L "https://github.com/paradedb/pg_analytics/releases/download/v0.3.1/pg_analytics_17-0.3.1-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_analytics.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -27,7 +27,7 @@ Because `pg_search`, `pg_analytics`, and `pgvector` are independent extensions, 
 For the latest available version, please refer to the respective Github repos:
 
 1. [`pg_search`](https://github.com/paradedb/paradedb/releases) is on version `0.15.0`
-2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.3.0`
+2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.3.1`
 3. [`pgvector`](https://github.com/pgvector/pgvector/tags) is on version `0.8.0`
 
 ## Updating ParadeDB Docker Image
@@ -51,7 +51,7 @@ The latest version of the Docker image should be `0.15.0`.
 
 ```sql
 ALTER EXTENSION pg_search UPDATE TO '0.15.0';
-ALTER EXTENSION pg_analytics UPDATE TO '0.3.0';
+ALTER EXTENSION pg_analytics UPDATE TO '0.3.1';
 ALTER EXTENSION vector UPDATE TO '0.8.0';
 ```
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This removes a no-longer-necessary fix now that we bundle it properly in code in `pg_analytics`, and upgrades to the `v0.3.1` version. We first need to do a `pg_analytics` release before the Docker test passes.

## Why
^

## How
^

## Tests
CI