### PR TITLE
fix: ORDER BY ... LIMIT ... is pushed down on partitioned table

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -159,6 +159,7 @@ impl CustomScan for PdbScan {
             let ff_cnt =
                 exec_methods::fast_fields::count(&mut builder, rti, &table, &schema, target_list);
             let maybe_ff = builder.custom_private().maybe_ff();
+
             let is_topn = limit.is_some() && pathkey.is_some();
             let which_fast_fields = exec_methods::fast_fields::collect(
                 builder.custom_private().maybe_ff(),

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1119,39 +1119,39 @@ unsafe fn is_partitioned_table_setup(
         if (*rte).relkind as u8 != pg_sys::RELKIND_RELATION {
             continue;
         }
+    }
 
-        // Check if this relation belongs to a partitioned table in baserels
-        // We'll do this by checking for overlaps between baserels and partitioned tables
+    // Check if this relation belongs to a partitioned table in baserels
+    // We'll do this by checking for overlaps between baserels and partitioned tables
 
-        // Iterate through all relations to find partitioned tables
-        for i in 0..(*root).simple_rel_array_size as usize {
-            let possible_parent_ptr = *(*root).simple_rel_array.add(i);
-            if possible_parent_ptr.is_null() {
-                continue;
-            }
+    // Iterate through all relations to find partitioned tables
+    for i in 0..(*root).simple_rel_array_size as usize {
+        let possible_parent_ptr = *(*root).simple_rel_array.add(i);
+        if possible_parent_ptr.is_null() {
+            continue;
+        }
 
-            let possible_parent = &*possible_parent_ptr;
+        let possible_parent = &*possible_parent_ptr;
 
-            // Skip if not in baserels
-            if !pg_sys::bms_is_member(i as i32, baserels) {
-                continue;
-            }
+        // Skip if not in baserels
+        if !pg_sys::bms_is_member(i as i32, baserels) {
+            continue;
+        }
 
-            // Skip if it doesn't have partitions
-            if possible_parent.all_partrels.is_null() {
-                continue;
-            }
+        // Skip if it doesn't have partitions
+        if possible_parent.all_partrels.is_null() {
+            continue;
+        }
 
-            // Check if the possible parent's RTE is a partitioned table
-            let parent_rte = pg_sys::rt_fetch(i as pg_sys::Index, rtable);
-            if (*parent_rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
-                continue;
-            }
+        // Check if the possible parent's RTE is a partitioned table
+        let parent_rte = pg_sys::rt_fetch(i as pg_sys::Index, rtable);
+        if (*parent_rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
+            continue;
+        }
 
-            // Check if our member is one of its partitions
-            if pg_sys::bms_is_member(member, possible_parent.all_partrels) {
-                return true;
-            }
+        // Check if our member is one of its partitions
+        if pg_sys::bms_is_subset(rel_relids, possible_parent.all_partrels) {
+            return true;
         }
     }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1085,6 +1085,33 @@ pub fn is_block_all_visible(
     }
 }
 
+// Helper function to convert Bitmapset to Vec<i32>
+unsafe fn bms_is_empty(bms: *mut pg_sys::Bitmapset) -> bool {
+    let mut set_bit: i32 = -1;
+    // Get the set bits, which are offsets into the RangeTable.
+    set_bit = pg_sys::bms_next_member(bms, set_bit);
+    if set_bit < 0 {
+        return true;
+    }
+    false
+}
+
+// Helper function to convert Bitmapset to Vec<i32>
+unsafe fn bms_to_integers(bms: *mut pg_sys::Bitmapset) -> Vec<i32> {
+    let mut set_bit: i32 = -1;
+    let mut result = Vec::new();
+    loop {
+        // Get the set bits, which are offsets into the RangeTable.
+        set_bit = pg_sys::bms_next_member(bms, set_bit);
+        if set_bit < 0 {
+            break;
+        }
+
+        result.push(set_bit);
+    }
+    result
+}
+
 // Helper function to determine if we're dealing with a partitioned table setup
 unsafe fn is_partitioned_table_setup(
     root: *mut pg_sys::PlannerInfo,
@@ -1093,66 +1120,42 @@ unsafe fn is_partitioned_table_setup(
 ) -> bool {
     use pgrx::pg_sys::{self};
 
-    // Get the rtable for relkind checks
-    let rtable = (*(*root).parse).rtable;
+    // Get the relids of our current relation
+    if bms_is_empty(rel_relids) {
+        return false;
+    }
 
-    // For each relid in rel_relids, check if it's a partition
-    let mut member: i32 = -1;
-    while {
-        member = pg_sys::bms_next_member(rel_relids, member);
-        member >= 0
-    } {
+    // Find partitioned tables in the baserels
+    let baserels_ints = bms_to_integers(baserels);
+    let rtable = (*(*root).parse).rtable;
+    for baserel_idx in baserels_ints {
         // Skip invalid indices
-        if member <= 0 || member as usize >= (*root).simple_rel_array_size as usize {
+        if baserel_idx <= 0 || baserel_idx as usize >= (*root).simple_rel_array_size as usize {
             continue;
         }
 
-        // Get the rel info for this member
-        let rel_info_ptr = *(*root).simple_rel_array.add(member as usize);
+        // Get the RTE to determine if this is a partitioned table
+        let rte = pg_sys::rt_fetch(baserel_idx as pg_sys::Index, (*(*root).parse).rtable);
+        if (*rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
+            continue;
+        }
+
+        // This is a partitioned table, get its RelOptInfo to find partitions
+        let rel_info_ptr = *(*root).simple_rel_array.add(baserel_idx as usize);
         if rel_info_ptr.is_null() {
             continue;
         }
 
         let rel_info = &*rel_info_ptr;
 
-        // Get the RTE to check if this is a relation
-        let rte = pg_sys::rt_fetch(member as pg_sys::Index, rtable);
-        if (*rte).relkind as u8 != pg_sys::RELKIND_RELATION {
+        // Check if it has partitions
+        if rel_info.all_partrels.is_null() {
             continue;
         }
 
-        // Check if this relation belongs to a partitioned table in baserels
-        // We'll do this by checking for overlaps between baserels and partitioned tables
-
-        // Iterate through all relations to find partitioned tables
-        for i in 0..(*root).simple_rel_array_size as usize {
-            let possible_parent_ptr = *(*root).simple_rel_array.add(i);
-            if possible_parent_ptr.is_null() {
-                continue;
-            }
-
-            let possible_parent = &*possible_parent_ptr;
-
-            // Skip if not in baserels
-            if !pg_sys::bms_is_member(i as i32, baserels) {
-                continue;
-            }
-
-            // Skip if it doesn't have partitions
-            if possible_parent.all_partrels.is_null() {
-                continue;
-            }
-
-            // Check if the possible parent's RTE is a partitioned table
-            let parent_rte = pg_sys::rt_fetch(i as pg_sys::Index, rtable);
-            if (*parent_rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
-                continue;
-            }
-
-            // Check if our member is one of its partitions
-            if pg_sys::bms_is_member(member, possible_parent.all_partrels) {
-                return true;
-            }
+        // This is a partitioned table, check if rel_relids overlaps with its partitions
+        if pg_sys::bms_overlap(rel_info.all_partrels, rel_relids) {
+            return true;
         }
     }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -159,7 +159,6 @@ impl CustomScan for PdbScan {
             let ff_cnt =
                 exec_methods::fast_fields::count(&mut builder, rti, &table, &schema, target_list);
             let maybe_ff = builder.custom_private().maybe_ff();
-
             let is_topn = limit.is_some() && pathkey.is_some();
             let which_fast_fields = exec_methods::fast_fields::collect(
                 builder.custom_private().maybe_ff(),

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1084,7 +1084,7 @@ pub fn is_block_all_visible(
     }
 }
 
-// Helper function to convert Bitmapset to Vec<i32>
+// Helper function to check if a Bitmapset is empty
 unsafe fn bms_is_empty(bms: *mut pg_sys::Bitmapset) -> bool {
     let mut set_bit: i32 = -1;
     // Get the set bits, which are offsets into the RangeTable.

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1119,39 +1119,39 @@ unsafe fn is_partitioned_table_setup(
         if (*rte).relkind as u8 != pg_sys::RELKIND_RELATION {
             continue;
         }
-    }
 
-    // Check if this relation belongs to a partitioned table in baserels
-    // We'll do this by checking for overlaps between baserels and partitioned tables
+        // Check if this relation belongs to a partitioned table in baserels
+        // We'll do this by checking for overlaps between baserels and partitioned tables
 
-    // Iterate through all relations to find partitioned tables
-    for i in 0..(*root).simple_rel_array_size as usize {
-        let possible_parent_ptr = *(*root).simple_rel_array.add(i);
-        if possible_parent_ptr.is_null() {
-            continue;
-        }
+        // Iterate through all relations to find partitioned tables
+        for i in 0..(*root).simple_rel_array_size as usize {
+            let possible_parent_ptr = *(*root).simple_rel_array.add(i);
+            if possible_parent_ptr.is_null() {
+                continue;
+            }
 
-        let possible_parent = &*possible_parent_ptr;
+            let possible_parent = &*possible_parent_ptr;
 
-        // Skip if not in baserels
-        if !pg_sys::bms_is_member(i as i32, baserels) {
-            continue;
-        }
+            // Skip if not in baserels
+            if !pg_sys::bms_is_member(i as i32, baserels) {
+                continue;
+            }
 
-        // Skip if it doesn't have partitions
-        if possible_parent.all_partrels.is_null() {
-            continue;
-        }
+            // Skip if it doesn't have partitions
+            if possible_parent.all_partrels.is_null() {
+                continue;
+            }
 
-        // Check if the possible parent's RTE is a partitioned table
-        let parent_rte = pg_sys::rt_fetch(i as pg_sys::Index, rtable);
-        if (*parent_rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
-            continue;
-        }
+            // Check if the possible parent's RTE is a partitioned table
+            let parent_rte = pg_sys::rt_fetch(i as pg_sys::Index, rtable);
+            if (*parent_rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
+                continue;
+            }
 
-        // Check if our member is one of its partitions
-        if pg_sys::bms_is_subset(rel_relids, possible_parent.all_partrels) {
-            return true;
+            // Check if our member is one of its partitions
+            if pg_sys::bms_is_member(member, possible_parent.all_partrels) {
+                return true;
+            }
         }
     }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -81,53 +81,6 @@ impl ExecMethod for PdbScan {
     }
 }
 
-unsafe fn bms_to_integers(bms: *mut pg_sys::Bitmapset) -> Vec<i32> {
-    let mut set_bit: i32 = -1;
-    let mut result = Vec::new();
-    loop {
-        // Get the set bits, which are offsets into the RangeTable.
-        set_bit = pg_sys::bms_next_member(bms, set_bit);
-        if set_bit < 0 {
-            break;
-        }
-
-        result.push(set_bit);
-    }
-    result
-}
-
-unsafe fn bms_to_reloids(
-    root: *mut pg_sys::PlannerInfo,
-    bms: *mut pg_sys::Bitmapset,
-) -> Vec<String> {
-    bms_to_integers(bms)
-        .into_iter()
-        .map(|range_table_index| {
-            // Get the relevant range table entry.
-            let rte = pg_sys::rt_fetch(range_table_index as pg_sys::Index, (*(*root).parse).rtable);
-            let partition_info = if (*rte).relkind as u8 == pg_sys::RELKIND_PARTITIONED_TABLE {
-                // If the rte is a partitioned table, figure out what partitions are
-                // involved.
-                let partitioned_table_reloptinfo = (*root)
-                    .simple_rel_array
-                    .offset(range_table_index as isize)
-                    .read();
-                format!(
-                    " (partition relids: {:?})",
-                    bms_to_integers((*partitioned_table_reloptinfo).all_partrels)
-                )
-            } else {
-                "".to_owned()
-            };
-            format!(
-                "range_table_index: {range_table_index}, relid: {:?}, relkind: {}{partition_info}",
-                (*rte).relid,
-                (*rte).relkind
-            )
-        })
-        .collect()
-}
-
 impl CustomScan for PdbScan {
     const NAME: &'static CStr = c"ParadeDB Scan";
 
@@ -178,13 +131,6 @@ impl CustomScan for PdbScan {
             #[cfg(any(feature = "pg16", feature = "pg17"))]
             let baserels = (*builder.args().root).all_query_rels;
 
-            pgrx::log!(
-                ">>> limit_tuples: {:?}, relids: {:?}, baserels: {:?}",
-                (*builder.args().root).limit_tuples,
-                bms_to_reloids(root, (*builder.args().rel).relids),
-                bms_to_reloids(root, baserels),
-            );
-
             let limit = if (*builder.args().root).limit_tuples > -1.0 {
                 // Check if this is a single relation or a partitioned table setup
                 let rel_is_single_or_partitioned =
@@ -194,13 +140,6 @@ impl CustomScan for PdbScan {
                             (*builder.args().rel).relids,
                             baserels,
                         );
-
-                pgrx::log!(
-                    ">>> rel_is_single_or_partitioned: {}, bms_equal: {}, is_partitioned_table_setup: {}",
-                    rel_is_single_or_partitioned,
-                    pg_sys::bms_equal((*builder.args().rel).relids, baserels),
-                    is_partitioned_table_setup(builder.args().root, (*builder.args().rel).relids, baserels)
-                );
 
                 if rel_is_single_or_partitioned {
                     // We can use the limit for estimates if:
@@ -220,11 +159,6 @@ impl CustomScan for PdbScan {
             let ff_cnt =
                 exec_methods::fast_fields::count(&mut builder, rti, &table, &schema, target_list);
             let maybe_ff = builder.custom_private().maybe_ff();
-
-            pgrx::log!(
-                ">>> limit: {limit:?}, pathkey.is_some(): {}",
-                pathkey.is_some()
-            );
 
             let is_topn = limit.is_some() && pathkey.is_some();
             let which_fast_fields = exec_methods::fast_fields::collect(
@@ -297,8 +231,6 @@ impl CustomScan for PdbScan {
                 builder.custom_private().set_range_table_index(rti);
                 builder.custom_private().set_quals(quals);
                 builder.custom_private().set_limit(limit);
-
-                pgrx::log!(">>> is_topn: {is_topn}");
 
                 if is_topn {
                     // sorting by a field only works if we're not doing const projections
@@ -383,8 +315,6 @@ impl CustomScan for PdbScan {
                     let pathkey_cnt =
                         PgList::<pg_sys::PathKey>::from_pg((*builder.args().root).query_pathkeys)
                             .len();
-
-                    pgrx::log!(">>> pathkey_cnt: {pathkey_cnt}, cardinality: {cardinality}");
 
                     if pathkey_cnt == 1 || cardinality > 1_000_000.0 {
                         // if we only have 1 path key or if our estimated cardinality is over some
@@ -1155,7 +1085,34 @@ pub fn is_block_all_visible(
     }
 }
 
-// Add helper function to determine if we're dealing with a partitioned table setup
+// Helper function to convert Bitmapset to Vec<i32>
+unsafe fn bms_is_empty(bms: *mut pg_sys::Bitmapset) -> bool {
+    let mut set_bit: i32 = -1;
+    // Get the set bits, which are offsets into the RangeTable.
+    set_bit = pg_sys::bms_next_member(bms, set_bit);
+    if set_bit < 0 {
+        return true;
+    }
+    false
+}
+
+// Helper function to convert Bitmapset to Vec<i32>
+unsafe fn bms_to_integers(bms: *mut pg_sys::Bitmapset) -> Vec<i32> {
+    let mut set_bit: i32 = -1;
+    let mut result = Vec::new();
+    loop {
+        // Get the set bits, which are offsets into the RangeTable.
+        set_bit = pg_sys::bms_next_member(bms, set_bit);
+        if set_bit < 0 {
+            break;
+        }
+
+        result.push(set_bit);
+    }
+    result
+}
+
+// Helper function to determine if we're dealing with a partitioned table setup
 unsafe fn is_partitioned_table_setup(
     root: *mut pg_sys::PlannerInfo,
     rel_relids: *mut pg_sys::Bitmapset,
@@ -1163,30 +1120,14 @@ unsafe fn is_partitioned_table_setup(
 ) -> bool {
     use pgrx::pg_sys::{self};
 
-    pgrx::log!(">>> Entering is_partitioned_table_setup");
-
-    // Get all the RTEs and print their relation kind
-    let rtable = (*(*root).parse).rtable;
-    let rtable_list = pgrx::PgList::<pg_sys::RangeTblEntry>::from_pg(rtable);
-
-    for (i, rte) in rtable_list.iter_ptr().enumerate() {
-        let relkind_str = match (*rte).relkind as u8 {
-            k if k == pg_sys::RELKIND_RELATION => "RELATION",
-            k if k == pg_sys::RELKIND_PARTITIONED_TABLE => "PARTITIONED_TABLE",
-            _ => "OTHER",
-        };
-        pgrx::log!(
-            ">>> RTE {}: relid: {:?}, relkind: {} ({})",
-            i + 1,
-            (*rte).relid,
-            (*rte).relkind,
-            relkind_str
-        );
+    // Get the relids of our current relation
+    if bms_is_empty(rel_relids) {
+        return false;
     }
 
     // Find partitioned tables in the baserels
     let baserels_ints = bms_to_integers(baserels);
-    pgrx::log!(">>> Baserels: {:?}", baserels_ints);
+    let rtable = (*(*root).parse).rtable;
 
     for baserel_idx in baserels_ints {
         // Skip invalid indices
@@ -1197,19 +1138,12 @@ unsafe fn is_partitioned_table_setup(
         // Get the RTE for this baserel
         let rte = pg_sys::rt_fetch(baserel_idx as pg_sys::Index, rtable);
         if (*rte).relkind as u8 != pg_sys::RELKIND_PARTITIONED_TABLE {
-            pgrx::log!(">>> Baserel {} is not a partitioned table", baserel_idx);
             continue;
         }
-
-        pgrx::log!(">>> Found partitioned table at index {}", baserel_idx);
 
         // This is a partitioned table, get its RelOptInfo to find partitions
         let rel_info_ptr = *(*root).simple_rel_array.add(baserel_idx as usize);
         if rel_info_ptr.is_null() {
-            pgrx::log!(
-                ">>> RelOptInfo is null for partitioned table {}",
-                baserel_idx
-            );
             continue;
         }
 
@@ -1217,41 +1151,15 @@ unsafe fn is_partitioned_table_setup(
 
         // Check if it has partitions
         if rel_info.all_partrels.is_null() {
-            pgrx::log!(">>> Partitioned table {} has no partrels", baserel_idx);
             continue;
         }
 
-        // Get all partition relids
-        let partition_relids = bms_to_integers(rel_info.all_partrels);
-        pgrx::log!(
-            ">>> Partitioned table {} has partrels: {:?}",
-            baserel_idx,
-            partition_relids
-        );
-
-        // Check if our rel_relids is one of the partitions
-        let rel_relids_ints = bms_to_integers(rel_relids);
-        pgrx::log!(">>> Current rel_relids: {:?}", rel_relids_ints);
-
-        for rel_relid in rel_relids_ints {
-            if partition_relids.contains(&rel_relid) {
-                pgrx::log!(
-                    ">>> Found match! rel_relid {} is a partition of baserel {}",
-                    rel_relid,
-                    baserel_idx
-                );
-                return true;
-            }
-        }
-
-        // Another approach: check if any bit in all_partrels is also set in rel_relids
-        let is_overlap = !pg_sys::bms_overlap(rel_info.all_partrels, rel_relids);
-        pgrx::log!(">>> Bitmap overlap check: {}", is_overlap);
+        // Alternative approach using direct bitmap operations
+        let is_overlap = pg_sys::bms_overlap(rel_info.all_partrels, rel_relids);
         if is_overlap {
             return true;
         }
     }
 
-    pgrx::log!(">>> No partition relationship found");
     false
 }

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -973,7 +973,7 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
 }
 
 #[rstest]
-#[ignore]
+#[should_panic]
 fn view_no_order_by_limit_pushdown(mut conn: PgConnection) {
     // First drop any existing tables or views
     r#"

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -974,6 +974,7 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
 
 #[rstest]
 #[should_panic]
+// This test is broken until issue #2200 is fixed
 fn view_no_order_by_limit_pushdown(mut conn: PgConnection) {
     // First drop any existing tables or views
     r#"

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -961,12 +961,13 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
 
     // Check that the first result is the earliest date
     if !results.is_empty() {
-        let earliest_date = results[0].1.clone();
+        let mut prev_date = &results[0].1;
         for result in &results[1..] {
             assert!(
-                result.1 >= earliest_date,
+                &result.1 >= prev_date,
                 "Results should be sorted by date in ascending order"
             );
+            prev_date = &result.1;
         }
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2405

## What
Enable ORDER BY LIMIT push down optimization for BM25 indexes on partitioned tables.

## Why
Previously, when running queries with ORDER BY LIMIT on partitioned tables with BM25 indexes, the TopN optimization was not applied. This resulted in less efficient execution, as each partition was scanned separately using NormalScanExecState, and sorting/limiting was done after combining results.

## How
- Modified the limit detection logic to recognize when we're dealing with a partitioned table structure
- Created a helper function `is_partitioned_table_setup` that:
  - Examines all partitioned tables in baserels
  - Checks if our current relation is a partition of any of these tables using bitmap operations
  - Uses direct bitmap overlap check (bms_overlap) for efficient relationship detection
- When a partition relationship is detected, the TopN optimization is applied, pushing down ORDER BY and LIMIT to the scan level

## Tests
- Added a test case 'partitioned_order_by_limit_pushdown' that verifies the optimizer correctly uses TopNScanExecState for BM25 indexes on partitioned tables and ensures results are properly sorted
- Added a counter-example test 'non_partitioned_no_order_by_limit_pushdown' that confirms the optimization is not applied to non-partitioned tables in UNION queries, correctly using NormalScanExecState instead
- Identified and documented issue #2441 with an ignored test case: `view_no_order_by_limit_pushdown`

All tests validate both the query execution plan and the correctness of query results, ensuring the optimization produces the expected outcome.