### PR TITLE
ci: Avoid some red Xs in CI

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -31,7 +31,7 @@ jobs:
   benchmark-pg_search:
     name: Benchmark pg_search
     runs-on: ubicloud-standard-8
-    if: github.event.pull_request.draft == false
+    if: !cancelled() && github.event.pull_request.draft == false
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -31,7 +31,7 @@ jobs:
   test-pg_search-stressgres:
     name: Run Stressgres ${{ matrix.test_file }} on pg_search with PostgreSQL ${{ matrix.pg_version }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
-    if: github.event.pull_request.draft == false
+    if: !cancelled() && github.event.pull_request.draft == false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
When a partially completed job gets cancelled because a new run of the same commit was triggered, it shows as a red X in GitHub UI. Even though the job hasn't "failed", it was just skipped. This is because Microsoft hates us and loves money.

This PR cannot fully solves this, but it will at least make jobs that haven't launched yet and get cancelled do so with a green check. Because green is good.

## Why
^

## How
^

## Tests
^