### PR TITLE
chore: Move the selection of the custom scan execution method to planning

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -20,6 +20,7 @@
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchFieldType;
+use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use tantivy::columnar::StrColumn;
 use tantivy::fastfield::{Column, FastFieldReaders};
@@ -240,7 +241,7 @@ impl FFType {
     }
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub enum WhichFastField {
     Junk(String),
     Ctid,
@@ -249,7 +250,7 @@ pub enum WhichFastField {
     Named(String, FastFieldType),
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub enum FastFieldType {
     String,
     Numeric,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -396,6 +396,8 @@ impl SearchIndexReader {
     ///
     /// It has no understanding of Postgres MVCC visibility.  It is the caller's responsibility to
     /// handle that, if it's necessary.
+    ///
+    /// TODO: Remove `_estimated_rows`.
     pub fn search(
         &self,
         need_scores: bool,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -104,7 +104,7 @@ impl OrderByStyle {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum ExecMethodType {
     #[default]
     Normal,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -123,6 +123,24 @@ pub enum ExecMethodType {
     },
 }
 
+impl ExecMethodType {
+    ///
+    /// Returns true if this execution method will emit results in sorted order with the given
+    /// number of workers.
+    ///
+    pub fn is_sorted(&self, nworkers: usize) -> bool {
+        match self {
+            ExecMethodType::TopN { .. } if nworkers == 0 => {
+                // TODO: To allow sorted output with parallel workers, we would need to partition
+                // our segments across the workers so that each worker emitted all of its results
+                // in sorted order.
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Args {
     pub root: *mut pg_sys::PlannerInfo,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::Cardinality;
+use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::CustomScan;
 use pgrx::{pg_sys, PgList};
 use serde::{Deserialize, Serialize};
@@ -101,6 +102,25 @@ impl OrderByStyle {
             (*self.pathkey()).pk_strategy.into()
         }
     }
+}
+
+#[derive(Default)]
+pub enum ExecMethodType {
+    #[default]
+    Normal,
+    TopN {
+        heaprelid: pg_sys::Oid,
+        limit: usize,
+        sort_direction: SortDirection,
+        need_scores: bool,
+    },
+    FastFieldString {
+        field: String,
+        which_fast_fields: Vec<WhichFastField>,
+    },
+    FastFieldNumeric {
+        which_fast_fields: Vec<WhichFastField>,
+    },
 }
 
 #[derive(Debug)]

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -38,7 +38,7 @@ use crate::postgres::customscan::exec::{
     mark_pos_custom_scan, rescan_custom_scan, restr_pos_custom_scan, shutdown_custom_scan,
 };
 
-use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, SortDirection};
+use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
@@ -51,14 +51,6 @@ use std::ptr::NonNull;
 
 pub trait CustomScanState: Default {
     fn init_exec_method(&mut self, cstate: *mut pg_sys::CustomScanState);
-
-    fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
-        None
-    }
-
-    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
-        None
-    }
 }
 
 pub trait CustomScan: ExecMethod + Default + Sized {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -81,7 +81,7 @@ impl ExecMethod for NumericFastFieldExecState {
                 state.need_scores(),
                 false,
                 &state.search_query_input,
-                state.limit,
+                None,
             );
             self.inner.did_query = true;
             true

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -359,13 +359,13 @@ impl CustomScan for PdbScan {
                 .custom_private()
                 .set_exec_method_type(exec_method_type);
 
-            // If we are sorting our output (which we will only do if we have a limit!) and we
-            // are _not_ using parallel workers, then we can claim that the output is sorted.
-            //
-            // TODO: To allow sorted output with parallel workers, we would need to partition
-            // our segments across the workers so that each worker emitted all of its results
-            // in sorted order.
-            if nworkers == 0 && builder.custom_private().is_sorted() && limit.is_some() {
+            // Once we have chosen an execution method type, we have a final determination of the
+            // properties of the output, and can make claims about whether it is sorted.
+            if builder
+                .custom_private()
+                .exec_method_type()
+                .is_sorted(nworkers)
+            {
                 if let Some(pathkey) = pathkey.as_ref() {
                     builder = builder.add_path_key(pathkey);
                 }

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -16,8 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::{AsCStr, Cardinality, Varno};
-use crate::postgres::customscan::builders::custom_path::OrderByStyle;
-use crate::postgres::customscan::builders::custom_path::SortDirection;
+use crate::index::fast_fields_helper::WhichFastField;
+use crate::postgres::customscan::builders::custom_path::{OrderByStyle, SortDirection};
+use crate::postgres::customscan::pdbscan::ExecMethodType;
 use crate::query::SearchQueryInput;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::{pg_sys, PgList};
@@ -37,6 +38,10 @@ pub struct PrivateData {
     var_attname_lookup: Option<FxHashMap<(Varno, pg_sys::AttrNumber), String>>,
     maybe_ff: bool,
     segment_count: usize,
+    which_fast_fields: Option<Vec<WhichFastField>>,
+    targetlist_len: usize,
+    need_scores: bool,
+    exec_method_type: ExecMethodType,
 }
 
 mod var_attname_lookup_serializer {
@@ -186,6 +191,22 @@ impl PrivateData {
     pub fn set_segment_count(&mut self, segment_count: usize) {
         self.segment_count = segment_count;
     }
+
+    pub fn set_which_fast_fields(&mut self, which_fast_fields: Option<Vec<WhichFastField>>) {
+        self.which_fast_fields = which_fast_fields;
+    }
+
+    pub fn set_exec_method_type(&mut self, exec_method_type: ExecMethodType) {
+        self.exec_method_type = exec_method_type;
+    }
+
+    pub fn set_targetlist_len(&mut self, targetlist_len: usize) {
+        self.targetlist_len = targetlist_len;
+    }
+
+    pub fn set_need_scores(&mut self, maybe: bool) {
+        self.need_scores = maybe;
+    }
 }
 
 //
@@ -238,5 +259,21 @@ impl PrivateData {
 
     pub fn segment_count(&self) -> usize {
         self.segment_count
+    }
+
+    pub fn which_fast_fields(&self) -> &Option<Vec<WhichFastField>> {
+        &self.which_fast_fields
+    }
+
+    pub fn exec_method_type(&self) -> &ExecMethodType {
+        &self.exec_method_type
+    }
+
+    pub fn targetlist_len(&self) -> usize {
+        self.targetlist_len
+    }
+
+    pub fn need_scores(&self) -> bool {
+        self.need_scores
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -96,20 +96,6 @@ impl CustomScanState for PdbScanState {
             (*self.exec_method.get()).init(self, cstate)
         }
     }
-
-    fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
-        match (self.limit, self.sort_direction) {
-            (Some(limit), Some(sort_direction)) => Some((limit, sort_direction)),
-            _ => None,
-        }
-    }
-
-    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
-        match (self.limit, self.sort_direction) {
-            (Some(limit), Some(SortDirection::None)) => Some(limit),
-            _ => None,
-        }
-    }
 }
 
 impl PdbScanState {

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -18,7 +18,7 @@
 use crate::api::Varno;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
-use crate::postgres::customscan::builders::custom_path::SortDirection;
+use crate::postgres::customscan::builders::custom_path::{ExecMethodType, SortDirection};
 use crate::postgres::customscan::pdbscan::exec_methods::ExecMethod;
 use crate::postgres::customscan::pdbscan::projections::snippet::SnippetInfo;
 use crate::postgres::customscan::pdbscan::qual_inspect::Qual;
@@ -46,12 +46,15 @@ pub struct PdbScanState {
     pub search_reader: Option<SearchIndexReader>,
 
     pub search_results: SearchResults,
-    pub which_fast_fields: Option<Vec<WhichFastField>>,
     pub targetlist_len: usize,
 
+    // TODO: Remove in favor of `exec_method_type`.
+    pub which_fast_fields: Option<Vec<WhichFastField>>,
     pub limit: Option<usize>,
     pub sort_field: Option<String>,
     pub sort_direction: Option<SortDirection>,
+
+    pub exec_method_type: ExecMethodType,
     pub retry_count: usize,
     pub heap_tuple_check_count: usize,
     pub virtual_tuple_count: usize,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2453

## What

Moves the choice of execution method to the planning phase, so that we can directly consume the chosen method to make assertions about the properties of the output.

## Why

As described on #2453: the current split can cause the type of confusion exemplified by #2452, where although a property like `sort_direction` is set on the builder, whether it is actually _used_ is not known until an execution method is chosen. For example: the `TopN` execution mode will consume the `sort_direction` and `limit`, but other execution modes will not apply a sort.

## How

Introduce `enum ExecMethodType`, which is chosen during planning and then consumed verbatim during execution to construct the `ExecMethod`. 

## Tests

Existing tests.