### PR TITLE
ci: Avoid wasteful CI runs

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -19,8 +19,11 @@ on:
       - "**/*.toml"
   workflow_dispatch:
 
+# - New commits to a feature branch PR cancel previous runs.
+# - Pushes to `dev` get grouped under "dev".
+# - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
 concurrency:
-  group: benchmark-pg_search-${{ github.head_ref || github.ref }}
+  group: benchmark-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -19,6 +19,13 @@ on:
       - "**/stressgres/*.toml"
   workflow_dispatch:
 
+# - New commits to a feature branch PR cancel previous runs.
+# - Pushes to `dev` get grouped under "dev".
+# - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
+concurrency:
+  group: test-pg_search-stressgres-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   test-pg_search-stressgres:
     name: Run Stressgres ${{ matrix.test_file }} on pg_search with PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -25,8 +25,11 @@ on:
       - "**/*.toml"
   workflow_dispatch:
 
+# - New commits to a feature branch PR cancel previous runs.
+# - Pushes to `dev` get grouped under "dev".
+# - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
 concurrency:
-  group: test-pg_search-${{ github.head_ref || github.ref }}
+  group: test-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Previously, if we had a PR open from `dev` to `main` it would run our CI, and all pushes to `dev` would also run the Stressgres/benchmark CI. This would be running the same commit of the code, but twice.

This PR fixes that.

## Why
Less $$ for Bill Gates, and more $$ for us.

## How
Smarter concurrency group.

## Tests
It's hard to test this without merging, so would appreciate a good review.