### PR TITLE
fix: Force custom scan if scores are requested

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
@@ -23,8 +23,11 @@ use pgrx::{
 use std::ptr::addr_of_mut;
 
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
-fn score_from_relation(_relation_reference: AnyElement) -> Option<f32> {
-    None
+fn score_from_relation(_relation_reference: AnyElement) -> f32 {
+    panic!(
+        "No score was computed. Please report the \
+        relevant query and schema to the maintainers!"
+    )
 }
 
 extension_sql!(

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -345,7 +345,6 @@ fn scores_survive_joins(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[should_panic]
 fn scores_partitioned(mut conn: PgConnection) {
     // Not indexing `sale_date` means that our index doesn't fully cover the query. But
     // we must still custom scan due to the use of the score function.
@@ -371,8 +370,8 @@ fn scores_partitioned(mut conn: PgConnection) {
         // This is all that we need to assert, because our result type above has already
         // asserted that no columns are NULL.
         assert!(
-            search_results.len() > 0,
-            "Expected at least one item in each table."
+            search_results.len() == 1,
+            "Expected one item in each table."
         );
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2191.

## What

In some cases of querying on non-indexed fields with `paradedb.score` requested, our custom scan was not running. This resulted in `NULL` scores.

## Why

When the planner decides to apply a non-indexed field as a filter, it is not included as a `qual`. But our custom scan was only actually deciding to run if there were `qual`s included, even though it also needed to run if a `paradedb.score` had been requested.

## How

Force the custom scan to run if the `paradedb.score` is requested.

## Tests

New test to validate that scores are computed for both partitioned and un-partitioned tables, even when no `qual`s are pushed down.