### PR TITLE
fix: remove non-pg_search overhead from CI stressgres job

### DIFF
--- a/.github/stressgres/single-server.toml
+++ b/.github/stressgres/single-server.toml
@@ -68,8 +68,10 @@ refresh_ms = 100
 title = "Index Scan"
 log_tps = true
 log_count = true
-sql = """
+on_connect = """
 SET enable_indexonlyscan to OFF;
+"""
+sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:cheese';
 """
 
@@ -78,9 +80,11 @@ refresh_ms = 5
 title = "Custom Scan"
 log_tps = true
 log_count = true
-sql = """
+on_connect = """
 SET enable_indexonlyscan to OFF;
 SET enable_indexscan to OFF;
+"""
+sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:beer';
 """
 

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/test-pg_search-stressgres.yml"
       - "**/*.rs"
       - "**/*.toml"
+      - "**/stressgres/*.toml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Move the "SET" statements out of the query that gets run and into the `on_connect=` property so that they're only run once, and not included in the measurement of the SELECT statement itself.

## Why

I think this is why the stressgres graphs show our custom scan being slower.  We'll find out.  Regardless, there's no need for these SET statements to run more often than when the connection is first created.

## How

## Tests
