### PR TITLE
feat: support expressions in indexes

### DIFF
--- a/docs/documentation/full-text/sorting.mdx
+++ b/docs/documentation/full-text/sorting.mdx
@@ -124,6 +124,7 @@ LIMIT 5;
 Not all `ORDER BY`s are pushed down. The following queries are not pushed down:
 
 1. `ORDER BY` without a `LIMIT`.
+2. `ORDER BY` for [indexed expressions](https://www.postgresql.org/docs/current/indexes-expressional.html).
 </Note>
 
 ## Partial Ordering with Multiple Sort Fields

--- a/docs/documentation/indexing/create_index.mdx
+++ b/docs/documentation/indexing/create_index.mdx
@@ -24,7 +24,7 @@ Note that the index's column list contains fields of type text, JSON, numeric, t
 
 ```sql
 CREATE INDEX <index_name> ON <schema_name>.<table_name>
-USING bm25 (<columns>)
+USING bm25 (<columns_or_expressions>)
 WITH (key_field='<key_field>');
 ```
 
@@ -37,8 +37,8 @@ WITH (key_field='<key_field>');
 <ParamField body="table_name" required>
   The name of the table being indexed.
 </ParamField>
-<ParamField body="columns" required>
-  A comma-separated list of columns to index, starting with the key field. Text, numeric, datetime, boolean, range, enum, and JSON types can be indexed.
+<ParamField body="columns_or_expressions" required>
+  A comma-separated list of columns or [expressions](https://www.postgresql.org/docs/current/indexes-expressional.html) to index, starting with the `key_field`. Text, numeric, datetime, boolean, range, enum, and JSON types can be indexed.
 </ParamField>
 <ParamField body="key_field" required>
   The name of a column in the table that represents a unique identifier for each

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -380,8 +380,8 @@ pub unsafe fn attname_from_var(
     (heaprelid, attname)
 }
 
-/// Given a [`pg_sys::PlannerInfo`] and a [`pg_sys::Node`] from it, figure out the name of the `Node`,
-/// it supports `FuncExpr` and `Var` nodes. Note that for the heap relation, the `Var` must be
+/// Given a [`pg_sys::PlannerInfo`] and a [`pg_sys::Node`] from it, figure out the name of the `Node`.
+/// It supports `FuncExpr` and `Var` nodes. Note that for the heap relation, the `Var` must be
 /// the first argument of the `FuncExpr`.
 /// This function requires the node to be related to a `bm25` index, otherwise it will panic.
 ///

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -21,11 +21,14 @@ mod text;
 use crate::api::{fieldname_typoid, FieldName};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
-use crate::postgres::utils::locate_bm25_index;
+use crate::nodecast;
+use crate::postgres::expression::{find_funcexpr_attnum, PG_SEARCH_PREFIX};
+use crate::postgres::utils::locate_bm25_index_from_heaprel;
 use crate::postgres::var::find_var_relation;
 use crate::query::SearchQueryInput;
 use pgrx::callconv::{BoxRet, FcInfo};
 use pgrx::datum::Datum;
+use pgrx::pg_sys::{FuncExpr, NodeTag};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -150,20 +153,20 @@ pub(crate) fn estimate_selectivity(
 unsafe fn make_search_query_input_opexpr_node(
     srs: *mut pg_sys::SupportRequestSimplify,
     input_args: &mut PgList<pg_sys::Node>,
-    var: *mut pg_sys::Var,
+    lhs: *mut pg_sys::Node,
     query: Option<SearchQueryInput>,
-    parse_with_field: Option<(*mut pg_sys::Node, FieldName)>,
+    parse_with_field: Option<(*mut pg_sys::Node, Option<FieldName>)>,
     opoid: pg_sys::Oid,
     procoid: pg_sys::Oid,
 ) -> ReturnedNodePointer {
-    let (relid, _varattno, targetlist) = find_var_relation(var, (*srs).root);
+    let (relid, _nodeattno, targetlist) = find_node_relation(lhs, (*srs).root);
     if relid == pg_sys::Oid::INVALID {
-        panic!("could not determine relation for var");
+        panic!("could not determine relation for node");
     }
 
     // we need to use what should be the only `USING bm25` index on the table
     let heaprel = PgRelation::open(relid);
-    let indexrel = locate_bm25_index(relid).unwrap_or_else(|| {
+    let indexrel = locate_bm25_index_from_heaprel(&heaprel).unwrap_or_else(|| {
         panic!(
             "relation `{}.{}` must have a `USING bm25` index",
             heaprel.namespace(),
@@ -178,36 +181,39 @@ unsafe fn make_search_query_input_opexpr_node(
         .get(0)
         .unwrap_or_else(|| panic!("attribute `{}` not found", keys[0]));
 
-    if let Some(targetlist) = &targetlist {
-        // if we have a targetlist, find the first field of the index definition in it -- its location
-        // in the target list becomes the var's attno
-        let mut found = false;
-        for (i, te) in targetlist.iter_ptr().enumerate() {
-            if te.is_null() {
-                continue;
+    if (*lhs).type_ == NodeTag::T_Var {
+        let var = nodecast!(Var, T_Var, lhs).expect("lhs is not a Var");
+        if let Some(targetlist) = &targetlist {
+            // if we have a targetlist, find the first field of the index definition in it -- its location
+            // in the target list becomes the var's attno
+            let mut found = false;
+            for (i, te) in targetlist.iter_ptr().enumerate() {
+                if te.is_null() {
+                    continue;
+                }
+                if (*te).resorigcol == keys[0] {
+                    (*var).varattno = (i + 1) as _;
+                    (*var).varattnosyn = (*var).varattno;
+                    found = true;
+                    break;
+                }
             }
-            if (*te).resorigcol == keys[0] {
-                (*var).varattno = (i + 1) as _;
-                (*var).varattnosyn = (*var).varattno;
-                found = true;
-                break;
+
+            if !found {
+                panic!("index's first column is not in the var's targetlist");
             }
+        } else {
+            // the Var must look like the first attribute from the index definition
+            (*var).varattno = keys[0];
+            (*var).varattnosyn = (*var).varattno;
         }
 
-        if !found {
-            panic!("index's first column is not in the var's targetlist");
-        }
-    } else {
-        // the Var must look like the first attribute from the index definition
-        (*var).varattno = keys[0];
-        (*var).varattnosyn = (*var).varattno;
+        // the Var must also assume the type of the first attribute from the index definition,
+        // regardless of where we found the Var
+        (*var).vartype = att.atttypid;
+        (*var).vartypmod = att.atttypmod;
+        (*var).varcollid = att.attcollation;
     }
-
-    // the Var must also assume the type of the first attribute from the index definition,
-    // regardless of where we found the Var
-    (*var).vartype = att.atttypid;
-    (*var).vartypmod = att.atttypmod;
-    (*var).varcollid = att.attcollation;
 
     // we're about to fabricate a new pg_sys::OpExpr node to return
     // that represents the `@@@(anyelement, paradedb.searchqueryinput)` operator
@@ -237,23 +243,27 @@ unsafe fn make_search_query_input_opexpr_node(
 
         newopexpr.opno = anyelement_query_input_opoid();
         newopexpr.opfuncid = anyelement_query_input_procoid();
-    } else if let Some((param, field)) = parse_with_field {
+    } else if let Some((rhs, attname)) = parse_with_field {
         // rewrite the rhs to be a function call to our `paradedb.parse_with_field(...)` function
         let mut parse_with_field_args = PgList::<pg_sys::Node>::new();
 
-        parse_with_field_args.push(
-            pg_sys::makeConst(
-                fieldname_typoid(),
-                -1,
-                pg_sys::Oid::INVALID,
-                -1,
-                field.into_datum().unwrap(),
-                false,
-                false,
-            )
-            .cast(),
-        );
-        parse_with_field_args.push(param.cast());
+        if let Some(attname) = attname {
+            parse_with_field_args.push(
+                pg_sys::makeConst(
+                    fieldname_typoid(),
+                    -1,
+                    pg_sys::Oid::INVALID,
+                    -1,
+                    attname.into_datum().unwrap(),
+                    false,
+                    false,
+                )
+                .cast(),
+            );
+        } else {
+            parse_with_field_args.push(lhs);
+        }
+        parse_with_field_args.push(rhs.cast());
         parse_with_field_args.push(
             pg_sys::makeConst(
                 pg_sys::BOOLOID,
@@ -307,6 +317,101 @@ unsafe fn make_search_query_input_opexpr_node(
     let newopexpr = newopexpr.into_pg();
 
     ReturnedNodePointer(NonNull::new(newopexpr.cast()))
+}
+
+/// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the relation Oid that
+/// is referenced by the node.
+///
+/// It's possible the returned Oid will be [`pg_sys::Oid::INVALID`] if the Node doesn't eventually
+/// come from a relation. In case of a FuncExpr we stop on the first relation found.
+///
+/// The returned [`pg_sys::AttrNumber`] is the physical attribute number in the relation the Node
+/// is from.
+pub unsafe fn find_node_relation(
+    node: *mut pg_sys::Node,
+    root: *mut pg_sys::PlannerInfo,
+) -> (
+    pg_sys::Oid,
+    pg_sys::AttrNumber,
+    Option<PgList<pg_sys::TargetEntry>>,
+) {
+    match (*node).type_ {
+        NodeTag::T_Var => find_var_relation(node.cast(), root),
+        NodeTag::T_FuncExpr => {
+            let funcexpr: *mut FuncExpr = node.cast();
+            let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
+            args.iter_ptr()
+                .filter_map(|arg| match (*arg).type_ {
+                    NodeTag::T_FuncExpr | NodeTag::T_Var => Some(find_node_relation(arg, root)),
+                    _ => None,
+                })
+                .reduce(|(acc_oid, acc_attno, acc_tl), (oid, _attno, _tl)| {
+                    if acc_oid != oid {
+                        panic!("expressions cannot contain multiple relations");
+                    }
+                    (acc_oid, acc_attno, acc_tl)
+                })
+                .unwrap_or_else(|| panic!("could not find a Var in the expression tree"))
+        }
+        _ => (pg_sys::Oid::INVALID, 0, None),
+    }
+}
+
+/// Given a [`pg_sys::PlannerInfo`] and a [`pg_sys::Var`] from it, figure out the name of the `Var`
+///
+/// Returns the heap relation [`pg_sys::Oid`] that contains the `Var` along with its name.
+pub unsafe fn attname_from_var(
+    root: *mut pg_sys::PlannerInfo,
+    var: *mut pg_sys::Var,
+) -> (pg_sys::Oid, Option<FieldName>) {
+    let (heaprelid, varattno, _) = find_var_relation(var, root);
+    if (*var).varattno == 0 {
+        return (heaprelid, None);
+    }
+    let heaprel = PgRelation::open(heaprelid);
+    let tupdesc = heaprel.tuple_desc();
+    let attname = if varattno == pg_sys::SelfItemPointerAttributeNumber as pg_sys::AttrNumber {
+        Some("ctid".into())
+    } else {
+        tupdesc
+            .get(varattno as usize - 1)
+            .map(|attribute| attribute.name().into())
+    };
+    (heaprelid, attname)
+}
+
+/// Given a [`pg_sys::PlannerInfo`] and a [`pg_sys::Node`] from it, figure out the name of the `Node`,
+/// it supports `FuncExpr` and `Var` nodes. Note that for the heap relation, the `Var` must be
+/// the first argument of the `FuncExpr`.
+/// This function requires the node to be related to a `bm25` index, otherwise it will panic.
+///
+/// Returns the heap relation [`pg_sys::Oid`] that contains the `Node` along with its name.
+pub unsafe fn fieldname_from_node(
+    root: *mut pg_sys::PlannerInfo,
+    node: *mut pg_sys::Node,
+) -> Option<(pg_sys::Oid, Option<FieldName>)> {
+    match (*node).type_ {
+        NodeTag::T_FuncExpr => {
+            // We expect the funcexpr to contain the var of the field name we're looking for
+            let (heaprelid, _, _) = find_node_relation(node, root);
+            if heaprelid == pg_sys::Oid::INVALID {
+                panic!("could not find heap relation for node");
+            }
+            let heaprel = PgRelation::open(heaprelid);
+            let indexrel = locate_bm25_index_from_heaprel(&heaprel)
+                .expect("could not find bm25 index for heaprelid");
+
+            let attnum = find_funcexpr_attnum(&heaprel, &indexrel, node)?;
+            let expression_str = format!("{}{}", PG_SEARCH_PREFIX, attnum).into();
+            Some((heaprelid, Some(expression_str)))
+        }
+        NodeTag::T_Var => {
+            let var = nodecast!(Var, T_Var, node).expect("node is not a Var");
+            let (oid, attname) = attname_from_var(root, var);
+            Some((oid, attname))
+        }
+        _ => None,
+    }
 }
 
 extension_sql!(

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -215,10 +215,10 @@ fn query_input_support_request_simplify(arg: pg_sys::Datum) -> Option<ReturnedNo
             arg.cast_mut_ptr::<pg_sys::Node>()
         )?;
 
-        // Rewrite this node touse the @@@(key_field, paradedb.searchqueryinput) operator.
+        // Rewrite this node to use the @@@(key_field, paradedb.searchqueryinput) operator.
         // This involves converting the rhs of the operator into a SearchQueryInput.
         let mut input_args = PgList::<pg_sys::Node>::from_pg((*(*srs).fcall).args);
-        let var = nodecast!(Var, T_Var, input_args.get_ptr(0)?)?;
+        let lhs = input_args.get_ptr(0)?;
 
         // NB:  there was a point where we only allowed a relation reference on the left of @@@
         // when the right side uses a builder function, but we've decided that also allowing a field
@@ -236,7 +236,7 @@ fn query_input_support_request_simplify(arg: pg_sys::Datum) -> Option<ReturnedNo
         Some(make_search_query_input_opexpr_node(
             srs,
             &mut input_args,
-            var,
+            lhs,
             query,
             None,
             anyelement_query_input_opoid(),

--- a/pg_search/src/api/operator/text.rs
+++ b/pg_search/src/api/operator/text.rs
@@ -127,7 +127,7 @@ unsafe fn make_query_from_node_and_const(
     node: *mut pg_sys::Node,
     const_: *mut pg_sys::Const,
 ) -> (pg_sys::Oid, SearchQueryInput) {
-    let (heaprelid, attname) = fieldname_from_node(root, node).expect("node is not a Var/FuncExpr");
+    let (heaprelid, attname) = fieldname_from_node(root, node).expect("node is not a Var/Expr");
     // the query comes from the rhs of the @@@ operator.  we've already proved it's a `pg_sys::Const` node
     let query_string = String::from_datum((*const_).constvalue, (*const_).constisnull)
         .expect("query must not be NULL");

--- a/pg_search/src/api/operator/text.rs
+++ b/pg_search/src/api/operator/text.rs
@@ -20,10 +20,11 @@ use crate::api::operator::{
     make_search_query_input_opexpr_node, ReturnedNodePointer,
 };
 use crate::postgres::utils::locate_bm25_index;
-use crate::postgres::var::{fieldname_from_var, find_var_relation};
 use crate::query::SearchQueryInput;
 use crate::{nodecast, UNKNOWN_SELECTIVITY};
 use pgrx::{pg_extern, pg_sys, AnyElement, FromDatum, Internal, PgList};
+
+use super::fieldname_from_node;
 
 /// This is the function behind the `@@@(anyelement, text)` operator. Since we transform those to
 /// use `@@@(anyelement, searchqueryinput`), this function won't be called in normal circumstances, but it
@@ -58,19 +59,18 @@ fn text_support_request_simplify(arg: Internal) -> Option<ReturnedNodePointer> {
 
         let lhs = input_args.get_ptr(0)?;
         let rhs = input_args.get_ptr(1)?;
-        let var = nodecast!(Var, T_Var, lhs)?;
         let (query, param) = if let Some(const_) = nodecast!(Const, T_Const, rhs) {
             // the field name comes from the lhs of the @@@ operator
-            let (_, query) = make_query_from_var_and_const((*srs).root, var, const_);
+            let (_, query) = make_query_from_node_and_const((*srs).root, lhs, const_);
             (Some(query), None)
         } else {
-            let (heaprelid, varattno, _) = find_var_relation(var, (*srs).root);
+            let (_, attname) =
+                fieldname_from_node((*srs).root, lhs).expect("lhs is not a Var/FuncExpr");
             (
                 None,
                 Some((
                     rhs,
-                    fieldname_from_var(heaprelid, var, varattno)
-                        .expect("should be able to determine Var name"),
+                    Some(attname.expect("should be able to determine Node name")),
                 )),
             )
         };
@@ -78,7 +78,7 @@ fn text_support_request_simplify(arg: Internal) -> Option<ReturnedNodePointer> {
         Some(make_search_query_input_opexpr_node(
             srs,
             &mut input_args,
-            var,
+            lhs,
             query,
             param,
             anyelement_text_opoid(),
@@ -102,10 +102,10 @@ pub fn text_restrict(
             let info = planner_info.unwrap()?.cast_mut_ptr::<pg_sys::PlannerInfo>();
             let args =
                 PgList::<pg_sys::Node>::from_pg(args.unwrap()?.cast_mut_ptr::<pg_sys::List>());
-            let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
+            let lhs = args.get_ptr(0)?;
             let const_ = nodecast!(Const, T_Const, args.get_ptr(1)?)?;
 
-            let (heaprelid, search_query_input) = make_query_from_var_and_const(info, var, const_);
+            let (heaprelid, search_query_input) = make_query_from_node_and_const(info, lhs, const_);
             let indexrel = locate_bm25_index(heaprelid)?;
 
             estimate_selectivity(&indexrel, &search_query_input)
@@ -122,13 +122,12 @@ pub fn text_restrict(
     selectivity
 }
 
-unsafe fn make_query_from_var_and_const(
+unsafe fn make_query_from_node_and_const(
     root: *mut pg_sys::PlannerInfo,
-    var: *mut pg_sys::Var,
+    node: *mut pg_sys::Node,
     const_: *mut pg_sys::Const,
 ) -> (pg_sys::Oid, SearchQueryInput) {
-    let (heaprelid, varattno, _) = find_var_relation(var, root);
-    let attname = fieldname_from_var(heaprelid, var, varattno);
+    let (heaprelid, attname) = fieldname_from_node(root, node).expect("node is not a Var/FuncExpr");
     // the query comes from the rhs of the @@@ operator.  we've already proved it's a `pg_sys::Const` node
     let query_string = String::from_datum((*const_).constvalue, (*const_).constisnull)
         .expect("query must not be NULL");

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -28,9 +28,8 @@ use tokenizers::{create_normalizer_manager, create_tokenizer_manager, SearchToke
 pub fn setup_tokenizers(relation_oid: pg_sys::Oid, index: &mut Index) -> Result<()> {
     let index_relation = unsafe { PgRelation::open(relation_oid) };
     let options = unsafe { SearchIndexOptions::from_relation(&index_relation) };
-    let tuple_desc = index_relation.tuple_desc();
     let schema = SearchIndexSchema::open(relation_oid)?;
-    let categorized_fields = categorize_fields(&tuple_desc, &schema);
+    let categorized_fields = categorize_fields(&index_relation, &schema);
 
     let mut tokenizers: Vec<SearchTokenizer> = Vec::new();
     for (search_field, _) in categorized_fields {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -315,7 +315,7 @@ impl WorkerBuildState {
         };
         let writer = SerialIndexWriter::open(indexrel, config)?;
         let schema = SearchIndexSchema::open(indexrel.oid())?;
-        let categorized_fields = categorize_fields(&indexrel, &schema);
+        let categorized_fields = categorize_fields(indexrel, &schema);
         let key_field_name = schema.key_field().field_name();
         Ok(Self {
             writer,

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -315,8 +315,7 @@ impl WorkerBuildState {
         };
         let writer = SerialIndexWriter::open(indexrel, config)?;
         let schema = SearchIndexSchema::open(indexrel.oid())?;
-        let tupdesc = indexrel.tuple_desc();
-        let categorized_fields = categorize_fields(&tupdesc, &schema);
+        let categorized_fields = categorize_fields(&indexrel, &schema);
         let key_field_name = schema.key_field().field_name();
         Ok(Self {
             writer,

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -641,7 +641,7 @@ unsafe fn node_opexpr(
         rhs = (*relabel_target).arg.cast();
     }
 
-    let (var, const_) = (nodecast!(Var, T_Var, lhs)?, nodecast!(Const, T_Const, rhs));
+    let const_ = nodecast!(Const, T_Const, rhs);
 
     let is_our_operator = (*opexpr).opno == pdbopoid;
 

--- a/pg_search/src/postgres/expression.rs
+++ b/pg_search/src/postgres/expression.rs
@@ -1,0 +1,51 @@
+use pgrx::{
+    pg_sys::{self, AsPgCStr},
+    PgList, PgRelation,
+};
+
+pub const PG_SEARCH_PREFIX: &str = "_pg_search_";
+
+/// Returns the attribute number of the node in the index.
+pub fn find_funcexpr_attnum(
+    heaprel: &PgRelation,
+    indexrel: &PgRelation,
+    node: *mut pg_sys::Node,
+) -> Option<i32> {
+    let index_info = unsafe { *pg_sys::BuildIndexInfo(indexrel.as_ptr()) };
+
+    let expressions = unsafe { PgList::<pg_sys::Expr>::from_pg(index_info.ii_Expressions) };
+    let ref_str = unsafe { get_expr_str(node, heaprel) };
+    let mut expressions_iter = expressions.iter_ptr();
+
+    for i in 0..index_info.ii_NumIndexAttrs {
+        let heap_attno = index_info.ii_IndexAttrNumbers[i as usize];
+        if heap_attno == 0 {
+            let Some(expression) = expressions_iter.next() else {
+                panic!("Expected expression for index attribute {i}.");
+            };
+            let node = expression.cast();
+
+            let expr_str = unsafe { get_expr_str(node, heaprel) };
+            if expr_str == ref_str {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+unsafe fn get_expr_str(node: *mut pg_sys::Node, heaprel: &PgRelation) -> String {
+    let pg_cstr = pg_sys::deparse_expression(
+        node,
+        pg_sys::deparse_context_for(heaprel.name().as_pg_cstr(), heaprel.oid()),
+        false,
+        false,
+    );
+    let ref_str = core::ffi::CStr::from_ptr(pg_cstr)
+        .to_str()
+        .expect("Invalid UTF8 in result of deparse_expression.")
+        .to_owned();
+
+    pg_sys::pfree(pg_cstr.cast());
+    ref_str
+}

--- a/pg_search/src/postgres/expression.rs
+++ b/pg_search/src/postgres/expression.rs
@@ -1,3 +1,20 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use pgrx::{
     pg_sys::{self, AsPgCStr},
     PgList, PgRelation,

--- a/pg_search/src/postgres/expression.rs
+++ b/pg_search/src/postgres/expression.rs
@@ -15,23 +15,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::{
-    pg_sys::{self, AsPgCStr},
-    PgList, PgRelation,
-};
+use pgrx::{pg_sys, PgList, PgRelation};
 
 pub const PG_SEARCH_PREFIX: &str = "_pg_search_";
 
 /// Returns the attribute number of the node in the index.
-pub fn find_funcexpr_attnum(
-    heaprel: &PgRelation,
-    indexrel: &PgRelation,
-    node: *mut pg_sys::Node,
-) -> Option<i32> {
+pub fn find_expr_attnum(indexrel: &PgRelation, node: *mut pg_sys::Node) -> Option<i32> {
     let index_info = unsafe { *pg_sys::BuildIndexInfo(indexrel.as_ptr()) };
 
     let expressions = unsafe { PgList::<pg_sys::Expr>::from_pg(index_info.ii_Expressions) };
-    let ref_str = unsafe { get_expr_str(node, heaprel) };
     let mut expressions_iter = expressions.iter_ptr();
 
     for i in 0..index_info.ii_NumIndexAttrs {
@@ -40,29 +32,11 @@ pub fn find_funcexpr_attnum(
             let Some(expression) = expressions_iter.next() else {
                 panic!("Expected expression for index attribute {i}.");
             };
-            let node = expression.cast();
 
-            let expr_str = unsafe { get_expr_str(node, heaprel) };
-            if expr_str == ref_str {
+            if unsafe { pg_sys::equal(node.cast(), expression.cast()) } {
                 return Some(i);
             }
         }
     }
     None
-}
-
-unsafe fn get_expr_str(node: *mut pg_sys::Node, heaprel: &PgRelation) -> String {
-    let pg_cstr = pg_sys::deparse_expression(
-        node,
-        pg_sys::deparse_context_for(heaprel.name().as_pg_cstr(), heaprel.oid()),
-        false,
-        false,
-    );
-    let ref_str = core::ffi::CStr::from_ptr(pg_cstr)
-        .to_str()
-        .expect("Invalid UTF8 in result of deparse_expression.")
-        .to_owned();
-
-    pg_sys::pfree(pg_cstr.cast());
-    ref_str
 }

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -31,7 +31,7 @@ use crate::postgres::utils::{
     categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
 };
 use crate::schema::{SearchField, SearchIndexSchema};
-use pgrx::{check_for_interrupts, pg_guard, pg_sys, PgMemoryContexts, PgRelation, PgTupleDesc};
+use pgrx::{check_for_interrupts, pg_guard, pg_sys, PgMemoryContexts, PgRelation};
 use std::panic::{catch_unwind, resume_unwind};
 use tantivy::{SegmentMeta, TantivyDocument};
 
@@ -53,8 +53,7 @@ impl InsertState {
         };
         let writer = SerialIndexWriter::with_mvcc(indexrel, MvccSatisfies::Mergeable, config)?;
         let schema = SearchIndexSchema::open(indexrel.oid())?;
-        let tupdesc = unsafe { PgTupleDesc::from_pg_unchecked(indexrel.rd_att) };
-        let categorized_fields = categorize_fields(&tupdesc, &schema);
+        let categorized_fields = categorize_fields(indexrel, &schema);
         let key_field_name = schema.key_field().field_name();
 
         let per_row_context = pg_sys::AllocSetContextCreateExtended(

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -27,6 +27,7 @@ use tantivy::SegmentReader;
 mod build;
 mod cost;
 mod delete;
+pub mod expression;
 pub mod insert;
 pub mod options;
 mod range;

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -18,6 +18,7 @@
 use crate::api::FieldName;
 use crate::api::HashMap;
 use crate::postgres::insert::DEFAULT_LAYER_SIZES;
+use crate::postgres::utils::extract_field_attributes;
 use crate::schema::IndexRecordOption;
 use crate::schema::{SearchFieldConfig, SearchFieldType};
 
@@ -29,8 +30,6 @@ use serde_json::Map;
 use std::ffi::CStr;
 use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
-
-use super::utils::extract_field_attributes;
 
 /* ADDING OPTIONS
  * in init(), call pg_sys::add_{type}_reloption (check postgres docs for what args you need)
@@ -655,11 +654,10 @@ fn ctid_field_config() -> SearchFieldConfig {
 
 fn get_attribute_oid(field_name: &str, relation_oid: pg_sys::Oid) -> Option<PgOid> {
     let index_relation = unsafe { PgRelation::open(relation_oid) };
-    let tuple_desc = index_relation.tuple_desc();
-    tuple_desc
-        .iter()
-        .find(|attribute| attribute.name() == field_name)
-        .map(|attribute| attribute.type_oid())
+    extract_field_attributes(&index_relation)
+        .into_iter()
+        .find(|(name, _)| name == field_name)
+        .map(|(_, type_oid)| type_oid.into())
 }
 
 fn get_field_type(field_name: &str, relation_oid: pg_sys::Oid) -> SearchFieldType {

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -30,6 +30,8 @@ use std::ffi::CStr;
 use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 
+use super::utils::extract_field_attributes;
+
 /* ADDING OPTIONS
  * in init(), call pg_sys::add_{type}_reloption (check postgres docs for what args you need)
  * add the corresponding entries to SearchIndexOptionsData struct definition

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -30,7 +30,7 @@ use tantivy::schema::OwnedValue;
 
 use super::expression::PG_SEARCH_PREFIX;
 
-extern "C" {
+extern "C-unwind" {
     // SAFETY: `IsTransactionState()` doesn't raise an ERROR.  As such, we can avoid the pgrx
     // sigsetjmp overhead by linking to the function directly.
     pub fn IsTransactionState() -> bool;

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -23,11 +23,14 @@ use crate::schema::{SearchField, SearchIndexSchema};
 use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, NaiveTime};
 use pgrx::itemptr::{item_pointer_get_both, item_pointer_set_all};
+use pgrx::pg_sys::Oid;
 use pgrx::*;
 use std::str::FromStr;
 use tantivy::schema::OwnedValue;
 
-extern "C-unwind" {
+use super::expression::PG_SEARCH_PREFIX;
+
+extern "C" {
     // SAFETY: `IsTransactionState()` doesn't raise an ERROR.  As such, we can avoid the pgrx
     // sigsetjmp overhead by linking to the function directly.
     pub fn IsTransactionState() -> bool;
@@ -36,8 +39,13 @@ extern "C-unwind" {
 /// Finds and returns the `USING bm25` index on the specified relation with the
 /// highest OID, or [`None`] if there aren't any.
 pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgRelation> {
+    unsafe { locate_bm25_index_from_heaprel(&PgRelation::open(heaprelid)) }
+}
+
+/// Finds and returns the `USING bm25` index on the specified relation with the
+/// highest OID, or [`None`] if there aren't any.
+pub fn locate_bm25_index_from_heaprel(heaprel: &PgRelation) -> Option<PgRelation> {
     unsafe {
-        let heaprel = PgRelation::open(heaprelid);
         let indices = heaprel.indices(pg_sys::AccessShareLock as _);
 
         // Find all bm25 indexes and keep the one with highest OID
@@ -85,54 +93,80 @@ pub struct CategorizedFieldData {
 }
 
 pub fn categorize_fields(
-    tupdesc: &PgTupleDesc,
+    indexrel: &PgRelation,
     schema: &SearchIndexSchema,
 ) -> Vec<(SearchField, CategorizedFieldData)> {
-    let mut categorized_fields = Vec::new();
-
     let mut alias_lookup = schema.alias_lookup();
+    extract_field_attributes(indexrel)
+        .into_iter()
+        .enumerate()
+        .flat_map(|(attno, (attname, attribute_type_oid))| {
+            // List any indexed fields that use this column as source data.
+            let mut search_fields = alias_lookup.remove(&attname).unwrap_or_default();
 
-    // Create a vector of index entries from the postgres row.
-    for (attno, attribute) in tupdesc.iter().enumerate() {
-        let attname = attribute.name().to_string();
-        let attribute_type_oid = attribute.type_oid();
-        let mut search_fields = Vec::new();
-
-        if let Some(alias_fields) = alias_lookup.remove(&attname) {
-            search_fields.extend(alias_fields.into_iter());
-        }
-
-        // If there's an indexed field with the same name as this column, add it to the list
-        if let Some(index_field) = schema.search_field(&attname) {
-            search_fields.push(index_field.clone());
-        }
-
-        for search_field in search_fields {
-            let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid.value()) };
-            let (base_oid, is_array) = if array_type != pg_sys::InvalidOid {
-                (PgOid::from(array_type), true)
-            } else {
-                (attribute_type_oid, false)
+            // If there's an indexed field with the same name as a this column, add it to the list.
+            if let Some(index_field) = schema.search_field(&attname) {
+                search_fields.push(index_field)
             };
 
-            let is_json = matches!(
-                base_oid,
-                PgOid::BuiltIn(pg_sys::BuiltinOid::JSONBOID | pg_sys::BuiltinOid::JSONOID)
-            );
+            search_fields
+                .into_iter()
+                .map(|search_field| {
+                    let array_type = unsafe { pg_sys::get_element_type(attribute_type_oid) };
+                    let (base_oid, is_array) = if array_type != pg_sys::InvalidOid {
+                        (array_type, true)
+                    } else {
+                        (attribute_type_oid, false)
+                    };
 
-            categorized_fields.push((
-                search_field,
-                CategorizedFieldData {
-                    attno,
-                    base_oid,
-                    is_array,
-                    is_json,
-                },
-            ));
-        }
+                    let base_oid = PgOid::from(base_oid);
+                    let is_json = matches!(
+                        base_oid,
+                        PgOid::BuiltIn(pg_sys::BuiltinOid::JSONBOID | pg_sys::BuiltinOid::JSONOID)
+                    );
+                    (
+                        search_field.clone(),
+                        CategorizedFieldData {
+                            attno,
+                            base_oid,
+                            is_array,
+                            is_json,
+                        },
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// Extracts the field attributes from the index relation.
+/// It returns a vector of tuples containing the field name and its type OID.
+pub fn extract_field_attributes(indexrel: &PgRelation) -> Vec<(String, Oid)> {
+    let tupdesc = unsafe { PgTupleDesc::from_pg_unchecked(indexrel.rd_att) };
+    let index_info = unsafe { pg_sys::BuildIndexInfo(indexrel.as_ptr()) };
+    let expressions = unsafe { PgList::<pg_sys::Expr>::from_pg((*index_info).ii_Expressions) };
+    let mut expressions_iter = expressions.iter_ptr();
+
+    let mut field_attributes = Vec::new();
+    for i in 0..(unsafe { *index_info }).ii_NumIndexAttrs {
+        let heap_attno = (unsafe { *index_info }).ii_IndexAttrNumbers[i as usize];
+        let (attname, attribute_type_oid) = if heap_attno == 0 {
+            // Is an expression.
+            let Some(expression) = expressions_iter.next() else {
+                panic!("Expected expression for index attribute {i}.");
+            };
+            let node = expression.cast();
+            (format!("{}{}", PG_SEARCH_PREFIX, i), unsafe {
+                pg_sys::exprType(node)
+            })
+        } else {
+            // Is a field.
+            let att = tupdesc.get(i as usize).expect("attribute should exist");
+            (att.name().to_owned(), att.type_oid().value())
+        };
+        field_attributes.push((attname, attribute_type_oid));
     }
-
-    categorized_fields
+    field_attributes
 }
 
 pub unsafe fn row_to_search_document(

--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -123,7 +123,7 @@ impl MoreLikeThisQueryBuilder {
             .expect("more_like_this: should be able to open schema");
         let key_field = schema.key_field();
         let (key_field_name, key_oid) = (key_field.field_name(), key_field.field_type().typeoid());
-        let categorized_fields = categorize_fields(&index_relation.tuple_desc(), &schema);
+        let categorized_fields = categorize_fields(&index_relation, &schema);
 
         let doc_fields: Vec<(Field, Vec<OwnedValue>)> = pgrx::Spi::connect(|client| {
             let mut doc_fields = Vec::new();

--- a/tests/tests/expression.rs
+++ b/tests/tests/expression.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::db::Query;
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn expression_paradedb_term(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
+
+    CREATE INDEX index_config_index ON paradedb.index_config
+        USING bm25 (id, lower(description)) WITH (key_field='id');
+
+    INSERT INTO paradedb.index_config (description) VALUES ('Test description');
+    "#
+    .execute(&mut conn);
+
+    let (count,) =
+        "SELECT count(*) FROM paradedb.index_config WHERE index_config @@@ paradedb.term('_pg_search_1', 'test')"
+            .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+}
+
+#[rstest]
+fn expression_query_string(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
+
+    CREATE INDEX index_config_index ON paradedb.index_config
+        USING bm25 (id, lower(description)) WITH (key_field='id');
+
+    INSERT INTO paradedb.index_config (description) VALUES ('Test description');
+    "#
+    .execute(&mut conn);
+
+    let (count,) = "SELECT count(*) FROM paradedb.index_config WHERE lower(description) @@@ 'test'"
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+}
+
+#[rstest]
+fn expression_conflicting_query_string(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE expression_test (id SERIAL PRIMARY KEY, firstname TEXT, lastname TEXT);
+
+    CREATE INDEX expression_test_idx ON expression_test
+        USING bm25 (id, lower(firstname), lower(lastname)) WITH (key_field='id');
+
+    INSERT INTO expression_test (firstname, lastname) VALUES ('John', 'Doe');
+    "#
+    .execute(&mut conn);
+
+    let (count,) = "SELECT count(*) FROM expression_test WHERE lower(firstname) @@@ 'john'"
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+
+    let (count,) = "SELECT count(*) FROM expression_test WHERE lower(lastname) @@@ 'doe'"
+        .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+
+    let (count,) =
+        "SELECT count(*) FROM expression_test WHERE lower(firstname) @@@ 'john' AND lower(lastname) @@@ 'doe'"
+            .fetch_one::<(i64,)>(&mut conn);
+    assert_eq!(count, 1);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1936 

## What
This PR add support for expressions in pg_search's BM25 indexes.
Users can now directly use expressions instead of using generated columns to have the same result.
This PR supports both query syntaxes, here are some examples extracted from the tests:
```sql
=> CALL paradedb.create_bm25_test_table(table_name => 'index_config', schema_name => 'paradedb');
CALL

=> CREATE INDEX index_config_index ON paradedb.index_config
    USING bm25 (id, lower(description)) WITH (key_field='id');
CREATE INDEX

=> INSERT INTO paradedb.index_config (description) VALUES ('Test description');
INSERT 0 1

=> SELECT count(*) FROM paradedb.index_config WHERE index_config @@@ paradedb.term('_pg_search_1', 'test');
 count
-------
     1
(1 row)

=> SELECT count(*) FROM paradedb.index_config WHERE lower(description) @@@ 'test';
 count
-------
     1
(1 row)
```

## Why
Linked issue: #1936 

## How
Thanks to [@stuhood's initial work](https://github.com/paradedb/paradedb/compare/stuhood.index-expressions) and [@eeeebbbbrrrr 's insights](https://github.com/paradedb/paradedb/issues/1936#issuecomment-2756026289) which helped me get started.

I initially attempted to use the expression name directly, as provided by [the index `tupdesc`](https://github.com/RaphDal/paradedb/commit/4c6ee435661f99b0df00c4384a9be104e629673c), aiming for an approach closer to the standard `nbtree` integration. However, this approach proved inadequate because it led to information loss that couldn’t be recovered in the text operator. For example, both `lower(a)` and `lower(b)` would resolve to just `lower`, causing ambiguity when resolving the index field.
 
Using the full deparsed expression (e.g., lower(a)) worked initially, but it caused issues with Tantivy, which rejects certain characters due to its [field name grammar constraints](https://github.com/quickwit-oss/tantivy/blob/5cea16ef9fe31d1cb2ed721fed10837343d38c0e/query-grammar/src/query_grammar.rs#L26-L43).

Ultimately, I reverted to the original approach of using a custom field format: _pg_search_N, where N is the attribute number in the index. This approach works, but it could be [costly at runtime](https://github.com/RaphDal/paradedb/blob/e02dcfe92c4601db69ecabf4359d8969ca3338e6/pg_search/src/postgres/expression.rs#L8) for indexes with many expressions.

### Potential Improvement
A potential improvement could involve using a deterministic, escaped version of the expression as the field name. For example, `lower(a)` could be converted to something like `lower%28a%29` (URL-encoded) or handled via an alias mechanism within Tantivy.

Additionally, I had to modify the operators and qual_inspect to handle `Var` and `FuncExpr` differently. I'm not entirely satisfied with the current implementation, and I believe it may be incorrect. There’s certainely room for refinement.

## Tests
4 of them:
- create a simple index with an expression (from @stuhood original work)
- select an indexed expression with the Query Builder Syntax.
- select an indexed expression with the Query String Syntax.
- select an index with multiple expressions that might conflict (both using the same function). 