### PR TITLE
fix: Declare that top-N outputs are already sorted

### DIFF
--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -301,8 +301,6 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
 
     pub fn set_parallel(
         mut self,
-        is_topn: bool,
-        row_estimate: Cardinality,
         limit: Option<Cardinality>,
         segment_count: usize,
         sorted: bool,

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -59,12 +59,12 @@ fn sort_by_lower(mut conn: PgConnection) {
     "#.execute(&mut conn);
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE description @@@ 'keyboard OR shoes' ORDER BY lower(category) LIMIT 5".fetch_one::<(Value,)>(&mut conn);
+    eprintln!("{plan:#?}");
     let plan = plan
-        .pointer("/0/Plan/Plans/0/Plans/0")
+        .pointer("/0/Plan/Plans/0")
         .unwrap()
         .as_object()
         .unwrap();
-    eprintln!("{plan:#?}");
     assert_eq!(
         plan.get("   Sort Field"),
         Some(&Value::String(String::from("category")))
@@ -107,12 +107,12 @@ fn sort_by_raw(mut conn: PgConnection) {
     "#.execute(&mut conn);
 
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT * FROM paradedb.bm25_search WHERE description @@@ 'keyboard OR shoes' ORDER BY category LIMIT 5".fetch_one::<(Value,)>(&mut conn);
+    eprintln!("{plan:#?}");
     let plan = plan
-        .pointer("/0/Plan/Plans/0/Plans/0")
+        .pointer("/0/Plan/Plans/0")
         .unwrap()
         .as_object()
         .unwrap();
-    eprintln!("{plan:#?}");
     assert_eq!(
         plan.get("   Sort Field"),
         Some(&Value::String(String::from("category")))


### PR DESCRIPTION
# Ticket(s) Closed

- Relates to #2405.

## What

As reported in #2405, a bm25 index does not early-cutoff during execution the way that a B-Tree index does, for two reasons:
1. we do not push down the `ORDER BY` as a sort because we do not detect a `LIMIT` (as mentioned on #2405), and won't sort without a limit
2. when we _do_ execute a top-N, we don't declare that the output is ordered

## Why

Declaring that the output is ordered allows the planner to skip a `Sort`, but additionally is one of the requirements in order to apply early-cutoff (the "never executed" optimization from #2405) in the `Append` node.

## How

Set `pathkeys` on our `CustomPath`.

## Tests

Updated existing `EXPLAIN` tests for the removal of the `Sort` node.