### PR TITLE
feat: a view to inspect index layers

### DIFF
--- a/pg_search/sql/pg_search--0.15.10--0.15.11.sql
+++ b/pg_search/sql/pg_search--0.15.10--0.15.11.sql
@@ -1,0 +1,27 @@
+create view paradedb.index_layer_info as
+select relname::text,
+       layer_size,
+       case when segments = ARRAY [NULL] then 0 else count end       as count,
+       case when segments = ARRAY [NULL] then NULL else segments end as segments
+from (select relname,
+             coalesce(pg_size_pretty(case when low = 0 then null else low end), '') || '..' ||
+             coalesce(pg_size_pretty(case when high = 9223372036854775807 then null else high end), '') as layer_size,
+             count(*),
+             array_agg(segno) as segments
+      from (with indexes as (select oid::regclass as relname
+                             from pg_class
+                             where relam = (select oid from pg_am where amname = 'bm25')),
+                 segments as (select relname, index_info.*
+                              from indexes
+                                       inner join paradedb.index_info(indexes.relname, true) on true),
+                 layer_sizes as (select relname, coalesce(lead(unnest) over (), 0) low, unnest as high
+                                 from indexes
+                                          inner join lateral (select unnest(0 || paradedb.layer_sizes(indexes.relname) || 9223372036854775807)
+                                                              order by 1 desc) x on true)
+            select layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno
+            from layer_sizes
+                     left join segments on layer_sizes.relname = segments.relname and
+                                           (byte_size * 1.33)::bigint between low and high) x
+      where low < high
+      group by relname, low, high
+      order by relname, low desc) x;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -424,3 +424,37 @@ fn version_info() -> TableIterator<
 
     TableIterator::once((version, git_sha, build_mode))
 }
+
+extension_sql!(
+    r#"
+create view paradedb.index_layer_info as
+select relname::text,
+       layer_size,
+       case when segments = ARRAY [NULL] then 0 else count end       as count,
+       case when segments = ARRAY [NULL] then NULL else segments end as segments
+from (select relname,
+             coalesce(pg_size_pretty(case when low = 0 then null else low end), '') || '..' ||
+             coalesce(pg_size_pretty(case when high = 9223372036854775807 then null else high end), '') as layer_size,
+             count(*),
+             array_agg(segno) as segments
+      from (with indexes as (select oid::regclass as relname
+                             from pg_class
+                             where relam = (select oid from pg_am where amname = 'bm25')),
+                 segments as (select relname, index_info.*
+                              from indexes
+                                       inner join paradedb.index_info(indexes.relname, true) on true),
+                 layer_sizes as (select relname, coalesce(lead(unnest) over (), 0) low, unnest as high
+                                 from indexes
+                                          inner join lateral (select unnest(0 || paradedb.layer_sizes(indexes.relname) || 9223372036854775807)
+                                                              order by 1 desc) x on true)
+            select layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno
+            from layer_sizes
+                     left join segments on layer_sizes.relname = segments.relname and
+                                           (byte_size * 1.33)::bigint between low and high) x
+      where low < high
+      group by relname, low, high
+      order by relname, low desc) x;
+"#,
+    name = "index_layer_info",
+    requires = [index_info, layer_sizes]
+);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This is a view that makes figuring out how a segment is organized by its layers really simple.

```sq;
[v16.2][20023] test=# select * from paradedb.index_layer_info;
        relname        |   layer_size    | count |                                                                                                                 >
-----------------------+-----------------+-------+----------------------------------------------------------------------------------------------------------------->
 idxa                  | 1024 MB..       |     0 | 
 idxa                  | 10 kB..1024 MB  |    10 | {6c62932f,2ba1d9e6,1e74b134,b3578065,8d350491,56d2b06d,a766c091,805a5b84,2f3df680,b3b934a3}
 idxa                  | ..10 kB         |    26 | {db80be16,1feb730f,2c469a61,e4672946,10f54f52,6c4d12b4,343d85c4,bceb897d,46be6211,d4668ff6,79926b29,70212178,536>
 paradedb.partial_idx  | 100 MB..        |     0 | 
 paradedb.partial_idx  | 1024 kB..100 MB |     0 | 
 paradedb.partial_idx  | 100 kB..1024 kB |     0 | 
 paradedb.partial_idx  | ..100 kB        |     2 | {6bfb6c02,72fa4fb7}
 benchmark_logs_idx    | 100 MB..        |     0 | 
 benchmark_logs_idx    | 1024 kB..100 MB |    18 | {73610930,c645428e,23270824,682cdc9b,c4d56869,ee739368,0421a216,890c56c9,5ee58188,30aada74,3ce56327,0e0f9987,2e7>
 benchmark_logs_idx    | 100 kB..1024 kB |   513 | {e537b11f,e8755084,38a5a1e1,62aee3c8,3c95873f,e4544228,b005cc8f,317ab841,76fd844a,63e974e7,d453c753,5aaadf4f,f73>
 benchmark_logs_idx    | ..100 kB        |     0 | 
 test_bm25             | 100 MB..        |     0 | 
 test_bm25             | 1024 kB..100 MB |     0 | 
 test_bm25             | 100 kB..1024 kB |     0 | 
 test_bm25             | ..100 kB        |     0 | 
 mcp_server_search_idx | 100 MB..        |     0 | 
 mcp_server_search_idx | 1024 kB..100 MB |     0 | 
 mcp_server_search_idx | 100 kB..1024 kB |     0 | 
 mcp_server_search_idx | ..100 kB        |     0 | 
 idxlayer_sizes        | 100 MB..        |     0 | 
 idxlayer_sizes        | 1024 kB..100 MB |     0 | 
 idxlayer_sizes        | 100 kB..1024 kB |     0 | 
 idxlayer_sizes        | ..100 kB        |   103 | {bdea5bf6,d5032327,c122ad5a,8f245c92,ae39932c,183c4254,ff3901d4,dd13e44c,80d70e46,c09083aa,ad514b3a,d02f1ebd,3e1>
 idxtest               | 100 MB..        |     0 | 
 idxtest               | 1024 kB..100 MB |     0 | 
 idxtest               | 100 kB..1024 kB |     1 | {5c610743}
 idxtest               | ..100 kB        |    12 | {9d0a00d3,b53db0b9,6e9be885,9c881569,a854919a,36b4beba,7e82658c,b46c6bd0,896ffedb,9665f388,5e4b2c56,da3e86e0}
```

The view can, of course, be filtered and such.  For example:

```sql
[v16.2][20023] test=# select layer_size, count from paradedb.index_layer_info where relname = 'idxtest';
   layer_size    | count 
-----------------+-------
 100 MB..        |     0
 1024 kB..100 MB |     0
 100 kB..1024 kB |     1
 ..100 kB        |    12
(4 rows)
```

Essentially, it aggregates the layers into a histogram of sorts, based on the index's defined layer sizes.

## Why

## How

## Tests
