### PR TITLE
feat: Pushdown `IS NOT NULL` to Tantivy

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -545,14 +545,19 @@ pub unsafe fn extract_quals(
 
         pg_sys::NodeTag::T_NullTest => {
             let nulltest = nodecast!(NullTest, T_NullTest, node)?;
+            let attname = attname_from_var(root, (*nulltest).arg.cast());
             if (*nulltest).nulltesttype == pg_sys::NullTestType::IS_NOT_NULL {
                 Some(Qual::PushdownIsNotNull {
-                    attname: attname_from_var(root, (*nulltest).arg.cast())
+                    attname: attname
                         .1
-                        .expect("var should have an attname"),
+                        .expect("IS NOT NULL expression should have an attname"),
                 })
             } else {
-                None
+                Some(Qual::Not(Box::new(Qual::PushdownIsNotNull {
+                    attname: attname
+                        .1
+                        .expect("IS NULL expression should have an attname"),
+                })))
             }
         }
 

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -49,6 +49,9 @@ pub enum Qual {
     PushdownVarIsTrue {
         attname: String,
     },
+    PushdownIsNotNull {
+        attname: String,
+    },
     ScoreExpr {
         opoid: pg_sys::Oid,
         value: *mut pg_sys::Node,
@@ -66,6 +69,7 @@ impl Qual {
             Qual::Expr { .. } => false,
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarIsTrue { .. } => false,
+            Qual::PushdownIsNotNull { .. } => false,
             Qual::ScoreExpr { .. } => false,
             Qual::And(quals) => quals.iter().any(|q| q.contains_all()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_all()),
@@ -80,6 +84,7 @@ impl Qual {
             Qual::Expr { node, .. } => contains_exec_param(*node),
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarIsTrue { .. } => false,
+            Qual::PushdownIsNotNull { .. } => false,
             Qual::ScoreExpr { .. } => false,
             Qual::And(quals) => quals.iter().any(|q| q.contains_exec_param()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_exec_param()),
@@ -94,6 +99,7 @@ impl Qual {
             Qual::Expr { .. } => true,
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarIsTrue { .. } => true,
+            Qual::PushdownIsNotNull { .. } => false,
             Qual::ScoreExpr { .. } => false,
             Qual::And(quals) => quals.iter().any(|q| q.contains_exprs()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_exprs()),
@@ -108,6 +114,7 @@ impl Qual {
             Qual::Expr { .. } => false,
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarIsTrue { .. } => false,
+            Qual::PushdownIsNotNull { .. } => false,
             Qual::ScoreExpr { .. } => true,
             Qual::And(quals) => quals.iter().any(|q| q.contains_exprs()),
             Qual::Or(quals) => quals.iter().any(|q| q.contains_exprs()),
@@ -122,6 +129,7 @@ impl Qual {
             Qual::Expr { .. } => exprs.push(self),
             Qual::PushdownExpr { .. } => {}
             Qual::PushdownVarIsTrue { .. } => {}
+            Qual::PushdownIsNotNull { .. } => {}
             Qual::ScoreExpr { .. } => {}
             Qual::And(quals) => quals.iter_mut().for_each(|q| q.collect_exprs(exprs)),
             Qual::Or(quals) => quals.iter_mut().for_each(|q| q.collect_exprs(exprs)),
@@ -156,6 +164,9 @@ impl From<&Qual> for SearchQueryInput {
                 field: Some(attname.clone()),
                 value: OwnedValue::Bool(true),
                 is_datetime: false,
+            },
+            Qual::PushdownIsNotNull { attname } => SearchQueryInput::Exists {
+                field: attname.clone(),
             },
             Qual::ScoreExpr { opoid, value } => unsafe {
                 let score_value = {
@@ -322,6 +333,10 @@ impl From<Qual> for PgList<pg_sys::Node> {
                     list.push(makeString(Some("PUSHDOWN_VAR_IS_TRUE")));
                     list.push(makeString(Some(attname)));
                 }
+                Qual::PushdownIsNotNull { attname } => {
+                    list.push(makeString(Some("PUSHDOWN_IS_NOT_NULL")));
+                    list.push(makeString(Some(attname)));
+                }
                 Qual::ScoreExpr { opoid, value } => {
                     list.push(makeString(Some("SCORE")));
                     list.push(makeInteger(Some(opoid)));
@@ -386,6 +401,10 @@ impl From<PgList<pg_sys::Node>> for Qual {
                         "PUSHDOWN_VAR_IS_TRUE" => {
                             let attname = decodeString::<String>(value.get_ptr(1)?)?;
                             Some(Qual::PushdownVarIsTrue { attname })
+                        }
+                        "PUSHDOWN_IS_NOT_NULL" => {
+                            let attname = decodeString::<String>(value.get_ptr(1)?)?;
+                            Some(Qual::PushdownIsNotNull { attname })
                         }
                         "SCORE" => {
                             let (opoid, value) = (
@@ -522,6 +541,19 @@ pub unsafe fn extract_quals(
                     .1
                     .expect("var should have an attname"),
             })
+        }
+
+        pg_sys::NodeTag::T_NullTest => {
+            let nulltest = nodecast!(NullTest, T_NullTest, node)?;
+            if (*nulltest).nulltesttype == pg_sys::NullTestType::IS_NOT_NULL {
+                Some(Qual::PushdownIsNotNull {
+                    attname: attname_from_var(root, (*nulltest).arg.cast())
+                        .1
+                        .expect("var should have an attname"),
+                })
+            } else {
+                None
+            }
         }
 
         // we don't understand this clause so we can't do anything

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -153,19 +153,22 @@ fn pushdown_is_not_null(mut conn: PgConnection) {
         CREATE TABLE test (
             id SERIAL8 NOT NULL PRIMARY KEY,
             col_boolean boolean DEFAULT false,
-            col_text text
+            col_text text,
+            col_int8 int8
         );
     "#;
     sql.execute(&mut conn);
 
     let sql = r#"
-        CREATE INDEX idxtest ON test USING bm25 (id, col_boolean, col_text)
+        CREATE INDEX idxtest ON test USING bm25 (id, col_boolean, col_text, col_int8)
         WITH (key_field='id', text_fields = '{"col_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
     "#;
     sql.execute(&mut conn);
 
     "INSERT INTO test (id, col_text) VALUES (1, NULL);".execute(&mut conn);
     "INSERT INTO test (id, col_text) VALUES (2, 'foo');".execute(&mut conn);
+    "INSERT INTO test (id, col_text, col_int8) VALUES (3, 'bar', 333);".execute(&mut conn);
+    "INSERT INTO test (id, col_int8) VALUES (4, 444);".execute(&mut conn);
 
     "SET enable_indexscan TO off;".execute(&mut conn);
     "SET enable_bitmapscan TO off;".execute(&mut conn);
@@ -195,4 +198,113 @@ fn pushdown_is_not_null(mut conn: PgConnection) {
         plan.get("Node Type"),
         Some(&Value::String(String::from("Custom Scan")))
     );
+
+    // Verify that count is correct
+    let count = r#"
+        SELECT count(*)
+        FROM test
+        WHERE col_text IS NOT NULL
+        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(count, vec![(2,)]);
+
+    let count = r#"
+        SELECT count(*)
+        FROM test
+        WHERE col_int8 IS NOT NULL
+        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(count, vec![(2,)]);
+
+    let count = r#"
+        SELECT count(*)
+        FROM test
+        WHERE col_int8 IS NOT NULL
+        AND col_text IS NOT NULL
+        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(count, vec![(1,)]);
+
+    // Verify that IS NOT NULL works with other predicates
+    let count = r#"
+        SELECT count(*)
+        FROM test
+        WHERE col_text IS NOT NULL
+        AND id @@@ '>2';
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(count, vec![(1,)]);
+
+    // Verify that results are correct and ordered
+    let result = r#"
+        SELECT id
+        FROM test
+        WHERE col_text IS NOT NULL
+        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+        ORDER BY id DESC;
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(result, vec![(3,), (2,)]);
+
+    // Verify that GROUP BY works
+    let result = r#"
+        SELECT col_text, count(*)
+        FROM test
+        WHERE col_text IS NOT NULL
+        and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+        GROUP BY col_text
+        ORDER BY col_text;
+    "#
+    .fetch::<(String, i64)>(&mut conn);
+    assert_eq!(
+        result,
+        vec![(String::from("bar"), 1), (String::from("foo"), 1)]
+    );
+
+    // Verify that DISTIINCT works
+    let result = r#"
+        SELECT COUNT(DISTINCT col_text)
+        FROM test
+        WHERE col_text IS NOT NULL
+        and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(result, vec![(2,)]);
+
+    // Verify that JOIN works
+    "CREATE TABLE test2 (id SERIAL8 NOT NULL PRIMARY KEY, ref_id int8, ref_text text);"
+        .execute(&mut conn);
+    let sql = r#"
+        CREATE INDEX idxtest2 ON test2 USING bm25 (id, ref_id, ref_text)
+        WITH (key_field='id', text_fields = '{"ref_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
+    "#;
+    sql.execute(&mut conn);
+
+    "INSERT INTO test2 (ref_id, ref_text) VALUES (1, 'qux');".execute(&mut conn);
+    "INSERT INTO test2 (ref_id, ref_text) VALUES (3, 'foo');".execute(&mut conn);
+
+    let join = r#"
+        SELECT test.id, test.col_text, test2.ref_text
+        FROM test
+        INNER JOIN test2 ON test.id = test2.ref_id
+        WHERE test.col_text IS NOT NULL
+        AND test.id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+        ORDER BY test.id;
+    "#
+    .fetch_one::<(i64, String, String)>(&mut conn);
+    assert_eq!(join, (3, String::from("bar"), String::from("foo")));
+
+    // Verify that NULL is not counted after update
+    "UPDATE test SET col_text = NULL".execute(&mut conn);
+    let count = r#"
+        SELECT count(*)
+        FROM test
+        WHERE col_text IS NOT NULL
+        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+    "#
+    .fetch::<(i64,)>(&mut conn);
+    assert_eq!(count, vec![(0,)]);
 }

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -147,8 +147,8 @@ fn pushdown(mut conn: PgConnection) {
     }
 }
 
-#[rstest]
-fn pushdown_is_not_null(mut conn: PgConnection) {
+#[fixture]
+fn setup_test_table(mut conn: PgConnection) -> PgConnection {
     let sql = r#"
         CREATE TABLE test (
             id SERIAL8 NOT NULL PRIMARY KEY,
@@ -173,138 +173,443 @@ fn pushdown_is_not_null(mut conn: PgConnection) {
     "SET enable_indexscan TO off;".execute(&mut conn);
     "SET enable_bitmapscan TO off;".execute(&mut conn);
     "SET max_parallel_workers TO 0;".execute(&mut conn);
+    conn
+}
 
-    let sql = r#"
-        EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
-        SELECT count(*)
-        FROM test
-        WHERE col_text IS NOT NULL
-        AND id @@@ '1';
-    "#;
+mod pushdown_is_not_null {
+    use super::*;
 
-    eprintln!("/----------/");
-    eprintln!("{sql}");
+    #[rstest]
+    fn custom_scan(#[from(setup_test_table)] mut conn: PgConnection) {
+        let sql = r#"
+            EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ '1';
+        "#;
 
-    let (plan,) = sql.fetch_one::<(Value,)>(&mut conn);
-    eprintln!("{plan:#?}");
+        eprintln!("/----------/");
+        eprintln!("{sql}");
 
-    // Verify that the custom scan is used
-    let plan = plan
-        .pointer("/0/Plan/Plans/0")
-        .unwrap()
-        .as_object()
-        .unwrap();
-    pretty_assertions::assert_eq!(
-        plan.get("Node Type"),
-        Some(&Value::String(String::from("Custom Scan")))
-    );
+        let (plan,) = sql.fetch_one::<(Value,)>(&mut conn);
+        eprintln!("{plan:#?}");
 
-    // Verify that count is correct
-    let count = r#"
-        SELECT count(*)
-        FROM test
-        WHERE col_text IS NOT NULL
-        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(count, vec![(2,)]);
+        // Verify that the custom scan is used
+        let plan = plan
+            .pointer("/0/Plan/Plans/0")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        pretty_assertions::assert_eq!(
+            plan.get("Node Type"),
+            Some(&Value::String(String::from("Custom Scan")))
+        );
+    }
 
-    let count = r#"
-        SELECT count(*)
-        FROM test
-        WHERE col_int8 IS NOT NULL
-        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(count, vec![(2,)]);
+    #[rstest]
+    fn with_count(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that count is correct
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(2,)]);
 
-    let count = r#"
-        SELECT count(*)
-        FROM test
-        WHERE col_int8 IS NOT NULL
-        AND col_text IS NOT NULL
-        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(count, vec![(1,)]);
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_int8 IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(2,)]);
 
-    // Verify that IS NOT NULL works with other predicates
-    let count = r#"
-        SELECT count(*)
-        FROM test
-        WHERE col_text IS NOT NULL
-        AND id @@@ '>2';
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(count, vec![(1,)]);
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_int8 IS NOT NULL
+            AND col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(1,)]);
+    }
 
-    // Verify that results are correct and ordered
-    let result = r#"
-        SELECT id
-        FROM test
-        WHERE col_text IS NOT NULL
-        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
-        ORDER BY id DESC;
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(result, vec![(3,), (2,)]);
+    #[rstest]
+    fn with_return_values(#[from(setup_test_table)] mut conn: PgConnection) {
+        let res = r#"
+            SELECT *
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range)
+            ORDER BY id;
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(
+            res,
+            vec![
+                (2, false, Some(String::from("foo")), None),
+                (3, false, Some(String::from("bar")), Some(333))
+            ]
+        );
 
-    // Verify that GROUP BY works
-    let result = r#"
-        SELECT col_text, count(*)
-        FROM test
-        WHERE col_text IS NOT NULL
-        and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
-        GROUP BY col_text
-        ORDER BY col_text;
-    "#
-    .fetch::<(String, i64)>(&mut conn);
-    assert_eq!(
-        result,
-        vec![(String::from("bar"), 1), (String::from("foo"), 1)]
-    );
+        let res = r#"
+            SELECT *
+            FROM test
+            WHERE col_int8 IS NOT NULL
+            AND col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![(3, false, Some(String::from("bar")), Some(333))]);
+    }
 
-    // Verify that DISTIINCT works
-    let result = r#"
-        SELECT COUNT(DISTINCT col_text)
-        FROM test
-        WHERE col_text IS NOT NULL
-        and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(result, vec![(2,)]);
+    #[rstest]
+    fn with_multiple_predicates(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that IS NOT NULL works with other predicates
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ '>2';
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(1,)]);
 
-    // Verify that JOIN works
-    "CREATE TABLE test2 (id SERIAL8 NOT NULL PRIMARY KEY, ref_id int8, ref_text text);"
-        .execute(&mut conn);
-    let sql = r#"
-        CREATE INDEX idxtest2 ON test2 USING bm25 (id, ref_id, ref_text)
-        WITH (key_field='id', text_fields = '{"ref_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
-    "#;
-    sql.execute(&mut conn);
+        let res = r#"
+            SELECT *
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ '>2';
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![(3, false, Some(String::from("bar")), Some(333))]);
+    }
 
-    "INSERT INTO test2 (ref_id, ref_text) VALUES (1, 'qux');".execute(&mut conn);
-    "INSERT INTO test2 (ref_id, ref_text) VALUES (3, 'foo');".execute(&mut conn);
+    #[rstest]
+    fn with_ordering(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that results are correct and ordered
+        let result = r#"
+            SELECT id
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY id DESC;
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(result, vec![(3,), (2,)]);
+    }
 
-    let join = r#"
-        SELECT test.id, test.col_text, test2.ref_text
-        FROM test
-        INNER JOIN test2 ON test.id = test2.ref_id
-        WHERE test.col_text IS NOT NULL
-        AND test.id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
-        ORDER BY test.id;
-    "#
-    .fetch_one::<(i64, String, String)>(&mut conn);
-    assert_eq!(join, (3, String::from("bar"), String::from("foo")));
+    #[rstest]
+    fn with_aggregation(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that GROUP BY works
+        let result = r#"
+            SELECT col_text, count(*)
+            FROM test
+            WHERE col_text IS NOT NULL
+            and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            GROUP BY col_text
+            ORDER BY col_text;
+        "#
+        .fetch::<(String, i64)>(&mut conn);
+        assert_eq!(
+            result,
+            vec![(String::from("bar"), 1), (String::from("foo"), 1)]
+        );
+    }
 
-    // Verify that NULL is not counted after update
-    "UPDATE test SET col_text = NULL".execute(&mut conn);
-    let count = r#"
-        SELECT count(*)
-        FROM test
-        WHERE col_text IS NOT NULL
-        AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
-    "#
-    .fetch::<(i64,)>(&mut conn);
-    assert_eq!(count, vec![(0,)]);
+    #[rstest]
+    fn with_distinct(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that DISTIINCT works
+        let count = r#"
+            SELECT COUNT(DISTINCT col_text)
+            FROM test
+            WHERE col_text IS NOT NULL
+            and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(2,)]);
+
+        let res = r#"
+            SELECT DISTINCT col_text
+            FROM test
+            WHERE col_text IS NOT NULL
+            and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY col_text;
+        "#
+        .fetch::<(Option<String>,)>(&mut conn);
+        assert_eq!(
+            res,
+            vec![(Some(String::from("bar")),), (Some(String::from("foo")),)]
+        );
+    }
+
+    #[rstest]
+    fn with_join(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that JOIN works
+        "CREATE TABLE test2 (id SERIAL8 NOT NULL PRIMARY KEY, ref_id int8, ref_text text);"
+            .execute(&mut conn);
+        let sql = r#"
+            CREATE INDEX idxtest2 ON test2 USING bm25 (id, ref_id, ref_text)
+            WITH (key_field='id', text_fields = '{"ref_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
+        "#;
+        sql.execute(&mut conn);
+
+        "INSERT INTO test2 (ref_id, ref_text) VALUES (1, 'qux');".execute(&mut conn);
+        "INSERT INTO test2 (ref_id, ref_text) VALUES (3, 'foo');".execute(&mut conn);
+
+        let join = r#"
+            SELECT test.id, test.col_text, test2.ref_text
+            FROM test
+            INNER JOIN test2 ON test.id = test2.ref_id
+            WHERE test.col_text IS NOT NULL
+            AND test.id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY test.id;
+        "#
+        .fetch_one::<(i64, String, String)>(&mut conn);
+        assert_eq!(join, (3, String::from("bar"), String::from("foo")));
+    }
+
+    #[rstest]
+    fn post_update(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that NULL is not counted after update
+        "UPDATE test SET col_text = NULL".execute(&mut conn);
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(0,)]);
+
+        let res = r#"
+            SELECT *
+            FROM test
+            WHERE col_text IS NOT NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![]);
+    }
+}
+
+mod pushdown_is_null {
+    use super::*;
+
+    #[rstest]
+    fn custom_scan(#[from(setup_test_table)] mut conn: PgConnection) {
+        let sql = r#"
+            EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ '1';
+        "#;
+
+        eprintln!("/----------/");
+        eprintln!("{sql}");
+
+        let (plan,) = sql.fetch_one::<(Value,)>(&mut conn);
+        eprintln!("{plan:#?}");
+
+        // Verify that the custom scan is used
+        let plan = plan
+            .pointer("/0/Plan/Plans/0")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        pretty_assertions::assert_eq!(
+            plan.get("Node Type"),
+            Some(&Value::String(String::from("Custom Scan")))
+        );
+    }
+
+    #[rstest]
+    fn with_count(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that count is correct
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(2,)]);
+
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_int8 IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(2,)]);
+
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_int8 IS NULL
+            AND col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(1,)]);
+    }
+
+    #[rstest]
+    fn with_return_values(#[from(setup_test_table)] mut conn: PgConnection) {
+        let res = r#"
+            SELECT id, col_boolean, col_int8
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5]'::int8range)
+            ORDER BY id;
+        "#
+        .fetch::<(i64, bool, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![(1, false, None), (4, false, Some(444))]);
+
+        let res = r#"
+            SELECT *
+            FROM test
+            WHERE col_int8 IS NULL
+            AND col_text IS NULL
+            AND id @@@ '1' OR id @@@ '2' OR id @@@ '3' OR id @@@ '4'
+            ORDER BY id;
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(
+            res,
+            vec![
+                (2, false, Some(String::from("foo")), None),
+                (3, false, Some(String::from("bar")), Some(333))
+            ]
+        );
+    }
+
+    #[rstest]
+    fn with_multiple_predicates(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that IS NULL works with other predicates
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ '>2';
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(1,)]);
+
+        let res = r#"
+            SELECT id, col_boolean, col_int8
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ '>2';
+        "#
+        .fetch::<(i64, bool, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![(4, false, Some(444))]);
+    }
+
+    #[rstest]
+    fn with_ordering(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that results are correct and ordered
+        let result = r#"
+            SELECT id
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY id DESC;
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(result, vec![(4,), (1,)]);
+    }
+
+    #[rstest]
+    fn with_aggregation(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that GROUP BY works
+        let result = r#"
+            SELECT col_int8, count(*)
+            FROM test
+            WHERE col_text IS NULL
+            and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            GROUP BY col_int8
+            ORDER BY col_int8;
+        "#
+        .fetch::<(Option<i64>, i64)>(&mut conn);
+        assert_eq!(result, vec![(Some(444), 1), (None, 1)]);
+    }
+
+    #[rstest]
+    fn with_distinct(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that DISTIINCT works
+        let result = r#"
+            SELECT COUNT(DISTINCT col_int8)
+            FROM test
+            WHERE col_text IS NULL
+            and id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(result, vec![(1,)]);
+    }
+
+    #[rstest]
+    fn with_join(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that JOIN works
+        "CREATE TABLE test2 (id SERIAL8 NOT NULL PRIMARY KEY, ref_id int8, ref_text text);"
+            .execute(&mut conn);
+        let sql = r#"
+            CREATE INDEX idxtest2 ON test2 USING bm25 (id, ref_id, ref_text)
+            WITH (key_field='id', text_fields = '{"ref_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
+        "#;
+        sql.execute(&mut conn);
+
+        "INSERT INTO test2 (ref_id, ref_text) VALUES (2, 'qux');".execute(&mut conn);
+        "INSERT INTO test2 (ref_id, ref_text) VALUES (4, 'foo');".execute(&mut conn);
+
+        let join = r#"
+            SELECT test.id, test.col_text, test2.ref_text
+            FROM test
+            INNER JOIN test2 ON test.id = test2.ref_id
+            WHERE test.col_int8 IS NULL
+            AND test.id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY test.id;
+        "#
+        .fetch_one::<(i64, String, String)>(&mut conn);
+        assert_eq!(join, (2, String::from("foo"), String::from("qux")));
+    }
+
+    #[rstest]
+    fn post_update(#[from(setup_test_table)] mut conn: PgConnection) {
+        // Verify that NULL is not counted after update
+        "UPDATE test SET col_text = NULL".execute(&mut conn);
+        let count = r#"
+            SELECT count(*)
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range);
+        "#
+        .fetch::<(i64,)>(&mut conn);
+        assert_eq!(count, vec![(4,)]);
+
+        let res = r#"
+            SELECT id, col_int8, col_boolean
+            FROM test
+            WHERE col_text IS NULL
+            AND id @@@ paradedb.range(field=> 'id', range=> '[1, 5)'::int8range)
+            ORDER BY id;
+        "#
+        .fetch::<(i64, Option<i64>, bool)>(&mut conn);
+        assert_eq!(
+            res,
+            vec![
+                (1, None, false),
+                (2, None, false),
+                (3, Some(333), false),
+                (4, Some(444), false)
+            ]
+        )
+    }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2232 

## What
This PR implements pushdown of `IS NOT NULL` into Tantivy and avoids query builder to query null values.

## Why
User requested to query for null values without query builder. Plus, tiny bit of query performance improvement.

## How
Detect NullTest in query and pushdown to Tantivy.

## Tests
test included in `pushdown.rs` to check if ParadeDB Custom Scan is generated when the query includes `IS NOT NULL`