### PR TITLE
feat: Support the new tantivy Directory panic handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4921,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "bitpacking",
 ]
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "nom",
 ]
@@ -5025,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=46488b5ca649d5e08dcebe18b7c1fbb1fb204a78#46488b5ca649d5e08dcebe18b7c1fbb1fb204a78"
+source = "git+https://github.com/paradedb/tantivy.git?rev=81c6d2bf74307682830a598bb5d99d237c946deb#81c6d2bf74307682830a598bb5d99d237c946deb"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "46488b5ca649d5e08dcebe18b7c1fbb1fb204a78", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "81c6d2bf74307682830a598bb5d99d237c946deb", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "46488b5ca649d5e08dcebe18b7c1fbb1fb204a78" }
+tantivy-common = { git = "https://github.com/paradedb/tantivy.git", rev = "81c6d2bf74307682830a598bb5d99d237c946deb" }


### PR DESCRIPTION

# Ticket(s) Closed

- Closes #

## What

We added support for tantivy's `Directory` to have a panic handler, to be used when a thread pool worker (from committing and merging) panics.

This implements one on MVCCDirectory (and delegats down to it for ChannelDirectory) that makes a best effort to report the panic back to Postgres, rolling back the current transaction, rather than causing rust to abort the whole process, taking down the entire Postgres cluster with it.

Also moves our tantivy dependency rev to 81c6d2bf74307682830a598bb5d99d237c946deb.
## Why

Having rust, from a background thread, abort() the process, which crashes Postgres, is bad.

## How

## Tests
