### PR TITLE
feat: feat: segment merging now happens on the main thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
+checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
 dependencies = [
  "autocfg",
  "libm",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1835,8 +1835,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1853,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1863,7 +1864,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -1916,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1940,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1961,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -2144,10 +2145,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -2280,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a7befb5d88825458151ab9c1a70d36d695b023e79d57333f9e6bb42614115e"
+checksum = "5fc96440caa8bb9e832f1fc737ca807d603117e598ebb7d00c96d9558e8d7a30"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2310,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c638aa18cbd3a1717be3cf1436c731d3b243d4ff833cdcab7c8e966d930d57b1"
+checksum = "97718bf9918752bd31d9de979a1a900768b54ab741f6b0e52c22ac22205a72ec"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2323,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd2c590cbe3d625884a91173402d26d6ea462b846dd21f7866cb186301832f3"
+checksum = "396b5be33424f4843e6dd8f2c98baebb1697cac3c0807846a07d9c65968fb849"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2348,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c830a7c74366772acc3f5a2ee220b1610e894df17aa4aaa03f00806309bb56"
+checksum = "495e16ea16f066739b4d4920dac11e9a46dfd12fdfb6062b41c06d8d41776059"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2361,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b914b28e4d37df485bb39d71b6c9ade8d53b24989424798e1c4618ccfc2fd7ca"
+checksum = "e4eea658adf10e0ee13059599c708b5ffac3058fc78984f792e1a703a1fbb1a8"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2374,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ko-dic"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c07ee1925e44a1a93113c8bf2071c689e051a87c53767cbbdc13c2a7712800"
+checksum = "c1cb7bbef870ea429532b05c37f246e2a7c47e349309ccc526e1323af3c78490"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2387,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "0.40.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c332ab8ab9c6225d26878810d780f8d3828d7ce491f4ae0ecf5f87cdf8abc480"
+checksum = "b074127b5117e24bf2023c4ec569e1055254113a6c243bac92261e043a94eb11"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2647,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oneshot"
@@ -2723,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2806,9 +2808,9 @@ checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -2817,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2827,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2840,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -3712,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -3753,9 +3755,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4039,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4425,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4436,6 +4438,7 @@ dependencies = [
  "census",
  "crc32fast",
  "crossbeam-channel",
+ "deranged",
  "downcast-rs",
  "fastdivide",
  "fnv",
@@ -4476,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "bitpacking",
 ]
@@ -4484,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4499,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4521,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "nom",
 ]
@@ -4529,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4542,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4552,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c#f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1dfc6c0492a5185f235fa65b9d362e515f057932#1dfc6c0492a5185f235fa65b9d362e515f057932"
 dependencies = [
  "serde",
 ]
@@ -4583,7 +4586,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -4759,7 +4762,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4805,7 +4808,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.0",
- "socket2 0.5.8",
+ "socket2 0.5.9",
  "tokio",
  "tokio-util",
  "whoami",
@@ -5067,9 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -5328,23 +5331,27 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
@@ -5359,10 +5366,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5382,7 +5411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.2",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -5409,6 +5438,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]
@@ -5671,7 +5709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.3",
+ "rustix 1.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "1dfc6c0492a5185f235fa65b9d362e515f057932", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "063df2622b62181f6f3d0e742f27352f08cf5f5e", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "f2ce6c5ba5fb253d47d58cc7c8c4719a98a9b52c", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "1dfc6c0492a5185f235fa65b9d362e515f057932", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",

--- a/pg_search/src/index/directory/channel.rs
+++ b/pg_search/src/index/directory/channel.rs
@@ -21,7 +21,7 @@ use tantivy::directory::{
     DirectoryLock, DirectoryPanicHandler, FileHandle, Lock, OwnedBytes, TerminatingWrite,
     WatchCallback, WatchHandle, WritePtr,
 };
-use tantivy::index::{SegmentId, SegmentMetaInventory};
+use tantivy::index::SegmentMetaInventory;
 use tantivy::{Directory, IndexMeta, TantivyError};
 
 pub type Overwrite = bool;
@@ -258,19 +258,6 @@ impl ChannelRequestHandler {
                 }
             }),
         }
-    }
-
-    /// Drop the pins that are held on the specified [`SegmentId`]s.
-    ///
-    /// # Safety
-    ///
-    /// This does not remove the segments themselves from being accessible by the internal
-    /// [`MVCCDirectory`] which means that attempts to use these segments after dropping their pins
-    /// will likely lead to incorrect behavior.  It is the callers responsibility to ensure they
-    /// don't do that.
-    #[doc(hidden)]
-    pub(crate) unsafe fn drop_pins(&mut self, segment_ids: &[SegmentId]) -> tantivy::Result<()> {
-        self.directory.drop_pins(segment_ids)
     }
 
     #[track_caller]

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -18,8 +18,9 @@
 use super::utils::{load_metas, save_new_metas, save_schema, save_settings};
 use crate::index::channel::{ChannelRequest, ChannelRequestHandler};
 use crate::index::reader::segment_component::SegmentComponentReader;
+use crate::index::writer::segment_component::SegmentComponentWriter;
 use crate::postgres::storage::block::{
-    FileEntry, MVCCEntry, SegmentMetaEntry, SEGMENT_METAS_START,
+    bm25_max_free_space, FileEntry, MVCCEntry, SegmentMetaEntry, SEGMENT_METAS_START,
 };
 use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use crate::postgres::storage::LinkedItemList;
@@ -35,6 +36,7 @@ use std::fmt::{Debug, Display};
 use std::panic::panic_any;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::{io, result};
 use tantivy::directory::error::{
@@ -76,6 +78,7 @@ impl MvccSatisfies {
     }
 }
 
+type AtomicFileEntry = (FileEntry, Arc<AtomicUsize>);
 /// Tantivy Directory trait implementation over block storage
 /// This Directory implementation respects Postgres MVCC visibility rules
 /// and should back all Tantivy Indexes used in insert and scan operations
@@ -89,6 +92,7 @@ pub struct MVCCDirectory {
     // cloned, we don't lose all the work we did originally creating the FileHandler impls.  And
     // it's cloned a lot!
     readers: Arc<Mutex<FxHashMap<PathBuf, Arc<dyn FileHandle>>>>,
+    new_files: Arc<Mutex<FxHashMap<PathBuf, AtomicFileEntry>>>,
 
     // a lazily loaded [`IndexMeta`], which is only created once per MVCCDirectory instance
     // we cannot tolerate tantivy calling `load_metas()` multiple times and giving it a different
@@ -134,7 +138,8 @@ impl MVCCDirectory {
             relation_oid,
             snapshot,
             mvcc_style,
-            readers: Arc::new(Mutex::new(FxHashMap::default())),
+            readers: Default::default(),
+            new_files: Default::default(),
             loaded_metas: Default::default(),
             pin_cushion: Default::default(),
             all_entries: Default::default(),
@@ -184,6 +189,20 @@ impl MVCCDirectory {
 
         Ok(())
     }
+
+    pub(crate) unsafe fn drop_pin(&mut self, segment_id: &SegmentId) -> Option<()> {
+        let all_entries = self.all_entries.lock();
+        let segment_meta_entry = all_entries.get(segment_id)?;
+        let mut pin_cushion = self.pin_cushion.lock();
+        let pin_cushion = pin_cushion.as_mut()?;
+
+        pin_cushion.remove(segment_meta_entry.pintest_blockno());
+        Some(())
+    }
+
+    pub(crate) fn all_entries(&self) -> HashMap<SegmentId, SegmentMetaEntry> {
+        self.all_entries.lock().clone()
+    }
 }
 
 impl Directory for MVCCDirectory {
@@ -193,11 +212,24 @@ impl Directory for MVCCDirectory {
             Entry::Occupied(reader) => Ok(reader.get().clone()),
             Entry::Vacant(vacant) => {
                 let file_entry = unsafe {
-                    self.directory_lookup(path)
-                        .map_err(|err| OpenReadError::IoError {
-                            io_error: io::Error::new(io::ErrorKind::Other, err.to_string()).into(),
-                            filepath: PathBuf::from(path),
-                        })?
+                    match self.directory_lookup(path) {
+                        Ok(file_entry) => file_entry,
+                        Err(err) => {
+                            if let Some((file_entry, total_bytes)) = self.new_files.lock().get(path)
+                            {
+                                FileEntry {
+                                    starting_block: file_entry.starting_block,
+                                    total_bytes: total_bytes.load(Ordering::Relaxed),
+                                }
+                            } else {
+                                return Err(OpenReadError::IoError {
+                                    io_error: io::Error::new(io::ErrorKind::Other, err.to_string())
+                                        .into(),
+                                    filepath: PathBuf::from(path),
+                                });
+                            }
+                        }
+                    }
                 };
                 Ok(vacant
                     .insert(Arc::new(unsafe {
@@ -221,7 +253,15 @@ impl Directory for MVCCDirectory {
     /// Returns a segment writer that implements std::io::Write
     /// Our [`ChannelDirectory`] is what gets called for doing writes, not this impl
     fn open_write(&self, path: &Path) -> result::Result<WritePtr, OpenWriteError> {
-        unimplemented!("open_write should not be called for {:?}", path);
+        let writer = unsafe { SegmentComponentWriter::new(self.relation_oid, path) };
+        self.new_files.lock().insert(
+            path.to_path_buf(),
+            (writer.file_entry(), writer.total_bytes()),
+        );
+        Ok(io::BufWriter::with_capacity(
+            bm25_max_free_space(),
+            Box::new(writer),
+        ))
     }
 
     /// atomic_read is used by Tantivy to read from managed.json and meta.json
@@ -291,9 +331,22 @@ impl Directory for MVCCDirectory {
         previous_meta: &IndexMeta,
         payload: &mut (dyn Any + '_),
     ) -> tantivy::Result<()> {
-        let payload = payload
-            .downcast_mut::<FxHashMap<PathBuf, FileEntry>>()
-            .expect("save_metas should have a payload");
+        let mut file_entries = FxHashMap::default();
+        let payload = if let Some(payload) = payload.downcast_mut::<FxHashMap<PathBuf, FileEntry>>()
+        {
+            payload
+        } else {
+            for (path, (file_entry, total_bytes)) in self.new_files.lock().iter() {
+                file_entries.insert(
+                    path.clone(),
+                    FileEntry {
+                        starting_block: file_entry.starting_block,
+                        total_bytes: total_bytes.load(Ordering::Relaxed),
+                    },
+                );
+            }
+            &mut file_entries
+        };
 
         // Save Schema and IndexSettings if this is the first time
         save_schema(self.relation_oid, &meta.schema)

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -92,7 +92,13 @@ pub unsafe fn save_new_metas(
     let mut modified_ids = previous_ids.intersection(&new_ids).collect::<Vec<_>>();
     let deleted_ids = previous_ids.difference(&new_ids).collect::<Vec<_>>();
 
-    modified_ids.retain(|id| new_files.contains_key(id));
+    modified_ids.retain(|id| {
+        if let Some(new_files) = new_files.get(id) {
+            new_files.contains_key(&SegmentComponent::Delete)
+        } else {
+            false
+        }
+    });
 
     let deleting_xid = pg_sys::GetCurrentTransactionIdIfAny();
 

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -27,7 +27,6 @@ use tokenizers::{create_normalizer_manager, create_tokenizer_manager};
 pub enum WriterResources {
     CreateIndex,
     Statement,
-    PostStatementMerge,
     Vacuum,
 }
 pub type Parallelism = NonZeroUsize;
@@ -42,10 +41,6 @@ impl WriterResources {
                 gucs::create_index_memory_budget(),
             ),
             WriterResources::Statement => (
-                gucs::statement_parallelism(),
-                gucs::statement_memory_budget(),
-            ),
-            WriterResources::PostStatementMerge => (
                 gucs::statement_parallelism(),
                 gucs::statement_memory_budget(),
             ),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

https://github.com/paradedb/tantivy/pull/36 allows us to now do segment merging on the main thread.  

This is a followup to PR #2383.

Also clean up the (relatively new) `SearchIndexMerger` API a bit and also the public `merge_index_with_policy()` details.

## Why

This eliminates a lot of general complexity in the backend merge path, specifically, it's not necessary to use the `ChannelDirectory` for merging.  This ought to improve performance of merging large segments.

## How

## Tests

All existing tests pass.