### PR TITLE
chore: Don't pre-install pg_analytics

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -19,7 +19,6 @@ for DB in template1 "$POSTGRES_DB"; do
   echo "Loading ParadeDB extensions into $DB"
   psql -d "$DB" <<-'EOSQL'
     CREATE EXTENSION IF NOT EXISTS pg_search;
-    CREATE EXTENSION IF NOT EXISTS pg_analytics;
     CREATE EXTENSION IF NOT EXISTS pg_ivm;
     CREATE EXTENSION IF NOT EXISTS vector;
     CREATE EXTENSION IF NOT EXISTS postgis;

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -15,7 +15,13 @@ ParadeDB's integrations that make it easy to ingest this data without data proce
 In this example, we will query and copy a Parquet file stored in S3 to Postgres. The Parquet file
 contains 3 million NYC taxi trips from January 2024, hosted in a public S3 bucket provided by ParadeDB.
 
-To begin, let's create a [Postgres foreign data wrapper](https://wiki.postgresql.org/wiki/Foreign_data_wrappers), which is how ParadeDB connects to S3.
+To begin, enable the ParadeDB integrations with:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_analytics;
+```
+
+Now, let's create a [Postgres foreign data wrapper](https://wiki.postgresql.org/wiki/Foreign_data_wrappers), which is how ParadeDB connects to S3.
 
 ```sql
 CREATE FOREIGN DATA WRAPPER parquet_wrapper


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We've seen small demand for pg_analytics. As such, we won't pre-install it in the database anymore. It'll still be possible to use it by running `CREATE EXTENSION pg_analytics;`.

## Why
^

## How
^

## Tests
^