### PR TITLE
fix: Remove unnecessary sorts, and add necessary sorts

### DIFF
--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -277,17 +277,15 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
         self
     }
 
-    pub fn add_path_key(mut self, pathkey: &Option<OrderByStyle>) -> Self {
+    pub fn add_path_key(mut self, style: &OrderByStyle) -> Self {
         unsafe {
-            if let Some(style) = pathkey {
-                let mut pklist =
-                    PgList::<pg_sys::PathKey>::from_pg(self.custom_path_node.path.pathkeys);
-                pklist.push(style.pathkey());
+            let mut pklist =
+                PgList::<pg_sys::PathKey>::from_pg(self.custom_path_node.path.pathkeys);
+            pklist.push(style.pathkey());
 
-                self.custom_path_node.path.pathkeys = pklist.into_pg();
-            }
-            self
+            self.custom_path_node.path.pathkeys = pklist.into_pg();
         }
+        self
     }
 
     pub fn set_force_path(mut self, force: bool) -> Self {

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -299,8 +299,6 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
 
     pub fn set_parallel(
         mut self,
-        is_topn: bool,
-        row_estimate: Cardinality,
         limit: Option<Cardinality>,
         segment_count: usize,
         sorted: bool,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -78,6 +78,7 @@ impl From<SortDirection> for u32 {
     }
 }
 
+#[derive(Debug)]
 pub enum OrderByStyle {
     Score(*mut pg_sys::PathKey),
     Field(*mut pg_sys::PathKey, String),

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -324,7 +324,7 @@ impl CustomScan for PdbScan {
                     if pathkey_cnt == 1 || cardinality > 1_000_000.0 {
                         // if we only have 1 path key or if our estimated cardinality is over some
                         // hardcoded value, it's seemingly more efficient to do a parallel scan
-                        builder = builder.set_parallel(false, rows, limit, segment_count, true);
+                        builder = builder.set_parallel(limit, segment_count, true);
                     } else {
                         // otherwise we'll do a regular scan and indicate that we're emitting results
                         // sorted by the first pathkey
@@ -334,8 +334,6 @@ impl CustomScan for PdbScan {
                 } else {
                     let sortdir = builder.custom_private().sort_direction();
                     builder = builder.set_parallel(
-                        is_topn,
-                        rows,
                         limit,
                         segment_count,
                         !matches!(sortdir, Some(SortDirection::None)) && sortdir.is_some(),

--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -1,9 +1,10 @@
+use crate::api::Cardinality;
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::pdbscan::PdbScan;
 use crate::postgres::customscan::CustomScan;
 use crate::postgres::ParallelScanState;
-use pgrx::pg_sys::{shm_toc, ParallelContext, Size};
+use pgrx::pg_sys::{self, shm_toc, ParallelContext, Size};
 use std::collections::HashSet;
 use std::os::raw::c_void;
 use tantivy::index::SegmentId;
@@ -81,6 +82,39 @@ impl ParallelQueryCapable for PdbScan {
             }
         }
     }
+}
+
+///
+/// Compute the number of workers that should be used for the given limit, segment_count, and sort
+/// condition, or return 0 if workers cannot or should not be used.
+///
+pub fn compute_nworkers(limit: Option<Cardinality>, segment_count: usize, sorted: bool) -> usize {
+    // we will try to parallelize based on the number of index segments
+    let mut nworkers = unsafe { segment_count.min(pg_sys::max_parallel_workers as usize) };
+
+    if let Some(limit) = limit {
+        if !sorted && limit <= (segment_count * segment_count * segment_count) as Cardinality {
+            // not worth it to do a parallel scan
+            return 0;
+        }
+
+        // if the limit is less than some arbitrarily large value
+        // use at most half the number of parallel workers as there are segments
+        // this generally seems to perform better than directly using `max_parallel_workers`
+        if limit < 1_000_000.0 {
+            nworkers = (segment_count / 2).min(nworkers);
+        }
+    }
+
+    #[cfg(not(any(feature = "pg14", feature = "pg15")))]
+    unsafe {
+        if nworkers == 0 && pg_sys::debug_parallel_query != 0 {
+            // force a parallel worker if the `debug_parallel_query` GUC is on
+            nworkers = 1;
+        }
+    }
+
+    nworkers
 }
 
 pub unsafe fn checkout_segment(pscan_state: *mut ParallelScanState) -> Option<SegmentId> {

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -77,14 +77,12 @@ impl PrivateData {
         self.sort_direction = sort_direction;
     }
 
-    pub fn set_sort_info(&mut self, pathkey: &Option<OrderByStyle>) {
-        if let Some(style) = pathkey {
-            match style {
-                OrderByStyle::Score(_) => {}
-                OrderByStyle::Field(_, name) => self.sort_field = Some(name.clone()),
-            }
-            self.sort_direction = Some(style.direction())
+    pub fn set_sort_info(&mut self, style: &OrderByStyle) {
+        match &style {
+            OrderByStyle::Score(_) => {}
+            OrderByStyle::Field(_, name) => self.sort_field = Some(name.clone()),
         }
+        self.sort_direction = Some(style.direction())
     }
 
     pub fn set_var_attname_lookup(&mut self, var_attname_lookup: *mut pg_sys::List) {

--- a/tests/tests/sorting.rs
+++ b/tests/tests/sorting.rs
@@ -84,6 +84,9 @@ fn sort_by_lower_parallel(mut conn: PgConnection) {
     "SET max_parallel_workers = 8;".execute(&mut conn);
     if pg_major_version(&mut conn) >= 16 {
         "SET debug_parallel_query TO on".execute(&mut conn);
+    } else {
+        // We cannot reliably force parallel workers to be used without `debug_parallel_query`.
+        return;
     }
     let plan = field_sort_fixture(&mut conn);
     let plan = plan


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2405

## What

The last piece of #2405 was ensuring that we declare sorted outputs sorted, by marking the resulting plan with the relevant `pathkey`.

But additionally:
* we were occasionally marking parallel-workers results sorted, which is not correct because each worker might consume multiple segments.
* we were not marking some other cases where we push down sorting to Tantivy as resulting in sorted outputs, meaning that Postgres would re-sort them. 

## Why

The early-cutoff feature described in #2405 requires that outputs are declared sorted.

## Tests

Added tests for partitioned early cutoff, and tests that we do not declare any output sorted when parallel workers are used.