### PR TITLE
fix: make `dont_merge_create_index_segments` test less flakey

### DIFF
--- a/tests/tests/layered_merge.rs
+++ b/tests/tests/layered_merge.rs
@@ -110,11 +110,21 @@ fn dont_merge_create_index_segments(mut conn: PgConnection) {
 
     let (num_deleted_before,) = "SELECT sum(num_deleted)::int8 FROM paradedb.index_info('idxdont_merge_create_index_segments');"
         .fetch_one::<(i64,)>(&mut conn);
-    "INSERT INTO dont_merge_create_index_segments (id) VALUES (1)".execute(&mut conn);
+
+    // Perform many inserts to trigger a merge that merges away the deleted segments
+    for _ in 0..10 {
+        "INSERT INTO dont_merge_create_index_segments (id) VALUES (1)".execute(&mut conn);
+    }
+
     let (num_deleted_after,) = "SELECT sum(num_deleted)::int8 FROM paradedb.index_info('idxdont_merge_create_index_segments');"
         .fetch_one::<(i64,)>(&mut conn);
 
-    assert!(num_deleted_after < num_deleted_before);
+    assert!(
+        num_deleted_after < num_deleted_before,
+        "num_deleted_after {}, num_deleted_before {}",
+        num_deleted_after,
+        num_deleted_before
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

I think the issue is that sometimes a merge isn't happening, so perform more inserts so that a merge has to be triggered.

## Why

## How

## Tests
