### PR TITLE
fix: don't default to `stored = true`

### DIFF
--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -146,7 +146,7 @@ pub enum SearchFieldConfig {
         indexed: bool,
         #[serde(default)]
         fast: bool,
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default = "default_as_true")]
         fieldnorms: bool,
@@ -164,7 +164,7 @@ pub enum SearchFieldConfig {
         indexed: bool,
         #[serde(default)]
         fast: bool,
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default = "default_as_true")]
         fieldnorms: bool,
@@ -180,7 +180,7 @@ pub enum SearchFieldConfig {
         column: Option<String>,
     },
     Range {
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default)]
         column: Option<String>,
@@ -190,7 +190,7 @@ pub enum SearchFieldConfig {
         indexed: bool,
         #[serde(default = "default_as_true")]
         fast: bool,
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default)]
         column: Option<String>,
@@ -200,7 +200,7 @@ pub enum SearchFieldConfig {
         indexed: bool,
         #[serde(default = "default_as_true")]
         fast: bool,
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default)]
         column: Option<String>,
@@ -210,7 +210,7 @@ pub enum SearchFieldConfig {
         indexed: bool,
         #[serde(default = "default_as_true")]
         fast: bool,
-        #[serde(default = "default_as_false")]
+        #[serde(default)]
         stored: bool,
         #[serde(default)]
         column: Option<String>,
@@ -986,10 +986,6 @@ pub enum SearchIndexSchemaError {
 }
 
 fn default_as_true() -> bool {
-    true
-}
-
-fn default_as_false() -> bool {
     true
 }
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -1083,7 +1083,7 @@ mod tests {
         let json = r#"{
             "indexed": true,
             "fast": false,
-            "stored": true,
+            "stored": false,
             "fieldnorms": true,
             "type": "default",
             "record": "basic",
@@ -1109,7 +1109,7 @@ mod tests {
     fn test_search_numeric_options() {
         let json = r#"{
             "indexed": true,
-            "stored": true,
+            "stored": false,
             "fieldnorms": false,
             "fast": true
         }"#;
@@ -1125,7 +1125,7 @@ mod tests {
     fn test_search_boolean_options() {
         let json = r#"{
             "indexed": true,
-            "stored": true,
+            "stored": false,
             "fieldnorms": false,
             "fast": true
         }"#;
@@ -1142,7 +1142,7 @@ mod tests {
         let json = r#"{
             "indexed": true,
             "fast": false,
-            "stored": true,
+            "stored": false,
             "expand_dots": true,
             "type": "default",
             "record": "basic",

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -509,3 +509,21 @@ fn language_stem_filter(mut conn: PgConnection) {
         .execute(&mut conn);
     }
 }
+
+#[rstest]
+fn default_config_is_stored_false(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+
+    CREATE INDEX bm25_search_idx ON paradedb.bm25_search
+        USING bm25 (id, description)
+        WITH (key_field='id');
+    "#
+    .execute(&mut conn);
+
+    // we are using our default configurations for this index and none of them should be `stored = true`
+    let count: (i64,) =
+        r#"SELECT COUNT(*) FROM paradedb.schema('paradedb.bm25_search_idx') WHERE stored = true"#
+            .fetch_one(&mut conn);
+    assert_eq!(count.0, 0);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We don't use tantivy's document store and we **want** all fields to **NOT** be stored.

This PR fixes an issue where indexed fields that use our default configurations would actually default to `stored = true`.  This wastes space and time -- two precious resources.

## Why

## How

## Tests

A new test was added and existing tests pass.