### PR TITLE
feat: improved parameterized plan support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: no-commit-to-branch
         args: ["--branch", "main", "--branch", "dev"]
@@ -42,17 +42,17 @@ repos:
         args: ["--indent-size", "2"]
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.9.0
+    rev: v0.10.0
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.37.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
 
@@ -64,22 +64,22 @@ repos:
       - id: cargo-check
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: v3.0.1
+    rev: v3.3.4
     hooks:
       - id: pylint
 
-  - repo: https://github.com/CoderJoshDK/precommit-mintlify-validate/
-    rev: v0.2.0
-    hooks:
-      - id: mintlify-validate
-        args: [docs]
+  #  - repo: https://github.com/CoderJoshDK/precommit-mintlify-validate/
+  #    rev: v0.2.0
+  #    hooks:
+  #      - id: mintlify-validate
+  #        args: [docs]
 
   - repo: https://github.com/ComPWA/mirrors-taplo
     rev: "v0.9.3"

--- a/pg_search/sql/pg_search--0.15.2--0.15.3.sql
+++ b/pg_search/sql/pg_search--0.15.2--0.15.3.sql
@@ -1,0 +1,11 @@
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/searchqueryinput.rs:55
+-- pg_search::api::operator::searchqueryinput::with_index
+CREATE  FUNCTION "with_index"(
+    "index" regclass, /* pgrx::rel::PgRelation */
+    "query" SearchQueryInput /* pg_search::query::SearchQueryInput */
+) RETURNS SearchQueryInput /* pg_search::query::SearchQueryInput */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'with_index_wrapper';

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -76,7 +76,7 @@ pub fn search_with_query_input(
         .index_oid()
         .unwrap_or_else(|| panic!("the query argument must be wrapped in a `SearchQueryInput::WithIndex` variant.  Try using `paradedb.with_index('<index name>', <original expression>)`"));
 
-    // get the Cache attached to this instance of the funtion
+    // get the Cache attached to this instance of the function
     let cache = unsafe { pg_func_extra(fcinfo, Cache::default) };
 
     // and get/initialize the SearchReader and FFHelper for this index_oid

--- a/pg_search/src/api/operator/text.rs
+++ b/pg_search/src/api/operator/text.rs
@@ -63,24 +63,16 @@ fn text_support_request_simplify(arg: Internal) -> Option<ReturnedNodePointer> {
             // the field name comes from the lhs of the @@@ operator
             let (_, query) = make_query_from_var_and_const((*srs).root, var, const_);
             (Some(query), None)
-        } else if let Some(param) = nodecast!(Param, T_Param, rhs) {
+        } else {
             (
                 None,
                 Some((
-                    param.cast(),
+                    rhs,
                     attname_from_var((*srs).root, var)
                         .1
                         .expect("should be able to determine Var name"),
                 )),
             )
-        } else {
-            // This would happen in situations where the rhs of @@@ is ::TEXT, but not text that can
-            // be evaluated during planning, either as a Const node or a Param node.
-            //
-            // An example of this would be using some kind of volatile function/expression on the rhs:
-            //
-            //    SELECT * FROM t WHERE f @@@ random()::text;
-            panic!("when the left side of the `@@@` operator is a column name the right side must be a text literal");
         };
 
         Some(make_search_query_input_opexpr_node(

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -32,12 +32,15 @@ use self::postgres::customscan;
 use pgrx::*;
 use telemetry::setup_telemetry_background_worker;
 
-// A hardcoded value when we can't figure out a good selectivity value
+/// A hardcoded value when we can't figure out a good selectivity value
 const UNKNOWN_SELECTIVITY: f64 = 0.00001;
 
-// An arbitrary value for what it costs for a plan with one of our operators (@@@) to do whatever
-// initial work it needs to do (open tantivy index, start the query, etc).  The value is largely
-// meaningless but we should be honest that do _something_.
+/// A hardcoded value for parameterized plan queries
+const PARAMETERIZED_SELECTIVITY: f64 = 0.10;
+
+/// An arbitrary value for what it costs for a plan with one of our operators (@@@) to do whatever
+/// initial work it needs to do (open tantivy index, start the query, etc).  The value is largely
+/// meaningless but we should be honest that do _something_.
 const DEFAULT_STARTUP_COST: f64 = 10.0;
 
 pgrx::pg_module_magic!();

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -306,7 +306,6 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
         limit: Option<Cardinality>,
         segment_count: usize,
         sorted: bool,
-        has_exec_param: bool,
     ) -> Self {
         unsafe {
             let mut nworkers = segment_count.min(pg_sys::max_parallel_workers as usize);
@@ -330,8 +329,8 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
 
             // we will try to parallelize based on the number of index segments
             if nworkers > 0 && (*self.args.rel).consider_parallel {
-                self.custom_path_node.path.parallel_aware = !has_exec_param;
-                self.custom_path_node.path.parallel_safe = !has_exec_param;
+                self.custom_path_node.path.parallel_aware = true;
+                self.custom_path_node.path.parallel_safe = true;
                 self.custom_path_node.path.parallel_workers =
                     nworkers.try_into().expect("nworkers should be a valid i32");
             }

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -306,7 +306,7 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
         limit: Option<Cardinality>,
         segment_count: usize,
         sorted: bool,
-        has_sublinks: bool,
+        has_exec_param: bool,
     ) -> Self {
         unsafe {
             let mut nworkers = segment_count.min(pg_sys::max_parallel_workers as usize);
@@ -328,11 +328,10 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
                 }
             }
 
-            pgrx::warning!("has_sublinks={}", has_sublinks);
             // we will try to parallelize based on the number of index segments
             if nworkers > 0 && (*self.args.rel).consider_parallel {
-                self.custom_path_node.path.parallel_aware = !has_sublinks;
-                self.custom_path_node.path.parallel_safe = !has_sublinks;
+                self.custom_path_node.path.parallel_aware = !has_exec_param;
+                self.custom_path_node.path.parallel_safe = !has_exec_param;
                 self.custom_path_node.path.parallel_workers =
                     nworkers.try_into().expect("nworkers should be a valid i32");
             }

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -327,9 +327,12 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
                 }
             }
 
-            if nworkers == 0 && pg_sys::debug_parallel_query != 0 {
-                // force a parallel worker if the `debug_parallel_query` GUC is on
-                nworkers = 1;
+            #[cfg(not(any(feature = "pg13", feature = "pg14", feature = "pg15")))]
+            {
+                if nworkers == 0 && pg_sys::debug_parallel_query != 0 {
+                    // force a parallel worker if the `debug_parallel_query` GUC is on
+                    nworkers = 1;
+                }
             }
 
             // we will try to parallelize based on the number of index segments

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -327,6 +327,11 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
                 }
             }
 
+            if nworkers == 0 && pg_sys::debug_parallel_query != 0 {
+                // force a parallel worker if the `debug_parallel_query` GUC is on
+                nworkers = 1;
+            }
+
             // we will try to parallelize based on the number of index segments
             if nworkers > 0 && (*self.args.rel).consider_parallel {
                 self.custom_path_node.path.parallel_aware = true;

--- a/pg_search/src/postgres/customscan/builders/custom_state.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_state.rs
@@ -28,6 +28,7 @@ pub struct Args {
 pub struct CustomScanStateWrapper<CS: CustomScan> {
     pub csstate: pg_sys::CustomScanState,
     custom_state: CS::State,
+    pub runtime_context: *mut pg_sys::ExprContext,
 }
 
 impl<CS: CustomScan> Debug for CustomScanStateWrapper<CS>
@@ -125,6 +126,7 @@ impl<CS: CustomScan, P: From<*mut pg_sys::List>> CustomScanStateBuilder<CS, P> {
                     slotOps: std::ptr::null_mut(),
                 },
                 custom_state: self.custom_state,
+                runtime_context: std::ptr::null_mut(),
             })
         }
     }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -161,12 +161,16 @@ impl NormalScanExecState {
         if self.did_query {
             return false;
         }
-        self.search_results = state.search_reader.as_ref().unwrap().search(
-            state.need_scores(),
-            false,
-            &state.search_query_input,
-            state.limit,
-        );
+        self.search_results = state
+            .search_reader
+            .as_ref()
+            .expect("must have a search_reader to do a query")
+            .search(
+                state.need_scores(),
+                false,
+                &state.search_query_input,
+                state.limit,
+            );
         self.did_query = true;
         true
     }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -22,6 +22,7 @@ mod privdat;
 mod projections;
 mod qual_inspect;
 mod scan_state;
+mod solve_expr;
 
 use crate::api::operator::{
     anyelement_query_input_opoid, attname_from_var, estimate_selectivity, find_var_relation,
@@ -53,7 +54,7 @@ use crate::postgres::customscan::pdbscan::projections::snippet::{
 use crate::postgres::customscan::pdbscan::projections::{
     inject_placeholders, maybe_needs_const_projections, pullout_funcexprs,
 };
-use crate::postgres::customscan::pdbscan::qual_inspect::{extract_quals, Qual};
+use crate::postgres::customscan::pdbscan::qual_inspect::extract_quals;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use crate::postgres::customscan::{CustomScan, CustomScanState, ExecMethod};
 use crate::postgres::rel_get_bm25_index;
@@ -677,10 +678,6 @@ impl CustomScan for PdbScan {
                 .init_postgres_expressions(planstate);
             state.custom_state_mut().nexprs = nexprs;
 
-            pgrx::warning!(
-                "have {nexprs} expressions: {}",
-                pg_sys::ParallelWorkerNumber
-            );
             if nexprs > 0 {
                 // we have some runtime Postgres expressions that need to be evaluated in `rescan_custom_scan`
                 //

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -166,7 +166,6 @@ impl CustomScan for PdbScan {
                 ri_type,
             ) {
                 let has_expressions = quals.contains_exprs();
-                let has_exec_param = false; // quals.contains_exec_param();
                 let selectivity = if let Some(limit) = limit {
                     // use the limit
                     limit
@@ -293,14 +292,7 @@ impl CustomScan for PdbScan {
                     if pathkey_cnt == 1 || cardinality > 1_000_000.0 {
                         // if we only have 1 path key or if our estimated cardinality is over some
                         // hardcoded value, it's seemingly more efficient to do a parallel scan
-                        builder = builder.set_parallel(
-                            false,
-                            rows,
-                            limit,
-                            segment_count,
-                            true,
-                            has_exec_param,
-                        );
+                        builder = builder.set_parallel(false, rows, limit, segment_count, true);
                     } else {
                         // otherwise we'll do a regular scan and indicate that we're emitting results
                         // sorted by the first pathkey
@@ -315,7 +307,6 @@ impl CustomScan for PdbScan {
                         limit,
                         segment_count,
                         !matches!(sortdir, Some(SortDirection::None)) && sortdir.is_some(),
-                        has_exec_param,
                     );
                 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -17,9 +17,9 @@
 
 use crate::nodecast;
 use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
-use crate::postgres::customscan::pdbscan::privdat::deserialize::decodeString;
+use crate::postgres::customscan::pdbscan::privdat::deserialize::{decodeBoolean, decodeString};
 use crate::postgres::customscan::pdbscan::privdat::serialize::{
-    makeInteger, makeString, AsValueNode,
+    makeBoolean, makeInteger, makeString, AsValueNode,
 };
 use crate::query::SearchQueryInput;
 use pgrx::{pg_sys, FromDatum, PgList};
@@ -27,15 +27,17 @@ use pgrx::{pg_sys, FromDatum, PgList};
 #[derive(Debug, Clone)]
 pub enum Qual {
     All,
-    OperatorExpression {
+    OpExpr {
         var: *mut pg_sys::Var,
         opno: pg_sys::Oid,
         val: *mut pg_sys::Const,
     },
-    Param {
+    Expr {
         var: *mut pg_sys::Var,
         opno: pg_sys::Oid,
         node: *mut pg_sys::Node,
+        is_volatile: bool,
+        expr_state: *mut pg_sys::ExprState,
     },
     And(Vec<Qual>),
     Or(Vec<Qual>),
@@ -46,8 +48,8 @@ impl Qual {
     pub fn contains_all(&self) -> bool {
         match self {
             Qual::All => true,
-            Qual::OperatorExpression { .. } => false,
-            Qual::Param { .. } => false,
+            Qual::OpExpr { .. } => false,
+            Qual::Expr { .. } => false,
             Qual::And(quals) => quals.iter().any(|q| q.contains_all()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_all()),
             Qual::Not(qual) => qual.contains_all(),
@@ -57,11 +59,33 @@ impl Qual {
     pub fn contains_param(&self) -> bool {
         match self {
             Qual::All => false,
-            Qual::OperatorExpression { .. } => false,
-            Qual::Param { .. } => true,
+            Qual::OpExpr { .. } => false,
+            Qual::Expr { node, .. } => contains_param(*node),
             Qual::And(quals) => quals.iter().any(|q| q.contains_param()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_param()),
             Qual::Not(qual) => qual.contains_param(),
+        }
+    }
+
+    pub fn contains_exprs(&self) -> bool {
+        match self {
+            Qual::All => false,
+            Qual::OpExpr { .. } => false,
+            Qual::Expr { .. } => true,
+            Qual::And(quals) => quals.iter().any(|q| q.contains_exprs()),
+            Qual::Or(quals) => quals.iter().any(|q| q.contains_exprs()),
+            Qual::Not(qual) => qual.contains_exprs(),
+        }
+    }
+
+    pub fn collect_exprs<'a>(&'a mut self, exprs: &mut Vec<&'a mut Qual>) {
+        match self {
+            Qual::All => {}
+            Qual::OpExpr { .. } => {}
+            Qual::Expr { .. } => exprs.push(self),
+            Qual::And(quals) => quals.iter_mut().for_each(|q| q.collect_exprs(exprs)),
+            Qual::Or(quals) => quals.iter_mut().for_each(|q| q.collect_exprs(exprs)),
+            Qual::Not(qual) => qual.collect_exprs(exprs),
         }
     }
 }
@@ -74,11 +98,17 @@ impl From<&Qual> for SearchQueryInput {
                 query: Box::new(SearchQueryInput::All),
                 score: 0.0,
             },
-            Qual::OperatorExpression { val, .. } => unsafe {
+            Qual::OpExpr { val, .. } => unsafe {
                 SearchQueryInput::from_datum((**val).constvalue, (**val).constisnull)
                     .expect("rhs of @@@ operator Qual must not be null")
             },
-            Qual::Param { .. } => todo!("parameterized plans are not currently supported.  Please `SET plan_cache_mode = force_custom_plan;` in this session, or set it in postgresql.conf and reload the configuration."),
+            Qual::Expr {
+                var,
+                opno,
+                node,
+                is_volatile,
+                expr_state,
+            } => SearchQueryInput::postgres_expression(*var, *opno, *node),
             Qual::And(quals) => {
                 let mut must = Vec::new();
                 let mut should = Vec::new();
@@ -130,17 +160,24 @@ impl From<Qual> for PgList<pg_sys::Node> {
 
             match value {
                 Qual::All => list.push(makeString(Some("ALL"))),
-                Qual::OperatorExpression { var, opno, val } => {
-                    list.push(makeString(Some("OPERATOR_EXPRESSION")));
+                Qual::OpExpr { var, opno, val } => {
+                    list.push(makeString(Some("OPEXPR")));
                     list.push(var.cast());
                     list.push(makeInteger(Some(opno)));
                     list.push(val.cast());
                 }
-                Qual::Param { var, opno, node } => {
-                    list.push(makeString(Some("PARAM")));
+                Qual::Expr {
+                    var,
+                    opno,
+                    node,
+                    is_volatile,
+                    ..
+                } => {
+                    list.push(makeString(Some("EXPR")));
                     list.push(var.cast());
                     list.push(makeInteger(Some(opno)));
                     list.push(node);
+                    list.push(makeBoolean(Some(is_volatile)));
                 }
                 Qual::And(quals) => {
                     list.push(makeString(Some("AND")));
@@ -179,21 +216,28 @@ impl From<PgList<pg_sys::Node>> for Qual {
                 if let Some(type_) = decodeString::<String>(first) {
                     match type_.as_str() {
                         "ALL" => Some(Qual::All),
-                        "OPERATOR_EXPRESSION" => {
+                        "OPEXPR" => {
                             let (var, opno, val) = (
                                 nodecast!(Var, T_Var, value.get_ptr(1)?)?,
                                 pg_sys::Oid::from_value_node(value.get_ptr(2)?)?,
                                 nodecast!(Const, T_Const, value.get_ptr(3)?)?,
                             );
-                            Some(Qual::OperatorExpression { var, opno, val })
+                            Some(Qual::OpExpr { var, opno, val })
                         }
-                        "PARAM" => {
-                            let (var, opno, node) = (
+                        "EXPR" => {
+                            let (var, opno, node, is_volatile) = (
                                 nodecast!(Var, T_Var, value.get_ptr(1)?)?,
                                 pg_sys::Oid::from_value_node(value.get_ptr(2)?)?,
                                 value.get_ptr(3)?,
+                                decodeBoolean(value.get_ptr(4)?)?,
                             );
-                            Some(Qual::Param { var, opno, node })
+                            Some(Qual::Expr {
+                                var,
+                                opno,
+                                node,
+                                is_volatile,
+                                expr_state: std::ptr::null_mut(),
+                            })
                         }
                         "AND" => {
                             let len = usize::from_value_node(value.get_ptr(1)?)?;
@@ -315,59 +359,79 @@ unsafe fn opexpr(
 ) -> Option<Qual> {
     let opexpr = nodecast!(OpExpr, T_OpExpr, node)?;
     let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
-    let (lhs, rhs) = (
-        nodecast!(Var, T_Var, args.get_ptr(0)?),
+    let (var, const_) = (
+        nodecast!(Var, T_Var, args.get_ptr(0)?)?,
         nodecast!(Const, T_Const, args.get_ptr(1)?),
     );
 
     let is_our_operator = (*opexpr).opno == pdbopoid;
 
-    if lhs.is_none() || rhs.is_none() {
-        if contains_param(args.get_ptr(1)?) {
-            if matches!(ri_type, RestrictInfoType::BaseRelation) {
-                return None;
-            }
+    if const_.is_none() {
+        // the rhs expression is not a Const, so it's some kind of expression
+        // that we'll need to execute during query execution
+        let node = args.get_ptr(1)?;
 
-            // TODO:  this would be for moving towards parameterized plans
-            return Some(Qual::Param {
-                var: lhs?,
+        if is_our_operator {
+            // and it uses our operator, so we directly know how to handle it
+            return Some(Qual::Expr {
+                var,
                 opno: (*opexpr).opno,
-                node: args.get_ptr(1)?,
+                node,
+                is_volatile: pg_sys::contain_volatile_functions(node),
+                expr_state: std::ptr::null_mut(),
             });
-        } else if matches!(ri_type, RestrictInfoType::Join) {
+        } else if (*var).varno as i32 != rti as i32 && matches!(ri_type, RestrictInfoType::Join) {
+            // it doesn't use our operator and comes from a different range table entry,
+            // which likely means its part of a join condition
+            // we choose to just select everything in this situation
             return Some(Qual::All);
         } else {
+            // it doesn't user our operator. we can't handle it
+            // TODO:  this would be an integration point for predicate pushdown -- converting
+            //        postgres operators into ours
             return None;
         }
     }
-    let (lhs, rhs) = (lhs?, rhs?);
 
+    let (lhs, rhs) = (var, const_?);
     if is_our_operator {
-        if (*lhs).varno as i32 != rti as i32 {
-            if matches!(ri_type, RestrictInfoType::Join) {
-                Some(Qual::All)
-            } else {
-                None
-            }
-        } else {
-            Some(Qual::OperatorExpression {
+        // the rhs expression is a Const, so we can use it directly
+
+        if (*lhs).varno as i32 == rti as i32 {
+            // the var comes from this range table entry, so we can use the full expression directly
+            Some(Qual::OpExpr {
                 var: lhs,
                 opno: (*opexpr).opno,
                 val: rhs,
             })
+        } else {
+            // the var comes from a different range table
+            if matches!(ri_type, RestrictInfoType::Join) {
+                // and we're doing a join, so in this case we choose to just select everything
+                Some(Qual::All)
+            } else {
+                // the var comes from a different range table and we're not doing a join (how is that possible?!)
+                // so we don't do anything
+                None
+            }
         }
     } else {
+        // it doesn't user our operator. we can't handle it
+        // TODO:  this would be an integration point for predicate pushdown -- converting
+        //        postgres operators into ours
         None
     }
 }
 
-unsafe fn contains_param(root: *mut pg_sys::Node) -> bool {
+fn contains_param(root: *mut pg_sys::Node) -> bool {
     unsafe extern "C" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
-        if nodecast!(Param, T_Param, node).is_some() {
-            return true;
-        }
-        pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
+        nodecast!(Param, T_Param, node).is_some()
+            || pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
     }
 
-    pg_sys::expression_tree_walker(root, Some(walker), std::ptr::null_mut())
+    if root.is_null() {
+        return false;
+    }
+
+    unsafe { pg_sys::expression_tree_walker(root, Some(walker), std::ptr::null_mut()) }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -426,7 +426,7 @@ unsafe fn opexpr(
             }
         }
     } else {
-        // it doesn't user our operator. we can't handle it
+        // it doesn't use our operator. we can't handle it
         // TODO:  this would be an integration point for predicate pushdown -- converting
         //        postgres operators into ours
         None

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -40,6 +40,7 @@ pub struct PdbScanState {
     pub rti: pg_sys::Index,
 
     pub search_query_input: SearchQueryInput,
+    pub nexprs: usize,
     pub search_reader: Option<SearchIndexReader>,
 
     pub search_results: SearchResults,

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -40,6 +40,7 @@ pub struct PdbScanState {
     pub rti: pg_sys::Index,
 
     pub search_query_input: SearchQueryInput,
+    pub serialized_query: Vec<u8>,
     pub nexprs: usize,
     pub search_reader: Option<SearchIndexReader>,
 

--- a/pg_search/src/query/iter_mut.rs
+++ b/pg_search/src/query/iter_mut.rs
@@ -1,0 +1,63 @@
+use crate::query::SearchQueryInput;
+
+pub struct SearchQueryInputIter<'a> {
+    stack: Vec<&'a mut SearchQueryInput>,
+}
+
+impl<'a> Iterator for SearchQueryInputIter<'a> {
+    type Item = &'a mut SearchQueryInput;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let node = self.stack.pop()?;
+
+            match node {
+                SearchQueryInput::Boolean {
+                    must,
+                    should,
+                    must_not,
+                } => {
+                    self.stack.extend(must_not.iter_mut().rev());
+                    self.stack.extend(should.iter_mut().rev());
+                    self.stack.extend(must.iter_mut().rev());
+                    continue;
+                }
+                SearchQueryInput::Boost { query, .. } => {
+                    self.stack.push(query);
+                    continue;
+                }
+                SearchQueryInput::ConstScore { query, .. } => {
+                    self.stack.push(query);
+                    continue;
+                }
+                SearchQueryInput::DisjunctionMax { disjuncts, .. } => {
+                    self.stack.extend(disjuncts.iter_mut().rev());
+                    continue;
+                }
+                SearchQueryInput::WithIndex { query, .. } => {
+                    self.stack.push(query);
+                    continue;
+                }
+
+                _ => {}
+            }
+
+            return Some(node);
+        }
+    }
+}
+
+impl SearchQueryInput {
+    pub fn iter_mut(&mut self) -> SearchQueryInputIter {
+        SearchQueryInputIter { stack: vec![self] }
+    }
+}
+
+impl<'a> IntoIterator for &'a mut SearchQueryInput {
+    type Item = &'a mut SearchQueryInput;
+    type IntoIter = SearchQueryInputIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -15,7 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+pub mod iter_mut;
 mod range;
+mod solve_expr;
 
 use crate::postgres::utils::convert_pg_date_string;
 use crate::query::range::{Comparison, RangeField};
@@ -24,7 +26,9 @@ use anyhow::Result;
 use core::panic;
 use pgrx::{pg_sys, PgBuiltInOids, PgOid, PostgresType};
 use range::{deserialize_bound, serialize_bound};
-use serde::{Deserialize, Serialize};
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Debug, Formatter};
 use std::{collections::HashMap, ops::Bound};
 use tantivy::DateTime;
 use tantivy::{
@@ -74,6 +78,8 @@ impl AsHumanReadable for OwnedValue {
 #[derive(Debug, PostgresType, Deserialize, Serialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchQueryInput {
+    #[default]
+    Uninitialized,
     All,
     Boolean {
         #[serde(default)]
@@ -100,7 +106,6 @@ pub enum SearchQueryInput {
         disjuncts: Vec<SearchQueryInput>,
         tie_breaker: Option<f32>,
     },
-    #[default]
     Empty,
     Exists {
         field: String,
@@ -256,9 +261,32 @@ pub enum SearchQueryInput {
         oid: pg_sys::Oid,
         query: Box<SearchQueryInput>,
     },
+    PostgresExpression {
+        expr: PostgresExpression,
+        #[serde(skip)]
+        query: Option<Box<SearchQueryInput>>,
+    },
 }
 
 impl SearchQueryInput {
+    pub fn postgres_expression(
+        var: *mut pg_sys::Var,
+        opoid: pg_sys::Oid,
+        node: *mut pg_sys::Node,
+    ) -> Self {
+        assert!(!var.is_null());
+        assert!(!node.is_null());
+        SearchQueryInput::PostgresExpression {
+            expr: PostgresExpression {
+                var: PostgresPointer(var.cast()),
+                opoid,
+                node: PostgresPointer(node.cast()),
+                expr_state: PostgresPointer::<true>(std::ptr::null_mut()),
+            },
+            query: None,
+        }
+    }
+
     pub fn contains_more_like_this(&self) -> bool {
         match self {
             SearchQueryInput::Boolean {
@@ -666,6 +694,7 @@ impl SearchQueryInput {
         searcher: &Searcher,
     ) -> Result<Box<dyn Query>, Box<dyn std::error::Error>> {
         match self {
+            Self::Uninitialized => panic!("this `SearchQueryInput` instance is uninitialized"),
             Self::All => Ok(Box::new(AllQuery)),
             Self::Boolean {
                 must,
@@ -1768,6 +1797,10 @@ impl SearchQueryInput {
             Self::WithIndex { query, .. } => {
                 query.into_tantivy_query(field_lookup, parser, searcher)
             }
+            Self::PostgresExpression { query, .. } => match query {
+                None => panic!("postgres expressions have not been solved"),
+                Some(query) => query.into_tantivy_query(field_lookup, parser, searcher),
+            },
         }
     }
 }
@@ -1926,4 +1959,119 @@ enum QueryError {
            make sure to use column:term pairs, and to capitalize AND/OR."#
     )]
     ParseError(#[source] tantivy::query::QueryParserError, String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PostgresPointer<const ALWAYS_NULL: bool = false>(*mut std::os::raw::c_void);
+
+impl Default for PostgresPointer<true> {
+    fn default() -> Self {
+        PostgresPointer(std::ptr::null_mut())
+    }
+}
+
+impl Serialize for PostgresPointer<false> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0.is_null() {
+            serializer.serialize_none()
+        } else {
+            unsafe {
+                let s = pg_sys::nodeToString(self.0.cast());
+                let cstr = core::ffi::CStr::from_ptr(s)
+                    .to_str()
+                    .map_err(serde::ser::Error::custom)?;
+                let string = cstr.to_owned();
+                pg_sys::pfree(s.cast());
+                serializer.serialize_some(&string)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PostgresPointer<false> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NodeVisitor;
+        impl<'de> Visitor<'de> for NodeVisitor {
+            type Value = PostgresPointer;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                write!(formatter, "a string representing a Postgres node")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                unsafe {
+                    let cstr = std::ffi::CString::new(v).map_err(E::custom)?;
+                    let node = pg_sys::stringToNode(cstr.as_ptr());
+                    Ok(PostgresPointer(node.cast()))
+                }
+            }
+        }
+
+        deserializer.deserialize_option(NodeVisitor)
+    }
+}
+
+impl Serialize for PostgresPointer<true> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_none()
+    }
+}
+
+impl<'de> Deserialize<'de> for PostgresPointer<true> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(PostgresPointer(std::ptr::null_mut()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PostgresExpression {
+    var: PostgresPointer,
+    opoid: pg_sys::Oid,
+    node: PostgresPointer,
+    #[serde(skip)]
+    expr_state: PostgresPointer<true>,
+}
+
+impl PostgresExpression {
+    #[inline]
+    pub fn var(&self) -> *mut pg_sys::Var {
+        unsafe {
+            assert!(pgrx::is_a(self.var.0.cast(), pg_sys::NodeTag::T_Var));
+            self.var.0.cast()
+        }
+    }
+
+    #[inline]
+    pub fn opoid(&self) -> pg_sys::Oid {
+        self.opoid
+    }
+
+    #[inline]
+    pub fn node(&self) -> *mut pg_sys::Node {
+        self.node.0.cast()
+    }
+
+    #[inline]
+    pub fn expr_state(&self) -> *mut pg_sys::ExprState {
+        assert!(
+            !self.expr_state.0.is_null(),
+            "ExprState has not been initialized"
+        );
+        self.expr_state.0.cast()
+    }
 }

--- a/pg_search/src/query/solve_expr.rs
+++ b/pg_search/src/query/solve_expr.rs
@@ -1,0 +1,64 @@
+use crate::api::operator::searchqueryinput_typoid;
+use crate::query::{PostgresExpression, PostgresPointer, SearchQueryInput};
+use pgrx::{pg_sys, FromDatum, PgMemoryContexts};
+
+impl SearchQueryInput {
+    pub fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) -> usize {
+        let mut cnt = 0;
+        for sqi in self {
+            if let SearchQueryInput::PostgresExpression { expr, query } = sqi {
+                *query = None;
+                expr.init(planstate);
+                cnt += 1;
+            }
+        }
+        cnt
+    }
+
+    pub fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext) {
+        assert!(
+            !expr_context.is_null(),
+            "expr_context was never initialized"
+        );
+        unsafe {
+            pg_sys::MemoryContextReset((*expr_context).ecxt_per_tuple_memory);
+
+            PgMemoryContexts::For((*expr_context).ecxt_per_tuple_memory).switch_to(|_| {
+                let sqi_typoid = searchqueryinput_typoid();
+                for sqi in self {
+                    if let SearchQueryInput::PostgresExpression { expr, query } = sqi {
+                        *query = Some(Box::new(
+                            expr.solve(expr_context, sqi_typoid)
+                                .expect("PostgresExpression should not evaluate to NULL"),
+                        ));
+                    }
+                }
+            })
+        }
+    }
+}
+
+impl PostgresExpression {
+    pub fn init(&mut self, planstate: *mut pg_sys::PlanState) {
+        unsafe {
+            let estate = pg_sys::ExecInitExpr(self.node().cast(), planstate);
+            self.expr_state = PostgresPointer(estate.cast())
+        }
+    }
+
+    pub fn solve(
+        &self,
+        expr_context: *mut pg_sys::ExprContext,
+        sqi_typoid: pg_sys::Oid,
+    ) -> Option<SearchQueryInput> {
+        unsafe {
+            assert!(pg_sys::exprType(self.node().cast()) == sqi_typoid);
+
+            let mut is_null = false;
+            let expr_state = self.expr_state();
+
+            let result = pg_sys::ExecEvalExpr(expr_state, expr_context, &mut is_null);
+            SearchQueryInput::from_datum(result, is_null)
+        }
+    }
+}

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -34,6 +34,12 @@ pub fn database() -> Db {
     block_on(async { Db::new().await })
 }
 
+pub fn pg_major_version(conn: &mut PgConnection) -> usize {
+    r#"select (regexp_match(version(), 'PostgreSQL (\d+)'))[1]::int;"#
+        .fetch_one::<(i32,)>(conn)
+        .0 as usize
+}
+
 #[fixture]
 pub fn conn(database: Db) -> PgConnection {
     block_on(async {

--- a/tests/tests/parallel_index_scan.rs
+++ b/tests/tests/parallel_index_scan.rs
@@ -25,9 +25,7 @@ use sqlx::PgConnection;
 
 #[rstest]
 fn index_scan_under_parallel_path(mut conn: PgConnection) {
-    let (major_version,) = r#"select (regexp_match(version(), 'PostgreSQL (\d+)'))[1]::int;"#
-        .fetch_one::<(i32,)>(&mut conn);
-    if major_version < 16 {
+    if pg_major_version(&mut conn) < 16 {
         // the `debug_parallel_query` was added in pg16, so we simply cannot run this test on anything
         // less than pg16
         return;

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -57,7 +57,9 @@ fn parallel_with_subselect(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    "SET debug_parallel_query TO on".execute(&mut conn);
+    if pg_major_version(&mut conn) >= 16 {
+        "SET debug_parallel_query TO on".execute(&mut conn);
+    }
 
     "PREPARE foo AS SELECT count(*) FROM test WHERE value @@@ (select $1);".execute(&mut conn);
     let (count,) = "EXECUTE foo('contains')".fetch_one::<(i64,)>(&mut conn);
@@ -96,7 +98,10 @@ fn parallel_function_with_agg_subselect(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    "SET debug_parallel_query TO on".execute(&mut conn);
+    if pg_major_version(&mut conn) >= 16 {
+        "SET debug_parallel_query TO on".execute(&mut conn);
+    }
+
     "PREPARE foo AS SELECT id FROM test WHERE id @@@ paradedb.term_set((select array_agg(paradedb.term('value', token)) from paradedb.tokenize(paradedb.tokenizer('default'), $1))) ORDER BY id;".execute(&mut conn);
 
     let results = "EXECUTE foo('no matches')".fetch::<(i64,)>(&mut conn);

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -1,0 +1,122 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use serde_json::Value;
+use sqlx::PgConnection;
+
+#[rstest]
+fn self_referencing_var(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS test;
+    CREATE TABLE test (
+        id bigint NOT NULL PRIMARY KEY,
+        value text
+    );
+
+    INSERT INTO test (id, value) SELECT x, md5(x::text) FROM generate_series(1, 100) x;
+    UPDATE test SET value = 'value contains id = ' || id WHERE id BETWEEN 10 and 20;
+
+    CREATE INDEX idxtest ON test USING bm25 (id, value) WITH (key_field='id');
+    "#
+    .execute(&mut conn);
+
+    let results =
+        "SELECT id FROM test WHERE value @@@ paradedb.with_index('idxtest', paradedb.term('value', id::text)) ORDER BY id;".fetch::<(i64,)>(&mut conn);
+    assert_eq!(
+        results,
+        vec![
+            (10,),
+            (11,),
+            (12,),
+            (13,),
+            (14,),
+            (15,),
+            (16,),
+            (17,),
+            (18,),
+            (19,),
+            (20,),
+        ]
+    );
+}
+
+#[rstest]
+fn parallel_with_subselect(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS test;
+    CREATE TABLE test (
+        id bigint NOT NULL PRIMARY KEY,
+        value text
+    );
+
+    INSERT INTO test (id, value) SELECT x, md5(x::text) FROM generate_series(1, 100) x;
+    UPDATE test SET value = 'value contains id = ' || id WHERE id BETWEEN 10 and 20;
+
+    CREATE INDEX idxtest ON test USING bm25 (id, value) WITH (key_field='id');
+    "#
+    .execute(&mut conn);
+
+    "SET debug_parallel_query TO on".execute(&mut conn);
+
+    "PREPARE foo AS SELECT count(*) FROM test WHERE value @@@ (select $1);".execute(&mut conn);
+    let (count,) = "EXECUTE foo('contains')".fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 11);
+
+    // next 4 executions use one plan, and the 5th shouldn't change
+    for _ in 0..5 {
+        let (plan,) = "EXPLAIN (ANALYZE, FORMAT JSON) EXECUTE foo('contains');"
+            .fetch_one::<(Value,)>(&mut conn);
+        eprintln!("{plan:#?}");
+        let plan = plan
+            .pointer("/0/Plan/Plans/1/Plans/0")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        pretty_assertions::assert_eq!(
+            plan.get("Custom Plan Provider"),
+            Some(&Value::String(String::from("ParadeDB Scan")))
+        );
+    }
+}
+
+#[rstest]
+fn parallel_function_with_agg_subselect(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS test;
+    CREATE TABLE test (
+        id bigint NOT NULL PRIMARY KEY,
+        value text
+    );
+
+    INSERT INTO test (id, value) SELECT x, md5(x::text) FROM generate_series(1, 100) x;
+    UPDATE test SET value = 'value contains id = ' || id WHERE id BETWEEN 10 and 20;
+
+    CREATE INDEX idxtest ON test USING bm25 (id, value) WITH (key_field='id');
+    "#
+    .execute(&mut conn);
+
+    "SET debug_parallel_query TO on".execute(&mut conn);
+    "PREPARE foo AS SELECT id FROM test WHERE id @@@ paradedb.term_set((select array_agg(paradedb.term('value', token)) from paradedb.tokenize(paradedb.tokenizer('default'), $1))) ORDER BY id;".execute(&mut conn);
+
+    let results = "EXECUTE foo('no matches')".fetch::<(i64,)>(&mut conn);
+    assert_eq!(results.len(), 0);
+
+    let results = "EXECUTE foo('value contains id')".fetch::<(i64,)>(&mut conn);
+    assert_eq!(
+        results,
+        vec![
+            (10,),
+            (11,),
+            (12,),
+            (13,),
+            (14,),
+            (15,),
+            (16,),
+            (17,),
+            (18,),
+            (19,),
+            (20,),
+        ]
+    );
+}

--- a/tests/tests/query_edge_cases.rs
+++ b/tests/tests/query_edge_cases.rs
@@ -23,7 +23,10 @@ fn query_empty_table(mut conn: PgConnection) {
         "SELECT count(*) FROM test_table WHERE value @@@ 'beer';".fetch_one::<(i64,)>(&mut conn);
     assert_eq!(count, 0);
 
-    "SET max_parallel_workers = 8; SET debug_parallel_query = true;".execute(&mut conn);
+    "SET max_parallel_workers = 8;".execute(&mut conn);
+    if pg_major_version(&mut conn) >= 16 {
+        "SET debug_parallel_query TO on".execute(&mut conn);
+    }
     let (count,) =
         "SELECT count(*) FROM test_table WHERE value @@@ 'beer';".fetch_one::<(i64,)>(&mut conn);
     assert_eq!(count, 0);

--- a/tests/tests/query_edge_cases.rs
+++ b/tests/tests/query_edge_cases.rs
@@ -5,6 +5,31 @@ use rstest::*;
 use sqlx::PgConnection;
 
 #[rstest]
+fn query_empty_table(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS test_table;
+    CREATE TABLE test_table (
+        id SERIAL PRIMARY KEY,
+        value text[]
+    );
+
+    CREATE INDEX test_index ON test_table
+    USING bm25 (id, value) WITH (key_field='id', text_fields='{"value": {}}');
+    "#
+    .execute(&mut conn);
+
+    "SET max_parallel_workers = 0;".execute(&mut conn);
+    let (count,) =
+        "SELECT count(*) FROM test_table WHERE value @@@ 'beer';".fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 0);
+
+    "SET max_parallel_workers = 8; SET debug_parallel_query = true;".execute(&mut conn);
+    let (count,) =
+        "SELECT count(*) FROM test_table WHERE value @@@ 'beer';".fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 0);
+}
+
+#[rstest]
 fn unary_not_issue2141(mut conn: PgConnection) {
     r#"
     CREATE TABLE test_table (


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2061

## What

This adds improved support for parameterized queries/plans to our (Parallel) Custom Scan implementation.

## Why

In order for our Custom Scan to solve more query types directly, parameterized plan support is essential.  Parameterized plans can come from, at least, the PREPARE statement along with queries that use subselects.

## How

Lots of tracing through the Postgres sources to understand how query parameters work!

## Tests

Existing tests all pass, including the ones around joins,  Additionally, a new `tests/parameterized_queries.rs` has been added that exercises the general cases this PR was meant to solve.