### PR TITLE
fix: transpose_cost_one param name

### DIFF
--- a/docs/documentation/advanced/full-text/match.mdx
+++ b/docs/documentation/advanced/full-text/match.mdx
@@ -49,7 +49,7 @@ WHERE id @@@
   Levenshtein distance (i.e. single character edits) allowed to consider a term
   in the index as a match for the query term. Maximum value is `2`.
 </ParamField>
-<ParamField body="transpose_cost_one" default={true}>
+<ParamField body="transposition_cost_one" default={true}>
   When set to `true` and fuzzy matching is enabled, transpositions (swapping two
   adjacent characters) as a single edit in the Levenshtein distance calculation,
   while `false` considers it two separate edits (a deletion and an insertion).

--- a/docs/documentation/advanced/term/fuzzy_term.mdx
+++ b/docs/documentation/advanced/term/fuzzy_term.mdx
@@ -50,7 +50,7 @@ LIMIT 5;
   consider a term in the index as a match for the query term. Maximum value is
   `2`.
 </ParamField>
-<ParamField body="transpose_cost_one" default={true}>
+<ParamField body="transposition_cost_one" default={true}>
   When set to `true`, transpositions (swapping two adjacent characters) as a
   single edit in the Levenshtein distance calculation, while `false` considers
   it two separate edits (a deletion and an insertion).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2179 

## What

Fixes the documentation to use the right param name.

## Why

The documentation was incorrect, which can lead to errors for users.

## How

## Tests
