### PR TITLE
feat: new GUC: `paradedb.segment_merge_scale_factor`

### DIFF
--- a/docs/documentation/configuration/write.mdx
+++ b/docs/documentation/configuration/write.mdx
@@ -48,3 +48,15 @@ write and search performance is achieved.
 ```sql
 SET paradedb.max_mergeable_segment_size = 200MB;
 ```
+
+## Segment Merge Scale Factor
+
+`paradedb.segment_merge_scale_factor` is an integer, defaulting to `1` (one), that can be used to defer merging segments util the index has at least `"available parallelism" * paradedb.segment_merge_scale_factor + 1` segments.
+
+This can be helpful for ensuring newly-created small segments aren't always merged together with existing larger segments, but rather merged together at some future point.segment_merge_scale_factor
+
+Determining the proper value will depend on the number of rows typical INSERT/UPDATE statements create along with how having more segments impacts search performance.
+
+```sql
+SET paradedb.segment_merge_scale_factor = 1;
+```

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -277,7 +277,7 @@ mod tests {
         // this is expected to merge iteratively as NPlusOneMergePolicy also tries to keep
         // segments balanced by size, so it takes a few iterations before it's able to do so
         // down to the count we expect
-        for expectation in [21, 13, 11, 10, 9] {
+        for expectation in [21, 16, 12, 10, 9] {
             let lookup = segments
                 .iter()
                 .map(|s| (s.id(), s))

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -253,6 +253,7 @@ unsafe fn do_merge(indexrelid: Oid) -> Option<()> {
         ndocs += entry.num_docs() + entry.num_deleted_docs();
     }
 
+    pgrx::warning!("nvisible={nvisible}, target_segments={target_segments}");
     let recycled_entries = if nvisible > target_segments + 1 {
         let avg_byte_size_per_doc = nbytes as f64 / ndocs as f64;
 

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::gucs::max_mergeable_segment_size;
+use crate::gucs::{max_mergeable_segment_size, segment_merge_scale_factor};
 use crate::index::merge_policy::NPlusOneMergePolicy;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::SearchIndexWriter;
@@ -237,7 +237,8 @@ pub fn paradedb_aminsertcleanup(mut writer: Option<SearchIndexWriter>) {
 unsafe fn do_merge(indexrelid: Oid) -> Option<()> {
     let target_segments = std::thread::available_parallelism()
         .expect("failed to get available_parallelism")
-        .get();
+        .get()
+        * segment_merge_scale_factor();
     let snapshot = pg_sys::GetActiveSnapshot();
 
     let mut items = LinkedItemList::<SegmentMetaEntry>::open(indexrelid, SEGMENT_METAS_START);

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -20,7 +20,6 @@ mod fixtures;
 use fixtures::*;
 use rstest::*;
 use sqlx::PgConnection;
-use time::format_description::parse;
 
 #[rstest]
 fn validate_checksum(mut conn: PgConnection) {

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -226,7 +226,8 @@ fn bulk_insert_merge_behavior(mut conn: PgConnection) {
 
 #[rstest]
 fn segment_merge_scale_factor(mut conn: PgConnection) {
-    "CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);".execute(&mut conn);
+    "CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL) WITH (autovacuum_enabled = off);"
+        .execute(&mut conn);
     "CREATE INDEX idxtest_table ON test_table USING bm25(id, value) WITH (key_field = 'id');"
         .execute(&mut conn);
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This new GUC, `paradedb.segment_merge_scale_factor` is an integer that's multiplied by the host's available parallelism at the time we decide if we're going to attempt a merge.  The default is `1` (one).

If the index segment count is less than this calculated value, then we will skip merging.

Also fixes a bug with `NPlusOneMergePolicy` where it would merge all the segments down to one if they all happened to be the same size.  Test included.

## Why

The ability to defer merging small segments created via atomic INSERT/UPDATE statements, essentially into batches, at some future INSERT/UPDATE can help to improve overall update performance.

## How

## Tests
