### PR TITLE
fix: properly return `paradedb.snippet()`s from JOINs

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/mod.rs
@@ -199,17 +199,21 @@ pub unsafe fn inject_placeholders(
                 if let Some(attname) = data.attname_lookup.get(&key) {
                     for snippet_info in data.snippet_infos.keys() {
                         if &snippet_info.field == attname {
-                            let const_ = pg_sys::makeConst(
-                                pg_sys::TEXTOID,
-                                -1,
-                                pg_sys::DEFAULT_COLLATION_OID,
-                                -1,
-                                pg_sys::Datum::null(),
-                                true,
-                                false,
-                            );
-                            data.const_snippet_nodes
-                                .insert(snippet_info.clone(), const_);
+                            let const_ = data
+                                .const_snippet_nodes
+                                .entry(snippet_info.clone())
+                                .or_insert_with(|| {
+                                    pg_sys::makeConst(
+                                        pg_sys::TEXTOID,
+                                        -1,
+                                        pg_sys::DEFAULT_COLLATION_OID,
+                                        -1,
+                                        pg_sys::Datum::null(),
+                                        true,
+                                        false,
+                                    )
+                                });
+
                             return Some(const_.cast());
                         }
                     }

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -1,0 +1,55 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn snippet_from_join(mut conn: PgConnection) -> Result<(), sqlx::Error> {
+    r#"
+    CREATE TABLE a (
+        id bigint,
+        value text
+    );
+    CREATE TABLE b (
+        id bigint,
+        value text
+    );
+
+    INSERT INTO a (id, value) VALUES (1, 'beer'), (2, 'wine'), (3, 'cheese');
+    INSERT INTO b (id, value) VALUES (1, 'beer'), (2, 'wine'), (3, 'cheese');
+
+    CREATE INDEX idxa ON a USING bm25 (id, value) WITH (key_field='id', text_fields='{"value": {}}');
+    CREATE INDEX idxb ON b USING bm25 (id, value) WITH (key_field='id', text_fields='{"value": {}}');
+    "#
+        .execute(&mut conn);
+
+    let (snippet,) = r#"select paradedb.snippet(a.value) from a left join b on a.id = b.id where a.value @@@ 'beer';"#
+    .fetch_one::<(String,)>(&mut conn);
+    assert_eq!(snippet, String::from("<b>beer</b>"));
+
+    let (snippet,) = r#"select paradedb.snippet(b.value) from a left join b on a.id = b.id where a.value @@@ 'beer' and b.value @@@ 'beer';"#
+    .fetch_one::<(String,)>(&mut conn);
+    assert_eq!(snippet, String::from("<b>beer</b>"));
+
+    // NB:  the result of this is wrong for now...
+    let results = r#"select a.id, b.id, paradedb.snippet(a.value), paradedb.snippet(b.value) from a left join b on a.id = b.id where a.value @@@ 'beer' or b.value @@@ 'wine' order by a.id, b.id;"#
+        .fetch_result::<(i64, i64, Option<String>, Option<String>)>(&mut conn)?;
+
+    // ... this is what we'd actually expect from the above query
+    /*
+    let expected = vec![
+        (1, 1, Some(String::from("<b>beer</b>")), None),
+        (2, 2, None, Some(String::from("<b>wine</b>"))),
+    ];
+     */
+    // but due to query planning weirdness that I haven't figured out yet, this is what we actually get
+    // Even tho this "expected" result is not correct I want to encode validating this result
+    // so that when we do improve our custom scan/planner integrations this test will light up,
+    // and we can then confirm that it's actually the above
+    let expected = vec![(1, 1, None, None), (2, 2, None, None)];
+
+    assert_eq!(results, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We had a bug where `paradedb.snippet()` when used with a JOIN could cause us to generate its corresponding `pg_sys::Const` node placeholder multiple times, and then when injecting the actual snippet, we'd send it to the wrong `pg_sys::Const` pointer.

## Why

Because of this bug, it was possible for the user to think we were returning NULL for the snippet.  Technically we were, but that was incorrect!

## How

## Tests

Added a new test file to test for this.  It notes another problem we have (and encodes the current behavior), but that problem is out of scope for this simple fix.