### PR TITLE
fix: issue #2442 -- using the `normalizer` setting requires `fast:true`

### DIFF
--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -262,6 +262,11 @@ impl SearchFieldConfig {
         }?;
 
         let normalizer = match obj.get("normalizer") {
+            Some(_) if !fast => {
+                return Err(anyhow::anyhow!(
+                    "'normalizer' is only valid when `\"fast\": true`"
+                ))
+            }
             Some(v) => serde_json::from_value(v.clone()),
             None => Ok(SearchNormalizer::Raw),
         }?;

--- a/tests/tests/term.rs
+++ b/tests/tests/term.rs
@@ -176,7 +176,7 @@ fn text_term(mut conn: PgConnection) {
     USING bm25 (id, value_text, value_varchar, value_uuid) WITH (key_field='id', text_fields='{
         "value_text": {}, 
         "value_varchar": {}, 
-        "value_uuid": {"tokenizer": {"type": "raw"}, "normalizer": "raw", "record": "basic", "fieldnorms": false}
+        "value_uuid": {"tokenizer": {"type": "raw"}, "normalizer": "raw", "record": "basic", "fieldnorms": false, "fast": true}
     }');
     "#
     .execute(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2442

## What

In order to set a normalizer, the field must be a fast field.  

## Why

Otherwise, while the setting would have no effect, it's very confusing to know you've set a `normalizer` but then never see it in the `paradedb.schema()` output.

## How

Raise an error if `normalizer` is set but the field isn't `fast: true`

## Tests

There's a new test to validate we now raise an error and an existing test needed to be adjusted because it set a normalizer but didn't also set the field to fast.