### PR TITLE
chore: bring back `is_merging`

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -160,6 +160,12 @@ unsafe fn merge_info(
     table
 }
 
+/// Deprecated: Use `paradedb.merge_info` instead.
+#[pg_extern]
+fn is_merging(index: PgRelation) -> bool {
+    unsafe { merge_info(index).next().is_some() }
+}
+
 #[pg_extern]
 unsafe fn vacuum_info(index: PgRelation) -> SetOfIterator<'static, String> {
     let mut merge_lock = MergeLock::acquire(index.oid());


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Bring back `paradedb.is_merging` so the extension can upgrade.

## Why

## How

## Tests
