### PR TITLE
fix: Revert "Move the selection of the custom scan execution method to planning (#2492)"

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -20,7 +20,6 @@
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchFieldType;
-use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use tantivy::columnar::StrColumn;
 use tantivy::fastfield::{Column, FastFieldReaders};
@@ -241,7 +240,7 @@ impl FFType {
     }
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
 pub enum WhichFastField {
     Junk(String),
     Ctid,
@@ -250,7 +249,7 @@ pub enum WhichFastField {
     Named(String, FastFieldType),
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
 pub enum FastFieldType {
     String,
     Numeric,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -396,8 +396,6 @@ impl SearchIndexReader {
     ///
     /// It has no understanding of Postgres MVCC visibility.  It is the caller's responsibility to
     /// handle that, if it's necessary.
-    ///
-    /// TODO: Remove `_estimated_rows`.
     pub fn search(
         &self,
         need_scores: bool,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -16,7 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::Cardinality;
-use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::CustomScan;
 use pgrx::{pg_sys, PgList};
 use serde::{Deserialize, Serialize};
@@ -100,43 +99,6 @@ impl OrderByStyle {
             assert!(!pathkey.is_null());
 
             (*self.pathkey()).pk_strategy.into()
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub enum ExecMethodType {
-    #[default]
-    Normal,
-    TopN {
-        heaprelid: pg_sys::Oid,
-        limit: usize,
-        sort_direction: SortDirection,
-        need_scores: bool,
-    },
-    FastFieldString {
-        field: String,
-        which_fast_fields: Vec<WhichFastField>,
-    },
-    FastFieldNumeric {
-        which_fast_fields: Vec<WhichFastField>,
-    },
-}
-
-impl ExecMethodType {
-    ///
-    /// Returns true if this execution method will emit results in sorted order with the given
-    /// number of workers.
-    ///
-    pub fn is_sorted(&self, nworkers: usize) -> bool {
-        match self {
-            ExecMethodType::TopN { .. } if nworkers == 0 => {
-                // TODO: To allow sorted output with parallel workers, we would need to partition
-                // our segments across the workers so that each worker emitted all of its results
-                // in sorted order.
-                true
-            }
-            _ => false,
         }
     }
 }

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -38,7 +38,7 @@ use crate::postgres::customscan::exec::{
     mark_pos_custom_scan, rescan_custom_scan, restr_pos_custom_scan, shutdown_custom_scan,
 };
 
-use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
+use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, SortDirection};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
@@ -51,6 +51,14 @@ use std::ptr::NonNull;
 
 pub trait CustomScanState: Default {
     fn init_exec_method(&mut self, cstate: *mut pg_sys::CustomScanState);
+
+    fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
+        None
+    }
+
+    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
+        None
+    }
 }
 
 pub trait CustomScan: ExecMethod + Default + Sized {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -23,11 +23,16 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::nodecast;
 use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
-use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
+use crate::postgres::customscan::builders::custom_state::{
+    CustomScanStateBuilder, CustomScanStateWrapper,
+};
 use crate::postgres::customscan::explainer::Explainer;
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::numeric::NumericFastFieldExecState;
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::string::StringFastFieldExecState;
+use crate::postgres::customscan::pdbscan::exec_methods::normal::NormalScanExecState;
 use crate::postgres::customscan::pdbscan::privdat::PrivateData;
 use crate::postgres::customscan::pdbscan::projections::score::{score_funcoid, uses_scores};
-use crate::postgres::customscan::pdbscan::{scan_state::PdbScanState, ExecMethodType, PdbScan};
+use crate::postgres::customscan::pdbscan::{scan_state::PdbScanState, CustomScanState, PdbScan};
 use crate::schema::SearchIndexSchema;
 use itertools::Itertools;
 use pgrx::{pg_sys, IntoDatum, PgList, PgOid, PgRelation, PgTupleDesc};
@@ -266,19 +271,56 @@ pub unsafe fn pullup_fast_fields(
     Some(matches)
 }
 
-pub fn is_string_agg_capable(privdata: &PrivateData) -> Option<String> {
-    if privdata.limit().is_some() {
+/// If the query can return "fast fields", make that determination here, falling back to the
+/// [`NormalScanExecState`] if not.
+///
+/// We support [`StringFastFieldExecState`] when there's 1 fast field and it's a string, or
+/// [`NumericFastFieldExecState`] when there's one or more numeric fast fields
+///
+/// `paradedb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
+/// these specialized [`ExecMethod`]s.
+pub fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
+    if let Some(field) = is_string_agg_capable(builder.custom_state()) {
+        let which_fast_fields = builder.custom_state().which_fast_fields.clone().unwrap();
+        builder
+            .custom_state()
+            .assign_exec_method(StringFastFieldExecState::new(field, which_fast_fields));
+    } else if is_numeric_fast_field_capable(builder.custom_state()) {
+        let which_fast_fields = builder
+            .custom_state()
+            .which_fast_fields
+            .clone()
+            .unwrap_or_default();
+        builder
+            .custom_state()
+            .assign_exec_method(NumericFastFieldExecState::new(which_fast_fields));
+    } else {
+        builder
+            .custom_state()
+            .assign_exec_method(NormalScanExecState::default());
+    }
+}
+
+fn is_string_agg_capable(state: &PdbScanState) -> Option<String> {
+    is_string_agg_capable_ex(state.limit, &state.which_fast_fields)
+}
+
+pub fn is_string_agg_capable_ex(
+    limit: Option<usize>,
+    which_fast_fields: &Option<Vec<WhichFastField>>,
+) -> Option<String> {
+    if limit.is_some() {
         // doing a string_agg when there's a limit is always a loss, performance-wise
         return None;
     }
-    if is_all_junk(privdata.which_fast_fields()) {
+    if is_all_junk(which_fast_fields) {
         // if all the fast fields we have are Junk fields, then we're not actually
         // projecting fast fields
         return None;
     }
 
     let mut string_field = None;
-    for ff in privdata.which_fast_fields().iter().flatten() {
+    for ff in which_fast_fields.iter().flatten() {
         match ff {
             WhichFastField::Named(_, FastFieldType::String) if string_field.is_none() => {
                 string_field = Some(ff.name())
@@ -295,23 +337,22 @@ pub fn is_string_agg_capable(privdata: &PrivateData) -> Option<String> {
     string_field
 }
 
-pub fn is_numeric_fast_field_capable(privdata: &PrivateData) -> bool {
-    if privdata.targetlist_len() == 0 {
+fn is_numeric_fast_field_capable(state: &PdbScanState) -> bool {
+    if state.targetlist_len == 0 {
         return true;
     }
 
-    let which_fast_fields = privdata.which_fast_fields();
-    if which_fast_fields.is_none() {
+    if state.which_fast_fields.is_none() {
         return false;
     }
 
-    if is_all_junk(which_fast_fields) {
+    if is_all_junk(&state.which_fast_fields) {
         // if all the fast fields we have are Junk fields, then we're not actually
         // projecting fast fields
         return false;
     }
 
-    for ff in which_fast_fields.iter().flatten() {
+    for ff in state.which_fast_fields.iter().flatten() {
         if matches!(ff, WhichFastField::Named(_, FastFieldType::String)) {
             return false;
         }
@@ -328,25 +369,20 @@ fn is_all_junk(which_fast_fields: &Option<Vec<WhichFastField>>) -> bool {
 
 /// Add nodes to `EXPLAIN` output to describe the "fast fields" being used by the query, if any
 pub fn explain(state: &CustomScanStateWrapper<PdbScan>, explainer: &mut Explainer) {
-    if let ExecMethodType::FastFieldString {
-        which_fast_fields, ..
-    }
-    | ExecMethodType::FastFieldNumeric {
-        which_fast_fields, ..
-    } = &state.custom_state().exec_method_type
-    {
-        explainer.add_text(
-            "Fast Fields",
-            which_fast_fields
-                .iter()
-                .map(|field| field.name())
-                .collect::<Vec<_>>()
-                .join(", "),
-        );
-    }
-
-    if let ExecMethodType::FastFieldString { field, .. } = &state.custom_state().exec_method_type {
-        explainer.add_text("String Agg Field", field);
+    if state.custom_state().is_top_n_capable().is_none() {
+        if let Some(fast_fields) = state.custom_state().which_fast_fields.as_ref() {
+            explainer.add_text(
+                "Fast Fields",
+                fast_fields
+                    .iter()
+                    .map(|field| field.name())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+            if let Some(string_agg_field) = is_string_agg_capable(state.custom_state()) {
+                explainer.add_text("String Agg Field", string_agg_field);
+            }
+        }
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -81,7 +81,7 @@ impl ExecMethod for NumericFastFieldExecState {
                 state.need_scores(),
                 false,
                 &state.search_query_input,
-                None,
+                state.limit,
             );
             self.inner.did_query = true;
             true

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -32,7 +32,7 @@ use crate::api::Cardinality;
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::customscan::builders::custom_path::{
-    CustomPathBuilder, ExecMethodType, Flags, OrderByStyle, RestrictInfoType, SortDirection,
+    CustomPathBuilder, Flags, OrderByStyle, RestrictInfoType, SortDirection,
 };
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
@@ -41,7 +41,7 @@ use crate::postgres::customscan::builders::custom_state::{
 use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
-    estimate_cardinality, is_string_agg_capable,
+    estimate_cardinality, is_string_agg_capable_ex,
 };
 use crate::postgres::customscan::pdbscan::parallel::{compute_nworkers, list_segment_ids};
 use crate::postgres::customscan::pdbscan::privdat::PrivateData;
@@ -56,13 +56,13 @@ use crate::postgres::customscan::pdbscan::projections::{
 };
 use crate::postgres::customscan::pdbscan::qual_inspect::extract_quals;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
-use crate::postgres::customscan::{self, CustomScan, CustomScanState};
+use crate::postgres::customscan::{CustomScan, CustomScanState, ExecMethod};
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::query::{AsHumanReadable, SearchQueryInput};
 use crate::schema::SearchIndexSchema;
 use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
-use exec_methods::normal::NormalScanExecState;
+use exec_methods::top_n::TopNScanExecState;
 use exec_methods::ExecState;
 use pgrx::pg_sys::CustomExecMethods;
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList, PgMemoryContexts, PgRelation};
@@ -152,7 +152,7 @@ impl PdbScan {
     }
 }
 
-impl customscan::ExecMethod for PdbScan {
+impl ExecMethod for PdbScan {
     fn exec_methods() -> *const CustomExecMethods {
         <PdbScan as ParallelQueryCapable>::exec_methods()
     }
@@ -232,23 +232,18 @@ impl CustomScan for PdbScan {
 
             // quick look at the target list to see if we might need to do our const projections
             let target_list = (*(*builder.args().root).parse).targetList;
-            builder
-                .custom_private()
-                .set_targetlist_len(PgList::<pg_sys::TargetEntry>::from_pg(target_list).len());
             let maybe_needs_const_projections = maybe_needs_const_projections(target_list.cast());
             let ff_cnt =
                 exec_methods::fast_fields::count(&mut builder, rti, &table, &schema, target_list);
             let maybe_ff = builder.custom_private().maybe_ff();
             let is_topn = limit.is_some() && pathkey.is_some();
-            builder
-                .custom_private()
-                .set_which_fast_fields(exec_methods::fast_fields::collect(
-                    maybe_ff,
-                    target_list,
-                    rti,
-                    &schema,
-                    &table,
-                ));
+            let which_fast_fields = exec_methods::fast_fields::collect(
+                builder.custom_private().maybe_ff(),
+                target_list,
+                rti,
+                &schema,
+                &table,
+            );
 
             //
             // look for quals we can support
@@ -391,7 +386,8 @@ impl CustomScan for PdbScan {
 
             if pathkey.is_some()
                 && !is_topn
-                && is_string_agg_capable(builder.custom_private()).is_some()
+                && is_string_agg_capable_ex(builder.custom_private().limit(), &which_fast_fields)
+                    .is_some()
             {
                 let pathkey = pathkey.as_ref().unwrap();
 
@@ -431,18 +427,13 @@ impl CustomScan for PdbScan {
                 builder = builder.set_parallel(nworkers);
             }
 
-            let exec_method_type = choose_exec_method(builder.custom_private());
-            builder
-                .custom_private()
-                .set_exec_method_type(exec_method_type);
-
-            // Once we have chosen an execution method type, we have a final determination of the
-            // properties of the output, and can make claims about whether it is sorted.
-            if builder
-                .custom_private()
-                .exec_method_type()
-                .is_sorted(nworkers)
-            {
+            // If we are sorting our output (which we will only do if we have a limit!) and we
+            // are _not_ using parallel workers, then we can claim that the output is sorted.
+            //
+            // TODO: To allow sorted output with parallel workers, we would need to partition
+            // our segments across the workers so that each worker emitted all of its results
+            // in sorted order.
+            if nworkers == 0 && builder.custom_private().is_sorted() && limit.is_some() {
                 if let Some(pathkey) = pathkey.as_ref() {
                     builder = builder.add_path_key(pathkey);
                 }
@@ -522,11 +513,24 @@ impl CustomScan for PdbScan {
                 .range_table_index()
                 .expect("range table index should have been set");
 
-            builder.custom_state().exec_method_type =
-                builder.custom_private().exec_method_type().clone();
+            {
+                let indexrel = PgRelation::open(builder.custom_state().indexrelid);
+                let heaprel = indexrel
+                    .heap_relation()
+                    .expect("index should belong to a table");
+                let directory = MVCCDirectory::snapshot(indexrel.oid());
+                let index = Index::open(directory)
+                    .expect("create_custom_scan_state: should be able to open index");
+                let schema = SearchIndexSchema::open(index.schema(), &indexrel);
 
-            builder.custom_state().which_fast_fields =
-                builder.custom_private().which_fast_fields().clone();
+                builder.custom_state().which_fast_fields = exec_methods::fast_fields::collect(
+                    builder.custom_private().maybe_ff(),
+                    builder.target_list().as_ptr(),
+                    builder.custom_state().rti,
+                    &schema,
+                    &heaprel,
+                );
+            }
 
             builder.custom_state().targetlist_len = builder.target_list().len();
 
@@ -574,8 +578,32 @@ impl CustomScan for PdbScan {
                     .collect();
 
             let need_snippets = builder.custom_state().need_snippets();
-
-            assign_exec_method(builder.custom_state());
+            let need_scores = builder.custom_state().need_scores();
+            if let Some((limit, sort_direction)) = builder.custom_state().is_top_n_capable() {
+                // having a valid limit and sort direction means we can do a TopN query
+                // and TopN can do snippets
+                let heaprelid = builder.custom_state().heaprelid;
+                builder
+                    .custom_state()
+                    .assign_exec_method(TopNScanExecState::new(
+                        heaprelid,
+                        limit,
+                        sort_direction,
+                        need_scores,
+                    ));
+            } else if let Some(limit) = builder.custom_state().is_unsorted_top_n_capable() {
+                let heaprelid = builder.custom_state().heaprelid;
+                builder
+                    .custom_state()
+                    .assign_exec_method(TopNScanExecState::new(
+                        heaprelid,
+                        limit,
+                        SortDirection::None,
+                        need_scores,
+                    ));
+            } else {
+                exec_methods::fast_fields::assign_exec_method(&mut builder);
+            }
 
             builder.build()
         }
@@ -899,73 +927,6 @@ impl CustomScan for PdbScan {
                 pg_sys::relation_close(indexrel, state.custom_state().lockmode);
             }
         }
-    }
-}
-
-///
-/// Choose and return an ExecMethodType based on the properties of the builder.
-///
-/// If the query can return "fast fields", make that determination here, falling back to the
-/// [`NormalScanExecState`] if not.
-///
-/// We support [`StringFastFieldExecState`] when there's 1 fast field and it's a string, or
-/// [`NumericFastFieldExecState`] when there's one or more numeric fast fields
-///
-/// `paradedb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
-/// these specialized [`ExecMethod`]s.
-///
-fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
-    if let Some((limit, sort_direction)) = privdata.limit().zip(privdata.sort_direction()) {
-        // having a valid limit and sort direction means we can do a TopN query
-        // and TopN can do snippets
-        ExecMethodType::TopN {
-            heaprelid: privdata.heaprelid().expect("heaprelid must be set"),
-            limit,
-            sort_direction,
-            need_scores: privdata.need_scores(),
-        }
-    } else if let Some(field) = exec_methods::fast_fields::is_string_agg_capable(privdata) {
-        ExecMethodType::FastFieldString {
-            field,
-            which_fast_fields: privdata.which_fast_fields().clone().unwrap(),
-        }
-    } else if exec_methods::fast_fields::is_numeric_fast_field_capable(privdata) {
-        ExecMethodType::FastFieldNumeric {
-            which_fast_fields: privdata.which_fast_fields().clone().unwrap_or_default(),
-        }
-    } else {
-        ExecMethodType::Normal
-    }
-}
-
-fn assign_exec_method(custom_state: &mut PdbScanState) {
-    match &custom_state.exec_method_type {
-        ExecMethodType::Normal => custom_state.assign_exec_method(NormalScanExecState::default()),
-        ExecMethodType::TopN {
-            heaprelid,
-            limit,
-            sort_direction,
-            need_scores,
-        } => custom_state.assign_exec_method(exec_methods::top_n::TopNScanExecState::new(
-            *heaprelid,
-            *limit,
-            *sort_direction,
-            *need_scores,
-        )),
-        ExecMethodType::FastFieldString {
-            field,
-            which_fast_fields,
-        } => custom_state.assign_exec_method(
-            exec_methods::fast_fields::string::StringFastFieldExecState::new(
-                field.to_owned(),
-                which_fast_fields.clone(),
-            ),
-        ),
-        ExecMethodType::FastFieldNumeric { which_fast_fields } => custom_state.assign_exec_method(
-            exec_methods::fast_fields::numeric::NumericFastFieldExecState::new(
-                which_fast_fields.clone(),
-            ),
-        ),
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -16,9 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::{AsCStr, Cardinality, Varno};
-use crate::index::fast_fields_helper::WhichFastField;
-use crate::postgres::customscan::builders::custom_path::{OrderByStyle, SortDirection};
-use crate::postgres::customscan::pdbscan::ExecMethodType;
+use crate::postgres::customscan::builders::custom_path::OrderByStyle;
+use crate::postgres::customscan::builders::custom_path::SortDirection;
 use crate::query::SearchQueryInput;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::{pg_sys, PgList};
@@ -38,10 +37,6 @@ pub struct PrivateData {
     var_attname_lookup: Option<FxHashMap<(Varno, pg_sys::AttrNumber), String>>,
     maybe_ff: bool,
     segment_count: usize,
-    which_fast_fields: Option<Vec<WhichFastField>>,
-    targetlist_len: usize,
-    need_scores: bool,
-    exec_method_type: ExecMethodType,
 }
 
 mod var_attname_lookup_serializer {
@@ -191,22 +186,6 @@ impl PrivateData {
     pub fn set_segment_count(&mut self, segment_count: usize) {
         self.segment_count = segment_count;
     }
-
-    pub fn set_which_fast_fields(&mut self, which_fast_fields: Option<Vec<WhichFastField>>) {
-        self.which_fast_fields = which_fast_fields;
-    }
-
-    pub fn set_exec_method_type(&mut self, exec_method_type: ExecMethodType) {
-        self.exec_method_type = exec_method_type;
-    }
-
-    pub fn set_targetlist_len(&mut self, targetlist_len: usize) {
-        self.targetlist_len = targetlist_len;
-    }
-
-    pub fn set_need_scores(&mut self, maybe: bool) {
-        self.need_scores = maybe;
-    }
 }
 
 //
@@ -259,21 +238,5 @@ impl PrivateData {
 
     pub fn segment_count(&self) -> usize {
         self.segment_count
-    }
-
-    pub fn which_fast_fields(&self) -> &Option<Vec<WhichFastField>> {
-        &self.which_fast_fields
-    }
-
-    pub fn exec_method_type(&self) -> &ExecMethodType {
-        &self.exec_method_type
-    }
-
-    pub fn targetlist_len(&self) -> usize {
-        self.targetlist_len
-    }
-
-    pub fn need_scores(&self) -> bool {
-        self.need_scores
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -18,7 +18,7 @@
 use crate::api::Varno;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
-use crate::postgres::customscan::builders::custom_path::{ExecMethodType, SortDirection};
+use crate::postgres::customscan::builders::custom_path::SortDirection;
 use crate::postgres::customscan::pdbscan::exec_methods::ExecMethod;
 use crate::postgres::customscan::pdbscan::projections::snippet::SnippetInfo;
 use crate::postgres::customscan::pdbscan::qual_inspect::Qual;
@@ -46,15 +46,12 @@ pub struct PdbScanState {
     pub search_reader: Option<SearchIndexReader>,
 
     pub search_results: SearchResults,
+    pub which_fast_fields: Option<Vec<WhichFastField>>,
     pub targetlist_len: usize,
 
-    // TODO: Remove in favor of `exec_method_type`.
-    pub which_fast_fields: Option<Vec<WhichFastField>>,
     pub limit: Option<usize>,
     pub sort_field: Option<String>,
     pub sort_direction: Option<SortDirection>,
-
-    pub exec_method_type: ExecMethodType,
     pub retry_count: usize,
     pub heap_tuple_check_count: usize,
     pub virtual_tuple_count: usize,
@@ -94,6 +91,20 @@ impl CustomScanState for PdbScanState {
         unsafe {
             // SAFETY: inner_scan_state is always initialized and call to `init()` could never move `self`
             (*self.exec_method.get()).init(self, cstate)
+        }
+    }
+
+    fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
+        match (self.limit, self.sort_direction) {
+            (Some(limit), Some(sort_direction)) => Some((limit, sort_direction)),
+            _ => None,
+        }
+    }
+
+    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
+        match (self.limit, self.sort_direction) {
+            (Some(limit), Some(SortDirection::None)) => Some(limit),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2505.

## What

Revert #2492.

## Why

The target lists used during planning and execution were different, and so #2492 resulted in #2505.

## How

Revert #2492 for now, and then we can re-land it later with a test for #2505, and an appropriate target list.