### PR TITLE
feat: improved JOIN support

### DIFF
--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -96,6 +96,7 @@ pub extern "C" fn paradedb_rel_pathlist_callback<CS: CustomScan>(
                 // non-partial path available for it to consider
                 let copy = PgMemoryContexts::CurrentMemoryContext
                     .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+                (*copy).path.parallel_aware = false;
                 (*copy).path.total_cost = 1000000000.0;
                 (*copy).path.startup_cost = 1000000000.0;
 

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -16,35 +16,69 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::nodecast;
+use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
 use crate::postgres::customscan::pdbscan::privdat::deserialize::decodeString;
 use crate::postgres::customscan::pdbscan::privdat::serialize::{
     makeInteger, makeString, AsValueNode,
 };
 use crate::query::SearchQueryInput;
-use pgrx::{node_to_string, pg_sys, FromDatum, PgList};
+use pgrx::{pg_sys, FromDatum, PgList};
 
 #[derive(Debug, Clone)]
 pub enum Qual {
-    Ignore,
+    All,
     OperatorExpression {
         var: *mut pg_sys::Var,
         opno: pg_sys::Oid,
         val: *mut pg_sys::Const,
+    },
+    Param {
+        var: *mut pg_sys::Var,
+        opno: pg_sys::Oid,
+        node: *mut pg_sys::Node,
     },
     And(Vec<Qual>),
     Or(Vec<Qual>),
     Not(Box<Qual>),
 }
 
+impl Qual {
+    pub fn contains_all(&self) -> bool {
+        match self {
+            Qual::All => true,
+            Qual::OperatorExpression { .. } => false,
+            Qual::Param { .. } => false,
+            Qual::And(quals) => quals.iter().any(|q| q.contains_all()),
+            Qual::Or(quals) => quals.iter().any(|q| q.contains_all()),
+            Qual::Not(qual) => qual.contains_all(),
+        }
+    }
+
+    pub fn contains_param(&self) -> bool {
+        match self {
+            Qual::All => false,
+            Qual::OperatorExpression { .. } => false,
+            Qual::Param { .. } => true,
+            Qual::And(quals) => quals.iter().any(|q| q.contains_param()),
+            Qual::Or(quals) => quals.iter().any(|q| q.contains_param()),
+            Qual::Not(qual) => qual.contains_param(),
+        }
+    }
+}
+
 impl From<&Qual> for SearchQueryInput {
+    #[track_caller]
     fn from(value: &Qual) -> Self {
         match value {
-            Qual::Ignore => SearchQueryInput::All,
+            Qual::All => SearchQueryInput::ConstScore {
+                query: Box::new(SearchQueryInput::All),
+                score: 0.0,
+            },
             Qual::OperatorExpression { val, .. } => unsafe {
                 SearchQueryInput::from_datum((**val).constvalue, (**val).constisnull)
                     .expect("rhs of @@@ operator Qual must not be null")
             },
-
+            Qual::Param { .. } => todo!("parameterized plans are not currently supported.  Please `SET plan_cache_mode = force_custom_plan;` in this session, or set it in postgresql.conf and reload the configuration."),
             Qual::And(quals) => {
                 let mut must = Vec::new();
                 let mut should = Vec::new();
@@ -97,27 +131,33 @@ impl From<Qual> for PgList<pg_sys::Node> {
             let mut list = PgList::new();
 
             match value {
-                Qual::Ignore => list.push(makeString(Some("IGNORE"))),
+                Qual::All => list.push(makeString(Some("ALL"))),
                 Qual::OperatorExpression { var, opno, val } => {
                     list.push(makeString(Some("OPERATOR_EXPRESSION")));
                     list.push(var.cast());
                     list.push(makeInteger(Some(opno)));
                     list.push(val.cast());
                 }
+                Qual::Param { var, opno, node } => {
+                    list.push(makeString(Some("PARAM")));
+                    list.push(var.cast());
+                    list.push(makeInteger(Some(opno)));
+                    list.push(node);
+                }
                 Qual::And(quals) => {
                     list.push(makeString(Some("AND")));
                     list.push(makeInteger(Some(quals.len())));
                     for qual in quals {
-                        let or: PgList<pg_sys::Node> = qual.into();
-                        list.push(or.into_pg().cast());
+                        let and: PgList<pg_sys::Node> = qual.into();
+                        list.push(and.into_pg().cast());
                     }
                 }
                 Qual::Or(quals) => {
                     list.push(makeString(Some("OR")));
                     list.push(makeInteger(Some(quals.len())));
                     for qual in quals {
-                        let and: PgList<pg_sys::Node> = qual.into();
-                        list.push(and.into_pg().cast());
+                        let or: PgList<pg_sys::Node> = qual.into();
+                        list.push(or.into_pg().cast());
                     }
                 }
                 Qual::Not(not) => {
@@ -140,7 +180,7 @@ impl From<PgList<pg_sys::Node>> for Qual {
 
                 if let Some(type_) = decodeString::<String>(first) {
                     match type_.as_str() {
-                        "IGNORE" => Some(Qual::Ignore),
+                        "ALL" => Some(Qual::All),
                         "OPERATOR_EXPRESSION" => {
                             let (var, opno, val) = (
                                 nodecast!(Var, T_Var, value.get_ptr(1)?)?,
@@ -148,6 +188,14 @@ impl From<PgList<pg_sys::Node>> for Qual {
                                 nodecast!(Const, T_Const, value.get_ptr(3)?)?,
                             );
                             Some(Qual::OperatorExpression { var, opno, val })
+                        }
+                        "PARAM" => {
+                            let (var, opno, node) = (
+                                nodecast!(Var, T_Var, value.get_ptr(1)?)?,
+                                pg_sys::Oid::from_value_node(value.get_ptr(2)?)?,
+                                value.get_ptr(3)?,
+                            );
+                            Some(Qual::Param { var, opno, node })
                         }
                         "AND" => {
                             let len = usize::from_value_node(value.get_ptr(1)?)?;
@@ -199,10 +247,11 @@ pub unsafe fn extract_quals(
     rti: pg_sys::Index,
     node: *mut pg_sys::Node,
     pdbopoid: pg_sys::Oid,
+    ri_type: RestrictInfoType,
 ) -> Option<Qual> {
     match (*node).type_ {
         pg_sys::NodeTag::T_List => {
-            let mut quals = list(rti, node.cast(), pdbopoid)?;
+            let mut quals = list(rti, node.cast(), pdbopoid, ri_type)?;
             if quals.len() == 1 {
                 quals.pop()
             } else {
@@ -220,15 +269,15 @@ pub unsafe fn extract_quals(
             } else {
                 (*ri).clause
             };
-            extract_quals(rti, clause.cast(), pdbopoid)
+            extract_quals(rti, clause.cast(), pdbopoid, ri_type)
         }
 
-        pg_sys::NodeTag::T_OpExpr => opexpr(rti, node, pdbopoid),
+        pg_sys::NodeTag::T_OpExpr => opexpr(rti, node, pdbopoid, ri_type),
 
         pg_sys::NodeTag::T_BoolExpr => {
             let boolexpr = nodecast!(BoolExpr, T_BoolExpr, node)?;
             let args = PgList::<pg_sys::Node>::from_pg((*boolexpr).args);
-            let mut quals = list(rti, (*boolexpr).args, pdbopoid)?;
+            let mut quals = list(rti, (*boolexpr).args, pdbopoid, ri_type)?;
 
             match (*boolexpr).boolop {
                 pg_sys::BoolExprType::AND_EXPR => Some(Qual::And(quals)),
@@ -250,11 +299,12 @@ unsafe fn list(
     rti: pg_sys::Index,
     list: *mut pg_sys::List,
     pdbopoid: pg_sys::Oid,
+    ri_type: RestrictInfoType,
 ) -> Option<Vec<Qual>> {
     let args = PgList::<pg_sys::Node>::from_pg(list);
     let mut quals = Vec::new();
     for child in args.iter_ptr() {
-        quals.push(extract_quals(rti, child, pdbopoid)?)
+        quals.push(extract_quals(rti, child, pdbopoid, ri_type)?)
     }
     Some(quals)
 }
@@ -263,6 +313,7 @@ unsafe fn opexpr(
     rti: pg_sys::Index,
     node: *mut pg_sys::Node,
     pdbopoid: pg_sys::Oid,
+    ri_type: RestrictInfoType,
 ) -> Option<Qual> {
     let opexpr = nodecast!(OpExpr, T_OpExpr, node)?;
     let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
@@ -271,18 +322,35 @@ unsafe fn opexpr(
         nodecast!(Const, T_Const, args.get_ptr(1)?),
     );
 
+    let is_our_operator = (*opexpr).opno == pdbopoid;
+
     if lhs.is_none() || rhs.is_none() {
-        pgrx::debug1!(
-            "unrecognized `OpExpr`: {}",
-            node_to_string(opexpr.cast()).expect("node_to_string should not return null")
-        );
-        return None;
+        if contains_param(args.get_ptr(1)?) {
+            if matches!(ri_type, RestrictInfoType::BaseRelation) {
+                return None;
+            }
+
+            // TODO:  this would be for moving towards parameterized plans
+            return Some(Qual::Param {
+                var: lhs?,
+                opno: (*opexpr).opno,
+                node: args.get_ptr(1)?,
+            });
+        } else if matches!(ri_type, RestrictInfoType::Join) {
+            return Some(Qual::All);
+        } else {
+            return None;
+        }
     }
     let (lhs, rhs) = (lhs?, rhs?);
 
-    if (*opexpr).opno == pdbopoid {
+    if is_our_operator {
         if (*lhs).varno as i32 != rti as i32 {
-            Some(Qual::Ignore)
+            if matches!(ri_type, RestrictInfoType::Join) {
+                Some(Qual::All)
+            } else {
+                None
+            }
         } else {
             Some(Qual::OperatorExpression {
                 var: lhs,
@@ -293,4 +361,15 @@ unsafe fn opexpr(
     } else {
         None
     }
+}
+
+unsafe fn contains_param(root: *mut pg_sys::Node) -> bool {
+    unsafe extern "C" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
+        if nodecast!(Param, T_Param, node).is_some() {
+            return true;
+        }
+        pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
+    }
+
+    pg_sys::expression_tree_walker(root, Some(walker), std::ptr::null_mut())
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -262,7 +262,7 @@ where a.description @@@ 'bear' AND b.description @@@ 'teddy bear';"#
 }
 
 #[rstest]
-fn simple_join_with_scores_or_both_sides(mut conn: PgConnection) {
+fn simple_join_with_scores_on_both_sides(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let result = r#"
@@ -274,7 +274,7 @@ from (select paradedb.score(id), * from paradedb.bm25_search) a
 inner join (select paradedb.score(id), * from paradedb.bm25_search) b on a.id = b.id
 where a.description @@@ 'bear' OR b.description @@@ 'teddy bear';"#
         .fetch_one::<(i32, f32, i32, f32)>(&mut conn);
-    assert_eq!(result, (40, 4.332205, 40, 7.664409));
+    assert_eq!(result, (40, 3.3322046, 40, 6.664409));
 }
 
 #[rstest]
@@ -383,9 +383,9 @@ fn join_issue_1776(mut conn: PgConnection) {
         LIMIT 5;
     "#.fetch_result::<(i32, String, String, f32, f32)>(&mut conn).expect("query failed");
 
-    assert_eq!(results[0], (3, "Sleek running shoes".into(), "Alice Johnson".into(), 4.921624, 2.4849067));
-    assert_eq!(results[1], (6, "White jogging shoes".into(), "Alice Johnson".into(), 4.921624, 2.4849067));
-    assert_eq!(results[2], (36,"White jogging shoes".into(), "Alice Johnson".into(), 4.921624, 2.4849067));
+    assert_eq!(results[0], (3, "Sleek running shoes".into(), "Alice Johnson".into(), 2.9216242, 2.4849067));
+    assert_eq!(results[1], (6, "White jogging shoes".into(), "Alice Johnson".into(), 2.9216242, 2.4849067));
+    assert_eq!(results[2], (36,"White jogging shoes".into(), "Alice Johnson".into(), 2.9216242, 2.4849067));
 }
 
 #[rustfmt::skip]
@@ -427,7 +427,7 @@ fn join_issue_1826(mut conn: PgConnection) {
         LIMIT 1;
     "#.fetch_result::<(i32, String, String, f32, f32)>(&mut conn).expect("query failed");
 
-    assert_eq!(results[0], (3, "Sleek running shoes".into(), "Alice Johnson".into(), 4.921624, 2.4849067));
+    assert_eq!(results[0], (3, "Sleek running shoes".into(), "Alice Johnson".into(), 2.9216242, 2.4849067));
 }
 
 #[rstest]

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -2,7 +2,82 @@ mod fixtures;
 
 use fixtures::*;
 use rstest::*;
+use serde_json::Value;
 use sqlx::PgConnection;
+
+#[rstest]
+fn joins_return_correct_results(mut conn: PgConnection) -> Result<(), sqlx::Error> {
+    r#"
+    DROP TABLE IF EXISTS a;
+    DROP TABLE IF EXISTS b;
+    CREATE TABLE a (
+        id bigint,
+        value text
+    );
+    CREATE TABLE b (
+        id bigint,
+        value text
+    );
+    
+    INSERT INTO public.a VALUES (1, 'beer wine');
+    INSERT INTO public.a VALUES (2, 'beer wine');
+    INSERT INTO public.a VALUES (3, 'cheese');
+    INSERT INTO public.a VALUES (4, 'food stuff');
+    INSERT INTO public.a VALUES (5, 'only_in_a');
+
+    INSERT INTO public.b VALUES (1, 'beer');
+    INSERT INTO public.b VALUES (2, 'wine');
+    INSERT INTO public.b VALUES (3, 'cheese');
+    INSERT INTO public.b VALUES (4, 'wine beer cheese');
+                            -- mind the gap
+    INSERT INTO public.b VALUES (6, 'only_in_b');
+
+    INSERT INTO a (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 200000) x;
+    INSERT INTO b (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 200000) x;
+        
+    CREATE INDEX idxa ON public.a USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');
+    CREATE INDEX idxb ON public.b USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');
+    "#
+        .execute(&mut conn);
+
+    type RowType = (Option<i64>, Option<i64>, Option<String>, Option<String>);
+    // the pg_search queries also ORDER BY paradedb.score() to ensure we get a paradedb CustomScan
+    let queries = [
+        [
+            "select a.id, b.id, a.value a, b.value b from a left join b on a.id = b.id where a.value @@@   'beer'   or b.value @@@   'wine'   or a.value @@@ 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id, paradedb.score(a.id), paradedb.score(b.id);",
+            "select a.id, b.id, a.value a, b.value b from a left join b on a.id = b.id where a.value ilike '%beer%' or b.value ilike '%wine%' or a.value   = 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id;",
+        ],
+        [
+            "select a.id, b.id, a.value a, b.value b from a right join b on a.id = b.id where a.value @@@   'beer'   or b.value @@@   'wine'   or a.value @@@ 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id, paradedb.score(a.id), paradedb.score(b.id);",
+            "select a.id, b.id, a.value a, b.value b from a right join b on a.id = b.id where a.value ilike '%beer%' or b.value ilike '%wine%' or a.value   = 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id;",
+        ],
+        [
+            "select a.id, b.id, a.value a, b.value b from a inner join b on a.id = b.id where a.value @@@   'beer'   or b.value @@@   'wine'   or a.value @@@ 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id, paradedb.score(a.id), paradedb.score(b.id);",
+            "select a.id, b.id, a.value a, b.value b from a inner join b on a.id = b.id where a.value ilike '%beer%' or b.value ilike '%wine%' or a.value   = 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id;",
+        ],
+        [
+            "select a.id, b.id, a.value a, b.value b from a full join b on a.id = b.id where a.value @@@   'beer'   or b.value @@@   'wine'   or a.value @@@ 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id, paradedb.score(a.id), paradedb.score(b.id);",
+            "select a.id, b.id, a.value a, b.value b from a full join b on a.id = b.id where a.value ilike '%beer%' or b.value ilike '%wine%' or a.value   = 'only_in_a' or b.value @@@ 'only_in_b' order by a.id, b.id;",
+        ],
+    ];
+
+    for [pg_search, postgres] in queries {
+        eprintln!("pg_search: {pg_search:?}");
+        eprintln!("postgres: {postgres:?}");
+
+        let (pg_search_plan,) = format!("EXPLAIN (ANALYZE, FORMAT JSON) {}", pg_search)
+            .fetch_one::<(Value,)>(&mut conn);
+        eprintln!("pg_search_plan: {pg_search_plan:#?}");
+        assert!(format!("{pg_search_plan:?}").contains("ParadeDB Scan"));
+
+        let pg_search = pg_search.fetch_result::<RowType>(&mut conn)?;
+        let postgres = postgres.fetch_result::<RowType>(&mut conn)?;
+
+        assert_eq!(pg_search, postgres);
+    }
+
+    Ok(())
+}
 
 #[rstest]
 fn snippet_from_join(mut conn: PgConnection) -> Result<(), sqlx::Error> {
@@ -24,12 +99,12 @@ fn snippet_from_join(mut conn: PgConnection) -> Result<(), sqlx::Error> {
     "#
         .execute(&mut conn);
 
-    let (snippet,) = r#"select paradedb.snippet(a.value) from a left join b on a.id = b.id where a.value @@@ 'beer';"#
-    .fetch_one::<(String,)>(&mut conn);
+    let (snippet, ) = r#"select paradedb.snippet(a.value) from a left join b on a.id = b.id where a.value @@@ 'beer';"#
+        .fetch_one::<(String,)>(&mut conn);
     assert_eq!(snippet, String::from("<b>beer</b>"));
 
-    let (snippet,) = r#"select paradedb.snippet(b.value) from a left join b on a.id = b.id where a.value @@@ 'beer' and b.value @@@ 'beer';"#
-    .fetch_one::<(String,)>(&mut conn);
+    let (snippet, ) = r#"select paradedb.snippet(b.value) from a left join b on a.id = b.id where a.value @@@ 'beer' and b.value @@@ 'beer';"#
+        .fetch_one::<(String,)>(&mut conn);
     assert_eq!(snippet, String::from("<b>beer</b>"));
 
     // NB:  the result of this is wrong for now...
@@ -37,17 +112,10 @@ fn snippet_from_join(mut conn: PgConnection) -> Result<(), sqlx::Error> {
         .fetch_result::<(i64, i64, Option<String>, Option<String>)>(&mut conn)?;
 
     // ... this is what we'd actually expect from the above query
-    /*
     let expected = vec![
         (1, 1, Some(String::from("<b>beer</b>")), None),
         (2, 2, None, Some(String::from("<b>wine</b>"))),
     ];
-     */
-    // but due to query planning weirdness that I haven't figured out yet, this is what we actually get
-    // Even tho this "expected" result is not correct I want to encode validating this result
-    // so that when we do improve our custom scan/planner integrations this test will light up,
-    // and we can then confirm that it's actually the above
-    let expected = vec![(1, 1, None, None), (2, 2, None, None)];
 
     assert_eq!(results, expected);
 

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -32,8 +32,9 @@ fn joins_return_correct_results(mut conn: PgConnection) -> Result<(), sqlx::Erro
                             -- mind the gap
     INSERT INTO public.b VALUES (6, 'only_in_b');
 
-    INSERT INTO a (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
-    INSERT INTO b (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
+-- loading all this extra data makes the test take too long on CI
+--    INSERT INTO a (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
+--    INSERT INTO b (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
         
     CREATE INDEX idxa ON public.a USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');
     CREATE INDEX idxb ON public.b USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -32,8 +32,8 @@ fn joins_return_correct_results(mut conn: PgConnection) -> Result<(), sqlx::Erro
                             -- mind the gap
     INSERT INTO public.b VALUES (6, 'only_in_b');
 
-    INSERT INTO a (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 200000) x;
-    INSERT INTO b (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 200000) x;
+    INSERT INTO a (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
+    INSERT INTO b (id, value) SELECT x, md5(random()::text) FROM generate_series(7, 10000) x;
         
     CREATE INDEX idxa ON public.a USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');
     CREATE INDEX idxb ON public.b USING bm25 (id, value) WITH (key_field=id, text_fields='{"value": {}}');


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This adds improved Join support, allowing our (Parallel) Custom Scans to be used for the left and right sides of the JOIN.

It also ensures that snippets and scores are pulled up from each side of the join and go to their proper Const pointer slot in the projection list.

This PR also adds some basic integration points for parameterized plans, however they are not supported.  Our custom scan implementation will raise an ERROR if it's asked to execute a parameterized plan. 

For better compatibility with PREPAREd statements, users should `SET plan_cache_mode = force_custom_plan;` in their session or directly in `postgresql.conf`.

## Why

Our JOIN support wasn't exactly complete, especially as it related to being able to use our Custom Scans and pulling up scores/snippets from them.  The latter requires the former.

## How

## Tests

A small handful of tests that already tested scores-from-joins have been changed to reflect the **correct** score (the tests/code were wrong) now that things are more correctly implemented.

Additionally, a few other tests were updated and new ones added to test all the various inner/left/right/full join configurations.

