### PR TITLE
fix: remove merge lock "last merge xid" tracking

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -23,7 +23,6 @@ use crate::postgres::storage::block::{
 };
 use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::merge::MergeLock;
-use crate::postgres::storage::merge::MergeLockData;
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use crate::postgres::utils::{
     categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
@@ -218,9 +217,7 @@ unsafe fn create_metadata(index_relation: &PgRelation) {
     // Init merge lock buffer
     let mut merge_lock = bman.new_buffer();
     assert_eq!(merge_lock.number(), MERGE_LOCK);
-    let mut page = merge_lock.init_page();
-    let metadata = page.contents_mut::<MergeLockData>();
-    metadata.last_merge = pg_sys::InvalidTransactionId;
+    merge_lock.init_page();
 
     // Init cleanup lock buffer
     let mut cleanup_lock = bman.new_buffer();

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -31,11 +31,9 @@ use tantivy::index::SegmentId;
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {
-    pub last_merge: pg_sys::TransactionId,
-
     /// This space was once used but no longer is.  As such, it needs to remain dead forever
     #[allow(dead_code)]
-    pub _dead_space: u32,
+    pub _dead_space: [u32; 2],
 
     /// Contains the [`pg_sys::BlockNumber`] of the active merge list
     active_vacuum_list: pg_sys::BlockNumber,
@@ -58,7 +56,6 @@ pub struct MergeLock {
     // run before the `bman` from which it originated
     buffer: BufferMut,
     bman: BufferManager,
-    save_xid: bool,
 }
 
 impl MergeLock {
@@ -69,7 +66,6 @@ impl MergeLock {
         MergeLock {
             buffer: merge_lock,
             bman,
-            save_xid: false,
         }
     }
 
@@ -79,7 +75,6 @@ impl MergeLock {
         let mut page = merge_lock.page_mut();
         let metadata = page.contents_mut::<MergeLockData>();
 
-        metadata.last_merge = pg_sys::InvalidTransactionId;
         metadata.active_vacuum_list = pg_sys::InvalidBlockNumber;
         metadata.ambulkdelete_sentinel = pg_sys::InvalidBlockNumber;
     }
@@ -273,26 +268,6 @@ impl MergeLock {
                 LinkedBytesList::open(relation_id, recycled_entry.segment_ids_start_blockno);
             bytes_list.mark_deleted(recycled_entry.xmax);
             bytes_list.return_to_fsm(&recycled_entry, None);
-        }
-    }
-}
-
-impl Drop for MergeLock {
-    fn drop(&mut self) {
-        unsafe {
-            if self.save_xid && crate::postgres::utils::IsTransactionState() {
-                let mut current_xid = pg_sys::GetCurrentTransactionIdIfAny();
-
-                // if we don't have a transaction id (typically from a parallel vacuum)...
-                if current_xid == pg_sys::InvalidTransactionId {
-                    // ... then use the next transaction id as ours
-                    current_xid = pg_sys::ReadNextTransactionId()
-                }
-
-                let mut page = self.buffer.page_mut();
-                let metadata = page.contents_mut::<MergeLockData>();
-                metadata.last_merge = current_xid;
-            }
         }
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

With the advent of concurrent merges we no longer need to keep track of when we last merged.

We do, however, move the `MergeLockData.last_merge` space into the `_dead_space` so that future changes don't accidentally reuse this previously-used space.

## Why

This was an oversight when implementing #2320.

## How

## Tests
