### PR TITLE
fix: issue #2187 - properly support recursive executor calls

### DIFF
--- a/pg_search/src/postgres/fake_aminsertcleanup.rs
+++ b/pg_search/src/postgres/fake_aminsertcleanup.rs
@@ -1,37 +1,83 @@
-//! This module fakes the behavior of pg17+'s `aminsertcleanup` by hooking the executor's "finish"
-//! hook along with the "process utility hook".
+// Copyright (c) 2023-2025 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! This module fakes the behavior of pg17+'s `aminsertcleanup` by hooking the executor's "run",
+//! "finish", and "process utility" hooks.
 #![allow(static_mut_refs)]
 
 use crate::postgres::insert::{paradedb_aminsertcleanup, InsertState};
+use pgrx::pg_sys::{uint64, QueryDesc, ScanDirection};
 use pgrx::{pg_guard, pg_sys};
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::Entry;
 
-static mut PENDING_TANTIVY_COMMIT: Option<InsertState> = None;
-
-#[inline]
-pub unsafe fn get_pending_insert_state() -> Option<&'static mut InsertState> {
-    PENDING_TANTIVY_COMMIT.as_mut()
+#[derive(Default)]
+struct ExecutorRunEntry {
+    active: FxHashMap<pg_sys::Oid, InsertState>,
 }
 
+static mut EXECUTOR_RUN_STACK: Vec<Option<ExecutorRunEntry>> = Vec::new();
+
 #[inline]
-pub unsafe fn set_pending_insert_state(insert_state: InsertState) {
-    assert!(
-        PENDING_TANTIVY_COMMIT.is_none(),
-        "already have a pending tantivy commit state"
+pub unsafe fn get_insert_state(indexrelid: pg_sys::Oid) -> Option<&'static mut InsertState> {
+    let entry = EXECUTOR_RUN_STACK.last_mut().expect(
+        "get_insert_state: ExecutorRunEntry should have already been pushed onto the stack",
     );
-    PENDING_TANTIVY_COMMIT = Some(insert_state);
+    match entry {
+        Some(state) => state.active.get_mut(&indexrelid),
+        None => unreachable!("get_insert_state: tried to get the InsertState for relation {indexrelid:?} but it was never pushed"),
+    }
 }
 
 #[inline]
-pub unsafe fn reset_pending_insert_state() {
-    PENDING_TANTIVY_COMMIT = None;
+pub unsafe fn push_insert_state(insert_state: InsertState) {
+    if EXECUTOR_RUN_STACK.is_empty() {
+        pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, || {
+            EXECUTOR_RUN_STACK.clear();
+        });
+    }
+
+    let entry = EXECUTOR_RUN_STACK
+        .last_mut()
+        .expect(
+            "push_insert_state: ExecutorRunEntry should have already been pushed onto the stack",
+        )
+        .get_or_insert_default();
+    match entry.active.entry(insert_state.indexrelid) {
+        Entry::Vacant(slot) => slot.insert(insert_state),
+
+        // this shouldn't ever happen unless there's some logic bug between here and `postgres/insert.rs`
+        Entry::Occupied(_) => unreachable!(
+            "already have an ExecutorRunEntry for index {:?}",
+            insert_state.indexrelid
+        ),
+    };
 }
 
 pub unsafe fn register() {
     static mut PREV_PROCESS_UTILITY_HOOK: pg_sys::ProcessUtility_hook_type = None;
+    static mut PREV_EXECUTOR_RUN_HOOK: pg_sys::ExecutorRun_hook_type = None;
     static mut PREV_EXECUTOR_FINISH_HOOK: pg_sys::ExecutorFinish_hook_type = None;
 
     PREV_PROCESS_UTILITY_HOOK = pg_sys::ProcessUtility_hook;
     pg_sys::ProcessUtility_hook = Some(process_utility_hook);
+
+    PREV_EXECUTOR_RUN_HOOK = pg_sys::ExecutorRun_hook;
+    pg_sys::ExecutorRun_hook = Some(executor_run_hook);
 
     PREV_EXECUTOR_FINISH_HOOK = pg_sys::ExecutorFinish_hook;
     pg_sys::ExecutorFinish_hook = Some(executor_finish_hook);
@@ -50,13 +96,14 @@ pub unsafe fn register() {
         dest: *mut pg_sys::DestReceiver,
         qc: *mut pg_sys::QueryCompletion,
     ) {
+        EXECUTOR_RUN_STACK.push(None);
         if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
             prev_hook(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
         } else {
             pg_sys::standard_ProcessUtility(pstmt, query_string, read_only_tree, context, params, query_env, dest, qc)
         }
 
-        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
+        aminsertcleanup_stack();
     }
 
     #[cfg(feature = "pg13")]
@@ -72,23 +119,44 @@ pub unsafe fn register() {
         dest: *mut pg_sys::DestReceiver,
         qc: *mut pg_sys::QueryCompletion,
     ) {
+        EXECUTOR_RUN_STACK.push(None);
         if let Some(prev_hook) = PREV_PROCESS_UTILITY_HOOK {
             prev_hook(pstmt, query_string, context, params, query_env, dest, qc);
         } else {
             pg_sys::standard_ProcessUtility(pstmt, query_string, context, params, query_env, dest, qc)
         }
 
-        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
+        aminsertcleanup_stack();
+    }
+
+    #[pg_guard]
+    unsafe extern "C" fn executor_run_hook(
+        query_desc: *mut QueryDesc,
+        direction: ScanDirection::Type,
+        count: uint64,
+        execute_once: bool,
+    ) {
+        EXECUTOR_RUN_STACK.push(None);
+        pg_sys::standard_ExecutorRun(query_desc, direction, count, execute_once);
     }
 
     #[pg_guard]
     unsafe extern "C" fn executor_finish_hook(query_desc: *mut pg_sys::QueryDesc) {
-        paradedb_aminsertcleanup(PENDING_TANTIVY_COMMIT.take().and_then(|state| state.writer));
-
+        aminsertcleanup_stack();
         if let Some(prev_hook) = PREV_EXECUTOR_FINISH_HOOK {
             prev_hook(query_desc);
         } else {
             pg_sys::standard_ExecutorFinish(query_desc);
         }
+    }
+
+    unsafe fn aminsertcleanup_stack() -> Option<()> {
+        let entry = EXECUTOR_RUN_STACK
+            .pop()
+            .expect("should have an ExecutorRuntimeState entry")?;
+        for (_, insert_state) in entry.active {
+            paradedb_aminsertcleanup(insert_state.writer);
+        }
+        None
     }
 }

--- a/tests/tests/executor_hooks.rs
+++ b/tests/tests/executor_hooks.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2023-2025 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn multiple_index_changes_in_same_xact(mut conn: PgConnection) {
+    r#"
+        CREATE TABLE a (id int, value text);
+        CREATE TABLE b (id int, value text);
+        CREATE TABLE c (id int, value text);
+        CREATE INDEX idxa ON a USING bm25(id, value) WITH (key_field='id');
+        CREATE INDEX idxb ON b USING bm25(id, value) WITH (key_field='id');
+        CREATE INDEX idxc ON c USING bm25(id, value) WITH (key_field='id');
+        INSERT INTO a (id, value) VALUES (1, 'a');
+        INSERT INTO b (id, value) VALUES (1, 'b');
+        INSERT INTO c (id, value) VALUES (1, 'c');
+    "#
+    .execute(&mut conn);
+
+    let results = r#"
+        SELECT * FROM a WHERE value @@@ 'a'
+           UNION
+        SELECT * FROM b WHERE value @@@ 'b'
+           UNION
+        SELECT * FROM c WHERE value @@@ 'c'
+        ORDER BY 1, 2;
+    "#
+    .fetch::<(i32, String)>(&mut conn);
+    assert_eq!(
+        results,
+        vec![
+            (1, "a".to_string()),
+            (1, "b".to_string()),
+            (1, "c".to_string()),
+        ]
+    )
+}
+
+#[rstest]
+fn issue2187_executor_hooks(mut conn: PgConnection) {
+    r#"
+        DROP TABLE IF EXISTS test_table;
+        CREATE TABLE test_table
+        (
+            id           UUID NOT NULL DEFAULT gen_random_uuid(),
+            email        TEXT NOT NULL DEFAULT (
+                'user' || floor(random() * 150)::TEXT || '@example.com'
+                ),
+            is_processed BOOLEAN       DEFAULT FALSE,
+            PRIMARY KEY (id, email)
+        ) PARTITION BY HASH (email);
+
+
+        DO
+        $$
+            DECLARE
+                i INT;
+            BEGIN
+                FOR i IN 0..15
+                    LOOP
+                        EXECUTE format(
+                                'CREATE TABLE test_table_p%s PARTITION OF test_table
+                                 FOR VALUES WITH (MODULUS 16, REMAINDER %s);', i, i
+                                );
+                    END LOOP;
+            END
+        $$;
+
+
+        INSERT INTO test_table (is_processed)
+        SELECT FALSE
+        FROM generate_series(1, 100000);
+
+
+        DO
+        $$
+            DECLARE
+                i          INT;
+                table_name TEXT;
+                index_name TEXT;
+            BEGIN
+                FOR i IN 0..15
+                    LOOP
+                        table_name := format('test_table_p%s', i);
+                        index_name := format('test_table_search_p%s', i);
+
+                        EXECUTE format(
+                                'CREATE INDEX %I ON %I
+                                 USING bm25 (id, is_processed)
+                                 WITH (
+                                     key_field = ''id'',
+                                     boolean_fields = ''{
+                                         "is_processed": {
+                                             "fast": true,
+                                             "indexed": true
+                                         }
+                                     }''
+                                 )', index_name, table_name);
+                    END LOOP;
+            END
+        $$;
+
+
+        DO
+        $$
+            DECLARE
+                batch_size INT := 1000;
+                uuid_batch UUID[];
+            BEGIN
+                LOOP
+                    SELECT ARRAY_AGG(id)
+                    INTO uuid_batch
+                    FROM (SELECT id
+                          FROM test_table
+                          WHERE is_processed = FALSE
+                          LIMIT batch_size) sub;
+
+                    IF uuid_batch IS NULL OR array_length(uuid_batch, 1) = 0 THEN
+                        EXIT;
+                    END IF;
+
+                    UPDATE test_table
+                    SET is_processed = TRUE
+                    WHERE id = ANY (uuid_batch);
+                END LOOP;
+            END
+        $$;
+    "#
+    .execute(&mut conn);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2187

## What

For Postgres versions before v17 we have to fake a system similar to the `aminsertcleanup()` function by hooking the executor.

Our efforts to do that were not nearly complete enough and didn't account for the fact the postgres executor is reentrant.

## Why

## How

Now we hook the ExecutorRun_hook along with the ExecutorFinish_hook and push/pop a stack a of our own state tracking information so we know what indexes have been modified by `aminsert()` at that level of the executor.  This allows us to do the cleanup work necessary for that level.

## Tests

Existing tests pass, and a few new ones were added, including the entire re-create from #2187.