### PR TITLE
perf: Made cheaper expression first

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -154,7 +154,7 @@ pub unsafe fn row_to_search_document(
         let datum = *values.add(*attno);
         let isnull = *isnull.add(*attno);
 
-        if key_field_name == search_field.name.as_ref() && isnull {
+        if isnull && key_field_name == search_field.name.as_ref() {
             return Err(IndexError::KeyIdNull(key_field_name.to_string()));
         }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`isnull` checked after comparing the attribute names.

## Why

The operands are executed from left to right, so the `dev` version tries to compare strings first and only then check `isnull`. That's totally inefficient.

## How

Using my favorite text editor.

## Tests

Nope.