### PR TITLE
ci: Enable manually publishing individual Docker images

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: ${{ github.event.inputs.version }}
+        pg_version: ${{ fromJson(github.event.inputs.pg_version || '[14, 15, 16, 17]') }}
     env:
       default_pg_version: 17
 

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -11,8 +11,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - phil/point-updates
   workflow_dispatch:
     inputs:
       version:
@@ -90,8 +88,8 @@ jobs:
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ github.event.inputs.version == '' }}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && github.event.inputs.version == '' }}
+            type=raw,value=latest-pg${{ matrix.pg_version }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
 

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -11,6 +11,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - phil/point-updates
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -76,9 +76,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # The pg_version-tag Docker tag syntax is necessary for our CloudNativePG Helm chart
-      #
-      # Note: We only tag the image with the `latest` tags if there is no version input provided,
-      # as the manual version input is meant to be used for testing images only.
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -17,6 +17,10 @@ on:
         description: "The version to set for the ParadeDB release. This publishes the latest commit of the chosen branch and tags it with the provided version."
         required: true
         default: ""
+      pg_version:
+        description: "The Postgres major version(s) to build ParadeDB for. This needs to be a comma-separated list of integers (e.g. [14] or [14, 15, 16, 17])."
+        required: true
+        default: "[14, 15, 16, 17]"
 
 concurrency:
   group: publish-paradedb-docker-${{ github.head_ref || github.ref }}
@@ -33,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg_version: [14, 15, 16, 17]
+        pg_version: ${{ github.event.inputs.version }}
     env:
       default_pg_version: 17
 
@@ -72,6 +76,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # The pg_version-tag Docker tag syntax is necessary for our CloudNativePG Helm chart
+      #
+      # Note: We only tag the image with the `latest` tags if there is no version input provided,
+      # as the manual version input is meant to be used for testing images only.
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -81,8 +88,8 @@ jobs:
             type=raw,value=${{ matrix.pg_version }}-${{ steps.version.outputs.tag }}
             type=raw,value=${{ steps.version.outputs.tag }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version }}
+            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ github.event.inputs.version == '' }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && github.event.inputs.version == '' }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
 
@@ -118,11 +125,8 @@ jobs:
           push-to-registry: true
 
   publish-paradedb-helm-chart:
-    name: Publish ParadeDB Helm Chart for PostgreSQL ${{ matrix.pg_version }}
+    name: Publish ParadeDB Helm Chart
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        pg_version: [17]
 
     steps:
       - name: Retrieve GitHub Release Version


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This PR enables publishing Docker images with a specific tag and for a specific PG version. We can then use this to push tags for arbitrary branches and do individual testing on live deployments.

## Why
Easily troubleshoot issues/add logs.

## How
Added a new input for PG major version and made sure we don't trigger the `latest` tags if a manual version is provided.

## Tests
Need to test manually