### PR TITLE
fix: `MergeEntry` should indicate it doesn't have a "pintest_blockno"

### DIFF
--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -383,8 +383,11 @@ pub trait MVCCEntry {
         // if the xmax transaction is no longer in progress
         !pg_sys::TransactionIdIsInProgress(xmax)
 
-        // and there's no pin on our pintest buffer
-        && bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some()
+        // and there's no pin on our pintest buffer, assuming we have a valid buffer
+        && {
+            self.pintest_blockno() != pg_sys::InvalidBlockNumber
+                && bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some()
+        }
     }
 
     unsafe fn mergeable(&self) -> bool {

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -453,7 +453,7 @@ impl MVCCEntry for MergeEntry {
     }
 
     fn pintest_blockno(&self) -> pg_sys::BlockNumber {
-        unimplemented!("pintest_blockno not supported for MergeEntry");
+        pg_sys::InvalidBlockNumber
     }
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The `MergeEntry`, rather than panicking, should return `pg_sys::InvalidBlockNumber` from its `pintest_blockno`, and we should not try to get a conditional lock on it during recyclable-checking.

`MergeEntry` goes through the same general "is recyclable" process as `SegmentMetaEntry`, but doesn't also have the requirement of pinning a page

## Why

## How

## Tests
