### PR TITLE
fix: fixed snippets not respecting max_num_chars and added tests for the same

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/snippet.rs
@@ -26,6 +26,7 @@ use std::ptr::addr_of_mut;
 
 const DEFAULT_SNIPPET_PREFIX: &str = "<b>";
 const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
+const DEFAULT_SNIPPET_MAX_NUM_CHARS: i32 = 150;
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct SnippetInfo {
@@ -116,7 +117,8 @@ pub unsafe fn uses_snippets(
                         field: attname,
                         start_tag: start_tag.unwrap_or_else(|| DEFAULT_SNIPPET_PREFIX.to_string()),
                         end_tag: end_tag.unwrap_or_else(|| DEFAULT_SNIPPET_POSTFIX.to_string()),
-                        max_num_chars: max_num_chars_arg as usize,
+                        max_num_chars: max_num_chars.unwrap_or(DEFAULT_SNIPPET_MAX_NUM_CHARS)
+                            as usize,
                     });
                 } else {
                     panic!("`paradedb.snippet()`'s arguments must be literals")

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -377,6 +377,24 @@ fn snippet(mut conn: PgConnection) {
     assert_eq!(row.0, 3);
     assert_eq!(row.1, "Sleek running <h1>shoes</h1>");
     assert_relative_eq!(row.2, 2.484906, epsilon = 1e-6);
+
+    let row: (i32, String, f32) = "
+        SELECT id, paradedb.snippet(description, max_num_chars=>17), paradedb.score(id)
+        FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:shoes' ORDER BY id"
+        .fetch_one(&mut conn);
+
+    assert_eq!(row.0, 3);
+    assert_eq!(row.1, "<b>shoes</b>");
+    assert_relative_eq!(row.2, 2.484906, epsilon = 1e-6);
+
+    let row: (i32, String, f32) = "
+        SELECT id, paradedb.snippet(description, max_num_chars=>17), paradedb.score(id)
+        FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:shoes' ORDER BY score DESC"
+        .fetch_one(&mut conn);
+
+    assert_eq!(row.0, 5);
+    assert_eq!(row.1, "Generic <b>shoes</b>");
+    assert_relative_eq!(row.2, 2.877260, epsilon = 1e-6);
 }
 
 #[rstest]

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -394,7 +394,7 @@ fn snippet(mut conn: PgConnection) {
 
     assert_eq!(row.0, 5);
     assert_eq!(row.1, "Generic <b>shoes</b>");
-    assert_relative_eq!(row.2, 2.877260, epsilon = 1e-6);
+    assert_relative_eq!(row.2, 2.877_26, epsilon = 1e-6);
 }
 
 #[rstest]

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -379,13 +379,13 @@ fn snippet(mut conn: PgConnection) {
     assert_relative_eq!(row.2, 2.484906, epsilon = 1e-6);
 
     let row: (i32, String, f32) = "
-        SELECT id, paradedb.snippet(description, max_num_chars=>17), paradedb.score(id)
-        FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:shoes' ORDER BY id"
+        SELECT id, paradedb.snippet(description, max_num_chars=>14), paradedb.score(id)
+        FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:keyboard' ORDER BY id;"
         .fetch_one(&mut conn);
 
-    assert_eq!(row.0, 3);
-    assert_eq!(row.1, "<b>shoes</b>");
-    assert_relative_eq!(row.2, 2.484906, epsilon = 1e-6);
+    assert_eq!(row.0, 1);
+    assert_eq!(row.1, "metal <b>keyboard</b>");
+    assert_relative_eq!(row.2, 2.821378, epsilon = 1e-6);
 
     let row: (i32, String, f32) = "
         SELECT id, paradedb.snippet(description, max_num_chars=>17), paradedb.score(id)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1952 

## What
Fixes max_num_chars not being respected while querying for highlights using the snippets function.
## Why
The function was not following tantivy behaviour and also wasn't consistent with paradedb docs.
## How
max_num_chars wasn't being respected because we were casting a pointer to the snippetinfo config instead of the actual value that was provided in the arg due to which max_num_chars was being set to a very high value. 
## Tests
Yes, added a few extra asserts to test for max_num_chars changes. 