### PR TITLE
fix: move the selection of the custom scan execution method to planning

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -20,6 +20,7 @@
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchFieldType;
+use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use tantivy::columnar::StrColumn;
 use tantivy::fastfield::{Column, FastFieldReaders};
@@ -240,7 +241,7 @@ impl FFType {
     }
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub enum WhichFastField {
     Junk(String),
     Ctid,
@@ -249,7 +250,7 @@ pub enum WhichFastField {
     Named(String, FastFieldType),
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
 pub enum FastFieldType {
     String,
     Numeric,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -396,6 +396,8 @@ impl SearchIndexReader {
     ///
     /// It has no understanding of Postgres MVCC visibility.  It is the caller's responsibility to
     /// handle that, if it's necessary.
+    ///
+    /// TODO: Remove `_estimated_rows`.
     pub fn search(
         &self,
         need_scores: bool,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -396,8 +396,6 @@ impl SearchIndexReader {
     ///
     /// It has no understanding of Postgres MVCC visibility.  It is the caller's responsibility to
     /// handle that, if it's necessary.
-    ///
-    /// TODO: Remove `_estimated_rows`.
     pub fn search(
         &self,
         need_scores: bool,

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::Cardinality;
+use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::CustomScan;
 use pgrx::{pg_sys, PgList};
 use serde::{Deserialize, Serialize};
@@ -99,6 +100,43 @@ impl OrderByStyle {
             assert!(!pathkey.is_null());
 
             (*self.pathkey()).pk_strategy.into()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub enum ExecMethodType {
+    #[default]
+    Normal,
+    TopN {
+        heaprelid: pg_sys::Oid,
+        limit: usize,
+        sort_direction: SortDirection,
+        need_scores: bool,
+    },
+    FastFieldString {
+        field: String,
+        which_fast_fields: Vec<WhichFastField>,
+    },
+    FastFieldNumeric {
+        which_fast_fields: Vec<WhichFastField>,
+    },
+}
+
+impl ExecMethodType {
+    ///
+    /// Returns true if this execution method will emit results in sorted order with the given
+    /// number of workers.
+    ///
+    pub fn is_sorted(&self, nworkers: usize) -> bool {
+        match self {
+            ExecMethodType::TopN { .. } if nworkers == 0 => {
+                // TODO: To allow sorted output with parallel workers, we would need to partition
+                // our segments across the workers so that each worker emitted all of its results
+                // in sorted order.
+                true
+            }
+            _ => false,
         }
     }
 }

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -38,7 +38,7 @@ use crate::postgres::customscan::exec::{
     mark_pos_custom_scan, rescan_custom_scan, restr_pos_custom_scan, shutdown_custom_scan,
 };
 
-use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, SortDirection};
+use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
@@ -51,14 +51,6 @@ use std::ptr::NonNull;
 
 pub trait CustomScanState: Default {
     fn init_exec_method(&mut self, cstate: *mut pg_sys::CustomScanState);
-
-    fn is_top_n_capable(&self) -> Option<(usize, SortDirection)> {
-        None
-    }
-
-    fn is_unsorted_top_n_capable(&self) -> Option<usize> {
-        None
-    }
 }
 
 pub trait CustomScan: ExecMethod + Default + Sized {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -318,6 +318,7 @@ pub unsafe fn pullup_fast_fields(
         // we cannot support more than 1 different String fast field
         return None;
     }
+
     Some(matches)
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -281,7 +281,7 @@ pub unsafe fn pullup_fast_fields(
             }
 
             _ => {
-                // Check if we've already processed this attribute number
+                // Check if this column is already in our processed attribute numbers
                 if processed_attnos.contains(&attno) {
                     continue;
                 }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -167,9 +167,9 @@ pub unsafe fn collect_fast_fields(
     maybe_ff: bool,
     target_list: *mut pg_sys::List,
     referenced_columns: &HashSet<pg_sys::AttrNumber>,
+    rti: pg_sys::Index,
     schema: &SearchIndexSchema,
     heaprel: &PgRelation,
-    rti: pg_sys::Index,
 ) -> Option<Vec<WhichFastField>> {
     if maybe_ff {
         pullup_fast_fields(target_list, referenced_columns, schema, heaprel, rti)

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -258,6 +258,8 @@ pub unsafe fn pullup_fast_fields(
             matches.push(WhichFastField::Junk("window".into()));
             continue;
         }
+        // we only support Vars or our score function in the target list
+        return None;
     }
 
     // Now also consider all referenced columns from other parts of the query

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -23,16 +23,11 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::nodecast;
 use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
-use crate::postgres::customscan::builders::custom_state::{
-    CustomScanStateBuilder, CustomScanStateWrapper,
-};
+use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::explainer::Explainer;
-use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::numeric::NumericFastFieldExecState;
-use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::string::StringFastFieldExecState;
-use crate::postgres::customscan::pdbscan::exec_methods::normal::NormalScanExecState;
 use crate::postgres::customscan::pdbscan::privdat::PrivateData;
 use crate::postgres::customscan::pdbscan::projections::score::{score_funcoid, uses_scores};
-use crate::postgres::customscan::pdbscan::{scan_state::PdbScanState, CustomScanState, PdbScan};
+use crate::postgres::customscan::pdbscan::{scan_state::PdbScanState, ExecMethodType, PdbScan};
 use crate::schema::SearchIndexSchema;
 use itertools::Itertools;
 use pgrx::{pg_sys, IntoDatum, PgList, PgOid, PgRelation, PgTupleDesc};
@@ -271,56 +266,19 @@ pub unsafe fn pullup_fast_fields(
     Some(matches)
 }
 
-/// If the query can return "fast fields", make that determination here, falling back to the
-/// [`NormalScanExecState`] if not.
-///
-/// We support [`StringFastFieldExecState`] when there's 1 fast field and it's a string, or
-/// [`NumericFastFieldExecState`] when there's one or more numeric fast fields
-///
-/// `paradedb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
-/// these specialized [`ExecMethod`]s.
-pub fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
-    if let Some(field) = is_string_agg_capable(builder.custom_state()) {
-        let which_fast_fields = builder.custom_state().which_fast_fields.clone().unwrap();
-        builder
-            .custom_state()
-            .assign_exec_method(StringFastFieldExecState::new(field, which_fast_fields));
-    } else if is_numeric_fast_field_capable(builder.custom_state()) {
-        let which_fast_fields = builder
-            .custom_state()
-            .which_fast_fields
-            .clone()
-            .unwrap_or_default();
-        builder
-            .custom_state()
-            .assign_exec_method(NumericFastFieldExecState::new(which_fast_fields));
-    } else {
-        builder
-            .custom_state()
-            .assign_exec_method(NormalScanExecState::default());
-    }
-}
-
-fn is_string_agg_capable(state: &PdbScanState) -> Option<String> {
-    is_string_agg_capable_ex(state.limit, &state.which_fast_fields)
-}
-
-pub fn is_string_agg_capable_ex(
-    limit: Option<usize>,
-    which_fast_fields: &Option<Vec<WhichFastField>>,
-) -> Option<String> {
-    if limit.is_some() {
+pub fn is_string_agg_capable(privdata: &PrivateData) -> Option<String> {
+    if privdata.limit().is_some() {
         // doing a string_agg when there's a limit is always a loss, performance-wise
         return None;
     }
-    if is_all_junk(which_fast_fields) {
+    if is_all_junk(privdata.which_fast_fields()) {
         // if all the fast fields we have are Junk fields, then we're not actually
         // projecting fast fields
         return None;
     }
 
     let mut string_field = None;
-    for ff in which_fast_fields.iter().flatten() {
+    for ff in privdata.which_fast_fields().iter().flatten() {
         match ff {
             WhichFastField::Named(_, FastFieldType::String) if string_field.is_none() => {
                 string_field = Some(ff.name())
@@ -337,22 +295,23 @@ pub fn is_string_agg_capable_ex(
     string_field
 }
 
-fn is_numeric_fast_field_capable(state: &PdbScanState) -> bool {
-    if state.targetlist_len == 0 {
+pub fn is_numeric_fast_field_capable(privdata: &PrivateData) -> bool {
+    if privdata.targetlist_len() == 0 {
         return true;
     }
 
-    if state.which_fast_fields.is_none() {
+    let which_fast_fields = privdata.which_fast_fields();
+    if which_fast_fields.is_none() {
         return false;
     }
 
-    if is_all_junk(&state.which_fast_fields) {
+    if is_all_junk(which_fast_fields) {
         // if all the fast fields we have are Junk fields, then we're not actually
         // projecting fast fields
         return false;
     }
 
-    for ff in state.which_fast_fields.iter().flatten() {
+    for ff in which_fast_fields.iter().flatten() {
         if matches!(ff, WhichFastField::Named(_, FastFieldType::String)) {
             return false;
         }
@@ -369,20 +328,25 @@ fn is_all_junk(which_fast_fields: &Option<Vec<WhichFastField>>) -> bool {
 
 /// Add nodes to `EXPLAIN` output to describe the "fast fields" being used by the query, if any
 pub fn explain(state: &CustomScanStateWrapper<PdbScan>, explainer: &mut Explainer) {
-    if state.custom_state().is_top_n_capable().is_none() {
-        if let Some(fast_fields) = state.custom_state().which_fast_fields.as_ref() {
-            explainer.add_text(
-                "Fast Fields",
-                fast_fields
-                    .iter()
-                    .map(|field| field.name())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
-            if let Some(string_agg_field) = is_string_agg_capable(state.custom_state()) {
-                explainer.add_text("String Agg Field", string_agg_field);
-            }
-        }
+    if let ExecMethodType::FastFieldString {
+        which_fast_fields, ..
+    }
+    | ExecMethodType::FastFieldNumeric {
+        which_fast_fields, ..
+    } = &state.custom_state().exec_method_type
+    {
+        explainer.add_text(
+            "Fast Fields",
+            which_fast_fields
+                .iter()
+                .map(|field| field.name())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+
+    if let ExecMethodType::FastFieldString { field, .. } = &state.custom_state().exec_method_type {
+        explainer.add_text("String Agg Field", field);
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -119,9 +119,9 @@ impl ExecMethod for NumericFastFieldExecState {
                         (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
                         (*slot).tts_nvalid = natts as _;
 
-                        // Use the shared process_fast_fields function
+                        // Use the shared extract_data_from_fast_fields function
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
-                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::process_fast_fields(
+                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::extract_data_from_fast_fields(
                             natts,
                             tupdesc,
                             &self.inner.which_fast_fields,

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -81,7 +81,7 @@ impl ExecMethod for NumericFastFieldExecState {
                 state.need_scores(),
                 false,
                 &state.search_query_input,
-                None,
+                state.limit,
             );
             self.inner.did_query = true;
             true

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -81,7 +81,7 @@ impl ExecMethod for NumericFastFieldExecState {
                 state.need_scores(),
                 false,
                 &state.search_query_input,
-                state.limit,
+                None,
             );
             self.inner.did_query = true;
             true

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -17,9 +17,7 @@
 
 use crate::index::fast_fields_helper::{FFHelper, WhichFastField};
 use crate::index::reader::index::SearchResults;
-use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
-    ff_to_datum, FastFieldExecState,
-};
+use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::FastFieldExecState;
 use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
 use crate::postgres::customscan::pdbscan::is_block_all_visible;
 use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
@@ -121,80 +119,18 @@ impl ExecMethod for NumericFastFieldExecState {
                         (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
                         (*slot).tts_nvalid = natts as _;
 
-                        let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
-                        let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
-
-                        // Create mapping from attributes to fast fields
-                        let fast_fields = &mut self.inner.ffhelper;
-                        let which_fast_fields = &self.inner.which_fast_fields;
+                        // Use the shared process_fast_fields function
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
-
-                        // Build attribute to fast field mapping
-                        let mut attr_to_ff_map = std::collections::HashMap::new();
-                        let mut next_ff_idx = 0;
-                        for i in 0..natts {
-                            if !attr_to_ff_map.contains_key(&i)
-                                && next_ff_idx < which_fast_fields.len()
-                            {
-                                attr_to_ff_map.insert(i, next_ff_idx);
-                                next_ff_idx += 1;
-                            }
-                        }
-
-                        // Ensure every attribute has a mapping
-                        for i in 0..natts {
-                            debug_assert!(
-                                attr_to_ff_map.contains_key(&i),
-                                "Attribute at position {} has no fast field mapping",
-                                i
-                            );
-                            // Verify that the fast field index is valid
-                            if let Some(&ff_idx) = attr_to_ff_map.get(&i) {
-                                debug_assert!(
-                                    ff_idx < which_fast_fields.len(),
-                                    "Attribute at position {} maps to invalid fast field index {}",
-                                    i,
-                                    ff_idx
-                                );
-                            }
-                        }
-
-                        // Process attributes using our mapping
-                        for i in 0..natts {
-                            if let Some(&ff_idx) = attr_to_ff_map.get(&i) {
-                                if ff_idx < which_fast_fields.len() {
-                                    let which_fast_field = &which_fast_fields[ff_idx];
-                                    let att = tupdesc.get(i).unwrap();
-
-                                    match ff_to_datum(
-                                        (which_fast_field, ff_idx),
-                                        att.atttypid,
-                                        scored.bm25,
-                                        doc_address,
-                                        fast_fields,
-                                        &mut self.inner.strbuf,
-                                        slot,
-                                    ) {
-                                        None => {
-                                            datums[i] = pg_sys::Datum::null();
-                                            isnull[i] = true;
-                                        }
-                                        Some(datum) => {
-                                            datums[i] = datum;
-                                            isnull[i] = false;
-                                        }
-                                    }
-                                } else {
-                                    // Fast field index out of bounds
-                                    datums[i] = pg_sys::Datum::null();
-                                    isnull[i] = true;
-                                }
-                            } else {
-                                // This attribute doesn't have a matching fast field
-                                datums[i] = pg_sys::Datum::null();
-                                isnull[i] = true;
-                            }
-                        }
+                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::process_fast_fields(
+                            natts,
+                            tupdesc,
+                            &self.inner.which_fast_fields,
+                            &mut self.inner.ffhelper,
+                            slot,
+                            scored,
+                            doc_address,
+                            &mut self.inner.strbuf,
+                        );
 
                         ExecState::Virtual { slot }
                     } else {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -141,31 +141,75 @@ impl ExecMethod for StringFastFieldExecState {
                         let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
                         let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
 
-                        #[rustfmt::skip]
-                        debug_assert!(natts == self.inner.which_fast_fields.len());
-
+                        // Create mapping from attributes to fast fields
                         let fast_fields = &mut self.inner.ffhelper;
                         let which_fast_fields = &self.inner.which_fast_fields;
-                        for (i, att) in self.inner.tupdesc.as_ref().unwrap().iter().enumerate() {
-                            let which_fast_field = &which_fast_fields[i];
+                        let tupdesc = self.inner.tupdesc.as_ref().unwrap();
 
-                            match ff_to_datum(
-                                (which_fast_field, i),
-                                att.atttypid,
-                                scored.bm25,
-                                doc_address,
-                                fast_fields,
-                                &mut term,
-                                slot,
-                            ) {
-                                None => {
+                        // Build attribute to fast field mapping
+                        let mut attr_to_ff_map = std::collections::HashMap::new();
+                        let mut next_ff_idx = 0;
+                        for i in 0..natts {
+                            if !attr_to_ff_map.contains_key(&i)
+                                && next_ff_idx < which_fast_fields.len()
+                            {
+                                attr_to_ff_map.insert(i, next_ff_idx);
+                                next_ff_idx += 1;
+                            }
+                        }
+
+                        // Ensure every attribute has a mapping
+                        for i in 0..natts {
+                            debug_assert!(
+                                attr_to_ff_map.contains_key(&i),
+                                "Attribute at position {} has no fast field mapping",
+                                i
+                            );
+                            // Verify that the fast field index is valid
+                            if let Some(&ff_idx) = attr_to_ff_map.get(&i) {
+                                debug_assert!(
+                                    ff_idx < which_fast_fields.len(),
+                                    "Attribute at position {} maps to invalid fast field index {}",
+                                    i,
+                                    ff_idx
+                                );
+                            }
+                        }
+
+                        // Process attributes using our mapping
+                        for i in 0..natts {
+                            if let Some(&ff_idx) = attr_to_ff_map.get(&i) {
+                                if ff_idx < which_fast_fields.len() {
+                                    let which_fast_field = &which_fast_fields[ff_idx];
+                                    let att = tupdesc.get(i).unwrap();
+
+                                    match ff_to_datum(
+                                        (which_fast_field, ff_idx),
+                                        att.atttypid,
+                                        scored.bm25,
+                                        doc_address,
+                                        fast_fields,
+                                        &mut term,
+                                        slot,
+                                    ) {
+                                        None => {
+                                            datums[i] = pg_sys::Datum::null();
+                                            isnull[i] = true;
+                                        }
+                                        Some(datum) => {
+                                            datums[i] = datum;
+                                            isnull[i] = false;
+                                        }
+                                    }
+                                } else {
+                                    // Fast field index out of bounds
                                     datums[i] = pg_sys::Datum::null();
                                     isnull[i] = true;
                                 }
-                                Some(datum) => {
-                                    datums[i] = datum;
-                                    isnull[i] = false;
-                                }
+                            } else {
+                                // This attribute doesn't have a matching fast field
+                                datums[i] = pg_sys::Datum::null();
+                                isnull[i] = true;
                             }
                         }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -136,9 +136,9 @@ impl ExecMethod for StringFastFieldExecState {
                         (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
                         (*slot).tts_nvalid = natts as _;
 
-                        // Use the shared process_fast_fields function
+                        // Use the shared extract_data_from_fast_fields function
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
-                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::process_fast_fields(
+                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::extract_data_from_fast_fields(
                             natts,
                             tupdesc,
                             &self.inner.which_fast_fields,

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -32,7 +32,7 @@ use crate::api::Cardinality;
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::customscan::builders::custom_path::{
-    CustomPathBuilder, Flags, OrderByStyle, RestrictInfoType, SortDirection,
+    CustomPathBuilder, ExecMethodType, Flags, OrderByStyle, RestrictInfoType, SortDirection,
 };
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
@@ -41,7 +41,7 @@ use crate::postgres::customscan::builders::custom_state::{
 use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
-    estimate_cardinality, is_string_agg_capable_ex,
+    estimate_cardinality, is_string_agg_capable,
 };
 use crate::postgres::customscan::pdbscan::parallel::{compute_nworkers, list_segment_ids};
 use crate::postgres::customscan::pdbscan::privdat::PrivateData;
@@ -56,13 +56,13 @@ use crate::postgres::customscan::pdbscan::projections::{
 };
 use crate::postgres::customscan::pdbscan::qual_inspect::extract_quals;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
-use crate::postgres::customscan::{CustomScan, CustomScanState, ExecMethod};
+use crate::postgres::customscan::{self, CustomScan, CustomScanState};
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::query::{AsHumanReadable, SearchQueryInput};
 use crate::schema::SearchIndexSchema;
 use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
-use exec_methods::top_n::TopNScanExecState;
+use exec_methods::normal::NormalScanExecState;
 use exec_methods::ExecState;
 use pgrx::pg_sys::CustomExecMethods;
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList, PgMemoryContexts, PgRelation};
@@ -152,7 +152,7 @@ impl PdbScan {
     }
 }
 
-impl ExecMethod for PdbScan {
+impl customscan::ExecMethod for PdbScan {
     fn exec_methods() -> *const CustomExecMethods {
         <PdbScan as ParallelQueryCapable>::exec_methods()
     }
@@ -232,18 +232,23 @@ impl CustomScan for PdbScan {
 
             // quick look at the target list to see if we might need to do our const projections
             let target_list = (*(*builder.args().root).parse).targetList;
+            builder
+                .custom_private()
+                .set_targetlist_len(PgList::<pg_sys::TargetEntry>::from_pg(target_list).len());
             let maybe_needs_const_projections = maybe_needs_const_projections(target_list.cast());
             let ff_cnt =
                 exec_methods::fast_fields::count(&mut builder, rti, &table, &schema, target_list);
             let maybe_ff = builder.custom_private().maybe_ff();
             let is_topn = limit.is_some() && pathkey.is_some();
-            let which_fast_fields = exec_methods::fast_fields::collect(
-                builder.custom_private().maybe_ff(),
-                target_list,
-                rti,
-                &schema,
-                &table,
-            );
+            builder
+                .custom_private()
+                .set_which_fast_fields(exec_methods::fast_fields::collect(
+                    maybe_ff,
+                    target_list,
+                    rti,
+                    &schema,
+                    &table,
+                ));
 
             //
             // look for quals we can support
@@ -386,8 +391,7 @@ impl CustomScan for PdbScan {
 
             if pathkey.is_some()
                 && !is_topn
-                && is_string_agg_capable_ex(builder.custom_private().limit(), &which_fast_fields)
-                    .is_some()
+                && is_string_agg_capable(builder.custom_private()).is_some()
             {
                 let pathkey = pathkey.as_ref().unwrap();
 
@@ -427,13 +431,18 @@ impl CustomScan for PdbScan {
                 builder = builder.set_parallel(nworkers);
             }
 
-            // If we are sorting our output (which we will only do if we have a limit!) and we
-            // are _not_ using parallel workers, then we can claim that the output is sorted.
-            //
-            // TODO: To allow sorted output with parallel workers, we would need to partition
-            // our segments across the workers so that each worker emitted all of its results
-            // in sorted order.
-            if nworkers == 0 && builder.custom_private().is_sorted() && limit.is_some() {
+            let exec_method_type = choose_exec_method(builder.custom_private());
+            builder
+                .custom_private()
+                .set_exec_method_type(exec_method_type);
+
+            // Once we have chosen an execution method type, we have a final determination of the
+            // properties of the output, and can make claims about whether it is sorted.
+            if builder
+                .custom_private()
+                .exec_method_type()
+                .is_sorted(nworkers)
+            {
                 if let Some(pathkey) = pathkey.as_ref() {
                     builder = builder.add_path_key(pathkey);
                 }
@@ -513,24 +522,11 @@ impl CustomScan for PdbScan {
                 .range_table_index()
                 .expect("range table index should have been set");
 
-            {
-                let indexrel = PgRelation::open(builder.custom_state().indexrelid);
-                let heaprel = indexrel
-                    .heap_relation()
-                    .expect("index should belong to a table");
-                let directory = MVCCDirectory::snapshot(indexrel.oid());
-                let index = Index::open(directory)
-                    .expect("create_custom_scan_state: should be able to open index");
-                let schema = SearchIndexSchema::open(index.schema(), &indexrel);
+            builder.custom_state().exec_method_type =
+                builder.custom_private().exec_method_type().clone();
 
-                builder.custom_state().which_fast_fields = exec_methods::fast_fields::collect(
-                    builder.custom_private().maybe_ff(),
-                    builder.target_list().as_ptr(),
-                    builder.custom_state().rti,
-                    &schema,
-                    &heaprel,
-                );
-            }
+            builder.custom_state().which_fast_fields =
+                builder.custom_private().which_fast_fields().clone();
 
             builder.custom_state().targetlist_len = builder.target_list().len();
 
@@ -578,32 +574,8 @@ impl CustomScan for PdbScan {
                     .collect();
 
             let need_snippets = builder.custom_state().need_snippets();
-            let need_scores = builder.custom_state().need_scores();
-            if let Some((limit, sort_direction)) = builder.custom_state().is_top_n_capable() {
-                // having a valid limit and sort direction means we can do a TopN query
-                // and TopN can do snippets
-                let heaprelid = builder.custom_state().heaprelid;
-                builder
-                    .custom_state()
-                    .assign_exec_method(TopNScanExecState::new(
-                        heaprelid,
-                        limit,
-                        sort_direction,
-                        need_scores,
-                    ));
-            } else if let Some(limit) = builder.custom_state().is_unsorted_top_n_capable() {
-                let heaprelid = builder.custom_state().heaprelid;
-                builder
-                    .custom_state()
-                    .assign_exec_method(TopNScanExecState::new(
-                        heaprelid,
-                        limit,
-                        SortDirection::None,
-                        need_scores,
-                    ));
-            } else {
-                exec_methods::fast_fields::assign_exec_method(&mut builder);
-            }
+
+            assign_exec_method(builder.custom_state());
 
             builder.build()
         }
@@ -927,6 +899,73 @@ impl CustomScan for PdbScan {
                 pg_sys::relation_close(indexrel, state.custom_state().lockmode);
             }
         }
+    }
+}
+
+///
+/// Choose and return an ExecMethodType based on the properties of the builder.
+///
+/// If the query can return "fast fields", make that determination here, falling back to the
+/// [`NormalScanExecState`] if not.
+///
+/// We support [`StringFastFieldExecState`] when there's 1 fast field and it's a string, or
+/// [`NumericFastFieldExecState`] when there's one or more numeric fast fields
+///
+/// `paradedb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
+/// these specialized [`ExecMethod`]s.
+///
+fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
+    if let Some((limit, sort_direction)) = privdata.limit().zip(privdata.sort_direction()) {
+        // having a valid limit and sort direction means we can do a TopN query
+        // and TopN can do snippets
+        ExecMethodType::TopN {
+            heaprelid: privdata.heaprelid().expect("heaprelid must be set"),
+            limit,
+            sort_direction,
+            need_scores: privdata.need_scores(),
+        }
+    } else if let Some(field) = exec_methods::fast_fields::is_string_agg_capable(privdata) {
+        ExecMethodType::FastFieldString {
+            field,
+            which_fast_fields: privdata.which_fast_fields().clone().unwrap(),
+        }
+    } else if exec_methods::fast_fields::is_numeric_fast_field_capable(privdata) {
+        ExecMethodType::FastFieldNumeric {
+            which_fast_fields: privdata.which_fast_fields().clone().unwrap_or_default(),
+        }
+    } else {
+        ExecMethodType::Normal
+    }
+}
+
+fn assign_exec_method(custom_state: &mut PdbScanState) {
+    match &custom_state.exec_method_type {
+        ExecMethodType::Normal => custom_state.assign_exec_method(NormalScanExecState::default()),
+        ExecMethodType::TopN {
+            heaprelid,
+            limit,
+            sort_direction,
+            need_scores,
+        } => custom_state.assign_exec_method(exec_methods::top_n::TopNScanExecState::new(
+            *heaprelid,
+            *limit,
+            *sort_direction,
+            *need_scores,
+        )),
+        ExecMethodType::FastFieldString {
+            field,
+            which_fast_fields,
+        } => custom_state.assign_exec_method(
+            exec_methods::fast_fields::string::StringFastFieldExecState::new(
+                field.to_owned(),
+                which_fast_fields.clone(),
+            ),
+        ),
+        ExecMethodType::FastFieldNumeric { which_fast_fields } => custom_state.assign_exec_method(
+            exec_methods::fast_fields::numeric::NumericFastFieldExecState::new(
+                which_fast_fields.clone(),
+            ),
+        ),
     }
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -261,9 +261,9 @@ impl CustomScan for PdbScan {
                     maybe_ff,
                     target_list,
                     &referenced_columns,
+                    rti,
                     &schema,
                     &table,
-                    rti,
                 ),
             );
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -950,10 +950,7 @@ fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
         // For StringFastFieldExecState, check that we won't have more columns
         // in the target list than fast fields
         if let Some(which_fast_fields) = privdata.which_fast_fields() {
-            // Important: Use the larger of targetlist_len and referenced_columns_count
-            // to account for all potential columns that might be accessed
-            let target_list_len = privdata.target_list_len().unwrap_or(0);
-            let columns_used = target_list_len + privdata.referenced_columns_count();
+            let columns_used = privdata.referenced_columns_count();
 
             // If the number of columns used is greater than our fast fields,
             // the execution method won't be compatible - fall back to Normal
@@ -969,9 +966,7 @@ fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
     } else if exec_methods::fast_fields::is_numeric_fast_field_capable(privdata) {
         // Similar check for numeric fast fields
         if let Some(which_fast_fields) = privdata.which_fast_fields() {
-            // Important: Use the larger of targetlist_len and referenced_columns_count
-            let target_list_len = privdata.target_list_len().unwrap_or(0);
-            let columns_used = target_list_len + privdata.referenced_columns_count();
+            let columns_used = privdata.referenced_columns_count();
 
             if columns_used > which_fast_fields.len() {
                 return ExecMethodType::Normal;

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -39,7 +39,7 @@ pub struct PrivateData {
     maybe_ff: bool,
     segment_count: usize,
     which_fast_fields: Option<Vec<WhichFastField>>,
-    targetlist_len: usize,
+    referenced_columns_count: usize,
     need_scores: bool,
     exec_method_type: ExecMethodType,
 }
@@ -200,8 +200,8 @@ impl PrivateData {
         self.exec_method_type = exec_method_type;
     }
 
-    pub fn set_targetlist_len(&mut self, targetlist_len: usize) {
-        self.targetlist_len = targetlist_len;
+    pub fn set_referenced_columns_count(&mut self, count: usize) {
+        self.referenced_columns_count = count;
     }
 
     pub fn set_need_scores(&mut self, maybe: bool) {
@@ -269,8 +269,8 @@ impl PrivateData {
         &self.exec_method_type
     }
 
-    pub fn targetlist_len(&self) -> usize {
-        self.targetlist_len
+    pub fn referenced_columns_count(&self) -> usize {
+        self.referenced_columns_count
     }
 
     pub fn need_scores(&self) -> bool {

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -16,8 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::{AsCStr, Cardinality, Varno};
-use crate::postgres::customscan::builders::custom_path::OrderByStyle;
-use crate::postgres::customscan::builders::custom_path::SortDirection;
+use crate::index::fast_fields_helper::WhichFastField;
+use crate::postgres::customscan::builders::custom_path::{OrderByStyle, SortDirection};
+use crate::postgres::customscan::pdbscan::ExecMethodType;
 use crate::query::SearchQueryInput;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::{pg_sys, PgList};
@@ -37,6 +38,10 @@ pub struct PrivateData {
     var_attname_lookup: Option<FxHashMap<(Varno, pg_sys::AttrNumber), String>>,
     maybe_ff: bool,
     segment_count: usize,
+    which_fast_fields: Option<Vec<WhichFastField>>,
+    targetlist_len: usize,
+    need_scores: bool,
+    exec_method_type: ExecMethodType,
 }
 
 mod var_attname_lookup_serializer {
@@ -186,6 +191,22 @@ impl PrivateData {
     pub fn set_segment_count(&mut self, segment_count: usize) {
         self.segment_count = segment_count;
     }
+
+    pub fn set_which_fast_fields(&mut self, which_fast_fields: Option<Vec<WhichFastField>>) {
+        self.which_fast_fields = which_fast_fields;
+    }
+
+    pub fn set_exec_method_type(&mut self, exec_method_type: ExecMethodType) {
+        self.exec_method_type = exec_method_type;
+    }
+
+    pub fn set_targetlist_len(&mut self, targetlist_len: usize) {
+        self.targetlist_len = targetlist_len;
+    }
+
+    pub fn set_need_scores(&mut self, maybe: bool) {
+        self.need_scores = maybe;
+    }
 }
 
 //
@@ -238,5 +259,21 @@ impl PrivateData {
 
     pub fn segment_count(&self) -> usize {
         self.segment_count
+    }
+
+    pub fn which_fast_fields(&self) -> &Option<Vec<WhichFastField>> {
+        &self.which_fast_fields
+    }
+
+    pub fn exec_method_type(&self) -> &ExecMethodType {
+        &self.exec_method_type
+    }
+
+    pub fn targetlist_len(&self) -> usize {
+        self.targetlist_len
+    }
+
+    pub fn need_scores(&self) -> bool {
+        self.need_scores
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -39,6 +39,7 @@ pub struct PrivateData {
     maybe_ff: bool,
     segment_count: usize,
     which_fast_fields: Option<Vec<WhichFastField>>,
+    target_list_len: Option<usize>,
     referenced_columns_count: usize,
     need_scores: bool,
     exec_method_type: ExecMethodType,
@@ -200,6 +201,10 @@ impl PrivateData {
         self.exec_method_type = exec_method_type;
     }
 
+    pub fn set_target_list_len(&mut self, len: Option<usize>) {
+        self.target_list_len = len;
+    }
+
     pub fn set_referenced_columns_count(&mut self, count: usize) {
         self.referenced_columns_count = count;
     }
@@ -267,6 +272,10 @@ impl PrivateData {
 
     pub fn exec_method_type(&self) -> &ExecMethodType {
         &self.exec_method_type
+    }
+
+    pub fn target_list_len(&self) -> Option<usize> {
+        self.target_list_len
     }
 
     pub fn referenced_columns_count(&self) -> usize {

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -274,11 +274,8 @@ impl PrivateData {
         &self.exec_method_type
     }
 
-    pub fn target_list_len(&self) -> Option<usize> {
-        self.target_list_len
-    }
-
     pub fn referenced_columns_count(&self) -> usize {
+        debug_assert!(self.referenced_columns_count >= self.target_list_len.unwrap_or(0));
         self.referenced_columns_count
     }
 

--- a/scripts/pg_search_run.sh
+++ b/scripts/pg_search_run.sh
@@ -10,12 +10,16 @@
 #   PGVER=<version> ./pg_search_run.sh [psql arguments]
 #   Example: PGVER=17.4 ./pg_search_run.sh psql -c "SELECT 1"
 
+CURRENT_DIR=$(pwd)
+
 set -Eeuo pipefail
 
 # Source the common setup script
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=./scripts/pg_search_common.sh
 source "${SCRIPT_DIR}/pg_search_common.sh"
+
+cd "${CURRENT_DIR}"
 
 # Connect to the database with psql and pass any additional arguments
 psql "${DATABASE_URL}" "$@"

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -1076,3 +1076,52 @@ fn uses_max_parallel_workers_per_gather_issue2515(mut conn: PgConnection) {
         Some(&Value::Number(Number::from(2)))
     );
 }
+
+#[rstest]
+fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS a;
+    DROP TABLE IF EXISTS b;
+
+    CREATE TABLE a (
+        a_id_pk TEXT,
+        content TEXT
+    );
+
+    CREATE TABLE b (
+        b_id_pk TEXT,
+        a_id_fk TEXT,
+        content TEXT
+    );
+
+    CREATE INDEX idxa ON a USING bm25 (a_id_pk, content) WITH (key_field = 'a_id_pk');
+
+    CREATE INDEX idxb ON b USING bm25 (b_id_pk, a_id_fk, content) WITH (key_field = 'b_id_pk', 
+      text_fields = '{ "a_id_fk": { "fast": true, "tokenizer": { "type": "keyword" } } }');
+
+    INSERT INTO a (a_id_pk, content) VALUES ('this-is-a-id', 'beer');
+    INSERT INTO b (b_id_pk, a_id_fk, content) VALUES ('this-is-b-id', 'this-is-a-id', 'wine');
+
+    VACUUM a, b;  -- needed to get Visibility Map up-to-date
+    "#
+    .execute(&mut conn);
+
+    // This query previously failed with:
+    // "ERROR: assertion failed: natts == self.inner.which_fast_fields.len()"
+    let result = r#"
+    SELECT a.a_id_pk as my_a_id_pk, b.b_id_pk as my_b_id_pk
+    FROM b
+    JOIN a ON a.a_id_pk = b.a_id_fk
+    WHERE a.content @@@ 'beer' AND b.content @@@ 'wine';
+    "#
+    .fetch_result::<(String, String)>(&mut conn)
+    .expect("JOIN query with string fast fields should execute successfully");
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0],
+        ("this-is-a-id".to_string(), "this-is-b-id".to_string())
+    );
+
+    "DROP TABLE a; DROP TABLE b;".execute(&mut conn);
+}

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -1086,13 +1086,13 @@ fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
     CREATE TABLE a (
         a_id_pk TEXT,
         content TEXT
-    );
+    ) WITH (autovacuum_enabled = false);
 
     CREATE TABLE b (
         b_id_pk TEXT,
         a_id_fk TEXT,
         content TEXT
-    );
+    ) WITH (autovacuum_enabled = false);
 
     CREATE INDEX idxa ON a USING bm25 (a_id_pk, content) WITH (key_field = 'a_id_pk');
 
@@ -1101,10 +1101,10 @@ fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
 
     INSERT INTO a (a_id_pk, content) VALUES ('this-is-a-id', 'beer');
     INSERT INTO b (b_id_pk, a_id_fk, content) VALUES ('this-is-b-id', 'this-is-a-id', 'wine');
-
-    VACUUM a, b;  -- needed to get Visibility Map up-to-date
     "#
     .execute(&mut conn);
+
+    "VACUUM a, b;  -- needed to get Visibility Map up-to-date".execute(&mut conn);
 
     // This query previously failed with:
     // "ERROR: assertion failed: natts == self.inner.which_fast_fields.len()"

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -1010,10 +1010,10 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
     .collect::<Vec<String>>()
     .join("\n");
 
-    // Verify NormalScanExecState is used (not TopNScanExecState)
+    // Verify NumericFastFieldExecState is used (not TopNScanExecState)
     assert!(
-        explain_output.contains("NormalScanExecState"),
-        "Expected NormalScanExecState in the execution plan"
+        explain_output.contains("NumericFastFieldExecState"),
+        "Expected NumericFastFieldExecState in the execution plan"
     );
 
     assert!(


### PR DESCRIPTION
This reverts commit 31665d1bad2456de6ba273c71bd3d3c190b9090f.

# Ticket(s) Closed

- Closes #2505
- Closes #2453
- 
## What

This PR fixes an issue with incorrect query plans for JOIN operations with string fast fields. The bug caused an assertion failure with the error `natts == self.inner.which_fast_fields.len()` when executing JOINs that reference TEXT fields in JOIN conditions.

## Why

When handling JOIN queries, the system needs to be aware of all columns referenced throughout the query, not just those in the target list. The issue occurred because:

1. The execution method selection only considered columns in the target list
2. For JOIN queries, additional columns used in JOIN conditions weren't properly accounted for
3. This led to choosing specialized execution methods (like StringFastFieldExecState) when they couldn't handle all the necessary columns

## How

This PR implements a comprehensive solution:

1. Enhanced column collection to identify all columns referenced in the query:
   - Added comprehensive parsing of JOIN conditions to find column references

2. Improved execution method selection using this enhanced column information:
   - Now considering all columns referenced anywhere in the query, not just in the target list
   - Using `referenced_columns_count` to determine if a specialized execution method can handle all needed columns
   - Falling back to the safer Normal execution method when there's a mismatch between available fast fields and actually needed columns

3. Added better error handling and documentation:
   - Documented the issue and solution to make future maintenance easier
   - Improved safety checks to avoid crashes when accessing PostgreSQL's internal structures

These changes ensure that when a JOIN query references a fast TEXT field in its JOIN condition, we properly account for it during execution method selection, preventing the assertion failure.

## Tests

A follow-up PR will have the test.