### PR TITLE
ci: Fix some nitpicks for `staging` releases

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          # on prod we update patch and reset dev RC to 0
+          # On `main` we update patch and reset the RC version to 1
           if [[ ${{ github.ref }} == "refs/heads/main" ]]; then
             gh api \
               --method PATCH \
@@ -77,8 +77,8 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/paradedb/paradedb/actions/variables/VERSION_RC \
               -f name='VERSION_RC' \
-              -f value='0'
-          # on staging we only update RC
+              -f value='1'
+          # On `staging` we only update the RC version
           elif [[ ${{ github.ref }} == "refs/heads/staging" ]]; then
             gh api \
               --method PATCH \

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -141,34 +141,3 @@ jobs:
           subject-name: index.docker.io/paradedb/paradedb
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
-
-  publish-paradedb-helm-chart:
-    name: Publish ParadeDB Helm Chart
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Retrieve GitHub Release Version
-        id: version
-        run: |
-          # If no workflow_dispatch version is provided, we use workflow tag trigger version
-          if [ -z "${{ github.event.inputs.version }}" ]; then
-            if [[ $GITHUB_REF == refs/tags/v* ]]; then
-              VERSION=${GITHUB_REF#refs/tags/v}
-            else
-              # If there is no tag and no provided version, it's a test run and we set a default version
-              VERSION="0.0.0"
-            fi
-          else
-            VERSION=${{ github.event.inputs.version }}
-          fi
-          echo "GitHub Tag Version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Trigger paradedb/charts Release Workflow
-        uses: multinarity/workflow-dispatch@master
-        with:
-          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
-          workflow: paradedb-publish-chart.yml
-          repo: paradedb/charts
-          ref: main
-          inputs: '{ "appVersion": "${{ steps.version.outputs.version }}" }'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
- Default the `-rc` version to 1 rather than 0 to match what is done elsewhere.
- Remove the Helm release. We don't need this, it stemmed from a misunderstanding I had of how to publish Helm charts.

## Why
^

## How
^

## Tests
^