### PR TITLE
chore: Remove dependence on Tantivy store everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,7 +2725,6 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4427,7 +4426,6 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4479,7 +4477,6 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "bitpacking",
 ]
@@ -4487,7 +4484,6 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4502,7 +4498,6 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4524,7 +4519,6 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "nom",
 ]
@@ -4532,7 +4526,6 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4545,7 +4538,6 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4555,7 +4547,6 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5e99b796d5101c0d82d1aafc46da15d67d48fc3c#5e99b796d5101c0d82d1aafc46da15d67d48fc3c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4426,6 +4427,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4477,6 +4479,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "bitpacking",
 ]
@@ -4484,6 +4487,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4498,6 +4502,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4519,6 +4524,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "nom",
 ]
@@ -4526,6 +4532,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4538,6 +4545,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4547,6 +4555,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "5e99b796d5101c0d82d1aafc46da15d67d48fc3c", features = [
+tantivy = { path = "../tantivy", package = "tantivy", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { path = "../tantivy", package = "tantivy", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "eb9027a8590475b1435bad764c7fd1bcd95dc8c7", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",

--- a/docs/documentation/advanced/specialized/more_like_this.mdx
+++ b/docs/documentation/advanced/specialized/more_like_this.mdx
@@ -13,14 +13,6 @@ You must pass either:
 
 All other parameters are compatible with both `document_id` and `document_fields`.
 
-<Note>
-  When querying with the `document_id` parameter, the index fields must be configured with the
-  [stored](/documentation/indexing/field_options#all-configuration-options) parameter set to `true`.
-
-The `key_field` of an index is configured automatically as `stored: true`.
-
-</Note>
-
 <CodeGroup>
 ```sql Function Syntax
 -- document_id

--- a/docs/documentation/indexing/field_options.mdx
+++ b/docs/documentation/indexing/field_options.mdx
@@ -4,7 +4,7 @@ title: Overview
 
 ## Basic Usage
 
-You can change how individual fields are tokenized and stored by passing JSON strings to the `WITH` clause of `CREATE INDEX`.
+You can change how individual fields are tokenized by passing JSON strings to the `WITH` clause of `CREATE INDEX`.
 For instance, the following statement configures an ngram tokenizer for the `description` field.
 
 ```sql
@@ -89,11 +89,6 @@ The nested configuration JSON for `text_fields` accepts the following keys.
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
-  </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
     `true` to calculate the BM25 score.
@@ -141,11 +136,6 @@ The nested configuration JSON for `json_fields` accepts the following keys.
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
-  </ParamField>
   <ParamField body="fieldnorms" default={true}>
     Fieldnorms store information about the length of the text field. Must be
     `true` to calculate the BM25 score.
@@ -178,11 +168,6 @@ WITH (
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
-  </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
     have `fast` set to `true`. Fast fields are also useful for accelerated
@@ -211,11 +196,6 @@ WITH (
   <ParamField body="indexed" default={true}>
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
-  </ParamField>
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
@@ -246,41 +226,10 @@ WITH (
     Whether the field is indexed. Must be `true` in order for the field to be
     tokenized and searchable.
   </ParamField>
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
-  </ParamField>
   <ParamField body="fast" default={true}>
     Fast fields can be random-accessed rapidly. Fields used for aggregation must
     have `fast` set to `true`. Fast fields are also useful for accelerated
     scoring and filtering.
-  </ParamField>
-</Accordion>
-
-### Range Fields
-
-Options for columns of type `int4range`, `int8range`, `numrange`, `tsrange`, and `tstzrange` should be passed to `range_fields`.
-The [range term](/documentation/advanced/term/range_term) query is used to filter over these fields.
-
-```sql
-CREATE INDEX search_idx ON mock_items
-USING bm25 (id, weight_range)
-WITH (
-  key_field = 'id',
-  range_fields = '{
-    "weight_range": {"stored": true}
-  }'
-);
-```
-
-`CREATE INDEX` accepts several configuration options for `range_fields`:
-
-<Accordion title="Advanced Options">
-  <ParamField body="stored" default={false}>
-    Whether the original value of the field is stored. Required only for use
-    with the [More Like
-    This](/documentation/advanced/specialized/more_like_this) query.
   </ParamField>
 </Accordion>
 

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -599,7 +599,7 @@ pub unsafe fn term_with_operator(
         pg_sys::TIMETZOID => make_query!(operator, field, time_with_time_zone, pgrx::datum::TimeWithTimeZone, value, true),
         pg_sys::TIMESTAMPOID => make_query!(operator, field, timestamp, pgrx::datum::Timestamp, value, true),
         pg_sys::TIMESTAMPTZOID => make_query!(operator, field, timestamp_with_time_zone, pgrx::datum::TimestampWithTimeZone, value, true),
-        
+
 
         other => panic!("unsupported type: {other:?}"),
     }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -335,6 +335,7 @@ impl SearchIndexReader {
                 ),
                 &mut parser,
                 &self.searcher,
+                self.index_oid,
             )
             .expect("must be able to parse query")
     }

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -420,14 +420,12 @@ impl SearchIndexCreateOptions {
                 SearchFieldConfig::Numeric {
                     indexed: true,
                     fast: true,
-                    stored: false,
                     column: None,
                 }
             }
             SearchFieldType::Text => SearchFieldConfig::Text {
                 indexed: true,
                 fast: true,
-                stored: false,
                 fieldnorms: false,
 
                 // NB:  This should use the `SearchTokenizer::Keyword` tokenizer but for historical
@@ -443,7 +441,6 @@ impl SearchIndexCreateOptions {
             SearchFieldType::Json => SearchFieldConfig::Json {
                 indexed: true,
                 fast: true,
-                stored: false,
                 fieldnorms: false,
                 expand_dots: false,
                 #[allow(deprecated)]
@@ -452,20 +449,15 @@ impl SearchIndexCreateOptions {
                 normalizer: SearchNormalizer::Raw,
                 column: None,
             },
-            SearchFieldType::Range => SearchFieldConfig::Range {
-                stored: false,
-                column: None,
-            },
+            SearchFieldType::Range => SearchFieldConfig::Range { column: None },
             SearchFieldType::Bool => SearchFieldConfig::Boolean {
                 indexed: true,
                 fast: true,
-                stored: false,
                 column: None,
             },
             SearchFieldType::Date => SearchFieldConfig::Date {
                 indexed: true,
                 fast: true,
-                stored: false,
                 column: None,
             },
         };
@@ -481,7 +473,6 @@ impl SearchIndexCreateOptions {
             SearchFieldConfig::Numeric {
                 indexed: true,
                 fast: true,
-                stored: false,
                 column: None,
             },
             Some(SearchFieldType::U64),

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -493,12 +493,13 @@ impl TryFrom<TantivyValue> for i32 {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::I64(val) = value.0 {
-            Ok(val as i32)
-        } else {
-            Err(TantivyValueError::UnsupportedIntoConversion(
+        match value.0 {
+            OwnedValue::U64(val) => Ok(val as i32),
+            OwnedValue::I64(val) => Ok(val as i32),
+            OwnedValue::F64(val) => Ok(val as i32),
+            _ => Err(TantivyValueError::UnsupportedIntoConversion(
                 "i32".to_string(),
-            ))
+            )),
         }
     }
 }
@@ -515,12 +516,13 @@ impl TryFrom<TantivyValue> for i64 {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::I64(val) = value.0 {
-            Ok(val)
-        } else {
-            Err(TantivyValueError::UnsupportedIntoConversion(
+        match value.0 {
+            OwnedValue::U64(val) => Ok(val as i64),
+            OwnedValue::I64(val) => Ok(val),
+            OwnedValue::F64(val) => Ok(val as i64),
+            _ => Err(TantivyValueError::UnsupportedIntoConversion(
                 "i64".to_string(),
-            ))
+            )),
         }
     }
 }
@@ -591,12 +593,13 @@ impl TryFrom<TantivyValue> for u32 {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::U64(val) = value.0 {
-            Ok(val as u32)
-        } else {
-            Err(TantivyValueError::UnsupportedIntoConversion(
+        match value.0 {
+            OwnedValue::U64(val) => Ok(val as u32),
+            OwnedValue::I64(val) => Ok(val as u32),
+            OwnedValue::F64(val) => Ok(val as u32),
+            _ => Err(TantivyValueError::UnsupportedIntoConversion(
                 "u32".to_string(),
-            ))
+            )),
         }
     }
 }
@@ -613,12 +616,13 @@ impl TryFrom<TantivyValue> for u64 {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::U64(val) = value.0 {
-            Ok(val)
-        } else {
-            Err(TantivyValueError::UnsupportedIntoConversion(
+        match value.0 {
+            OwnedValue::U64(val) => Ok(val),
+            OwnedValue::I64(val) => Ok(val as u64),
+            OwnedValue::F64(val) => Ok(val as u64),
+            _ => Err(TantivyValueError::UnsupportedIntoConversion(
                 "u64".to_string(),
-            ))
+            )),
         }
     }
 }
@@ -637,12 +641,13 @@ impl TryFrom<TantivyValue> for pgrx::AnyNumeric {
     type Error = TantivyValueError;
 
     fn try_from(value: TantivyValue) -> Result<Self, Self::Error> {
-        if let tantivy::schema::OwnedValue::F64(val) = value.0 {
-            Ok(val.try_into()?)
-        } else {
-            Err(TantivyValueError::UnsupportedIntoConversion(
+        match value.0 {
+            OwnedValue::U64(val) => Ok(pgrx::AnyNumeric::from(val)),
+            OwnedValue::I64(val) => Ok(pgrx::AnyNumeric::from(val)),
+            OwnedValue::F64(val) => Ok(val.try_into()?),
+            _ => Err(TantivyValueError::UnsupportedIntoConversion(
                 "numeric".to_string(),
-            ))
+            )),
         }
     }
 }

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod iter_mut;
+mod more_like_this;
 mod range;
 mod score;
 
@@ -717,6 +718,7 @@ impl SearchQueryInput {
         field_lookup: &impl AsFieldType<String>,
         parser: &mut QueryParser,
         searcher: &Searcher,
+        index_oid: pg_sys::Oid,
     ) -> Result<Box<dyn Query>, Box<dyn std::error::Error>> {
         match self {
             Self::Uninitialized => panic!("this `SearchQueryInput` instance is uninitialized"),
@@ -730,36 +732,36 @@ impl SearchQueryInput {
                 for input in must {
                     subqueries.push((
                         Occur::Must,
-                        input.into_tantivy_query(field_lookup, parser, searcher)?,
+                        input.into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
                     ));
                 }
                 for input in should {
                     subqueries.push((
                         Occur::Should,
-                        input.into_tantivy_query(field_lookup, parser, searcher)?,
+                        input.into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
                     ));
                 }
                 for input in must_not {
                     subqueries.push((
                         Occur::MustNot,
-                        input.into_tantivy_query(field_lookup, parser, searcher)?,
+                        input.into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
                     ));
                 }
                 Ok(Box::new(BooleanQuery::new(subqueries)))
             }
             Self::Boost { query, factor } => Ok(Box::new(BoostQuery::new(
-                query.into_tantivy_query(field_lookup, parser, searcher)?,
+                query.into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
                 factor,
             ))),
             Self::ConstScore { query, score } => Ok(Box::new(ConstScoreQuery::new(
-                query.into_tantivy_query(field_lookup, parser, searcher)?,
+                query.into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
                 score,
             ))),
             Self::ScoreFilter { bounds, query } => Ok(Box::new(ScoreFilter::new(
                 bounds,
                 query
                     .expect("ScoreFilter's query should have been set")
-                    .into_tantivy_query(field_lookup, parser, searcher)?,
+                    .into_tantivy_query(field_lookup, parser, searcher, index_oid)?,
             ))),
             Self::DisjunctionMax {
                 disjuncts,
@@ -767,7 +769,9 @@ impl SearchQueryInput {
             } => {
                 let disjuncts = disjuncts
                     .into_iter()
-                    .map(|query| query.into_tantivy_query(field_lookup, parser, searcher))
+                    .map(|query| {
+                        query.into_tantivy_query(field_lookup, parser, searcher, index_oid)
+                    })
                     .collect::<Result<_, _>>()?;
                 if let Some(tie_breaker) = tie_breaker {
                     Ok(Box::new(DisjunctionMaxQuery::with_tie_breaker(
@@ -1048,7 +1052,7 @@ impl SearchQueryInput {
                     lenient,
                     conjunction_mode,
                 }
-                .into_tantivy_query(field_lookup, parser, searcher)
+                .into_tantivy_query(field_lookup, parser, searcher, index_oid)
             }
             Self::Phrase {
                 field,
@@ -1829,7 +1833,7 @@ impl SearchQueryInput {
                 Ok(Box::new(TermSetQuery::new(terms)))
             }
             Self::WithIndex { query, .. } => {
-                query.into_tantivy_query(field_lookup, parser, searcher)
+                query.into_tantivy_query(field_lookup, parser, searcher, index_oid)
             }
             Self::PostgresExpression { .. } => panic!("postgres expressions have not been solved"),
         }

--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -121,7 +121,7 @@ impl MoreLikeThisQueryBuilder {
         let index_relation = unsafe { pgrx::PgRelation::open(index_oid) };
         let heap_relation = index_relation
             .heap_relation()
-            .expect("index should have a heap relation");
+            .expect("more_like_this: index should have a heap relation");
         let directory = MVCCDirectory::snapshot(index_relation.oid());
         let index = Index::open(directory).expect("more_like_this: should be able to open index");
         let schema = SearchIndexSchema::open(index.schema(), &index_relation);
@@ -143,7 +143,7 @@ impl MoreLikeThisQueryBuilder {
                     unsafe {
                         &[TantivyValue(key_value)
                             .try_into_datum(key_oid)
-                            .expect("should be able to convert key value to datum")
+                            .expect("more_like_this: should be able to convert key value to datum")
                             .into()]
                     },
                 )?
@@ -158,7 +158,7 @@ impl MoreLikeThisQueryBuilder {
                     if categorized.is_array {
                         let values = unsafe {
                             TantivyValue::try_from_datum_array(datum, categorized.base_oid)
-                                .expect("should be able to convert datum to tantivy value")
+                                .expect("more_like_this: should be able to convert array to tantivy value")
                                 .into_iter()
                                 .map(|v| v.into())
                                 .collect::<Vec<_>>()
@@ -167,7 +167,7 @@ impl MoreLikeThisQueryBuilder {
                     } else if categorized.is_json {
                         let values = unsafe {
                             TantivyValue::try_from_datum_json(datum, categorized.base_oid)
-                                .expect("should be able to convert datum to tantivy value")
+                                .expect("more_like_this: should be able to convert json to tantivy value")
                                 .into_iter()
                                 .map(|v| v.into())
                                 .collect::<Vec<_>>()
@@ -176,7 +176,7 @@ impl MoreLikeThisQueryBuilder {
                     } else {
                         let value = unsafe {
                             TantivyValue::try_from_datum(datum, categorized.base_oid)
-                                .expect("should be able to convert datum to tantivy value")
+                                .expect("more_like_this: should be able to convert datum to tantivy value")
                         };
                         doc_fields.push((field.id.0, vec![value.into()]));
                     }
@@ -185,7 +185,7 @@ impl MoreLikeThisQueryBuilder {
 
             Ok::<_, pgrx::spi::SpiError>(doc_fields)
         })
-        .expect("should be able to construct document");
+        .expect("more_like_this: should be able to construct document");
 
         MoreLikeThisQuery {
             mlt: self.mlt,

--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -1,0 +1,178 @@
+use crate::index::mvcc::MVCCDirectory;
+use crate::postgres::options::SearchIndexCreateOptions;
+use crate::postgres::types::TantivyValue;
+use std::collections::HashMap;
+use tantivy::index::Index;
+use tantivy::query::{
+    BooleanQuery, EnableScoring, MoreLikeThis as TantivyMoreLikeThis, Query, ScoreTerm, Weight,
+};
+use tantivy::schema::{Field, OwnedValue, Value};
+use tantivy::{Result, Searcher, TantivyError, Term};
+
+#[derive(Debug, Default, Clone)]
+pub struct MoreLikeThis {
+    inner: TantivyMoreLikeThis,
+}
+
+impl MoreLikeThis {
+    pub fn query_with_document_fields<'a, V: Value<'a>>(
+        &self,
+        searcher: &Searcher,
+        doc_fields: &[(Field, Vec<V>)],
+    ) -> Result<BooleanQuery> {
+        self.inner.query_with_document_fields(searcher, doc_fields)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MoreLikeThisQuery {
+    mlt: MoreLikeThis,
+    doc_fields: Vec<(Field, Vec<OwnedValue>)>,
+}
+
+impl MoreLikeThisQuery {
+    pub fn builder() -> MoreLikeThisQueryBuilder {
+        MoreLikeThisQueryBuilder::default()
+    }
+}
+
+impl Query for MoreLikeThisQuery {
+    fn weight(&self, enable_scoring: EnableScoring<'_>) -> Result<Box<dyn Weight>> {
+        let searcher = match enable_scoring {
+            EnableScoring::Enabled { searcher, .. } => searcher,
+            EnableScoring::Disabled { .. } => {
+                let err = "MoreLikeThisQuery requires to enable scoring.".to_string();
+                return Err(TantivyError::InvalidArgument(err));
+            }
+        };
+
+        let values = self
+            .doc_fields
+            .iter()
+            .map(|(field, values)| (*field, values.iter().collect::<Vec<&OwnedValue>>()))
+            .collect::<Vec<_>>();
+
+        self.mlt
+            .query_with_document_fields(searcher, &values)?
+            .weight(enable_scoring)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MoreLikeThisQueryBuilder {
+    mlt: MoreLikeThis,
+}
+
+impl MoreLikeThisQueryBuilder {
+    #[must_use]
+    pub fn with_min_doc_frequency(mut self, value: u64) -> Self {
+        self.mlt.inner.min_doc_frequency = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_doc_frequency(mut self, value: u64) -> Self {
+        self.mlt.inner.max_doc_frequency = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_min_term_frequency(mut self, value: usize) -> Self {
+        self.mlt.inner.min_term_frequency = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_query_terms(mut self, value: usize) -> Self {
+        self.mlt.inner.max_query_terms = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_min_word_length(mut self, value: usize) -> Self {
+        self.mlt.inner.min_word_length = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_word_length(mut self, value: usize) -> Self {
+        self.mlt.inner.max_word_length = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_boost_factor(mut self, value: f32) -> Self {
+        self.mlt.inner.boost_factor = Some(value);
+        self
+    }
+
+    #[must_use]
+    pub fn with_stop_words(mut self, value: Vec<String>) -> Self {
+        self.mlt.inner.stop_words = value;
+        self
+    }
+
+    pub fn with_document(
+        self,
+        key_field: pgrx::AnyElement,
+        index_oid: pgrx::pg_sys::Oid,
+    ) -> MoreLikeThisQuery {
+        let index_relation = unsafe { pgrx::PgRelation::open(index_oid) };
+        let heap_relation = index_relation.heap_relation();
+        let heap_oid = heap_relation
+            .expect("index should have a heap relation")
+            .oid();
+        let options = unsafe { SearchIndexCreateOptions::from_relation(&index_relation) };
+        let key_field = options.get_key_field().expect("key_field is required").0;
+        let directory = MVCCDirectory::snapshot(index_relation.oid());
+        let index = Index::open(directory).expect("custom_scan: should be able to open index");
+        let schema = index.schema();
+
+        let doc_fields: Vec<(Field, Vec<OwnedValue>)> = pgrx::Spi::connect(|client| {
+            if let Some(htup) = client
+                .select(
+                    &format!(
+                        "SELECT * FROM {}::regclass WHERE {} = $1",
+                        heap_oid.as_u32(),
+                        key_field
+                    ),
+                    None,
+                    &[key_field.into()],
+                )?
+                .first()
+                .get_heap_tuple()?
+            {
+                let mut fields_map = vec![];
+                for (field, entry) in schema.fields() {
+                    let spi_datum = htup.get_datum_by_name(entry.name())?;
+                    if let Some(datum) = spi_datum.value::<pgrx::pg_sys::Datum>()? {
+                        let value = unsafe { TantivyValue::try_from_datum(
+                            datum,
+                            pgrx::PgOid::from(spi_datum.oid()),
+                        ).expect("should be able to convert datum to tantivy value") };
+                        fields_map.push((field, vec![value.into()]));
+                    }
+                }
+
+                Ok::<_, pgrx::spi::SpiError>(fields_map)
+            } else {
+                Ok::<_, pgrx::spi::SpiError>(vec![])
+            }
+        }).expect("should be able to construct document");
+
+        MoreLikeThisQuery {
+            mlt: self.mlt,
+            doc_fields,
+        }
+    }
+
+    pub fn with_document_fields(
+        self,
+        doc_fields: Vec<(Field, Vec<OwnedValue>)>,
+    ) -> MoreLikeThisQuery {
+        MoreLikeThisQuery {
+            mlt: self.mlt,
+            doc_fields,
+        }
+    }
+}

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -1789,19 +1789,7 @@ fn specialized_queries(mut conn: PgConnection) {
 
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, description, category, rating, in_stock, created_at, metadata)
-    WITH (
-        key_field='id',
-        text_fields='{
-            "description": { "stored": true },
-            "category": { "stored": true }
-        }',
-        numeric_fields='{"rating": { "stored": true } }',
-        boolean_fields='{"in_stock": { "stored": true } }',
-        json_fields='{"metadata": { "stored": true } }',
-        datetime_fields='{
-            "created_at": { "stored": true }
-        }'
-    );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -2300,12 +2288,7 @@ fn field_configuration(mut conn: PgConnection) {
     r#"
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, weight_range)
-    WITH (
-    key_field = 'id',
-    range_fields = '{
-        "weight_range": {"stored": true}
-    }'
-    );
+    WITH (key_field='id');
     DROP INDEX search_idx;
     "#
     .execute(&mut conn);

--- a/tests/tests/fixtures/tables/simple_products.rs
+++ b/tests/tests/fixtures/tables/simple_products.rs
@@ -44,20 +44,6 @@ BEGIN;
     CREATE INDEX bm25_search_bm25_index
     ON paradedb.bm25_search
     USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
-    WITH (
-        key_field='id',
-        text_fields='{
-            "description": { "stored": true },
-            "category": { "stored": true }
-        }',
-        numeric_fields='{"rating": { "stored": true } }',
-        boolean_fields='{"in_stock": { "stored": true } }',
-        json_fields='{"metadata": { "stored": true } }',
-        datetime_fields='{
-            "created_at": { "stored": true },
-            "last_updated_date": { "stored": true },
-            "latest_available_time": { "stored": true }
-        }'
-    );
+    WITH (key_field='id');
 COMMIT;
 "#;

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -46,7 +46,7 @@ fn tokenizer_filters(mut conn: PgConnection) {
     // Test en_stem tokenizer with default layers (lowercase => true, remove_long => 255).
     let rows: Vec<(String, i32)> = r#"
     SELECT * FROM paradedb.tokenize(
-      paradedb.tokenizer('en_stem'), 
+      paradedb.tokenizer('en_stem'),
       'Hello, hello, ladiesandgentlemen!'
     );
     "#
@@ -113,6 +113,7 @@ fn list_tokenizers(mut conn: PgConnection) {
             rows,
             vec![
                 ("default".into(),),
+                ("keyword".into(),),
                 ("raw".into(),),
                 ("en_stem".into(),),
                 ("stem".into(),),
@@ -149,16 +150,16 @@ fn test_format_create_bm25_basic(mut conn: PgConnection) {
     // Get the CREATE INDEX statement
     let sql = r#"
         SELECT paradedb.format_create_bm25(
-            'my_index'::text, 
-            'my_table'::text, 
-            'id'::text, 
-            'public'::text, 
-            '{"title": {}}'::jsonb, 
-            '{"price": {}}'::jsonb, 
-            '{"is_available": {}}'::jsonb, 
-            '{"details": {}}'::jsonb, 
-            '{"price_range": {}}'::jsonb, 
-            '{"published_date": {}}'::jsonb, 
+            'my_index'::text,
+            'my_table'::text,
+            'id'::text,
+            'public'::text,
+            '{"title": {}}'::jsonb,
+            '{"price": {}}'::jsonb,
+            '{"is_available": {}}'::jsonb,
+            '{"details": {}}'::jsonb,
+            '{"price_range": {}}'::jsonb,
+            '{"published_date": {}}'::jsonb,
             'price > 0'::text
         );
     "#
@@ -188,16 +189,16 @@ fn test_format_create_index_no_predicate(mut conn: PgConnection) {
     // Get and execute CREATE INDEX statement
     let sql = r#"
         SELECT paradedb.format_create_bm25(
-            'another_index', 
-            'products', 
-            'product_id', 
-            'inventory', 
-            '{"name": {}}'::jsonb, 
-            '{}'::jsonb, 
-            '{}'::jsonb, 
-            '{}'::jsonb, 
-            '{}'::jsonb, 
-            '{}'::jsonb, 
+            'another_index',
+            'products',
+            'product_id',
+            'inventory',
+            '{"name": {}}'::jsonb,
+            '{}'::jsonb,
+            '{}'::jsonb,
+            '{}'::jsonb,
+            '{}'::jsonb,
+            '{}'::jsonb,
             ''
         );
     "#

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -361,7 +361,6 @@ fn test_index_fields(mut conn: PgConnection) {
     let id_config = fields.get("id").unwrap().get("Numeric").unwrap();
     assert_eq!(id_config.get("indexed").unwrap(), true);
     assert_eq!(id_config.get("fast").unwrap(), true);
-    assert_eq!(id_config.get("stored").unwrap(), false);
 
     // Check text field (title)
     assert!(fields.contains_key("title"));
@@ -377,10 +376,6 @@ fn test_index_fields(mut conn: PgConnection) {
     assert_eq!(
         title_config.get("indexed").unwrap().as_bool().unwrap(),
         true
-    );
-    assert_eq!(
-        title_config.get("stored").unwrap().as_bool().unwrap(),
-        false
     );
 
     // Check numeric field (price)
@@ -415,10 +410,6 @@ fn test_index_fields(mut conn: PgConnection) {
         stock_config.get("indexed").unwrap().as_bool().unwrap(),
         true
     );
-    assert_eq!(
-        stock_config.get("stored").unwrap().as_bool().unwrap(),
-        false
-    );
 
     // Check JSON field (metadata)
     assert!(fields.contains_key("metadata"));
@@ -435,10 +426,6 @@ fn test_index_fields(mut conn: PgConnection) {
         metadata_config.get("indexed").unwrap().as_bool().unwrap(),
         true
     );
-    assert_eq!(
-        metadata_config.get("stored").unwrap().as_bool().unwrap(),
-        false
-    );
 
     // Check range field (price_range)
     assert!(fields.contains_key("price_range"));
@@ -451,10 +438,6 @@ fn test_index_fields(mut conn: PgConnection) {
         .unwrap()
         .as_object()
         .unwrap();
-    assert_eq!(
-        range_config.get("stored").unwrap().as_bool().unwrap(),
-        false
-    );
 
     // Check datetime field (created_at)
     assert!(fields.contains_key("created_at"));
@@ -468,7 +451,6 @@ fn test_index_fields(mut conn: PgConnection) {
         .as_object()
         .unwrap();
     assert_eq!(date_config.get("indexed").unwrap().as_bool().unwrap(), true);
-    assert_eq!(date_config.get("stored").unwrap().as_bool().unwrap(), false);
 
     // Cleanup
     r#"DROP TABLE test_fields CASCADE;"#.execute(&mut conn);

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -427,17 +427,7 @@ fn test_index_fields(mut conn: PgConnection) {
         true
     );
 
-    // Check range field (price_range)
     assert!(fields.contains_key("price_range"));
-    let range_config = fields
-        .get("price_range")
-        .unwrap()
-        .as_object()
-        .unwrap()
-        .get("Range")
-        .unwrap()
-        .as_object()
-        .unwrap();
 
     // Check datetime field (created_at)
     assert!(fields.contains_key("created_at"));

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -29,7 +29,7 @@ use sqlx::{PgConnection, Row};
 fn boolean_tree(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     paradedb.boolean(
         should => ARRAY[
             paradedb.parse('description:shoes'),
@@ -54,14 +54,14 @@ fn fuzzy_term(mut conn: PgConnection) {
     assert_eq!(columns.id, vec![1, 2, 12, 22, 32], "wrong results");
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     paradedb.term(field => 'category', value => 'electornics')
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert!(columns.is_empty(), "without fuzzy field should be empty");
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.fuzzy_term(
             field => 'description',
             value => 'keybaord',
@@ -76,7 +76,7 @@ fn fuzzy_term(mut conn: PgConnection) {
     );
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.fuzzy_term(
             field => 'description',
             value => 'keybaord',
@@ -92,7 +92,7 @@ fn fuzzy_term(mut conn: PgConnection) {
     );
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.fuzzy_term(
             field => 'description',
             value => 'keybaord',
@@ -108,14 +108,14 @@ fn single_queries(mut conn: PgConnection) {
 
     // All
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     paradedb.all() ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
 
     // Boost
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     paradedb.boost(query => paradedb.all(), factor => 1.5)
     ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -131,7 +131,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // DisjunctionMax
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     paradedb.disjunction_max(disjuncts => ARRAY[paradedb.parse('description:shoes')])
     ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -157,14 +157,14 @@ fn single_queries(mut conn: PgConnection) {
 
     // Parse
     let columns: SimpleProductsTableVec = r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.parse('description:teddy') ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 1);
 
     // PhrasePrefix
     let columns: SimpleProductsTableVec = r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.phrase_prefix(field => 'description', phrases => ARRAY['har'])
         ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -172,7 +172,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // Phrase with invalid term list
     match r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.phrase(field => 'description', phrases => ARRAY['robot'])
         ORDER BY id"#
         .fetch_result::<SimpleProductsTable>(&mut conn)
@@ -194,7 +194,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // Range
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.range(field => 'last_updated_date', range => '[2023-05-01,2023-05-03]'::daterange)
     ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -323,7 +323,7 @@ fn exists_query(mut conn: PgConnection) {
 
     // Simple exists query
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.exists('rating')
     "#
     .fetch_collect(&mut conn);
@@ -331,7 +331,7 @@ fn exists_query(mut conn: PgConnection) {
 
     // Non fast field should fail
     match r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.exists('description')
     "#
     .execute_result(&mut conn)
@@ -345,7 +345,7 @@ fn exists_query(mut conn: PgConnection) {
         .execute(&mut conn);
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         paradedb.boolean(
             must => ARRAY[
                 paradedb.exists('rating'),
@@ -365,27 +365,22 @@ fn more_like_this_raw(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     match r#"
-    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@ 
+    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@
         paradedb.more_like_this();
     "#
     .fetch_result::<()>(&mut conn)
@@ -429,22 +424,17 @@ fn more_like_this_empty(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -472,22 +462,17 @@ fn more_like_this_text(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -511,7 +496,7 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (true, 'apple'),
         (false, 'banana')
     "#
@@ -519,18 +504,13 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(bool, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
        min_doc_frequency => 0,
        min_term_frequency => 0,
@@ -549,22 +529,17 @@ fn more_like_this_uuid_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('f159c89e-2162-48cd-85e3-e42b71d2ecd0', 'apple'),
-        ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'banana'), 
-        ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'cherry'), 
+        ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'banana'),
+        ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'cherry'),
         ('eb833eb6-c598-4042-b84a-0045828fceea', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -588,28 +563,23 @@ fn more_like_this_i64_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(i64, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
@@ -628,22 +598,17 @@ fn more_like_this_i32_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -667,22 +632,17 @@ fn more_like_this_i16_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -706,7 +666,7 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
         (2.2, 'banana'),
         (3.3, 'cherry'),
@@ -716,12 +676,7 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -744,28 +699,23 @@ fn more_like_this_f64_key(mut conn: PgConnection) {
     id FLOAT8 PRIMARY KEY,
     flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
-        (2.2, 'banana'), 
-        (3.3, 'cherry'), 
+        (2.2, 'banana'),
+        (3.3, 'cherry'),
         (4.4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(f64, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
@@ -783,23 +733,18 @@ fn more_like_this_numeric_key(mut conn: PgConnection) {
     id NUMERIC PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
-        (2.2, 'banana'), 
-        (3.3, 'cherry'), 
+        (2.2, 'banana'),
+        (3.3, 'cherry'),
         (4.4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -822,22 +767,17 @@ fn more_like_this_date_key(mut conn: PgConnection) {
     id DATE PRIMARY KEY,
     flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03', 'apple'),
-        ('2023-05-04', 'banana'), 
-        ('2023-05-05', 'cherry'), 
+        ('2023-05-04', 'banana'),
+        ('2023-05-05', 'cherry'),
         ('2023-05-06', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -860,29 +800,24 @@ fn more_like_this_time_key(mut conn: PgConnection) {
     id TIME PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('08:09:10', 'apple'),
-        ('09:10:11', 'banana'), 
-        ('10:11:12', 'cherry'), 
+        ('09:10:11', 'banana'),
+        ('10:11:12', 'cherry'),
         ('11:12:13', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
@@ -900,29 +835,24 @@ fn more_like_this_timestamp_key(mut conn: PgConnection) {
         id TIMESTAMP PRIMARY KEY,
         flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03 08:09:10', 'apple'),
-        ('2023-05-04 09:10:11', 'banana'), 
-        ('2023-05-05 10:11:12', 'cherry'), 
+        ('2023-05-04 09:10:11', 'banana'),
+        ('2023-05-05 10:11:12', 'cherry'),
         ('2023-05-06 11:12:13', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
@@ -940,29 +870,24 @@ fn more_like_this_timestamptz_key(mut conn: PgConnection) {
     id TIMESTAMP WITH TIME ZONE PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03 08:09:10 EST', 'apple'),
-        ('2023-05-04 09:10:11 PST', 'banana'), 
-        ('2023-05-05 10:11:12 MST', 'cherry'), 
+        ('2023-05-04 09:10:11 PST', 'banana'),
+        ('2023-05-05 10:11:12 MST', 'cherry'),
         ('2023-05-06 11:12:13 CST', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ 
+    WHERE test_more_like_this_table @@@
     paradedb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
@@ -980,7 +905,7 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
         id TIME WITH TIME ZONE PRIMARY KEY,
         flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('08:09:10 EST',
         'apple'),
         ('09:10:11 PST', 'banana'),
@@ -990,12 +915,7 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
     .execute(&mut conn);
     r#"
         CREATE INDEX test_more_like_this_index on test_more_like_this_table USING bm25 (id, flavour)
-        WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+        WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -1047,7 +967,7 @@ fn parse_lenient(mut conn: PgConnection) {
 
     // Default lenient should be false
     let result = r#"
-    SELECT id FROM paradedb.bm25_search 
+    SELECT id FROM paradedb.bm25_search
     WHERE paradedb.bm25_search.id @@@ paradedb.parse('shoes keyboard')
     ORDER BY id;
     "#
@@ -1056,7 +976,7 @@ fn parse_lenient(mut conn: PgConnection) {
 
     // With lenient enabled
     let rows: Vec<(i32,)> = r#"
-    SELECT id FROM paradedb.bm25_search 
+    SELECT id FROM paradedb.bm25_search
     WHERE paradedb.bm25_search.id @@@ paradedb.parse('shoes keyboard', lenient => true)
     ORDER BY id;
     "#
@@ -1069,7 +989,7 @@ fn parse_conjunction(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let rows: Vec<(i32,)> = r#"
-    SELECT id FROM paradedb.bm25_search 
+    SELECT id FROM paradedb.bm25_search
     WHERE paradedb.bm25_search.id @@@ paradedb.parse('description:(shoes running)', conjunction_mode => true)
     ORDER BY id;
     "#.fetch(&mut conn);
@@ -1081,7 +1001,7 @@ fn parse_with_field_conjunction(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let rows: Vec<(i32,)> = r#"
-    SELECT id FROM paradedb.bm25_search 
+    SELECT id FROM paradedb.bm25_search
     WHERE paradedb.bm25_search.id @@@ paradedb.parse_with_field('description', 'shoes running', conjunction_mode => true)
     ORDER BY id;
     "#.fetch(&mut conn);

--- a/tests/tests/query_json.rs
+++ b/tests/tests/query_json.rs
@@ -26,7 +26,7 @@ use sqlx::PgConnection;
 fn boolean_tree(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
    '{
         "boolean": {
             "should": [
@@ -53,14 +53,14 @@ fn fuzzy_term(mut conn: PgConnection) {
     assert_eq!(columns.id, vec![1, 2, 12, 22, 32], "wrong results");
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     '{"term": {"field": "category", "value": "electornics"}}'::jsonb
     ORDER BY id"#
         .fetch_collect(&mut conn);
     assert!(columns.is_empty(), "without fuzzy field should be empty");
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{
             "fuzzy_term": {
                 "field": "description",
@@ -77,7 +77,7 @@ fn fuzzy_term(mut conn: PgConnection) {
     );
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{
             "fuzzy_term": {
                 "field": "description",
@@ -95,7 +95,7 @@ fn fuzzy_term(mut conn: PgConnection) {
     );
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{
             "fuzzy_term": {
                 "field": "description",
@@ -113,14 +113,14 @@ fn single_queries(mut conn: PgConnection) {
 
     // All
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     '{"all": null}'::jsonb ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
 
     // Boost
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     '{"boost": {"query": {"all": null}, "factor": 1.5}}'::jsonb
     ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -136,7 +136,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // DisjunctionMax
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     '{"disjunction_max": {"disjuncts": [{"parse": {"query_string": "description:shoes"}}]}}'::jsonb
     ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -164,14 +164,14 @@ fn single_queries(mut conn: PgConnection) {
 
     // Parse
     let columns: SimpleProductsTableVec = r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{"parse": {"query_string": "description:teddy"}}'::jsonb ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 1);
 
     // PhrasePrefix
     let columns: SimpleProductsTableVec = r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{"phrase_prefix": {"field": "description", "phrases": ["har"]}}'::jsonb
         ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -179,7 +179,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // Phrase with invalid term list
     match r#"
-        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+        SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{"phrase": {"field": "description", "phrases": ["robot"]}}'::jsonb
         ORDER BY id"#
         .fetch_result::<SimpleProductsTable>(&mut conn)
@@ -203,7 +203,7 @@ fn single_queries(mut conn: PgConnection) {
 
     // Range
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{
             "range": {
                 "field": "last_updated_date",
@@ -263,14 +263,14 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // All
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('all', null) ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 41);
 
     // Boost
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('boost', jsonb_build_object(
         'query', jsonb_build_object('all', null),
         'factor', 1.5)) ORDER BY id"#
@@ -279,7 +279,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // ConstScore
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('const_score', jsonb_build_object(
         'query', jsonb_build_object('all', null),
         'score', 3.9)) ORDER BY id"#
@@ -288,7 +288,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // DisjunctionMax
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('disjunction_max', jsonb_build_object(
         'disjuncts', jsonb_build_array(
             jsonb_build_object('parse', jsonb_build_object(
@@ -298,14 +298,14 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Empty
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('empty', null) ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 0);
 
     // FuzzyTerm
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('fuzzy_term', jsonb_build_object(
         'field', 'description',
         'value', 'wolo',
@@ -317,7 +317,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Parse
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('parse', jsonb_build_object(
         'query_string', 'description:teddy')) ORDER BY id"#
         .fetch_collect(&mut conn);
@@ -325,7 +325,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // PhrasePrefix
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('phrase_prefix', jsonb_build_object(
         'field', 'description',
         'phrases', jsonb_build_array('har'))) ORDER BY id"#
@@ -334,7 +334,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Phrase with invalid term list
     match r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('phrase', jsonb_build_object(
         'field', 'description',
         'phrases', jsonb_build_array('robot'))) ORDER BY id"#
@@ -348,7 +348,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Phrase
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('phrase', jsonb_build_object(
         'field', 'description',
         'phrases', jsonb_build_array('robot', 'building', 'kit'))) ORDER BY id"#
@@ -357,7 +357,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Range
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('range', jsonb_build_object(
         'field', 'last_updated_date',
         'lower_bound', jsonb_build_object('included', '2023-05-01T00:00:00.000000Z'),
@@ -368,7 +368,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Regex
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('regex', jsonb_build_object(
         'field', 'description',
         'pattern', '(hardcover|plush|leather|running|wireless)')) ORDER BY id"#
@@ -377,7 +377,7 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Term
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('term', jsonb_build_object(
         'field', 'description',
         'value', 'shoes')) ORDER BY id"#
@@ -386,14 +386,14 @@ fn single_queries_jsonb_build_object(mut conn: PgConnection) {
 
     // Term with no field (should search all columns)
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('term', jsonb_build_object('value', 'shoes')) ORDER BY id"#
         .fetch_collect(&mut conn);
     assert_eq!(columns.len(), 3);
 
     // TermSet
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
     jsonb_build_object('term_set', jsonb_build_object(
         'terms', jsonb_build_array(
             jsonb_build_array('description', 'shoes', false),
@@ -408,7 +408,7 @@ fn exists_query(mut conn: PgConnection) {
 
     // Simple exists query
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{"exists": {"field": "rating"}}'::jsonb
     "#
     .fetch_collect(&mut conn);
@@ -416,7 +416,7 @@ fn exists_query(mut conn: PgConnection) {
 
     // Non fast field should fail
     match r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{"exists": {"field": "description"}}'::jsonb
     "#
     .execute_result(&mut conn)
@@ -430,7 +430,7 @@ fn exists_query(mut conn: PgConnection) {
         .execute(&mut conn);
 
     let columns: SimpleProductsTableVec = r#"
-    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT * FROM paradedb.bm25_search WHERE bm25_search @@@
         '{
             "boolean": {
                 "must": [
@@ -452,28 +452,23 @@ fn more_like_this_raw(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
     // Missing keys should fail.
     match r#"
-    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@ 
+    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@
         '{"more_like_this": {}}'::jsonb;
     "#
     .fetch_result::<()>(&mut conn)
@@ -488,10 +483,10 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     // Conflicting keys should fail.
     match r#"
-    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@ 
+    SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@
         '{"more_like_this": {
             "document_id": 0,
-            "document_fields": [["flavour", "banana"]]            
+            "document_fields": [["flavour", "banana"]]
         }}'::jsonb;
     "#
     .fetch_result::<()>(&mut conn)
@@ -539,22 +534,17 @@ fn more_like_this_empty(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -582,22 +572,17 @@ fn more_like_this_text(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (flavour) VALUES 
+    INSERT INTO test_more_like_this_table (flavour) VALUES
         ('apple'),
-        ('banana'), 
-        ('cherry'), 
+        ('banana'),
+        ('cherry'),
         ('banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -623,7 +608,7 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (true, 'apple'),
         (false, 'banana')
     "#
@@ -631,12 +616,7 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -662,22 +642,17 @@ fn more_like_this_uuid_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('f159c89e-2162-48cd-85e3-e42b71d2ecd0', 'apple'),
-        ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'banana'), 
-        ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'cherry'), 
+        ('38bf27a0-1aa8-42cd-9cb0-993025e0b8d0', 'banana'),
+        ('b5faacc0-9eba-441a-81f8-820b46a3b57e', 'cherry'),
         ('eb833eb6-c598-4042-b84a-0045828fceea', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -703,22 +678,17 @@ fn more_like_this_i64_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -744,22 +714,17 @@ fn more_like_this_i32_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -785,22 +750,17 @@ fn more_like_this_i16_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1, 'apple'),
-        (2, 'banana'), 
-        (3, 'cherry'), 
+        (2, 'banana'),
+        (3, 'cherry'),
         (4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -826,7 +786,7 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
         flavour TEXT
     );
 
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
         (2.2, 'banana'),
         (3.3, 'cherry'),
@@ -836,12 +796,7 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -866,22 +821,17 @@ fn more_like_this_f64_key(mut conn: PgConnection) {
     id FLOAT8 PRIMARY KEY,
     flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
-        (2.2, 'banana'), 
-        (3.3, 'cherry'), 
+        (2.2, 'banana'),
+        (3.3, 'cherry'),
         (4.4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -906,23 +856,18 @@ fn more_like_this_numeric_key(mut conn: PgConnection) {
     id NUMERIC PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         (1.1, 'apple'),
-        (2.2, 'banana'), 
-        (3.3, 'cherry'), 
+        (2.2, 'banana'),
+        (3.3, 'cherry'),
         (4.4, 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -947,22 +892,17 @@ fn more_like_this_date_key(mut conn: PgConnection) {
     id DATE PRIMARY KEY,
     flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03', 'apple'),
-        ('2023-05-04', 'banana'), 
-        ('2023-05-05', 'cherry'), 
+        ('2023-05-04', 'banana'),
+        ('2023-05-05', 'cherry'),
         ('2023-05-06', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -987,23 +927,18 @@ fn more_like_this_time_key(mut conn: PgConnection) {
     id TIME PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('08:09:10', 'apple'),
-        ('09:10:11', 'banana'), 
-        ('10:11:12', 'cherry'), 
+        ('09:10:11', 'banana'),
+        ('10:11:12', 'cherry'),
         ('11:12:13', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -1028,23 +963,18 @@ fn more_like_this_timestamp_key(mut conn: PgConnection) {
         id TIMESTAMP PRIMARY KEY,
         flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03 08:09:10', 'apple'),
-        ('2023-05-04 09:10:11', 'banana'), 
-        ('2023-05-05 10:11:12', 'cherry'), 
+        ('2023-05-04 09:10:11', 'banana'),
+        ('2023-05-05 10:11:12', 'cherry'),
         ('2023-05-06 11:12:13', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -1069,23 +999,18 @@ fn more_like_this_timestamptz_key(mut conn: PgConnection) {
     id TIMESTAMP WITH TIME ZONE PRIMARY KEY,
     flavour TEXT
     );
-    
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('2023-05-03 08:09:10 EST', 'apple'),
-        ('2023-05-04 09:10:11 PST', 'banana'), 
-        ('2023-05-05 10:11:12 MST', 'cherry'), 
+        ('2023-05-04 09:10:11 PST', 'banana'),
+        ('2023-05-05 10:11:12 MST', 'cherry'),
         ('2023-05-06 11:12:13 CST', 'banana split');
     "#
     .execute(&mut conn);
 
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -1110,7 +1035,7 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
         id TIME WITH TIME ZONE PRIMARY KEY,
         flavour TEXT
     );
-    INSERT INTO test_more_like_this_table (id, flavour) VALUES 
+    INSERT INTO test_more_like_this_table (id, flavour) VALUES
         ('08:09:10 EST', 'apple'),
         ('09:10:11 PST', 'banana'),
         ('10:11:12 MST', 'cherry'),
@@ -1119,12 +1044,7 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
     .execute(&mut conn);
     r#"
     CREATE INDEX test_more_like_this_index ON test_more_like_this_table USING bm25 (id, flavour)
-    WITH (
-            key_field='id',
-            text_fields='{
-                "flavour": { "stored": true }
-            }'
-        );
+    WITH (key_field='id');
     "#
     .execute(&mut conn);
 
@@ -1260,7 +1180,7 @@ fn range_term(mut conn: PgConnection) {
 fn parse_error(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let result = r#"
-    SELECT id FROM paradedb.bm25_search WHERE bm25_search @@@ 
+    SELECT id FROM paradedb.bm25_search WHERE bm25_search @@@
     '{"all": {}}'::jsonb ORDER BY id"#
         .fetch_result::<(i32,)>(&mut conn);
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The only holdout to us removing the Tantivy store for all fields is the "more like this" query, which looks up a document in the store.

This PR reroutes the "more like this" query to construct the document from the Postgres heap instead of the Tantivy store.

Now that store is no longer required anywhere, we also remove `store` from the code base, tests, and docs.

## Why

This PR paves the way for a follow-on PR to make Tantivy not write to the store file at all (right now it writes some fixed data to the store file even if no fields are stored).

## How

Implemented our own `MoreLikeThis` query that reads from the Postgres heap instead of the Tantivy store.

Depends on https://github.com/paradedb/tantivy/pull/39

## Tests

All existing tests pass with `store` removed.