### PR TITLE
fix: issue #2308 and issue #2301

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -545,19 +545,12 @@ pub unsafe fn extract_quals(
 
         pg_sys::NodeTag::T_NullTest => {
             let nulltest = nodecast!(NullTest, T_NullTest, node)?;
-            let attname = attname_from_var(root, (*nulltest).arg.cast());
+            let (_, attname) = attname_from_var(root, (*nulltest).arg.cast());
+            let attname = attname?; // if the attribute isn't
             if (*nulltest).nulltesttype == pg_sys::NullTestType::IS_NOT_NULL {
-                Some(Qual::PushdownIsNotNull {
-                    attname: attname
-                        .1
-                        .expect("IS NOT NULL expression should have an attname"),
-                })
+                Some(Qual::PushdownIsNotNull { attname })
             } else {
-                Some(Qual::Not(Box::new(Qual::PushdownIsNotNull {
-                    attname: attname
-                        .1
-                        .expect("IS NULL expression should have an attname"),
-                })))
+                Some(Qual::Not(Box::new(Qual::PushdownIsNotNull { attname })))
             }
         }
 

--- a/tests/tests/matview.rs
+++ b/tests/tests/matview.rs
@@ -1,0 +1,31 @@
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn refresh_matview_concurrently_issue2308(mut conn: PgConnection) {
+    // if this doesn't raise an ERROR then it worked
+    r#"
+    DROP MATERIALIZED VIEW IF EXISTS TEST_mv;
+    DROP TABLE IF EXISTS TEST_tbl;
+
+    -- 2) Setup table
+    CREATE table TEST_tbl (
+        id integer
+    );
+
+    -- 3) insert data (data is optional for it to fail)
+    -- INSERT INTO TEST_1 VALUES (1), (2), (3), (4);
+
+    -- 4) Setup materialized view
+    CREATE MATERIALIZED VIEW TEST_mv AS (SELECT * FROM TEST_tbl);
+    CREATE UNIQUE INDEX test_idx ON TEST_mv (id); -- required for `CONCURRENTLY` to work
+    CREATE INDEX TEST_bm25 ON TEST_mv USING bm25 (id) WITH (key_field='id');
+
+    -- 5) Refresh the view concurrently
+    REFRESH MATERIALIZED VIEW CONCURRENTLY TEST_mv;
+    "#
+    .execute(&mut conn);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2308
- Closes #2301

## What

This fixes an issue with the recent `IS [NOT] NULL` pushdown feature where if the attribute isn't found in the root we'd panic, rather than returning `None`, indicating that it's not a predicate we can use.

## Why

## How

## Tests

Two new tests added.