### PR TITLE
fix: error handling cleanup

### DIFF
--- a/pg_search/src/index/reader/channel.rs
+++ b/pg_search/src/index/reader/channel.rs
@@ -23,7 +23,7 @@ impl ChannelReader {
                 path.to_path_buf(),
                 oneshot_sender,
             ))
-            .unwrap();
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, format!("{e:?}")))?;
 
         let entry = oneshot_receiver.recv()?;
         Ok(Self { entry, sender })


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Just some code cleanup as a fallout from PR #2237.

## Why

Blindly unwrapping in the cases where we can cleanly return a `Result::Error` is uncool.

## How

## Tests
