### PR TITLE
fix: parallel scans respect `max_parallel_workers_per_gather`

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -89,7 +89,7 @@ impl ParallelQueryCapable for PdbScan {
 ///
 pub fn compute_nworkers(limit: Option<Cardinality>, segment_count: usize, sorted: bool) -> usize {
     // we will try to parallelize based on the number of index segments
-    // from Postgres docs: Parallel workers are limited by max_parallel_workers
+    // parallel workers available to a gather node are limited by max_parallel_workers_per_gather and max_parallel_workers
     let mut nworkers = unsafe {
         segment_count
             .min(pg_sys::max_parallel_workers_per_gather as usize)

--- a/pg_search/src/postgres/customscan/pdbscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/parallel.rs
@@ -89,7 +89,8 @@ impl ParallelQueryCapable for PdbScan {
 ///
 pub fn compute_nworkers(limit: Option<Cardinality>, segment_count: usize, sorted: bool) -> usize {
     // we will try to parallelize based on the number of index segments
-    let mut nworkers = unsafe { segment_count.min(pg_sys::max_parallel_workers as usize) };
+    let mut nworkers =
+        unsafe { segment_count.min(pg_sys::max_parallel_workers_per_gather as usize) };
 
     if let Some(limit) = limit {
         if !sorted && limit <= (segment_count * segment_count * segment_count) as Cardinality {
@@ -99,7 +100,7 @@ pub fn compute_nworkers(limit: Option<Cardinality>, segment_count: usize, sorted
 
         // if the limit is less than some arbitrarily large value
         // use at most half the number of parallel workers as there are segments
-        // this generally seems to perform better than directly using `max_parallel_workers`
+        // this generally seems to perform better than directly using `max_parallel_workers_per_gather`
         if limit < 1_000_000.0 {
             nworkers = (segment_count / 2).min(nworkers);
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2515 

## What

`compute_nworkers` uses `max_parallel_workers_per_gather` instead of `max_parallel_workers`.

## Why

This is the correct setting to use.

## How

## Tests
Added test for parallel custom and index only scans.