### PR TITLE
feat: Snapshots are no longer necessary during insert

### DIFF
--- a/.github/stressgres/single-server.toml
+++ b/.github/stressgres/single-server.toml
@@ -49,8 +49,6 @@ DROP EXTENSION pg_search CASCADE;
 [monitor]
 refresh_ms = 10
 title = "Monitor Index Size"
-log_tps = true
-log_count = true
 log_columns = ["block_count", "segment_count"]
 
 # Combined query returning both columns
@@ -67,7 +65,6 @@ SELECT
 refresh_ms = 100
 title = "Index Scan"
 log_tps = true
-log_count = true
 on_connect = """
 SET enable_indexonlyscan to OFF;
 """
@@ -79,7 +76,6 @@ SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'mes
 refresh_ms = 5
 title = "Custom Scan"
 log_tps = true
-log_count = true
 on_connect = """
 SET enable_indexonlyscan to OFF;
 SET enable_indexscan to OFF;
@@ -92,7 +88,6 @@ SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'mes
 refresh_ms = 5
 title = "Index Only Scan"
 log_tps = true
-log_count = true
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'message:wine';
 """
@@ -101,7 +96,6 @@ SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where id @@@ 'mes
 refresh_ms = 25
 title = "Update random values"
 log_tps = true
-log_count = true
 sql = """
 UPDATE test
 SET message = substring(message FROM 1 FOR length(message)-1)
@@ -113,7 +107,6 @@ WHERE id < 10;
 refresh_ms = 10
 title = "Insert value"
 log_tps = true
-log_count = true
 sql = """
 INSERT INTO test (message) VALUES ('test');
 """
@@ -122,7 +115,6 @@ INSERT INTO test (message) VALUES ('test');
 refresh_ms = 10
 title = "Insert value"
 log_tps = true
-log_count = true
 sql = """
 INSERT INTO test (message) VALUES ('test');
 """
@@ -130,8 +122,6 @@ INSERT INTO test (message) VALUES ('test');
 [[jobs]]
 refresh_ms = 10
 title = "Delete values"
-log_tps = true
-log_count = true
 sql = """
 DELETE FROM test WHERE id > 14;
 """
@@ -140,7 +130,6 @@ DELETE FROM test WHERE id > 14;
 refresh_ms = 3000
 title = "Vacuum"
 log_tps = true
-log_count = true
 sql = """
 SET vacuum_freeze_min_age = 0;
 VACUUM test;

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -361,21 +361,24 @@ pub trait MVCCEntry {
         xmin_visible && !deleted
     }
 
-    unsafe fn recyclable(
-        &self,
-        snapshot: pg_sys::Snapshot,
-        heap_relation: pg_sys::Relation,
-    ) -> bool {
+    unsafe fn recyclable(&self, heap_relation: pg_sys::Relation) -> bool {
         let xmax = self.get_xmax();
         if xmax == pg_sys::InvalidTransactionId {
             return false;
         }
 
-        if pg_sys::XidInMVCCSnapshot(xmax, snapshot) {
-            return false;
-        }
-
         pg_sys::GlobalVisCheckRemovableXid(heap_relation, xmax)
+    }
+
+    unsafe fn mergeable(&self, current_xid: pg_sys::TransactionId) -> bool {
+        let xmin = self.get_xmin();
+        let xmax = self.get_xmax();
+
+        // mergeable if we haven't deleted it
+        xmax == pg_sys::InvalidTransactionId
+
+            // and it's from the current transaction or a transaction that is not in progress
+            && (xmin == current_xid || !pg_sys::TransactionIdIsInProgress(xmin))
     }
 
     unsafe fn xmin_needs_freeze(&self, freeze_limit: pg_sys::TransactionId) -> bool {

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -168,7 +168,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
 
     pub unsafe fn garbage_collect(&mut self) -> Vec<T> {
         // Delete all items that are definitely dead
-        let snapshot = pg_sys::GetActiveSnapshot();
         let heap_oid = pg_sys::IndexGetRelation(self.relation_oid, false);
         let heap_relation = pg_sys::RelationIdGetRelation(heap_oid);
         let freeze_limit = vacuum_get_freeze_limit(heap_relation);
@@ -187,7 +186,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
 
             while offsetno <= max_offset {
                 if let Some((entry, _)) = page.read_item::<T>(offsetno) {
-                    if entry.recyclable(snapshot, heap_relation) {
+                    if entry.recyclable(heap_relation) {
                         page.mark_item_dead(offsetno);
 
                         recycled_entries.push(entry);

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -201,7 +201,7 @@ impl MergeLock {
 
     pub unsafe fn record_in_progress_segment_ids<'a>(
         mut self,
-        segment_ids: impl IntoIterator<Item = &'a &'a SegmentId>,
+        segment_ids: impl IntoIterator<Item = &'a SegmentId>,
     ) -> anyhow::Result<MergeEntry> {
         assert!(pg_sys::IsTransactionState());
 

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -52,11 +52,6 @@ impl BM25Page for pg_sys::Page {
             return false;
         }
 
-        let snapshot = pg_sys::GetActiveSnapshot();
-        if pg_sys::XidInMVCCSnapshot((*special).xmax, snapshot) {
-            return false;
-        }
-
         pg_sys::GlobalVisCheckRemovableXid(heap_relation, (*special).xmax)
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

When insert/updating tuples, specifically for the "merge" portion of the insert, we no longer require a Postgres `Snapshot`.

Essentially, we don't need to use the snapshot to determine if a segment meta entry (or block!) is recyclable, and we don't need a snapshot to determine if a segment is mergable.

## Why

This allows us to simplify the code quite a bit and eliminates a complexity around `aminsert()` that behaves differently between community and enterprise (with logical replication).

## How

## Tests

Existing tests pass