### PR TITLE
feat: Upgraded Barman Cloud to version 3.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ COPY --from=builder-pg_search /tmp/target/release/pg_search-pg${PG_VERSION_MAJOR
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libpq5 python3-pip python3-dev python3-psycopg2 && \
     rm /usr/lib/python*/EXTERNALLY-MANAGED && \
-    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]<3.12' && \
+    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]==3.13.2' && \
     apt-get remove -y python3-dev python3-pip --purge && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2431 

## What

Upgrades and pins Barman to `v3.13.2`

## Why

## How

## Tests

