### PR TITLE
fix: schema upgrade scripts

### DIFF
--- a/pg_search/sql/pg_search--0.15.2--0.15.3.sql
+++ b/pg_search/sql/pg_search--0.15.2--0.15.3.sql
@@ -11,31 +11,3 @@ CREATE  FUNCTION "with_index"(
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'with_index_wrapper';
-
---
--- b/c of predicate pushdown work (#2197)
---
-/* <begin connected objects> */
--- pg_search/src/api/index.rs:549
--- pg_search::api::index::term_with_operator
-CREATE  FUNCTION "term_with_operator"(
-    "field" FieldName, /* pg_search::api::index::FieldName */
-    "operator" TEXT, /* alloc::string::String */
-    "value" anyelement /* pgrx::datum::anyelement::AnyElement */
-) RETURNS SearchQueryInput /* core::result::Result<pg_search::query::SearchQueryInput, anyhow::Error> */
-    IMMUTABLE STRICT PARALLEL SAFE
-    LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'term_with_operator_wrapper';
-/* </end connected objects> */
-DROP FUNCTION IF EXISTS term(field fieldname, value pg_catalog.timestamptz);
-/* </end connected objects> */
-/* <begin connected objects> */
--- pg_search/src/api/index.rs:762
--- pg_search::api::index::term
-CREATE  FUNCTION "term"(
-    "field" FieldName DEFAULT NULL, /* core::option::Option<pg_search::api::index::FieldName> */
-    "value" timestamp with time zone DEFAULT NULL /* core::option::Option<pgrx::datum::time_stamp_with_timezone::TimestampWithTimeZone> */
-) RETURNS SearchQueryInput /* pg_search::query::SearchQueryInput */
-    IMMUTABLE PARALLEL SAFE
-    LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'timestamp_with_time_zone_wrapper';

--- a/pg_search/sql/pg_search--0.15.5--0.15.6.sql
+++ b/pg_search/sql/pg_search--0.15.5--0.15.6.sql
@@ -1,3 +1,5 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.15.6'" to load this file. \quit
+
 -- pg_search/src/bootstrap/create_bm25.rs:235
 -- pg_search::bootstrap::create_bm25::is_merging
 CREATE  FUNCTION "is_merging"(
@@ -6,3 +8,31 @@ CREATE  FUNCTION "is_merging"(
     STRICT
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'is_merging_wrapper';
+
+--
+-- b/c of predicate pushdown work (#2197)
+--
+/* <begin connected objects> */
+-- pg_search/src/api/index.rs:549
+-- pg_search::api::index::term_with_operator
+CREATE  FUNCTION "term_with_operator"(
+    "field" FieldName, /* pg_search::api::index::FieldName */
+    "operator" TEXT, /* alloc::string::String */
+    "value" anyelement /* pgrx::datum::anyelement::AnyElement */
+) RETURNS SearchQueryInput /* core::result::Result<pg_search::query::SearchQueryInput, anyhow::Error> */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'term_with_operator_wrapper';
+/* </end connected objects> */
+DROP FUNCTION IF EXISTS term(field fieldname, value pg_catalog.timestamptz);
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/index.rs:762
+-- pg_search::api::index::term
+CREATE  FUNCTION "term"(
+    "field" FieldName DEFAULT NULL, /* core::option::Option<pg_search::api::index::FieldName> */
+    "value" timestamp with time zone DEFAULT NULL /* core::option::Option<pgrx::datum::time_stamp_with_timezone::TimestampWithTimeZone> */
+) RETURNS SearchQueryInput /* pg_search::query::SearchQueryInput */
+    IMMUTABLE PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'timestamp_with_time_zone_wrapper';


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The predicate pushdown work added two new UDFs and were originally added to the 0.15.2--0.15.3 upgrade path, but weren't actually merged until after 0.15.5, so their schema definitions need to be moved.

## Why

## How

## Tests
