### PR TITLE
fix: don't re-merge segments that fall below the layer size

### DIFF
--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -470,7 +470,7 @@ fn force_merge_raw_bytes(
         PgRelation::with_lock(oid, pg_sys::RowExclusiveLock as _)
     };
 
-    let merge_policy = LayeredMergePolicy::new(vec![oversized_layer_size_bytes.try_into()?]);
+    let merge_policy = LayeredMergePolicy::new(vec![oversized_layer_size_bytes.try_into()?], false);
     let (ncandidates, nmerged) =
         unsafe { merge_index_with_policy(index, merge_policy, true, true, true) };
     Ok(TableIterator::once((

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -74,12 +74,6 @@ impl MergePolicy for LayeredMergePolicy {
 
         // Process layer sizes in order from largest to smallest
         for (i, &layer_size) in layer_sizes.iter().enumerate() {
-            // individual segments that total a certain byte amount typically merge together into
-            // a segment of a smaller size than the individual source segments.  So we fudge things
-            // by a third more in the hopes the final segment will be >= to this layer size, ensuring
-            // it doesn't merge again
-            let next_smaller_layer = layer_sizes.get(i + 1).copied().unwrap_or(0);
-
             // collect the list of mergeable segments so that we can combine those that fit in the next layer
             let segments =
                 self.collect_mergeable_segments(original_segments, &merged_segments, avg_doc_size);
@@ -106,6 +100,8 @@ impl MergePolicy for LayeredMergePolicy {
                     continue;
                 }
 
+                // determine whether this segment is closer to the lower or upper layer size
+                let next_smaller_layer = layer_sizes.get(i + 1).copied().unwrap_or(0);
                 if self.exclude_already_merged_segments
                     && is_merged(segment.id(), &self.mergeable_segments)
                     && (next_smaller_layer < actual_size)

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -8,6 +8,8 @@ use tantivy::index::{DeleteMeta, InnerSegmentMeta, SegmentId};
 use tantivy::indexer::{MergeCandidate, MergePolicy};
 use tantivy::{Directory, Inventory, SegmentMeta};
 
+// Because the size of segments that merge together is usually less than the sum of their parts,
+// we multiply the size of the segments by this factor to ensure we don't merge segments too soon
 const LAYER_FUDGE_FACTOR: f64 = 1.33;
 
 #[derive(Debug)]

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -105,8 +105,15 @@ impl MergePolicy for LayeredMergePolicy {
                 if self.exclude_already_merged_segments
                     && is_merged(segment.id(), &self.mergeable_segments)
                     && (next_smaller_layer < actual_size)
-                    && (layer_size - actual_size) > (actual_size - next_smaller_layer)
+                    && (layer_size - actual_size) < (actual_size - next_smaller_layer)
                 {
+                    logger(
+                        directory,
+                        &format!(
+                            "compute_merge_candidates: segment {} was likely created by a previous merge but fell below the target layer size... skipping",
+                            segment.id()
+                        ),
+                    );
                     // this segment was likely created by a previous merge but fell below the target layer size... skip it
                     continue;
                 }

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -78,7 +78,6 @@ impl MergePolicy for LayeredMergePolicy {
             // a segment of a smaller size than the individual source segments.  So we fudge things
             // by a third more in the hopes the final segment will be >= to this layer size, ensuring
             // it doesn't merge again
-            let extended_layer_size = layer_size + layer_size / 3;
             let next_smaller_layer = layer_sizes.get(i + 1).copied().unwrap_or(0);
 
             // collect the list of mergeable segments so that we can combine those that fit in the next layer
@@ -127,12 +126,12 @@ impl MergePolicy for LayeredMergePolicy {
                 candidate_byte_size += actual_size_minus_terms;
                 candidates.last_mut().unwrap().1 .0.push(segment.id());
 
-                if (candidate_byte_size + largest_terms_size) >= extended_layer_size {
+                if (candidate_byte_size + largest_terms_size) >= layer_size {
                     logger(
                         directory,
                         &format!(
                             "compute_merge_candidates: candidate size {} exceeds layer size {}",
-                            candidate_byte_size, extended_layer_size
+                            candidate_byte_size, layer_size
                         ),
                     );
 
@@ -146,13 +145,13 @@ impl MergePolicy for LayeredMergePolicy {
                         &format!(
                             "compute_merge_candidates: candidate size {} too small for layer size {}",
                             candidate_byte_size,
-                            extended_layer_size
+                            layer_size
                         ),
                     );
                 }
             }
 
-            if (candidate_byte_size + largest_terms_size) < extended_layer_size {
+            if (candidate_byte_size + largest_terms_size) < layer_size {
                 // the last candidate isn't full, so throw it away
                 candidates.pop();
             }

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -98,7 +98,7 @@ impl MergePolicy for LayeredMergePolicy {
                 let adjusted_size =
                     adjusted_byte_size(segment, &self.mergeable_segments, avg_doc_size);
                 let actual_size = actual_byte_size(segment, &self.mergeable_segments, avg_doc_size);
-                let terms_size = terms_size(segment, &self.mergeable_segments);
+                let terms_size = terms_byte_size(segment, &self.mergeable_segments);
                 largest_terms_size = largest_terms_size.max(terms_size);
                 let actual_size_minus_terms = actual_size - terms_size;
 
@@ -329,7 +329,7 @@ fn actual_byte_size(
 }
 
 #[inline]
-fn terms_size(meta: &SegmentMeta, all_entries: &HashMap<SegmentId, SegmentMetaEntry>) -> u64 {
+fn terms_byte_size(meta: &SegmentMeta, all_entries: &HashMap<SegmentId, SegmentMetaEntry>) -> u64 {
     all_entries
         .get(&meta.id())
         .map(|entry| entry.terms.map(|file| file.total_bytes).unwrap_or(0) as u64)

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -248,7 +248,8 @@ unsafe fn do_merge(indexrelid: pg_sys::Oid) -> (NumCandidates, NumMerged) {
     };
 
     let index_options = SearchIndexCreateOptions::from_relation(&indexrel);
-    let merge_policy = LayeredMergePolicy::new(index_options.layer_sizes(DEFAULT_LAYER_SIZES));
+    let merge_policy =
+        LayeredMergePolicy::new(index_options.layer_sizes(DEFAULT_LAYER_SIZES), true);
 
     merge_index_with_policy(indexrel, merge_policy, false, false, false)
 }

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -42,6 +42,7 @@ use crate::schema::{IndexRecordOption, SearchFieldConfig, SearchFieldName, Searc
  * (because SearchIndexCreateOptions is a postgres-allocated object) and use getters and setters
 */
 
+const DEFAULT_LAYER_FUDGE_FACTOR: f64 = 1.33;
 static mut RELOPT_KIND_PDB: pg_sys::relopt_kind::Type = 0;
 
 // Postgres handles string options by placing each option offset bytes from the start of rdopts and
@@ -58,6 +59,7 @@ pub struct SearchIndexCreateOptions {
     datetime_fields_offset: i32,
     key_field_offset: i32,
     layer_sizes_offset: i32,
+    layer_fudge_factor_offset: i32,
 }
 
 #[pg_guard]
@@ -164,6 +166,17 @@ extern "C" fn validate_layer_sizes(value: *const std::os::raw::c_char) {
     assert!(cnt >= 2, "There must be at least 2 layers in `layer_sizes`");
 }
 
+#[pg_guard]
+extern "C" fn validate_layer_fudge_factor(value: *const std::os::raw::c_char) {
+    if value.is_null() {
+        // a NULL value means we're to use whatever our defaults are
+        return;
+    }
+
+    let f64: f64 = value.parse().expect("`layer_fudge_factor` must be a valid f64");
+    assert!(f64 >= 1.0 && f64 <= 10.0, "`layer_fudge_factor` must be between 1.0 and 10.0");
+}
+
 fn get_layer_sizes(s: &str) -> impl Iterator<Item = u64> + use<'_> {
     s.split(",").map(|part| {
         unsafe {
@@ -177,6 +190,10 @@ fn get_layer_sizes(s: &str) -> impl Iterator<Item = u64> + use<'_> {
             .expect("a single layer size must be greater than zero")
         }
     })
+}
+
+fn get_layer_fudge_factor(s: &str) -> f64 {
+    s.parse().expect("`layer_fudge_factor` must be a valid f64")
 }
 
 #[inline]
@@ -237,6 +254,11 @@ pub unsafe extern "C" fn amoptions(
             optname: "layer_sizes".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
             offset: offset_of!(SearchIndexCreateOptions, layer_sizes_offset) as i32,
+        },
+        pg_sys::relopt_parse_elt {
+            optname: "layer_fudge_factor".as_pg_cstr(),
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_REAL,
+            offset: offset_of!(SearchIndexCreateOptions, layer_fudge_factor_offset) as i32,
         },
     ];
     build_relopts(reloptions, validate, options)
@@ -692,5 +714,12 @@ pub unsafe fn init() {
         std::ptr::null(),
         Some(validate_layer_sizes),
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
+    );
+    pg_sys::add_real_reloption(
+        RELOPT_KIND_PDB,
+        "layer_fudge_factor".as_pg_cstr(),
+        "Because the size of segments that merge together is usually less than the sum of their parts, we fudge the size of the segments by this factor to ensure we don't merge segments too soon".as_pg_cstr(),
+        std::ptr::null(),
+        Some(validate_layer_fudge_factor),
     );
 }

--- a/tests/tests/layered_merge.rs
+++ b/tests/tests/layered_merge.rs
@@ -32,7 +32,7 @@ fn merges_to_1_100k_segment(mut conn: PgConnection) {
     // one might think 100 individual inserts of 1022 bytes each would get us right at 100k of
     // segment data, and while it does, LayeredMergePolicy has a fudge factor of 33% built in
     // so we actually need more to get to the point of actually merging
-    for _ in 0..133 {
+    for _ in 0..183 {
         // creates a segment of 1022 bytes
         "insert into layer_sizes select x from generate_series(1, 33) x;".execute(&mut conn);
     }
@@ -40,7 +40,7 @@ fn merges_to_1_100k_segment(mut conn: PgConnection) {
     // assert we actually have 133 segments and that a merge didn't happen yet
     let (nsegments,) = "select count(*) from paradedb.index_info('idxlayer_sizes');"
         .fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(nsegments, 133);
+    assert_eq!(nsegments, 183);
 
     // creates another segment of 1022 bytes, and will cause a merge based on our default layer sizes
     // leaving behind 2 segments.  one that's a merge of all the segments we created above, and then
@@ -73,13 +73,13 @@ fn force_merge(mut conn: PgConnection) {
     // force merge into a layer of 800 bytes
     let (nsegments, nmerged) = "select * from paradedb.force_merge('idxforce_merge', 800);"
         .fetch_one::<(i64, i64)>(&mut conn);
-    assert_eq!(nsegments, 3);
-    assert_eq!(nmerged, 9);
+    assert_eq!(nsegments, 5);
+    assert_eq!(nmerged, 10);
 
-    // which leaves us with 4 segments
+    // which leaves us with 5 segments
     let (nsegments,) = "select count(*) from paradedb.index_info('idxforce_merge');"
         .fetch_one::<(i64,)>(&mut conn);
-    assert_eq!(nsegments, 4);
+    assert_eq!(nsegments, 5);
 }
 
 #[rstest]

--- a/tests/tests/merge.rs
+++ b/tests/tests/merge.rs
@@ -33,7 +33,7 @@ fn merge_with_no_positions(mut conn: PgConnection) {
     .execute(&mut conn);
 
     // this will merge on the 12th insert
-    for _ in 0..13 {
+    for _ in 0..11 {
         "insert into test (message) select null from generate_series(1, 1000);".execute(&mut conn);
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

- If a segment was merged and is closer to the upper layer size than the lower layer size, we determine it was probably created by a merge targeting the upper layer size but fell below it and shouldn't be re-merged into the upper layer size
- Exclude all term dicts besides the largest term dict when calculating the candidate byte size

## Why

Reducing write amplification and better targeting the layer size should improve write perf

## How

## Tests

Some of the results of the existing merge tests had to be tweaked because the threshold for layer size is now different.