### PR TITLE
fix: revert PR #2443 - don't require fast=true when setting a normalizer

### DIFF
--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -274,11 +274,6 @@ impl SearchFieldConfig {
         }?;
 
         let normalizer = match obj.get("normalizer") {
-            Some(_) if !fast => {
-                return Err(anyhow::anyhow!(
-                    "'normalizer' is only valid when `\"fast\": true`"
-                ))
-            }
             Some(v) => serde_json::from_value(v.clone()),
             None => Ok(SearchNormalizer::Raw),
         }?;

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -365,57 +365,6 @@ fn raw_tokenizer_config(mut conn: PgConnection) {
 }
 
 #[rstest]
-fn keyword_tokenizer_config(mut conn: PgConnection) {
-    r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
-
-    CREATE INDEX bm25_search_idx ON paradedb.bm25_search
-        USING bm25 (id, description)
-        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "keyword"}}}');
-    "#
-    .execute(&mut conn);
-
-    let count: (i64,) = r#"
-        SELECT COUNT(*) FROM paradedb.bm25_search
-        WHERE bm25_search @@@ 'description:shoes'"#
-        .fetch_one(&mut conn);
-    assert_eq!(count.0, 0);
-
-    // the literal "description" value is `"Generic shoes"`, so searching for "GENERIC SHOES" will
-    // not find a match
-    let count: (i64,) = r#"
-        SELECT COUNT(*) FROM paradedb.bm25_search
-        WHERE bm25_search @@@ 'description:"GENERIC SHOES"'"#
-        .fetch_one(&mut conn);
-    assert_eq!(count.0, 0);
-
-    // whereas, searching for the literal value will
-    let count: (i64,) = r#"
-        SELECT COUNT(*) FROM paradedb.bm25_search
-        WHERE bm25_search @@@ 'description:"Generic shoes"'"#
-        .fetch_one(&mut conn);
-    assert_eq!(count.0, 1);
-}
-
-#[rstest]
-fn normalizer_requires_fast(mut conn: PgConnection) {
-    let result = r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
-
-    CREATE INDEX bm25_search_idx ON paradedb.bm25_search
-        USING bm25 (id, description)
-        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "raw"}, "normalizer": "raw" } }');
-    "#
-        .execute_result(&mut conn);
-
-    assert!(result.is_err());
-    let err = result.err().unwrap();
-    assert!(err
-        .to_string()
-        .contains("'normalizer' is only valid when `\"fast\": true`"));
-}
-
-#[rstest]
 fn regex_tokenizer_config(mut conn: PgConnection) {
     "CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb')"
         .execute(&mut conn);

--- a/tests/tests/term.rs
+++ b/tests/tests/term.rs
@@ -176,7 +176,7 @@ fn text_term(mut conn: PgConnection) {
     USING bm25 (id, value_text, value_varchar, value_uuid) WITH (key_field='id', text_fields='{
         "value_text": {}, 
         "value_varchar": {}, 
-        "value_uuid": {"tokenizer": {"type": "raw"}, "normalizer": "raw", "record": "basic", "fieldnorms": false, "fast": true}
+        "value_uuid": {"tokenizer": {"type": "raw"}, "normalizer": "raw", "record": "basic", "fieldnorms": false}
     }');
     "#
     .execute(&mut conn);


### PR DESCRIPTION
PR #2443 introduced an incompatible change with existing indexes created prior to it being merged/released.

The most expedient thing is to revert it.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
