### PR TITLE
fix: if segment has no docs, adjust byte size to `0`

### DIFF
--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -286,6 +286,10 @@ fn adjusted_byte_size(
     all_entries: &HashMap<SegmentId, SegmentMetaEntry>,
     avg_doc_size: u64,
 ) -> u64 {
+    if meta.num_docs() == 0 {
+        return 0;
+    }
+
     all_entries
         .get(&meta.id())
         .map(|entry| {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`adjust_byte_size` can be smarter about a segment's size and say it's `0` if it has all deleted docs. Without this condition, `adjust_byte_size` can estimate that a segment's size is much larger than `0`.

## Why

## How

## Tests
