### PR TITLE
fix: make `create_index_parallelism` userset

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -98,7 +98,7 @@ pub fn init() {
             .get()
             .try_into()
             .expect("your computer has too many cores"),
-        GucContext::Suset,
+        GucContext::Userset,
         GucFlags::default(),
     );
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We seemed to have missed this setting in #2194 

## Why

## How

## Tests
