### PR TITLE
fix: bool pushdown is no longer confused with scoring

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -153,9 +153,9 @@ impl Qual {
             Qual::PushdownVarIsFalse { .. } => false,
             Qual::PushdownIsNotNull { .. } => false,
             Qual::ScoreExpr { .. } => true,
-            Qual::And(quals) => quals.iter().any(|q| q.contains_exprs()),
-            Qual::Or(quals) => quals.iter().any(|q| q.contains_exprs()),
-            Qual::Not(qual) => qual.contains_exprs(),
+            Qual::And(quals) => quals.iter().any(|q| q.contains_score_exprs()),
+            Qual::Or(quals) => quals.iter().any(|q| q.contains_score_exprs()),
+            Qual::Not(qual) => qual.contains_score_exprs(),
         }
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We had a bug where a `bool_field = TRUE | FALSE` in a query would cause our custom scan code to think the query needed scores when it did not.

## Why

Looks like a cut-n-paste error from the original predicate pushdown PR #2197 

## How

## Tests

A new test has been added to tickle the exact condition reported by the user.
