### PR TITLE
fix: move the `raw` tokenizer deprecation warning to CREATE INDEX

### DIFF
--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -22,8 +22,7 @@ pub mod range;
 use anyhow::{Context, Result};
 use derive_more::{AsRef, Display, From, Into};
 pub use document::*;
-use pgrx::pg_sys::panic::ErrorReport;
-use pgrx::{function_name, PgBuiltInOids, PgLogLevel, PgOid, PgRelation, PgSqlErrorCode};
+use pgrx::{PgBuiltInOids, PgOid, PgRelation};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
@@ -256,17 +255,6 @@ impl SearchFieldConfig {
             Some(v) => SearchTokenizer::from_json_value(v),
             None => Ok(SearchTokenizer::default()),
         }?;
-
-        #[allow(deprecated)]
-        if matches!(tokenizer, SearchTokenizer::Raw(_)) {
-            ErrorReport::new(
-                PgSqlErrorCode::ERRCODE_WARNING_DEPRECATED_FEATURE,
-                "the `raw` tokenizer is deprecated",
-                function_name!(),
-            )
-                .set_detail("the `raw` tokenizer is deprecated as it also lowercases and truncates the input and this is probably not what you want")
-            .set_hint("use `keyword` instead").report(PgLogLevel::WARNING);
-        }
 
         let record = match obj.get("record") {
             Some(v) => serde_json::from_value(v.clone()),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Rather than warning that the `raw` tokenizer is deprecated whenever we deserialize a schema configuraiton, only do it during CREATE INDEX.

## Why

The previous location generated too much WARNING spam!

## How

## Tests
