### PR TITLE
fix: issue #2198 -- don't truncate TEXT `key_field`s

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -223,7 +223,7 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
             fast: true,
             stored: false,
             fieldnorms: false,
-            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::raw()),
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
             column: None,

--- a/pg_search/src/postgres/index.rs
+++ b/pg_search/src/postgres/index.rs
@@ -121,7 +121,7 @@ pub unsafe fn get_fields(index_relation: &PgRelation) -> (Fields, KeyFieldIndex)
             fast: true,
             stored: false,
             fieldnorms: false,
-            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+            tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::raw()),
             record: IndexRecordOption::Basic,
             normalizer: SearchNormalizer::Raw,
             column: None,

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -366,7 +366,7 @@ impl SearchIndexCreateOptions {
                 fast: true,
                 stored: true,
                 fieldnorms: false,
-                tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::default()),
+                tokenizer: SearchTokenizer::Raw(SearchTokenizerFilters::raw()),
                 record: IndexRecordOption::Basic,
                 normalizer: SearchNormalizer::Raw,
                 column: None,

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -587,3 +587,23 @@ fn custom_enum_parse(mut conn: PgConnection) {
 
     assert_eq!(rows, vec![(1, "Item 1".into())]);
 }
+
+#[rstest]
+fn long_text_key_field_issue2198(mut conn: PgConnection) {
+    "CREATE TABLE issue2198 (id TEXT, value TEXT)".execute(&mut conn);
+
+    "CREATE INDEX idxissue2198 ON issue2198 USING bm25 (id, value) WITH (key_field='id')"
+        .execute(&mut conn);
+
+    let long_string = "a".repeat(10000);
+
+    format!("INSERT INTO issue2198(id) VALUES ('{long_string}')").execute(&mut conn);
+    let (count,) = format!("SELECT count(*) FROM issue2198 WHERE id @@@ '{long_string}'")
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+
+    let (count,) =
+        format!("SELECT count(*) FROM issue2198 WHERE id @@@ paradedb.term('id', '{long_string}')")
+            .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+}

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -42,6 +42,19 @@ pub struct SearchTokenizerFilters {
 }
 
 impl SearchTokenizerFilters {
+    /// Returns a [`SearchTokenizerFilter`] instance that effectively does not filter, or otherwise
+    /// mutate tokens.  
+    ///
+    /// This should be used for declaring the "key field" in an index.  It can be used for other
+    /// text types that don't want tokenization too.
+    pub fn raw() -> Self {
+        SearchTokenizerFilters {
+            remove_long: Some(usize::MAX),
+            lowercase: Some(false),
+            stemmer: None,
+        }
+    }
+
     fn from_json_value(value: &serde_json::Value) -> Result<Self, anyhow::Error> {
         let mut filters = SearchTokenizerFilters::default();
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2198

## What

Prior to this PR, we would trucate TEXT `key_field` values to 255 characters.  This undoes that, effectively allowing a TEXT key_field value to be as long as necessary.

This will potentially require users that use TEXT primary keys to REINDEX their `USING bm25` indexes as now our understanding of the index's schema does not match what's on disk.  This will lead to incorrect search results due to tokenization differences.

## Why

Truncating `key_field` values can make it impossible to later search for them by their whole value using (at least) the `paradedb.term()` function.

## How

## Tests

A new test has been added to validate this change.