### PR TITLE
fix: `SearchIndexReader` takes share lock on `SEGMENT_META_ENTRY`

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -256,9 +256,9 @@ pub struct SearchIndexReader {
     // buffer dropped once
     _cleanup_lock: Arc<PinnedBuffer>,
 
-    // If we are a WAL receiver, the SearchIndexReader holds a share lock on the SEGMENT_METAS_START buffer
+    // If we are a WAL receiver, the SearchIndexReader must hold a share lock on the SEGMENT_METAS_START buffer
     // to prevent WAL records from a concurrent save_new_metas from being applied while a parallel custom/index scan
-    // is running
+    // is running (since applying a WAL record requires an exclusive lock).
     _segment_metas_share_lock: Arc<Option<Buffer>>,
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

If we are a WAL receiver, the SearchIndexReader must hold a share lock on the `SEGMENT_METAS_START` buffer to prevent WAL records from a concurrent save_new_metas from being applied while a parallel custom/index scan is running (since applying a WAL record requires an exclusive lock).

WAL streaming is enterprise-only but putting this in community keeps things consistent.

## Why

## How

## Tests
