### PR TITLE
feat: allow disabling telemetry at compile time

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["pg17"]
+default = ["telemetry", "pg17"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
@@ -17,6 +17,7 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 icu = ["tokenizers/icu"]
+telemetry = []
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 
 [dependencies]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -85,6 +85,7 @@ pub unsafe extern "C" fn _PG_init() {
     #[cfg(not(feature = "pg17"))]
     postgres::fake_aminsertcleanup::register();
 
+    #[cfg(feature = "telemetry")]
     setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
 
     // Register our tracing / logging hook, so that we can ensure that the logger


### PR DESCRIPTION
This allows not running a background worker that would just be idle
anyway if a hosting provider were to globally disable
paradedb.pg_search_telemetry.
