### PR TITLE
perf: cache `FileEntry`s in `MvccDirectory`

### DIFF
--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -290,6 +290,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub unsafe fn lookup<Cmp: Fn(&T) -> bool>(&self, cmp: Cmp) -> Result<T> {
         self.lookup_ex(cmp).map(|(t, _, _)| t)
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Tantivy looks up `FileEntry` instances quite often, and it's to our benefit to just cache all of them when we lookup the first one.

If for some reason the requested entry isn't in the cache we'll re-populate the cache.  This can happen from a tantivy instance that has internally added a new segment during commit.

## Why

This improves the SELECT TPS rate of one particular stressgres test by around 50%, which is pretty great.

## How

## Tests
