### PR TITLE
fix: `ChannelRequest`s must wait on reply

### DIFF
--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -23,19 +23,30 @@ use tantivy::directory::{
 };
 use tantivy::index::SegmentMetaInventory;
 use tantivy::merge_policy::MergePolicy;
-use tantivy::{Directory, IndexMeta};
+use tantivy::{Directory, IndexMeta, TantivyError};
 
 pub type Overwrite = bool;
 
 pub enum ChannelRequest {
-    RegisterFilesAsManaged(Vec<PathBuf>, Overwrite),
-    SegmentRead(Range<usize>, FileEntry, oneshot::Sender<OwnedBytes>),
-    SegmentWrite(PathBuf, Vec<u8>),
-    SegmentFlush(PathBuf),
-    SegmentWriteTerminate(PathBuf),
-    GetSegmentComponent(PathBuf, oneshot::Sender<FileEntry>),
-    SaveMetas(IndexMeta, IndexMeta),
-    LoadMetas(SegmentMetaInventory, oneshot::Sender<IndexMeta>),
+    RegisterFilesAsManaged(
+        Vec<PathBuf>,
+        Overwrite,
+        oneshot::Sender<tantivy::Result<()>>,
+    ),
+    SegmentRead(
+        Range<usize>,
+        FileEntry,
+        oneshot::Sender<std::io::Result<OwnedBytes>>,
+    ),
+    SegmentWrite(PathBuf, Vec<u8>, oneshot::Sender<std::io::Result<()>>),
+    SegmentFlush(PathBuf, oneshot::Sender<std::io::Result<()>>),
+    SegmentWriteTerminate(PathBuf, oneshot::Sender<std::io::Result<()>>),
+    GetSegmentComponent(PathBuf, oneshot::Sender<tantivy::Result<FileEntry>>),
+    SaveMetas(IndexMeta, IndexMeta, oneshot::Sender<tantivy::Result<()>>),
+    LoadMetas(
+        SegmentMetaInventory,
+        oneshot::Sender<tantivy::Result<IndexMeta>>,
+    ),
     ReconsiderMergePolicy(
         IndexMeta,
         IndexMeta,
@@ -44,7 +55,6 @@ pub enum ChannelRequest {
     Panic(Box<dyn Any + Send>),
     WantsCancel(oneshot::Sender<bool>),
 }
-
 #[derive(Clone, Debug)]
 pub struct ChannelDirectory {
     sender: Sender<ChannelRequest>,
@@ -63,7 +73,7 @@ impl Directory for ChannelDirectory {
         Ok(Arc::new(unsafe {
             ChannelReader::new(path, self.sender.clone()).map_err(|e| {
                 OpenReadError::wrap_io_error(
-                    io::Error::new(io::ErrorKind::Other, format!("{:?}", e)),
+                    io::Error::new(io::ErrorKind::NotConnected, e),
                     path.to_path_buf(),
                 )
             })?
@@ -129,11 +139,18 @@ impl Directory for ChannelDirectory {
         files: Vec<PathBuf>,
         overwrite: bool,
     ) -> tantivy::Result<()> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
-            .send(ChannelRequest::RegisterFilesAsManaged(files, overwrite))
-            .unwrap();
+            .send(ChannelRequest::RegisterFilesAsManaged(
+                files,
+                overwrite,
+                oneshot_sender,
+            ))
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.to_string()))?;
 
-        Ok(())
+        oneshot_receiver
+            .recv()
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e))?
     }
 
     fn save_metas(
@@ -142,23 +159,29 @@ impl Directory for ChannelDirectory {
         previous_meta: &IndexMeta,
         _payload: &mut (dyn Any + '_),
     ) -> tantivy::Result<()> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
             .send(ChannelRequest::SaveMetas(
                 meta.clone(),
                 previous_meta.clone(),
+                oneshot_sender,
             ))
-            .unwrap();
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.to_string()))?;
 
-        Ok(())
+        oneshot_receiver
+            .recv()
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e))?
     }
 
     fn load_metas(&self, inventory: &SegmentMetaInventory) -> tantivy::Result<IndexMeta> {
         let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
             .send(ChannelRequest::LoadMetas(inventory.clone(), oneshot_sender))
-            .unwrap();
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.to_string()))?;
 
-        Ok(oneshot_receiver.recv().unwrap())
+        oneshot_receiver
+            .recv()
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e))?
     }
 
     fn reconsider_merge_policy(
@@ -322,48 +345,51 @@ impl ChannelRequestHandler {
 
     fn process_message(&mut self, message: ChannelRequest) -> Result<ShouldTerminate> {
         match message {
-            ChannelRequest::RegisterFilesAsManaged(files, overwrite) => {
-                self.directory.register_files_as_managed(files, overwrite)?;
+            ChannelRequest::RegisterFilesAsManaged(files, overwrite, sender) => {
+                sender.send(self.directory.register_files_as_managed(files, overwrite))?;
             }
             ChannelRequest::GetSegmentComponent(path, sender) => {
                 if self.file_entries.contains_key(&path) {
-                    sender.send(*self.file_entries.get(&path).unwrap())?;
-                    return Ok(false);
+                    sender.send(Ok(*self.file_entries.get(&path).unwrap()))?;
+                } else {
+                    let file_entry = unsafe {
+                        self.directory
+                            .directory_lookup(&path)
+                            .map_err(|e| TantivyError::SystemError(e.to_string()))
+                    };
+                    sender.send(file_entry)?;
                 }
-
-                let file_entry = unsafe { self.directory.directory_lookup(&path)? };
-                sender.send(file_entry)?;
             }
             ChannelRequest::SegmentRead(range, handle, sender) => {
                 let reader = self.readers.entry(handle).or_insert_with(|| unsafe {
                     SegmentComponentReader::new(self.relation_oid, handle)
                 });
-                let data = reader.read_bytes(range)?;
-                sender.send(data)?;
+                sender.send(reader.read_bytes(range))?;
             }
-            ChannelRequest::SegmentWrite(path, data) => {
+            ChannelRequest::SegmentWrite(path, data, sender) => {
                 let writer = self.writers.entry(path.clone()).or_insert_with(|| unsafe {
                     SegmentComponentWriter::new(self.relation_oid, &path)
                 });
-                writer.write_all(&data)?;
+                sender.send(writer.write_all(&data))?
             }
-            ChannelRequest::SegmentFlush(path) => {
+            ChannelRequest::SegmentFlush(path, sender) => {
                 if let Some(writer) = self.writers.get_mut(&path) {
-                    writer.flush()?;
+                    sender.send(writer.flush())?
                 }
             }
-            ChannelRequest::SegmentWriteTerminate(path) => {
+            ChannelRequest::SegmentWriteTerminate(path, sender) => {
                 let writer = self.writers.remove(&path).expect("writer should exist");
                 self.file_entries.insert(writer.path(), writer.file_entry());
-                writer.terminate()?;
+                sender.send(writer.terminate())?;
             }
-            ChannelRequest::SaveMetas(metas, previous_metas) => {
-                self.directory
-                    .save_metas(&metas, &previous_metas, &mut self.file_entries)?;
+            ChannelRequest::SaveMetas(metas, previous_metas, sender) => {
+                let result =
+                    self.directory
+                        .save_metas(&metas, &previous_metas, &mut self.file_entries);
+                sender.send(result)?;
             }
             ChannelRequest::LoadMetas(inventory, sender) => {
-                let metas = self.directory.load_metas(&inventory)?;
-                sender.send(metas)?;
+                sender.send(self.directory.load_metas(&inventory))?;
             }
             ChannelRequest::ReconsiderMergePolicy(meta, previous_meta, sender) => {
                 let policy = self

--- a/pg_search/src/index/writer/channel.rs
+++ b/pg_search/src/index/writer/channel.rs
@@ -20,32 +20,51 @@ impl ChannelWriter {
 
 impl Write for ChannelWriter {
     fn write(&mut self, data: &[u8]) -> Result<usize> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
             .send(ChannelRequest::SegmentWrite(
                 self.path.clone(),
                 data.to_vec(),
+                oneshot_sender,
             ))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))?;
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e.to_string()))?;
+
+        let _ = oneshot_receiver
+            .recv()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e))?;
         Ok(data.len())
     }
 
     fn flush(&mut self) -> Result<()> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
-            .send(ChannelRequest::SegmentFlush(self.path.clone()))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))?;
-        Ok(())
+            .send(ChannelRequest::SegmentFlush(
+                self.path.clone(),
+                oneshot_sender,
+            ))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e.to_string()))?;
+
+        oneshot_receiver
+            .recv()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e))?
     }
 
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        let _ = self.write(buf)?;
-        Ok(())
+        self.write(buf).map(|_| ())
     }
 }
 
 impl TerminatingWrite for ChannelWriter {
     fn terminate_ref(&mut self, _: AntiCallToken) -> Result<()> {
+        let (oneshot_sender, oneshot_receiver) = oneshot::channel();
         self.sender
-            .send(ChannelRequest::SegmentWriteTerminate(self.path.clone()))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e}")))
+            .send(ChannelRequest::SegmentWriteTerminate(
+                self.path.clone(),
+                oneshot_sender,
+            ))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e.to_string()))?;
+        oneshot_receiver
+            .recv()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::NotConnected, e))?
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Not all of our ChannelRequest variants were defined with a response channel (a `oneshot::Sender<T>`), but they all need to be, so that the reply and return value (some kind of `Result<T>` in nearly every case) can be properly returned to tantivy.

## Why

Without this, many of the channel requests, including SaveMetas, were not waiting for the operation to actually finish on the main thread before returning control back to tantivy.  And in those cases, we also weren't passing the `Result<T>` result from the actual request back to tantivy either, we'd just lie and say that it worked.

This could cause tantivy to get ahead, in terms of its execution, from the processing we need to do on the main thread, leading to various kinds of undefined, and at least incredibly confusing, behavior.

## How

## Tests
