### PR TITLE
feat: truncate index during vacuum

### DIFF
--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -75,7 +75,6 @@ pub extern "C" fn amvacuumcleanup(
             metadata.ambulkdelete_sentinel
         };
 
-        let mut last_used_blockno = FIXED_BLOCK_NUMBERS.last().unwrap() + 1;
         for blockno in FIXED_BLOCK_NUMBERS.last().unwrap() + 1..nblocks {
             if blockno == vacuum_sentinel_blockno {
                 // don't try to open the vacuum_sentinel_blockno block -- only `ambulkdelete` should ever
@@ -90,8 +89,6 @@ pub extern "C" fn amvacuumcleanup(
 
             if page.is_recyclable(heap_relation) {
                 bman.record_free_index_page(buffer);
-            } else if blockno >= last_used_blockno {
-                last_used_blockno = blockno;
             }
         }
 

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -45,7 +45,7 @@ pub extern "C" fn amvacuumcleanup(
         // Truncate to the last non-recyclable block
         let first_vacuumable_blockno = FIXED_BLOCK_NUMBERS.last().unwrap() + 1;
         assert!(
-            nblocks > first_vacuumable_blockno,
+            nblocks >= first_vacuumable_blockno,
             "the index has fewer blocks than should be possible"
         );
 

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -68,6 +68,7 @@ pub extern "C" fn amvacuumcleanup(
 
         pg_sys::UnlockRelationForExtension(info.index, pg_sys::ExclusiveLock as i32);
 
+        // Return the rest to the free space map, if recyclable
         let vacuum_sentinel_blockno = {
             let merge_lock = bman.get_buffer(MERGE_LOCK);
             let page = merge_lock.page();
@@ -91,7 +92,6 @@ pub extern "C" fn amvacuumcleanup(
                 bman.record_free_index_page(buffer);
             }
         }
-
         pg_sys::RelationClose(heap_relation);
         pg_sys::IndexFreeSpaceMapVacuum(info.index);
     }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -54,14 +54,16 @@ pub extern "C" fn amvacuumcleanup(
                 pg_sys::vacuum_delay_point();
             }
 
-            let buffer = bman.get_buffer(blockno);
-            let page = buffer.page();
-
-            if !page.is_recyclable(heap_relation) {
-                if blockno != (nblocks - 1) {
-                    nblocks = blockno + 1;
-                    pg_sys::RelationTruncate(info.index, nblocks);
+            if let Some(buffer) = bman.get_buffer_conditional(blockno) {
+                let page = buffer.page();
+                if !page.is_recyclable(heap_relation) {
+                    if blockno != (nblocks - 1) {
+                        nblocks = blockno + 1;
+                        pg_sys::RelationTruncate(info.index, nblocks);
+                    }
+                    break;
                 }
+            } else {
                 break;
             }
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

It turns out that index relations, not just heap relations, CAN be truncated.

## Why

This allows vacuum to reduce the physical size of an index. If there are recyclable pages at the end of an index, they will be truncated.

## How

Take an exclusive lock on the index, find the truncation point, truncate the index, and then unlock the index. Return remaining pages to the FSM like before.

## Tests
