### PR TITLE
fix: issue #2199 - UUID fields need to use the `raw` tokenizer/normalizer

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -158,7 +158,9 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
             .get_text_fields()
             .into_iter()
             .map(|(name, config)| match name_type_map.get(&name) {
-                Some(field_type @ SearchFieldType::Text) => (name, config, *field_type),
+                Some(field_type @ (SearchFieldType::Text | SearchFieldType::Uuid)) => {
+                    (name, config, *field_type)
+                }
                 _ => panic!("'{name}' cannot be indexed as a text field"),
             });
 
@@ -228,6 +230,7 @@ pub unsafe fn index_fields(index: PgRelation) -> JsonB {
             normalizer: SearchNormalizer::Raw,
             column: None,
         },
+        SearchFieldType::Uuid => SearchFieldConfig::default_uuid(),
         SearchFieldType::Json => SearchFieldConfig::Json {
             indexed: true,
             fast: true,

--- a/pg_search/src/postgres/index.rs
+++ b/pg_search/src/postgres/index.rs
@@ -59,7 +59,10 @@ pub unsafe fn get_fields(index_relation: &PgRelation) -> (Fields, KeyFieldIndex)
 
     for (name, config) in rdopts.get_text_fields() {
         let name = SearchFieldName(config.column().unwrap_or(&name.0).into());
-        if !matches!(name_type_map.get(&name), Some(SearchFieldType::Text)) {
+        if !matches!(
+            name_type_map.get(&name),
+            Some(SearchFieldType::Text | SearchFieldType::Uuid)
+        ) {
             panic!("'{name}' cannot be indexed as a text field");
         }
     }
@@ -126,6 +129,7 @@ pub unsafe fn get_fields(index_relation: &PgRelation) -> (Fields, KeyFieldIndex)
             normalizer: SearchNormalizer::Raw,
             column: None,
         },
+        SearchFieldType::Uuid => SearchFieldConfig::default_uuid(),
         SearchFieldType::Json => SearchFieldConfig::Json {
             indexed: true,
             fast: true,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2199

## What

We index fields of type UUID as text and until now their values were being tokenized using Tantivy's default tokenizer.  Which in the case of well-formed UUIDs would split the value into 5 tokens, splitting on the dash (`-`).

This PR will necessitate that users that store UUIDs perform a REINDEX of all their `USING bm25` indexes so that the index schema matches what we believe to be true.

## Why

This is problematic because it is then impossible for the (at least) `paradedb.term()` function to find docs matching a full UUID value.

## How

Absent a user-specific `text_fields:{}` configuration for a UUID column, we hardcode our own default, which uses the `raw` tokenizer and normalizer

## Tests

A new test has been added to assert this behavior.