### PR TITLE
feat: add tantivy-jieba tokenizer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cee-scape"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +824,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +992,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "der"
@@ -1537,6 +1579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1693,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1657,7 +1718,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2031,6 +2092,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
+dependencies = [
+ "include-flate-codegen",
+ "lazy_static",
+ "libflate",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
+dependencies = [
+ "libflate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2127,6 +2211,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jieba-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c676b32a471d3cfae8dac2ad2f8334cd52e53377733cca8c1fb0a5062fec192"
+dependencies = [
+ "phf_codegen",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1bcad6332969e4d48ee568d430e14ee6dea70740c2549d005d87677ebefb0c"
+dependencies = [
+ "cedarwood",
+ "fxhash",
+ "include-flate",
+ "jieba-macros",
+ "lazy_static",
+ "phf",
+ "regex",
+]
 
 [[package]]
 name = "jiff"
@@ -2227,6 +2335,30 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2458,7 +2590,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2876,7 +3008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.2",
  "indexmap",
  "serde",
 ]
@@ -3067,6 +3199,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,7 +3387,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3364,7 +3516,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3545,6 +3697,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rsa"
@@ -4129,7 +4287,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.15.2",
  "hashlink",
  "indexmap",
  "log",
@@ -4558,6 +4716,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy-jieba"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2fe65c125f0d76d06f0f2ce9fbb9287b53f0dafb51a6270d984a840e2f16c1"
+dependencies = [
+ "jieba-rs",
+ "lazy_static",
+ "tantivy-tokenizer-api",
+]
+
+[[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=eb9027a8590475b1435bad764c7fd1bcd95dc8c7#eb9027a8590475b1435bad764c7fd1bcd95dc8c7"
@@ -4784,6 +4953,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tantivy",
+ "tantivy-jieba",
  "tracing",
 ]
 
@@ -5786,11 +5956,31 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.24",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
 ], default-features = false }
 pgrx = "=0.14.1"
 pgrx-tests = "=0.14.1"
+tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "eb9027a8590475b1435bad764c7fd1bcd95dc8c7" }

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -105,7 +105,8 @@ fn list_tokenizers(mut conn: PgConnection) {
                 ("chinese_lindera".into(),),
                 ("japanese_lindera".into(),),
                 ("korean_lindera".into(),),
-                ("icu".into(),)
+                ("icu".into(),),
+                ("jieba".into(),)
             ]
         );
     } else {
@@ -126,6 +127,7 @@ fn list_tokenizers(mut conn: PgConnection) {
                 ("chinese_lindera".into(),),
                 ("japanese_lindera".into(),),
                 ("korean_lindera".into(),),
+                ("jieba".into(),)
             ]
         );
     }

--- a/tests/tests/jieba.rs
+++ b/tests/tests/jieba.rs
@@ -49,34 +49,18 @@ fn test_jieba_tokenizer_basic(mut conn: PgConnection) {
     );
 
     let tokens = get_tokens(&mut conn, "jieba", "李宇");
-     assert_eq!(
-        tokens,
-        vec![
-            ("李宇".to_string(), 0),
-        ],
-        "Failed on '李宇'"
-    );
+    assert_eq!(tokens, vec![("李宇".to_string(), 0),], "Failed on '李宇'");
 
-     let tokens = get_tokens(&mut conn, "jieba", "公安");
-     assert_eq!(
-        tokens,
-        vec![
-            ("公安".to_string(), 0),
-        ],
-        "Failed on '公安'"
-    );
+    let tokens = get_tokens(&mut conn, "jieba", "公安");
+    assert_eq!(tokens, vec![("公安".to_string(), 0),], "Failed on '公安'");
 
-     let tokens = get_tokens(&mut conn, "jieba", "转移就业");
-     assert_eq!(
+    let tokens = get_tokens(&mut conn, "jieba", "转移就业");
+    assert_eq!(
         tokens,
-        vec![
-            ("转移".to_string(), 0),
-            ("就业".to_string(), 2),
-        ],
+        vec![("转移".to_string(), 0), ("就业".to_string(), 2),],
         "Failed on '转移就业'"
     );
 }
-
 
 #[rstest]
 fn test_jieba_tokenizer_indexing(mut conn: PgConnection) {
@@ -84,13 +68,14 @@ fn test_jieba_tokenizer_indexing(mut conn: PgConnection) {
     r#"CREATE TABLE chinese_texts (
             id SERIAL PRIMARY KEY,
             content TEXT
-        );"#.execute(&mut conn);
+        );"#
+    .execute(&mut conn);
 
     r#"INSERT INTO chinese_texts (content) VALUES
             ('我们都有光明的前途'),
             ('李宇给公安局打了电话'),
             ('这项政策旨在促进劳动力转移就业');"#
-         .execute(&mut conn);
+        .execute(&mut conn);
 
     r#"CREATE INDEX chinese_texts_idx ON chinese_texts
         USING bm25 (id, content)
@@ -99,7 +84,8 @@ fn test_jieba_tokenizer_indexing(mut conn: PgConnection) {
             text_fields = '{
                 "content": { "tokenizer": {"type": "jieba"} }
             }'
-        );"#.execute(&mut conn);
+        );"#
+    .execute(&mut conn);
 
     // Test searching using fetch/fetch_one extension methods
     let rows: Vec<(i32,)> =
@@ -110,10 +96,10 @@ fn test_jieba_tokenizer_indexing(mut conn: PgConnection) {
     let row: (i32,) =
         r#"SELECT id FROM chinese_texts WHERE chinese_texts @@@ 'content:公安局' ORDER BY id"#
             .fetch_one(&mut conn);
-     assert_eq!(row, (2,), "Failed on 'content:公安局'");
+    assert_eq!(row, (2,), "Failed on 'content:公安局'");
 
     let row: (i32,) =
         r#"SELECT id FROM chinese_texts WHERE chinese_texts @@@ 'content:就业' ORDER BY id"#
             .fetch_one(&mut conn);
     assert_eq!(row, (3,), "Failed on 'content:就业'");
-} 
+}

--- a/tests/tests/jieba.rs
+++ b/tests/tests/jieba.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::*;
+use pretty_assertions::assert_eq;
+use rstest::*;
+use sqlx::PgConnection;
+
+// Helper function to run tokenize and collect results
+fn get_tokens(conn: &mut PgConnection, tokenizer_type: &str, text: &str) -> Vec<(String, i32)> {
+    let query_str = format!(
+        "SELECT token, position FROM paradedb.tokenize(paradedb.tokenizer('{}'), '{}') ORDER BY position;",
+        tokenizer_type, text
+    );
+    query_str.fetch(conn)
+}
+
+#[rstest]
+fn test_jieba_tokenizer_basic(mut conn: PgConnection) {
+    // Test the paradedb.tokenize function directly
+    let tokens = get_tokens(&mut conn, "jieba", "我们都有光明的前途");
+    assert_eq!(
+        tokens,
+        vec![
+            ("我们".to_string(), 0),
+            ("都".to_string(), 2),
+            ("有".to_string(), 3),
+            ("光明".to_string(), 4),
+            ("的".to_string(), 6),
+            ("前途".to_string(), 7),
+        ],
+        "Failed on '我们都有光明的前途'"
+    );
+
+    let tokens = get_tokens(&mut conn, "jieba", "李宇");
+     assert_eq!(
+        tokens,
+        vec![
+            ("李宇".to_string(), 0),
+        ],
+        "Failed on '李宇'"
+    );
+
+     let tokens = get_tokens(&mut conn, "jieba", "公安");
+     assert_eq!(
+        tokens,
+        vec![
+            ("公安".to_string(), 0),
+        ],
+        "Failed on '公安'"
+    );
+
+     let tokens = get_tokens(&mut conn, "jieba", "转移就业");
+     assert_eq!(
+        tokens,
+        vec![
+            ("转移".to_string(), 0),
+            ("就业".to_string(), 2),
+        ],
+        "Failed on '转移就业'"
+    );
+}
+
+
+#[rstest]
+fn test_jieba_tokenizer_indexing(mut conn: PgConnection) {
+    // Create a table and index using the jieba tokenizer
+    r#"CREATE TABLE chinese_texts (
+            id SERIAL PRIMARY KEY,
+            content TEXT
+        );"#.execute(&mut conn);
+
+    r#"INSERT INTO chinese_texts (content) VALUES
+            ('我们都有光明的前途'),
+            ('李宇给公安局打了电话'),
+            ('这项政策旨在促进劳动力转移就业');"#
+         .execute(&mut conn);
+
+    r#"CREATE INDEX chinese_texts_idx ON chinese_texts
+        USING bm25 (id, content)
+        WITH (
+            key_field = 'id',
+            text_fields = '{
+                "content": { "tokenizer": {"type": "jieba"} }
+            }'
+        );"#.execute(&mut conn);
+
+    // Test searching using fetch/fetch_one extension methods
+    let rows: Vec<(i32,)> =
+        r#"SELECT id FROM chinese_texts WHERE chinese_texts @@@ 'content:光明' ORDER BY id"#
+            .fetch(&mut conn);
+    assert_eq!(rows, vec![(1,)], "Failed on 'content:光明'");
+
+    let row: (i32,) =
+        r#"SELECT id FROM chinese_texts WHERE chinese_texts @@@ 'content:公安局' ORDER BY id"#
+            .fetch_one(&mut conn);
+     assert_eq!(row, (2,), "Failed on 'content:公安局'");
+
+    let row: (i32,) =
+        r#"SELECT id FROM chinese_texts WHERE chinese_texts @@@ 'content:就业' ORDER BY id"#
+            .fetch_one(&mut conn);
+    assert_eq!(row, (3,), "Failed on 'content:就业'");
+} 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,6 +21,7 @@ tantivy.workspace = true
 tracing = "0.1.41"
 strum_macros = "0.27.1"
 strum = { version = "0.27.1", features = ["derive"] }
+tantivy-jieba = { workspace = true }
 
 [dependencies.rust_icu_ubrk]
 version = "5.0.0"


### PR DESCRIPTION
Integrates the tantivy-jieba crate, allowing users to select 'jieba' as a tokenizer type for BM25 indices. Includes basic tokenization and indexing tests.

NOTE: I am very much in "no one knows you're a dog on the internet" mode here, since 2.5 pro has done the heavy lifting here. I can only say that: 

* I built it locally against pg native and the docker versions; 
* I got it working, created tests, checked them, they passed;
* pgrx dependencies were giving me exceptional grief and I skipped the pre-commit hooks after spending even more time trying to sort that than hacking on the actual extension itself. It appears to be a Mac + C interaction, and I simply exhausted all available methods short of jumping to linux and doing everything again. 

# Ticket(s) Closed

- Closes #2490

## What

This PR adds support for the `jieba` Chinese language tokenizer to `pg_search` by integrating the `tantivy-jieba` crate. Users can now specify `{"type": "jieba"}` in their BM25 index configuration for text fields.

## Why

Current options for Chinese tokenization (`chinese_compatible`) are very basic (single character splits). While `chinese_lindera` offers dictionary-based tokenization, `jieba` often provides superior segmentation, particularly for compound words, proper nouns, and potentially ambiguous phrases, by using a combination of dictionary lookups and Hidden Markov Models. This can lead to improved search relevance.

Comparison tests (see Issue #2490 for detailed output) show `jieba` producing more granular and contextually relevant tokens in several cases compared to `chinese_compatible` and `chinese_lindera`.

Note that tantivy is 5x slower than chinese_compatible and 1.6x slower than chinese_lindera.

## How

1.  **Dependencies:** Added `tantivy-jieba = "0.11.0"` to `tokenizers/Cargo.toml`.
2.  **Tantivy Patch:** Added a `[patch.crates-io]` section to the root `Cargo.toml` pointing `tantivy` and `tantivy-tokenizer-api` to commit `eb9027a...`. This is necessary because the `jieba` integration required upstream changes in Tantivy that are not yet in a crates.io release.
3.  **Tokenizer Registration:** Modified `tokenizers/src/manager.rs` to:
    *   Add a `Jieba(SearchTokenizerFilters)` variant to the `SearchTokenizer` enum.
    *   Handle the `"jieba"` type in JSON serialization/deserialization (`to_json_value`, `from_json_value`).
    *   Construct the `tantivy::tokenizer::TextAnalyzer` using `tantivy_jieba::JiebaTokenizer` in `to_tantivy_tokenizer`.
    *   Update helper methods (`filters`, `name`) accordingly.
4.  **Lockfile:** Updated `Cargo.lock` with the new dependencies/patches.

## Tests

*   Added `tests/tests/jieba.rs` containing two test functions:
    *   `test_jieba_tokenizer_basic`: Directly calls `paradedb.tokenize` with the `jieba` tokenizer on various phrases and asserts the expected token/position output, confirming basic functionality.
    *   `test_jieba_tokenizer_indexing`: Creates a table, inserts Chinese text, builds a BM25 index using the `jieba` tokenizer, and performs basic single-term searches (`@@@`) to verify that indexing and searching work.
*   **Note:** Standard phrase query tests (`@@@ 'field:"term1 term2"'`) were omitted. Due to `jieba` often outputting non-sequential token positions (based on character/byte offsets), standard phrase search expecting adjacent positions does not reliably work. Exact phrase matching would require using the `keyword` tokenizer in parallel via field aliasing.