### PR TITLE
docs: Update upgrade docs

### DIFF
--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -28,8 +28,10 @@ SELECT * FROM paradedb.version_info();
 ```
 
 The reason that there are two statements is because `paradedb.version_info()` is the actual version of `pg_search` that is installed,
-whereas `pg_extension` is what Postgres' catalog thinks the version of `pg_search` is. If Postgres was not restarted after the previous upgrade,
-the two versions will not match.
+whereas `pg_extension` is what Postgres' catalog thinks the version of the extension is.
+
+If `paradedb.version_info()` is greater than `pg_extension`, it typically means that `ALTER EXTENSION` was not run after the previous upgrade, and that the SQL upgrade scripts were not applied.
+If `pg_extension` is greater than `paradedb.version_info()`, it means that the extension didn't fully upgrade, and that Postgres needs to be restarted.
 
 ## Getting the Latest Version
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -9,7 +9,7 @@ ParadeDB ships its functionality inside a Postgres extension, `pg_search`. Upgra
 <Note>
   ParadeDB uses `pgvector` for vector search. This extension is not managed by
   ParadeDB. Please refer to the [pgvector
-  documentation](https://github.com/pgvector/pgvector) for instructions on how
+  documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#upgrading) for instructions on how
   to upgrade it.
 </Note>
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -4,33 +4,68 @@ title: Upgrading ParadeDB
 
 ## Overview
 
-ParadeDB ships all of its functionality via Postgres extensions. All updates to ParadeDB can be
-received by updating one or more of the following extensions:
+ParadeDB ships its functionality inside a Postgres extension, `pg_search`. Upgrading ParadeDB is as simple as updating the `pg_search` extension.
 
-1. `pg_search` for full text search and facets
-2. `pg_analytics` for querying data lakes
+<Note>
+  ParadeDB uses `pgvector` for vector search. This extension is not managed by
+  ParadeDB. Please refer to the [pgvector
+  documentation](https://github.com/pgvector/pgvector) for instructions on how
+  to upgrade it.
+</Note>
 
 ## Getting the Current Version
 
 To inspect the current version of an extension, run the following command.
 
 ```sql
--- Get the version of pg_search
 SELECT extversion FROM pg_extension WHERE extname = 'pg_search';
--- Get the version of pg_analytics
-SELECT extversion FROM pg_extension WHERE extname = 'pg_analytics';
 ```
+
+Verify that it matches `paradedb.version_info()`:
+
+```sql
+SELECT * FROM paradedb.version_info();
+```
+
+The reason that there are two statements is because `paradedb.version_info()` is the actual version of `pg_search` that is installed,
+whereas `pg_extension` is what Postgres' catalog thinks the version of `pg_search` is. If Postgres was not restarted after the previous upgrade,
+the two versions will not match.
 
 ## Getting the Latest Version
 
-Because `pg_search`, `pg_analytics`, and `pgvector` are independent extensions, they each have their own versions.
-For the latest available version, please refer to the respective Github repos:
+The latest version of `pg_search` is `0.15.11`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
-1. [`pg_search`](https://github.com/paradedb/paradedb/releases) is on version `0.15.12`
-2. [`pg_analytics`](https://github.com/paradedb/pg_analytics/blob/main/pg_analytics.control) is on version `0.3.5`
-3. [`pgvector`](https://github.com/pgvector/pgvector/tags) is on version `0.8.0`
+## Updating ParadeDB
 
-## Updating ParadeDB Docker Image
+### Helm Chart
+
+To upgrade the ParadeDB Helm chart:
+
+1. Update the `paradedb` chart to the latest version.
+
+```bash
+helm repo update
+```
+
+2. Get the latest version of the `paradedb` chart.
+
+```bash
+helm search repo paradedb
+```
+
+3. Get the latest version of the ParadeDB extension, which is the value of `version.paradedb` in the chart [README](https://github.com/paradedb/charts/tree/dev/charts/paradedb#values).
+
+4. Run `helm upgrade` with the latest version of the chart and the latest version of the extension.
+
+```bash
+helm upgrade paradedb paradedb/paradedb --namespace paradedb --reuse-values --version <helm_version> --set version.paradedb=<paradedb_version> --atomic
+```
+
+Replace `<helm_version>` with the latest version of the chart and `<paradedb_version>` with the latest version of the extension.
+
+5. If you are using [ParadeDB BYOC](/deploy/byoc), an automatic rollout will begin. One by one, the pods will be restarted to apply the new version of the extension.
+
+### Docker Image
 
 To upgrade the ParadeDB Docker image while preserving your data volume:
 
@@ -40,30 +75,36 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:<version_number>
+docker pull paradedb/paradedb:0.15.11
 ```
 
 The latest version of the Docker image should be `0.15.12`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
-4. Run the following commands to upgrade all extensions to their latest version.
-
-```sql
-ALTER EXTENSION pg_search UPDATE TO '0.15.12';
-ALTER EXTENSION pg_analytics UPDATE TO '0.3.5';
-ALTER EXTENSION vector UPDATE TO '0.8.0';
-```
-
-## Updating Extensions
+### Self-Managed Postgres
 
 To upgrade the extensions running in a self-managed Postgres:
 
-1. Stop Postgres (e.g. via `pg_ctl stop -D </path/to/data/directory>`)
-2. Download and install the extension you wish to upgrade in the same way that it was initially installed (e.g. via cURL)
-3. Start Postgres (e.g. via `pg_ctl start -D /usr/local/var/postgres`)
-4. Run the following command in every database that has previously run `CREATE EXTENSION <extension_name>`
+1. Stop Postgres (e.g. `pg_ctl stop -D </path/to/data/directory>`).
+2. Download and install the extension you wish to upgrade in the same way that it was initially installed.
+3. Start Postgres (e.g. `pg_ctl start -D </path/to/data/directory>`).
+
+## Alter Extension
+
+After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This applies to any environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION <extension_name> UPDATE TO '<extension_version>';
+ALTER EXTENSION pg_search UPDATE TO '0.15.11';
 ```
+
+## Verify the Upgrade
+
+After upgrading the extension and restarting Postgres, verify that the version numbers returned by the following commands match:
+
+```sql
+SELECT extversion FROM pg_extension WHERE extname = 'pg_search';
+SELECT * FROM paradedb.version_info();
+```
+
+If the two versions do not match, restart Postgres and try again.

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -9,8 +9,8 @@ ParadeDB ships its functionality inside a Postgres extension, `pg_search`. Upgra
 <Note>
   ParadeDB uses `pgvector` for vector search. This extension is not managed by
   ParadeDB. Please refer to the [pgvector
-  documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#upgrading) for instructions on how
-  to upgrade it.
+  documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#upgrading)
+  for instructions on how to upgrade it.
 </Note>
 
 ## Getting the Current Version
@@ -94,7 +94,7 @@ To upgrade the extensions running in a self-managed Postgres:
 
 ## Alter Extension
 
-After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This applies to any environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
+After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This command runs the SQL upgrade scripts and applies to any environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
 ALTER EXTENSION pg_search UPDATE TO '0.15.11';

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -94,7 +94,7 @@ To upgrade the extensions running in a self-managed Postgres:
 
 ## Alter Extension
 
-After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
+After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
 ALTER EXTENSION pg_search UPDATE TO '0.15.12';

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -94,7 +94,7 @@ To upgrade the extensions running in a self-managed Postgres:
 
 ## Alter Extension
 
-After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This command runs the SQL upgrade scripts and applies to any environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
+After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
 ALTER EXTENSION pg_search UPDATE TO '0.15.11';

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -35,7 +35,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.15.11`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.15.12`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -77,7 +77,7 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.15.11
+docker pull paradedb/paradedb:0.15.12
 ```
 
 The latest version of the Docker image should be `0.15.12`.
@@ -97,7 +97,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded,connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.15.11';
+ALTER EXTENSION pg_search UPDATE TO '0.15.12';
 ```
 
 ## Verify the Upgrade


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Updated our upgrade docs to include:

1. `paradedb.version_info`
2. Helm chart instructions

Removed `pg_analytics` from it as well.

## Why

## How

## Tests
