### PR TITLE
fix: Improve atomicity of `LinkedItemList`s

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -346,11 +346,11 @@ fn storage_info(
     let segment_components =
         LinkedItemList::<SegmentMetaEntry>::open(index.oid(), SEGMENT_METAS_START);
     let bman = segment_components.bman();
-    let mut blockno = segment_components.get_start_blockno();
+    let (mut blockno, mut buffer) = segment_components.get_start_blockno();
     let mut data = vec![];
 
     while blockno != pg_sys::InvalidBlockNumber {
-        let buffer = bman.get_buffer(blockno);
+        buffer = bman.get_buffer_exchange(blockno, buffer);
         let page = buffer.page();
         let max_offset = page.max_offset_number();
         data.push((blockno as i64, max_offset as i32));

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -19,22 +19,22 @@ use tantivy::{
 };
 
 pub fn save_schema(relation_oid: pg_sys::Oid, tantivy_schema: &Schema) -> Result<()> {
-    let mut schema = LinkedBytesList::open(relation_oid, SCHEMA_START);
+    let schema = LinkedBytesList::open(relation_oid, SCHEMA_START);
     if schema.is_empty() {
         let bytes = serde_json::to_vec(tantivy_schema)?;
         unsafe {
-            let _ = schema.write(&bytes)?;
+            schema.writer().write(&bytes)?;
         }
     }
     Ok(())
 }
 
 pub fn save_settings(relation_oid: pg_sys::Oid, tantivy_settings: &IndexSettings) -> Result<()> {
-    let mut settings = LinkedBytesList::open(relation_oid, SETTINGS_START);
+    let settings = LinkedBytesList::open(relation_oid, SETTINGS_START);
     if settings.is_empty() {
         let bytes = serde_json::to_vec(tantivy_settings)?;
         unsafe {
-            let _ = settings.write(&bytes)?;
+            settings.writer().write(&bytes)?;
         }
     }
     Ok(())

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -1,7 +1,7 @@
 use crate::index::mvcc::{MvccSatisfies, PinCushion};
 use crate::postgres::storage::block::{
-    DeleteEntry, FileEntry, MVCCEntry, PgItem, SegmentFileDetails, SegmentMetaEntry, SCHEMA_START,
-    SEGMENT_METAS_START, SETTINGS_START,
+    DeleteEntry, FileEntry, LinkedList, MVCCEntry, PgItem, SegmentFileDetails, SegmentMetaEntry,
+    SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
 };
 use crate::postgres::storage::merge::MergeLock;
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -48,8 +48,9 @@ pub unsafe fn save_new_metas(
 ) -> Result<()> {
     // in order to ensure that all of our mutations to the list of segments appear atomically on
     // physical replicas, we atomically operate on a deep copy of the list.
-    let mut linked_list =
-        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START).atomically();
+    let mut segment_metas_linked_list =
+        LinkedItemList::<SegmentMetaEntry>::open(relation_oid, SEGMENT_METAS_START);
+    let mut linked_list = segment_metas_linked_list.atomically();
 
     let incoming_segments = new_meta
         .segments

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -1,5 +1,5 @@
 use crate::postgres::storage::block::{bm25_max_free_space, FileEntry};
-use crate::postgres::storage::LinkedBytesList;
+use crate::postgres::storage::{LinkedBytesList, LinkedBytesListWriter};
 use pgrx::*;
 use std::io::{Result, Write};
 use std::path::{Path, PathBuf};
@@ -11,7 +11,7 @@ pub struct SegmentComponentWriter {
     path: PathBuf,
     header_blockno: pg_sys::BlockNumber,
     total_bytes: Arc<AtomicUsize>,
-    buffer: ExactBuffer<{ bm25_max_free_space() }, LinkedBytesList>,
+    buffer: ExactBuffer<{ bm25_max_free_space() }, LinkedBytesListWriter>,
 }
 
 impl SegmentComponentWriter {
@@ -23,7 +23,7 @@ impl SegmentComponentWriter {
             header_blockno: segment_component.header_blockno,
             total_bytes: Default::default(),
             buffer: ExactBuffer {
-                writer: segment_component,
+                writer: segment_component.writer(),
                 buffer: [0; bm25_max_free_space()],
                 len: 0,
             },

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -419,10 +419,11 @@ pub unsafe fn merge_index_with_policy(
 
 unsafe fn garbage_collect_index(indexrel: &PgRelation) {
     let indexrelid = indexrel.oid();
-    let mut segment_meta_list =
-        LinkedItemList::<SegmentMetaEntry>::open(indexrelid, SEGMENT_METAS_START).atomically();
-    let recycled_entries = segment_meta_list.garbage_collect();
-    segment_meta_list.commit();
+    let mut segment_metas_linked_list =
+        LinkedItemList::<SegmentMetaEntry>::open(indexrelid, SEGMENT_METAS_START);
+    let mut segment_metas = segment_metas_linked_list.atomically();
+    let recycled_entries = segment_metas.garbage_collect();
+    segment_metas.commit();
     for entry in recycled_entries {
         for (file_entry, _) in entry.file_entries() {
             LinkedBytesList::open(indexrelid, file_entry.starting_block).return_to_fsm();

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -417,17 +417,45 @@ pub unsafe fn merge_index_with_policy(
     (ncandidates, nmerged)
 }
 
+///
+/// Garbage collect the segments, removing any which are no longer visible in transactions
+/// occurring in this process.
+///
+/// If physical replicas might still be executing transactions on some segments, then they are
+/// moved to the `SEGMENT_METAS_GARBAGE` list until those replicas indicate that they are no longer
+/// in use, at which point they can be freed by `free_garbage`.
+///
 unsafe fn garbage_collect_index(indexrel: &PgRelation) {
     let indexrelid = indexrel.oid();
+
+    // Remove items which are no longer visible to active local transactions from SEGMENT_METAS,
+    // and place them in SEGMENT_METAS_RECYLCABLE until they are no longer visible to remote
+    // transactions either.
+    //
+    // SEGMENT_METAS must be updated atomically so that a consistent list is visible for consumers:
+    // SEGMENT_METAS_GARBAGE need not be because it is only ever consumed on the physical
+    // replication primary.
     let mut segment_metas_linked_list =
         LinkedItemList::<SegmentMetaEntry>::open(indexrelid, SEGMENT_METAS_START);
     let mut segment_metas = segment_metas_linked_list.atomically();
-    let recycled_entries = segment_metas.garbage_collect();
+    let entries = segment_metas.garbage_collect();
+
+    // Replication is not enabled: immediately free the entries. It doesn't matter when we
+    // commit the segment metas list in this case.
     segment_metas.commit();
-    for entry in recycled_entries {
+    free_entries(indexrel, entries);
+}
+
+pub fn free_entries(indexrel: &PgRelation, freeable_entries: Vec<SegmentMetaEntry>) {
+    for entry in freeable_entries {
         for (file_entry, _) in entry.file_entries() {
-            LinkedBytesList::open(indexrelid, file_entry.starting_block).return_to_fsm();
-            pg_sys::IndexFreeSpaceMapVacuum(indexrel.as_ptr());
+            unsafe {
+                LinkedBytesList::open(indexrel.oid(), file_entry.starting_block).return_to_fsm();
+            }
         }
+    }
+
+    unsafe {
+        pg_sys::IndexFreeSpaceMapVacuum(indexrel.as_ptr());
     }
 }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -115,6 +115,7 @@ pub trait LinkedList {
 
     fn block_for_ord(&self, ord: usize) -> Option<pg_sys::BlockNumber>;
 
+    // TODO: Remove.
     unsafe fn get_linked_list_data(&self) -> LinkedListData;
 }
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::storage::buffer::BufferManager;
+use crate::postgres::storage::buffer::{Buffer, BufferManager, BufferMut};
 use pgrx::pg_sys::BlockNumber;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
@@ -88,20 +88,43 @@ impl Debug for LinkedListData {
 
 /// Every linked list must implement this trait
 pub trait LinkedList {
-    // Required methods
     fn get_header_blockno(&self) -> pg_sys::BlockNumber;
 
-    // Provided methods
-    fn get_start_blockno(&self) -> pg_sys::BlockNumber {
-        let metadata = unsafe { self.get_linked_list_data() };
+    fn bman(&self) -> &BufferManager;
+
+    fn bman_mut(&mut self) -> &mut BufferManager;
+
+    ///
+    /// Get the start blockno of the LinkedList, and return a Buffer for the header block of
+    /// the list, which must be held until the start blockno is actually dereferenced.
+    ///
+    fn get_start_blockno(&self) -> (pg_sys::BlockNumber, Buffer) {
+        let buffer = self.bman().get_buffer(self.get_header_blockno());
+        let metadata = buffer.page().contents::<LinkedListData>();
         let start_blockno = metadata.start_blockno;
         assert!(start_blockno != 0);
         assert!(start_blockno != pg_sys::InvalidBlockNumber);
-        start_blockno
+        (start_blockno, buffer)
+    }
+
+    ///
+    /// See `get_start_blockno`.
+    ///
+    fn get_start_blockno_mut(&mut self) -> (pg_sys::BlockNumber, BufferMut) {
+        let header_blockno = self.get_header_blockno();
+        let buffer = self.bman_mut().get_buffer_mut(header_blockno);
+        let metadata = buffer.page().contents::<LinkedListData>();
+        let start_blockno = metadata.start_blockno;
+        assert!(start_blockno != 0);
+        assert!(start_blockno != pg_sys::InvalidBlockNumber);
+        (start_blockno, buffer)
     }
 
     fn get_last_blockno(&self) -> pg_sys::BlockNumber {
-        let metadata = unsafe { self.get_linked_list_data() };
+        // TODO: If concurrency is a concern for "append" cases, then we'd want to iterate from the
+        // hand-over-hand from the head to the tail rather than jumping immediately to the tail.
+        let buffer = self.bman().get_buffer(self.get_header_blockno());
+        let metadata = buffer.page().contents::<LinkedListData>();
         let last_blockno = metadata.last_blockno;
         assert!(last_blockno != 0);
         assert!(last_blockno != pg_sys::InvalidBlockNumber);
@@ -109,14 +132,21 @@ pub trait LinkedList {
     }
 
     fn npages(&self) -> u32 {
-        let metadata = unsafe { self.get_linked_list_data() };
-        metadata.npages - 1
+        let buffer = self.bman().get_buffer(self.get_header_blockno());
+        buffer.page().contents::<LinkedListData>().npages - 1
     }
 
     fn block_for_ord(&self, ord: usize) -> Option<pg_sys::BlockNumber>;
 
-    // TODO: Remove.
-    unsafe fn get_linked_list_data(&self) -> LinkedListData;
+    ///
+    /// Note: It is not safe to begin iteration of the list using this method, as the buffer for
+    /// the metadata is released when it returns. Use `get_start_blockno` to begin iteration.
+    unsafe fn get_linked_list_data(&self) -> LinkedListData {
+        self.bman()
+            .get_buffer(self.get_header_blockno())
+            .page()
+            .contents::<LinkedListData>()
+    }
 }
 
 // ---------------------------------------------------------

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -36,10 +36,6 @@ impl Buffer {
         }
     }
 
-    pub fn page_contents<T: Copy>(&self) -> T {
-        self.page().contents()
-    }
-
     pub fn number(&self) -> pg_sys::BlockNumber {
         unsafe { pg_sys::BufferGetBlockNumber(self.pg_buffer) }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -114,8 +114,8 @@ impl BufferMut {
     pub fn return_to_fsm(mut self, bman: &mut BufferManager) {
         unsafe {
             let blockno = self.page_mut().mark_deleted();
-            assert!(
-                blockno > *FIXED_BLOCK_NUMBERS.last().unwrap(),
+            debug_assert!(
+                FIXED_BLOCK_NUMBERS.iter().all(|fb| *fb != blockno),
                 "record_free_index_page: blockno {blockno} cannot ever be recycled"
             );
             pg_sys::RecordPageWithFreeSpace(bman.bcache.indexrel(), blockno, bm25_max_free_space());

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -474,6 +474,18 @@ impl BufferManager {
         }
     }
 
+    ///
+    /// A convenience wrapper around `get_buffer` to handle acquiring a lock on the Buffer for the
+    /// given blockno before releasing the lock on the given Buffer.
+    ///
+    /// Useful for hand-over-hand locking.
+    ///
+    pub fn get_buffer_exchange(&self, blockno: pg_sys::BlockNumber, old_buffer: Buffer) -> Buffer {
+        let buffer = self.get_buffer(blockno);
+        std::mem::drop(old_buffer);
+        buffer
+    }
+
     pub fn get_buffer_mut(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
             BufferMut {
@@ -484,6 +496,19 @@ impl BufferManager {
                 ),
             }
         }
+    }
+
+    ///
+    /// See `get_buffer_exchange`.
+    ///
+    pub fn get_buffer_exchange_mut(
+        &mut self,
+        blockno: pg_sys::BlockNumber,
+        old_buffer: BufferMut,
+    ) -> BufferMut {
+        let buffer = self.get_buffer_mut(blockno);
+        std::mem::drop(old_buffer);
+        buffer
     }
 
     #[allow(dead_code)]

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -275,8 +275,8 @@ impl LinkedBytesList {
         for starting_blockno in [self.metadata.start_blockno, self.metadata.blocklist_start] {
             let mut blockno = starting_blockno;
             while blockno != pg_sys::InvalidBlockNumber {
-                assert!(
-                    blockno > *FIXED_BLOCK_NUMBERS.last().unwrap(),
+                debug_assert!(
+                    FIXED_BLOCK_NUMBERS.iter().all(|fb| *fb != blockno),
                     "mark_deleted:  blockno {blockno} cannot ever be recycled"
                 );
                 let mut buffer = self.bman.get_buffer_mut(blockno);

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -68,27 +68,100 @@ use std::sync::OnceLock;
 pub struct LinkedBytesList {
     bman: BufferManager,
     pub header_blockno: pg_sys::BlockNumber,
-    metadata: LinkedListData,
-    blocklist_builder: blocklist::builder::BlockList,
     blocklist_reader: OnceLock<blocklist::reader::BlockList>,
 }
 
-impl Write for LinkedBytesList {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        unsafe {
-            self.write(buf)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+pub struct LinkedBytesListWriter {
+    list: LinkedBytesList,
+    blocklist_builder: blocklist::builder::BlockList,
+    last_blockno: pg_sys::BlockNumber,
+}
+
+impl LinkedBytesListWriter {
+    pub unsafe fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        let mut data_cursor = Cursor::new(bytes);
+        let mut bytes_written = 0;
+
+        while bytes_written < bytes.len() {
+            check_for_interrupts!();
+            self.blocklist_builder.push(self.last_blockno);
+
+            let mut buffer = self.list.bman.get_buffer_mut(self.last_blockno);
+            let mut page = buffer.page_mut();
+            let free_space = page.header().free_space();
+            assert!(free_space <= bm25_max_free_space());
+
+            let bytes_to_write = min(free_space, bytes.len() - bytes_written);
+            if bytes_to_write == 0 {
+                let mut new_buffer = self.list.bman.new_buffer();
+
+                // Set next blockno
+                let new_blockno = new_buffer.number();
+                let special = page.special_mut::<BM25PageSpecialData>();
+                special.next_blockno = new_blockno;
+
+                // Initialize new page
+                new_buffer.init_page();
+
+                // Set last blockno to new blockno
+                let mut header_buffer = self
+                    .list
+                    .bman
+                    .get_buffer_mut(self.list.get_header_blockno());
+
+                let mut page = header_buffer.page_mut();
+                let metadata = page.contents_mut::<LinkedListData>();
+                metadata.last_blockno = new_blockno;
+                metadata.npages += 1;
+
+                self.last_blockno = new_blockno;
+                continue;
+            }
+
+            let page_slice = page
+                .free_space_slice_mut(bytes_to_write)
+                .expect("page is full");
+            data_cursor.read_exact(page_slice)?;
+            bytes_written += bytes_to_write;
+
+            page.header_mut().pd_lower += bytes_to_write as u16;
         }
+
+        Ok(())
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        if let Some(blockno) = self.blocklist_builder.finish(&mut self.bman) {
-            let mut header_block = self.bman.get_buffer_mut(self.header_blockno);
+    fn flush_inner(&mut self) -> Result<()> {
+        // TODO: Do we need to flush the currently open block in `self.buffer`?
+
+        // TODO: `finish` implies that this method should only be called once: rather than being in
+        // `flush`, it should potentially only be in `finish`?
+        if let Some(blockno) = self.blocklist_builder.finish(&mut self.list.bman) {
+            let mut header_block = self.list.bman.get_buffer_mut(self.list.header_blockno);
             let mut page = header_block.page_mut();
             let metadata = page.contents_mut::<LinkedListData>();
             metadata.blocklist_start = blockno;
         }
         Ok(())
+    }
+
+    pub fn into_inner(mut self) -> Result<LinkedBytesList> {
+        self.flush_inner()?;
+        Ok(self.list)
+    }
+}
+
+impl Write for LinkedBytesListWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        unsafe {
+            self.write(buf)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.flush_inner()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
 }
 
@@ -100,13 +173,17 @@ impl LinkedList for LinkedBytesList {
     fn block_for_ord(&self, ord: usize) -> Option<BlockNumber> {
         self.blocklist_reader
             .get_or_init(|| {
-                blocklist::reader::BlockList::new(&self.bman, self.metadata.blocklist_start)
+                blocklist::reader::BlockList::new(&self.bman, unsafe {
+                    self.get_linked_list_data().blocklist_start
+                })
             })
             .get(ord)
     }
 
     unsafe fn get_linked_list_data(&self) -> LinkedListData {
-        self.metadata
+        let header_buffer = self.bman.get_buffer(self.get_header_blockno());
+        let page = header_buffer.page();
+        page.contents::<LinkedListData>()
     }
 }
 
@@ -156,16 +233,9 @@ impl Deref for RangeData {
 
 impl LinkedBytesList {
     pub fn open(relation_oid: pg_sys::Oid, header_blockno: pg_sys::BlockNumber) -> Self {
-        let bman = BufferManager::new(relation_oid);
-        let metadata = bman
-            .get_buffer(header_blockno)
-            .page_contents::<LinkedListData>();
-
         Self {
-            bman,
+            bman: BufferManager::new(relation_oid),
             header_blockno,
-            metadata,
-            blocklist_builder: Default::default(),
             blocklist_reader: Default::default(),
         }
     }
@@ -190,61 +260,17 @@ impl LinkedBytesList {
         Self {
             bman,
             header_blockno,
-            metadata: *metadata,
-            blocklist_builder: Default::default(),
             blocklist_reader: Default::default(),
         }
     }
 
-    pub unsafe fn write(&mut self, bytes: &[u8]) -> Result<usize> {
-        let mut data_cursor = Cursor::new(bytes);
-        let mut bytes_written = 0;
-
-        let mut insert_blockno = self.get_last_blockno();
-        while bytes_written < bytes.len() {
-            check_for_interrupts!();
-            self.blocklist_builder.push(insert_blockno);
-
-            let mut buffer = self.bman.get_buffer_mut(insert_blockno);
-            let mut page = buffer.page_mut();
-            let free_space = page.header().free_space();
-            assert!(free_space <= bm25_max_free_space());
-
-            let bytes_to_write = min(free_space, bytes.len() - bytes_written);
-            if bytes_to_write == 0 {
-                let mut new_buffer = self.bman.new_buffer();
-
-                // Set next blockno
-                let new_blockno = new_buffer.number();
-                let special = page.special_mut::<BM25PageSpecialData>();
-                special.next_blockno = new_blockno;
-
-                // Initialize new page
-                new_buffer.init_page();
-
-                // Set last blockno to new blockno
-                let mut header_buffer = self.bman.get_buffer_mut(self.get_header_blockno());
-
-                let mut page = header_buffer.page_mut();
-                let metadata = page.contents_mut::<LinkedListData>();
-                metadata.last_blockno = new_blockno;
-                metadata.npages += 1;
-                self.metadata = *metadata;
-
-                insert_blockno = new_blockno;
-                continue;
-            }
-
-            let page_slice = page
-                .free_space_slice_mut(bytes_to_write)
-                .expect("page is full");
-            data_cursor.read_exact(page_slice)?;
-            bytes_written += bytes_to_write;
-
-            page.header_mut().pd_lower += bytes_to_write as u16;
+    pub fn writer(self) -> LinkedBytesListWriter {
+        let last_blockno = self.get_last_blockno();
+        LinkedBytesListWriter {
+            list: self,
+            blocklist_builder: Default::default(),
+            last_blockno,
         }
-
-        Ok(bytes_written)
     }
 
     pub unsafe fn read_all(&self) -> Vec<u8> {
@@ -272,7 +298,8 @@ impl LinkedBytesList {
     pub unsafe fn return_to_fsm(mut self) {
         // in addition to the list itself, we also have a secondary list of linked blocks (which
         // contain the blocknumbers of this list) that needs to be marked deleted too
-        for starting_blockno in [self.metadata.start_blockno, self.metadata.blocklist_start] {
+        let metadata = self.get_linked_list_data();
+        for starting_blockno in [metadata.start_blockno, metadata.blocklist_start] {
             let mut blockno = starting_blockno;
             while blockno != pg_sys::InvalidBlockNumber {
                 debug_assert!(
@@ -381,8 +408,10 @@ mod tests {
         // Test read/write from newly created linked list
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
         let start_blockno = {
-            let mut linked_list = LinkedBytesList::create(relation_oid);
-            linked_list.write(&bytes).unwrap();
+            let linked_list = LinkedBytesList::create(relation_oid);
+            let mut writer = linked_list.writer();
+            writer.write(&bytes).unwrap();
+            let linked_list = writer.into_inner().unwrap();
             let read_bytes = linked_list.read_all();
             assert_eq!(bytes, read_bytes);
 
@@ -404,11 +433,13 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let mut linked_list = LinkedBytesList::create(relation_oid);
+        let linked_list = LinkedBytesList::create(relation_oid);
         assert!(linked_list.is_empty());
 
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
-        linked_list.write(&bytes).unwrap();
+        let mut writer = linked_list.writer();
+        writer.write(&bytes).unwrap();
+        let linked_list = writer.into_inner().unwrap();
         assert!(!linked_list.is_empty());
     }
 
@@ -421,9 +452,11 @@ mod tests {
                 .expect("spi should succeed")
                 .unwrap();
 
-        let mut linked_list = LinkedBytesList::create(relation_oid);
+        let linked_list = LinkedBytesList::create(relation_oid);
         let bytes: Vec<u8> = (1..=255).cycle().take(100_000).collect();
-        linked_list.write(&bytes).unwrap();
+        let mut writer = linked_list.writer();
+        writer.write(&bytes).unwrap();
+        let linked_list = writer.into_inner().unwrap();
         let mut blockno = linked_list.get_start_blockno();
         linked_list.return_to_fsm();
 

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -303,10 +303,10 @@ impl MergeLock {
         }
 
         let relation_id = (*self.bman.bm25cache().indexrel()).rd_id;
-        let mut entries_list =
-            LinkedItemList::<MergeEntry>::open(relation_id, metadata.merge_list).atomically();
+        // Merge entries are only consumed on a primary, and so do not need to be published
+        // atomically.
+        let mut entries_list = LinkedItemList::<MergeEntry>::open(relation_id, metadata.merge_list);
         let recycled_entries = entries_list.garbage_collect();
-        entries_list.commit();
         for recycled_entry in recycled_entries {
             LinkedBytesList::open(relation_id, recycled_entry.segment_ids_start_blockno)
                 .return_to_fsm();

--- a/pg_search/src/postgres/storage/mod.rs
+++ b/pg_search/src/postgres/storage/mod.rs
@@ -98,5 +98,5 @@ pub mod linked_items;
 pub mod merge;
 pub mod utils;
 
-pub use self::linked_bytes::LinkedBytesList;
+pub use self::linked_bytes::{LinkedBytesList, LinkedBytesListWriter};
 pub use self::linked_items::LinkedItemList;


### PR DESCRIPTION
## What

Fix issues with consistency of the `SEGMENT_METAS` list in the presence of physical replication.

## Why

Physical replicas replay the WAL without regard for locks held on the primary. Consequently, there is no lock that we can hold that will prevent a physical replica from consuming a snapshot of the `SegmentMetaEntry`s immediately before one of the segment's files is deleted.

Additionally, two other bugs were causing the `SegmentMetaEntry`s to appear non-atomically on physical replicas: a bug in the `atomically` method, and the lack of hand-over-hand-locking in `LinkedList` implementations.

## How

* Split `LinkedItemList::retain` out of `LinkedItemList::garbage_collect` to provide different selection logic when we're deciding whether something can actually be freed.
* Add a `segment_metas_garbage` list, which contains segments which are no longer visible on a physical replication primary, but which might still be visible on a replica.
* Split out `impl Write for LinkedBytesListWriter` in order to simplify metadata management in `LinkedBytesList`.
* Execute hand-over-hand locking in `LinkedList` implementations to fix segment-corruption issues when partially written or freed pages are accessed.
* Fix issue in `atomically` where the previous content of a list might be freed before the header was flushed.

## Tests

`stressgres`.