### PR TITLE
ci: Move concurrency groups to within job

### DIFF
--- a/.github/workflows/benchmark-pg_search.yml
+++ b/.github/workflows/benchmark-pg_search.yml
@@ -22,15 +22,14 @@ on:
 # - New commits to a feature branch PR cancel previous runs.
 # - Pushes to `dev` get grouped under "dev".
 # - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
-concurrency:
-  group: benchmark-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
     runs-on: ubicloud-standard-8
     if: github.event.pull_request.draft == false
+    concurrency:
+      group: benchmark-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
+      cancel-in-progress: true
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -22,15 +22,14 @@ on:
 # - New commits to a feature branch PR cancel previous runs.
 # - Pushes to `dev` get grouped under "dev".
 # - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
-concurrency:
-  group: test-pg_search-stressgres-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   test-pg_search-stressgres:
     name: Run Stressgres ${{ matrix.test_file }} on pg_search with PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     if: github.event.pull_request.draft == false
+    concurrency:
+      group: test-pg_search-stressgres-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -28,15 +28,14 @@ on:
 # - New commits to a feature branch PR cancel previous runs.
 # - Pushes to `dev` get grouped under "dev".
 # - A PR from `dev` to `main` uses the same key as pushes to `dev`, avoiding duplicate runs when doing a promotion.
-concurrency:
-  group: test-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   test-pg_search-postgres:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     if: github.event.pull_request.draft == false
+    concurrency:
+      group: test-pg_search-${{ (github.event_name == 'push' || github.event.pull_request.head.ref == 'dev') && 'dev' || github.event.pull_request.number }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This will make it so that skipped jobs don't show up as failed runs.

## Why
CI not reporting false negatives.

## How
Moved to inside job

## Tests
N/A