### PR TITLE
fix: Extract fast fields in more locations at planning time

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -50,7 +50,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -137,7 +137,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, since
       # /bin/sh does not support the `[[` syntax.

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -205,7 +205,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -151,7 +151,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -54,7 +54,7 @@ jobs:
           path: paradedb
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0 # Fetch the entire history
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Extract pgrx Version
         id: pgrx
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Extract pgrx Version
         id: pgrx

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -90,10 +90,8 @@ pub fn search_with_query_input(
         let key_field = search_reader.key_field();
         let key_field_name = key_field.name.0;
         let key_field_type = key_field.type_.into();
-        let ff_helper = FFHelper::with_fields(
-            &search_reader,
-            &[Some((key_field_name, key_field_type).into())],
-        );
+        let ff_helper =
+            FFHelper::with_fields(&search_reader, &[(key_field_name, key_field_type).into()]);
 
         (search_reader, ff_helper)
     });

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -37,7 +37,7 @@ impl FFHelper {
         Self(vec![])
     }
 
-    pub fn with_fields(reader: &SearchIndexReader, fields: &[Option<WhichFastField>]) -> Self {
+    pub fn with_fields(reader: &SearchIndexReader, fields: &[WhichFastField]) -> Self {
         let fast_fields = reader
             .segment_readers()
             .iter()
@@ -46,28 +46,19 @@ impl FFHelper {
                 let mut lookup = Vec::new();
                 for field in fields {
                     match field {
-                        Some(WhichFastField::Named(name, _)) => lookup.push((
+                        WhichFastField::Named(name, _) => lookup.push((
                             fast_fields_reader.clone(),
                             name.to_string(),
                             OnceLock::default(),
                         )),
-                        Some(
-                            WhichFastField::Ctid
-                            | WhichFastField::TableOid
-                            | WhichFastField::Score
-                            | WhichFastField::Junk(_),
-                        )
-                        | None => {
-                            // When a field is None or not a named fast field, we treat it as Junk
-                            // This happens for fields that aren't marked as fast fields during planning
-                            // or when a tuple descriptor column doesn't match any fast field
-                            // Using Junk means we'll return NULL for this field rather than crashing
-                            lookup.push((
-                                fast_fields_reader.clone(),
-                                String::from("junk"),
-                                OnceLock::from(FFType::Junk),
-                            ))
-                        }
+                        WhichFastField::Ctid
+                        | WhichFastField::TableOid
+                        | WhichFastField::Score
+                        | WhichFastField::Junk(_) => lookup.push((
+                            fast_fields_reader.clone(),
+                            String::from("junk"),
+                            OnceLock::from(FFType::Junk),
+                        )),
                     }
                 }
                 lookup
@@ -248,7 +239,7 @@ impl FFType {
     }
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize, Hash)]
 pub enum WhichFastField {
     Junk(String),
     Ctid,
@@ -257,7 +248,7 @@ pub enum WhichFastField {
     Named(String, FastFieldType),
 }
 
-#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize, Hash)]
 pub enum FastFieldType {
     String,
     Numeric,

--- a/pg_search/src/postgres/customscan/builders/custom_state.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_state.rs
@@ -103,6 +103,10 @@ impl<CS: CustomScan, P: From<*mut pg_sys::List>> CustomScanStateBuilder<CS, P> {
         &mut self.custom_state
     }
 
+    pub fn custom_state_ref(&self) -> &CS::State {
+        &self.custom_state
+    }
+
     pub fn target_list(&self) -> PgList<pg_sys::TargetEntry> {
         unsafe { PgList::from_pg((*self.args.cscan).scan.plan.targetlist) }
     }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
@@ -114,7 +114,7 @@ impl MixedFastFieldExecState {
         }
 
         Self {
-            inner: FastFieldExecState::new(),
+            inner: FastFieldExecState::new(which_fast_fields),
             mixed_results: MixedAggResults::None,
             string_fields,
             numeric_fields,
@@ -254,7 +254,7 @@ impl ExecMethod for MixedFastFieldExecState {
                         }
 
                         let fast_fields = &mut self.inner.ffhelper;
-                        let which_fast_fields = &state.exec_tuple_which_fast_fields;
+                        let which_fast_fields = &self.inner.which_fast_fields;
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
                         debug_assert!(natts == which_fast_fields.len());
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
@@ -256,6 +256,7 @@ impl ExecMethod for MixedFastFieldExecState {
                         let fast_fields = &mut self.inner.ffhelper;
                         let which_fast_fields = &state.exec_tuple_which_fast_fields;
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
+                        debug_assert!(natts == which_fast_fields.len());
 
                         // Take the string buffer from inner
                         let mut string_buf = self.inner.strbuf.take().unwrap_or_default();
@@ -267,7 +268,7 @@ impl ExecMethod for MixedFastFieldExecState {
                                 continue;
                             }
 
-                            let which_fast_field = which_fast_fields.get(i).unwrap_or(&None);
+                            let which_fast_field = &which_fast_fields[i];
 
                             // Get attribute info if available
                             let att_info = if i < tupdesc.len() {
@@ -283,8 +284,7 @@ impl ExecMethod for MixedFastFieldExecState {
                                 .unwrap_or_default();
 
                             // Try the optimized fast field path first
-                            if let Some(WhichFastField::Named(field_name, field_type)) =
-                                which_fast_field
+                            if let WhichFastField::Named(field_name, field_type) = which_fast_field
                             {
                                 match field_type {
                                     // String field handling

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -339,7 +339,7 @@ pub fn fast_field_capable_prereqs(privdata: &PrivateData) -> bool {
         return false;
     }
 
-    let which_fast_fields = privdata.which_fast_fields().as_ref().unwrap();
+    let which_fast_fields = privdata.planned_which_fast_fields().as_ref().unwrap();
 
     if is_all_special_or_junk_fields(which_fast_fields) {
         // if all the fast fields we have are Junk fields, then we're not actually
@@ -371,7 +371,7 @@ pub fn is_mixed_fast_field_capable(privdata: &PrivateData) -> bool {
     }
 
     // Normal mixed fast field detection logic
-    let which_fast_fields = privdata.which_fast_fields().as_ref().unwrap();
+    let which_fast_fields = privdata.planned_which_fast_fields().as_ref().unwrap();
 
     // Filter out junk and system fields for our analysis - we only care about real column fast fields
     let field_types = which_fast_fields
@@ -404,7 +404,7 @@ pub fn is_string_agg_capable(privdata: &PrivateData) -> Option<String> {
         return None;
     }
 
-    let which_fast_fields = privdata.which_fast_fields().as_ref().unwrap();
+    let which_fast_fields = privdata.planned_which_fast_fields().as_ref().unwrap();
 
     let mut string_field = None;
     // Count the number of string fields
@@ -434,7 +434,7 @@ pub fn is_string_agg_capable(privdata: &PrivateData) -> Option<String> {
 
 // Check if we can use numeric fast field execution method
 pub fn is_numeric_fast_field_capable(privdata: &PrivateData) -> bool {
-    let which_fast_fields = privdata.which_fast_fields().as_ref().unwrap();
+    let which_fast_fields = privdata.planned_which_fast_fields().as_ref().unwrap();
     // Make sure we don't have any string fast fields
     for ff in which_fast_fields.iter() {
         if matches!(ff, WhichFastField::Named(_, FastFieldType::String)) {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -33,7 +33,7 @@ pub struct NumericFastFieldExecState {
 impl NumericFastFieldExecState {
     pub fn new(which_fast_fields: Vec<WhichFastField>) -> Self {
         Self {
-            inner: FastFieldExecState::new(),
+            inner: FastFieldExecState::new(which_fast_fields),
         }
     }
 }
@@ -111,7 +111,7 @@ impl ExecMethod for NumericFastFieldExecState {
                         crate::postgres::customscan::pdbscan::exec_methods::fast_fields::extract_data_from_fast_fields(
                             natts,
                             tupdesc,
-                            &state.exec_tuple_which_fast_fields,
+                            &self.inner.which_fast_fields,
                             &mut self.inner.ffhelper,
                             slot,
                             scored,

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -44,7 +44,7 @@ pub struct StringFastFieldExecState {
 impl StringFastFieldExecState {
     pub fn new(field: String, which_fast_fields: Vec<WhichFastField>) -> Self {
         Self {
-            inner: FastFieldExecState::new(),
+            inner: FastFieldExecState::new(which_fast_fields),
             search_results: StringAggResults::None,
             field,
         }
@@ -128,7 +128,7 @@ impl ExecMethod for StringFastFieldExecState {
                         crate::postgres::customscan::pdbscan::exec_methods::fast_fields::extract_data_from_fast_fields(
                             natts,
                             tupdesc,
-                            &state.exec_tuple_which_fast_fields,
+                            &self.inner.which_fast_fields,
                             &mut self.inner.ffhelper,
                             slot,
                             scored,

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -276,15 +276,6 @@ impl CustomScan for PdbScan {
                 .custom_private()
                 .set_referenced_columns_count(referenced_columns.len());
 
-            exec_methods::fast_fields::count_fast_fields(
-                &mut builder,
-                rti,
-                &table,
-                &schema,
-                target_list,
-                &referenced_columns,
-            );
-            let maybe_ff = builder.custom_private().maybe_ff();
             let is_topn = limit.is_some() && pathkey.is_some();
 
             // When collecting which_fast_fields, analyze the entire set of referenced columns,
@@ -293,7 +284,6 @@ impl CustomScan for PdbScan {
             // execution-time target list: see `assign_exec_method` for more info.
             builder.custom_private().set_planned_which_fast_fields(
                 exec_methods::fast_fields::collect_fast_fields(
-                    maybe_ff,
                     target_list,
                     &referenced_columns,
                     rti,
@@ -303,6 +293,7 @@ impl CustomScan for PdbScan {
                 .into_iter()
                 .collect(),
             );
+            let maybe_ff = builder.custom_private().maybe_ff();
 
             //
             // look for quals we can support
@@ -1167,7 +1158,6 @@ fn compute_exec_which_fast_fields(
         // In order for our planned ExecMethodType to be accurate, this must always be a
         // subset of the fast fields which were extracted at planning time.
         exec_methods::fast_fields::collect_fast_fields(
-            builder.custom_private().maybe_ff(),
             builder.target_list().as_ptr(),
             // At this point, all fast fields which we need to extract are listed directly
             // in our execution-time target list, so there is no need to extract from other

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -30,6 +30,7 @@ use crate::api::operator::{
 };
 use crate::api::Cardinality;
 use crate::gucs;
+use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::customscan::builders::custom_path::{
@@ -65,7 +66,7 @@ use crate::schema::SearchIndexSchema;
 use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use pgrx::pg_sys::CustomExecMethods;
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList, PgMemoryContexts, PgRelation};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashSet;
 use std::ffi::CStr;
 use std::ptr::addr_of_mut;
@@ -584,52 +585,6 @@ impl CustomScan for PdbScan {
                 .range_table_index()
                 .expect("range table index should have been set");
 
-            {
-                let indexrel = PgRelation::open(builder.custom_state().indexrelid);
-                let heaprel = indexrel
-                    .heap_relation()
-                    .expect("index should belong to a table");
-                let directory = MVCCDirectory::snapshot(indexrel.oid());
-                let index = Index::open(directory)
-                    .expect("create_custom_scan_state: should be able to open index");
-                let schema = SearchIndexSchema::open(index.schema(), &indexrel);
-
-                // Calculate the ordered set of fast fields which have actually been requested in
-                // the target list.
-                //
-                // In order for our planned ExecMethodType to be accurate, this must always be a
-                // subset of the fast fields which were extracted at planning time.
-                builder.custom_state().exec_tuple_which_fast_fields =
-                    exec_methods::fast_fields::collect_fast_fields(
-                        builder.custom_private().maybe_ff(),
-                        builder.target_list().as_ptr(),
-                        // At this point, all fast fields which we need to extract are listed directly
-                        // in our execution-time target list, so there is no need to extract from other
-                        // positions.
-                        &HashSet::default(),
-                        builder.custom_state().rti,
-                        &schema,
-                        &heaprel,
-                    );
-
-                let planned_which_fast_fields = builder
-                    .custom_private()
-                    .which_fast_fields()
-                    .as_ref()
-                    .unwrap();
-                let missing_fast_fields = builder
-                    .custom_state_ref()
-                    .exec_tuple_which_fast_fields
-                    .iter()
-                    .filter(|ff| !planned_which_fast_fields.contains(ff))
-                    .collect::<Vec<_>>();
-                assert!(
-                    missing_fast_fields.is_empty(),
-                    "Failed to extract all fast fields at planning time: {missing_fast_fields:?} ({planned_which_fast_fields:?} vs {:?})",
-                    builder.custom_state_ref().exec_tuple_which_fast_fields,
-                );
-            }
-
             builder.custom_state().exec_method_type =
                 builder.custom_private().exec_method_type().clone();
 
@@ -682,7 +637,7 @@ impl CustomScan for PdbScan {
             .map(|field| (field, None))
             .collect();
 
-            assign_exec_method(builder.custom_state());
+            assign_exec_method(&mut builder);
 
             builder.build()
         }
@@ -1106,40 +1061,103 @@ fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
 ///
 /// Creates and assigns the execution method which was chosen at planning time.
 ///
-/// Note that the `which_fast_fields` which are used here are the subset of the planning
-/// `which_fast_fields` that corresponds to the execution time output tuple.
-///
-fn assign_exec_method(custom_state: &mut PdbScanState) {
-    match &custom_state.exec_method_type {
-        ExecMethodType::Normal => custom_state.assign_exec_method(NormalScanExecState::default()),
+fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
+    match builder.custom_state_ref().exec_method_type.clone() {
+        ExecMethodType::Normal => builder
+            .custom_state()
+            .assign_exec_method(NormalScanExecState::default()),
         ExecMethodType::TopN {
             heaprelid,
             limit,
             sort_direction,
             need_scores,
-        } => custom_state.assign_exec_method(exec_methods::top_n::TopNScanExecState::new(
-            *heaprelid,
-            *limit,
-            *sort_direction,
-            *need_scores,
-        )),
-        ExecMethodType::FastFieldString { field, .. } => custom_state.assign_exec_method(
-            exec_methods::fast_fields::string::StringFastFieldExecState::new(
-                field.to_owned(),
-                custom_state.exec_tuple_which_fast_fields.clone(),
-            ),
-        ),
-        ExecMethodType::FastFieldNumeric { .. } => custom_state.assign_exec_method(
-            exec_methods::fast_fields::numeric::NumericFastFieldExecState::new(
-                custom_state.exec_tuple_which_fast_fields.clone(),
-            ),
-        ),
-        ExecMethodType::FastFieldMixed { .. } => custom_state.assign_exec_method(
-            exec_methods::fast_fields::mixed::MixedFastFieldExecState::new(
-                custom_state.exec_tuple_which_fast_fields.clone(),
-            ),
-        ),
+        } => {
+            builder
+                .custom_state()
+                .assign_exec_method(exec_methods::top_n::TopNScanExecState::new(
+                    heaprelid,
+                    limit,
+                    sort_direction,
+                    need_scores,
+                ))
+        }
+        ExecMethodType::FastFieldString {
+            field,
+            which_fast_fields,
+        } => {
+            let which_fast_fields = compute_exec_which_fast_fields(builder, which_fast_fields);
+            builder.custom_state().assign_exec_method(
+                exec_methods::fast_fields::string::StringFastFieldExecState::new(
+                    field,
+                    which_fast_fields,
+                ),
+            )
+        }
+        ExecMethodType::FastFieldNumeric { which_fast_fields } => {
+            let which_fast_fields = compute_exec_which_fast_fields(builder, which_fast_fields);
+            builder.custom_state().assign_exec_method(
+                exec_methods::fast_fields::numeric::NumericFastFieldExecState::new(
+                    which_fast_fields,
+                ),
+            )
+        }
+        ExecMethodType::FastFieldMixed { which_fast_fields } => {
+            let which_fast_fields = compute_exec_which_fast_fields(builder, which_fast_fields);
+            builder.custom_state().assign_exec_method(
+                exec_methods::fast_fields::mixed::MixedFastFieldExecState::new(which_fast_fields),
+            )
+        }
     }
+}
+
+///
+/// Computes the execution time `which_fast_fields`, which are validated to be a subset of the
+/// planning time `which_fast_fields`.
+///
+fn compute_exec_which_fast_fields(
+    builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>,
+    planned_which_fast_fields: FxHashSet<WhichFastField>,
+) -> Vec<WhichFastField> {
+    let exec_which_fast_fields = unsafe {
+        let indexrel = PgRelation::open(builder.custom_state().indexrelid);
+        let heaprel = indexrel
+            .heap_relation()
+            .expect("index should belong to a table");
+        let directory = MVCCDirectory::snapshot(indexrel.oid());
+        let index =
+            Index::open(directory).expect("create_custom_scan_state: should be able to open index");
+        let schema = SearchIndexSchema::open(index.schema(), &indexrel);
+
+        // Calculate the ordered set of fast fields which have actually been requested in
+        // the target list.
+        //
+        // In order for our planned ExecMethodType to be accurate, this must always be a
+        // subset of the fast fields which were extracted at planning time.
+        exec_methods::fast_fields::collect_fast_fields(
+            builder.custom_private().maybe_ff(),
+            builder.target_list().as_ptr(),
+            // At this point, all fast fields which we need to extract are listed directly
+            // in our execution-time target list, so there is no need to extract from other
+            // positions.
+            &HashSet::default(),
+            builder.custom_state().rti,
+            &schema,
+            &heaprel,
+        )
+    };
+
+    let missing_fast_fields = exec_which_fast_fields
+        .iter()
+        .filter(|ff| !planned_which_fast_fields.contains(ff))
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing_fast_fields.is_empty(),
+        "Failed to extract all fast fields at planning time: {missing_fast_fields:?} ({planned_which_fast_fields:?} vs {:?})",
+        exec_which_fast_fields,
+    );
+
+    exec_which_fast_fields
 }
 
 /// Use the [`VisibilityChecker`] to lookup the [`SearchIndexScore`] document in the underlying heap

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -36,7 +36,6 @@ pub struct PrivateData {
     sort_direction: Option<SortDirection>,
     #[serde(with = "var_attname_lookup_serializer")]
     var_attname_lookup: Option<FxHashMap<(Varno, pg_sys::AttrNumber), String>>,
-    maybe_ff: bool,
     segment_count: usize,
     // The fast fields which were identified during planning time as potentially being
     // needed at execution time. In order for our planning-time-chosen ExecMethodType to be
@@ -189,10 +188,6 @@ impl PrivateData {
         self.var_attname_lookup = Some(var_attname_lookup);
     }
 
-    pub fn set_maybe_ff(&mut self, maybe: bool) {
-        self.maybe_ff = maybe;
-    }
-
     pub fn set_segment_count(&mut self, segment_count: usize) {
         self.segment_count = segment_count;
     }
@@ -266,7 +261,8 @@ impl PrivateData {
     }
 
     pub fn maybe_ff(&self) -> bool {
-        self.maybe_ff
+        // If we have planned fast fields, then maybe we can use them!
+        !self.planned_which_fast_fields.as_ref().unwrap().is_empty()
     }
 
     pub fn segment_count(&self) -> usize {

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -42,7 +42,7 @@ pub struct PrivateData {
     // needed at execution time. In order for our planning-time-chosen ExecMethodType to be
     // accurate, this must always be a superset of the fields extracted from the execution
     // time target list.
-    which_fast_fields: Option<FxHashSet<WhichFastField>>,
+    planned_which_fast_fields: Option<FxHashSet<WhichFastField>>,
     target_list_len: Option<usize>,
     referenced_columns_count: usize,
     need_scores: bool,
@@ -197,8 +197,11 @@ impl PrivateData {
         self.segment_count = segment_count;
     }
 
-    pub fn set_which_fast_fields(&mut self, which_fast_fields: FxHashSet<WhichFastField>) {
-        self.which_fast_fields = Some(which_fast_fields);
+    pub fn set_planned_which_fast_fields(
+        &mut self,
+        planned_which_fast_fields: FxHashSet<WhichFastField>,
+    ) {
+        self.planned_which_fast_fields = Some(planned_which_fast_fields);
     }
 
     pub fn set_exec_method_type(&mut self, exec_method_type: ExecMethodType) {
@@ -270,8 +273,8 @@ impl PrivateData {
         self.segment_count
     }
 
-    pub fn which_fast_fields(&self) -> &Option<FxHashSet<WhichFastField>> {
-        &self.which_fast_fields
+    pub fn planned_which_fast_fields(&self) -> &Option<FxHashSet<WhichFastField>> {
+        &self.planned_which_fast_fields
     }
 
     pub fn exec_method_type(&self) -> &ExecMethodType {

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -29,7 +29,6 @@ use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::postgres::ParallelScanState;
 use crate::query::SearchQueryInput;
 use pgrx::heap_tuple::PgHeapTuple;
-use pgrx::pg_sys::TupleDescData;
 use pgrx::{name_data_to_str, pg_sys, PgRelation, PgTupleDesc};
 use rustc_hash::FxHashMap;
 use std::cell::UnsafeCell;
@@ -49,11 +48,9 @@ pub struct PdbScanState {
     pub search_results: SearchResults,
     pub targetlist_len: usize,
 
-    // The fast fields extracted from the query at query planning time
-    pub planned_which_fast_fields: Option<Vec<WhichFastField>>,
-    // The fast fields aligned with the tuple descriptor at execution time
-    // This is used to index into the exec_tuple_which_fast_fields array using the tuple attribute position
-    pub exec_tuple_which_fast_fields: Vec<Option<WhichFastField>>,
+    // The fast fields extract from the target list at execution time: always a subset
+    // of the fast fields which were extracted during planning.
+    pub exec_tuple_which_fast_fields: Vec<WhichFastField>,
 
     pub limit: Option<usize>,
     pub sort_field: Option<String>,
@@ -258,40 +255,6 @@ impl PdbScanState {
         self.virtual_tuple_count = 0;
         self.invisible_tuple_count = 0;
         self.exec_method_mut().reset(self);
-    }
-
-    /// Aligns the planned_which_fast_fields with the tuple descriptor.
-    /// This ensures that we can index into exec_tuple_which_fast_fields using the tuple attribute position.
-    ///
-    /// For each attribute in the tuple descriptor, this method attempts to find a matching field
-    /// in planned_which_fast_fields. If found, it stores the field in exec_tuple_which_fast_fields
-    /// at the attribute's position. If not found, that position will contain None.
-    ///
-    /// Note: When a field from planned_which_fast_fields doesn't match any attribute in the tuple descriptor,
-    /// that field won't be included in exec_tuple_which_fast_fields. When an attribute position contains None,
-    /// it will be treated as a non-fast field (as FFType::Junk) during execution.
-    pub fn align_fast_fields_with_tuple_descriptor(&mut self, tupdesc: &TupleDescData) {
-        let which_fast_fields = self.planned_which_fast_fields.as_ref().unwrap();
-
-        let natts = tupdesc.natts as usize;
-        // Create an array with None values for each attribute in the tuple descriptor
-        self.exec_tuple_which_fast_fields = vec![None; natts];
-        let attrs = unsafe { tupdesc.attrs.as_slice(natts) };
-
-        // Map field names from which_fast_fields to their positions in the tuple descriptor
-        for field in which_fast_fields {
-            if let WhichFastField::Named(field_name, field_type) = field {
-                // Find this field in the tuple descriptor
-
-                for (i, att) in attrs.iter().enumerate().take(natts) {
-                    if att.name() == field_name {
-                        // Found a match, store a clone of this field at the right position
-                        self.exec_tuple_which_fast_fields[i] = Some(field.clone());
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     /// Given a ctid and field name, get the corresponding value from the heap

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -286,7 +286,6 @@ impl PdbScanState {
                 for (i, att) in attrs.iter().enumerate().take(natts) {
                     if att.name() == field_name {
                         // Found a match, store a clone of this field at the right position
-
                         self.exec_tuple_which_fast_fields[i] = Some(field.clone());
                         break;
                     }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -16,7 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::Varno;
-use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::postgres::customscan::builders::custom_path::{ExecMethodType, SortDirection};
 use crate::postgres::customscan::pdbscan::exec_methods::ExecMethod;
@@ -47,10 +46,6 @@ pub struct PdbScanState {
 
     pub search_results: SearchResults,
     pub targetlist_len: usize,
-
-    // The fast fields extract from the target list at execution time: always a subset
-    // of the fast fields which were extracted during planning.
-    pub exec_tuple_which_fast_fields: Vec<WhichFastField>,
 
     pub limit: Option<usize>,
     pub sort_field: Option<String>,

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -155,7 +155,7 @@ pub extern "C-unwind" fn amrescan(
                 need_scores,
                 fast_fields: FFHelper::with_fields(
                     &search_reader,
-                    &[Some((key_field, key_field_type).into())],
+                    &[(key_field, key_field_type).into()],
                 ),
                 reader: search_reader,
                 search_query_input,

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
@@ -343,10 +343,11 @@ WHERE content @@@ 'Socienty';
          Table: pages
          Index: pages_search
          Segment Count: 1
-         Exec Method: NormalScanExecState
+         Exec Method: NumericFastFieldExecState
+         Fast Fields: page_number
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+(9 rows)
 
 -- Test other aggregations
 SELECT 

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
@@ -322,7 +322,7 @@ ORDER BY rating DESC, title;
                      Table: union_test_a
                      Index: union_test_a_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
+                     Exec Method: NormalScanExecState
                      Fast Fields: author, title, price, rating
                      String Fast Fields: author, title
                      Numeric Fast Fields: price, rating
@@ -332,7 +332,7 @@ ORDER BY rating DESC, title;
                      Table: union_test_b
                      Index: union_test_b_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
+                     Exec Method: NormalScanExecState
                      Fast Fields: author, title, price, rating
                      String Fast Fields: author, title
                      Numeric Fast Fields: price, rating
@@ -408,7 +408,7 @@ ORDER BY price;
                Table: union_test_a
                Index: union_test_a_idx
                Segment Count: 1
-               Exec Method: MixedFastFieldExecState
+               Exec Method: NormalScanExecState
                Fast Fields: title, price, year
                String Fast Fields: title
                Numeric Fast Fields: price, year
@@ -418,7 +418,7 @@ ORDER BY price;
                Table: union_test_b
                Index: union_test_b_idx
                Segment Count: 1
-               Exec Method: MixedFastFieldExecState
+               Exec Method: NormalScanExecState
                Fast Fields: title, price, year
                String Fast Fields: title
                Numeric Fast Fields: price, year
@@ -648,7 +648,7 @@ ORDER BY title, author, author_rank;
                                        Table: union_test_a
                                        Index: union_test_a_idx
                                        Segment Count: 1
-                                       Exec Method: MixedFastFieldExecState
+                                       Exec Method: NormalScanExecState
                                        Fast Fields: author, title, rating
                                        String Fast Fields: author, title
                                        Numeric Fast Fields: rating
@@ -658,7 +658,7 @@ ORDER BY title, author, author_rank;
                                        Table: union_test_b
                                        Index: union_test_b_idx
                                        Segment Count: 1
-                                       Exec Method: MixedFastFieldExecState
+                                       Exec Method: NormalScanExecState
                                        Fast Fields: author, title, rating
                                        String Fast Fields: author, title
                                        Numeric Fast Fields: rating
@@ -770,7 +770,7 @@ ORDER BY author, title;
                            Table: union_test_a
                            Index: union_test_a_idx
                            Segment Count: 1
-                           Exec Method: MixedFastFieldExecState
+                           Exec Method: NormalScanExecState
                            Fast Fields: author, title, is_published
                            String Fast Fields: author, title
                            Numeric Fast Fields: is_published
@@ -782,7 +782,7 @@ ORDER BY author, title;
                            Table: union_test_b
                            Index: union_test_b_idx
                            Segment Count: 1
-                           Exec Method: MixedFastFieldExecState
+                           Exec Method: NormalScanExecState
                            Fast Fields: author, title, is_published
                            String Fast Fields: author, title
                            Numeric Fast Fields: is_published
@@ -900,14 +900,13 @@ ORDER BY avg_rating DESC;
                                  Table: union_test_a
                                  Index: union_test_a_idx
                                  Segment Count: 1
-                                 Exec Method: StringFastFieldExecState
-                                 Fast Fields: author
-                                 String Agg Field: author
+                                 Exec Method: MixedFastFieldExecState
+                                 Fast Fields: author, price, rating
+                                 String Fast Fields: author
+                                 Numeric Fast Fields: price, rating
                                  Scores: false
-                                    Sort Field: author
-                                    Sort Direction: asc
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(19 rows)
+(18 rows)
 
 SELECT author, 
        AVG(rating) as avg_rating,
@@ -947,10 +946,9 @@ INTERSECT
                      Table: union_test_b
                      Index: union_test_b_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, rating
-                     String Fast Fields: author
-                     Numeric Fast Fields: rating
+                     Exec Method: NormalScanExecState
+                     Fast Fields: author
+                     String Agg Field: author
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
          ->  Subquery Scan on "*SELECT* 1"
@@ -958,13 +956,12 @@ INTERSECT
                      Table: union_test_a
                      Index: union_test_a_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, rating
-                     String Fast Fields: author
-                     Numeric Fast Fields: rating
+                     Exec Method: NormalScanExecState
+                     Fast Fields: author
+                     String Agg Field: author
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(24 rows)
+(22 rows)
 
 (SELECT author FROM union_test_a WHERE rating > 4.5 and title @@@ 'Book A')
 INTERSECT

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
@@ -357,9 +357,9 @@ LIMIT 10;
                Index: score_test_idx
                Segment Count: 1
                Exec Method: MixedFastFieldExecState
-               Fast Fields: title, rating
+               Fast Fields: title, id, rating
                String Fast Fields: title
-               Numeric Fast Fields: rating
+               Numeric Fast Fields: id, rating
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
@@ -401,9 +401,9 @@ LIMIT 5;
                Index: score_test_idx
                Segment Count: 1
                Exec Method: MixedFastFieldExecState
-               Fast Fields: author, title, rating, views
+               Fast Fields: author, title, id, rating, views
                String Fast Fields: author, title
-               Numeric Fast Fields: rating, views
+               Numeric Fast Fields: id, rating, views
                Scores: true
                   Top N Limit: 5
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research","lenient":null,"conjunction_mode":null}}}}
@@ -438,9 +438,9 @@ ORDER BY title, author, paradedb.score(id) DESC;
          Index: score_test_idx
          Segment Count: 1
          Exec Method: MixedFastFieldExecState
-         Fast Fields: author, title, is_featured, rating
+         Fast Fields: author, title, id
          String Fast Fields: author, title
-         Numeric Fast Fields: is_featured, rating
+         Numeric Fast Fields: id
          Scores: true
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"term":{"field":"is_featured","value":true,"is_datetime":false}}]}}
 (12 rows)
@@ -483,9 +483,9 @@ LIMIT 10;
                Index: score_test_idx
                Segment Count: 1
                Exec Method: MixedFastFieldExecState
-               Fast Fields: author, title, rating
+               Fast Fields: author, title, id, rating
                String Fast Fields: author, title
-               Numeric Fast Fields: rating
+               Numeric Fast Fields: id, rating
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science OR research","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}
@@ -616,21 +616,23 @@ LIMIT 10;
                      Table: score_test
                      Index: score_test_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title
+                     Exec Method: NormalScanExecState
+                     Fast Fields: author, title, id
                      String Fast Fields: author, title
+                     Numeric Fast Fields: id
                      Scores: true
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
                ->  Custom Scan (ParadeDB Scan) on score_test score_test_1
                      Table: score_test
                      Index: score_test_idx
                      Segment Count: 1
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title
+                     Exec Method: NormalScanExecState
+                     Fast Fields: author, title, id
                      String Fast Fields: author, title
+                     Numeric Fast Fields: id
                      Scores: true
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"technology","lenient":null,"conjunction_mode":null}}}}]}}]}}
-(22 rows)
+(24 rows)
 
 SELECT title, author, paradedb.score(id) as relevance
 FROM score_test
@@ -643,15 +645,15 @@ ORDER BY title, author, relevance DESC
 LIMIT 10;
   title   |  author  |  relevance   
 ----------+----------+--------------
- Post 1   | Author 2 |    1.0340093
+ Post 1   | Author 2 |   0.03400928
  Post 1   | Author 2 | 0.0144330505
- Post 10  | Author 1 |    1.0340093
+ Post 10  | Author 1 |   0.03400928
  Post 10  | Author 1 | 0.0144330505
- Post 100 | Author 1 |    1.0340093
+ Post 100 | Author 1 |   0.03400928
  Post 100 | Author 1 | 0.0144330505
- Post 11  | Author 2 |    1.0340093
+ Post 11  | Author 2 |   0.03400928
  Post 11  | Author 2 | 0.0144330505
- Post 12  | Author 3 |    1.0340093
+ Post 12  | Author 3 |   0.03400928
  Post 12  | Author 3 | 0.0144330505
 (10 rows)
 
@@ -698,10 +700,14 @@ ORDER BY a.title, a.author, a.rating, a.score, b.title;
                      Table: score_test
                      Index: score_test_idx
                      Segment Count: 1
-                     Exec Method: NormalScanExecState
+                     Exec Method: StringFastFieldExecState
+                     Fast Fields: author
+                     String Agg Field: author
                      Scores: false
+                        Sort Field: title
+                        Sort Direction: asc
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(28 rows)
+(32 rows)
 
 SELECT a.title, a.author, a.rating, a.score, b.title as related_title
 FROM (
@@ -807,9 +813,9 @@ LIMIT 10;
                Index: score_test_idx
                Segment Count: 1
                Exec Method: MixedFastFieldExecState
-               Fast Fields: author, title, rating
+               Fast Fields: author, title, id, rating
                String Fast Fields: author, title
-               Numeric Fast Fields: rating
+               Numeric Fast Fields: id, rating
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research OR development","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
@@ -450,9 +450,9 @@ LIMIT 10;
                            Index: products_idx
                            Segment Count: 1
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: name, price
+                           Fast Fields: name, id, price
                            String Fast Fields: name
-                           Numeric Fast Fields: price
+                           Numeric Fast Fields: id, price
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
 (22 rows)
@@ -669,7 +669,7 @@ ORDER BY type, item_name;
                Table: categories
                Index: categories_idx
                Segment Count: 1
-               Exec Method: MixedFastFieldExecState
+               Exec Method: NormalScanExecState
                Fast Fields: description, name
                String Fast Fields: description, name
                Scores: false
@@ -771,10 +771,11 @@ ORDER BY p.price;
                            Table: categories
                            Index: categories_idx
                            Segment Count: 1
-                           Exec Method: NormalScanExecState
+                           Exec Method: NumericFastFieldExecState
+                           Fast Fields: id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"electronics OR clothing","lenient":null,"conjunction_mode":null}}}}
-(19 rows)
+(20 rows)
 
 SELECT p.name, p.price, p.stock_count
 FROM products p
@@ -939,9 +940,9 @@ ORDER BY r.rating DESC, p.price DESC;
                                  Index: products_idx
                                  Segment Count: 1
                                  Exec Method: MixedFastFieldExecState
-                                 Fast Fields: name, is_available, price
+                                 Fast Fields: name, id, price
                                  String Fast Fields: name
-                                 Numeric Fast Fields: is_available, price
+                                 Numeric Fast Fields: id, price
                                  Scores: false
                                  Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"is_available","value":true,"is_datetime":false}}]}}
 (27 rows)

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
@@ -140,8 +140,8 @@ ORDER BY d.id, f.id, p.id;
                            Index: files_search
                            Segment Count: 2
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: file_path, id, title
-                           String Fast Fields: file_path, id, title
+                           Fast Fields: documentid, file_path, id, title
+                           String Fast Fields: documentid, file_path, id, title
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
          ->  Custom Scan (ParadeDB Scan) on pages p
@@ -205,12 +205,10 @@ LIMIT 10;
                                  Table: files
                                  Index: files_search
                                  Segment Count: 2
-                                 Exec Method: StringFastFieldExecState
-                                 Fast Fields: id
-                                 String Agg Field: id
+                                 Exec Method: MixedFastFieldExecState
+                                 Fast Fields: documentid, id
+                                 String Fast Fields: documentid, id
                                  Scores: false
-                                    Sort Field: id
-                                    Sort Direction: asc
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
                      ->  Sort
                            Sort Key: pages.fileid
@@ -225,10 +223,14 @@ LIMIT 10;
                      Table: documents
                      Index: documents_search
                      Segment Count: 2
-                     Exec Method: NormalScanExecState
+                     Exec Method: StringFastFieldExecState
+                     Fast Fields: id
+                     String Agg Field: id
                      Scores: false
+                        Sort Field: id
+                        Sort Direction: asc
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-(37 rows)
+(39 rows)
 
 DROP TABLE IF EXISTS pages CASCADE;
 CREATE TABLE pages (
@@ -336,42 +338,44 @@ JOIN files ON documents.id = files.documentId
 JOIN pages ON pages.fileId = files.id
 WHERE documents.parents @@@ 'Factures' AND files.title @@@ 'Receipt' AND pages.content @@@ 'Socienty'
 LIMIT 10;
-                                                                                   QUERY PLAN                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Hash Join
-         Hash Cond: (documents.id = files.documentid)
-         ->  Custom Scan (ParadeDB Scan) on documents
-               Table: documents
-               Index: documents_search
-               Segment Count: 16
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-         ->  Hash
-               ->  Hash Join
-                     Hash Cond: (pages.fileid = files.id)
-                     ->  Custom Scan (ParadeDB Scan) on pages
-                           Table: pages
-                           Index: pages_search
-                           Segment Count: 15
+         Hash Cond: (files.documentid = documents.id)
+         ->  Hash Join
+               Hash Cond: (pages.fileid = files.id)
+               ->  Custom Scan (ParadeDB Scan) on pages
+                     Table: pages
+                     Index: pages_search
+                     Segment Count: 8
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: content, fileid, page_number
+                     String Fast Fields: content, fileid
+                     Numeric Fast Fields: page_number
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+               ->  Hash
+                     ->  Custom Scan (ParadeDB Scan) on files
+                           Table: files
+                           Index: files_search
+                           Segment Count: 8
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: content, fileid, page_number
-                           String Fast Fields: content, fileid
-                           Numeric Fast Fields: page_number
+                           Fast Fields: documentid, id
+                           String Fast Fields: documentid, id
                            Scores: false
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-                     ->  Hash
-                           ->  Custom Scan (ParadeDB Scan) on files
-                                 Table: files
-                                 Index: files_search
-                                 Segment Count: 16
-                                 Exec Method: StringFastFieldExecState
-                                 Fast Fields: id
-                                 String Agg Field: id
-                                 Scores: false
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
-(33 rows)
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
+         ->  Hash
+               ->  Custom Scan (ParadeDB Scan) on documents
+                     Table: documents
+                     Index: documents_search
+                     Segment Count: 8
+                     Exec Method: StringFastFieldExecState
+                     Fast Fields: id
+                     String Agg Field: id
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
+(35 rows)
 
 \i common/mixedff_queries_cleanup.sql
 -- Cleanup for relational query tests (07-10)

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
@@ -140,7 +140,7 @@ ORDER BY document_title, file_title, page_number;
            Table: documents
            Index: documents_search
            Segment Count: 2
-           Exec Method: MixedFastFieldExecState
+           Exec Method: NormalScanExecState
            Fast Fields: id, parents, title
            String Fast Fields: id, parents, title
            Scores: false

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
@@ -131,12 +131,10 @@ ORDER BY invoice_file_count DESC, d.id;
                        Table: files
                        Index: files_search
                        Segment Count: 2
-                       Exec Method: StringFastFieldExecState
-                       Fast Fields: documentid
-                       String Agg Field: documentid
+                       Exec Method: NormalScanExecState
                        Scores: false
                        Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Invoice","lenient":null,"conjunction_mode":null}}}},{}]}}
-(20 rows)
+(18 rows)
 
 -- Test with subquery
 SELECT d.id, d.title, d.parents,
@@ -151,7 +149,7 @@ ORDER BY invoice_file_count DESC, d.id;
   id  |    title     | parents  | invoice_file_count 
 ------+--------------+----------+--------------------
  doc1 | Invoice 2023 | Factures |                  2
- doc2 | Receipt 2023 | Factures |                  2
+ doc2 | Receipt 2023 | Factures |                  0
 (2 rows)
 
 \i common/mixedff_queries_cleanup.sql

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.86.0"

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -518,7 +518,8 @@ fn cte_issue_1951(mut conn: PgConnection) {
 }
 
 #[rstest]
-// See #TODO-ISSUE-NUMBER
+// TODO: See #2576: we fail to extract the execution-time fast fields here, and so we fall back to
+// `Normal` execution.
 #[should_panic]
 fn is_numeric_fast_field_capable(mut conn: PgConnection) {
     r#"
@@ -575,8 +576,7 @@ fn is_numeric_fast_field_capable(mut conn: PgConnection) {
     let (b, count) = sql.fetch_one::<(bool, i64)>(&mut conn);
     assert_eq!((b, count), (true, 8));
 
-    // This falls back to Normal because we fail to extract the relevant fast fields at execution
-    // time: see #TODO-ISSUE-NUMBER
+    // TODO: See the method doc.
     let (plan,) =
         format!("EXPLAIN (FORMAT JSON) {sql}").fetch_one::<(serde_json::Value,)>(&mut conn);
     eprintln!(">>> {plan:#?}");

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -518,6 +518,8 @@ fn cte_issue_1951(mut conn: PgConnection) {
 }
 
 #[rstest]
+// See #TODO-ISSUE-NUMBER
+#[should_panic]
 fn is_numeric_fast_field_capable(mut conn: PgConnection) {
     r#"
         CREATE TABLE test (
@@ -569,8 +571,24 @@ fn is_numeric_fast_field_capable(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    let (b, count) = "select assert(count(*), 8), count(*) from (select id from test where message @@@ 'beer' order by severity) x limit 8;".fetch_one::<(bool, i64)>(&mut conn);
+    let sql = "select assert(count(*), 8), count(*) from (select id from test where message @@@ 'beer' order by severity) x limit 8;";
+    let (b, count) = sql.fetch_one::<(bool, i64)>(&mut conn);
     assert_eq!((b, count), (true, 8));
+
+    // This falls back to Normal because we fail to extract the relevant fast fields at execution
+    // time: see #TODO-ISSUE-NUMBER
+    let (plan,) =
+        format!("EXPLAIN (FORMAT JSON) {sql}").fetch_one::<(serde_json::Value,)>(&mut conn);
+    eprintln!(">>> {plan:#?}");
+    assert_eq!(
+        plan.pointer("/0/Plan/Plans/0/Plans/0/Plans/0")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .get("Exec Method")
+            .unwrap(),
+        &Value::String("NumericFastFieldExecState".to_owned())
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2556.

## What

Moves to extracting fast fields from `RelOptInfo.reltarget.exprs` at planning time, which resolves the issue identified in #2554 and #2556 by ensuring that we always extract more fast fields at planning time than at execution time (which is now logged as a fallback in `compute_exec_which_fast_fields`, but which we haven't encountered any cases of in our tests). 

## Why

Ensuring that all fast fields are located at planning time allows us to revert the portion of #2554 which made `WhichFastFields` optional. Optional fast fields caused #2556, because NULLs would be emitted for any fast fields which we failed to detect. That caused a recurrence of #2505.

The failure was seemingly masked by missing `VACUUM`/`ANALYZE` statements, meaning that some tests which would otherwise have failed, instead fell back to fetching heap tuples rather than actually using fast fields. `VACUUM`/`ANALYZE` are necessary to update the visibility map and cause us to attempt to create `Virtual` tuples from fast fields.

It was surfaced by manual testing, and separately by #2547.

## Tests

Passes the existing tests, as well as the proptests in #2547, which previously failed due to #2556.

Regression tests are adjusted for the planning changes:
* `mixedff_queries_04_subquery.out` represents a bugfix
* `mixedff_queries_03_cte_test.out` and `mixedff_advanced_05_union_window_functions.out` are regressions in terms of `Mixed` support, but are still correct: @mdashti will follow up to see how we might be able to safely used `Mixed` in these cases
* the rest are improvements