### PR TITLE
fix: grant select permissions to public on the paradedb.index_layer_info view

### DIFF
--- a/pg_search/sql/pg_search--0.15.12--0.15.13.sql
+++ b/pg_search/sql/pg_search--0.15.12--0.15.13.sql
@@ -4,3 +4,5 @@ DROP FUNCTION IF EXISTS merge_info(index regclass);
 CREATE OR REPLACE FUNCTION merge_info(index regclass) RETURNS TABLE(index_name text, pid pg_catalog.int4, xmin pg_catalog."numeric", xmax pg_catalog."numeric", segno text) AS 'MODULE_PATHNAME', 'merge_info_wrapper' LANGUAGE c STRICT;
 DROP FUNCTION IF EXISTS vacuum_info(index regclass);
 CREATE OR REPLACE FUNCTION vacuum_info(index regclass) RETURNS TABLE(index_name text, segno text) AS 'MODULE_PATHNAME', 'vacuum_info_wrapper' LANGUAGE c STRICT;
+
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -538,6 +538,8 @@ from (select relname,
       where low < high
       group by relname, low, high
       order by relname, low desc) x;
+      
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;
 "#,
     name = "index_layer_info",
     requires = [index_info, layer_sizes]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We should give "PUBLIC" the ability to SELECT from our `paradedb.index_layer_info` view.  There's no PII in the view and not requiring superuser to select from it enables external monitoring tools to more easily use it.

## Why

## How

## Tests
