### PR TITLE
fix:  another edge case in NOT handling

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -48,13 +48,11 @@ impl From<&Qual> for SearchQueryInput {
             Qual::And(quals) => {
                 let mut must = Vec::new();
                 let mut should = Vec::new();
-                let mut must_not = Vec::new();
 
                 for qual in quals {
                     match qual {
                         Qual::And(ands) => must.extend(ands.iter().map(SearchQueryInput::from)),
                         Qual::Or(ors) => should.extend(ors.iter().map(SearchQueryInput::from)),
-                        Qual::Not(not) => must_not.push(SearchQueryInput::from(not.as_ref())),
                         other => must.push(SearchQueryInput::from(other)),
                     }
                 }
@@ -62,7 +60,7 @@ impl From<&Qual> for SearchQueryInput {
                 SearchQueryInput::Boolean {
                     must,
                     should,
-                    must_not,
+                    must_not: vec![],
                 }
             }
             Qual::Or(quals) => {

--- a/tests/tests/query_edge_cases.rs
+++ b/tests/tests/query_edge_cases.rs
@@ -57,4 +57,10 @@ fn unary_not_issue2141(mut conn: PgConnection) {
     "#
     .fetch_one::<(i64,)>(&mut conn);
     assert_eq!(count, 4);
+
+    let (count,) = r#"
+    SELECT count(*) FROM test_table WHERE NOT value @@@ 'wine' AND NOT value @@@ 'cheese';
+    "#
+    .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 2);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2141

## What

This fixes another bug with handling Postgres' `NOT` operator.

## Why

## How

## Tests

The existing test was insufficient, so it's been updated.