### PR TITLE
fix: issue #2141 -- unary `NOT` operator now works correctly

### DIFF
--- a/tests/tests/query_edge_cases.rs
+++ b/tests/tests/query_edge_cases.rs
@@ -1,0 +1,60 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn unary_not_issue2141(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id SERIAL PRIMARY KEY,
+        value text[]
+    );
+
+    INSERT INTO test_table (value) VALUES (ARRAY['beer', 'cheese']), (ARRAY['beer', 'wine']), (ARRAY['beer']), (ARRAY['beer']);
+    "#
+    .execute(&mut conn);
+
+    r#"
+    CREATE INDEX test_index ON test_table
+    USING bm25 (id, value) WITH (key_field='id', text_fields='{"value": {}}');
+    "#
+    .execute(&mut conn);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE value @@@ 'beer';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 4);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE NOT value @@@ 'beer';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 0);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE value @@@ 'wine';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE NOT value @@@ 'wine';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 3);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE value @@@ 'wine' AND NOT value @@@ 'cheese';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE NOT value @@@ 'wine' OR NOT value @@@ 'missing';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 4);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2141

## What

Postgres' `NOT` operator is unary, but tantivy's is binary. 

This resolves that mismatch by pulling up `NOT` clauses into `AND` clauses, and otherwises pairing a lone `NOT` clause with a `SearchQueryInput::All` query.

## Why

Bugfix

## How

## Tests

A new test file has been added where we can put tests for query edge cases, which this is one.