### PR TITLE
fix: stop leaking pages and make pages recyclable earlier

### DIFF
--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -46,8 +46,7 @@ pub unsafe extern "C" fn ambulkdelete(
 
     // first, we need an exclusive lock on the CLEANUP_LOCK.  Once we get it, we know that there
     // are no concurrent merges happening
-    let cleanup_lock =
-        BufferManager::new(index_relation.oid()).get_buffer_for_cleanup(CLEANUP_LOCK);
+    let cleanup_lock = BufferManager::new(index_relation.oid()).get_buffer_mut(CLEANUP_LOCK);
 
     // take the MergeLock
     let merge_lock = {

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -407,9 +407,8 @@ unsafe fn garbage_collect_index(indexrel: &PgRelation) {
     let recycled_entries = segment_meta_list.garbage_collect();
     segment_meta_list.commit();
     for entry in recycled_entries {
-        for (file_entry, type_) in entry.file_entries() {
-            let bytes = LinkedBytesList::open(indexrelid, file_entry.starting_block);
-            bytes.return_to_fsm(&entry, Some(type_));
+        for (file_entry, _) in entry.file_entries() {
+            LinkedBytesList::open(indexrelid, file_entry.starting_block).return_to_fsm();
             pg_sys::IndexFreeSpaceMapVacuum(indexrel.as_ptr());
         }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -105,6 +105,22 @@ impl BufferMut {
     pub fn page_size(&self) -> pg_sys::Size {
         self.inner.page_size()
     }
+
+    /// Return this [`BufferMut`] instance back to Postgres' Free Space Map, making
+    /// it available for future reuse as a new buffer.
+    ///
+    /// It's the caller's responsibility to later call [`pg_sys::IndexFreeSpaceMapVacuum`]
+    /// if necessary.
+    pub fn return_to_fsm(mut self, bman: &mut BufferManager) {
+        unsafe {
+            let blockno = self.page_mut().mark_deleted();
+            assert!(
+                blockno > *FIXED_BLOCK_NUMBERS.last().unwrap(),
+                "record_free_index_page: blockno {blockno} cannot ever be recycled"
+            );
+            pg_sys::RecordPageWithFreeSpace(bman.bcache.indexrel(), blockno, bm25_max_free_space());
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -199,18 +215,20 @@ pub struct PageMut<'a> {
 }
 
 impl PageMut<'_> {
-    pub fn mark_deleted(mut self, deleting_xid: pg_sys::TransactionId) {
+    fn mark_deleted(mut self) -> pg_sys::BlockNumber {
         let blockno = self.buffer.number();
         let special = self.special_mut::<BM25PageSpecialData>();
 
         assert!(
-            special.xmax == pg_sys::InvalidTransactionId || special.xmax == deleting_xid,
-            "page {} is already marked deleted with xid={}, trying to change to {deleting_xid}",
+            special.xmax == pg_sys::InvalidTransactionId
+                || special.xmax == pg_sys::FrozenTransactionId,
+            "page {} is already marked deleted with xid={}",
             blockno,
             special.xmax
         );
-        special.xmax = deleting_xid;
+        special.xmax = pg_sys::FrozenTransactionId;
         self.buffer.dirty = true;
+        blockno
     }
 
     pub fn max_offset_number(&self) -> pg_sys::OffsetNumber {
@@ -519,35 +537,5 @@ impl BufferManager {
 
     pub fn page_is_empty(&self, blockno: pg_sys::BlockNumber) -> bool {
         self.get_buffer(blockno).page().is_empty()
-    }
-
-    /// Return a [`Buffer`] back to the Free Space Map behind this index.
-    ///
-    /// It's the caller's responsibility to later call [`pg_sys::IndexFreeSpaceMapVacuum`]
-    /// if necessary.
-    pub fn return_to_fsm(&mut self, buffer: Buffer) {
-        unsafe {
-            let blockno = buffer.number();
-            assert!(
-                blockno > *FIXED_BLOCK_NUMBERS.last().unwrap(),
-                "record_free_index_page: blockno {blockno} cannot ever be recycled"
-            );
-            pg_sys::RecordPageWithFreeSpace(self.bcache.indexrel(), blockno, bm25_max_free_space());
-        }
-    }
-
-    /// Return a [`BufferMut`] back to the Free Space Map behind this index.
-    ///
-    /// It's the caller's responsibility to later call [`pg_sys::IndexFreeSpaceMapVacuum`]
-    /// if necessary.
-    pub fn return_to_fsm_mut(&mut self, buffer: BufferMut) {
-        unsafe {
-            let blockno = buffer.number();
-            assert!(
-                blockno > *FIXED_BLOCK_NUMBERS.last().unwrap(),
-                "record_free_index_page: blockno {blockno} cannot ever be recycled"
-            );
-            pg_sys::RecordPageWithFreeSpace(self.bcache.indexrel(), blockno, bm25_max_free_space());
-        }
     }
 }

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -26,7 +26,11 @@ pub trait BM25Page {
         &self,
         offsetno: pg_sys::OffsetNumber,
     ) -> Option<(T, pg_sys::Size)>;
-    unsafe fn recyclable(self, heap_relation: pg_sys::Relation) -> bool;
+
+    unsafe fn xmax(&self) -> pg_sys::TransactionId;
+
+    /// Return true if the page is able to reused as if it were a new page
+    unsafe fn is_reusable(&self) -> bool;
 }
 
 impl BM25Page for pg_sys::Page {
@@ -42,17 +46,20 @@ impl BM25Page for pg_sys::Page {
         Some((T::from(PgItem(item, size)), size))
     }
 
-    unsafe fn recyclable(self, heap_relation: pg_sys::Relation) -> bool {
-        if pg_sys::PageIsNew(self) {
+    unsafe fn xmax(&self) -> pg_sys::TransactionId {
+        let special = pg_sys::PageGetSpecialPointer(*self) as *mut BM25PageSpecialData;
+        (*special).xmax
+    }
+
+    unsafe fn is_reusable(&self) -> bool {
+        if pg_sys::PageIsNew(*self) {
             return true;
         }
 
-        let special = pg_sys::PageGetSpecialPointer(self) as *mut BM25PageSpecialData;
-        if (*special).xmax == pg_sys::InvalidTransactionId {
-            return false;
-        }
-
-        pg_sys::GlobalVisCheckRemovableXid(heap_relation, (*special).xmax)
+        // technically we're only called on pages given to us by the FSM, and in that case the page
+        // can be immediately reused if our internal `xmax` tracking is set to frozen, indicating
+        // that it's been deleted
+        self.xmax() == pg_sys::FrozenTransactionId
     }
 }
 
@@ -103,12 +110,12 @@ impl BM25BufferCache {
             if pg_sys::ConditionalLockBuffer(buffer) {
                 let page = pg_sys::BufferGetPage(buffer);
 
-                // the FSM would have returned a page to us that was previously known to be recyclable,
-                // but it may not still be recyclable now that we have a lock.
+                // the FSM would have returned a page to us that was previously known to be reusable,
+                // but it may not still be reusable now that we have a lock.
                 //
                 // between then and now some other backend could have gotten this page too, locked it,
-                // initialized it, and released its lock, making it unusable by us
-                if page.recyclable(self.heaprel) {
+                // (re)initialized it, and released its lock, making it unusable by us
+                if page.is_reusable() {
                     return buffer;
                 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR is four changes to cleanup our internal APIs around page recycling along with fixing two bugs where pages could be leaked.

First, internal APIs have been changed such that there's no longer a distinction between "mark_deleted" and "return_to_fsm".  Now, we simply `return_to_fsm` individual `BufferMut` instances or larger collections of them, such as with `LinkedBytesList`.  Internally, the underlying page is automatically marked as deleted.

The impetus for this internal API change is that the new `AtomicGuard::commit()` and `AtomicGuard::drop()` functions were leaking old (or new) pages because they failed to `.mark_deleted()`.  Now, that's just not possible.

Secondly, we rename `BM25Page::recyclable()` to `BM25Page::is_reusable()` and change its implementation to simply see if the page's `xmax` value equals the frozen transaction id.  If it does, it's reusable.  There is no longer a reliance on the "vacuum horizon" for this, which allows pages to be recycled much sooner.

Third, `save_new_metas` was leaking the `LinkedBytesLists` for existing ".deletes" files.  What happens now is we fabricate a fake segment meta entry to only represent the old ".deletes" file, configured in such a way as that it'll be immediately recyclable on the next garbage collect run.

And finally, the `LinkedItemList::list_and_pin()` function has been renamed to `for_each_and_pin()` and has been re-tooled to only pin the segments which pass the "accept" function closure.  The old implementation would pin every segment first, then `load_metas` would drop the pins on the segments that weren't visible to it based on its `MvccSatisfies` rules.  The problem with this is that holding pins on all segments, including those that were already known to be recyclable, means they couldn't be recycled at that moment.  This lead to a situation where the FSM was empty because these segments weren't recycled early, so new segments would end up allocating new space.  Only pinning the segments `load_metas` is interested in allows concurrent garbage collection/recycling to happen eagerly as it's no longer timing dependent.

---

As a drive-by, `ambulkdelete` doesn't need a cleanup lock on our `CLEANUP_LOCK` -- it needs a plain exclusive lock.  It doesn't need a cleanup lock because it doesn't also need to wait out concurrent readers, it only needs to wait out concurrent mergers, which already hold a share lock on `CLEANUP_LOCK` throughout their process.

## Why

We were leaking pages in 2 different places and also v0.15.12 introduced some complexity around segment pinning that kept too many segments pinned for too long, turning eager garbage collection into deferred garbage collection.  Together, these things would cause an index to essentially always allocate new buffers, growing in size indefinitely.

## How

## Tests

An hour-long stressgres run using our `single-server.toml` from CI shows that the index block count levels out.  I
![single-server](https://github.com/user-attachments/assets/abc1c9f5-f260-4c73-9daa-14992df0da76)

Whereas before these changes, it simply increases forever.  This is a 10 minute run from before these changes:
![stressgres-single-server toml](https://github.com/user-attachments/assets/e32ca68c-b9ee-414c-8c7b-4cd274ebc5e9)

