### PR TITLE
fix: clean up unused import if telemetry features is disabled

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -30,7 +30,6 @@ pub mod telemetry;
 
 use self::postgres::customscan;
 use pgrx::*;
-use telemetry::setup_telemetry_background_worker;
 
 /// A hardcoded value when we can't figure out a good selectivity value
 const UNKNOWN_SELECTIVITY: f64 = 0.00001;
@@ -88,8 +87,11 @@ pub unsafe extern "C" fn _PG_init() {
     #[cfg(not(feature = "pg17"))]
     postgres::fake_aminsertcleanup::register();
 
-    #[cfg(feature = "telemetry")]
-    setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
+    if cfg!(feature = "telemetry") {
+        use telemetry::setup_telemetry_background_worker;
+
+        setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
+    }
 
     // Register our tracing / logging hook, so that we can ensure that the logger
     // is initialized for all connections.


### PR DESCRIPTION
If the telemetry feature is disabled, then we don't need to the import. Import the function at time of use.
