### PR TITLE
ci: Added pgxn publication workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 .dockerignore export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
-.github export-ignorei
+.github export-ignore
 .hadolint.yaml export-ignore
 .markdownlint.yaml export-ignore
 .pre-commit-config.yaml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+.codespellignore export-ignore
+.dockerignore export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignorei
+.hadolint.yaml export-ignore
+.markdownlint.yaml export-ignore
+.pre-commit-config.yaml export-ignore
+.prettierignore export-ignore
+.prettierrc export-ignore
+META.json.in export-ignore

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -1,0 +1,31 @@
+# workflows/publish-pg_search-pgxn.yml
+#
+# Publish pg_search (PGXN)
+# Build and publish the pg_search extension to the PostgreSQL Extension Network (PGXN).
+
+name: Publish pg_search (PGXN)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish-pg_search:
+    name: Publish pg_search to PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Bundle the Release
+        run: make dist
+
+      - name: Release on PGXN
+        env:
+          PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+          PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+        run: pgxn-release

--- a/META.json.in
+++ b/META.json.in
@@ -7,7 +7,7 @@
    "maintainer": [
       "ParadeDB <support@paradedb.com>"
    ],
-   "license": "agpl-3.0",
+   "license": "agpl_3",
    "provides": {
       "pg_search": {
          "abstract": "Postgres for Search and Analytics",

--- a/META.json.in
+++ b/META.json.in
@@ -3,7 +3,7 @@
    "name": "pg_search",
    "abstract": "Full-text search for Postgres",
    "description": "pg_search is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
-   "version": "CRATE_VERSION@",
+   "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"
    ],

--- a/META.json.in
+++ b/META.json.in
@@ -3,7 +3,7 @@
    "name": "pg_search",
    "abstract": "Full-text search for Postgres",
    "description": "pg_search is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
-   "version": "@CARGO_VERSION@",
+   "version": "CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"
    ],
@@ -13,7 +13,7 @@
          "abstract": "Full-text search for Postgres",
          "file": "pg_search/src/lib.rs",
          "docfile": "pg_search/README.md",
-         "version": "@CARGO_VERSION@"
+         "version": "@CRATE_VERSION@"
       }
    },
    "prereqs": {

--- a/META.json.in
+++ b/META.json.in
@@ -1,7 +1,7 @@
 
 {
    "name": "pg_search",
-   "abstract": "Full-text search for Postgres",
+   "abstract": "@CRATE_DESC@",
    "description": "pg_search is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
    "version": "@CRATE_VERSION@",
    "maintainer": [

--- a/META.json.in
+++ b/META.json.in
@@ -42,6 +42,6 @@
       "paradedb",
       "full text",
       "full text search",
-      "full-text search",
+      "full-text search"
    ]
 }

--- a/META.json.in
+++ b/META.json.in
@@ -33,7 +33,7 @@
          "type": "git"
       }
    },
-   "generated_by": "Yoh Deadfall",
+   "generated_by": "ParadeDB",
    "meta-spec": {
       "version": "1.0.0",
       "url": "https://pgxn.org/meta/spec.txt"

--- a/META.json.in
+++ b/META.json.in
@@ -10,7 +10,7 @@
    "license": "agpl-3.0",
    "provides": {
       "pg_search": {
-         "abstract": "Full-text search for Postgres",
+         "abstract": "Postgres for Search and Analytics",
          "file": "pg_search/src/lib.rs",
          "docfile": "pg_search/README.md",
          "version": "@CRATE_VERSION@"

--- a/META.json.in
+++ b/META.json.in
@@ -1,0 +1,47 @@
+
+{
+   "name": "pg_search",
+   "abstract": "Full-text search for Postgres",
+   "description": "pg_search is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
+   "version": "@CARGO_VERSION@",
+   "maintainer": [
+      "ParadeDB <support@paradedb.com>"
+   ],
+   "license": "agpl-3.0",
+   "provides": {
+      "pg_search": {
+         "abstract": "Full-text search for Postgres",
+         "file": "pg_search/src/lib.rs",
+         "docfile": "pg_search/README.md",
+         "version": "@CARGO_VERSION@"
+      }
+   },
+   "prereqs": {
+      "runtime": {
+         "requires": {
+            "PostgreSQL": "14.0.0"
+         }
+      }
+   },
+   "resources": {
+      "bugtracker": {
+         "web": "https://github.com/paradedb/paradedb/issues/"
+      },
+      "repository": {
+         "url": "git://github.com/paradedb/paradedb.git",
+         "web": "https://github.com/paradedb/paradedb/",
+         "type": "git"
+      }
+   },
+   "generated_by": "Yoh Deadfall",
+   "meta-spec": {
+      "version": "1.0.0",
+      "url": "https://pgxn.org/meta/spec.txt"
+   },
+   "tags": [
+      "paradedb",
+      "full text",
+      "full text search",
+      "full-text search",
+   ]
+}

--- a/META.json.in
+++ b/META.json.in
@@ -40,8 +40,16 @@
    },
    "tags": [
       "paradedb",
-      "full text",
+      "search",
+      "analytics",
+      "bm25",
+      "text search",
       "full text search",
-      "full-text search"
+      "full-text search",
+      "hybrid search",
+      "faceted search",
+      "facets",
+      "columnar",
+      "olap"
    ]
 }

--- a/META.json.in
+++ b/META.json.in
@@ -2,7 +2,7 @@
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",
-   "description": "pg_search is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
+   "description": "ParadeDB pg_search is a Postgres extension that enables fast full-text, faceted and hybrid search over Postgres tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using pgrx.",
    "version": "@CRATE_VERSION@",
    "maintainer": [
       "ParadeDB <support@paradedb.com>"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+DISTNAME = $(shell grep -m 1 '^name' pg_search/Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+DISTVERSION  = $(shell grep -m 1 '^version' pg_search/Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+
+META.json: META.json.in pg_search/Cargo.toml
+	@sed "s/@CARGO_VERSION@/$(DISTVERSION)/g" $< > $@
+
+$(DISTNAME)-$(DISTVERSION).zip: META.json
+	git archive --format zip --prefix $(DISTNAME)-$(DISTVERSION)/ --add-file $< -o $(DISTNAME)-$(DISTVERSION).zip HEAD
+
+dist: $(DISTNAME)-$(DISTVERSION).zip
+
+clean:
+	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ DISTDESC     = $(shell grep -m 1 '^description' pg_search/Cargo.toml | sed -e 's
 DISTVERSION  = $(shell grep -m 1 '^version' Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
 PGRXV        = $(shell perl -nE '/^pgrx\s+=\s"=?([^"]+)/ && do { say $$1; exit }' Cargo.toml)
 PGV          = $(shell perl -E 'shift =~ /(\d+)/ && say $$1' "$(shell $(PG_CONFIG) --version)")
+EXTRA_CLEAN  = META.json $(DISTNAME)-$(DISTVERSION).zip target
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
 
 all: package
 
@@ -46,7 +50,3 @@ $(DISTNAME)-$(DISTVERSION).zip: META.json
 
 # Create a PGXN-compatible zip file.
 dist: $(DISTNAME)-$(DISTVERSION).zip
-
-# Delete files generated while making a PGXN-compatible zip file.
-clean:
-	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip target

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,50 @@
-DISTNAME = $(shell grep -m 1 '^name' pg_search/Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
-DISTVERSION  = $(shell grep -m 1 '^version' pg_search/Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+PG_CONFIG   ?= $(shell which pg_config)
+DISTNAME     = $(shell grep -m 1 '^name' pg_search/Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+DISTVERSION  = $(shell cargo tree --prefix=none --edges=normal | grep 'pgrx v' | sed 's/pgrx v//')
+PGRXV        = $(shell perl -nE '/^pgrx\s+=\s"=?([^"]+)/ && do { say $$1; exit }' Cargo.toml)
+PGV          = $(shell perl -E 'shift =~ /(\d+)/ && say $$1' "$(shell $(PG_CONFIG) --version)")
+
+all: package
+
+# Print the current Postgres version reported by pg_config.
+.PHONY: pg-version
+pg-version:
+	@echo $(PGV)
+
+# Print the current PGRX version from Cargo.toml
+.PHONY: pg-version
+pgrx-version:
+	@echo $(PGRXV)
+
+# Install the version of PGRX specified in Cargo.toml.
+.PHONY: install-pgrx
+install-pgrx: pg_search/Cargo.toml
+	@cargo install --package pg_search --locked cargo-pgrx --version "$(PGRXV)"
+
+# Initialize pgrx for the PostgreSQL version identified by pg_config.
+.PHONY: pgrx-init
+pgrx-init: pg_search/Cargo.toml
+	@cargo pgrx init "--pg$(PGV)"="$(PG_CONFIG)"
+
+# Install pg_search into the PostgreSQL cluster identified by pg_config.
+.PHONY: install
+install:
+	@cargo pgrx install --package pg_search --release --pg-config "$(PG_CONFIG)"
+
+# Build pg_search for the PostgreSQL cluster identified by pg_config.
+.DEFAULT_GOAL: package
+package:
+	@cargo pgrx package --package pg_search --pg-config "$(PG_CONFIG)"
 
 META.json: META.json.in pg_search/Cargo.toml
-	@sed "s/@CARGO_VERSION@/$(DISTVERSION)/g" $< > $@
+	@sed "s/@CRATE_VERSION@/$(DISTVERSION)/g" $< > $@
 
 $(DISTNAME)-$(DISTVERSION).zip: META.json
 	git archive --format zip --prefix $(DISTNAME)-$(DISTVERSION)/ --add-file $< -o $(DISTNAME)-$(DISTVERSION).zip HEAD
 
+# Create a PGXN-compatible zip file.
 dist: $(DISTNAME)-$(DISTVERSION).zip
 
+# Delete files generated while making a PGXN-compatible zip file.
 clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ package:
 	@cargo pgrx package --package pg_search --pg-config "$(PG_CONFIG)"
 
 META.json: META.json.in pg_search/Cargo.toml
-	@sed "s/@CRATE_DESC@/$(DISTDESC)/g" $< > $@
-	@sed "s/@CRATE_VERSION@/$(DISTVERSION)/g" $< > $@
+	@sed -e "s/@CRATE_DESC@/$(DISTDESC)/g" -e "s/@CRATE_VERSION@/$(DISTVERSION)/g" $< > $@
 
 $(DISTNAME)-$(DISTVERSION).zip: META.json
 	git archive --format zip --prefix $(DISTNAME)-$(DISTVERSION)/ --add-file $< -o $(DISTNAME)-$(DISTVERSION).zip HEAD


### PR DESCRIPTION
# Ticket(s) Closed

- Touches #1019.

## What

Adds a `pgxn` publication workflow.

## Why

Allows users to use `pgxn` to consume `pg_search`, and automates publication in `pgxn`.

## How

A new workflow according to the FAQ and paradedb/pg_analytics#203.

## Tests

Nope.