### PR TITLE
docs: ubuntu-20.04 has libicu-66 available

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -185,7 +185,10 @@ Ensure that the `libicu` library is installed. It should come preinstalled on mo
 # macOS
 brew install icu4c
 
-# Ubuntu 20.04 or 22.04
+# Ubuntu 20.04
+sudo apt-get install -y libicu66
+
+# Ubuntu 22.04
 sudo apt-get install -y libicu70
 
 # Ubuntu 24.04


### PR DESCRIPTION
I'm just reproducing the setup instructions here.
I came across this while installing it on a 20.04 box.
It looks like Ubuntu 20.04 has icu66 available.
https://launchpad.net/ubuntu/focal/+source/icu

