### PR TITLE
perf: adjust merge policy to only merge once per merge operation

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -131,7 +131,7 @@ mod tests {
 
         let candidates = policy.compute_merge_candidates(None, &segments);
 
-        assert_eq!(candidates.len(), 11);
+        assert_eq!(candidates.len(), 12);
     }
 
     fn new_segment_meta() -> SegmentMeta {

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -61,8 +61,9 @@ impl MergePolicy for NPlusOneMergePolicy {
             })
             .collect::<Vec<_>>();
 
-        // sort them smallest-to-largest, by # of alive docs
-        segments.sort_unstable_by_key(|a| a.num_docs());
+        // sort them largest to smallest by # of alive docs b/c we pop this list and want the
+        // smallest ones first
+        segments.sort_unstable_by(|a, b| a.num_docs().cmp(&b.num_docs()).reverse());
 
         let mut candidates = vec![MergeCandidate(vec![])];
         let mut adjusted_segment_count = segments.len() + 1;
@@ -74,6 +75,7 @@ impl MergePolicy for NPlusOneMergePolicy {
                     meta.num_docs() as usize * self.avg_byte_size_per_doc.ceil() as usize;
 
                 if current_candidate_size >= self.segment_freeze_size {
+                    // this MergeCandidate is full.  start a new one
                     candidates.push(MergeCandidate(vec![]));
                     adjusted_segment_count += 1;
                     current_candidate_size = 0;

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -168,10 +168,7 @@ impl MergePolicy for NPlusOneMergePolicy {
                 byte_size,
                 segment.num_docs(),
             );
-            candidates.last_mut().unwrap().0.push(segment.id());
-            current_candidate_byte_size += byte_size;
-
-            if current_candidate_byte_size >= self.segment_freeze_size {
+            if current_candidate_byte_size + byte_size >= self.segment_freeze_size {
                 my_eprintln!(
                     "{} segments in current candidate, size={current_candidate_byte_size}",
                     candidates.last().unwrap().0.len()
@@ -181,6 +178,9 @@ impl MergePolicy for NPlusOneMergePolicy {
                 candidates.push(MergeCandidate(vec![]));
                 current_candidate_byte_size = 0;
             }
+
+            candidates.last_mut().unwrap().0.push(segment.id());
+            current_candidate_byte_size += byte_size;
         }
         my_eprintln!(
             "{} segments in last candidate, size={current_candidate_byte_size}",

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -74,8 +74,8 @@ impl MergePolicy for NPlusOneMergePolicy {
                 let byte_size =
                     meta.num_docs() as usize * self.avg_byte_size_per_doc.ceil() as usize;
 
-                if current_candidate_size >= self.segment_freeze_size {
-                    // this MergeCandidate is full.  start a new one
+                if current_candidate_size + byte_size >= self.segment_freeze_size {
+                    // this MergeCandidate would be full if added this one too, so start a new one
                     candidates.push(MergeCandidate(vec![]));
                     adjusted_segment_count += 1;
                     current_candidate_size = 0;

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -193,7 +193,7 @@ fn vacuum_restores_segment_count(mut conn: PgConnection) {
     let nsegments = "SELECT COUNT(*) FROM paradedb.index_info('idxtest_table');"
         .fetch_one::<(i64,)>(&mut conn)
         .0 as usize;
-    assert!(nsegments >= expected_segments + 1);
+    assert!(nsegments > expected_segments);
 }
 
 #[rstest]

--- a/tests/tests/segment_merge_scale_factor.rs
+++ b/tests/tests/segment_merge_scale_factor.rs
@@ -52,9 +52,12 @@ fn segment_merge_scale_factor(mut conn: PgConnection) {
         }
     }
 
-    format!("INSERT INTO test_table (value) VALUES ('this should cause a merge to {parallelism}')")
+    "INSERT INTO test_table (value) VALUES ('this should cause a merge to 1 segment')"
         .execute(&mut conn);
     let (nsegments,) =
         "SELECT count(*) FROM paradedb.index_info('idxtest_table')".fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(nsegments as usize, parallelism + 1);
+
+    // the segments will end up merging down to one segment, because their total size is less than
+    // our default `max_mergeable_segment_size` which is 200MB
+    assert_eq!(nsegments as usize, 1);
 }

--- a/tests/tests/segment_merge_scale_factor.rs
+++ b/tests/tests/segment_merge_scale_factor.rs
@@ -52,12 +52,9 @@ fn segment_merge_scale_factor(mut conn: PgConnection) {
         }
     }
 
-    "INSERT INTO test_table (value) VALUES ('this should cause a merge to 1 segment')"
+    format!("INSERT INTO test_table (value) VALUES ('this should cause a merge to {parallelism}')")
         .execute(&mut conn);
     let (nsegments,) =
         "SELECT count(*) FROM paradedb.index_info('idxtest_table')".fetch_one::<(i64,)>(&mut conn);
-
-    // the segments will end up merging down to one segment, because their total size is less than
-    // our default `max_mergeable_segment_size` which is 200MB
-    assert_eq!(nsegments as usize, 1);
+    assert_eq!(nsegments as usize, parallelism + 1);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This changes our `NPlusOneMergePolicy` so that it will only do 1 full `compute_merge_candidates()` reduction during any given tantivy merge process.  All subsequent attempts by tantivy to compute merge candidates will return none.

This also, and probably more importantly, removes all the logic it contained around also trying to merge by document count -- it's strictly byte-sized based now and will create new candidates at the `max_mergeable_segment_size` value.

Finally, fixes a bug in `do_merge()` where we included the `segment_merge_scale_factor` as part of the actual target_segments -- that's not what we want.  We only want to use that GUC value to determine if we should merge and we account for non-mergable segments when figuring out if we're beyond the scale factor.

## Why

Trying to improve the throughput of large, consistent inserts.

## How

## Tests

stressgres really likes this.  With a test that simply insert 1k rows over and over and over, it produces a graph that looks like this
![stressgres](https://github.com/user-attachments/assets/fe57058d-32f1-47ca-bbde-a0145c425bb2)



Whereas v0.15.7's graph is like this, which is much worse all around:

![stressgres (1)](https://github.com/user-attachments/assets/316e7645-fa4d-4d1f-aec2-36007e3b88e5)

