### PR TITLE
feat: enable logging via Rust's `log` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371c15a3c178d0117091bd84414545309ca979555b1aad573ef591ad58818d41"
 dependencies = [
  "cmd_lib_macros",
- "env_logger",
+ "env_logger 0.10.2",
  "faccess",
  "lazy_static",
  "log",
@@ -1175,6 +1175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1195,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -2095,6 +2118,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +2861,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "derive_more",
+ "env_logger 0.11.7",
  "itertools 0.14.0",
  "json5",
  "memoffset",
@@ -3074,6 +3122,21 @@ dependencies = [
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -25,6 +25,7 @@ bitpacking = "0.9.2"
 chrono = "0.4.39"
 crossbeam = "0.8.4"
 derive_more = { version = "2.0.1", features = ["full"] }
+env_logger = "0.11.7"
 itertools = "0.14.0"
 json5 = "0.4.1"
 memoffset = "0.9.1"

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -78,6 +78,13 @@ pub fn MyDatabaseId() -> u32 {
 #[allow(non_snake_case)]
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
+    // initialize environment logging (to stderr) for dependencies that do logging
+    // we can't implement our own logger that sends messages to Postgres `ereport()` because
+    // of threading concerns
+    std::env::set_var("RUST_LOG", "warn");
+    std::env::set_var("RUST_LOG_STYLE", "never");
+    env_logger::init();
+
     if cfg!(not(feature = "pg17")) && !pg_sys::process_shared_preload_libraries_in_progress {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This enables, at runtime, any of our dependencies that do logging to do so at the `warn` level (or higher).  Such log messages will go straight to "stderr", which ought to be redirected to Postgres' configured log file/destination.

## Why

Sometimes, being able to see what a dependency has logged, specifically "tantivy", is incredibly helpful to debug production problems.

## How

## Tests
