### PR TITLE
fix: Incorrect `SearchQueryInput` generated by custom scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
  "parking_lot",
  "pgrx",
  "pgrx-tests",
+ "proptest",
  "rand 0.9.1",
  "rayon",
  "rstest",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -49,6 +49,7 @@ bincode = { version = "2.0.1", features = [
   "std",
 ], default-features = false }
 rand = "0.9.1"
+proptest = "1.6.0"
 
 [dev-dependencies]
 pgrx-tests.workspace = true

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -874,23 +874,7 @@ mod tests {
                     should,
                     must_not,
                 },
-            ) => {
-                // Either it's a negated boolean field
-                let is_negated_bool = matches!(
-                    **inner,
-                    Qual::PushdownVarEqTrue { .. }
-                        | Qual::PushdownVarEqFalse { .. }
-                        | Qual::PushdownVarIsTrue { .. }
-                        | Qual::PushdownVarIsFalse { .. }
-                );
-
-                // Or it's a standard negation with must_not
-                let is_standard_not = must.len() == 1
-                    && matches!(must[0], SearchQueryInput::All)
-                    && must_not.len() == 1;
-
-                is_negated_bool || is_standard_not
-            }
+            ) => must.len() == 1 && matches!(must[0], SearchQueryInput::All) && must_not.len() == 1,
 
             // Match negation of PushdownVarEqTrue mapping to PushdownVarEqFalse
             (

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -182,7 +182,7 @@ impl From<&Qual> for SearchQueryInput {
                 query: Box::new(SearchQueryInput::All),
                 score: 0.0,
             },
-            Qual::OpExpr { val, var, opno } => unsafe {
+            Qual::OpExpr { val, .. } => unsafe {
                 SearchQueryInput::from_datum((**val).constvalue, (**val).constisnull)
                     .expect("rhs of @@@ operator Qual must not be null")
             },

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -1136,6 +1136,6 @@ fn custom_scan_respects_parentheses_issue2526(mut conn: PgConnection) {
     WITH (key_field='id');
     "#.execute(&mut conn);
 
-    let result = "SELECT COUNT(*) from mock_items WHERE description @@@ 'shoes' AND (description @@@ 'keyboard' OR description @@@ 'hat')";
+    let result = "SELECT COUNT(*) from mock_items WHERE description @@@ 'shoes' AND (description @@@ 'keyboard' OR description @@@ 'hat')".fetch_result::<i64>(&mut conn);
     assert_eq!(result.len(), 0);
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -1136,6 +1136,6 @@ fn custom_scan_respects_parentheses_issue2526(mut conn: PgConnection) {
     WITH (key_field='id');
     "#.execute(&mut conn);
 
-    let result = "SELECT COUNT(*) from mock_items WHERE description @@@ 'shoes' AND (description @@@ 'keyboard' OR description @@@ 'hat')".fetch_result::<i64>(&mut conn);
-    assert_eq!(result.len(), 0);
+    let result: Vec<(i64,)> = "SELECT COUNT(*) from mock_items WHERE description @@@ 'shoes' AND (description @@@ 'keyboard' OR description @@@ 'hat')".fetch(&mut conn);
+    assert_eq!(result, vec![(0,)]);
 }

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -1096,7 +1096,7 @@ fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
 
     CREATE INDEX idxa ON a USING bm25 (a_id_pk, content) WITH (key_field = 'a_id_pk');
 
-    CREATE INDEX idxb ON b USING bm25 (b_id_pk, a_id_fk, content) WITH (key_field = 'b_id_pk', 
+    CREATE INDEX idxb ON b USING bm25 (b_id_pk, a_id_fk, content) WITH (key_field = 'b_id_pk',
       text_fields = '{ "a_id_fk": { "fast": true, "tokenizer": { "type": "keyword" } } }');
 
     INSERT INTO a (a_id_pk, content) VALUES ('this-is-a-id', 'beer');
@@ -1124,4 +1124,18 @@ fn join_with_string_fast_fields_issue_2505(mut conn: PgConnection) {
     );
 
     "DROP TABLE a; DROP TABLE b;".execute(&mut conn);
+}
+
+#[rstest]
+fn custom_scan_respects_parentheses_issue2526(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'mock_items', schema_name => 'public');
+
+    CREATE INDEX search_idx ON mock_items
+    USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
+    WITH (key_field='id');
+    "#.execute(&mut conn);
+
+    let result = "SELECT COUNT(*) from mock_items WHERE description @@@ 'shoes' AND (description @@@ 'keyboard' OR description @@@ 'hat')";
+    assert_eq!(result.len(), 0);
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2526 

## What

The previous logical scan implementation had a logical bug when converting `And`s with nested `Or`s into a `SearchQueryInput`

## Why

Fix wrong results being returned

## How

## Tests

- Introduced proptests to check for logical equivalence in the conversion.
- Wrote an integration test to make sure there's no regression