### PR TITLE
fix: install icu76 to /usr/local

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ RUN curl -L -o icu4c-76_1-src.tgz https://github.com/unicode-org/icu/releases/do
 
 # Compile and install the ICU library
 WORKDIR /tmp/icu/source/
-RUN ./runConfigureICU Linux --prefix=/opt/icu76 && \
+RUN ./runConfigureICU Linux --prefix=/usr/local && \
     make "-j$(nproc)" && \
     make install && \
     ldconfig && ldconfig # Yes, running it twice
@@ -253,11 +253,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Compile and install the ICU library and remove the source code to minimize the image size.
 WORKDIR /tmp/icu/source/
-RUN ./runConfigureICU Linux --prefix=/opt/icu76 && \
+RUN ./runConfigureICU Linux --prefix=/usr/local && \
     make "-j$(nproc)" && \
     make install && \
     rm -rf /tmp/icu && \
-    find /usr/local/ && \
     ldconfig && ldconfig # Yes, running it twice
 
 # In order for a user to manually install third party Postgres extensions (e.g. PostGIS, pg_partman, etc.) that ParadeDB does not


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This changes our `Dockerfile` to install the ICU v76 library to `/usr/local/`.  This is necessary as `/usr/local/lib/` is on the default `ld.so.conf` search path, at the top.

## Why

The library needs to be installed in a place that a) the `rust_icu`'s crate can find the `bin/icu-config` binary, and b) Postgres can ultimately find the ICU libraries when it's started.

## How

## Tests
