### PR TITLE
ci: Fixed schema diff generation

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history
+          ref: ${{ github.head_ref }}
 
       - name: Extract pgrx Version
         id: pgrx


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2285.

## What

I broke the diff generation while allowed making comments, but the last thing never happens as there's no diff produced.

## Why

I missed an important thing about `pull_request_target`. It's not only using the target's context, but also sets the git reference to it. Therefore, making a diff between the target branch and the target branch surely produces nothing.

## How

The fix explicitly specifies what commit the `checkout` action should use via the `ref` argument. The value is set to be `head_ref` of the `github` context ([docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context))

> The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.

An important point here is that GitHub doesn't use `head_ref` while running CI, but a merge commit. I don't suppose it matters here as the workflow needs to make a schema diff out of the changes, and a merge commit has nothing changed in it anyway. Anyway, here's a relevant discussion: https://github.com/actions/checkout/issues/518.

## Tests

Requires to be merged for testing.