### PR TITLE
fix: no need to assign a `TransactionId` if we don't have one

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -319,7 +319,7 @@ pub unsafe fn load_metas(
     let mut blockno = segment_metas.get_start_blockno();
 
     let bman = segment_metas.bman();
-    let current_xid = pg_sys::GetCurrentTransactionId();
+    let current_xid = pg_sys::GetCurrentTransactionIdIfAny();
     while blockno != pg_sys::InvalidBlockNumber {
         let buffer = bman.get_buffer(blockno);
         let page = buffer.page();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`load_metas()` might need to know the current transaction id to determine if an entry is mergeable, but if we don't have a transaction id we also don't need to assign one.

## Why

This would only happen during a postgres WAL recovery situation, so isn't even applicable here on community pg_search, but it's best to be as correct as we can.

## How

## Tests
