### PR TITLE
feat: Changed uuid handling from text to bytes

### DIFF
--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -886,8 +886,8 @@ impl TryFrom<pgrx::Uuid> for TantivyValue {
     type Error = TantivyValueError;
 
     fn try_from(val: pgrx::Uuid) -> Result<Self, Self::Error> {
-        Ok(TantivyValue(tantivy::schema::OwnedValue::Str(
-            val.to_string(),
+        Ok(TantivyValue(tantivy::schema::OwnedValue::Bytes(
+            val.as_bytes().to_vec(),
         )))
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1967

## What

The pull request changes how `uuid` fields are handled. Not they are treated as bytes in Tantivy.

## Why

Handling `uuid` as strings is inefficient and error prone as it's possible to specify a text config with the tokenizer not set to `raw`. See #2324.

## How

`ByteOptions` and friends.

## Tests

Existing.