### PR TITLE
ci: Fixed head ref resolution for diff generation

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -40,7 +40,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract pgrx Version
         id: pgrx


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2285.

## What

`ref` is just a branch name in most of cases (though it's different if it points to the main repository branch). Therefore, the `checkout` action cannot use an external `ref` to the current repository.

## Why

I'm your free CI/CD engineer that nerd-sniped himself with the issue he found, and there's no GitHub Actions sandbox to verify changes locally.

As I said above, without `repository` parameter `checkout` cannot execute without pointing to an external `ref`. Alternatively, it's possible to use `pull/ID/head` fake refs or just a HEAD's SHA:
* `${{ github.event.pull_request.head.sha }}`
* `refs/pull/${{ github.event.number }}/head`

## How

Using an explicit `ref` or by adding the `repository` parameter.

## Tests

In production.