### PR TITLE
chore: remove some `#[allow(...)]` annotations

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::types::TantivyValue;
 use crate::schema::SearchFieldType;

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 #![recursion_limit = "512"]
-#![allow(unexpected_cfgs)]
 
 mod api;
 mod bootstrap;

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::writer::index::IndexError;
+use crate::postgres::build::is_bm25_index;
 use crate::postgres::types::TantivyValue;
 use crate::schema::{SearchDocument, SearchField, SearchIndexSchema};
 use anyhow::{anyhow, Result};
@@ -40,11 +41,7 @@ pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgRelation> {
         // Find all bm25 indexes and keep the one with highest OID
         indices
             .into_iter()
-            .filter(|index| pg_sys::get_index_isvalid(index.oid()))
-            .filter(|index| {
-                !index.rd_indam.is_null()
-                    && (*index.rd_indam).ambuild == Some(crate::postgres::build::ambuild)
-            })
+            .filter(|index| pg_sys::get_index_isvalid(index.oid()) && is_bm25_index(index))
             .max_by_key(|index| index.oid().to_u32())
     }
 }

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // Copyright (c) 2023-2025 ParadeDB, Inc.
 //
 // This file is part of ParadeDB - Postgres for Search and Analytics

--- a/tests/tests/str_ff_exec.rs
+++ b/tests/tests/str_ff_exec.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // Copyright (c) 2023-2025 ParadeDB, Inc.
 //
 // This file is part of ParadeDB - Postgres for Search and Analytics


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Some of these allow annotations have bothered me for awhile and so now they're gone.

In particular, we now lookup the `USING bm25`'s index access method handler `pg_sys::Oid` in a new way -- by asking the SysCache.

## Why

These `#[allow(...)]` could hide bugs, and in fact, the `#![allow(unpredictable_function_pointer_comparisons)]` likely was, which was the impetus for rejiggering how we determine if an index is a `USING bm25` index.

## How

## Tests

All existing tests pass