### PR TITLE
chore: excise `reqwest` from our binary's dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,8 +2236,7 @@ dependencies = [
 [[package]]
 name = "lindera"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d8eeee3410e04f0375235b4420b105337db127e3759e6ceac52212f5b4e5ee"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2256,7 +2255,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum_macros 0.27.1",
  "unicode-blocks",
  "unicode-normalization",
  "unicode-segmentation",
@@ -2266,8 +2265,7 @@ dependencies = [
 [[package]]
 name = "lindera-cc-cedict"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cc396123063b1f2d7f546d36192caae78ec06be304dcac4091db33d02db00a"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2279,8 +2277,7 @@ dependencies = [
 [[package]]
 name = "lindera-dictionary"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb14e04b9937c7382a20e5b135f9a6c7077e0d9a57a3f69e560471e57300476"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2304,8 +2301,7 @@ dependencies = [
 [[package]]
 name = "lindera-ipadic"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdaf31dda57b0e1f0f5f2fa11dc4a3cc3ce2721c65e5d0e6f4aed30bb36da02"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2317,8 +2313,7 @@ dependencies = [
 [[package]]
 name = "lindera-ipadic-neologd"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0bdebbc648c4e866c2e3da31bd64f4b56741fa7f51d3a156c3f4b0145e128e"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2330,8 +2325,7 @@ dependencies = [
 [[package]]
 name = "lindera-ko-dic"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e722c201cd20b2b135effdc6b271f8701998227130de2102081abd3081b3366d"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2343,8 +2337,7 @@ dependencies = [
 [[package]]
 name = "lindera-unidic"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd580d23e6ab93843428c4f6bf22e97f44a7b1e39d0fe9fc2e3fbf8960835ffe"
+source = "git+https://github.com/paradedb/lindera.git?rev=5db30093bacf7bf9e05f38861b8787d6aae3e7f4#5db30093bacf7bf9e05f38861b8787d6aae3e7f4"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ pgrx-tests = "0.13.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
+lindera = { git = "https://github.com/paradedb/lindera.git", rev = "5db30093bacf7bf9e05f38861b8787d6aae3e7f4" }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -18,7 +18,7 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 icu = ["tokenizers/icu"]
-telemetry = []
+telemetry = ["dep:reqwest"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 
 [dependencies]
@@ -38,7 +38,7 @@ parking_lot = "0.12.3"
 tokenizers = { path = "../tokenizers" }
 pgrx.workspace = true
 rayon = "1.10.0"
-reqwest = { version = "0.12.12", features = ["blocking"] }
+reqwest = { version = "0.12.12", features = ["blocking"], optional = true }
 rustc-hash = "2.1.1"
 serde = "1.0.218"
 serde_json = { version = "1.0.139", features = ["preserve_order"] }

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -26,6 +26,7 @@ mod schema;
 #[cfg(test)]
 pub mod github;
 pub mod gucs;
+#[cfg(feature = "telemetry")]
 pub mod telemetry;
 
 use self::postgres::customscan;
@@ -87,11 +88,8 @@ pub unsafe extern "C" fn _PG_init() {
     #[cfg(not(feature = "pg17"))]
     postgres::fake_aminsertcleanup::register();
 
-    if cfg!(feature = "telemetry") {
-        use telemetry::setup_telemetry_background_worker;
-
-        setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
-    }
+    #[cfg(feature = "telemetry")]
+    telemetry::setup_telemetry_background_worker(telemetry::ParadeExtension::PgSearch);
 
     // Register our tracing / logging hook, so that we can ensure that the logger
     // is initialized for all connections.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Using our new `lindera` fork
(https://github.com/paradedb/lindera/commit/df56adc01b50ca125449ae19fb5d95a3ee86bb9a) we are now able to get `reqwest` out of our normal builds, which also removes `tokio` and a litany of other dependencies.

## Why

The impetus for this was a customer reporting that they got an error excuting a query:  `cannot spawn executor threads... Resource temporarily unavailable`.

## How

Turns out that phrase was coming from `tokio`'s `init()` function, which was being pulled in by `reqwuest`, which is actually only necessary for us when a) telemetry is turned on, and b) when `lindera` is running its `build.rs` -- *not* from its regular library.

## Tests
