### PR TITLE
fix: resolve issues with system ICU library incompatabilities

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ COPY . /tmp/
 # Install the ICU library binaries
 WORKDIR /tmp
 RUN wget --progress=dot:giga https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
-    WORKDIR / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+    tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 -C / && \
     rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
     ldconfig && ldconfig # yes, running it twice
 
@@ -244,7 +244,7 @@ RUN apt-get update && \
 # Install the ICU library binaries
 WORKDIR /tmp
 RUN wget --progress=dot:giga https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
-    WORKDIR / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+    tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 -C / && \
     rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
     ldconfig && ldconfig # yes, running it twice
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,8 +73,9 @@ ENV POSTHOG_API_KEY=${POSTHOG_API_KEY} \
 COPY . /tmp/
 
 # Install the ICU library binaries
-RUN cd /tmp && wget https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
-    cd / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+WORKDIR /tmp
+RUN wget --progress=dot:giga https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    WORKDIR / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
     rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
     ldconfig && ldconfig # yes, running it twice
 
@@ -237,16 +238,16 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 # downloading the packages. The user can run `apt-get update` themselves to fetch the package lists and install the desired third party
 # extension(s) if/when the time comes. This keeps the image as small as possible for each user's specific use case.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget
+    apt-get install -y --no-install-recommends wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install the ICU library binaries
-RUN cd /tmp && wget https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
-    cd / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+WORKDIR /tmp
+RUN wget --progress=dot:giga https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    WORKDIR / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
     rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
     ldconfig && ldconfig # yes, running it twice
-RUN find /usr/local/
 
-#
 # We also uninstall `wget` after adding the PostgreSQL APT repository to the list of sources to minimize the surface area for potential security risks.
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,11 +31,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libopenblas-dev \
     postgresql-server-dev-all \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain "${RUST_VERSION}" -y
 
-ENV PATH="/root/.cargo/bin:$PATH" \
+ENV PATH="/usr/local/bin:/root/.cargo/bin:$PATH" \
     PGX_HOME=/usr/lib/postgresql/${PG_VERSION_MAJOR}
 
 # Copy project because we need to extract the pgrx version
@@ -69,6 +71,12 @@ ENV POSTHOG_API_KEY=${POSTHOG_API_KEY} \
     PARADEDB_TELEMETRY=${PARADEDB_TELEMETRY}
 
 COPY . /tmp/
+
+# Install the ICU library binaries
+RUN cd /tmp && wget https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    cd / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+    rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    ldconfig && ldconfig # yes, running it twice
 
 # Build the extension
 WORKDIR /tmp/pg_search
@@ -199,6 +207,9 @@ RUN apt-get update && \
     find /var/cache -type f -exec truncate --size 0 {} \; && \
     find /var/log -type f -exec truncate --size 0 {} \;
 
+# Run "ldconfig" so that the final image sees the ICU libraries we copied above
+RUN ldconfig && ldconfig
+
 # Install Postgis and ca-certificates
 # ca-certificates required for TLS connection to PostHog (which is used for telemetry) and PostGIS
 ENV POSTGIS_VERSION_MAJOR=3
@@ -225,11 +236,19 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 # To minimize the burden on the user, we pre-fetch the key and the repository, but do not run `apt-get update` to avoid unnecessarily
 # downloading the packages. The user can run `apt-get update` themselves to fetch the package lists and install the desired third party
 # extension(s) if/when the time comes. This keeps the image as small as possible for each user's specific use case.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget
+
+# Install the ICU library binaries
+RUN cd /tmp && wget https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    cd / && tar xzvf /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz --strip-components=1 && \
+    rm -f /tmp/icu4c-76_1-Ubuntu22.04-x64.tgz && \
+    ldconfig && ldconfig # yes, running it twice
+RUN find /usr/local/
+
 #
 # We also uninstall `wget` after adding the PostgreSQL APT repository to the list of sources to minimize the surface area for potential security risks.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get purge -y wget && \
     apt-get autoremove -y && \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2211 (hopefully)

## What

install ICU v76.1 binary release directly from their github repository.

This fixes problems with tokenization we've seen, likely including issue #2211

## Why

It seems the `libicu72` that comes with Debian Bookworm, an operating system distro for which there is no alternative libicu version, is bugged, leading our code to an endless loop.

This manually "installs" the ICU v76.1 Ubuntu binary release from the unicode org's github repo.  

In fact, it "installs" it twice -- once because we need it to build pg_search so that it's the one that's found, and then again in the final stage so that all its files are actually available to the running Postgres instance.

## How

## Tests

I will leave this for someone else.  /cc @rebasedming 
