### PR TITLE
perf: Used unstable sorting for segment ids

### DIFF
--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -272,7 +272,7 @@ impl VacuumList {
         segment_ids: impl Iterator<Item = &'s SegmentId>,
     ) -> VacuumSentinel {
         let mut segment_ids = segment_ids.collect::<Vec<_>>();
-        segment_ids.sort();
+        segment_ids.sort_unstable();
 
         let mut bman = BufferManager::new(self.relation_oid);
         let mut buffer = bman.get_buffer_mut(self.start_block_number);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Segment identifiers are sorted with `slice::sort` that is stable.

## Why

From [`slice::sort` docs](https://doc.rust-lang.org/1.80.1/std/primitive.slice.html#method.sort):
> When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn’t allocate auxiliary memory. See [sort_unstable](https://doc.rust-lang.org/1.80.1/std/primitive.slice.html#method.sort_unstable).

And here you don't care about ordering of equal elements at all since they shouldn't be there at all.

## How

Using the right method.

## Tests

Covered by the tests.