### PR TITLE
fix: Fix metadata functions, and increase test coverage for partitioned tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 .idea/
 /*.iml
+*.swp
 
 # macOS
 .DS_Store

--- a/pg_search/sql/pg_search--0.15.12--0.15.13.sql
+++ b/pg_search/sql/pg_search--0.15.12--0.15.13.sql
@@ -1,0 +1,6 @@
+DROP FUNCTION IF EXISTS index_info(index regclass, show_invisible bool);
+CREATE OR REPLACE FUNCTION index_info(index regclass, show_invisible bool DEFAULT '(('f')::pg_catalog.bool)') RETURNS TABLE(index_name text, visible bool, recyclable bool, xmin pg_catalog."numeric", xmax pg_catalog."numeric", segno text, byte_size pg_catalog."numeric", num_docs pg_catalog."numeric", num_deleted pg_catalog."numeric", termdict_bytes pg_catalog."numeric", postings_bytes pg_catalog."numeric", positions_bytes pg_catalog."numeric", fast_fields_bytes pg_catalog."numeric", fieldnorms_bytes pg_catalog."numeric", store_bytes pg_catalog."numeric", deletes_bytes pg_catalog."numeric") AS 'MODULE_PATHNAME', 'index_info_wrapper' LANGUAGE c STRICT;
+DROP FUNCTION IF EXISTS merge_info(index regclass);
+CREATE OR REPLACE FUNCTION merge_info(index regclass) RETURNS TABLE(index_name text, pid pg_catalog.int4, xmin pg_catalog."numeric", xmax pg_catalog."numeric", segno text) AS 'MODULE_PATHNAME', 'merge_info_wrapper' LANGUAGE c STRICT;
+DROP FUNCTION IF EXISTS vacuum_info(index regclass);
+CREATE OR REPLACE FUNCTION vacuum_info(index regclass) RETURNS TABLE(index_name text, segno text) AS 'MODULE_PATHNAME', 'vacuum_info_wrapper' LANGUAGE c STRICT;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -18,6 +18,7 @@
 use crate::index::merge_policy::LayeredMergePolicy;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::index::IndexKind;
 use crate::postgres::insert::merge_index_with_policy;
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::storage::block::{
@@ -143,6 +144,9 @@ unsafe fn merge_info(
         name!(segno, String),
     ),
 > {
+    let IndexKind::Index(index) = IndexKind::for_index(index).unwrap() else {
+        panic!("The given index is partitioned: please try again with one of its child indexes.")
+    };
     let merge_lock = MergeLock::acquire(index.oid());
     let merge_entries = merge_lock.in_progress_merge_entries();
     let table = TableIterator::new(merge_entries.into_iter().flat_map(move |merge_entry| {
@@ -169,6 +173,9 @@ fn is_merging(index: PgRelation) -> bool {
 
 #[pg_extern]
 unsafe fn vacuum_info(index: PgRelation) -> SetOfIterator<'static, String> {
+    let IndexKind::Index(index) = IndexKind::for_index(index).unwrap() else {
+        panic!("The given index is partitioned: please try again with one of its child indexes.")
+    };
     let mut merge_lock = MergeLock::acquire(index.oid());
     let vacuum_list = merge_lock.list_vacuuming_segments();
     SetOfIterator::new(
@@ -215,6 +222,9 @@ fn index_info(
     // validated the existence of the relation. We are safe calling the function below as
     // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
     let index = unsafe { PgRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _) };
+    let IndexKind::Index(index) = IndexKind::for_index(index).unwrap() else {
+        panic!("The given index is partitioned: please try again with one of its child indexes.")
+    };
 
     // open the specified index
     let mut segment_components =

--- a/pg_search/src/postgres/index.rs
+++ b/pg_search/src/postgres/index.rs
@@ -17,7 +17,8 @@
 
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::schema::{SearchFieldConfig, SearchFieldName, SearchFieldType};
-use pgrx::PgRelation;
+use anyhow::{anyhow, Result};
+use pgrx::{pg_sys, PgRelation, Spi};
 
 type Fields = Vec<(SearchFieldName, SearchFieldConfig, SearchFieldType)>;
 type KeyFieldIndex = usize;
@@ -32,4 +33,56 @@ pub unsafe fn get_fields(index_relation: &PgRelation) -> (Fields, KeyFieldIndex)
         .expect("key field not found in columns"); // key field is already validated by now.
 
     (fields, key_field_index)
+}
+
+pub enum IndexKind {
+    Index(PgRelation),
+    PartitionedIndex(Vec<PgRelation>),
+}
+
+impl IndexKind {
+    ///
+    /// Get the IndexKind for the given relation, or an error if it is not an index.
+    ///
+    pub fn for_index(index_relation: PgRelation) -> Result<IndexKind> {
+        let index_relkind = unsafe { pg_sys::get_rel_relkind(index_relation.oid()) as u8 };
+        match index_relkind {
+            pg_sys::RELKIND_INDEX => {
+                // The index is not partitioned.
+                Ok(IndexKind::Index(index_relation))
+            }
+            pg_sys::RELKIND_PARTITIONED_INDEX => {
+                // Locate the child index Oids, and open them.
+                let child_array: Vec<pg_sys::Oid> = Spi::get_one_with_args(
+                    "SELECT ARRAY_AGG(c.oid)
+                     FROM pg_inherits i
+                     JOIN pg_class c ON i.inhrelid = c.oid
+                     WHERE i.inhparent = $1;",
+                    &[index_relation.oid().into()],
+                )
+                .expect("failed to lookup child partitions")
+                .unwrap();
+                let child_relations = child_array
+                    .into_iter()
+                    .map(|oid| {
+                        // TODO: Do these acquisitions need to be sorted?
+                        unsafe { PgRelation::with_lock(oid, pg_sys::AccessShareLock as _) }
+                    })
+                    .collect();
+                Ok(IndexKind::PartitionedIndex(child_relations))
+            }
+            _ => Err(anyhow!("Expected to receive an index argument.")),
+        }
+    }
+
+    ///
+    /// Return an iterator over the partitions of this index, which might be
+    /// of length 1 if it is not partitioned.
+    ///
+    pub fn partitions(self) -> Box<dyn Iterator<Item = PgRelation>> {
+        match self {
+            Self::Index(rel) => Box::new(std::iter::once(rel)),
+            Self::PartitionedIndex(rel) => Box::new(rel.into_iter()),
+        }
+    }
 }

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -56,6 +56,12 @@ pub fn conn(database: Db) -> PgConnection {
             .execute(&mut conn)
             .await
             .expect("could not create extension pg_search");
+
+        sqlx::query("SET log_error_verbosity TO VERBOSE;")
+            .execute(&mut conn)
+            .await
+            .expect("could not adjust log_error_verbosity");
+
         conn
     })
 }

--- a/tests/tests/fixtures/tables/mod.rs
+++ b/tests/tests/fixtures/tables/mod.rs
@@ -22,6 +22,7 @@ mod icu_arabic_posts;
 mod icu_czech_posts;
 mod icu_greek_posts;
 mod nyc_trips;
+mod partitioned;
 mod simple_products;
 mod user_session_logs;
 
@@ -32,5 +33,6 @@ pub use icu_arabic_posts::*;
 pub use icu_czech_posts::*;
 pub use icu_greek_posts::*;
 pub use nyc_trips::*;
+pub use partitioned::*;
 pub use simple_products::*;
 pub use user_session_logs::*;

--- a/tests/tests/fixtures/tables/partitioned.rs
+++ b/tests/tests/fixtures/tables/partitioned.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use chrono::{NaiveDate, NaiveDateTime};
+use soa_derive::StructOfArray;
+use sqlx::FromRow;
+
+#[derive(Debug, PartialEq, FromRow, StructOfArray, Default)]
+pub struct PartitionedTable {
+    pub id: i32,
+    pub sale_date: NaiveDateTime,
+    pub amount: f32,
+    pub description: String,
+}
+
+impl PartitionedTable {
+    pub fn setup() -> String {
+        PARTITIONED_TABLE_SETUP.into()
+    }
+}
+
+static PARTITIONED_TABLE_SETUP: &str = r#"
+BEGIN;
+    CREATE TABLE sales (
+        id SERIAL,
+        sale_date DATE NOT NULL,
+        amount REAL NOT NULL,
+        description TEXT,
+        PRIMARY KEY (id, sale_date)
+    ) PARTITION BY RANGE (sale_date);
+
+    CREATE TABLE sales_2023_q1 PARTITION OF sales
+      FOR VALUES FROM ('2023-01-01') TO ('2023-03-31');
+
+    CREATE TABLE sales_2023_q2 PARTITION OF sales
+      FOR VALUES FROM ('2023-04-01') TO ('2023-06-30');
+
+    CREATE INDEX sales_index ON sales
+      USING bm25 (id, description, sale_date, amount)
+      WITH (key_field='id', numeric_fields='{"amount": {"fast": true}}');
+COMMIT;
+"#;

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -505,6 +505,11 @@ fn partitioned_info(mut conn: PgConnection) {
             "Got {segment_count} for index partition {index_name}"
         );
     }
+
+    // Just cover `index_layer_info`.
+    let segments_per_partition: Vec<(String, String, i64)> =
+        "SELECT relname::text, layer_size, count FROM paradedb.index_layer_info".fetch(&mut conn);
+    assert!(!segments_per_partition.is_empty());
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

-

## What

We already supported partitioned tables to a large degree, but our tests were not validating that.

Additionally, metadata functions which did not check the relation kind that they were operating on [would fail with a TRAP](https://gist.github.com/stuhood/6d43e6b9caee5379722e4457d13b5b8c) due to assuming that the heap relation for the index was itself not partitioned.

## Why

See #2191.

## How

Extracted a partitioned table fixture, and then expanded test coverage on metadata functions and query planning.

Adjusted metadata functions to either:
* Render the schema of the first child partition (`paradedb.schema`)
* Expose information for all partitions (`paradedb.{merge,vacuum,index}_info`)

More work remains for #2191: see https://github.com/paradedb/paradedb/issues/2191#issuecomment-2763111092.

## Tests

See above.