### PR TITLE
chore: fixed two minor issues in cursor rules and test runner script.

### DIFF
--- a/.cursor/rules/03-development-workflow.mdc
+++ b/.cursor/rules/03-development-workflow.mdc
@@ -19,7 +19,7 @@ alwaysApply: false
 
 - Don't use `cargo test` directly
 - Use the `scripts/pg_search_test.sh` script for running tests:
-  - Example: `PGVER=17.4 ../scripts/pg_search_test.sh --test sorting`
+  - Example: `PGVER=17.4 ./scripts/pg_search_test.sh --test sorting`
   - This runs the specified test (in this example, the "sorting" test)
   - Possible PGVER values:
     - 14.17
@@ -31,7 +31,7 @@ alwaysApply: false
 ## SQL Queries
 
 - Use the `scripts/pg_search_run.sh` script for running SQL queries:
-  - Example: `PGVER=17.4 ../scripts/pg_search_run.sh psql -c "SELECT 1"`
+  - Example: `PGVER=17.4 ./scripts/pg_search_run.sh -c "SELECT 1"`
   - This script sets up the proper environment and database connection
 
 ## Debugging

--- a/scripts/pg_search_test.sh
+++ b/scripts/pg_search_test.sh
@@ -18,4 +18,4 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "${SCRIPT_DIR}/pg_search_common.sh"
 
 # Run the test suite with backtrace enabled and pass along all arguments
-RUST_BACKTRACE=1 cargo test --package tests --package tokenizers --features=icu $"@"
+RUST_BACKTRACE=1 cargo test --package tests --package tokenizers --features=icu "$@"


### PR DESCRIPTION
# Ticket(s) Closed

Fixes path references and script issues

## What

Fixed two issues:
1. Corrected command-line argument handling in pg_search_test.sh
2. Fixed incorrect path references in development workflow documentation

## Why

1. The test script had incorrect syntax for passing arguments (`$"@"` instead of `"$@"`)
2. Documentation examples incorrectly referenced scripts with `../scripts/` path instead of `./scripts/`

## How

1. Fixed the argument handling in pg_search_test.sh
2. Updated path references in development documentation
3. Removed redundant `psql` command in documentation example

## Tests

These changes fix script execution and documentation; no functional test changes needed.