### PR TITLE
fix: default indexing mem to 1gb

### DIFF
--- a/docs/documentation/configuration/index.mdx
+++ b/docs/documentation/configuration/index.mdx
@@ -2,7 +2,7 @@
 title: Index Build
 ---
 
-### Indexing Memory
+### Maintenance Working Memory
 
 The default Postgres `maintenance_work_mem` value of `64MB` is quite conservative and can significantly slow down index builds. For large indexes,
 we strongly recommend increasing `maintenance_work_mem`.
@@ -11,18 +11,22 @@ we strongly recommend increasing `maintenance_work_mem`.
 maintenance_work_mem = 16GB
 ```
 
-<Note>
-  `maintenance_work_mem` should not exceed the server's available memory.
-</Note>
+`maintenance_work_mem` should not exceed the server's available memory.
 
-In addition to improving build times, `maintenance_work_mem` also affects the number of [segments](/documentation/concepts/index#segment) created in the index.
-This is because, while ParadeDB tries to maintain as many segments as CPUs, a segment that cannot fit into memory will be split into a new segment.
-As a result, an insufficient `maintenance_work_mem` can lead to significantly more segments than available CPUs, which degrades search performance.
-To check if the chosen `maintenance_work_mem` value is high enough, you can [compare](/documentation/indexing/inspect_index#index-segments) the index's segment count
-with the server's CPU count.
+### Indexing Memory per Thread
 
-Generally speaking, `maintenance_work_mem` is the only setting that must be tuned to optimize index build times.
-The rest have sensible defaults.
+<Note>This setting requires superuser privileges.</Note>
+
+`paradedb.create_index_memory_budget` defaults to `1024MB`. It sets the amount of memory to dedicate per indexing thread before the index segment needs to be
+written to disk. The value is measured in megabytes. In terms of raw indexing performance, larger is generally better.
+
+If set to `0`, `maintenance_work_mem` divided by [indexing parallelism](#indexing-threads) will be used.
+
+```sql
+SET paradedb.create_index_memory_budget = 2048;
+```
+
+In addition to improving build times, this setting also affects the number of segments created in the index. This is because, while ParadeDB tries to maintain as many segments as CPUs, a segment that cannot fit into memory will be split into a new segment. As a result, an insufficient `paradedb.create_index_memory_budget` can lead to significantly more segments than available CPUs, which degrades search performance. To check if the chosen value value is high enough, you can compare the index’s segment count with the server’s CPU count.
 
 ### Indexing Progress
 
@@ -44,19 +48,6 @@ The logs will appear in the directory specified in `log_directory`.
 
 ```sql
 SHOW log_directory;
-```
-
-### Indexing Memory per Thread
-
-<Note>This setting requires superuser privileges.</Note>
-
-`paradedb.create_index_memory_budget` defaults to `maintenance_work_mem` divided by total [parallelism](#indexing-threads). It sets the amount of memory to dedicate per indexing thread before the index segment needs to be
-written to disk.
-
-The value is measured in megabytes. A value of `1024` is the same as `1GB`. In terms of raw indexing performance, larger is generally better.
-
-```sql
-SET paradedb.create_index_memory_budget = 1024;
 ```
 
 ### Indexing Threads

--- a/docs/documentation/configuration/write.mdx
+++ b/docs/documentation/configuration/write.mdx
@@ -4,17 +4,6 @@ title: Throughput
 
 Several settings can be used to tune the throughput of `INSERT`/`UPDATE`/`COPY` statements to the BM25 index.
 
-## Statement Memory
-
-Like [indexing memory](/documentation/configuration/index#indexing-memory), the amount of memory available to `INSERT`/`UPDATE`/`COPY` statements and number of segments
-created is affected by `maintenance_work_mem`.
-
-```bash postgresql.conf
-maintenance_work_mem = 16GB
-```
-
-Generally speaking, this is the only setting that must be tuned for optimizing these statements.
-
 ## Statement Parallelism
 
 <Note>This setting requires superuser privileges.</Note>
@@ -33,8 +22,10 @@ SET paradedb.statement_parallelism = 1;
 
 <Note>This setting requires superuser privileges.</Note>
 
-`paradedb.statement_memory_budget`, like [indexing memory](/documentation/configuration/index#indexing-memory) defaults to `maintenance_work_mem` divided by the total parallelism. It sets the amount of memory to dedicate per indexing thread before the index segment needs to be
-written to disk. The setting is measured in megabytes.
+`paradedb.statement_memory_budget` defaults to `1024MB`. It sets the amount of memory to dedicate per indexing thread before the index segment needs to be
+written to disk. The value is measured in megabytes. In terms of raw indexing performance, larger is generally better.
+
+If set to `0`, `maintenance_work_mem` divided by [statement parallelism](#statement-parallelism) will be used.
 
 If your typical update patterns are single-row atomic `INSERT`s or `UPDATE`s, then a value of `15MB` can prevent unnecessary memory from being allocated. For bulk inserts
 and updates, a larger value is better.
@@ -42,3 +33,5 @@ and updates, a larger value is better.
 ```sql
 SET paradedb.statement_memory_budget = 15;
 ```
+
+Like [`paradedb.create_index_memory_budget`](/documentation/configuration/index#indexing-memory-per-thread), this setting can affect the number of segments in the index.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -48,14 +48,14 @@ static CREATE_INDEX_PARALLELISM: GucSetting<i32> = GucSetting::<i32>::new(0);
 
 /// How much memory should tantivy use during CREATE INDEX.  This value is decided to each indexing
 /// thread.  So if there's 10 threads and this value is 100MB, then a total of 1GB will be allocated.
-static CREATE_INDEX_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(0);
+static CREATE_INDEX_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(1024);
 
 /// How many threads should tantivy use during a regular INSERT/UPDATE/COPY statement?
 static STATEMENT_PARALLELISM: GucSetting<i32> = GucSetting::<i32>::new(0);
 
 /// How much memory should tantivy use during a regular INSERT/UPDATE/COPY statement?  This value is decided to each indexing
 /// thread.  So if there's 10 threads and this value is 100MB, then a total of 1GB will be allocated.
-static STATEMENT_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(0);
+static STATEMENT_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(1024);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The previous default create index and statement memory of `maintenance_work_mem/parallelism` was way too small, since the default `maintenance_work_mem` is `15MB`. This makes the default 1GB.

## Why

## How

## Tests
