### PR TITLE
fix: custom scan tries to push down quals that aren't indexed

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
@@ -155,7 +155,7 @@ pub unsafe fn try_pushdown(
 
     static EQUALITY_OPERATOR_LOOKUP: OnceLock<FxHashMap<pg_sys::Oid, &str>> = OnceLock::new();
     match EQUALITY_OPERATOR_LOOKUP.get_or_init(|| initialize_equality_operator_lookup()).get(&(*opexpr).opno) {
-        Some(pgsearch_operator) => { pushdown!(&field.name.0, opexpr, pgsearch_operator, rhs); },
+        Some(pgsearch_operator) => { pushdown!(&pushdown.attname(), opexpr, pgsearch_operator, rhs); },
         None => {
             // TODO:  support other types of OpExprs
             None

--- a/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/pushdown.rs
@@ -40,7 +40,10 @@ impl PushdownField {
         schema: &SearchIndexSchema,
     ) -> Option<Self> {
         let (_, attname) = attname_from_var(root, var);
-        attname.map(Self)
+        let attname = attname?;
+        schema
+            .get_search_field(&SearchFieldName(attname.clone()))
+            .map(|_| Self(attname))
     }
 
     /// Create a new [`PushdownField`] from an attribute name.

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -722,7 +722,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_eq_true() {
         let qual = Qual::PushdownVarEqTrue {
-            field: PushdownField::new("foo".into()),
+            field: PushdownField::new("foo"),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -736,7 +736,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_eq_false() {
         let qual = Qual::PushdownVarEqFalse {
-            field: PushdownField::new("bar".into()),
+            field: PushdownField::new("bar"),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -750,7 +750,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_is_true() {
         let qual = Qual::PushdownVarIsTrue {
-            field: PushdownField::new("baz".into()),
+            field: PushdownField::new("baz"),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -764,7 +764,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_is_false() {
         let qual = Qual::PushdownVarIsFalse {
-            field: PushdownField::new("qux".into()),
+            field: PushdownField::new("qux"),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -778,7 +778,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_is_not_null() {
         let qual = Qual::PushdownIsNotNull {
-            field: PushdownField::new("fld".into()),
+            field: PushdownField::new("fld"),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Exists {

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -706,7 +706,6 @@ unsafe fn booltest(
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
-    use crate::schema::SearchField;
     use pgrx::prelude::*;
     use proptest::prelude::*;
 
@@ -723,7 +722,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_eq_true() {
         let qual = Qual::PushdownVarEqTrue {
-            field: PushdownField(SearchField::new("foo".into())),
+            field: PushdownField::new("foo".into()),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -737,7 +736,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_eq_false() {
         let qual = Qual::PushdownVarEqFalse {
-            field: PushdownField(SearchField::new("bar".into())),
+            field: PushdownField::new("bar".into()),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -751,7 +750,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_is_true() {
         let qual = Qual::PushdownVarIsTrue {
-            field: PushdownField(SearchField::new("baz".into())),
+            field: PushdownField::new("baz".into()),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -765,7 +764,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_var_is_false() {
         let qual = Qual::PushdownVarIsFalse {
-            field: PushdownField(SearchField::new("qux".into())),
+            field: PushdownField::new("qux".into()),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Term {
@@ -779,7 +778,7 @@ mod tests {
     #[pg_test]
     fn test_pushdown_is_not_null() {
         let qual = Qual::PushdownIsNotNull {
-            field: PushdownField(SearchField::new("fld".into())),
+            field: PushdownField::new("fld".into()),
         };
         let got = SearchQueryInput::from(&qual);
         let want = SearchQueryInput::Exists {
@@ -792,19 +791,19 @@ mod tests {
         prop_oneof![
             Just(Qual::All),
             "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqTrue {
-                field: PushdownField(SearchField::new(s.clone()))
+                field: PushdownField::new(&s)
             }),
             "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqFalse {
-                field: PushdownField(SearchField::new(s.clone()))
+                field: PushdownField::new(&s)
             }),
             "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsTrue {
-                field: PushdownField(SearchField::new(s.clone()))
+                field: PushdownField::new(&s)
             }),
             "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsFalse {
-                field: PushdownField(SearchField::new(s.clone()))
+                field: PushdownField::new(&s)
             }),
             "[a-z]{1,3}".prop_map(|s| Qual::PushdownIsNotNull {
-                field: PushdownField(SearchField::new(s.clone()))
+                field: PushdownField::new(&s)
             }),
         ]
     }

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -705,8 +705,8 @@ unsafe fn booltest(
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
-    use crate::schema::SearchField;
     use super::*;
+    use crate::schema::SearchField;
     use pgrx::prelude::*;
     use proptest::prelude::*;
 
@@ -791,11 +791,21 @@ mod tests {
     fn arb_leaf() -> impl Strategy<Value = Qual> {
         prop_oneof![
             Just(Qual::All),
-            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqTrue { field: PushdownField(SearchField::new(s.clone())) }),
-            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqFalse { field: PushdownField(SearchField::new(s.clone())) }),
-            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsTrue { field: PushdownField(SearchField::new(s.clone())) }),
-            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsFalse { field: PushdownField(SearchField::new(s.clone())) }),
-            "[a-z]{1,3}".prop_map(|s| Qual::PushdownIsNotNull { field: PushdownField(SearchField::new(s.clone())) }),
+            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqTrue {
+                field: PushdownField(SearchField::new(s.clone()))
+            }),
+            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarEqFalse {
+                field: PushdownField(SearchField::new(s.clone()))
+            }),
+            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsTrue {
+                field: PushdownField(SearchField::new(s.clone()))
+            }),
+            "[a-z]{1,3}".prop_map(|s| Qual::PushdownVarIsFalse {
+                field: PushdownField(SearchField::new(s.clone()))
+            }),
+            "[a-z]{1,3}".prop_map(|s| Qual::PushdownIsNotNull {
+                field: PushdownField(SearchField::new(s.clone()))
+            }),
         ]
     }
 
@@ -828,8 +838,7 @@ mod tests {
 
             // Match boolean field FALSE cases
             (
-                qual
-                @ (Qual::PushdownVarEqFalse { field } | Qual::PushdownVarIsFalse { field }),
+                qual @ (Qual::PushdownVarEqFalse { field } | Qual::PushdownVarIsFalse { field }),
                 SearchQueryInput::Term {
                     field: Some(f),
                     value,
@@ -880,7 +889,9 @@ mod tests {
                     value: OwnedValue::Bool(false),
                     ..
                 },
-            ) if matches!(**inner, Qual::PushdownVarEqTrue { field: ref a } if a.attname() == f) => true,
+            ) if matches!(**inner, Qual::PushdownVarEqTrue { field: ref a } if a.attname() == f) => {
+                true
+            }
 
             // Match negation of PushdownVarEqFalse mapping to PushdownVarEqTrue
             (
@@ -890,7 +901,9 @@ mod tests {
                     value: OwnedValue::Bool(true),
                     ..
                 },
-            ) if matches!(**inner, Qual::PushdownVarEqFalse { field: ref a } if a.attname() == f) => true,
+            ) if matches!(**inner, Qual::PushdownVarEqFalse { field: ref a } if a.attname() == f) => {
+                true
+            }
 
             _ => false,
         }

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -15,12 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::api::operator::attname_from_var;
 use crate::nodecast;
 use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
 use crate::postgres::customscan::operator_oid;
 use crate::postgres::customscan::pdbscan::projections::score::score_funcoid;
-use crate::postgres::customscan::pdbscan::pushdown::{is_complex, try_pushdown};
+use crate::postgres::customscan::pdbscan::pushdown::{is_complex, try_pushdown, PushdownField};
 use crate::query::SearchQueryInput;
 use crate::schema::SearchIndexSchema;
 use pgrx::{pg_sys, FromDatum, PgList};
@@ -47,31 +46,31 @@ pub enum Qual {
     /// - Used for direct field reference equality comparisons
     /// - Negation transforms to PushdownVarEqFalse without including NULLs
     PushdownVarEqTrue {
-        attname: String,
+        field: PushdownField,
     },
     /// Represents a SQL equality comparison: `bool_field = FALSE`
     /// - NULL values are excluded (NULL is not equal to FALSE)
     /// - Used for direct field reference equality comparisons
     /// - Negation transforms to PushdownVarEqTrue without including NULLs
     PushdownVarEqFalse {
-        attname: String,
+        field: PushdownField,
     },
     /// Represents a SQL IS operator: `bool_field IS TRUE`
     /// - NULL values are excluded (NULL is not TRUE)
     /// - Different from equality in negation semantics:
     ///   IS NOT TRUE includes both FALSE and NULL values
     PushdownVarIsTrue {
-        attname: String,
+        field: PushdownField,
     },
     /// Represents a SQL IS operator: `bool_field IS FALSE`
     /// - NULL values are excluded (NULL is not FALSE)
     /// - Different from equality in negation semantics:
     ///   IS NOT FALSE includes both TRUE and NULL values
     PushdownVarIsFalse {
-        attname: String,
+        field: PushdownField,
     },
     PushdownIsNotNull {
-        attname: String,
+        field: PushdownField,
     },
     ScoreExpr {
         opoid: pg_sys::Oid,
@@ -196,28 +195,28 @@ impl From<&Qual> for SearchQueryInput {
                 SearchQueryInput::from_datum(datum, is_null)
                     .expect("pushdown expression should not evaluate to NULL")
             },
-            Qual::PushdownVarEqTrue { attname } => SearchQueryInput::Term {
-                field: Some(attname.clone()),
+            Qual::PushdownVarEqTrue { field } => SearchQueryInput::Term {
+                field: Some(field.attname().to_string()),
                 value: OwnedValue::Bool(true),
                 is_datetime: false,
             },
-            Qual::PushdownVarEqFalse { attname } => SearchQueryInput::Term {
-                field: Some(attname.clone()),
+            Qual::PushdownVarEqFalse { field } => SearchQueryInput::Term {
+                field: Some(field.attname().to_string()),
                 value: OwnedValue::Bool(false),
                 is_datetime: false,
             },
-            Qual::PushdownVarIsTrue { attname } => SearchQueryInput::Term {
-                field: Some(attname.clone()),
+            Qual::PushdownVarIsTrue { field } => SearchQueryInput::Term {
+                field: Some(field.attname().to_string()),
                 value: OwnedValue::Bool(true),
                 is_datetime: false,
             },
-            Qual::PushdownVarIsFalse { attname } => SearchQueryInput::Term {
-                field: Some(attname.clone()),
+            Qual::PushdownVarIsFalse { field } => SearchQueryInput::Term {
+                field: Some(field.attname().to_string()),
                 value: OwnedValue::Bool(false),
                 is_datetime: false,
             },
-            Qual::PushdownIsNotNull { attname } => SearchQueryInput::Exists {
-                field: attname.clone(),
+            Qual::PushdownIsNotNull { field } => SearchQueryInput::Exists {
+                field: field.attname().to_string(),
             },
             Qual::ScoreExpr { opoid, value } => unsafe {
                 let score_value = {
@@ -328,14 +327,14 @@ impl From<&Qual> for SearchQueryInput {
                     // rather than using must_not, to avoid including NULLs
                     // This follows SQL standard where NOT (field = TRUE) is equivalent to (field = FALSE)
                     // and does NOT include NULL values
-                    Qual::PushdownVarEqTrue { attname } => Self::from(&Qual::PushdownVarEqFalse {
-                        attname: attname.clone(),
+                    Qual::PushdownVarEqTrue { field } => Self::from(&Qual::PushdownVarEqFalse {
+                        field: field.clone(),
                     }),
                     // Similarly, if we're negating a PushdownVarEqFalse, use PushdownVarEqTrue
                     // This follows SQL standard where NOT (field = FALSE) is equivalent to (field = TRUE)
                     // and does NOT include NULL values
-                    Qual::PushdownVarEqFalse { attname } => Self::from(&Qual::PushdownVarEqTrue {
-                        attname: attname.clone(),
+                    Qual::PushdownVarEqFalse { field } => Self::from(&Qual::PushdownVarEqTrue {
+                        field: field.clone(),
                     }),
                     // For other types of negation, use the standard Boolean query with must_not
                     // Note that when negating an IS operator (e.g., IS NOT TRUE), PostgreSQL handles
@@ -432,21 +431,20 @@ pub unsafe fn extract_quals(
         }
 
         pg_sys::NodeTag::T_Var if (*(node as *mut pg_sys::Var)).vartype == pg_sys::BOOLOID => {
-            Some(Qual::PushdownVarEqTrue {
-                attname: attname_from_var(root, node.cast())
-                    .1
-                    .expect("var should have an attname"),
-            })
+            PushdownField::try_new(root, node.cast(), schema)
+                .map(|field| Qual::PushdownVarEqTrue { field })
         }
 
         pg_sys::NodeTag::T_NullTest => {
             let nulltest = nodecast!(NullTest, T_NullTest, node)?;
-            let (_, attname) = attname_from_var(root, (*nulltest).arg.cast());
-            let attname = attname?; // if the attribute isn't
-            if (*nulltest).nulltesttype == pg_sys::NullTestType::IS_NOT_NULL {
-                Some(Qual::PushdownIsNotNull { attname })
+            if let Some(field) = PushdownField::try_new(root, (*nulltest).arg.cast(), schema) {
+                if (*nulltest).nulltesttype == pg_sys::NullTestType::IS_NOT_NULL {
+                    Some(Qual::PushdownIsNotNull { field })
+                } else {
+                    Some(Qual::Not(Box::new(Qual::PushdownIsNotNull { field })))
+                }
             } else {
-                Some(Qual::Not(Box::new(Qual::PushdownIsNotNull { attname })))
+                None
             }
         }
 
@@ -682,23 +680,20 @@ unsafe fn booltest(
     // We only support boolean test for simple field references (Var nodes)
     // For complex expressions, the optimizer will evaluate the condition later
     if let Some(arg_var) = nodecast!(Var, T_Var, arg) {
-        // Get the attribute name from the Var
-        let (_, attname) = attname_from_var(root, arg_var);
-        if let Some(attname) = attname {
+        if let Some(field) = PushdownField::try_new(root, arg_var, schema) {
             // It's a simple field reference, handle as specific cases
             match (*booltest).booltesttype {
-                pg_sys::BoolTestType::IS_TRUE => Some(Qual::PushdownVarIsTrue { attname }),
+                pg_sys::BoolTestType::IS_TRUE => Some(Qual::PushdownVarIsTrue { field }),
                 pg_sys::BoolTestType::IS_NOT_FALSE => {
-                    Some(Qual::Not(Box::new(Qual::PushdownVarIsFalse { attname })))
+                    Some(Qual::Not(Box::new(Qual::PushdownVarIsFalse { field })))
                 }
-                pg_sys::BoolTestType::IS_FALSE => Some(Qual::PushdownVarIsFalse { attname }),
+                pg_sys::BoolTestType::IS_FALSE => Some(Qual::PushdownVarIsFalse { field }),
                 pg_sys::BoolTestType::IS_NOT_TRUE => {
-                    Some(Qual::Not(Box::new(Qual::PushdownVarIsTrue { attname })))
+                    Some(Qual::Not(Box::new(Qual::PushdownVarIsTrue { field })))
                 }
                 _ => None,
             }
         } else {
-            // Var node but couldn't get attribute name
             None
         }
     } else {

--- a/pg_search/tests/pg_regress/expected/issue_2528.out
+++ b/pg_search/tests/pg_regress/expected/issue_2528.out
@@ -1,0 +1,7 @@
+SELECT id, paradedb.score(id) FROM mock_items_issue_2528 WHERE description @@@ 'shoes' and in_stock = true LIMIT 5;
+ id | score 
+----+-------
+  3 |      
+  5 |      
+(2 rows)
+

--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -1,1 +1,6 @@
 CREATE EXTENSION pg_search;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_issue_2528'
+);
+CREATE INDEX search_idx_issue_2528 ON mock_items_issue_2528 USING bm25 (id, description, category) WITH (key_field='id');

--- a/pg_search/tests/pg_regress/sql/issue_2528.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2528.sql
@@ -1,0 +1,1 @@
+SELECT id, paradedb.score(id) FROM mock_items_issue_2528 WHERE description @@@ 'shoes' and in_stock = true LIMIT 5;

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -1,1 +1,7 @@
 CREATE EXTENSION pg_search;
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_issue_2528'
+);
+CREATE INDEX search_idx_issue_2528 ON mock_items_issue_2528 USING bm25 (id, description, category) WITH (key_field='id');

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -227,7 +227,7 @@ fn issue2301_is_null_with_joins(mut conn: PgConnection) {
             removed_at timestamp with time zone
         );
         CREATE INDEX mcp_server_search_idx ON mcp_server
-        USING bm25 (id, name, description)
+        USING bm25 (id, name, description, synced_at, removed_at)
         WITH (key_field='id');
     "#
     .execute(&mut conn);
@@ -840,7 +840,7 @@ mod pushdown_is_bool_operator {
 
     INSERT INTO is_true (bool_field, message) VALUES (true, 'beer');
     INSERT INTO is_true (bool_field, message) VALUES (false, 'beer');
-    
+
     CREATE OR REPLACE FUNCTION is_true_test(b boolean) RETURNS boolean AS $$
     BEGIN
         RETURN b;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2528 

## What

Introduces a new struct that wraps around a `pg_sys::Var` that checks if the corresponding field is actually indexed.

## Why

Right now, certain queries error unless the custom scan is explicitly disabled.

## How

## Tests
Added pg_regress test