### PR TITLE
fix: issue #2397 -- endless loop during certain TopN queries

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -129,6 +129,19 @@ impl PartialOrd for TweakedScore {
     }
 }
 
+impl SearchResults {
+    pub fn len(&self) -> Option<usize> {
+        match self {
+            SearchResults::None => Some(0),
+            SearchResults::TopNByScore(_, _, iter) => Some(iter.len()),
+            SearchResults::TopNByTweakedScore(_, _, iter) => Some(iter.len()),
+            SearchResults::TopNByField(_, _, iter) => Some(iter.len()),
+            SearchResults::SingleSegment(_, _, _, _) => None,
+            SearchResults::AllSegments(_, _, _) => None,
+        }
+    }
+}
+
 impl Iterator for SearchResults {
     type Item = (SearchIndexScore, DocAddress);
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -42,6 +42,7 @@ pub struct TopNScanExecState {
     sort_field: Option<String>,
     search_results: SearchResults,
     nresults: usize,
+    have_less: bool,
     did_query: bool,
 
     // state tracking
@@ -72,8 +73,9 @@ impl TopNScanExecState {
         &mut self,
         state: &mut PdbScanState,
         current_segment: Option<SegmentId>,
+        expanding_results: bool,
     ) -> SearchResults {
-        if let Some(parallel_state) = state.parallel_state {
+        let search_results = if let Some(parallel_state) = state.parallel_state {
             // we're parallel, so either query the provided segment or go get a segment from the parallel state
             let segment_id = current_segment
                 .map(Some)
@@ -95,11 +97,11 @@ impl TopNScanExecState {
                 // no more segments to query
                 SearchResults::None
             }
-        } else if self.did_query {
+        } else if self.did_query && !expanding_results {
             // not parallel, so we're done
             SearchResults::None
         } else {
-            // not parallel, first time query
+            // not parallel, first time query or expanding
             let search_reader = &self.search_reader.as_ref().unwrap();
             self.did_query = true;
             search_reader.search_top_n(
@@ -109,7 +111,10 @@ impl TopNScanExecState {
                 self.limit.max(self.chunk_size),
                 self.need_scores,
             )
-        }
+        };
+
+        self.have_less = search_results.len().unwrap_or(0) < self.limit.max(self.chunk_size);
+        search_results
     }
 }
 
@@ -123,7 +128,7 @@ impl ExecMethod for TopNScanExecState {
     }
 
     fn query(&mut self, state: &mut PdbScanState) -> bool {
-        let search_results = self.query_more_results(state, None);
+        let search_results = self.query_more_results(state, None, false);
 
         self.did_query = true;
 
@@ -151,10 +156,13 @@ impl ExecMethod for TopNScanExecState {
                         return ExecState::Eof;
                     }
                     None => {
-                        if self.found >= self.limit || self.nresults < self.limit {
+                        if self.found >= self.limit || self.have_less {
                             // we found all the matching rows
                             return ExecState::Eof;
                         }
+                    }
+                    Some(_) if self.found >= self.limit => {
+                        return ExecState::Eof;
                     }
                     Some((scored, doc_address)) => {
                         self.nresults += 1;
@@ -198,8 +206,7 @@ impl ExecMethod for TopNScanExecState {
                     .max(self.limit * factor)
                     .min(MAX_CHUNK_SIZE);
 
-                self.did_query = false;
-                let mut results = self.query_more_results(state, Some(self.current_segment));
+                let mut results = self.query_more_results(state, Some(self.current_segment), true);
 
                 // fast forward and stop on the ctid we last found
                 for (scored, doc_address) in &mut results {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -145,11 +145,11 @@ impl ExecMethod for TopNScanExecState {
     }
 
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState {
-        check_for_interrupts!();
-
         unsafe {
             let mut next = self.search_results.next();
             loop {
+                check_for_interrupts!();
+
                 match next {
                     None if !self.did_query => {
                         // we haven't even done a query yet, so this is our very first time in


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2397

## What

Fixes possible endless loops in our "Top N".

## Why

The code would get confused about when it was done querying/expanding the results.

## How

## Tests

Existing tests pass and the `top_n_matches` test has been updated a bit to catch some cases that it didn't previously.