### PR TITLE
feat: `paradedb.force_merge()` now garbage collects after each merge

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -471,7 +471,8 @@ fn force_merge_raw_bytes(
     };
 
     let merge_policy = LayeredMergePolicy::new(vec![oversized_layer_size_bytes.try_into()?]);
-    let (ncandidates, nmerged) = unsafe { merge_index_with_policy(index, merge_policy, true) };
+    let (ncandidates, nmerged) =
+        unsafe { merge_index_with_policy(index, merge_policy, true, true) };
     Ok(TableIterator::once((
         ncandidates.try_into()?,
         nmerged.try_into()?,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This teaches `merge_index_with_policy()` how to garbage collect immediately after doing a merge, which gets the space freed by the merge returned to the FSM so that the next merge candidate can potentially use it.

While doing this, it exposed that in the non-force_merge case, we only need to garbage collect if a merge happened.  This frees up a bit of CPU and disk I/O in the normal happy path of inserting rows that don't need to be merged.

## Why

To ensure that a force merge has the opportunity to reuse existing space rather than potentially being required to allocate more.

## How

## Tests
