### PR TITLE
feat: enhance the paradedb.index_layer_info view

### DIFF
--- a/pg_search/sql/pg_search--0.15.11--0.15.12.sql
+++ b/pg_search/sql/pg_search--0.15.11--0.15.12.sql
@@ -1,0 +1,34 @@
+drop view if exists paradedb.index_layer_info;
+create view paradedb.index_layer_info as
+select relname::text,
+       layer_size,
+       low,
+       high,
+       byte_size,
+       case when segments = ARRAY [NULL] then 0 else count end       as count,
+       case when segments = ARRAY [NULL] then NULL else segments end as segments
+from (select relname,
+             coalesce(pg_size_pretty(case when low = 0 then null else low end), '') || '..' ||
+             coalesce(pg_size_pretty(case when high = 9223372036854775807 then null else high end), '') as layer_size,
+             count(*),
+             coalesce(sum(byte_size), 0)                                                                as byte_size,
+             min(low)                                                                                   as low,
+             max(high)                                                                                  as high,
+             array_agg(segno)                                                                           as segments
+      from (with indexes as (select oid::regclass as relname
+                             from pg_class
+                             where relam = (select oid from pg_am where amname = 'bm25')),
+                 segments as (select relname, index_info.*
+                              from indexes
+                                       inner join paradedb.index_info(indexes.relname, true) on true),
+                 layer_sizes as (select relname, coalesce(lead(unnest) over (), 0) low, unnest as high
+                                 from indexes
+                                          inner join lateral (select unnest(0 || paradedb.layer_sizes(indexes.relname) || 9223372036854775807)
+                                                              order by 1 desc) x on true)
+            select layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size
+            from layer_sizes
+                     left join segments on layer_sizes.relname = segments.relname and
+                                           (byte_size * 1.33)::bigint between low and high) x
+      where low < high
+      group by relname, low, high
+      order by relname, low desc) x;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -420,17 +420,22 @@ fn version_info() -> TableIterator<
 }
 
 extension_sql!(
-    r#"
-create view paradedb.index_layer_info as
+    r#"create view paradedb.index_layer_info as
 select relname::text,
        layer_size,
+       low,
+       high,
+       byte_size,
        case when segments = ARRAY [NULL] then 0 else count end       as count,
        case when segments = ARRAY [NULL] then NULL else segments end as segments
 from (select relname,
              coalesce(pg_size_pretty(case when low = 0 then null else low end), '') || '..' ||
              coalesce(pg_size_pretty(case when high = 9223372036854775807 then null else high end), '') as layer_size,
              count(*),
-             array_agg(segno) as segments
+             coalesce(sum(byte_size), 0)                                                                as byte_size,
+             min(low)                                                                                   as low,
+             max(high)                                                                                  as high,
+             array_agg(segno)                                                                           as segments
       from (with indexes as (select oid::regclass as relname
                              from pg_class
                              where relam = (select oid from pg_am where amname = 'bm25')),
@@ -441,7 +446,7 @@ from (select relname,
                                  from indexes
                                           inner join lateral (select unnest(0 || paradedb.layer_sizes(indexes.relname) || 9223372036854775807)
                                                               order by 1 desc) x on true)
-            select layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno
+            select layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size
             from layer_sizes
                      left join segments on layer_sizes.relname = segments.relname and
                                            (byte_size * 1.33)::bigint between low and high) x


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds 3 more columns to the `paradedb.index_layer_info` view:  `low`, `high`, `byte_size`, which are the low end of the layer size range, the high end of the layer size range, and the total byte size of the segments in that layer.

## Why

Practical usage of this view showed it needs a few more columns.

## How

## Tests
