### PR TITLE
fix: Add `LinkedItemList::atomically`, and use it for bulk operations on `SegmentMetaEntry`s

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -50,9 +50,12 @@ pub unsafe fn save_new_metas(
     // read the list before we're finished updating it
     let _schema_lock = BufferManager::new(relation_oid).get_buffer_mut(SCHEMA_START);
 
-    // this is where the segments are stored
-    let mut linked_list =
+    // in order to ensure that all of our mutations to the list of segments appear atomically on
+    // physical replicas, we mutate a deep copy of the list, and then atomically replace the real
+    // list as our last step.
+    let mut segment_metas_linked_list =
         LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
+    let mut linked_list = segment_metas_linked_list.atomically();
 
     let incoming_segments = new_meta
         .segments
@@ -249,6 +252,7 @@ pub unsafe fn save_new_metas(
     //
     // now change things on disk
     //
+    let mut bytes_lists_to_delete = Vec::new();
 
     // delete old entries and their corresponding files -- happens only as the result of a merge
     for (entry, blockno) in &deleted_entries {
@@ -274,8 +278,7 @@ pub unsafe fn save_new_metas(
         // so that when the lock is released and this buffer is readable by others, its xmax value
         // and the recyclable-status of all its linked files will match
         for (file_entry, _) in entry.file_entries() {
-            let mut file = LinkedBytesList::open(relation_oid, file_entry.starting_block);
-            file.mark_deleted(deleting_xid);
+            bytes_lists_to_delete.push((file_entry.starting_block, deleting_xid));
         }
 
         drop(buffer);
@@ -303,11 +306,10 @@ pub unsafe fn save_new_metas(
             //
             // we also do this while `buffer` has an exclusive lock so that when we're done updating
             // this entry in the entry list all its files will have the same recyclable setting
-            let mut deletes_file = LinkedBytesList::open(
-                relation_oid,
+            bytes_lists_to_delete.push((
                 entry.delete.as_ref().unwrap().file_entry.starting_block,
-            );
-            deletes_file.mark_deleted(entry.xmax);
+                entry.xmax,
+            ));
         }
 
         let PgItem(pg_item, size) = entry.into();
@@ -323,15 +325,19 @@ pub unsafe fn save_new_metas(
     // chase down the linked lists for any existing deleted entries and mark them as deleted
     for (existing_xmax, deleted_entry) in replaced_delete_entries {
         if existing_xmax == pg_sys::InvalidTransactionId {
-            let mut file =
-                LinkedBytesList::open(relation_oid, deleted_entry.file_entry.starting_block);
-            file.mark_deleted(deleting_xid);
+            bytes_lists_to_delete.push((deleted_entry.file_entry.starting_block, deleting_xid));
         }
     }
 
     // add the new entries -- happens via an index commit or the result of a merge
     if !created_entries.is_empty() {
         linked_list.add_items(&created_entries, None)?;
+    }
+
+    // atomically replace the SegmentMetaEntry list, and then mark any orphaned files deleted.
+    linked_list.commit();
+    for (starting_block, deleting_xid) in bytes_lists_to_delete {
+        LinkedBytesList::open(relation_oid, starting_block).mark_deleted(deleting_xid);
     }
 
     Ok(())

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -47,9 +47,8 @@ pub unsafe fn save_new_metas(
 ) -> Result<()> {
     // in order to ensure that all of our mutations to the list of segments appear atomically on
     // physical replicas, we atomically operate on a deep copy of the list.
-    let mut segment_metas_linked_list =
-        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
-    let mut linked_list = segment_metas_linked_list.atomically();
+    let mut linked_list =
+        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START).atomically();
 
     let incoming_segments = new_meta
         .segments

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -19,8 +19,8 @@ use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::scorer_iter::DeferredScorer;
 use crate::index::setup_tokenizers;
-use crate::postgres::storage::block::CLEANUP_LOCK;
-use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
+use crate::postgres::storage::block::{CLEANUP_LOCK, SEGMENT_METAS_START};
+use crate::postgres::storage::buffer::{Buffer, BufferManager, PinnedBuffer};
 use crate::query::SearchQueryInput;
 use crate::schema::SearchField;
 use crate::schema::{SearchFieldName, SearchIndexSchema};
@@ -255,10 +255,16 @@ pub struct SearchIndexReader {
     // also, it's an Arc b/c if we're clone'd (we do derive it, after all), we only want this
     // buffer dropped once
     _cleanup_lock: Arc<PinnedBuffer>,
+
+    // If we are a WAL receiver, the SearchIndexReader must hold a share lock on the SEGMENT_METAS_START buffer
+    // to prevent WAL records from a concurrent save_new_metas from being applied while a parallel custom/index scan
+    // is running (since applying a WAL record requires an exclusive lock).
+    _segment_metas_share_lock: Arc<Option<Buffer>>,
 }
 
 impl SearchIndexReader {
     pub fn open(index_relation: &PgRelation, mvcc_style: MvccSatisfies) -> Result<Self> {
+        let bman = BufferManager::new(index_relation.oid());
         // It is possible for index only scans and custom scans, which only check the visibility map
         // and do not fetch tuples from the heap, to suffer from the concurrent TID recycling problem.
         // This problem occurs due to a race condition: after vacuum is called, a concurrent index only or custom scan
@@ -270,6 +276,14 @@ impl SearchIndexReader {
         // It's sufficient, and **required** for parallel scans to operate correctly, for us to hold onto
         // a pinned but unlocked buffer.
         let cleanup_lock = BufferManager::new(index_relation.oid()).pinned_buffer(CLEANUP_LOCK);
+
+        // Parallel workers do not need to acquire the segment metas share lock, because the main process
+        // has already acquired it
+        let segment_metas_share_lock = if !matches!(mvcc_style, MvccSatisfies::ParallelWorker(_)) {
+            Some(bman.get_buffer(SEGMENT_METAS_START))
+        } else {
+            None
+        };
 
         let directory = mvcc_style.directory(index_relation);
         let mut index = Index::open(directory)?;
@@ -289,6 +303,7 @@ impl SearchIndexReader {
             underlying_reader: reader,
             underlying_index: index,
             _cleanup_lock: Arc::new(cleanup_lock),
+            _segment_metas_share_lock: Arc::new(segment_metas_share_lock),
         })
     }
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -48,7 +48,7 @@ pub const FIXED_BLOCK_NUMBERS: [pg_sys::BlockNumber; 5] = [
 // ---------------------------------------------------------
 
 // Struct for all page's LP_SPECIAL data
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BM25PageSpecialData {
     pub next_blockno: pg_sys::BlockNumber,
     pub xmax: pg_sys::TransactionId,

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -24,6 +24,7 @@ use anyhow::Result;
 use pgrx::pg_sys;
 use pgrx::pg_sys::BlockNumber;
 use std::fmt::Debug;
+use std::ops::{Deref, DerefMut};
 
 // ---------------------------------------------------------------
 // Linked list implementation over block storage,
@@ -101,26 +102,36 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
     }
 
     pub unsafe fn create(relation_oid: pg_sys::Oid) -> Self {
-        let mut bman = BufferManager::new(relation_oid);
+        let (mut _self, mut header_buffer) = Self::create_without_start_page(relation_oid);
 
-        let mut header_buffer = bman.new_buffer();
-        let header_blockno = header_buffer.number();
-        let mut start_buffer = bman.new_buffer();
+        let mut start_buffer = _self.bman.new_buffer();
         let start_blockno = start_buffer.number();
-
-        let mut header_page = header_buffer.init_page();
         start_buffer.init_page();
 
+        let mut header_page = header_buffer.page_mut();
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;
         metadata.npages = 0;
 
-        Self {
-            header_blockno,
-            bman,
-            _marker: std::marker::PhantomData,
-        }
+        _self
+    }
+
+    unsafe fn create_without_start_page(relation_oid: pg_sys::Oid) -> (Self, BufferMut) {
+        let mut bman = BufferManager::new(relation_oid);
+
+        let mut header_buffer = bman.new_buffer();
+        let header_blockno = header_buffer.number();
+        header_buffer.init_page();
+
+        (
+            Self {
+                header_blockno,
+                bman,
+                _marker: std::marker::PhantomData,
+            },
+            header_buffer,
+        )
     }
 
     /// Return a Vec of all the items in this linked list
@@ -346,6 +357,151 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
             pg_sys::GetCurrentTransactionIdIfAny()
         )))
     }
+
+    ///
+    /// Make a temporary copy of this list and all its backing buffers to allow for atomic
+    /// mutation. When the given guard is `commit()`ed, all changes will become visible atomically
+    /// in this list.
+    ///
+    /// TODO: For small lists which mutate large portions of this collection, we would likely be
+    /// better off converting it into a Rust collection (which would be easier to manipulate), and
+    /// then re-storing it from scratch to commit.
+    ///
+    pub unsafe fn atomically(&mut self) -> AtomicGuard<'_, T> {
+        // We create the duplicate without a start page: it will be filled in in the first
+        // iteration of the loop below.
+        let (mut cloned, mut header_buffer) =
+            LinkedItemList::create_without_start_page(self.bman.relation_oid());
+
+        // TODO: This code could either:
+        // * switch to compacting pages as it goes.
+        // * switch to using memcpy
+        // ... but not both.
+        let mut blockno = self.get_start_blockno();
+        assert!(
+            blockno != pg_sys::InvalidBlockNumber,
+            "Must contain at least one block."
+        );
+        let mut previous_new_buffer: Option<BufferMut> = None;
+        while blockno != pg_sys::InvalidBlockNumber {
+            let buffer = self.bman.get_buffer(blockno);
+            let page = buffer.page();
+            let mut offsetno = pg_sys::FirstOffsetNumber;
+            let max_offset = page.max_offset_number();
+
+            let mut new_buffer = cloned.bman.new_buffer();
+            let new_blockno = new_buffer.number();
+            let mut new_page = new_buffer.init_page();
+
+            // Link the new block in with the previous block, or with the header.
+            if let Some(mut previous_new_buffer) = previous_new_buffer {
+                previous_new_buffer
+                    .page_mut()
+                    .special_mut::<BM25PageSpecialData>()
+                    .next_blockno = new_blockno;
+            } else {
+                header_buffer
+                    .page_mut()
+                    .contents_mut::<LinkedListData>()
+                    .start_blockno = new_blockno;
+            }
+
+            while offsetno <= max_offset {
+                if let Some((deserialized, _)) = page.read_item::<T>(offsetno) {
+                    let PgItem(item, size) = deserialized.into();
+                    let new_offsetno = new_page.append_item(item, size, 0);
+                    assert!(new_offsetno != pg_sys::InvalidOffsetNumber);
+                }
+                offsetno += 1;
+            }
+
+            *new_page.special_mut::<BM25PageSpecialData>() =
+                (*page.special::<BM25PageSpecialData>()).clone();
+            blockno = page.next_blockno();
+            previous_new_buffer = Some(new_buffer);
+        }
+
+        AtomicGuard {
+            original: self,
+            cloned: Some(cloned),
+        }
+    }
+}
+
+pub struct AtomicGuard<'s, T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> {
+    original: &'s mut LinkedItemList<T>,
+    cloned: Option<LinkedItemList<T>>,
+}
+
+impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> Deref for AtomicGuard<'_, T> {
+    type Target = LinkedItemList<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.cloned.as_ref().expect("Cannot deref after commit!")
+    }
+}
+
+impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> DerefMut for AtomicGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.cloned
+            .as_mut()
+            .expect("Cannot deref_mut after commit!")
+    }
+}
+
+impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> AtomicGuard<'_, T> {
+    pub fn commit(&mut self) {
+        let mut cloned = self.cloned.take().expect("Cannot commit twice!");
+        // Update our header page to point to the new start block, and return the old one.
+        let mut blockno = {
+            // Open both header pages.
+            let mut original_header_buffer = self
+                .original
+                .bman
+                .get_buffer_mut(self.original.header_blockno);
+            let mut original_header_page = original_header_buffer.page_mut();
+            let cloned_header_buffer = cloned.bman.get_buffer(cloned.header_blockno);
+            let cloned_header_page = cloned_header_buffer.page();
+
+            // Capture our old start page, then overwrite our metadata.
+            let original_metadata = original_header_page.contents_mut::<LinkedListData>();
+            let old_start_blockno = original_metadata.start_blockno;
+            *original_metadata = cloned_header_page.contents::<LinkedListData>();
+
+            // Finally, garbage collect the cloned header block.
+            cloned.bman.return_to_fsm(cloned_header_buffer);
+
+            old_start_blockno
+        };
+
+        // And then collect our old contents, which are no longer reachable.
+        while blockno != pg_sys::InvalidBlockNumber {
+            let buffer = self.original.bman().get_buffer(blockno);
+            blockno = buffer.page().next_blockno();
+            self.original.bman.return_to_fsm(buffer);
+        }
+    }
+}
+
+impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> Drop for AtomicGuard<'_, T> {
+    fn drop(&mut self) {
+        let Some(mut cloned) = self.cloned.take() else {
+            return;
+        };
+
+        // The guard was dropped without a call to commit: return its pages.
+        let header_buffer = cloned.bman().get_buffer(cloned.header_blockno);
+        let mut blockno = header_buffer
+            .page()
+            .contents::<LinkedListData>()
+            .start_blockno;
+        cloned.bman.return_to_fsm(header_buffer);
+        while blockno != pg_sys::InvalidBlockNumber {
+            let buffer = cloned.bman().get_buffer(blockno);
+            blockno = buffer.page().next_blockno();
+            cloned.bman.return_to_fsm(buffer);
+        }
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -370,10 +526,10 @@ mod tests {
         let mut block_numbers = HashSet::new();
 
         while blockno != pg_sys::InvalidBlockNumber {
+            block_numbers.insert(blockno);
             let buffer = list.bman().get_buffer(blockno);
             let page = buffer.page();
             blockno = page.next_blockno();
-            block_numbers.insert(blockno);
         }
 
         block_numbers
@@ -381,12 +537,7 @@ mod tests {
 
     #[pg_test]
     unsafe fn test_linked_items_garbage_collect_single_page() {
-        Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id')").unwrap();
-        let relation_oid: pg_sys::Oid =
-            Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
-                .expect("spi should succeed")
-                .unwrap();
+        let relation_oid = init_bm25_index();
 
         let snapshot = pg_sys::GetActiveSnapshot();
         let delete_xid = (*snapshot).xmin - 1;
@@ -421,12 +572,7 @@ mod tests {
 
     #[pg_test]
     unsafe fn test_linked_items_garbage_collect_multiple_pages() {
-        Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
-        Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id')").unwrap();
-        let relation_oid: pg_sys::Oid =
-            Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
-                .expect("spi should succeed")
-                .unwrap();
+        let relation_oid = init_bm25_index();
 
         let snapshot = pg_sys::GetActiveSnapshot();
         let deleted_xid = (*snapshot).xmin - 1;
@@ -516,6 +662,61 @@ mod tests {
             assert!(pre_gc_blocks.len() > post_gc_blocks.len());
             assert!(post_gc_blocks.is_subset(&pre_gc_blocks));
         }
+    }
+
+    #[pg_test]
+    unsafe fn test_linked_items_duplicate_then_replace() {
+        let relation_oid = init_bm25_index();
+
+        let snapshot = pg_sys::GetActiveSnapshot();
+
+        // Add 2000 entries.
+        let mut list = LinkedItemList::<SegmentMetaEntry>::create(relation_oid);
+        let entries = (1..2000)
+            .map(|_| SegmentMetaEntry {
+                segment_id: random_segment_id(),
+                xmin: (*snapshot).xmin - 1,
+                xmax: pg_sys::InvalidTransactionId,
+                postings: Some(make_fake_postings(relation_oid)),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+
+        list.add_items(&entries, None).unwrap();
+
+        // Atomically modify the list, and then confirm that it contains unique blocks, and the
+        // same contents.
+        let list_block_numbers = linked_list_block_numbers(&list);
+        let list_contents = list.list();
+        let mut guard = list.atomically();
+        let duplicate_block_numbers = linked_list_block_numbers(&guard);
+        let duplicate_contents = guard.list();
+        assert_eq!(
+            list_block_numbers
+                .intersection(&duplicate_block_numbers)
+                .cloned()
+                .collect::<Vec<_>>(),
+            Vec::<pg_sys::BlockNumber>::new(),
+        );
+        assert_eq!(list_contents, duplicate_contents);
+
+        // Then `commit()` the guard, and confirm that the structure of the original list
+        // matches afterwards.
+        guard.commit();
+        // TODO: We have to drop the guard because it continues to borrow the list even after it is
+        // committed. It can't move the list in/out of itself because of how `garbage_collect` is
+        // structured.
+        std::mem::drop(guard);
+        assert_eq!(linked_list_block_numbers(&list), duplicate_block_numbers);
+        assert_eq!(list.list(), duplicate_contents);
+    }
+
+    fn init_bm25_index() -> pg_sys::Oid {
+        Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
+        Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id')").unwrap();
+        Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
+            .expect("spi should succeed")
+            .unwrap()
     }
 
     fn make_fake_postings(relation_oid: pg_sys::Oid) -> FileEntry {

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -261,8 +261,10 @@ impl MergeLock {
         }
 
         let relation_id = (*self.bman.bm25cache().indexrel()).rd_id;
-        let mut entries_list = LinkedItemList::<MergeEntry>::open(relation_id, metadata.merge_list);
+        let mut entries_list =
+            LinkedItemList::<MergeEntry>::open(relation_id, metadata.merge_list).atomically();
         let recycled_entries = entries_list.garbage_collect();
+        entries_list.commit();
         for recycled_entry in recycled_entries {
             let mut bytes_list =
                 LinkedBytesList::open(relation_id, recycled_entry.segment_ids_start_blockno);


### PR DESCRIPTION
## What

Adds `LinkedItemList::atomically`, and uses it in `save_new_metas` and `garbage_collect`

## Why

Although the primary holds exclusive locks to prevent other local processes from being able to observe a `LinkedItemList` in an inconsistent state, physical replicas cannot obey these locks, and can therefore observe the buffers of the list at any point in time.

That makes it necessary to publish bulk changes to `SegmentMetaEntry`s atomically, so that a physical replica can never observe it halfway through an operation like `save_new_metas` or `garbage_collect`. 

## How

We acquire an exclusive lock on the header of the `LinkedItemList`, clone it, and then operate on the clone until we're ready to commit all changes by swapping in the clone.

## Tests

Added a test of the `LinkedItemList::atomically` method, and had help stress testing it in a physical replication harness.