### PR TITLE
refactor: Unifies layer size parsing logic

### DIFF
--- a/tests/tests/layer_sizes.rs
+++ b/tests/tests/layer_sizes.rs
@@ -48,7 +48,7 @@ fn negative_layer_size(mut conn: PgConnection) {
     let err = result.err().unwrap();
     assert_eq!(
         err.into_database_error().unwrap().to_string(),
-        "a single layer size must be positive: TryFromIntError(())"
+        "a single layer size must be greater than zero"
     );
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Unifies the layer size parsing logic for `layer_sizes` and `validate_layer_sizes` functions.

## Why

Deduplication decreases the probability of the functions to desync and makes it easier to maintain the code.

## How

Making a new function.

## Tests

Covered by the existing tests.