### PR TITLE
chore: remove `packed` from the ParallelScanState struct

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -83,11 +83,10 @@ impl ParallelQueryCapable for PdbScan {
 }
 
 pub unsafe fn checkout_segment(pscan_state: *mut ParallelScanState) -> Option<SegmentId> {
-    let mutex = (*pscan_state).mutex.acquire();
-    if (*pscan_state).remaining_segments > 0 {
-        (*pscan_state).remaining_segments -= 1;
-
-        Some((*pscan_state).segment_id((*pscan_state).remaining_segments as usize))
+    let mutex = (*pscan_state).acquire_mutex();
+    if (*pscan_state).remaining_segments() > 0 {
+        let remaining_segments = (*pscan_state).decrement_remaining_segments();
+        Some((*pscan_state).segment_id(remaining_segments))
     } else {
         None
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This struct was inadvertently tagged as `, packed`, which was causing some compilation problems.

While here, tighten up access to the struct's member fields.

## Why

It's unsafe to access, via reference, members of a packed struct due to alignment.  What's curious is that only @rebasedming saw rustc give compilation errors about this.

## How

## Tests
