### PR TITLE
feat: basic query predicate pushdown

### DIFF
--- a/pg_search/sql/pg_search--0.15.2--0.15.3.sql
+++ b/pg_search/sql/pg_search--0.15.2--0.15.3.sql
@@ -9,3 +9,16 @@ CREATE  FUNCTION "with_index"(
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'with_index_wrapper';
+
+/* <begin connected objects> */
+-- pg_search/src/api/index.rs:549
+-- pg_search::api::index::term_with_operator
+CREATE  FUNCTION "term_with_operator"(
+    "field" FieldName, /* pg_search::api::index::FieldName */
+    "operator" TEXT, /* alloc::string::String */
+    "value" anyelement /* pgrx::datum::anyelement::AnyElement */
+) RETURNS SearchQueryInput /* core::result::Result<pg_search::query::SearchQueryInput, anyhow::Error> */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'term_with_operator_wrapper';
+/* </end connected objects> */

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -866,6 +866,12 @@ impl From<String> for FieldName {
     }
 }
 
+impl From<&str> for FieldName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
 impl InOutFuncs for FieldName {
     fn input(input: &CStr) -> Self
     where

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -580,7 +580,7 @@ pub unsafe fn term_with_operator(
         pg_sys::FLOAT4OID => make_query!(operator, field, term_f32, f32, value, false),
         pg_sys::FLOAT8OID => make_query!(operator, field, term_f64, f64, value, false),
         pg_sys::BOOLOID => make_query!(operator, field, term_bool, bool, value, false),
-        pg_sys::NUMERICOID => make_query!(operator, field, term_numeric, AnyNumeric, value, false),
+        pg_sys::NUMERICOID => make_query!(operator, field, numeric, AnyNumeric, value, false),
         pg_sys::UUIDOID => make_query!(operator, field, uuid, pgrx::datum::Uuid, value, false),
 
         pg_sys::DATEOID => make_query!(operator, field, date, pgrx::datum::Date, value, true),
@@ -750,7 +750,6 @@ term_fn!(term_i32, i32);
 term_fn!(term_i64, i64);
 term_fn!(term_f32, f32);
 term_fn!(term_f64, f64);
-term_fn!(term_numeric, AnyNumeric);
 term_fn!(term_bool, bool);
 term_fn!(date, pgrx::datum::Date);
 term_fn!(time, pgrx::datum::Time);

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -59,7 +59,7 @@ unsafe impl SqlTranslatable for ReturnedNodePointer {
     }
 }
 
-fn parse_with_field_procoid() -> pg_sys::Oid {
+pub fn parse_with_field_procoid() -> pg_sys::Oid {
     unsafe {
         direct_function_call::<pg_sys::Oid>(
             pg_sys::regprocedurein,
@@ -70,7 +70,7 @@ fn parse_with_field_procoid() -> pg_sys::Oid {
     }
 }
 
-fn anyelement_query_input_procoid() -> pg_sys::Oid {
+pub fn anyelement_query_input_procoid() -> pg_sys::Oid {
     unsafe {
         direct_function_call::<pg_sys::Oid>(
             pg_sys::regprocedurein,

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -203,15 +203,9 @@ pub fn query_input_restrict(
             let (heaprelid, _, _) = find_var_relation(var, info);
             let indexrel = locate_bm25_index(heaprelid)?;
 
-            // In case a sequential scan gets triggered, we need a way to pass the index oid
-            // to the scan function. It otherwise will not know which index to use.
-            let search_query_input = SearchQueryInput::WithIndex {
-                oid: indexrel.oid(),
-                query: Box::new(SearchQueryInput::from_datum(
-                    (*const_).constvalue,
-                    (*const_).constisnull,
-                )?),
-            };
+            // create the search query from the rhs Const node
+            let search_query_input =
+                SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
 
             estimate_selectivity(&indexrel, &search_query_input)
         }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -20,6 +20,7 @@ mod exec_methods;
 pub mod parallel;
 mod privdat;
 mod projections;
+mod pushdown;
 mod qual_inspect;
 mod scan_state;
 mod solve_expr;
@@ -160,10 +161,12 @@ impl CustomScan for PdbScan {
             // look for quals we can support
             //
             if let Some(quals) = extract_quals(
+                root,
                 rti,
                 restrict_info.as_ptr().cast(),
                 anyelement_query_input_opoid(),
                 ri_type,
+                &schema,
             ) {
                 let has_expressions = quals.contains_exprs();
                 let selectivity = if let Some(limit) = limit {

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -160,14 +160,26 @@ impl CustomScan for PdbScan {
             //
             // look for quals we can support
             //
-            if let Some(quals) = extract_quals(
+            let mut uses_our_operator = false;
+            let quals = extract_quals(
                 root,
                 rti,
                 restrict_info.as_ptr().cast(),
                 anyelement_query_input_opoid(),
                 ri_type,
                 &schema,
-            ) {
+                &mut uses_our_operator,
+            );
+
+            if !uses_our_operator {
+                // for now, we're not going to submit our custom scan for queries that don't also
+                // use our `@@@` operator.  Perhaps in the future we can do this, but we don't want to
+                // circumvent Postgres' other possible plans that might do index scans over a btree
+                // index or something
+                return None;
+            }
+
+            if let Some(quals) = quals {
                 let has_expressions = quals.contains_exprs();
                 let selectivity = if let Some(limit) = limit {
                     // use the limit

--- a/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
@@ -1,0 +1,200 @@
+// Copyright (c) 2023-2025 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::api::index::{fieldname_typoid, FieldName};
+use crate::api::operator::{attname_from_var, parse_with_field_procoid, searchqueryinput_typoid};
+use crate::nodecast;
+use crate::postgres::customscan::pdbscan::qual_inspect::Qual;
+use crate::schema::{SearchFieldName, SearchIndexSchema};
+use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
+use std::ffi::CString;
+
+macro_rules! pushdown {
+    ($attname:expr, $opexpr:ident, $pg_opsig:expr, $parse_operator:expr, $rhs:ident) => {
+        let opexpr: *mut pg_sys::OpExpr = $opexpr;
+        let pg_opoid: pg_sys::Oid = opoid(&$pg_opsig);
+
+        if (*opexpr).opno == pg_opoid {
+            let funcexpr = make_opexpr($attname, $opexpr, $parse_operator, $rhs);
+
+            if !is_complex(funcexpr.cast()) {
+                return Some(Qual::PushdownExpr { funcexpr });
+            } else {
+                return Some(Qual::Expr {
+                    node: funcexpr.cast(),
+                    expr_state: std::ptr::null_mut(),
+                });
+            }
+        }
+    };
+}
+
+/// Take a Postgres [`pg_sys::OpExpr`] pointer that is **not** one of our `@@@` operator, and try
+/// to convert it into one that is.
+///
+/// Returns `Some(Qual)` if we were able to convert it, `None` if not.
+#[rustfmt::skip]
+pub unsafe fn try_pushdown(
+    root: *mut pg_sys::PlannerInfo,
+    opexpr: *mut pg_sys::OpExpr,
+    schema: &SearchIndexSchema
+) -> Option<Qual> {
+    let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
+    let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
+    let rhs = args.get_ptr(1)?;
+
+    let (typeoid, attname) = attname_from_var(root, var);
+    let attname = attname?;
+
+    let _search_field = schema.get_search_field(&SearchFieldName(attname.clone()))?;
+
+    const OPERATORS:[&str; 6] = ["=", ">", "<", ">=", "<=", "<>"];
+    const TYPE_PAIRS:&[[&str;2]] = &[
+        // integers
+        ["int2", "int2"],
+        ["int4", "int4"],
+        ["int8", "int8"],
+        ["int2", "int4"],
+        ["int2", "int8"],
+        ["int4", "int8"],
+    
+        // floats
+        ["float4", "float4"],
+        ["float8", "float8"],
+        ["float4", "float8"],
+    
+        // boolean
+        ["boolean", "boolean"],
+    ];
+    
+    for o in OPERATORS {
+        for [l, r] in TYPE_PAIRS {
+            pushdown!(&attname, opexpr, format!("{o}({l}, {r})"), o, rhs);
+
+            // they can be swapped too
+            if l != r { pushdown!(&attname, opexpr, format!("{o}({r}, {l})"), o, rhs); }
+        }
+    }
+
+    None
+}
+
+unsafe fn opoid(signature: &str) -> pg_sys::Oid {
+    direct_function_call::<pg_sys::Oid>(
+        pg_sys::regoperatorin,
+        &[CString::new(signature).into_datum()],
+    )
+    .expect("should be able to lookup operator signature")
+}
+
+unsafe fn textanycat_procid() -> pg_sys::Oid {
+    direct_function_call::<pg_sys::Oid>(pg_sys::regprocin, &[c"pg_catalog.textanycat".into_datum()])
+        .expect("could not lookup the `pg_catalog.textanycat` function")
+}
+
+unsafe fn make_opexpr(
+    attname: &str,
+    orig_opexor: *mut pg_sys::OpExpr,
+    parse_operator: &str,
+    value: *mut pg_sys::Node,
+) -> *mut pg_sys::FuncExpr {
+    let fieldname_arg = pg_sys::makeConst(
+        fieldname_typoid(),
+        -1,
+        pg_sys::InvalidOid,
+        -1,
+        FieldName::from(attname).into_datum().unwrap(),
+        false,
+        false,
+    );
+
+    let paradedb_funcexpr: *mut pg_sys::FuncExpr =
+        pg_sys::palloc0(size_of::<pg_sys::FuncExpr>()).cast();
+    (*paradedb_funcexpr).xpr.type_ = pg_sys::NodeTag::T_FuncExpr;
+    (*paradedb_funcexpr).funcid = parse_with_field_procoid();
+    (*paradedb_funcexpr).funcresulttype = searchqueryinput_typoid();
+    (*paradedb_funcexpr).funcretset = false;
+    (*paradedb_funcexpr).funcvariadic = false;
+    (*paradedb_funcexpr).funcformat = pg_sys::CoercionForm::COERCE_EXPLICIT_CALL;
+    (*paradedb_funcexpr).funccollid = pg_sys::InvalidOid;
+    (*paradedb_funcexpr).inputcollid = (*orig_opexor).inputcollid;
+    (*paradedb_funcexpr).location = (*orig_opexor).location;
+    (*paradedb_funcexpr).args = {
+        // the caller gives us a `parse_operator` like "=" or ">", or "<=" and we want to concatenate
+        // that (what will become) text literal with whatever the original user's `value` expression
+        // was.  That happens through injecting a call to Postgres' `textanycat()` function, which
+        // we build here
+        let textconcat_func = pg_sys::makeFuncExpr(
+            textanycat_procid(),
+            pg_sys::TEXTOID,
+            {
+                let mut args = PgList::<pg_sys::Node>::new();
+                args.push(make_string_const(parse_operator, (*orig_opexor).location).cast());
+                args.push(value);
+                args.into_pg()
+            },
+            pg_sys::DEFAULT_COLLATION_OID,
+            pg_sys::DEFAULT_COLLATION_OID,
+            pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
+        );
+
+        let mut args = PgList::<pg_sys::Node>::new();
+        args.push(fieldname_arg.cast());
+        args.push(textconcat_func.cast());
+        args.push(pg_sys::makeBoolConst(false, false)); // "lenient" argument
+        args.push(pg_sys::makeBoolConst(false, false)); // "conjunction_mode" argument
+        args.into_pg()
+    };
+
+    paradedb_funcexpr
+}
+
+fn is_complex(root: *mut pg_sys::Node) -> bool {
+    unsafe extern "C" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
+        nodecast!(Var, T_Var, node).is_some()
+            || nodecast!(Param, T_Param, node).is_some()
+            || pg_sys::contain_volatile_functions(node)
+            || pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
+    }
+
+    if root.is_null() {
+        return false;
+    }
+
+    unsafe {
+        nodecast!(Var, T_Var, root).is_some()
+            || nodecast!(Param, T_Param, root).is_some()
+            || pg_sys::contain_volatile_functions(root)
+            || pg_sys::expression_tree_walker(root, Some(walker), std::ptr::null_mut())
+    }
+}
+
+unsafe fn make_string_const(str: &str, location: i32) -> *mut pg_sys::Const {
+    let const_: *mut pg_sys::Const = pg_sys::palloc0(size_of::<pg_sys::Const>()).cast();
+
+    (*const_).xpr.type_ = pg_sys::NodeTag::T_Const;
+    (*const_).constvalue = str.into_datum().unwrap();
+    (*const_).constisnull = false;
+    (*const_).constcollid = pg_sys::DEFAULT_COLLATION_OID;
+    (*const_).constbyval = false;
+    (*const_).consttype = pg_sys::TEXTOID;
+    (*const_).constlen = -1;
+    (*const_).consttypmod = -1;
+    (*const_).location = location;
+
+    const_
+}

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -999,39 +999,13 @@ impl SearchQueryInput {
                 lenient,
                 conjunction_mode,
             } => {
-                if query_string.starts_with("<>") {
-                    // rewrite not equals into a boolean must_not
-                    let query_string = query_string.trim_start_matches("<>");
-                    let query_string = format!("{field}:({query_string})");
-                    Self::Boolean {
-                        must: vec![Self::All],
-                        should: vec![],
-                        must_not: vec![Self::Parse {
-                            query_string,
-                            lenient,
-                            conjunction_mode,
-                        }],
-                    }
-                    .into_tantivy_query(field_lookup, parser, searcher)
-                } else if query_string.starts_with("=") {
-                    // a query_string that starts with `=` just needs to use `:` without the equal sign
-                    let query_string = query_string.trim_start_matches("=");
-                    let query_string = format!("{field}:({query_string})");
-                    Self::Parse {
-                        query_string,
-                        lenient,
-                        conjunction_mode,
-                    }
-                    .into_tantivy_query(field_lookup, parser, searcher)
-                } else {
-                    let query_string = format!("{field}:({query_string})");
-                    Self::Parse {
-                        query_string,
-                        lenient,
-                        conjunction_mode,
-                    }
-                    .into_tantivy_query(field_lookup, parser, searcher)
+                let query_string = format!("{field}:({query_string})");
+                Self::Parse {
+                    query_string,
+                    lenient,
+                    conjunction_mode,
                 }
+                .into_tantivy_query(field_lookup, parser, searcher)
             }
             Self::Phrase {
                 field,

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -37,6 +37,7 @@ use tokenizers::{SearchNormalizer, SearchTokenizer};
 use crate::postgres::index::get_fields;
 use crate::query::AsFieldType;
 pub use anyenum::AnyEnum;
+use tokenizers::manager::SearchTokenizerFilters;
 
 /// The id of a field, stored in the index.
 #[derive(Debug, Clone, Display, From, AsRef, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -676,6 +677,27 @@ pub struct SearchField {
     pub config: SearchFieldConfig,
     /// Field type
     pub type_: SearchFieldType,
+}
+
+impl SearchField {
+    pub fn is_text(&self) -> bool {
+        matches!(self.type_, SearchFieldType::Text)
+    }
+
+    pub fn is_raw(&self) -> bool {
+        matches!(
+            self.config,
+            SearchFieldConfig::Text {
+                tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters {
+                    remove_long: None,
+                    lowercase: None,
+                    stemmer: None
+                }),
+                normalizer: SearchNormalizer::Raw,
+                ..
+            }
+        )
+    }
 }
 
 impl From<&SearchField> for Field {

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -36,9 +36,9 @@ use tantivy::tokenizer::{
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 pub struct SearchTokenizerFilters {
-    remove_long: Option<usize>,
-    lowercase: Option<bool>,
-    stemmer: Option<Language>,
+    pub remove_long: Option<usize>,
+    pub lowercase: Option<bool>,
+    pub stemmer: Option<Language>,
 }
 
 impl SearchTokenizerFilters {


### PR DESCRIPTION
TODO items:

 - [ ] Unit tests for all operator/type combinations supported
 - [ ] Specialized support for allowing the `paradedb.score()` function in the WHERE clause (#2038)
 - [ ] Should we support the SQL `IN (x, y, z)` and `BETWEEN start AND end` clauses?

# Ticket(s) Closed

- Closes #

## What

This implements some basic query predicate pushdown, supporting the `=, <, >, <=, >=, <>` operators for a number of the core data types we can index.

## Why

Pushing as much of the query as possible down into tantivy can drastically improve query performance.

## How

## Tests

None yet -- this is a big TODO for this PR.