### PR TITLE
ci: Fixes bot comments for PRs from forked repos

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -6,7 +6,7 @@
 name: Check pg_search Schema Upgrade
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2285.

## What

There's an issue with the bot posting comments for a pull request comming from a forked repo.

## Why

That's due to where GitHub Actions takes secrets.

## How

From the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target):

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. **This event allows your workflow to do things like label or comment on pull requests from forks.** Avoid using this event if you need to build or run code from the pull request.

## Tests

Later, when it's merged. There's a suitable pull request to verify that.
