### PR TITLE
fix: `ChannelRequestHandler::wait_for()` should process all messages 

### DIFF
--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -213,7 +213,9 @@ impl SearchIndexWriter {
     /// channels with tantivy fail for some reason.
     pub fn merge(self) -> Result<()> {
         assert!(self.insert_queue.is_empty());
+        let start = std::time::Instant::now();
         self.commit()?;
+        pgrx::debug1!("merge complete in {:?}", start.elapsed());
         Ok(())
     }
 

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -197,7 +197,7 @@ impl SearchIndexWriter {
             .expect("spawned thread should not fail")?;
 
         self.handler
-            .wait_for(move || writer.wait_merging_threads())
+            .wait_for_final(move || writer.wait_merging_threads())
             .expect("spawned thread should not fail")?;
 
         Ok(self.cnt)


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`ChannelRequestHandler::wait_for_internal()` should try to process still-queued messages before running the caller's `action_func`.

It should also, when the caller has indicated it's the last action and the handler is going to be dropped, process in a blocking manner all other incoming messages after the action completed and until the remote sender is dropped

## Why

It was possible for a ChannelRequest message to get lost.

## How

## Tests

Existing tests pass.