### PR TITLE
feat: move page recycling to the foreground

### DIFF
--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -280,15 +280,7 @@ impl ChannelRequestHandler {
             }
 
             // caught a panic so let it continue
-            Err(e) => {
-                #[allow(clippy::implicit_saturating_sub)]
-                unsafe {
-                    if pg_sys::InterruptHoldoffCount > 0 {
-                        pg_sys::InterruptHoldoffCount -= 1;
-                    }
-                }
-                resume_unwind(e)
-            }
+            Err(e) => resume_unwind(e),
         }
     }
 

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -287,7 +287,6 @@ pub unsafe fn save_new_metas(
     for deleted_entry in replaced_delete_entries {
         let mut file = LinkedBytesList::open(relation_oid, deleted_entry.file_entry.starting_block);
         file.mark_deleted(deleting_xid);
-        pgrx::warning!("save_new_metas: doing replaced deleted entries");
     }
 
     // add the new entries

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -88,6 +88,8 @@ pub unsafe fn save_new_metas(
 
     modified_ids.retain(|id| new_files.contains_key(id));
 
+    let deleting_xid = pg_sys::GetCurrentTransactionIdIfAny();
+
     //
     // process the new segments
     //
@@ -170,7 +172,7 @@ pub unsafe fn save_new_metas(
     //
     // process the deleted segments
     //
-    // find the deleted segment entries and set their `xmax` to this transaction id
+    // find the deleted segment entries and set their `xmax` to the `deleting_xid` calculated above
     // and for each file in each deleted segment, locate its LinkedBytesList and .mark_deleted()
     //
     let deleted_entries = deleted_ids
@@ -187,7 +189,8 @@ pub unsafe fn save_new_metas(
             // it only applies .delete files, which we consider as modifications
             assert!(pg_sys::IsTransactionState());
 
-            meta_entry.xmax = pg_sys::GetCurrentTransactionId();
+            assert!(meta_entry.xmax == pg_sys::InvalidTransactionId);
+            meta_entry.xmax = deleting_xid;
             (meta_entry, blockno)
         })
         .collect::<Vec<_>>();
@@ -212,7 +215,7 @@ pub unsafe fn save_new_metas(
 
     // delete old entries and their corresponding files
     for (entry, blockno) in &deleted_entries {
-        assert!(entry.xmax == pg_sys::GetCurrentTransactionId());
+        assert!(entry.xmax == deleting_xid);
         let mut buffer = linked_list.bman_mut().get_buffer_mut(*blockno);
         let mut page = buffer.page_mut();
 
@@ -229,24 +232,16 @@ pub unsafe fn save_new_metas(
 
         let did_replace = page.replace_item(offno, pg_item, size);
         assert!(did_replace);
-        drop(buffer);
 
-        for file_entry in [
-            entry.postings,
-            entry.positions,
-            entry.fast_fields,
-            entry.field_norms,
-            entry.terms,
-            entry.store,
-            entry.temp_store,
-            entry.delete.map(|de| de.file_entry),
-        ]
-        .into_iter()
-        .flatten()
-        {
+        // we do this while holding an exclusive lock on the `buffer` containing the SegmentMetaEntry
+        // so that when the lock is released and this buffer is readable by others, its xmax value
+        // and the recyclable-status of all its linked files will match
+        for (file_entry, _) in entry.file_entries() {
             let mut file = LinkedBytesList::open(relation_oid, file_entry.starting_block);
-            file.mark_deleted();
+            file.mark_deleted(deleting_xid);
         }
+
+        drop(buffer);
     }
 
     // replace the modified entries
@@ -262,6 +257,22 @@ pub unsafe fn save_new_metas(
             );
         };
 
+        if entry.xmax != pg_sys::InvalidTransactionId {
+            // this entry was already marked with an xmax so we want to carry that same value through
+            // to the `.delete` file that's now attached to it.
+            //
+            // the entry having an xmax means it's been tagged for recycling but hasn't been recycled
+            // yet.  and we want this new delete file to be recycled along with it when that happens
+            //
+            // we also do this while `buffer` has an exclusive lock so that when we're done updating
+            // this entry in the entry list all its files will have the same recyclable setting
+            let mut deletes_file = LinkedBytesList::open(
+                relation_oid,
+                entry.delete.as_ref().unwrap().file_entry.starting_block,
+            );
+            deletes_file.mark_deleted(entry.xmax);
+        }
+
         let PgItem(pg_item, size) = entry.into();
         let did_replace = page.replace_item(offno, pg_item, size);
         if !did_replace {
@@ -275,7 +286,8 @@ pub unsafe fn save_new_metas(
     // chase down the linked lists for any existing deleted entries and mark them as deleted
     for deleted_entry in replaced_delete_entries {
         let mut file = LinkedBytesList::open(relation_oid, deleted_entry.file_entry.starting_block);
-        file.mark_deleted();
+        file.mark_deleted(deleting_xid);
+        pgrx::warning!("save_new_metas: doing replaced deleted entries");
     }
 
     // add the new entries
@@ -309,8 +321,13 @@ pub unsafe fn load_metas(
 
         while offsetno <= max_offset {
             if let Some((entry, _)) = page.read_item::<SegmentMetaEntry>(offsetno) {
-                if (matches!(solve_mvcc, MvccSatisfies::Any)
-                    && !entry.recyclable(snapshot, heap_relation))
+                if entry.recyclable(snapshot, heap_relation) {
+                    // we don't want anyone to see entries that are recyclable
+                    offsetno += 1;
+                    continue;
+                }
+
+                if (matches!(solve_mvcc, MvccSatisfies::Any))
                     || (matches!(solve_mvcc, MvccSatisfies::Snapshot) && entry.visible(snapshot))
                 {
                     let inner_segment_meta = InnerSegmentMeta {

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -286,7 +286,6 @@ unsafe fn do_merge(indexrelid: Oid) -> Option<()> {
         if !recycled_entries.is_empty() {
             let indexrel = pg_sys::RelationIdGetRelation(indexrelid);
             for entry in recycled_entries {
-                assert!(entry.recyclable(snapshot, std::ptr::null_mut()));
                 for (file_entry, type_) in entry.file_entries() {
                     let bytes = LinkedBytesList::open(indexrelid, file_entry.starting_block);
                     bytes.return_to_fsm(&entry, type_);

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -22,6 +22,7 @@ use anyhow::Result;
 use pgrx::pg_sys;
 use pgrx::pg_sys::BlockNumber;
 use std::fmt::Debug;
+
 // ---------------------------------------------------------------
 // Linked list implementation over block storage,
 // where each node in the list is a pg_sys::Item
@@ -145,8 +146,9 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         items
     }
 
-    pub unsafe fn garbage_collect(&mut self, strategy: pg_sys::BufferAccessStrategy) {
+    pub unsafe fn garbage_collect(&mut self) -> Vec<T> {
         // Delete all items that are definitely dead
+        let strategy = pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM);
         let snapshot = pg_sys::GetActiveSnapshot();
         let heap_oid = pg_sys::IndexGetRelation(self.relation_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
@@ -154,6 +156,8 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let start_blockno = self.get_start_blockno();
         let mut blockno = start_blockno;
         let mut last_filled_blockno = start_blockno;
+
+        let mut recycled_entries = Vec::new();
 
         while blockno != pg_sys::InvalidBlockNumber {
             let mut buffer = self.bman.get_buffer_for_cleanup(blockno, strategy);
@@ -165,6 +169,9 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
             while offsetno <= max_offset {
                 if let Some((entry, _)) = page.read_item::<T>(offsetno) {
                     if entry.recyclable(snapshot, heap_relation) {
+                        page.mark_item_dead(offsetno);
+
+                        recycled_entries.push(entry);
                         delete_offsets.push(offsetno);
                     } else {
                         let xmin_needs_freeze = entry.xmin_needs_freeze(freeze_limit);
@@ -193,13 +200,10 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
             // Compaction step: If the page is entirely empty, mark as deleted
             // Adjust the pointer from the last known non-empty node to point to the next non-empty node
             if new_max_offset == pg_sys::InvalidOffsetNumber && current_blockno != start_blockno {
-                page.mark_deleted();
-
-                // drop the buffer were holding onto as we might acquire an exclusive lock on another
-                // one below and we don't want concurrent backends that are otherwise racing through
-                // this linked list to end up causing a lock inversion where they've locked the page
-                // we want while we have this page locked
-                drop(buffer);
+                page.mark_deleted(pg_sys::GetCurrentTransactionId());
+                // this page is no longer useful to us so go ahead and return it to the FSM.  Doing
+                // so will also drop the lock
+                self.bman.return_to_fsm_mut(buffer);
 
                 // We've reached the end of the list, which means the last filled block is now the
                 // last entry in the list
@@ -229,6 +233,8 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         }
 
         pg_sys::RelationClose(heap_relation);
+
+        recycled_entries
     }
 
     pub unsafe fn add_items(&mut self, items: Vec<T>, buffer: Option<BufferMut>) -> Result<()> {
@@ -361,7 +367,6 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let strategy = pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM);
         let snapshot = pg_sys::GetActiveSnapshot();
         let delete_xid = {
             #[cfg(feature = "pg13")]
@@ -390,7 +395,7 @@ mod tests {
 
         list.add_items(entries_to_delete.clone(), None).unwrap();
         list.add_items(entries_to_keep.clone(), None).unwrap();
-        list.garbage_collect(strategy);
+        list.garbage_collect();
 
         assert!(list
             .lookup(|entry| entry.segment_id == entries_to_delete[0].segment_id)
@@ -409,7 +414,6 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let strategy = pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_VACUUM);
         let snapshot = pg_sys::GetActiveSnapshot();
         let deleted_xid = {
             #[cfg(feature = "pg13")]
@@ -441,7 +445,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             list.add_items(entries.clone(), None).unwrap();
-            list.garbage_collect(strategy);
+            list.garbage_collect();
 
             for entry in entries {
                 if entry.xmax == not_deleted_xid {
@@ -486,7 +490,7 @@ mod tests {
             list.add_items(entries_3.clone(), None).unwrap();
 
             let pre_gc_blocks = linked_list_block_numbers(&list);
-            list.garbage_collect(strategy);
+            list.garbage_collect();
 
             for entries in [entries_1, entries_2, entries_3] {
                 for entry in entries {

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -44,8 +44,11 @@ pub struct VacuumSentinel(PinnedBuffer);
 /// Only one merge can happen at a time, so we need to lock the merge process
 #[derive(Debug)]
 pub struct MergeLock {
-    bman: BufferManager,
+    // NB:  Rust's struct drop order is how the fields are defined in the source code
+    // and while it _probably_ doesn't matter, we'd prefer to have `buffer`'s drop impl
+    // run before the `bman` from which it originated
     buffer: BufferMut,
+    bman: BufferManager,
     save_xid: bool,
 }
 
@@ -106,8 +109,8 @@ impl MergeLock {
         let mut bman = BufferManager::new(relation_oid);
         let merge_lock = bman.get_buffer_mut(MERGE_LOCK);
         MergeLock {
-            bman,
             buffer: merge_lock,
+            bman,
             save_xid: false,
         }
     }
@@ -235,7 +238,7 @@ struct VacuumListData {
 }
 
 pub struct VacuumList {
-    bman: BufferManager,
+    relation_oid: pg_sys::Oid,
     start_block_number: pg_sys::BlockNumber,
     merge_lock: Option<MergeLock>,
 }
@@ -258,7 +261,7 @@ impl VacuumList {
         start_block_number: pg_sys::BlockNumber,
     ) -> VacuumList {
         Self {
-            bman: BufferManager::new(relation_oid),
+            relation_oid,
             start_block_number,
             merge_lock,
         }
@@ -271,7 +274,8 @@ impl VacuumList {
         let mut segment_ids = segment_ids.collect::<Vec<_>>();
         segment_ids.sort();
 
-        let mut buffer = self.bman.get_buffer_mut(self.start_block_number);
+        let mut bman = BufferManager::new(self.relation_oid);
+        let mut buffer = bman.get_buffer_mut(self.start_block_number);
         let mut page = buffer.page_mut();
         let mut contents = page.contents_mut::<VacuumListData>();
         contents.nentries = 0;
@@ -283,11 +287,11 @@ impl VacuumList {
                 // or by creating a new page
                 if page.next_blockno() != pg_sys::InvalidBlockNumber {
                     // we want to reuse the next block if we have one
-                    buffer = self.bman.get_buffer_mut(page.next_blockno());
+                    buffer = bman.get_buffer_mut(page.next_blockno());
                     page = buffer.page_mut();
                 } else {
                     // make a new next block and link it in
-                    let next_buffer = self.bman.new_buffer();
+                    let next_buffer = bman.new_buffer();
                     let special = page.special_mut::<BM25PageSpecialData>();
                     special.next_blockno = next_buffer.number();
 
@@ -310,7 +314,7 @@ impl VacuumList {
             .expect("VacuumList should own the MergeLock in this context")
             .pin_ambulkdelete_sentinel();
 
-        // yes, I know, but this makes it clear that our intention is to obtain the vacuum_sential
+        // yes, I know, but this makes it clear that our intention is to obtain the vacuum_sentinel
         // before we (and our contained MergeLock) are dropped
         drop(self);
         vacuum_sentinel
@@ -318,7 +322,9 @@ impl VacuumList {
 
     pub fn read_list(&self) -> HashSet<SegmentId> {
         let mut segment_ids = HashSet::new();
-        let mut buffer = self.bman.get_buffer(self.start_block_number);
+
+        let bman = BufferManager::new(self.relation_oid);
+        let mut buffer = bman.get_buffer(self.start_block_number);
         loop {
             let page = buffer.page();
             let contents = page.contents::<VacuumListData>();
@@ -339,7 +345,7 @@ impl VacuumList {
                 break;
             }
 
-            buffer = self.bman.get_buffer(page.next_blockno());
+            buffer = bman.get_buffer(page.next_blockno());
         }
 
         segment_ids

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -15,11 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::storage::block::{BM25PageSpecialData, PgItem};
+use crate::postgres::storage::block::{bm25_max_free_space, BM25PageSpecialData, PgItem};
 use parking_lot::Mutex;
 use pgrx::pg_sys;
 use pgrx::pg_sys::OffsetNumber;
-use pgrx::PgBox;
 use rustc_hash::FxHashMap;
 
 pub trait BM25Page {
@@ -72,8 +71,8 @@ impl BM25Page for pg_sys::Page {
 
 #[derive(Debug)]
 pub struct BM25BufferCache {
-    indexrel: PgBox<pg_sys::RelationData>,
-    heaprel: PgBox<pg_sys::RelationData>,
+    indexrel: pg_sys::Relation,
+    heaprel: pg_sys::Relation,
     cache: Mutex<FxHashMap<pg_sys::BlockNumber, Vec<u8>>>,
 }
 
@@ -87,30 +86,42 @@ impl BM25BufferCache {
             let heaprelid = pg_sys::IndexGetRelation(indexrelid, false);
             let heaprel = pg_sys::RelationIdGetRelation(heaprelid);
             Self {
-                indexrel: PgBox::from_pg(indexrel),
-                heaprel: PgBox::from_pg(heaprel),
+                indexrel,
+                heaprel,
                 cache: Default::default(),
             }
         }
     }
 
+    pub unsafe fn heaprel(&self) -> *mut pg_sys::RelationData {
+        self.heaprel
+    }
+
     pub unsafe fn indexrel(&self) -> *mut pg_sys::RelationData {
-        self.indexrel.as_ptr()
+        self.indexrel
     }
 
     pub unsafe fn new_buffer(&self) -> pg_sys::Buffer {
         // Try to find a recyclable page
         loop {
-            let blockno = pg_sys::GetFreeIndexPage(self.indexrel.as_ptr());
+            // ask for a page with at least `bm25_max_free_space()` -- that's how much we need to do our things
+            let blockno = pg_sys::GetPageWithFreeSpace(self.indexrel, bm25_max_free_space() as _);
             if blockno == pg_sys::InvalidBlockNumber {
                 break;
             }
+            // we got one, so let Postgres know so the FSM will stop considering it
+            pg_sys::RecordUsedIndexPage(self.indexrel, blockno);
 
             let buffer = self.get_buffer(blockno, None);
-
             if pg_sys::ConditionalLockBuffer(buffer) {
                 let page = pg_sys::BufferGetPage(buffer);
-                if page.recyclable(self.heaprel.as_ptr()) {
+
+                // the FSM would have returned a page to us that was previously known to be recyclable,
+                // but it may not still be recyclable now that we have a lock.
+                //
+                // between then and now some other backend could have gotten this page too, locked it,
+                // initialized it, and released its lock, making it unusable by us
+                if page.recyclable(self.heaprel) {
                     return buffer;
                 }
 
@@ -122,14 +133,14 @@ impl BM25BufferCache {
 
         // No recyclable pages found, create a new page
         // Postgres requires an exclusive lock on the relation to create a new page
-        pg_sys::LockRelationForExtension(self.indexrel.as_ptr(), pg_sys::ExclusiveLock as i32);
+        pg_sys::LockRelationForExtension(self.indexrel, pg_sys::ExclusiveLock as i32);
 
         let buffer = self.get_buffer(
             pg_sys::InvalidBlockNumber,
             Some(pg_sys::BUFFER_LOCK_EXCLUSIVE),
         );
 
-        pg_sys::UnlockRelationForExtension(self.indexrel.as_ptr(), pg_sys::ExclusiveLock as i32);
+        pg_sys::UnlockRelationForExtension(self.indexrel, pg_sys::ExclusiveLock as i32);
         buffer
     }
 
@@ -148,7 +159,7 @@ impl BM25BufferCache {
         lock: Option<u32>,
     ) -> pg_sys::Buffer {
         let buffer = pg_sys::ReadBufferExtended(
-            self.indexrel.as_ptr(),
+            self.indexrel,
             pg_sys::ForkNumber::MAIN_FORKNUM,
             blockno,
             pg_sys::ReadBufferMode::RBM_NORMAL,
@@ -175,18 +186,14 @@ impl BM25BufferCache {
 
         std::slice::from_raw_parts(slice.as_ptr(), slice.len())
     }
-
-    pub unsafe fn record_free_index_page(&self, blockno: pg_sys::BlockNumber) {
-        pg_sys::RecordFreeIndexPage(self.indexrel.as_ptr(), blockno);
-    }
 }
 
 impl Drop for BM25BufferCache {
     fn drop(&mut self) {
         unsafe {
             if crate::postgres::utils::IsTransactionState() {
-                pg_sys::RelationClose(self.indexrel.as_ptr());
-                pg_sys::RelationClose(self.heaprel.as_ptr());
+                pg_sys::RelationClose(self.indexrel);
+                pg_sys::RelationClose(self.heaprel);
             }
         }
     }

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,58 +15,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::storage::block::{FIXED_BLOCK_NUMBERS, MERGE_LOCK};
-use crate::postgres::storage::buffer::BufferManager;
-use crate::postgres::storage::merge::MergeLockData;
 use pgrx::*;
 
 #[pg_guard]
 pub extern "C" fn amvacuumcleanup(
-    info: *mut pg_sys::IndexVacuumInfo,
+    _info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
-    let info = unsafe { PgBox::from_pg(info) };
-    if info.analyze_only {
-        return stats;
-    }
-
-    // return all recyclable pages to the free space map
-    unsafe {
-        let index_relation = PgRelation::from_pg(info.index);
-        let index_oid = index_relation.oid();
-        let nblocks =
-            pg_sys::RelationGetNumberOfBlocksInFork(info.index, pg_sys::ForkNumber::MAIN_FORKNUM);
-        let mut bman = BufferManager::new(index_oid);
-        let heap_oid = pg_sys::IndexGetRelation(index_oid, false);
-        let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
-
-        let vacuum_sentinel_blockno = {
-            let merge_lock = bman.get_buffer(MERGE_LOCK);
-            let page = merge_lock.page();
-            let metadata = page.contents::<MergeLockData>();
-            metadata.ambulkdelete_sentinel
-        };
-
-        for blockno in FIXED_BLOCK_NUMBERS.last().unwrap() + 1..nblocks {
-            if blockno == vacuum_sentinel_blockno {
-                // don't try to open the vacuum_sentinel_blockno block -- only `ambulkdelete` should ever
-                // have a pin on it.
-                continue;
-            }
-            if blockno % 100 == 0 {
-                pg_sys::vacuum_delay_point();
-            }
-            let buffer = bman.get_buffer(blockno);
-            let page = buffer.page();
-
-            if page.is_recyclable(heap_relation) {
-                bman.record_free_index_page(buffer);
-            }
-        }
-        pg_sys::RelationClose(heap_relation);
-        pg_sys::IndexFreeSpaceMapVacuum(info.index);
-    }
-
-    // TODO: Update stats
     stats
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Until now, page recycling only happened during the `amvacuumcleanup` process.  With this PR it happens immediately after a segment merge is complete (at the end of our `aminsertcleanup`), which is the point in which pages have otherwise been freed and can be recycled.

The page reclimation itself happens outside of a lock as the segments its operating on are known to not be in use by any other backend but that one.

Additionally, `amvacuumcleanup` becomes a no-op.

There's a few minor internal API function name changes to make things a little easier to understand.  There's also a handful of new asserts to validate the invariants this requires -- namely that we never try to recycle pages we're not allowed (our "fixed block numbers list") and also that we don't mark as deleted pages that are already.

We also adjust our heuristics around getting a free buffer from the FSM by asking for one of the size we need for our bm25 pages.  The theory here is that it'll be be much less likely for it to then return a buffer we can't actually use.

## Why

Making unused space available as soon as possible essentially fixes our index bloat problem

## How

## Tests

Existing tests pass and I had a successful 20 minute stressgres run before I had to cancel it.  A subsequent stressgres run ran for 5h before I had to cancel it.