### PR TITLE
fix: `paradedb.validate_checksum()` works again

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -196,8 +196,15 @@ impl Directory for MVCCDirectory {
     /// Returns a list of all segment components to Tantivy,
     /// identified by <uuid>.<ext> PathBufs
     fn list_managed_files(&self) -> tantivy::Result<HashSet<PathBuf>> {
-        // because we don't support garbage collection
-        unimplemented!("list_managed_files should not be called");
+        unsafe {
+            let segment_metas =
+                LinkedItemList::<SegmentMetaEntry>::open(self.relation_oid, SEGMENT_METAS_START);
+            Ok(segment_metas
+                .list()
+                .into_iter()
+                .flat_map(|entry| entry.get_component_paths())
+                .collect())
+        }
     }
 
     // This is intentionally a no-op

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::mem::{offset_of, size_of};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::slice::from_raw_parts;
 use tantivy::index::{SegmentComponent, SegmentId};
 use tantivy::Opstamp;
@@ -228,6 +228,70 @@ impl SegmentMetaEntry {
             .map(|entry| entry.file_entry.total_bytes as u64)
             .unwrap_or(0);
         size
+    }
+
+    pub fn get_component_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::with_capacity(8);
+
+        let uuid = self.segment_id.uuid_string();
+        if self.postings.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::Postings
+            )));
+        }
+        if self.positions.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::Positions
+            )));
+        }
+        if self.fast_fields.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::FastFields
+            )));
+        }
+        if self.field_norms.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::FieldNorms
+            )));
+        }
+        if self.terms.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::Terms
+            )));
+        }
+        if self.store.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::Store
+            )));
+        }
+        if self.temp_store.is_some() {
+            paths.push(PathBuf::from(format!(
+                "{}.{}",
+                uuid,
+                SegmentComponent::TempStore
+            )));
+        }
+        if let Some(_entry) = &self.delete {
+            paths.push(PathBuf::from(format!(
+                "{}.0.{}", // we can hardcode zero as the opstamp component of the path as it's not used by anyone
+                uuid,
+                SegmentComponent::Delete
+            )));
+        }
+
+        paths
     }
 }
 

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -24,8 +24,9 @@ use sqlx::PgConnection;
 #[rstest]
 fn validate_checksum(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
-    let (count,) = "select count(*) from paradedb.validate_checksum('bm25_search_bm25_index')"
-        .fetch_one::<(i64,)>(&mut conn);
+    let (count,) =
+        "select count(*) from paradedb.validate_checksum('paradedb.bm25_search_bm25_index')"
+            .fetch_one::<(i64,)>(&mut conn);
     assert_eq!(count, 0);
 }
 

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -22,6 +22,14 @@ use rstest::*;
 use sqlx::PgConnection;
 
 #[rstest]
+fn validate_checksum(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    let (count,) = "select count(*) from paradedb.validate_checksum('bm25_search_bm25_index')"
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 0);
+}
+
+#[rstest]
 fn vacuum_full(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     "DELETE FROM paradedb.bm25_search WHERE id IN (1, 2, 3, 4, 5)".execute(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The function was lacking a test and so it failed to work.

## Why

This gets is working again by implementing `MVCCDirectory::list_managed_files()` and the necessary surrounding code.

## How

## Tests

Adds a test for `paradedb.validate_checksum()`.  Returning zero rows means the checksum passed.
