### PR TITLE
test: Convert `gqen` to `proptests`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +4829,8 @@ dependencies = [
  "pgvector",
  "portpicker",
  "pretty_assertions",
+ "proptest",
+ "proptest-derive",
  "rand 0.9.1",
  "rayon",
  "rstest",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -51,3 +51,5 @@ tokenizers = { path = "../tokenizers" }
 tokio = { version = "1.44.2", features = ["rt-multi-thread", "macros"] }
 uuid = "1.16.0"
 num-traits = "0.2.19"
+proptest = "1.6.0"
+proptest-derive = "0.5.1"

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -16,3 +16,46 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 pub mod joingen;
 pub mod wheregen;
+
+use std::fmt::Debug;
+
+use proptest::prelude::*;
+
+use joingen::{JoinExpr, JoinType};
+use wheregen::{Expr, SqlValue};
+
+///
+/// Generates arbitrary joins and where clauses for the given tables and columns.
+///
+pub fn arb_joins_and_wheres<V: Clone + Debug + Eq + SqlValue + 'static>(
+    join_types: impl Strategy<Value = JoinType> + Clone,
+    tables: Vec<impl AsRef<str>>,
+    columns: Vec<(impl AsRef<str>, V)>,
+) -> impl Strategy<Value = (JoinExpr, Expr<V>)> {
+    let table_names = tables
+        .into_iter()
+        .map(|tn| tn.as_ref().to_string())
+        .collect::<Vec<_>>();
+    let columns = columns
+        .into_iter()
+        .map(|(cn, v)| (cn.as_ref().to_string(), v))
+        .collect::<Vec<_>>();
+
+    // Choose how many tables will be joined.
+    (2..=table_names.len())
+        .prop_flat_map(move |join_size| {
+            // Then choose tables for that join size.
+            proptest::sample::subsequence(table_names.clone(), join_size)
+        })
+        .prop_flat_map(move |tables| {
+            // Finally, choose the joins and where clauses for those tables.
+            (
+                joingen::arb_joins(
+                    join_types.clone(),
+                    tables.clone(),
+                    columns.iter().map(|(cn, _)| cn.clone()).collect(),
+                ),
+                wheregen::arb_wheres(tables.clone(), columns.clone()),
+            )
+        })
+}

--- a/tests/tests/qgen.proptest-regressions
+++ b/tests/tests/qgen.proptest-regressions
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f72c048460d617ea52434bea9a1267d8df9208b7223cf3659954885f177cd0f2 # shrinks to (join, where_expr) = (JoinExpr { sql: "FROM users CROSS JOIN products", .. }, Or(Not(Atom("users.id", "3")), Atom("products.id", "3")))
+cc 8c21c606da860748226e7c0947c721e9182e5aa3984f03b778f6fd95344d2c94 # shrinks to (join, where_expr) = (JoinExpr { sql: "FROM products JOIN orders ON products.name = orders.name", .. }, Or(And(Atom("products.name", "bob"), Atom("products.id", "3")), Not(Atom("orders.id", "3")))), target_list = ["age"]
+cc b33b5d9a0b23c471963c2ab6580012fe97de890660ca480bffc18165af774fe7 # shrinks to (join, where_expr) = (JoinExpr { sql: "FROM users JOIN orders ON users.color = orders.color", .. }, Not(Not(And(Atom("users.color", "blue"), Atom("users.id", "3"))))), target_list = ["age"]
+cc 1f6666372781b50f0844cbbc1e19248b69c42de14a8458aaa5ac9f1202fc5452 # shrinks to (join, where_expr) = (JoinExpr { sql: "FROM users JOIN orders ON users.name = orders.name", .. }, And(Atom("users.id", "3"), Or(Atom("users.id", "3"), Atom("users.id", "3")))), target_list = ["color", "age"]

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -17,23 +17,25 @@
 
 mod fixtures;
 
-use crate::fixtures::querygen::joingen::JoinGenerator;
-use crate::fixtures::querygen::wheregen::WhereGenerator;
+use crate::fixtures::querygen::arb_joins_and_wheres;
+use crate::fixtures::querygen::joingen::JoinType;
+use crate::fixtures::querygen::wheregen::arb_wheres;
+
 use fixtures::*;
+
 use futures::executor::block_on;
 use lockfree_object_pool::MutexObjectPool;
-use parking_lot::Mutex;
-use rayon::prelude::*;
+use proptest::prelude::*;
 use rstest::*;
 use sqlx::PgConnection;
-use std::collections::HashMap;
 
-fn generated_queries_setup(conn: &mut PgConnection, tables: &[&str]) -> String {
+fn generated_queries_setup(conn: &mut PgConnection, tables: &[(&str, usize)]) -> String {
     "CREATE EXTENSION pg_search;".execute(conn);
+    "SET log_error_verbosity TO VERBOSE;".execute(conn);
 
     let mut setup_sql = String::new();
 
-    for tname in tables {
+    for (tname, row_count) in tables {
         let sql = format!(
             r#"
 CREATE TABLE {tname}
@@ -51,16 +53,16 @@ INSERT into {tname} (name, color, age)
 SELECT(ARRAY ['alice','bob','cloe', 'sally','brandy','brisket','anchovy']::text[])[(floor(random() * 7) + 1)::int],
       (ARRAY ['red','green','blue', 'orange','purple','pink','yellow']::text[])[(floor(random() * 7) + 1)::int],
       (floor(random() * 100) + 1)::int::text
-FROM generate_series(1, 10);    -- could make larger, but 10 finds failures and is fast
+FROM generate_series(1, {row_count});
 
 CREATE INDEX idx{tname} ON {tname} USING bm25 (id, name, color, age)
 WITH (
 key_field = 'id',
 text_fields = '
             {{
-                "name": {{ "tokenizer": {{ "type": "keyword" }} }},
-                "color": {{ "tokenizer": {{ "type": "keyword" }} }},
-                "age": {{ "tokenizer": {{ "type": "keyword" }} }}
+                "name": {{ "tokenizer": {{ "type": "keyword" }}, "fast": true }},
+                "color": {{ "tokenizer": {{ "type": "keyword" }}, "fast": true }},
+                "age": {{ "tokenizer": {{ "type": "keyword" }}, "fast": true }}
             }}'
 );
 CREATE INDEX idx{tname}_name ON {tname} (name);
@@ -78,169 +80,138 @@ ANALYZE;
     setup_sql
 }
 
+///
+/// Tests all JoinTypes against small tables (which are particularly important for joins which
+/// result in e.g. the cartesian product).
+///
 #[rstest]
 #[tokio::test]
-async fn generated_join_queries(database: Db) {
+async fn generated_joins_small(database: Db) {
     let pool = MutexObjectPool::<PgConnection>::new(
         move || block_on(async { database.connection().await }),
         |_| {},
     );
 
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &["users", "products", "orders"]);
+    let tables_and_sizes = [("users", 10), ("products", 10), ("orders", 10)];
+    let tables = tables_and_sizes
+        .iter()
+        .map(|(table, _)| table)
+        .collect::<Vec<_>>();
+    generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
 
-    let want = |table_name: &str| {
-        vec![
-            (format!("{table_name}.name"), "bob"),
-            (format!("{table_name}.color"), "blue"),
-            (format!("{table_name}.age"), "20"),
-        ]
-    };
+    proptest!(|(
+        (join, where_expr) in arb_joins_and_wheres(
+            any::<JoinType>(),
+            tables,
+            vec![("id", "3"), ("name", "bob"), ("color", "blue"), ("age", "20")]
+        ),
+    )| {
+        let join_clause = join.to_sql();
 
-    let pg_generators = {
-        let mut generators = HashMap::<&str, WhereGenerator<&str>>::default();
-        generators.insert("users", WhereGenerator::new(" = ", want("users")));
-        generators.insert("orders", WhereGenerator::new(" = ", want("orders")));
-        generators.insert("products", WhereGenerator::new(" = ", want("products")));
-        generators
-    };
-    let bm25_generators = {
-        let mut generators = HashMap::<&str, WhereGenerator<&str>>::default();
-        generators.insert("users", WhereGenerator::new("@@@", want("users")));
-        generators.insert("orders", WhereGenerator::new("@@@", want("orders")));
-        generators.insert("products", WhereGenerator::new("@@@", want("products")));
-        generators
-    };
+        let from = format!("SELECT COUNT(*) {join_clause} ");
 
-    let generators = Mutex::new((pg_generators, bm25_generators));
-    let errors = Mutex::new(String::new());
+        let pg = format!("{from} WHERE {}", where_expr.to_sql(" = "));
+        let bm25 = format!("{from} WHERE {}", where_expr.to_sql("@@@"));
 
-    for connector in ["AND", "OR", "AND NOT"] {
-        println!("connector={connector}");
+        let (pg_cnt,) = (&pg).fetch_one::<(i64,)>(&mut pool.pull());
+        let (bm25_cnt,) = (&bm25).fetch_one::<(i64,)>(&mut pool.pull());
+        prop_assert_eq!(
+            pg_cnt,
+            bm25_cnt,
+            "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
+            pg,
+            bm25,
+            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+        );
+    });
+}
 
-        JoinGenerator::new(vec![
-            ("users", vec!["name", "color", "age"]),
-            ("orders", vec!["name", "color", "age"]),
-            ("products", vec!["name", "color", "age"]),
-        ])
-        .take(100)
-        .enumerate()
-        .par_bridge()
-        .for_each(|(idx, (join_clause, used_tables))| {
-            let from = format!("SELECT COUNT(*) {join_clause} ");
+///
+/// Tests only the smallest JoinType against larger tables, with a target list, and a limit.
+///
+#[rstest]
+#[tokio::test]
+async fn generated_joins_large_limit(database: Db) {
+    let pool = MutexObjectPool::<PgConnection>::new(
+        move || block_on(async { database.connection().await }),
+        |_| {},
+    );
 
-            let mut pg_where_clauses = Vec::with_capacity(used_tables.len());
-            let mut bm25_where_clauses = Vec::with_capacity(used_tables.len());
+    let tables_and_sizes = [("users", 10000), ("products", 10000), ("orders", 10000)];
+    let tables = tables_and_sizes
+        .iter()
+        .map(|(table, _)| table)
+        .collect::<Vec<_>>();
+    generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
 
-            // populate the where clauses with what should be matching where clauses from the two different generators
-            {
-                let mut generators = generators.lock();
+    proptest!(|(
+        (join, where_expr) in arb_joins_and_wheres(
+            Just(JoinType::Inner),
+            tables,
+            vec![("id", "3"), ("name", "bob"), ("color", "blue"), ("age", "20")]
+        ),
+        target_list in proptest::sample::subsequence(vec!["id", "name", "color", "age"], 1..=4),
+    )| {
+        let join_clause = join.to_sql();
+        let used_tables = join.used_tables();
 
-                let nclauses = 1;
+        let target_list =
+            target_list
+                .into_iter()
+                .map(|column| format!("{}.{column}", used_tables[0]))
+                .collect::<Vec<_>>()
+                .join(", ");
+        let from = format!("SELECT {target_list} {join_clause} ");
 
-                for table_name in &used_tables {
-                    pg_where_clauses.extend(
-                        generators
-                            .0
-                            .get_mut(table_name.as_str())
-                            .unwrap()
-                            .take(nclauses),
-                    );
-                }
+        let pg = format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = "));
+        let bm25 = format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@"));
 
-                for table_name in used_tables {
-                    bm25_where_clauses.extend(
-                        generators
-                            .1
-                            .get_mut(table_name.as_str())
-                            .unwrap()
-                            .take(nclauses),
-                    );
-                }
-            }
-
-            let pg = format!(
-                "{from} WHERE {};",
-                pg_where_clauses.join(&format!(" {connector} "))
-            );
-            let bm25 = format!(
-                "{from} WHERE {};",
-                bm25_where_clauses.join(&format!(" {connector} ")),
-            );
-
-            let (pg_count,) = (&pg).fetch_one::<(i64,)>(&mut pool.pull());
-            let (bm25_count,) = (&bm25).fetch_one::<(i64,)>(&mut pool.pull());
-
-            if pg_count != bm25_count {
-                let mut errors = errors.lock();
-                errors.push_str(&format!("---- idx={idx} ----\n"));
-                errors.push_str(&format!("---- connector={connector} ----\n"));
-                errors.push_str(&format!("-- pg={pg_count}, bm25={bm25_count}\n"));
-                errors.push_str(&format!("{pg}\n"));
-                errors.push_str(&format!("{bm25}\n"));
-                errors.push('\n');
-            }
-        });
-    }
-
-    let errors = errors.into_inner();
-    if !errors.is_empty() {
-        panic!("{setup_sql}\n{errors}");
-    }
+        // Because we use a generated target list, we fetch as dynamic to allow for comparison.
+        let pg_rows = (&pg).fetch_dynamic(&mut pool.pull());
+        let bm25_rows = (&bm25).fetch_dynamic(&mut pool.pull());
+        prop_assert_eq!(
+            pg_rows.len(),
+            bm25_rows.len(),
+            "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
+            pg,
+            bm25,
+            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+        );
+    });
 }
 
 #[rstest]
 #[tokio::test]
-async fn generated_single_relation_queries(database: Db) {
+async fn generated_single_relation(database: Db) {
     let pool = MutexObjectPool::<PgConnection>::new(
         move || block_on(async { database.connection().await }),
         |_| {},
     );
 
     let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[table_name]);
+    generated_queries_setup(&mut pool.pull(), &[(table_name, 10)]);
 
-    let want = |table_name: &str| {
-        vec![
-            (format!("{table_name}.name"), "bob"),
-            (format!("{table_name}.color"), "blue"),
-            (format!("{table_name}.age"), "20"),
-        ]
-    };
+    proptest!(|(
+        where_expr in arb_wheres(
+            vec![table_name],
+            vec![("name", "bob"), ("color", "blue"), ("age", "20")]
+        ),
+    )| {
+        let where_clause = where_expr.to_sql(" = ");
+        let pg = format!("SELECT COUNT(*) FROM {table_name} WHERE {where_clause}");
+        let bm25 = format!(
+            "SELECT COUNT(*) FROM {table_name} WHERE ({where_clause}) AND id @@@ paradedb.all()"
+        ); // force a pushdown
 
-    let errors = Mutex::new(String::new());
-
-    // NB:  could adjust this envvar if 10k queries takes too long
-    let nqueries: usize = std::env::var("PG_SEARCH_N_SINGLE_RELATION_QUERIES")
-        .unwrap_or("10000".to_string())
-        .parse()
-        .expect("Failed to parse PG_SEARCH_N_SINGLE_RELATION_QUERIES");
-
-    WhereGenerator::new("=", want("users"))
-        .take(nqueries)
-        .enumerate()
-        .par_bridge()
-        .for_each(|(idx, where_clause)| {
-            let pg = format!("SELECT count(*) FROM {table_name} WHERE {where_clause}");
-            let bm25 = format!(
-                "SELECT count(*) FROM {table_name} WHERE ({where_clause}) AND id @@@ paradedb.all()"
-            ); // force a pushdown
-
-            let mut conn = pool.pull();
-            let (pg_cnt,) = (&pg).fetch_one::<(i64,)>(&mut conn);
-            let (bm25_cnt,) = (&bm25).fetch_one::<(i64,)>(&mut conn);
-
-            if pg_cnt != bm25_cnt {
-                let mut errors = errors.lock();
-                errors.push_str(&format!("---- idx={idx} ----\n"));
-                errors.push_str(&format!("-- pg={pg_cnt}, bm25={bm25_cnt}\n"));
-                errors.push_str(&format!("{pg}\n"));
-                errors.push_str(&format!("{bm25}\n"));
-                errors.push('\n');
-            }
-        });
-
-    let errors = errors.into_inner();
-    if !errors.is_empty() {
-        panic!("{setup_sql}\n{errors}");
-    }
+        let (pg_cnt,) = (&pg).fetch_one::<(i64,)>(&mut pool.pull());
+        let (bm25_cnt,) = (&bm25).fetch_one::<(i64,)>(&mut pool.pull());
+        prop_assert_eq!(
+            pg_cnt,
+            bm25_cnt,
+            "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
+            pg,
+            bm25,
+            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+        );
+    });
 }


### PR DESCRIPTION
## What

#2540 added `qgen` tests, which generate and compare many valid queries between btree and bm25 indexes: that infrastructure uncovered real bugs (see #2534).

This change migrates the existing `qgen` tests to tests atop the Rust `proptest` crate, and adds an additional test which reproduces #2544 and #2556.

## Why

`proptest` allows for randomly exploring a very large set of possible inputs. When it finds a failing input, it reduces the input as much as possible, and then records the failing seed in a file. Reproducing a failure that it has produced just requires re-running the test (which will start by trying all seeds it has ever seen fail based on the `regressions` file).

When reproducing the failure from #2533 for example, `proptest` automatically minimizes the failure to a much smaller query than the one where it was first encountered:
```sql
SELECT COUNT(*) FROM orders JOIN products ON orders.color = products.color  WHERE (NOT (orders.name @@@ 'bob')) OR (products.name @@@ 'bob')
```

## How

By default, `proptest` will run 256 random cases per run (always starting with any previously seen failures). There are environment variables to request that more cases be run (`PROPTEST_CASES=1000`), increase verbosity so that you can see which cases are being run (`PROPTEST_VERBOSE=3`), etc.

## Tests

This change ports the two existing tests from #2540 to proptests, and adds one more to reproduce #2544 and #2556.