### PR TITLE
chore: refreshing stressgres CI job

### DIFF
--- a/.github/stressgres/single-server.toml
+++ b/.github/stressgres/single-server.toml
@@ -1,0 +1,143 @@
+[setup]
+sql = """
+DROP EXTENSION IF EXISTS pg_search CASCADE;
+DROP TABLE IF EXISTS test CASCADE;
+CREATE EXTENSION pg_search;
+CREATE TABLE test (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    message TEXT
+);
+
+INSERT INTO test (message) VALUES ('beer wine cheese a');
+INSERT INTO test (message) VALUES ('beer wine a');
+INSERT INTO test (message) VALUES ('beer cheese a');
+INSERT INTO test (message) VALUES ('beer a');
+INSERT INTO test (message) VALUES ('wine cheese a');
+INSERT INTO test (message) VALUES ('wine a');
+INSERT INTO test (message) VALUES ('cheese a');
+INSERT INTO test (message) VALUES ('beer wine cheese a');
+INSERT INTO test (message) VALUES ('beer wine a');
+INSERT INTO test (message) VALUES ('beer cheese a');
+INSERT INTO test (message) VALUES ('beer a');
+INSERT INTO test (message) VALUES ('wine cheese a');
+INSERT INTO test (message) VALUES ('wine a');
+INSERT INTO test (message) VALUES ('cheese a');
+
+CREATE INDEX idxtest ON test USING bm25(id, message) WITH (key_field = 'id');
+CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool LANGUAGE plpgsql AS $$
+DECLARE
+    current_txid bigint;
+BEGIN
+    -- Get the current transaction ID
+    current_txid := txid_current();
+
+    -- Check if the values are not equal
+    IF a <> b THEN
+        RAISE EXCEPTION 'Assertion failed: % <> %. Transaction ID: %', a, b, current_txid;
+    END IF;
+
+    RETURN true;
+END;
+$$;
+"""
+
+[teardown]
+sql = """
+DROP TABLE test CASCADE;
+DROP EXTENSION pg_search CASCADE;
+"""
+[monitor]
+refresh_ms = 10
+title = "Monitor Index Size"
+log_tps = true
+log_count = true
+log_columns = ["block_count", "segment_count"]
+
+# Combined query returning both columns
+sql = """
+SELECT
+    pg_relation_size('idxtest') / current_setting('block_size')::int AS block_count,
+    (
+      SELECT COUNT(*)::bigint
+      FROM paradedb.index_info('idxtest')
+    ) AS segment_count
+"""
+
+[[jobs]]
+refresh_ms = 100
+title = "Index Scan"
+log_tps = true
+log_count = true
+sql = """
+SET enable_indexonlyscan to OFF;
+SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:cheese';
+"""
+
+[[jobs]]
+refresh_ms = 5
+title = "Custom Scan"
+log_tps = true
+log_count = true
+sql = """
+SET enable_indexonlyscan to OFF;
+SET enable_indexscan to OFF;
+SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:beer';
+"""
+
+[[jobs]]
+refresh_ms = 5
+title = "Index Only Scan"
+log_tps = true
+log_count = true
+sql = """
+SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:wine';
+"""
+
+[[jobs]]
+refresh_ms = 25
+title = "Update random values"
+log_tps = true
+log_count = true
+sql = """
+UPDATE test
+SET message = substring(message FROM 1 FOR length(message)-1)
+              || chr((trunc(random() * 26) + 65)::int)
+WHERE id < 10;
+"""
+
+[[jobs]]
+refresh_ms = 10
+title = "Insert value"
+log_tps = true
+log_count = true
+sql = """
+INSERT INTO test (message) VALUES ('test');
+"""
+
+[[jobs]]
+refresh_ms = 10
+title = "Insert value"
+log_tps = true
+log_count = true
+sql = """
+INSERT INTO test (message) VALUES ('test');
+"""
+
+[[jobs]]
+refresh_ms = 10
+title = "Delete values"
+log_tps = true
+log_count = true
+sql = """
+DELETE FROM test WHERE id > 14;
+"""
+
+[[jobs]]
+refresh_ms = 3000
+title = "Vacuum"
+log_tps = true
+log_count = true
+sql = """
+SET vacuum_freeze_min_age = 0;
+VACUUM test;
+"""

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -6,17 +6,8 @@
 name: Test pg_search Stressgres
 
 on:
-  #  schedule:
-  #    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - dev
-      - main
-    paths:
-      - ".github/workflows/test-pg_search-stressgres.yml"
-      - "**/*.rs"
-      - "**/*.toml"
+  schedule:
+    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
   push:
     branches: # Also run on `dev` and `main` to fill the GitHub Actions Rust cache in a way that PRs can see it
       - dev
@@ -104,7 +95,7 @@ jobs:
           sudo chmod a+rwx /var/run/postgresql/ && \
           cargo run --release -- auto \
           --log-path stressgres.log \
-          --runtime 5000 \
+          --runtime 600000 \
           `which pg_config` \
           /home/runner/work/paradedb/paradedb/paradedb/.github/stressgres/single-server.toml \
           /tmp/stressgres

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -6,13 +6,23 @@
 name: Test pg_search Stressgres
 
 on:
-  schedule:
-    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
+  #  schedule:
+  #    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - dev
+      - main
+    paths:
+      - ".github/workflows/test-pg_search-stressgres.yml"
+      - "**/*.rs"
+      - "**/*.toml"
   push:
     branches: # Also run on `dev` and `main` to fill the GitHub Actions Rust cache in a way that PRs can see it
       - dev
       - main
     paths:
+      - ".github/workflows/test-pg_search-stressgres.yml"
       - "**/*.rs"
       - "**/*.toml"
   workflow_dispatch:
@@ -63,11 +73,19 @@ jobs:
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
+      - name: Install & Configure Supported PostgreSQL Version
+        run: |
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+
       - name: Install cargo-pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize cargo-pgrx environment
-        run: cargo pgrx init "--pg${{ matrix.pg_version }}=download"
+        run: cargo pgrx init --pg${{ matrix.pg_version }}=`which pg_config`
 
       - name: Checkout Stressgres Repo
         uses: actions/checkout@v4
@@ -76,38 +94,24 @@ jobs:
           path: stressgres
           token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
 
-      - name: Add pg_search to shared_preload_libraries
-        if: matrix.pg_version < 17
-        working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
-        run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
-
       - name: Compile & install pg_search extension
         working-directory: paradedb/pg_search/
-        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=pg${{ matrix.pg_version }},icu
+        run: cargo pgrx install --sudo --release --pg-config `which pg_config` --features=pg${{ matrix.pg_version }},icu --no-default-features
 
-      - name: Start Postgres and create database
-        working-directory: paradedb/tests/
-        run: |
-          RUST_BACKTRACE=1 cargo pgrx start pg${{ matrix.pg_version }}
-          ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
-
-      - name: Run Stressgres Test Suite
+      - name: Run Stressgres Test Suite for 10 minutes
         working-directory: stressgres/
         run: |
-          RUST_BACKTRACE=1 cargo build && timeout 10m \
-          cargo run -- \
-            headless suites/ci.toml "host=localhost port=28817 dbname=postgres" \
-            --log-interval-ms 300 \
-            --log-file stressgres.log \
-            || EXIT_CODE=$?
-
-          if [ "$EXIT_CODE" -eq 124 ]; then
-            echo "Process timed out as expected."
-          fi
+          sudo chmod a+rwx /var/run/postgresql/ && \
+          cargo run --release -- auto \
+          --log-path stressgres.log \
+          --runtime 5000 \
+          `which pg_config` \
+          /home/runner/work/paradedb/paradedb/paradedb/.github/stressgres/single-server.toml \
+          /tmp/stressgres
 
       - name: Create Stressgres Graph
         working-directory: stressgres/
-        run: cargo run -- graph --output stressgres.png stressgres.log
+        run: cargo run --release -- graph --output stressgres.png stressgres.log
 
       - name: Upload Stressgres Graph
         id: artifact-graph
@@ -122,9 +126,6 @@ jobs:
         with:
           name: stressgres-logs
           path: stressgres/stressgres.log
-
-      - name: Print Postgres Logs
-        run: cat ~/.pgrx/${{ matrix.pg_version }}.log
 
       - name: Derive Short Commit
         id: commit_info
@@ -157,7 +158,12 @@ jobs:
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ARTIFACT_URL="${{ steps.artifact-logs.outputs.artifact-url }}"
-          MESSAGE="Stressgres pg_search Workflow failed in \`paradedb/paradedb\` -- investigate immediately! • GitHub Action Logs: ${GITHUB_RUN_URL} • Stressgres Log: ${ARTIFACT_URL}" echo "Sending failure notification to Slack..."
+          MESSAGE="Stressgres pg_search Workflow failed in \`paradedb/paradedb-enterprise\` -- investigate immediately! • GitHub Action Logs: ${GITHUB_RUN_URL} • Stressgres Log: ${ARTIFACT_URL}" echo "Sending failure notification to Slack..."
           curl -X POST -H 'Content-type: application/json' \
           --data "{\"text\": \"${MESSAGE}\"}" \
           ${SLACK_WEBHOOK_URL}
+
+      - name: Print Postgres Logs
+        run: |
+          cat /tmp/stressgres/stressgres/primary.log && \
+          cat /tmp/stressgres/stressgres/secondary.log

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -164,6 +164,4 @@ jobs:
           ${SLACK_WEBHOOK_URL}
 
       - name: Print Postgres Logs
-        run: |
-          cat /tmp/stressgres/stressgres/primary.log && \
-          cat /tmp/stressgres/stressgres/secondary.log
+        run: cat /tmp/stressgres/stressgres/primary.log

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -142,7 +142,7 @@ jobs:
           payload: |
             channel_id: ${{ secrets.SLACK_GITHUB_CHANNEL_ID }}
             initial_comment: |
-              *Stressgres Results*
+              *Community Stressgres Results*
               <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ steps.commit_info.outputs.short_commit }}> | <${{ steps.artifact-logs.outputs.artifact-url }} | Download Logs>
             file: "stressgres/stressgres.png"
             filename: "stressgres.png"


### PR DESCRIPTION
Working through using stressgres' new "auto" mode and an updated CI job that's consistent with what we're now doing on enterprise, but without logical replication