### PR TITLE
feat: Parallel Workers now open a specific list of segments

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -4,6 +4,7 @@ use crate::postgres::customscan::pdbscan::PdbScan;
 use crate::postgres::customscan::CustomScan;
 use crate::postgres::ParallelScanState;
 use pgrx::pg_sys::{shm_toc, ParallelContext, Size};
+use std::collections::HashSet;
 use std::os::raw::c_void;
 use tantivy::index::SegmentId;
 
@@ -90,4 +91,8 @@ pub unsafe fn checkout_segment(pscan_state: *mut ParallelScanState) -> Option<Se
     } else {
         None
     }
+}
+
+pub unsafe fn list_segment_ids(pscan_state: *mut ParallelScanState) -> HashSet<SegmentId> {
+    (*pscan_state).segments()
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -15,9 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 #![allow(unpredictable_function_pointer_comparisons)]
+
 use crate::postgres::parallel::Spinlock;
 use crate::query::SearchQueryInput;
 use pgrx::*;
+use std::collections::HashSet;
 use std::io::Write;
 use tantivy::index::SegmentId;
 use tantivy::SegmentReader;
@@ -199,6 +201,7 @@ impl ParallelScanPayload {
 pub struct ParallelScanState {
     mutex: Spinlock,
     remaining_segments: usize,
+    nsegments: usize,
     payload: ParallelScanPayload, // must be last field, b/c it allocates on the heap after this struct
 }
 
@@ -217,6 +220,7 @@ impl ParallelScanState {
     fn init_without_mutex(&mut self, segments: &[SegmentReader], query: &[u8]) {
         self.payload.init(segments, query);
         self.remaining_segments = segments.len();
+        self.nsegments = segments.len();
     }
 
     fn init_mutex(&mut self) {
@@ -234,6 +238,14 @@ impl ParallelScanState {
     pub fn decrement_remaining_segments(&mut self) -> usize {
         self.remaining_segments -= 1;
         self.remaining_segments
+    }
+
+    pub fn segments(&self) -> HashSet<SegmentId> {
+        let mut segments = HashSet::new();
+        for i in 0..self.nsegments {
+            segments.insert(self.segment_id(i));
+        }
+        segments
     }
 
     fn segment_id(&self, i: usize) -> SegmentId {

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -18,6 +18,7 @@
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::ParallelScanState;
 use pgrx::{pg_guard, pg_sys};
+use std::collections::HashSet;
 use std::ptr::addr_of_mut;
 use tantivy::index::SegmentId;
 
@@ -130,6 +131,10 @@ pub unsafe fn maybe_claim_segment(scan: pg_sys::IndexScanDesc) -> Option<Segment
         let remaining_segments = state.decrement_remaining_segments();
         Some(state.segment_id(remaining_segments))
     }
+}
+
+pub unsafe fn list_segment_ids(scan: pg_sys::IndexScanDesc) -> Option<HashSet<SegmentId>> {
+    Some(get_bm25_scan_state(&scan)?.segments())
 }
 
 fn get_bm25_scan_state(scan: &pg_sys::IndexScanDesc) -> Option<&mut ParallelScanState> {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Previously, Parallel Index/Custom Scan Workers would open an index backed by all the segments in the index but they can limit themselves to only the ones they (might) need.

## Why

This is preferable from a concurrency standpoint because it means less segment pinning for the opened `SearchIndexReader` and also likely helps to improve the situation on streaming WAL replication  hot standby nodes.

## How

## Tests

Existing tests pass.  So does stressgres, which includes both parallel index and custom scans.