### PR TITLE
fix: missing rows when using `StringFastFieldExec` method

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -441,6 +441,14 @@ mod term_ord_collector {
                     .entry(term_ord)
                     .or_default()
                     .push((scored, doc_address));
+            } else {
+                let doc_address = DocAddress::new(self.segment_ord, doc);
+                let ctid = self.ctid_ff.as_u64(doc).expect("ctid should be present");
+                let scored = SearchIndexScore::new(ctid, score);
+                self.results
+                    .entry(0) // testing with 0
+                    .or_default()
+                    .push((scored, doc_address));
             }
         }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -183,19 +183,22 @@ impl ExecMethod for StringFastFieldExecState {
     }
 }
 
+type SearchResultsIter = std::vec::IntoIter<(SearchIndexScore, DocAddress)>;
+type BatchedResultsIter = std::vec::IntoIter<(Option<String>, SearchResultsIter)>;
+type MergedResultsMap = BTreeMap<Option<String>, Vec<(SearchIndexScore, DocAddress)>>;
 #[derive(Default)]
 enum StringAggResults {
     #[default]
     None,
     Batched {
-        current: (String, std::vec::IntoIter<(SearchIndexScore, DocAddress)>),
-        set: std::vec::IntoIter<(String, std::vec::IntoIter<(SearchIndexScore, DocAddress)>)>,
+        current: (Option<String>, SearchResultsIter),
+        set: BatchedResultsIter,
     },
-    SingleSegment(crossbeam::channel::IntoIter<(SearchIndexScore, DocAddress, String)>),
+    SingleSegment(crossbeam::channel::IntoIter<(SearchIndexScore, DocAddress, Option<String>)>),
 }
 
 impl Iterator for StringAggResults {
-    type Item = (SearchIndexScore, DocAddress, String);
+    type Item = (SearchIndexScore, DocAddress, Option<String>);
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -253,14 +256,14 @@ impl StringAggSearcher<'_> {
         let field = field.to_string();
         let searcher = self.0.searcher().clone();
 
-        let merged: Mutex<BTreeMap<String, Vec<(SearchIndexScore, DocAddress)>>> =
-            Mutex::new(BTreeMap::new());
+        let merged: Mutex<MergedResultsMap> = Mutex::new(BTreeMap::new());
 
         results
             .into_par_iter()
             .for_each(|(str_ff, segment_results)| {
                 let keys = segment_results.keys().cloned().collect::<Vec<_>>();
-                let mut values = segment_results.into_iter();
+                let segment_values: Vec<_> = segment_results.into_iter().collect();
+                let mut values_iter = segment_values.into_iter();
                 let mut resolved = FxHashMap::default();
                 str_ff
                     .dictionary()
@@ -271,16 +274,28 @@ impl StringAggSearcher<'_> {
 
                         resolved.insert(
                             term,
-                            values.next().unwrap_or_else(|| panic!("internal error: don't have the same number of TermOrd keys and values")).1,
+                            values_iter.next().unwrap_or_else(|| panic!("internal error: don't have the same number of TermOrd keys and values")).1,
                         );
 
                         Ok(())
                     })
                     .expect("term ord resolution should succeed");
 
+                let mut null_results = Vec::new();
+                if str_ff.num_terms() == 0 {
+                    if let Some(next_value) = values_iter.next() {
+                        null_results.push(next_value);
+                        // Collect any additional remaining values
+                        null_results.extend(values_iter);
+                    }
+                }
                 let mut guard = merged.lock();
                 for (term, mut results) in resolved {
-                    guard.entry(term).or_default().append(&mut results);
+                    guard.entry(Some(term)).or_default().append(&mut results);
+                }
+
+                for (_, mut results) in null_results {
+                    guard.entry(None).or_default().append(&mut results);
                 }
             });
 
@@ -291,7 +306,7 @@ impl StringAggSearcher<'_> {
             .collect::<Vec<_>>()
             .into_iter();
         StringAggResults::Batched {
-            current: (String::default(), vec![].into_iter()),
+            current: (None, vec![].into_iter()),
             set,
         }
     }
@@ -356,7 +371,7 @@ impl StringAggSearcher<'_> {
                 });
                 for (scored, doc_address) in values {
                     sender
-                        .send((scored, doc_address, term.clone()))
+                        .send((scored, doc_address, Some(term.clone())))
                         .map_err(|_| {
                             std::io::Error::new(std::io::ErrorKind::Other, "failed to send term")
                         })?;
@@ -365,6 +380,17 @@ impl StringAggSearcher<'_> {
                 Ok(())
             })
             .expect("term ord lookup should succeed");
+
+        if dictionary.num_terms() == 0 && results.len() > 0 {
+            let (_, values) = results.next().unwrap_or_else(|| {
+                panic!("internal error: don't have the same number of TermOrd keys and values")
+            });
+            for (scored, doc_address) in values {
+                let _ = sender.send((scored, doc_address, None)).map_err(|_| {
+                    std::io::Error::new(std::io::ErrorKind::Other, "failed to send term")
+                });
+            }
+        }
 
         StringAggResults::SingleSegment(receiver.into_iter())
     }
@@ -432,21 +458,17 @@ mod term_ord_collector {
         );
 
         fn collect(&mut self, doc: DocId, score: Score) {
+            let doc_address = DocAddress::new(self.segment_ord, doc);
+            let ctid = self.ctid_ff.as_u64(doc).expect("ctid should be present");
+            let scored = SearchIndexScore::new(ctid, score);
             if let Some(term_ord) = self.ff.term_ords(doc).next() {
-                let doc_address = DocAddress::new(self.segment_ord, doc);
-                let ctid = self.ctid_ff.as_u64(doc).expect("ctid should be present");
-                let scored = SearchIndexScore::new(ctid, score);
-
                 self.results
                     .entry(term_ord)
                     .or_default()
                     .push((scored, doc_address));
             } else {
-                let doc_address = DocAddress::new(self.segment_ord, doc);
-                let ctid = self.ctid_ff.as_u64(doc).expect("ctid should be present");
-                let scored = SearchIndexScore::new(ctid, score);
                 self.results
-                    .entry(0) // testing with 0
+                    .entry(0)
                     .or_default()
                     .push((scored, doc_address));
             }

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -534,8 +534,10 @@ mod pushdown_is_null {
         assert_eq!(
             res,
             vec![
+                (1, false, None, None),
                 (2, false, Some(String::from("foo")), None),
-                (3, false, Some(String::from("bar")), Some(333))
+                (3, false, Some(String::from("bar")), Some(333)),
+                (4, false, None, Some(444))
             ]
         );
     }

--- a/tests/tests/str_ff_exec.rs
+++ b/tests/tests/str_ff_exec.rs
@@ -1,0 +1,87 @@
+#![allow(dead_code)]
+// Copyright (c) 2023-2025 Retake, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[fixture]
+fn setup_test_table(mut conn: PgConnection) -> PgConnection {
+    let sql = r#"
+        CREATE TABLE test (
+            id SERIAL8 NOT NULL PRIMARY KEY,
+            col_boolean boolean DEFAULT false,
+            col_text text,
+            col_int8 int8
+        );
+    "#;
+    sql.execute(&mut conn);
+
+    let sql = r#"
+        CREATE INDEX idxtest ON test USING bm25 (id, col_boolean, col_text, col_int8)
+        WITH (key_field='id', text_fields = '{"col_text": {"fast": true, "tokenizer": {"type":"raw"}}}');
+    "#;
+    sql.execute(&mut conn);
+
+    "INSERT INTO test (id, col_text) VALUES (1, NULL);".execute(&mut conn);
+    "INSERT INTO test (id, col_text) VALUES (2, 'foo');".execute(&mut conn);
+    "INSERT INTO test (id, col_text, col_int8) VALUES (3, 'bar', 333);".execute(&mut conn);
+    "INSERT INTO test (id, col_int8) VALUES (4, 444);".execute(&mut conn);
+
+    "SET enable_indexscan TO off;".execute(&mut conn);
+    "SET enable_bitmapscan TO off;".execute(&mut conn);
+    "SET max_parallel_workers TO 0;".execute(&mut conn);
+
+    conn
+}
+
+mod string_fast_field_exec {
+    use super::*;
+
+    #[rstest]
+    fn with_range(#[from(setup_test_table)] mut conn: PgConnection) {
+        let res = r#"
+            SELECT * FROM test
+            WHERE id @@@ paradedb.range(field => 'id', range => int8range(1, 5, '[]'))
+            ORDER BY id;
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(
+            res,
+            vec![
+                (1, false, None, None),
+                (2, false, Some(String::from("foo")), None),
+                (3, false, Some(String::from("bar")), Some(333)),
+                (4, false, None, Some(444))
+            ]
+        );
+    }
+
+    #[rstest]
+    fn with_filter(#[from(setup_test_table)] mut conn: PgConnection) {
+        let res = r#"
+            SELECT * FROM test
+            WHERE col_text IS NULL and id @@@ '>2'
+            ORDER BY id;
+        "#
+        .fetch::<(i64, bool, Option<String>, Option<i64>)>(&mut conn);
+        assert_eq!(res, vec![(4, false, None, Some(444))]);
+    }
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2282 

## What
fixes an issue where rows with `NULL` values in a string fast field were missing from query results when using the `StringFastFieldExecState` execution method.

## Why
queries involving string fast fields should return all matching rows, including those with `NULL` values in the fast field.

## How
updated `collect()` function in the `TermOrdSegmentCollector` (implementing the `SegmentCollector` trait) to properly handle `NULL` values in string fast fields.

## Tests
manual testing in `psql` confirms the correct results. Unit tests added to test suite are not returning expected values. 