### PR TITLE
fix: no longer use a Snapshot to acquire the MergeLock

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -96,7 +96,8 @@ impl MergeLock {
                         }
                         #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
                         {
-                            last_merge < pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel())
+                            let oldest_xmin =pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
+                            pg_sys::TransactionIdPrecedes(last_merge, oldest_xmin)
                         }
                 };
 

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -87,7 +87,18 @@ impl MergeLock {
 
                     // or the last_merge transaction's effects are known to be visible by all
                     // current/future transactions
-                    || last_merge < pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
+                    || {
+                        #[cfg(feature = "pg13")]
+                        {
+                            last_merge < pg_sys::TransactionIdLimitedForOldSnapshots(
+                                pg_sys::GetOldestXmin(bman.bm25cache().heaprel(), pg_sys::PROCARRAY_FLAGS_VACUUM as i32), bman.bm25cache().heaprel(),
+                            )
+                        }
+                        #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
+                        {
+                            last_merge < pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel())
+                        }
+                };
 
             if last_merge_visible {
                 metadata.last_merge = pg_sys::GetCurrentTransactionId();

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -66,52 +66,48 @@ impl MergeLock {
         }
 
         let mut bman = BufferManager::new(relation_oid);
+        let mut merge_lock = bman.get_buffer_conditional(MERGE_LOCK)?;
+        let mut page = merge_lock.page_mut();
+        let metadata = page.contents_mut::<MergeLockData>();
+        let last_merge = metadata.last_merge;
 
-        if let Some(mut merge_lock) = bman.get_buffer_conditional(MERGE_LOCK) {
-            let mut page = merge_lock.page_mut();
-            let metadata = page.contents_mut::<MergeLockData>();
-            let last_merge = metadata.last_merge;
+        // in order to return the MergeLock we need to make sure we can see the effects of the
+        // last merge that ran.
+        //
+        // We already know we're the only backend with the Buffer-level lock, because the
+        // `.get_buffer_conditional()` call above gave us the Buffer, so now we need to ensure
+        // we're allowed to touch the segments that may have been modified by the last merge
+        let last_merge_visible =
+            // the last_merge value is zero b/c we've never done a merge
+            last_merge == pg_sys::InvalidTransactionId
 
-            // in order to return the MergeLock we need to make sure we can see the effects of the
-            // last merge that ran.
-            //
-            // We already know we're the only backend with the Buffer-level lock, because the
-            // `.get_buffer_conditional()` call above gave us the Buffer, so now we need to ensure
-            // we're allowed to touch the segments that may have been modified by the last merge
-            let last_merge_visible =
-                // the last_merge value is zero b/c we've never done a merge
-                last_merge == pg_sys::InvalidTransactionId
+                // or it is from this transaction
+                || pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
 
-                    // or it is from this transaction
-                    || pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
+                // or the last_merge transaction's effects are known to be visible by all
+                // current/future transactions
+                || {
+                #[cfg(feature = "pg13")]
+                {
+                    last_merge < pg_sys::TransactionIdLimitedForOldSnapshots(
+                        pg_sys::GetOldestXmin(bman.bm25cache().heaprel(), pg_sys::PROCARRAY_FLAGS_VACUUM as i32), bman.bm25cache().heaprel(),
+                    )
+                }
+                #[cfg(any(
+                    feature = "pg14",
+                    feature = "pg15",
+                    feature = "pg16",
+                    feature = "pg17"
+                ))]
+                {
+                    let oldest_xmin = pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
+                    pg_sys::TransactionIdPrecedes(last_merge, oldest_xmin)
+                }
+            };
 
-                    // or the last_merge transaction's effects are known to be visible by all
-                    // current/future transactions
-                    || {
-                    #[cfg(feature = "pg13")]
-                    {
-                        last_merge < pg_sys::TransactionIdLimitedForOldSnapshots(
-                            pg_sys::GetOldestXmin(bman.bm25cache().heaprel(), pg_sys::PROCARRAY_FLAGS_VACUUM as i32), bman.bm25cache().heaprel(),
-                        )
-                    }
-                    #[cfg(any(
-                        feature = "pg14",
-                        feature = "pg15",
-                        feature = "pg16",
-                        feature = "pg17"
-                    ))]
-                    {
-                        let oldest_xmin = pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
-                        pg_sys::TransactionIdPrecedes(last_merge, oldest_xmin)
-                    }
-                };
-
-            if last_merge_visible {
-                metadata.last_merge = pg_sys::GetCurrentTransactionId();
-                Some(MergeLock(merge_lock))
-            } else {
-                None
-            }
+        if last_merge_visible {
+            metadata.last_merge = pg_sys::GetCurrentTransactionId();
+            Some(MergeLock(merge_lock))
         } else {
             None
         }

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -71,9 +71,38 @@ impl MergeLock {
             let mut page = merge_lock.page_mut();
             let metadata = page.contents_mut::<MergeLockData>();
             let last_merge = metadata.last_merge;
-            let snapshot = pg_sys::GetActiveSnapshot();
-            let last_merge_visible = pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
-                || !pg_sys::XidInMVCCSnapshot(last_merge, snapshot);
+
+            // in order to return the MergeLock we need to make sure we can see the effects of the
+            // last merge that ran.
+            //
+            // We already know we're the only backend with the Buffer-level lock, because the
+            // `.get_buffer_conditional()` call above gave us the Buffer, so now we need to ensure
+            // we're allowed to touch the segments that may have been modified by the last merge
+            let last_merge_visible =
+                // the last_merge value is zero b/c we've never done a merge
+                last_merge == pg_sys::InvalidTransactionId
+
+                    // or it is from this transaction
+                || pg_sys::TransactionIdIsCurrentTransactionId(last_merge)
+
+                    // or the last_merge transaction's effects are known to be visible by all
+                    // current/future transactions
+                || {
+                    #[cfg(feature = "pg13")]
+                    {
+                        pg_sys::TransactionIdPrecedes(last_merge, pg_sys::RecentGlobalXmin)
+                    }
+
+                    #[cfg(any(
+                        feature = "pg14",
+                        feature = "pg15",
+                        feature = "pg16",
+                        feature = "pg17"
+                    ))]
+                    {
+                        pg_sys::GlobalVisCheckRemovableXid(std::ptr::null_mut(), last_merge)
+                    }
+                };
 
             if last_merge_visible {
                 metadata.last_merge = pg_sys::GetCurrentTransactionId();

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -100,7 +100,7 @@ impl MergeLock {
                         feature = "pg17"
                     ))]
                     {
-                        pg_sys::GlobalVisCheckRemovableXid(std::ptr::null_mut(), last_merge)
+                        pg_sys::GlobalVisCheckRemovableXid(bman.bm25cache().heaprel(), last_merge)
                     }
                 };
 

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -89,9 +89,10 @@ impl MergeLock {
                 || {
                 #[cfg(feature = "pg13")]
                 {
-                    last_merge < pg_sys::TransactionIdLimitedForOldSnapshots(
+                    let oldest_xmin = pg_sys::TransactionIdLimitedForOldSnapshots(
                         pg_sys::GetOldestXmin(bman.bm25cache().heaprel(), pg_sys::PROCARRAY_FLAGS_VACUUM as i32), bman.bm25cache().heaprel(),
-                    )
+                    );
+                    pg_sys::TransactionIdPrecedes(last_merge, oldest_xmin)
                 }
                 #[cfg(any(
                     feature = "pg14",

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -96,8 +96,8 @@ impl MergeLock {
                         }
                         #[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
                         {
-                            let oldest_xmin =pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
-                            pg_sys::TransactionIdPrecedes(last_merge, oldest_xmin)
+                            let oldest_xmin = pg_sys::GetOldestNonRemovableTransactionId(bman.bm25cache().heaprel());
+                            pg_sys::TransactionIdPrecedesOrEquals(last_merge, oldest_xmin)
                         }
                 };
 

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -94,6 +94,10 @@ impl BM25BufferCache {
         }
     }
 
+    pub unsafe fn heaprel(&self) -> *mut pg_sys::RelationData {
+        self.heaprel.as_ptr()
+    }
+
     pub unsafe fn new_buffer(&self) -> pg_sys::Buffer {
         // Try to find a recyclable page
         loop {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We can check the "vacuum horizon" (my words) to decide if the last merge transaction's effects are visible to the backend trying to obtain a MergeLock, instead of looking at active Snapshot.

In fact, looking at the active Snapshot is not even possible when operating inside a Logical Replication Worker -- doing so leads to an assert failure in Postgres.

## Why

Better compatibility with logical replication.

## How

## Tests

Existing tests pass and stressgres has run solid for about 25 minutes w/o a problem.