### PR TITLE
chore: default scale factor to 5

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -63,7 +63,7 @@ static MAX_MERGEABLE_SEGMENT_SIZE: GucSetting<i32> = GucSetting::<i32>::new(200 
 
 /// Multiplied by the host's "parallelism" value, the resulting value is the segment count after which
 /// we'll consider performing a merge.
-static SEGMENT_MERGE_SCALE_FACTOR: GucSetting<i32> = GucSetting::<i32>::new(1);
+static SEGMENT_MERGE_SCALE_FACTOR: GucSetting<i32> = GucSetting::<i32>::new(5);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
@@ -175,7 +175,7 @@ pub fn init() {
     GucRegistry::define_int_guc(
         "paradedb.segment_merge_scale_factor",
         "An integer value multiplied by the host's 'parallelism' value, the resulting value is the segment count after which we'll consider performing a merge.",
-        "Default is `1` (one)",
+        "Default is `5`",
         &SEGMENT_MERGE_SCALE_FACTOR,
         0,
         i32::MAX,

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -65,6 +65,7 @@ fn create_and_drop_builtin_index(mut conn: PgConnection) {
 fn segment_count_matches_available_parallelism(mut conn: PgConnection) {
     // CREATE INDEX should create as many segments as there are available CPUs
     r#"
+        SET paradedb.segment_merge_scale_factor = 1;
         SET maintenance_work_mem = '1GB';
         DROP TABLE IF EXISTS test_table;
         CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
@@ -122,6 +123,7 @@ fn segment_count_matches_available_parallelism(mut conn: PgConnection) {
 #[rstest]
 fn segment_count_exceeds_target(mut conn: PgConnection) {
     r#"
+        SET paradedb.segment_merge_scale_factor = 1;
         SET maintenance_work_mem = '16MB';
         DROP TABLE IF EXISTS test_table;
         CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
@@ -156,7 +158,7 @@ fn vacuum_restores_segment_count(mut conn: PgConnection) {
         SET paradedb.statement_memory_budget = '15MB';
         DROP TABLE IF EXISTS test_table;
         CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
-        
+
         -- insert enough initial rows to ensure we actually get 1 segment per core
         INSERT INTO test_table (value) SELECT md5(random()::text) FROM generate_series(1, 200000);
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In our internal benchmarks, we've found that a default scale factor of `5` is a significant (10X+) improvement to write speeds. There can be a 2X reduction to search speeds, depending on the query.

## Why

## How

## Tests
