### PR TITLE
chore: no need to use our linda PR directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,8 +5807,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "lindera"
-version = "0.39.0"
-source = "git+https://github.com/lindera/lindera.git?rev=c5be457#c5be457b1be0e4a333bebebf9400b035d259b254"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,3 @@ pgrx-tests = "=0.13.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-lindera = { git = "https://github.com/lindera/lindera.git", rev = "c5be457" }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We just moved to lindera v0.40.0, which includes the PR I put up awhile back, so we don't need to patch that into our dependency tree anymore

## Why

## How

## Tests
