### PR TITLE
fix: Issue #2511 -- TopN scans no longer endless loop

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -26,7 +26,7 @@ use tantivy::index::SegmentId;
 
 // TODO:  should these be GUCs?  I think yes, probably
 const SUBSEQUENT_RETRY_SCALE_FACTOR: usize = 2;
-const MAX_CHUNK_SIZE: usize = 5000;
+const MAX_CHUNK_SIZE: usize = u32::MAX as usize;
 
 #[derive(Default)]
 pub struct TopNScanExecState {

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -652,6 +652,29 @@ fn top_n_matches(mut conn: PgConnection) {
 }
 
 #[rstest]
+fn top_n_completes_issue2511(mut conn: PgConnection) {
+    r#"
+        drop table if exists loop;
+        create table loop (id serial8 not null primary key, message text) with (autovacuum_enabled = false);
+        create index idxloop on loop using bm25 (id, message) WITH (key_field = 'id', layer_sizes = '1GB, 1GB');
+
+        insert into loop (message) select md5(x::text) from generate_series(1, 5000) x;
+
+        update loop set message = message || ' beer';
+        update loop set message = message || ' beer';
+        update loop set message = message || ' beer';
+        update loop set message = message || ' beer';
+    "#.execute(&mut conn);
+
+    let results = r#"
+            set max_parallel_workers = 1;
+            select * from loop where id @@@ paradedb.all() order by id desc limit 25 offset 0;
+        "#
+    .fetch::<(i64, String)>(&mut conn);
+    assert_eq!(results.len(), 25);
+}
+
+#[rstest]
 fn parallel_custom_scan_with_jsonb_issue2432(mut conn: PgConnection) {
     r#"
         DROP TABLE IF EXISTS test;

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -664,12 +664,13 @@ fn top_n_completes_issue2511(mut conn: PgConnection) {
         update loop set message = message || ' beer';
         update loop set message = message || ' beer';
         update loop set message = message || ' beer';
+
+        set max_parallel_workers = 1;
     "#.execute(&mut conn);
 
     let results = r#"
-            set max_parallel_workers = 1;
-            select * from loop where id @@@ paradedb.all() order by id desc limit 25 offset 0;
-        "#
+        select * from loop where id @@@ paradedb.all() order by id desc limit 25 offset 0;
+    "#
     .fetch::<(i64, String)>(&mut conn);
     assert_eq!(results.len(), 25);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2511

## What

As described in #2511, it's currently possible for a TopN scan to get stuck in an endless loop if the index/data is structured in just the right way.

## Why

This fixes it by continuing to expand the "top n" results from tantivy until we've accepted "N" visible docs or we've read every possible matching doc from the segment.

## How

By essentially not having a limit to the "MAX_CHUNK_SIZE".  It's now capped at u32::MAX, which is the max number of docs a segment could possibly contain.

## Tests

A full re-create has been added.