### PR TITLE
fix: "Top N" queries now work without parallel custom scans

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -65,6 +65,10 @@ pub trait ExecMethod {
         }
     }
 
+    fn increment_visible(&mut self) {
+        // default of noop
+    }
+
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState;
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -789,6 +789,7 @@ impl CustomScan for PdbScan {
                         let slot = match check_visibility(state, ctid, state.scanslot().cast()) {
                             // the ctid is visible
                             Some(slot) => {
+                                exec_method.increment_visible();
                                 state.custom_state_mut().heap_tuple_check_count += 1;
                                 slot
                             }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -572,3 +572,66 @@ fn is_numeric_fast_field_capable(mut conn: PgConnection) {
     let (b, count) = "select assert(count(*), 8), count(*) from (select id from test where message @@@ 'beer' order by severity) x limit 8;".fetch_one::<(bool, i64)>(&mut conn);
     assert_eq!((b, count), (true, 8));
 }
+
+#[rstest]
+fn top_n_matches(mut conn: PgConnection) {
+    r#"
+        DROP TABLE IF EXISTS test;
+        CREATE TABLE test (
+            id SERIAL8 NOT NULL PRIMARY KEY,
+            message TEXT,
+            severity INTEGER
+        ) WITH (autovacuum_enabled = false);
+        
+        INSERT INTO test (message, severity) VALUES ('beer wine cheese a', 1);
+        INSERT INTO test (message, severity) VALUES ('beer wine a', 2);
+        INSERT INTO test (message, severity) VALUES ('beer cheese a', 3);
+        INSERT INTO test (message, severity) VALUES ('beer a', 4);
+        INSERT INTO test (message, severity) VALUES ('wine cheese a', 5);
+        INSERT INTO test (message, severity) VALUES ('wine a', 6);
+        INSERT INTO test (message, severity) VALUES ('cheese a', 7);
+        INSERT INTO test (message, severity) VALUES ('beer wine cheese a', 1);
+        INSERT INTO test (message, severity) VALUES ('beer wine a', 2);
+        INSERT INTO test (message, severity) VALUES ('beer cheese a', 3);
+        INSERT INTO test (message, severity) VALUES ('beer a', 4);
+        INSERT INTO test (message, severity) VALUES ('wine cheese a', 5);
+        INSERT INTO test (message, severity) VALUES ('wine a', 6);
+        INSERT INTO test (message, severity) VALUES ('cheese a', 7);
+        
+        -- INSERT INTO test (message) SELECT 'space fillter ' || x FROM generate_series(1, 10000000) x;
+        
+        CREATE INDEX idxtest ON test USING bm25(id, message, severity) WITH (key_field = 'id');
+        CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS $$
+        DECLARE
+            current_txid bigint;
+        BEGIN
+            -- Get the current transaction ID
+            current_txid := txid_current();
+        
+            -- Check if the values are not equal
+            IF a <> b THEN
+                RAISE EXCEPTION 'Assertion failed: % <> %. Transaction ID: %', a, b, current_txid;
+            END IF;
+        
+            RETURN true;
+        END;
+        $$;    
+    "#.execute(&mut conn);
+
+    "UPDATE test SET severity = (floor(random() * 10) + 1)::int WHERE id < 10;".execute(&mut conn);
+    "UPDATE test SET severity = (floor(random() * 10) + 1)::int WHERE id < 10;".execute(&mut conn);
+    "UPDATE test SET severity = (floor(random() * 10) + 1)::int WHERE id < 10;".execute(&mut conn);
+
+    r#"
+        SET enable_indexonlyscan to OFF;
+        SET enable_indexscan to OFF;
+    "#
+    .execute(&mut conn);
+
+    for n in [1, 2, 3, 4, 5, 6, 7, 8, 100] {
+        let sql = format!("select assert(count(*), LEAST({n}, 8)), count(*) from (select id from test where message @@@ 'beer' order by severity limit {n}) x;");
+
+        let (b, count) = sql.fetch_one::<(bool, i64)>(&mut conn);
+        assert_eq!((b, count), (true, n.min(8)));
+    }
+}


### PR DESCRIPTION

# Ticket(s) Closed

- Closes #

## What

Our "Top N" queries got broken as part of the new block storage when Postgres planned a normal custom scan instead of a parallel custom scan.

## Why

## How

## Tests

New test included.