### PR TITLE
feat: Physical replication recommended settings docs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -200,6 +200,7 @@ RUN apt-get update \
 # extension requires a database to store its metadata tables. By using `postgres`, we ensure that it has a
 # stable, always-available database for its operations, no matter what other databases are created or deleted.
 RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_search,pg_cron'/" /usr/share/postgresql/postgresql.conf.sample && \
+    grep "shared_preload_libraries = 'pg_search,pg_cron'" /usr/share/postgresql/postgresql.conf.sample && \
     echo "cron.database_name = 'postgres'" >> /usr/share/postgresql/postgresql.conf.sample
 
 # The pg_search extension requires the ICU library binaries to be installed at runtime. Therefore, we download

--- a/docs/deploy/self-hosted/high-availability/configuration.mdx
+++ b/docs/deploy/self-hosted/high-availability/configuration.mdx
@@ -4,6 +4,15 @@ title: Configuration
 
 ## Synchronous Replication
 
+Between physical replicas, ParadeDB requires the use of a few settings (which are automatically set by [CNPG](/deploy/self-hosted/kubernetes)) in order to avoid query cancellation due to ongoing reorganization of the data on the primary replica.
+
+- `hot_standby_feedback=on` - The [`hot_standby_feedback`](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-HOT-STANDBY-FEEDBACK) setting controls whether nodes acting as `hot_standby`s (the replicas in physical replication) send feedback to the leader about their current transaction status. ParadeDB uses this transaction status to determine when it is safe for the primary to garbage collect its segments.
+- `primary_slot_name=$something` - The [`primary_slot_name`](https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-PRIMARY-SLOT-NAME) setting declares the name of the replication slot that a replica should use when it connects to the primary. In order for `hot_standby_feedback` to be used and persistent, a replication slot must be used.
+
+Without these settings, ParadeDB physical replicas will see much more frequent query cancels, and will report a message recommending that they are used.
+
+## Synchronous Replication
+
 By default, ParadeDB ships with asynchronuous replication, meaning transactions on the primary **do not** wait for confirmation from
 the standby instances before committing.
 


### PR DESCRIPTION
## What

Explain new (highly) recommended replication settings for `enterprise` users.

## Why

As the docs explain: failing to set these settings will result in frequent query cancels.

## How

New section of the `High Availability > Configuration` page.

## Tests

n/a