### PR TITLE
ci: Don't run Stressgres on drafts

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -27,6 +27,7 @@ jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
     runs-on: ubicloud-standard-8
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -23,6 +23,7 @@ jobs:
   test-pg_search-stressgres:
     name: Run Stressgres ${{ matrix.test_file }} on pg_search with PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I noticed these jobs were running on draft PRs, which they're not supposed to.

## Why
^

## How
^

## Tests
^