### PR TITLE
test: Fast fields should be used in custom scan on partitioned index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ the documentation changes locally. To install, use the following command:
 npm i -g mintlify
 ```
 
-Run the following command at the root of your documentation (where mint.json is)
+Run the following command at the root of your documentation (where `docs.json` is)
 
 ```bash
 mintlify dev

--- a/docs/deploy/enterprise.mdx
+++ b/docs/deploy/enterprise.mdx
@@ -56,6 +56,6 @@ For access to ParadeDB Enterprise, please [contact sales](mailto:sales@paradedb.
   This means that it leverages the Postgres buffer cache, which minimizes disk
   I/O.
   4. All listed deployment features and limitations are specific to the BM25 index. For instance,
-   ParadeDB Community supports physical/logical replication, crash recovery, etc. for heap tables and other Postgres indexes like btree.
+   ParadeDB Community supports physical/logical replication, crash recovery, etc. for heap tables and other Postgres indexes like B-Tree.
 </p>
 </Info>

--- a/docs/documentation/indexing/create_index.mdx
+++ b/docs/documentation/indexing/create_index.mdx
@@ -70,6 +70,12 @@ WITH (key_field = 'id');
 In Postgres, a partitioned index is an index created over a [partitioned table](https://www.postgresql.org/docs/current/ddl-partitioning.html).
 A BM25 index can be created over a partitioned table in the same way as a normal table.
 
+<Note>
+  If the partition key of your partitioned table is only indexed as a fast field by the BM25 index
+  (and not additionally indexed via a B-Tree index), note that the `@@@` operator [must be used](/documentation/aggregates/limitations#filtering)
+  in order for filtering to be optimized by the index.
+</Note>
+
 ## Partial Index
 
 The following code block demonstrates how to pass predicates to `CREATE INDEX`

--- a/tests/tests/fixtures/tables/partitioned.rs
+++ b/tests/tests/fixtures/tables/partitioned.rs
@@ -44,13 +44,17 @@ BEGIN;
     ) PARTITION BY RANGE (sale_date);
 
     CREATE TABLE sales_2023_q1 PARTITION OF sales
-      FOR VALUES FROM ('2023-01-01') TO ('2023-03-31');
+      FOR VALUES FROM ('2023-01-01') TO ('2023-04-01');
 
     CREATE TABLE sales_2023_q2 PARTITION OF sales
       FOR VALUES FROM ('2023-04-01') TO ('2023-06-30');
 
     CREATE INDEX sales_index ON sales
       USING bm25 (id, description, sale_date, amount)
-      WITH (key_field='id', numeric_fields='{"amount": {"fast": true}}');
+      WITH (
+        key_field='id',
+        numeric_fields='{"amount": {"fast": true}}',
+        datetime_fields = '{"sale_date": {"fast": true}}'
+      );
 COMMIT;
 "#;


### PR DESCRIPTION
# Ticket(s) Closed

None.

## What

Add a test that our custom scan still has filters pushed down after some partitions are pruned.

## Why

#2370 did not test this case, and it is a particularly important one for time-partitioned tables.

## How

Adjust `sale_date` in the partitioned fixture to be indexed as fast.

## Tests

See above.