### PR TITLE
fix: our `json` to `paradedb.searchqueryinput` cast function should be `IMMUTABLE STRICT PARALLEL SAFE`

### DIFF
--- a/pg_search/sql/pg_search--0.15.18--0.15.19.sql
+++ b/pg_search/sql/pg_search--0.15.18--0.15.19.sql
@@ -36,3 +36,5 @@ CREATE OR REPLACE FUNCTION merge_info(index regclass)
 AS
 'MODULE_PATHNAME',
 'merge_info_wrapper' LANGUAGE c STRICT;
+
+ALTER FUNCTION paradedb.jsonb_to_searchqueryinput IMMUTABLE STRICT PARALLEL SAFE;

--- a/pg_search/src/api/index.rs
+++ b/pg_search/src/api/index.rs
@@ -1043,7 +1043,7 @@ fn jsonb_to_searchqueryinput(query: JsonB) -> SearchQueryInput {
 }
 
 extension_sql!(
-    "ALTER FUNCTION jsonb_to_searchqueryinput IMMUTABLE;",
+    "ALTER FUNCTION jsonb_to_searchqueryinput IMMUTABLE STRICT PARALLEL SAFE;",
     name = "jsonb_to_searchqueryinput",
     requires = [jsonb_to_searchqueryinput]
 );


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2432

## What

If the cast function is not `PARALLEL SAFE`, then Postgres won't be able to plan a parallel custom scan.

If it's not `STRICT` then a user could call it directly, pass it a NULL, and crash Postgres.

## Why

## How

## Tests

A new test has been added