### PR TITLE
feat: add new `paradedb.force_merge()` function

### DIFF
--- a/pg_search/sql/pg_search--0.15.11--0.15.12.sql
+++ b/pg_search/sql/pg_search--0.15.11--0.15.12.sql
@@ -32,3 +32,29 @@ from (select relname,
       where low < high
       group by relname, low, high
       order by relname, low desc) x;
+
+-- pg_search/src/bootstrap/create_bm25.rs:424
+-- pg_search::bootstrap::create_bm25::force_merge
+CREATE  FUNCTION "force_merge"(
+    "index" regclass, /* pgrx::rel::PgRelation */
+    "oversized_layer_size_pretty" TEXT /* alloc::string::String */
+) RETURNS TABLE (
+                    "new_segments" bigint,  /* i64 */
+                    "merged_segments" bigint  /* i64 */
+                )
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'force_merge_pretty_bytes_wrapper';
+
+-- pg_search/src/bootstrap/create_bm25.rs:441
+-- pg_search::bootstrap::create_bm25::force_merge
+CREATE  FUNCTION "force_merge"(
+    "index" regclass, /* pgrx::rel::PgRelation */
+    "oversized_layer_size_bytes" bigint /* i64 */
+) RETURNS TABLE (
+                    "new_segments" bigint,  /* i64 */
+                    "merged_segments" bigint  /* i64 */
+                )
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'force_merge_raw_bytes_wrapper';

--- a/pg_search/sql/pg_search--0.15.11--0.15.12.sql
+++ b/pg_search/sql/pg_search--0.15.11--0.15.12.sql
@@ -58,3 +58,12 @@ CREATE  FUNCTION "force_merge"(
     STRICT
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'force_merge_raw_bytes_wrapper';
+
+-- pg_search/src/bootstrap/create_bm25.rs:460
+-- pg_search::bootstrap::create_bm25::merge_lock_garbage_collect
+CREATE  FUNCTION "merge_lock_garbage_collect"(
+    "index" regclass /* pgrx::rel::PgRelation */
+) RETURNS SETOF INT /* i32 */
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'merge_lock_garbage_collect_wrapper';

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -354,7 +354,11 @@ impl Directory for MVCCDirectory {
     }
 
     fn wants_cancel(&self) -> bool {
-        unsafe { pg_sys::QueryCancelPending != 0 }
+        unsafe {
+            pg_sys::QueryCancelPending != 0
+                || !pg_sys::IsTransactionState()
+                || pg_sys::IsAbortedTransactionBlockState()
+        }
     }
 
     fn log(&self, message: &str) {

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -366,22 +366,14 @@ impl Directory for MVCCDirectory {
     }
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 #[repr(transparent)]
 pub struct PinCushion(HashMap<pg_sys::BlockNumber, PinnedBuffer>);
 
 impl PinCushion {
-    #[inline]
-    pub unsafe fn new(bman: &BufferManager, entries: &[SegmentMetaEntry]) -> Self {
-        let pinned_blocks = entries
-            .iter()
-            .map(|entry| {
-                let blockno = entry.pintest_blockno();
-                (blockno, bman.pinned_buffer(blockno))
-            })
-            .collect();
-
-        PinCushion(pinned_blocks)
+    pub fn push(&mut self, bman: &BufferManager, entry: &SegmentMetaEntry) {
+        let blockno = entry.pintest_blockno();
+        self.0.insert(blockno, bman.pinned_buffer(blockno));
     }
 
     pub fn remove(&mut self, blockno: pg_sys::BlockNumber) {

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -57,7 +57,7 @@ impl MvccSatisfies {
     pub fn directory(self, index_relation: &PgRelation) -> MVCCDirectory {
         match self {
             MvccSatisfies::Snapshot => MVCCDirectory::snapshot(index_relation.oid()),
-            MvccSatisfies::Vacuum => MVCCDirectory::any(index_relation.oid()),
+            MvccSatisfies::Vacuum => MVCCDirectory::vacuum(index_relation.oid()),
             MvccSatisfies::Mergeable => MVCCDirectory::mergeable(index_relation.oid()),
         }
     }
@@ -111,7 +111,7 @@ impl MVCCDirectory {
         Self::with_mvcc_style(relation_oid, MvccSatisfies::Snapshot, Some(snapshot))
     }
 
-    pub fn any(relation_oid: pg_sys::Oid) -> Self {
+    pub fn vacuum(relation_oid: pg_sys::Oid) -> Self {
         Self::with_mvcc_style(relation_oid, MvccSatisfies::Vacuum, None)
     }
 

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -18,7 +18,10 @@
 use super::utils::{load_metas, save_new_metas, save_schema, save_settings};
 use crate::index::channel::{ChannelRequest, ChannelRequestHandler};
 use crate::index::reader::segment_component::SegmentComponentReader;
-use crate::postgres::storage::block::{FileEntry, SegmentMetaEntry, SEGMENT_METAS_START};
+use crate::postgres::storage::block::{
+    FileEntry, MVCCEntry, SegmentMetaEntry, SEGMENT_METAS_START,
+};
+use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use crate::postgres::storage::LinkedItemList;
 use crossbeam::channel::Receiver;
 use parking_lot::Mutex;
@@ -26,7 +29,7 @@ use pgrx::{pg_sys, PgRelation};
 use rustc_hash::FxHashMap;
 use std::any::Any;
 use std::collections::hash_map::Entry;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::panic::panic_any;
@@ -34,16 +37,19 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::{io, result};
-use tantivy::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
+use tantivy::directory::error::{
+    DeleteError, LockError, OpenDirectoryError, OpenReadError, OpenWriteError,
+};
 use tantivy::directory::{
     DirectoryLock, DirectoryPanicHandler, FileHandle, Lock, WatchCallback, WatchHandle, WritePtr,
 };
+use tantivy::index::SegmentId;
 use tantivy::{index::SegmentMetaInventory, Directory, IndexMeta, TantivyError};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MvccSatisfies {
     Snapshot,
-    Any,
+    Vacuum,
     Mergeable,
 }
 
@@ -51,7 +57,7 @@ impl MvccSatisfies {
     pub fn directory(self, index_relation: &PgRelation) -> MVCCDirectory {
         match self {
             MvccSatisfies::Snapshot => MVCCDirectory::snapshot(index_relation.oid()),
-            MvccSatisfies::Any => MVCCDirectory::any(index_relation.oid()),
+            MvccSatisfies::Vacuum => MVCCDirectory::any(index_relation.oid()),
             MvccSatisfies::Mergeable => MVCCDirectory::mergeable(index_relation.oid()),
         }
     }
@@ -86,8 +92,8 @@ pub struct MVCCDirectory {
     // we cannot tolerate tantivy calling `load_metas()` multiple times and giving it a different
     // answer
     loaded_metas: OnceLock<Arc<tantivy::Result<IndexMeta>>>,
-
-    entries_cache: Arc<Mutex<FxHashMap<PathBuf, FileEntry>>>,
+    all_entries: Arc<Mutex<HashMap<SegmentId, SegmentMetaEntry>>>,
+    pin_cushion: Arc<Mutex<Option<PinCushion>>>,
 }
 
 unsafe impl Send for MVCCDirectory {}
@@ -106,7 +112,7 @@ impl MVCCDirectory {
     }
 
     pub fn any(relation_oid: pg_sys::Oid) -> Self {
-        Self::with_mvcc_style(relation_oid, MvccSatisfies::Any, None)
+        Self::with_mvcc_style(relation_oid, MvccSatisfies::Vacuum, None)
     }
 
     pub fn mergeable(relation_oid: pg_sys::Oid) -> Self {
@@ -124,35 +130,30 @@ impl MVCCDirectory {
             mvcc_style,
             readers: Arc::new(Mutex::new(FxHashMap::default())),
             loaded_metas: Default::default(),
-            entries_cache: Default::default(),
+            pin_cushion: Default::default(),
+            all_entries: Default::default(),
         }
     }
 
     pub unsafe fn directory_lookup(&self, path: &Path) -> tantivy::Result<FileEntry> {
-        let mut entries_cache = self.entries_cache.lock();
-        if !entries_cache.contains_key(path) {
-            // segment_id not found in the entries_cache, so (re)populate the cache
-            let all_entries =
-                LinkedItemList::<SegmentMetaEntry>::open(self.relation_oid, SEGMENT_METAS_START)
-                    .list();
+        let file_name = path
+            .file_name()
+            .expect("path should have a filename")
+            .to_str()
+            .expect("path should be valid UTF8");
+        let file_name = &file_name[..file_name.find('.').unwrap_or(file_name.len())];
+        let segment_id = SegmentId::from_uuid_string(file_name)
+            .map_err(|e| TantivyError::InvalidArgument(e.to_string()))?;
 
-            for meta_entry in all_entries {
-                for (path, (file_entry, _)) in meta_entry
-                    .get_component_paths()
-                    .zip(meta_entry.file_entries())
-                {
-                    entries_cache.insert(path, *file_entry);
-                }
+        if let Some(meta_entry) = self.all_entries.lock().get(&segment_id) {
+            if let Some(file_entry) = meta_entry.file_entry(path) {
+                return Ok(file_entry);
             }
         }
 
-        match entries_cache.get(path) {
-            None => Err(TantivyError::SystemError(format!(
-                "`{}` not found in directory",
-                path.display()
-            ))),
-            Some(file_entry) => Ok(*file_entry),
-        }
+        Err(TantivyError::OpenDirectoryError(
+            OpenDirectoryError::DoesNotExist(path.to_path_buf()),
+        ))
     }
 }
 
@@ -286,14 +287,26 @@ impl Directory for MVCCDirectory {
     }
 
     fn load_metas(&self, inventory: &SegmentMetaInventory) -> tantivy::Result<IndexMeta> {
-        Clone::clone(self.loaded_metas.get_or_init(|| unsafe {
-            Arc::new(load_metas(
+        let loaded_metas = self.loaded_metas.get_or_init(|| unsafe {
+            match load_metas(
                 self.relation_oid,
                 inventory,
                 self.snapshot,
                 &self.mvcc_style,
-            ))
-        }))
+            ) {
+                Err(e) => Arc::new(Err(e)),
+                Ok((all_entries, index_meta, pin_cushion)) => {
+                    *self.all_entries.lock() = all_entries
+                        .into_iter()
+                        .map(|entry| (entry.segment_id, entry))
+                        .collect();
+                    *self.pin_cushion.lock() = Some(pin_cushion);
+                    Arc::new(Ok(index_meta))
+                }
+            }
+        });
+
+        Clone::clone(loaded_metas)
     }
 
     fn supports_garbage_collection(&self) -> bool {
@@ -346,6 +359,29 @@ impl Directory for MVCCDirectory {
 
     fn log(&self, message: &str) {
         pgrx::debug1!("{message}");
+    }
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct PinCushion(HashMap<pg_sys::BlockNumber, PinnedBuffer>);
+
+impl PinCushion {
+    #[inline]
+    pub unsafe fn new(bman: &BufferManager, entries: &[SegmentMetaEntry]) -> Self {
+        let pinned_blocks = entries
+            .iter()
+            .map(|entry| {
+                let blockno = entry.pintest_blockno();
+                (blockno, bman.pinned_buffer(blockno))
+            })
+            .collect();
+
+        PinCushion(pinned_blocks)
+    }
+
+    pub fn remove(&mut self, blockno: pg_sys::BlockNumber) {
+        self.0.remove(&blockno);
     }
 }
 

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -1,7 +1,7 @@
 use crate::index::mvcc::{MvccSatisfies, PinCushion};
 use crate::postgres::storage::block::{
-    DeleteEntry, FileEntry, MVCCEntry, PgItem, SegmentFileDetails, SegmentMetaEntry, SCHEMA_START,
-    SEGMENT_METAS_START, SETTINGS_START,
+    DeleteEntry, FileEntry, MVCCEntry, PgItem, SegmentFileDetails, SegmentMetaEntry, CLEANUP_LOCK,
+    SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
 };
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use anyhow::Result;
@@ -307,6 +307,7 @@ pub unsafe fn save_new_metas(
 
 impl LinkedItemList<SegmentMetaEntry> {
     pub unsafe fn list_and_pin(&self) -> (Vec<SegmentMetaEntry>, PinCushion) {
+        let _cleanup_lock = self.bman().get_buffer(CLEANUP_LOCK);
         let entries = self.list();
         let pin_cushion = PinCushion::new(self.bman(), &entries);
         (entries, pin_cushion)

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -60,7 +60,11 @@ impl MergePolicy for LayeredMergePolicy {
             .values()
             .map(|entry| entry.byte_size())
             .sum::<u64>()
-            / self.mergeable_segments.len() as u64;
+            / self
+                .mergeable_segments
+                .values()
+                .map(|entry| (entry.num_docs() + entry.num_deleted_docs()) as u64)
+                .sum::<u64>();
 
         let mut candidates = Vec::new();
         let mut merged_segments = HashSet::new();

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -431,7 +431,7 @@ impl SearchIndexReader {
             .iter()
             .enumerate()
             .find(|(_, reader)| reader.segment_id() == segment_id)
-            .expect("segment {segment_id} should exist");
+            .unwrap_or_else(|| panic!("segment {segment_id} should exist"));
         let iter = scorer_iter::ScorerIter::new(
             DeferredScorer::new(
                 query,
@@ -583,7 +583,7 @@ impl SearchIndexReader {
             .iter()
             .enumerate()
             .find(|(_, reader)| reader.segment_id() == segment_id)
-            .expect("segment {segment_id} should exist");
+            .unwrap_or_else(|| panic!("segment {segment_id} should exist"));
         let sort_field = self
             .schema
             .get_search_field(&SearchFieldName(sort_field.clone()))
@@ -636,7 +636,7 @@ impl SearchIndexReader {
             .iter()
             .enumerate()
             .find(|(_, reader)| reader.segment_id() == segment_id)
-            .expect("segment {segment_id} should exist");
+            .unwrap_or_else(|| panic!("segment {segment_id} should exist"));
 
         let query = self.query(query);
         let weight = query

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -20,7 +20,7 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::scorer_iter::DeferredScorer;
 use crate::index::setup_tokenizers;
 use crate::postgres::storage::block::CLEANUP_LOCK;
-use crate::postgres::storage::buffer::{Buffer, BufferManager};
+use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use crate::query::SearchQueryInput;
 use crate::schema::SearchField;
 use crate::schema::{SearchFieldName, SearchIndexSchema};
@@ -250,11 +250,11 @@ pub struct SearchIndexReader {
     underlying_reader: IndexReader,
     underlying_index: Index,
 
-    // [`Buffer`] has a Drop impl, so we hold onto it but don't otherwise use it
+    // [`PinnedBuffer`] has a Drop impl, so we hold onto it but don't otherwise use it
     //
     // also, it's an Arc b/c if we're clone'd (we do derive it, after all), we only want this
     // buffer dropped once
-    _cleanup_lock: Arc<Buffer>,
+    _cleanup_lock: Arc<PinnedBuffer>,
 }
 
 impl SearchIndexReader {
@@ -269,7 +269,7 @@ impl SearchIndexReader {
         //
         // It's sufficient, and **required** for parallel scans to operate correctly, for us to hold onto
         // a pinned but unlocked buffer.
-        let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer(CLEANUP_LOCK);
+        let cleanup_lock = BufferManager::new(index_relation.oid()).pinned_buffer(CLEANUP_LOCK);
 
         let directory = mvcc_style.directory(index_relation);
         let mut index = Index::open(directory)?;

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -29,8 +29,6 @@ use crate::index::channel::{ChannelDirectory, ChannelRequestHandler};
 use crate::index::merge_policy::LayeredMergePolicy;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::{get_index_schema, setup_tokenizers, WriterResources};
-use crate::postgres::storage::block::CLEANUP_LOCK;
-use crate::postgres::storage::buffer::{Buffer, BufferManager};
 use crate::{
     postgres::types::TantivyValueError,
     schema::{SearchDocument, SearchIndexSchema},
@@ -53,7 +51,6 @@ pub struct SearchIndexWriter {
     insert_queue: Vec<UserOperation>,
 
     cnt: usize,
-    _cleanup_lock: Buffer,
 }
 
 impl SearchIndexWriter {
@@ -62,7 +59,6 @@ impl SearchIndexWriter {
         directory_type: MvccSatisfies,
         resources: WriterResources,
     ) -> Result<Self> {
-        let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer(CLEANUP_LOCK);
         let (parallelism, memory_budget) = resources.resources();
 
         let (req_sender, req_receiver) = crossbeam::channel::bounded(1);
@@ -100,12 +96,10 @@ impl SearchIndexWriter {
             ctid_field,
             insert_queue: Vec::with_capacity(MAX_INSERT_QUEUE_SIZE),
             cnt: 0,
-            _cleanup_lock: cleanup_lock,
         })
     }
 
     pub fn create_index(index_relation: &PgRelation) -> Result<Self> {
-        let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer(CLEANUP_LOCK);
         let schema = get_index_schema(index_relation)?;
         let (parallelism, memory_budget) = WriterResources::CreateIndex.resources();
 
@@ -148,7 +142,6 @@ impl SearchIndexWriter {
             handler,
             insert_queue: Vec::with_capacity(MAX_INSERT_QUEUE_SIZE),
             cnt: 0,
-            _cleanup_lock: cleanup_lock,
         })
     }
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -44,29 +44,39 @@ pub unsafe extern "C" fn ambulkdelete(
         callback(&mut ctid, callback_state)
     };
 
+    // first, we need an exclusive lock on the CLEANUP_LOCK.  Once we get it, we know that there
+    // are no concurrent merges happening
+    let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer_mut(CLEANUP_LOCK);
+
     // take the MergeLock
-    let merge_lock = loop {
-        // acquire the CLEANUP_LOCK (for cleanup).  This will block us until the lock has no concurrent
-        // pins.  That means there are no readers and no merging happening
-        let cleanup_lock =
-            BufferManager::new(index_relation.oid()).get_buffer_for_cleanup(CLEANUP_LOCK);
-        drop(cleanup_lock);
+    let merge_lock = {
+        // this should acquire instantly as at this point, because of our exclusive lock on CLEANUP_LOCK
+        // we know there's nobody else that might also be holding the merge lock
+        let mut merge_lock = MergeLock::acquire(index_relation.oid());
 
-        // next we acquire the MergeLock.  This too is a blocking operation.  The hope here is that
-        // because of the waiting we did above to get the CLEANUP_LOCK, we'll be the next to acquire
-        // the MergeLock before another merge begins
-        let merge_lock = MergeLock::acquire(index_relation.oid());
-        if merge_lock.is_merge_in_progress() {
-            // but if another merge did begin we need to wait it out and retry.
-            check_for_interrupts!();
-            continue;
-        }
-        break merge_lock;
+        // garbage collecting the MergeLock is necessary to remove any stale entries that may have
+        // been leftover from a cancelled merge or crash during merge
+        merge_lock.garbage_collect();
+        pg_sys::IndexFreeSpaceMapVacuum(index_relation.as_ptr());
+
+        // and now we should not have any merges happening, and cannot
+        assert!(
+            !merge_lock.is_merge_in_progress(),
+            "ambulkdelete cannot run concurrently with an active merge operation"
+        );
+        merge_lock
     };
+    drop(cleanup_lock);
 
-    let mut index_writer =
-        SearchIndexWriter::open(&index_relation, MvccSatisfies::Any, WriterResources::Vacuum)
-            .expect("ambulkdelete: should be able to open a SearchIndexWriter");
+    let mut index_writer = SearchIndexWriter::open(
+        &index_relation,
+        MvccSatisfies::Vacuum,
+        WriterResources::Vacuum,
+    )
+    .expect("ambulkdelete: should be able to open a SearchIndexWriter");
+    let reader = SearchIndexReader::open(&index_relation, MvccSatisfies::Vacuum)
+        .expect("ambulkdelete: should be able to open a SearchIndexReader");
+
     let writer_segment_ids = index_writer.segment_ids();
 
     // write out the list of segment ids we're about to operate on.  Doing so drops the MergeLock
@@ -75,9 +85,6 @@ pub unsafe extern "C" fn ambulkdelete(
     let vacuum_sentinel = merge_lock
         .vacuum_list()
         .write_list(writer_segment_ids.iter());
-
-    let reader = SearchIndexReader::open(&index_relation, MvccSatisfies::Any)
-        .expect("ambulkdelete: should be able to open a SearchIndexReader");
 
     let mut did_delete = false;
     for segment_reader in reader.segment_readers() {

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -46,7 +46,8 @@ pub unsafe extern "C" fn ambulkdelete(
 
     // first, we need an exclusive lock on the CLEANUP_LOCK.  Once we get it, we know that there
     // are no concurrent merges happening
-    let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer_mut(CLEANUP_LOCK);
+    let cleanup_lock =
+        BufferManager::new(index_relation.oid()).get_buffer_for_cleanup(CLEANUP_LOCK);
 
     // take the MergeLock
     let merge_lock = {

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -390,10 +390,6 @@ pub trait MVCCEntry {
 
                 // and there's no pin on on our pintest buffer
                 && bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some()
-
-                // and nobody is holding a pin on the CLEANUP_LOCK, which would indicate, at least
-                // that they're reading the segment meta entries list
-                && bman.get_buffer_for_cleanup_conditional(CLEANUP_LOCK).is_some()
             )
     }
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::postgres::storage::buffer::BufferManager;
+use pgrx::pg_sys::BlockNumber;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
@@ -183,6 +185,15 @@ impl SegmentMetaEntry {
             .unwrap_or(0)
     }
 
+    pub fn file_entry(&self, path: &Path) -> Option<FileEntry> {
+        for (file_path, (file_entry, _)) in self.get_component_paths().zip(self.file_entries()) {
+            if path == file_path {
+                return Some(*file_entry);
+            }
+        }
+        None
+    }
+
     pub fn file_entries(&self) -> impl Iterator<Item = (&FileEntry, SegmentComponent)> {
         self.postings
             .iter()
@@ -349,6 +360,8 @@ pub trait MVCCEntry {
     fn get_xmax(&self) -> pg_sys::TransactionId;
     fn into_frozen(self, should_freeze_xmin: bool, should_freeze_xmax: bool) -> Self;
 
+    fn pintest_blockno(&self) -> pg_sys::BlockNumber;
+
     // Provided methods
     unsafe fn visible(&self, snapshot: pg_sys::Snapshot) -> bool {
         let xmin = self.get_xmin();
@@ -361,13 +374,20 @@ pub trait MVCCEntry {
         xmin_visible && !deleted
     }
 
-    unsafe fn recyclable(&self, heap_relation: pg_sys::Relation) -> bool {
+    unsafe fn recyclable(&self, bman: &mut BufferManager) -> bool {
         let xmax = self.get_xmax();
         if xmax == pg_sys::InvalidTransactionId {
             return false;
         }
 
-        pg_sys::GlobalVisCheckRemovableXid(heap_relation, xmax)
+        // recyclable if the xmax is beyond the vacuum horizon
+        pg_sys::GlobalVisCheckRemovableXid(bman.bm25cache().heaprel(), xmax)
+            // or if the xmax transaction is no longer in progress
+            || (!pg_sys::TransactionIdIsInProgress(xmax)
+                    // and there's no pin on on our pintest buffer
+                    && bman
+                        .get_buffer_for_cleanup_conditional(self.pintest_blockno())
+                        .is_some())
     }
 
     unsafe fn mergeable(&self, current_xid: pg_sys::TransactionId) -> bool {
@@ -412,6 +432,13 @@ impl MVCCEntry for SegmentMetaEntry {
                 self.xmax
             },
             ..self
+        }
+    }
+
+    fn pintest_blockno(&self) -> BlockNumber {
+        match self.file_entries().next() {
+            None => panic!("SegmentMetaEntry for `{}` has no files", self.segment_id),
+            Some((file_entry, _)) => file_entry.starting_block,
         }
     }
 }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -107,6 +107,7 @@ impl BufferMut {
     }
 }
 
+#[derive(Debug)]
 pub struct PinnedBuffer {
     pg_buffer: pg_sys::Buffer,
 }
@@ -182,10 +183,6 @@ impl Page<'_> {
 
     pub fn contents<T: Copy>(&self) -> T {
         unsafe { (pg_sys::PageGetContents(self.pg_page) as *const T).read_unaligned() }
-    }
-
-    pub fn is_recyclable(&self, heaprel: pg_sys::Relation) -> bool {
-        unsafe { self.pg_page.recyclable(heaprel) }
     }
 
     pub fn next_blockno(&self) -> pg_sys::BlockNumber {

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -293,7 +293,7 @@ impl LinkedBytesList {
     ///
     /// It's the caller's responsibility to later call [`pg_sys::IndexFreeSpaceMapVacuum`]
     /// if necessary.
-    pub unsafe fn return_to_fsm(mut self, entry: &impl Debug, type_: Option<SegmentComponent>) {
+    pub unsafe fn return_to_fsm(mut self, _entry: &impl Debug, _type: Option<SegmentComponent>) {
         // in addition to the list itself, we also have a secondary list of linked blocks (which
         // contain the blocknumbers of this list) that needs to freed too
         for starting_blockno in [self.metadata.start_blockno, self.metadata.blocklist_start] {
@@ -307,16 +307,6 @@ impl LinkedBytesList {
                 let buffer = self.bman.get_buffer(blockno);
                 let page = buffer.page();
                 let special = page.special::<BM25PageSpecialData>();
-
-                assert!(
-                    page.is_recyclable(self.bman.bm25cache().heaprel()),
-                    "blockno={blockno} should be recyclable, xmax={}, type={type_:?}, start={}, blocklist={}, header={} entry={:?}",
-                    special.xmax,
-                    { self.metadata.start_blockno },
-                    { self.metadata.blocklist_start} ,
-                    self.header_blockno,
-                    entry
-                );
 
                 blockno = special.next_blockno;
                 self.bman.return_to_fsm(buffer)

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -284,13 +284,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
                     let special = page.special_mut::<BM25PageSpecialData>();
                     special.next_blockno = new_blockno;
 
-                    // Update the header to point to the new last page
-                    let mut header_buffer = self.bman.get_buffer_mut(self.header_blockno);
-                    let mut page = header_buffer.page_mut();
-                    let metadata = page.contents_mut::<LinkedListData>();
-                    metadata.last_blockno = new_blockno;
-                    metadata.npages += 1;
-
                     if need_hold && hold_open.is_none() {
                         hold_open = Some(buffer);
                     }

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -174,7 +174,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let mut recycled_entries = Vec::new();
 
         while blockno != pg_sys::InvalidBlockNumber {
-            let mut buffer = self.bman.get_buffer_for_cleanup(blockno);
+            let mut buffer = self.bman.get_buffer_mut(blockno);
             let mut page = buffer.page_mut();
             let mut offsetno = pg_sys::FirstOffsetNumber;
             let max_offset = page.max_offset_number();

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -451,6 +451,10 @@ impl MVCCEntry for MergeEntry {
             ..self
         }
     }
+
+    fn pintest_blockno(&self) -> pg_sys::BlockNumber {
+        unimplemented!("pintest_blockno not supported for MergeEntry");
+    }
 }
 
 impl MergeEntry {

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -15,21 +15,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::storage::merge::MergeLock;
 use pgrx::*;
 
 #[pg_guard]
 pub unsafe extern "C" fn amvacuumcleanup(
-    info: *mut pg_sys::IndexVacuumInfo,
+    _info: *mut pg_sys::IndexVacuumInfo,
     stats: *mut pg_sys::IndexBulkDeleteResult,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
-    // garbage collect the MERGE_LOCK
-    // we keep it pruned during normal operations, but a cleanup could be necessary
-    // in the event of a panic/crash between creating a MergeEntry and removing it after merging
-    let mut merge_lock = MergeLock::acquire((*(*info).index).rd_id);
-    merge_lock.garbage_collect();
-    pg_sys::IndexFreeSpaceMapVacuum((*info).index);
-    drop(merge_lock);
-
     stats
 }

--- a/tests/tests/layerd_merge.rs
+++ b/tests/tests/layerd_merge.rs
@@ -32,21 +32,23 @@ fn merges_to_1_100k_segment(mut conn: PgConnection) {
     // one might think 100 individual inserts of 1022 bytes each would get us right at 100k of
     // segment data, and while it does, LayeredMergePolicy has a fudge factor of 33% built in
     // so we actually need more to get to the point of actually merging
-    for _ in 0..132 {
+    for _ in 0..133 {
         // creates a segment of 1022 bytes
         "insert into layer_sizes select x from generate_series(1, 33) x;".execute(&mut conn);
     }
 
-    // assert we actually have 132 segments and that a merge didn't happen yet
+    // assert we actually have 133 segments and that a merge didn't happen yet
     let (nsegments,) = "select count(*) from paradedb.index_info('idxlayer_sizes');"
         .fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(nsegments, 132);
+    assert_eq!(nsegments, 133);
 
     // creates another segment of 1022 bytes, and will cause a merge based on our default layer sizes
+    // leaving behind 2 segments.  one that's a merge of all the segments we created above, and then
+    // one that is the segment created by this insert statement
     "insert into layer_sizes select x from generate_series(1, 33) x;".execute(&mut conn);
     let (nsegments,) = "select count(*) from paradedb.index_info('idxlayer_sizes');"
         .fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(nsegments, 1);
+    assert_eq!(nsegments, 2);
 }
 
 #[rstest]

--- a/tests/tests/merge.rs
+++ b/tests/tests/merge.rs
@@ -33,12 +33,12 @@ fn merge_with_no_positions(mut conn: PgConnection) {
     .execute(&mut conn);
 
     // this will merge on the 12th insert
-    for _ in 0..12 {
+    for _ in 0..13 {
         "insert into test (message) select null from generate_series(1, 1000);".execute(&mut conn);
     }
 
     // and we should have 1 segment after it merges
     let (count,) =
         "select count(*) from paradedb.index_info('idxtest')".fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(count, 1);
+    assert_eq!(count, 2);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This adds a new UDF named `paradedb.force_merge()` that when given an index name and a byte size (either as exact byte number or a pretty string, ie, '10G') will essentially force a merge of segments up to the specified size -- effectively creating a new layer.

The intent is that the user would specify a byte size that's (significantly) larger than the largest layer_size configured on the index, but this is not required.

We also adjust our decision making around what segments a concurrent merge-after-insert might do such that we calculate the merge candidates ahead of time, enabling other concurrent merges to have access to more segments for merging, which includes the new `force_merge()` function.

---

Along with the above...

We used to use the "vacuum horizon" to be the determining factor in deciding when a segment can be garbage collected and its underlying storage recycled.

As it turns out, long-running transactions hold that "vacuum horizon" longer cause segments to build up in any index.  This happens because they're not recyclable yet as the long-running transaction, regardless of what it's actually doing, _could_ see those segments. And the new `force_merge()` function could be considered a long-running transaction. Things like `CREATE INDEX [CONCURRENTLY]` can too.

However, we don't actually need to worry about the vacuum horizon.  When we delete a segment, it can be recycled as soon as the deleting transaction is no longer in progress and if we know there's no concurrent readers/writers using any part of that segment.

So we change how we determine when a segment is recycleable to be a coordinated effort between holding a pin on a buffer in a segment whenever we have an open `MVCCDirectory` and determining if that buffer can be locked.  The logic in `block.rs#377` is pretty straightfoward.

We're also able to now remove the "retry" loop in `ambulkdelete()` and move the `MergeLock::garbage_collect()` there, and remove it from `amvacuumcleanup()`.

---

Finally, we had two problems with the above.  The first is that the segment merge process itself would move tuples from transactions that are known "not in progress anymore" into a transaction that is.  That's now addressed by ensuring merged segments (the original segments and the resulting merged segment) maintain their "not in progress anymore" transaction status by assigning them to the pg_sys::FrozenTransactionId.

A minor side effect of this is that the transaction doing the merge can't merge any of the segments it created -- only segments that are from transactions that are no longer in progress.  Tests have been adjusted accordingly.

Secondly, due to the concurrent nature of both merging and now garbage collection, it was possible for a backend reading the list of segments to see an incomplete view of the list if there was a concurrent backend updating the list.  Tantivy expects the reads/writes of "IndexMeta" to be atomic.  And that's addressed that by having writers changing the list take an exclusive lock on a page while writing to the list, and readers take a shared lock on the same page while reading the list.

---

And that exposed one oversight which is that parallel custom scan workers, and parallel index scan workers, can't use our "MvccSatisfies::Snapshot" rules and instead must use the new `MvccSatisfies::ParallelWorker` rules, which is literally "every segment". 

This is because the parallel workers address segments by their `segment_id`, but the specific segments could have been merged and marked as deleted between when the leader started and any given parallel worker started.  Because the leader holds a pin on each segment, they're still there -- it's just that the parallel worker might not be able to see it anymore due to the visibility rules for `MvccSatisfies::Snapshot`.  Having the workers simply see all the segments allows them to address a specific segment directly by its segment_id.

## Why

It can be desirable to generally elide merging into large gigabyte+-sized segments and allow a DBA to do this explicitly.  This means that normal operations won't unexpectedly block for a long period of time doing a large merge.  The trade-off, of course, is a bit of human intervention and increased segment counts.

## How

## Tests

A new test to ensure that a standalone `force_merge()` works.