### PR TITLE
feat: make memory/parallelism GUCs USERSET instead of SUSET

### DIFF
--- a/docs/documentation/configuration/index.mdx
+++ b/docs/documentation/configuration/index.mdx
@@ -52,8 +52,6 @@ SHOW log_directory;
 
 ### Indexing Threads
 
-<Note>This setting requires superuser privileges.</Note>
-
 `paradedb.create_index_parallelism` sets the number of threads used during `CREATE INDEX`. The default is `0`, which
 automatically detects the "available parallelism" of the host computer.
 

--- a/docs/documentation/configuration/write.mdx
+++ b/docs/documentation/configuration/write.mdx
@@ -6,8 +6,6 @@ Several settings can be used to tune the throughput of `INSERT`/`UPDATE`/`COPY` 
 
 ## Statement Parallelism
 
-<Note>This setting requires superuser privileges.</Note>
-
 `paradedb.statement_parallelism` controls the number of indexing threads used during `INSERT/UPDATE/COPY`. The default is `0`, which automatically detects the
 "available parallelism" of the host computer.
 
@@ -19,8 +17,6 @@ SET paradedb.statement_parallelism = 1;
 ```
 
 ## Statement Memory Budget
-
-<Note>This setting requires superuser privileges.</Note>
 
 `paradedb.statement_memory_budget` defaults to `1024MB`. It sets the amount of memory to dedicate per indexing thread before the index segment needs to be
 written to disk. The value is measured in megabytes. In terms of raw indexing performance, larger is generally better.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -124,11 +124,11 @@ pub fn init() {
     GucRegistry::define_int_guc(
         "paradedb.create_index_memory_budget",
         "The amount of memory to allocate to 1 thread during indexing",
-        "Default is `maintenance_work_mem`",
+        "Default is `1GB`, which is allocated to each thread defined by `paradedb.create_index_parallelism`",
         &CREATE_INDEX_MEMORY_BUDGET,
         0,
         i32::MAX,
-        GucContext::Suset,
+        GucContext::Userset,
         GucFlags::UNIT_MB,
     );
 
@@ -139,18 +139,18 @@ pub fn init() {
         &STATEMENT_PARALLELISM,
         0,
         std::thread::available_parallelism().expect("your computer should have at least one core").get().try_into().expect("your computer has too many cores"),
-        GucContext::Suset,
+        GucContext::Userset,
         GucFlags::default(),
     );
 
     GucRegistry::define_int_guc(
         "paradedb.statement_memory_budget",
         "The amount of memory to allocate to 1 thread during an INSERT/UPDATE/COPY statement",
-        "Default is `maintenance_work_mem`",
+        "Default is `1GB`, which is allocated to each thread defined by `paradedb.statement_parallelism`",
         &STATEMENT_MEMORY_BUDGET,
         0,
         i32::MAX,
-        GucContext::Suset,
+        GucContext::Userset,
         GucFlags::UNIT_MB,
     );
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2194

## What

This changes the `paradedb.create_index_memory_budget/parallelism` and `paradedb.statement_memory_budget/parallelism` GUCS to be USERSET so that they can be changed by regular users.

## Why

Perhaps in production environments it's unrealistic to require superuser privileges to change the variables.

## How

## Tests

No additional tests necessary.