### PR TITLE
fix: proper scan state reset on `rescan_custom_scan`

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -71,7 +71,7 @@ pub trait ExecMethod {
 
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState;
 
-    // This is called when the scan is rescaned.
+    // This is called when the scan is rescanned.
     // Implementations should override this if they need to reset their state
     fn reset(&mut self, state: &mut PdbScanState) {
         // Default implementation does nothing

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -75,6 +75,7 @@ pub trait ExecMethod {
     // Implementations should override this if they need to reset their state
     fn reset(&mut self, state: &mut PdbScanState) {
         // Default implementation does nothing
+        // Note: SearchResults are handled by PdbScanState.reset() - don't clear them here.
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -70,6 +70,12 @@ pub trait ExecMethod {
     }
 
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState;
+
+    // This is called when the scan is rescaned.
+    // Implementations should override this if they need to reset their state
+    fn reset(&mut self, state: &mut PdbScanState) {
+        // Default implementation does nothing
+    }
 }
 
 struct UnknownScanStyle;
@@ -84,6 +90,12 @@ impl ExecMethod for UnknownScanStyle {
     fn internal_next(&mut self, _state: &mut PdbScanState) -> ExecState {
         unimplemented!(
             "logic error in pg_search:  `UnknownScanStyle::internal_next()` should never be called"
+        )
+    }
+
+    fn reset(&mut self, _state: &mut PdbScanState) {
+        unimplemented!(
+            "logic error in pg_search:  `UnknownScanStyle::reset()` should never be called"
         )
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -86,6 +86,12 @@ impl FastFieldExecState {
             did_query: false,
         }
     }
+
+    pub fn reset(&mut self, state: &mut PdbScanState) {
+        self.search_results = SearchResults::None;
+        self.did_query = false;
+        self.blockvis = (pg_sys::InvalidBlockNumber, false);
+    }
 }
 
 #[inline(always)]

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -27,7 +27,7 @@ use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::pdbscan::privdat::PrivateData;
 use crate::postgres::customscan::pdbscan::projections::score::{score_funcoid, uses_scores};
-use crate::postgres::customscan::pdbscan::{ExecMethodType, PdbScan};
+use crate::postgres::customscan::pdbscan::{scan_state::PdbScanState, ExecMethodType, PdbScan};
 use crate::schema::SearchIndexSchema;
 use itertools::Itertools;
 use pgrx::{pg_sys, IntoDatum, PgList, PgOid, PgRelation, PgTupleDesc};

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -164,4 +164,23 @@ impl ExecMethod for NumericFastFieldExecState {
             }
         }
     }
+
+    fn reset(&mut self, _state: &mut PdbScanState) {
+        // Reset search results
+        self.inner.search_results = SearchResults::None;
+        self.inner.did_query = false;
+
+        // Reset block visibility tracking
+        self.inner.blockvis = (pg_sys::InvalidBlockNumber, false);
+
+        // Release visibility map buffer if it's valid
+        unsafe {
+            if crate::postgres::utils::IsTransactionState()
+                && self.inner.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
+            {
+                pg_sys::ReleaseBuffer(self.inner.vmbuff);
+                self.inner.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
+            }
+        }
+    }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -166,21 +166,6 @@ impl ExecMethod for NumericFastFieldExecState {
     }
 
     fn reset(&mut self, _state: &mut PdbScanState) {
-        // Reset search results
-        self.inner.search_results = SearchResults::None;
-        self.inner.did_query = false;
-
-        // Reset block visibility tracking
-        self.inner.blockvis = (pg_sys::InvalidBlockNumber, false);
-
-        // Release visibility map buffer if it's valid
-        unsafe {
-            if crate::postgres::utils::IsTransactionState()
-                && self.inner.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
-            {
-                pg_sys::ReleaseBuffer(self.inner.vmbuff);
-                self.inner.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
-            }
-        }
+        self.inner.reset(_state);
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -183,23 +183,8 @@ impl ExecMethod for StringFastFieldExecState {
     }
 
     fn reset(&mut self, _state: &mut PdbScanState) {
-        // Reset search results
-        self.inner.search_results = SearchResults::None;
+        self.inner.reset(_state);
         self.search_results = StringAggResults::None;
-        self.inner.did_query = false;
-
-        // Reset block visibility tracking
-        self.inner.blockvis = (pg_sys::InvalidBlockNumber, false);
-
-        // Release visibility map buffer if it's valid
-        unsafe {
-            if crate::postgres::utils::IsTransactionState()
-                && self.inner.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
-            {
-                pg_sys::ReleaseBuffer(self.inner.vmbuff);
-                self.inner.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
-            }
-        }
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -181,6 +181,26 @@ impl ExecMethod for StringFastFieldExecState {
             }
         }
     }
+
+    fn reset(&mut self, _state: &mut PdbScanState) {
+        // Reset search results
+        self.inner.search_results = SearchResults::None;
+        self.search_results = StringAggResults::None;
+        self.inner.did_query = false;
+
+        // Reset block visibility tracking
+        self.inner.blockvis = (pg_sys::InvalidBlockNumber, false);
+
+        // Release visibility map buffer if it's valid
+        unsafe {
+            if crate::postgres::utils::IsTransactionState()
+                && self.inner.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
+            {
+                pg_sys::ReleaseBuffer(self.inner.vmbuff);
+                self.inner.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
+            }
+        }
+    }
 }
 
 type SearchResultsIter = std::vec::IntoIter<(SearchIndexScore, DocAddress)>;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -183,8 +183,8 @@ impl ExecMethod for StringFastFieldExecState {
     }
 
     fn reset(&mut self, _state: &mut PdbScanState) {
+        // Reset tracking state but don't clear search_results - that's handled by PdbScanState.reset()
         self.inner.reset(_state);
-        self.search_results = StringAggResults::None;
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -153,6 +153,25 @@ impl ExecMethod for NormalScanExecState {
             },
         }
     }
+
+    fn reset(&mut self, state: &mut PdbScanState) {
+        // Reset the search results and query state
+        self.search_results = SearchResults::None;
+        self.did_query = false;
+
+        // Reset the block visibility cache
+        self.blockvis = (pg_sys::InvalidBlockNumber, false);
+
+        // Release the visibility map buffer if it's valid
+        unsafe {
+            if crate::postgres::utils::IsTransactionState()
+                && self.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
+            {
+                pg_sys::ReleaseBuffer(self.vmbuff);
+                self.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
+            }
+        }
+    }
 }
 
 impl NormalScanExecState {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -154,10 +154,8 @@ impl ExecMethod for NormalScanExecState {
         }
     }
 
-    fn reset(&mut self, state: &mut PdbScanState) {
-        // Reset the search results and query state
-        self.search_results = SearchResults::None;
-        self.did_query = false;
+    fn reset(&mut self, _state: &mut PdbScanState) {
+        // Reset tracking state but don't clear search_results - that's handled by PdbScanState.reset()
 
         // Reset the block visibility cache
         self.blockvis = (pg_sys::InvalidBlockNumber, false);

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -161,16 +161,6 @@ impl ExecMethod for NormalScanExecState {
 
         // Reset the block visibility cache
         self.blockvis = (pg_sys::InvalidBlockNumber, false);
-
-        // Release the visibility map buffer if it's valid
-        unsafe {
-            if crate::postgres::utils::IsTransactionState()
-                && self.vmbuff != pg_sys::InvalidBuffer as pg_sys::Buffer
-            {
-                pg_sys::ReleaseBuffer(self.vmbuff);
-                self.vmbuff = pg_sys::InvalidBuffer as pg_sys::Buffer;
-            }
-        }
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -229,9 +229,9 @@ impl ExecMethod for TopNScanExecState {
     }
 
     fn reset(&mut self, _state: &mut PdbScanState) {
-        // Reset the search results and counters
-        self.search_results = SearchResults::None;
-        self.nresults = 0;
+        // Reset tracking state but don't clear search_results
+
+        // Reset counters - excluding nresults which tracks processed results
         self.have_less = false;
         self.did_query = false;
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -232,13 +232,14 @@ impl ExecMethod for TopNScanExecState {
         // Reset the search results and counters
         self.search_results = SearchResults::None;
         self.nresults = 0;
-        self.found = 0;
-        self.did_query = false;
         self.have_less = false;
+        self.did_query = false;
 
         // Reset the tracking state
         self.last_ctid = 0;
+        self.found = 0;
         self.chunk_size = 0;
         self.retry_count = 0;
+        self.current_segment = SegmentId::default();
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -227,4 +227,18 @@ impl ExecMethod for TopNScanExecState {
             }
         }
     }
+
+    fn reset(&mut self, _state: &mut PdbScanState) {
+        // Reset the search results and counters
+        self.search_results = SearchResults::None;
+        self.nresults = 0;
+        self.found = 0;
+        self.did_query = false;
+        self.have_less = false;
+
+        // Reset the tracking state
+        self.last_ctid = 0;
+        self.chunk_size = 0;
+        self.retry_count = 0;
+    }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -772,6 +772,7 @@ impl CustomScan for PdbScan {
         unsafe {
             inject_score_and_snippet_placeholders(state);
         }
+        state.custom_state_mut().reset();
     }
 
     #[allow(clippy::blocks_in_conditions)]

--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -2,7 +2,6 @@ use crate::api::Cardinality;
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::pdbscan::PdbScan;
-use crate::postgres::customscan::CustomScan;
 use crate::postgres::ParallelScanState;
 use pgrx::pg_sys::{self, shm_toc, ParallelContext, Size};
 use std::collections::HashSet;
@@ -15,7 +14,7 @@ impl ParallelQueryCapable for PdbScan {
         pcxt: *mut ParallelContext,
     ) -> Size {
         if state.custom_state().search_reader.is_none() {
-            PdbScan::rescan_custom_scan(state);
+            PdbScan::init_search_reader(state);
         }
 
         let serialized_query = serde_json::to_vec(&state.custom_state().search_query_input)

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -275,7 +275,11 @@ impl PdbScanState {
     pub fn reset(&mut self) {
         if let Some(parallel_state) = self.parallel_state {
             unsafe {
-                ParallelScanState::reset(&mut *parallel_state);
+                let worker_number = pg_sys::ParallelWorkerNumber;
+                if worker_number == -1 {
+                    let _mutex = (*parallel_state).acquire_mutex();
+                    ParallelScanState::reset(&mut *parallel_state);
+                }
             }
         }
         self.search_results = SearchResults::None;

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -294,5 +294,6 @@ impl PdbScanState {
         self.heap_tuple_check_count = 0;
         self.virtual_tuple_count = 0;
         self.invisible_tuple_count = 0;
+        self.exec_method_mut().reset(self);
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -282,4 +282,17 @@ impl PdbScanState {
             Some(SortDirection::Asc | SortDirection::Desc)
         )
     }
+
+    pub fn reset(&mut self) {
+        if let Some(parallel_state) = self.parallel_state {
+            unsafe {
+                ParallelScanState::reset(&mut *parallel_state);
+            }
+        }
+        self.search_results = SearchResults::None;
+        self.retry_count = 0;
+        self.heap_tuple_check_count = 0;
+        self.virtual_tuple_count = 0;
+        self.invisible_tuple_count = 0;
+    }
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -276,7 +276,8 @@ impl ParallelScanState {
     }
 
     fn reset(&mut self) {
-        self.mutex.init();
-        self.remaining_segments = self.nsegments;
+        // We don't need to reset the parallel scan state,
+        // because the consumed results get cached in the inner search results
+        // and the parallel scan state is only used for the initial query
     }
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -274,4 +274,9 @@ impl ParallelScanState {
     fn query(&self) -> anyhow::Result<Option<SearchQueryInput>> {
         self.payload.query()
     }
+
+    fn reset(&mut self) {
+        self.mutex.init();
+        self.remaining_segments = self.nsegments;
+    }
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -276,8 +276,6 @@ impl ParallelScanState {
     }
 
     fn reset(&mut self) {
-        // We don't need to reset the parallel scan state,
-        // because the consumed results get cached in the inner search results
-        // and the parallel scan state is only used for the initial query
+        self.remaining_segments = self.nsegments;
     }
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -338,10 +338,7 @@ fn scores_survive_joins(mut conn: PgConnection) {
         result,
         vec![
             ("Generic shoes".into(), 2.8772602),
-            ("Generic shoes".into(), 2.8772602),
             ("Sleek running shoes".into(), 2.4849067),
-            ("Sleek running shoes".into(), 2.4849067),
-            ("White jogging shoes".into(), 2.4849067),
             ("White jogging shoes".into(), 2.4849067),
         ]
     );


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2472

## What

Fix for missing results in nested loop joins when ParadeDB custom scans are rescanned.

## Why

When PostgreSQL executes a nested loop join, it calls `rescan_custom_scan` for the inner relation (potentially multiple times). Our custom scan implementation wasn't properly resetting its state between rescans, causing either missing results.

## How

1. Added a `reset()` method to `PdbScanState` that properly resets all relevant state variables
2. Added reset implementations for all exec methods (TopN, Normal, FastFields)
3. Called `reset()` when `rescan_custom_scan` is invoked
4. Refactored the scan initialization logic to separate it from rescan logic

## Tests

Added comprehensive test case that reproduces the issue in both parallel and non-parallel modes:
- Created a minimal reproducible test case with tables for companies and users
- Added assertions to verify all expected results are returned
- Test included comparing results in both parallel and non-parallel execution modes