### PR TITLE
fix: Parallel workers use multi-segment Searchers to stabilize output

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -381,7 +381,7 @@ pub unsafe fn load_metas(
                 let missing = only_these
                     .difference(&alive_entries.iter().map(|s| s.segment_id).collect())
                     .cloned()
-                    .collect::<std::collections::HashSet<SegmentId>>();
+                    .collect::<FxHashSet<SegmentId>>();
                 let found = only_these.difference(&missing).collect::<FxHashSet<_>>();
 
                 panic!(
@@ -396,7 +396,7 @@ pub unsafe fn load_metas(
                 let actual = alive_entries
                     .iter()
                     .map(|s| s.segment_id)
-                    .collect::<std::collections::HashSet<_>>();
+                    .collect::<FxHashSet<_>>();
                 assert_eq!(
                     &actual, only_these,
                     "Got the wrong segments in parallel worker: \

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -711,13 +711,6 @@ impl SearchIndexReader {
         // `top_by_field_in_subset`.
         let segments_subset = self.segments_subset.as_ref().unwrap();
 
-        unsafe {
-            pgrx::log!(
-                ">>> worker {} operating on: {segments_subset:?}",
-                pg_sys::ParallelWorkerNumber
-            );
-        }
-
         let mut fruits = Vec::with_capacity(segments_subset.len());
         for (segment_ord, segment_reader) in self.searcher.segment_readers().iter().enumerate() {
             if !segments_subset.contains(&segment_reader.segment_id()) {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -23,6 +23,7 @@ use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use pgrx::pg_sys;
 use tantivy::{DocAddress, Score};
 
+#[derive(Debug)]
 pub enum ExecState {
     RequiresVisibilityCheck {
         ctid: u64,

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -298,17 +298,10 @@ impl ParallelScanState {
         let prev_remaining_segments = self.remaining_segments;
         self.remaining_segments -= segment_count;
 
-        // All segments.
         let segments = (0..self.nsegments).map(|i| self.segment_id(i)).collect();
         let segments_subset = (self.remaining_segments..prev_remaining_segments)
             .map(|i| self.segment_id(i))
             .collect();
-        unsafe {
-            pgrx::log!(
-                ">>> worker {} using segments: {segments_subset:?}",
-                pg_sys::ParallelWorkerNumber
-            );
-        }
 
         (segments, segments_subset)
     }
@@ -319,12 +312,9 @@ impl ParallelScanState {
         let prev_remaining_segments = self.remaining_segments;
         self.remaining_segments = 0;
 
-        let subset = (0..prev_remaining_segments)
+        (0..prev_remaining_segments)
             .map(|segment_idx| self.segment_id(segment_idx))
-            .collect();
-
-        pgrx::log!(">>> leader checking out remaining segments: {subset:?}");
-        subset
+            .collect()
     }
 
     pub fn segments(&mut self) -> FxHashMap<SegmentId, u32> {

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -694,9 +694,9 @@ fn parallel_custom_scan_with_jsonb_issue2432(mut conn: PgConnection) {
         limit 10;
     "#.fetch_one::<(serde_json::Value, )>(&mut conn);
 
-    eprintln!("{plan}");
+    eprintln!("{plan:#?}");
     let node = plan
-        .pointer("/0/Plan/Plans/0/Plans/0/Plans/0/Parallel Aware")
+        .pointer("/0/Plan/Plans/0/Plans/0/Parallel Aware")
         .unwrap();
     let parallel_aware = node
         .as_bool()


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2416

## What

Parallel workers for `TopN` currently search over a segment at a time, consuming the `limit` from the result, and then opening the next segment.

This change moves to having all workers divide the segments amongst themselves as they start up, and then has the leader claim any remaining segments.

## Why

The current implementation means that parallel `TopN`:
1. does not reliably emit "the same" `limit` results, because it depends on the order that the segments are visited in.
2. does not emit its results in sorted order (which is correct, but slightly less efficient because planning needs to wrap the result in extra `Sort` nodes)

## How

* Introduce the `ParallelScanState::{worker_checkout_segments,leader_checkout_remaining_segments}` methods for workers and the leader to use to claim batches of segments, and have the leader (attempt to: see the code comments) wait until its workers have started up before claiming the remaining segments.
* Merged single-segment `SearchIndexReader` methods into their multi-segment counterparts (mostly: note the TODOs), and adjusted all `ExecMethods` to operate over the same segments for their whole lifetime.
* Begin claiming that `TopN` outputs are sorted under parallel workers. This avoids extraneous `Sort` nodes, because our `Custom Scan` will immediately be wrapped in a `Gather Merge`.

## Tests

* Added support for calling `create_bm25_test_table` in two phases, to allow for creating multiple segments for an index on the created table.
* Added a multi-segment `limit`/`offset` test which reproduced the issue.