### PR TITLE
chore: removed "Segment Count" from the explainer if `COSTS` are turned off.

### DIFF
--- a/pg_search/src/postgres/customscan/explainer.rs
+++ b/pg_search/src/postgres/customscan/explainer.rs
@@ -37,6 +37,10 @@ impl Explainer {
         unsafe { (*self.state.as_ptr()).analyze }
     }
 
+    pub fn is_costs(&self) -> bool {
+        unsafe { (*self.state.as_ptr()).costs }
+    }
+
     pub fn add_text<S: AsRef<str>>(&mut self, key: &str, value: S) {
         unsafe {
             pg_sys::ExplainPropertyText(

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -642,11 +642,13 @@ impl CustomScan for PdbScan {
     ) {
         explainer.add_text("Table", state.custom_state().heaprelname());
         explainer.add_text("Index", state.custom_state().indexrelname());
-        explainer.add_unsigned_integer(
-            "Segment Count",
-            state.custom_state().segment_count as u64,
-            None,
-        );
+        if explainer.is_costs() {
+            explainer.add_unsigned_integer(
+                "Segment Count",
+                state.custom_state().segment_count as u64,
+                None,
+            );
+        }
 
         if explainer.is_analyze() {
             explainer.add_unsigned_integer(

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
@@ -312,11 +312,10 @@ WHERE content @@@ 'Socienty';
    ->  Custom Scan (ParadeDB Scan) on pages
          Table: pages
          Index: pages_search
-         Segment Count: 1
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+(7 rows)
 
 -- Test COUNT aggregation
 SELECT COUNT(*)
@@ -342,12 +341,11 @@ WHERE content @@@ 'Socienty';
    ->  Custom Scan (ParadeDB Scan) on pages
          Table: pages
          Index: pages_search
-         Segment Count: 1
          Exec Method: NumericFastFieldExecState
          Fast Fields: page_number
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(8 rows)
 
 -- Test other aggregations
 SELECT 

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_02_mixed_fast_non_fast.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_02_mixed_fast_non_fast.out
@@ -314,14 +314,13 @@ ORDER BY fileId, page_number;
    ->  Custom Scan (ParadeDB Scan) on pages
          Table: pages
          Index: pages_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: fileid, page_number
          String Fast Fields: fileid
          Numeric Fast Fields: page_number
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Query with only fast fields
 SELECT fileId, page_number
@@ -347,11 +346,10 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on pages
          Table: pages
          Index: pages_search
-         Segment Count: 1
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(8 rows)
 
 -- Query with non-fast field
 SELECT content

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
@@ -350,14 +350,13 @@ LIMIT 10;
    ->  Custom Scan (ParadeDB Scan) on limit_topn_test
          Table: limit_topn_test
          Index: limit_topn_idx
-         Segment Count: 1
          Exec Method: TopNScanExecState
          Scores: false
             Sort Field: rating
             Sort Direction: desc
             Top N Limit: 10
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 -- Test LIMIT with mixed text and numeric fields
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -372,14 +371,13 @@ LIMIT 5;
    ->  Custom Scan (ParadeDB Scan) on limit_topn_test
          Table: limit_topn_test
          Index: limit_topn_idx
-         Segment Count: 1
          Exec Method: TopNScanExecState
          Scores: false
             Sort Field: price
             Sort Direction: asc
             Top N Limit: 5
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 SELECT title, category, rating, price
 FROM limit_topn_test
@@ -408,14 +406,13 @@ LIMIT 15;
    ->  Custom Scan (ParadeDB Scan) on limit_topn_test
          Table: limit_topn_test
          Index: limit_topn_idx
-         Segment Count: 1
          Exec Method: TopNScanExecState
          Scores: false
             Sort Field: title
             Sort Direction: asc
             Top N Limit: 15
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Books OR Electronics","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 SELECT title, category
 FROM limit_topn_test
@@ -513,14 +510,13 @@ LIMIT 8;
    ->  Custom Scan (ParadeDB Scan) on limit_topn_test
          Table: limit_topn_test
          Index: limit_topn_idx
-         Segment Count: 1
          Exec Method: TopNScanExecState
          Scores: false
             Sort Field: price
             Sort Direction: desc
             Top N Limit: 8
          Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"included":2.5},"upper_bound":null,"is_datetime":false}},{"range":{"field":"rating","lower_bound":null,"upper_bound":{"included":4.5},"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Toys OR Clothing","lenient":null,"conjunction_mode":null}}}}]}}
-(11 rows)
+(10 rows)
 
 SELECT title, category, rating, price
 FROM limit_topn_test

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_04_execution_method_selection.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_04_execution_method_selection.out
@@ -357,13 +357,12 @@ ORDER BY text_field1, text_field2;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, text_field2
          String Fast Fields: text_field1, text_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 SELECT text_field1, text_field2
 FROM exec_method_test
@@ -436,14 +435,13 @@ ORDER BY text_field1, num_field1, num_field2;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1, num_field2
          String Fast Fields: text_field1
          Numeric Fast Fields: num_field1, num_field2
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"excluded":10},"upper_bound":null,"is_datetime":false}}]}}
-(12 rows)
+(11 rows)
 
 SELECT text_field1, num_field1, num_field2
 FROM exec_method_test
@@ -506,14 +504,13 @@ ORDER BY text_field1, text_field2, num_field1, bool_field;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, text_field2, bool_field, num_field1
          String Fast Fields: text_field1, text_field2
          Numeric Fast Fields: bool_field, num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"bool_field","value":true,"is_datetime":false}}]}}
-(12 rows)
+(11 rows)
 
 SELECT text_field1, text_field2, num_field1, bool_field
 FROM exec_method_test
@@ -561,7 +558,6 @@ ORDER BY text_field1;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: StringFastFieldExecState
          Fast Fields: text_field1
          String Agg Field: text_field1
@@ -569,7 +565,7 @@ ORDER BY text_field1;
             Sort Field: text_field1
             Sort Direction: asc
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+(12 rows)
 
 SELECT text_field1
 FROM exec_method_test
@@ -642,12 +638,11 @@ ORDER BY num_field1, num_field2;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: NumericFastFieldExecState
          Fast Fields: num_field1, num_field2
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"range":{"field":"num_field1","lower_bound":{"excluded":25},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}]}}
-(10 rows)
+(9 rows)
 
 SELECT num_field1, num_field2
 FROM exec_method_test
@@ -695,11 +690,10 @@ ORDER BY text_field1, non_indexed_field;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(8 rows)
 
 SELECT text_field1, non_indexed_field
 FROM exec_method_test
@@ -772,14 +766,13 @@ ORDER BY text_field1, num_field1 DESC;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1
          String Fast Fields: text_field1
          Numeric Fast Fields: num_field1
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 SELECT text_field1, num_field1
 FROM exec_method_test
@@ -855,14 +848,13 @@ ORDER BY text_field1, text_field2, num_field1, bool_field;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, text_field2, bool_field, num_field1
          String Fast Fields: text_field1, text_field2
          Numeric Fast Fields: bool_field, num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"text_field2","query_string":"Sample","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"included":10},"upper_bound":null,"is_datetime":false}},{"range":{"field":"num_field1","lower_bound":null,"upper_bound":{"included":40},"is_datetime":false}},{"term":{"field":"bool_field","value":true,"is_datetime":false}}]}}
-(12 rows)
+(11 rows)
 
 SELECT text_field1, text_field2, num_field1, bool_field
 FROM exec_method_test
@@ -908,14 +900,13 @@ ORDER BY t.text_field1, t.num_field1;
    ->  Custom Scan (ParadeDB Scan) on exec_method_test
          Table: exec_method_test
          Index: exec_method_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1
          String Fast Fields: text_field1
          Numeric Fast Fields: num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"excluded":10},"upper_bound":null,"is_datetime":false}},{"range":{"field":"num_field1","lower_bound":null,"upper_bound":{"excluded":30},"is_datetime":false}}]}}
-(12 rows)
+(11 rows)
 
 SELECT t.text_field1, t.num_field1
 FROM (

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
@@ -321,7 +321,6 @@ ORDER BY rating DESC, title;
                ->  Custom Scan (ParadeDB Scan) on union_test_a
                      Table: union_test_a
                      Index: union_test_a_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author, title, price, rating
                      String Fast Fields: author, title
@@ -331,14 +330,13 @@ ORDER BY rating DESC, title;
                ->  Custom Scan (ParadeDB Scan) on union_test_b
                      Table: union_test_b
                      Index: union_test_b_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author, title, price, rating
                      String Fast Fields: author, title
                      Numeric Fast Fields: price, rating
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}}]}}
-(25 rows)
+(23 rows)
 
 SELECT title, author, rating, price
 FROM union_test_a
@@ -407,7 +405,6 @@ ORDER BY price;
          ->  Custom Scan (ParadeDB Scan) on union_test_a
                Table: union_test_a
                Index: union_test_a_idx
-               Segment Count: 1
                Exec Method: NormalScanExecState
                Fast Fields: title, price, year
                String Fast Fields: title
@@ -417,14 +414,13 @@ ORDER BY price;
          ->  Custom Scan (ParadeDB Scan) on union_test_b
                Table: union_test_b
                Index: union_test_b_idx
-               Segment Count: 1
                Exec Method: NormalScanExecState
                Fast Fields: title, price, year
                String Fast Fields: title
                Numeric Fast Fields: price, year
                Scores: false
                Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":null,"upper_bound":{"excluded":45.0},"is_datetime":false}},{"range":{"field":"year","lower_bound":{"excluded":1982},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}}]}}
-(23 rows)
+(21 rows)
 
 SELECT title, price, year
 FROM union_test_a
@@ -465,14 +461,13 @@ ORDER BY title, author, author_rank;
                ->  Custom Scan (ParadeDB Scan) on union_test_a
                      Table: union_test_a
                      Index: union_test_a_idx
-                     Segment Count: 1
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: author, title, price, rating
                      String Fast Fields: author, title
                      Numeric Fast Fields: price, rating
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+(14 rows)
 
 SELECT title, author, price, rating,
        ROW_NUMBER() OVER (PARTITION BY author, price ORDER BY rating DESC) as author_rank
@@ -550,14 +545,13 @@ ORDER BY title, author, price;
                ->  Custom Scan (ParadeDB Scan) on union_test_a
                      Table: union_test_a
                      Index: union_test_a_idx
-                     Segment Count: 1
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: author, title, price
                      String Fast Fields: author, title
                      Numeric Fast Fields: price
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+(14 rows)
 
 SELECT title, author, price,
        AVG(price) OVER (PARTITION BY author ORDER BY price) as running_avg_price
@@ -647,7 +641,6 @@ ORDER BY title, author, author_rank;
                                  ->  Custom Scan (ParadeDB Scan) on union_test_a
                                        Table: union_test_a
                                        Index: union_test_a_idx
-                                       Segment Count: 1
                                        Exec Method: NormalScanExecState
                                        Fast Fields: author, title, rating
                                        String Fast Fields: author, title
@@ -657,14 +650,13 @@ ORDER BY title, author, author_rank;
                                  ->  Custom Scan (ParadeDB Scan) on union_test_b
                                        Table: union_test_b
                                        Index: union_test_b_idx
-                                       Segment Count: 1
                                        Exec Method: NormalScanExecState
                                        Fast Fields: author, title, rating
                                        String Fast Fields: author, title
                                        Numeric Fast Fields: rating
                                        Scores: false
                                        Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":2.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(29 rows)
+(27 rows)
 
 WITH combined_books AS (
     SELECT title, author, rating, 'A' as source
@@ -769,7 +761,6 @@ ORDER BY author, title;
                      ->  Custom Scan (ParadeDB Scan) on union_test_a
                            Table: union_test_a
                            Index: union_test_a_idx
-                           Segment Count: 1
                            Exec Method: NormalScanExecState
                            Fast Fields: author, title, is_published
                            String Fast Fields: author, title
@@ -781,14 +772,13 @@ ORDER BY author, title;
                      ->  Custom Scan (ParadeDB Scan) on union_test_b
                            Table: union_test_b
                            Index: union_test_b_idx
-                           Segment Count: 1
                            Exec Method: NormalScanExecState
                            Fast Fields: author, title, is_published
                            String Fast Fields: author, title
                            Numeric Fast Fields: is_published
                            Scores: false
                            Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_published","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author 1","lenient":null,"conjunction_mode":null}}}}]}}
-(29 rows)
+(27 rows)
 
 SELECT title, author, is_published
 FROM union_test_a
@@ -899,14 +889,13 @@ ORDER BY avg_rating DESC;
                            ->  Custom Scan (ParadeDB Scan) on union_test_a
                                  Table: union_test_a
                                  Index: union_test_a_idx
-                                 Segment Count: 1
                                  Exec Method: MixedFastFieldExecState
                                  Fast Fields: author, price, rating
                                  String Fast Fields: author
                                  Numeric Fast Fields: price, rating
                                  Scores: false
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+(17 rows)
 
 SELECT author, 
        AVG(rating) as avg_rating,
@@ -945,7 +934,6 @@ INTERSECT
                ->  Custom Scan (ParadeDB Scan) on union_test_b
                      Table: union_test_b
                      Index: union_test_b_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author
                      String Agg Field: author
@@ -955,13 +943,12 @@ INTERSECT
                ->  Custom Scan (ParadeDB Scan) on union_test_a
                      Table: union_test_a
                      Index: union_test_a_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author
                      String Agg Field: author
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(22 rows)
+(20 rows)
 
 (SELECT author FROM union_test_a WHERE rating > 4.5 and title @@@ 'Book A')
 INTERSECT

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
@@ -355,7 +355,6 @@ LIMIT 10;
          ->  Custom Scan (ParadeDB Scan) on score_test
                Table: score_test
                Index: score_test_idx
-               Segment Count: 1
                Exec Method: MixedFastFieldExecState
                Fast Fields: title, id, rating
                String Fast Fields: title
@@ -363,7 +362,7 @@ LIMIT 10;
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+(13 rows)
 
 SELECT title, paradedb.score(id), rating
 FROM score_test
@@ -399,7 +398,6 @@ LIMIT 5;
          ->  Custom Scan (ParadeDB Scan) on score_test
                Table: score_test
                Index: score_test_idx
-               Segment Count: 1
                Exec Method: MixedFastFieldExecState
                Fast Fields: author, title, id, rating, views
                String Fast Fields: author, title
@@ -407,7 +405,7 @@ LIMIT 5;
                Scores: true
                   Top N Limit: 5
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+(13 rows)
 
 SELECT title, author, rating, views, paradedb.score(id)
 FROM score_test
@@ -436,14 +434,13 @@ ORDER BY title, author, paradedb.score(id) DESC;
    ->  Custom Scan (ParadeDB Scan) on score_test
          Table: score_test
          Index: score_test_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: author, title, id
          String Fast Fields: author, title
          Numeric Fast Fields: id
          Scores: true
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"term":{"field":"is_featured","value":true,"is_datetime":false}}]}}
-(12 rows)
+(11 rows)
 
 SELECT title, author, paradedb.score(id)
 FROM score_test
@@ -481,7 +478,6 @@ LIMIT 10;
          ->  Custom Scan (ParadeDB Scan) on score_test
                Table: score_test
                Index: score_test_idx
-               Segment Count: 1
                Exec Method: MixedFastFieldExecState
                Fast Fields: author, title, id, rating
                String Fast Fields: author, title
@@ -489,7 +485,7 @@ LIMIT 10;
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science OR research","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}
-(14 rows)
+(13 rows)
 
 WITH scored_posts AS (
     SELECT title, author, rating, paradedb.score(id) as relevance
@@ -532,14 +528,13 @@ ORDER BY sp.title, sp.author, sp.relevance DESC;
    ->  Custom Scan (ParadeDB Scan) on score_test
          Table: score_test
          Index: score_test_idx
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: author, title, id
          String Fast Fields: author, title
          Numeric Fast Fields: id
          Scores: true
          Tantivy Query: {"score_filter":{"bounds":[[{"Excluded":0.5},"Unbounded"]],"query":{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}}}
-(12 rows)
+(11 rows)
 
 SELECT sp.title, sp.author, sp.relevance
 FROM (
@@ -615,7 +610,6 @@ LIMIT 10;
                ->  Custom Scan (ParadeDB Scan) on score_test
                      Table: score_test
                      Index: score_test_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author, title, id
                      String Fast Fields: author, title
@@ -625,14 +619,13 @@ LIMIT 10;
                ->  Custom Scan (ParadeDB Scan) on score_test score_test_1
                      Table: score_test
                      Index: score_test_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Fast Fields: author, title, id
                      String Fast Fields: author, title
                      Numeric Fast Fields: id
                      Scores: true
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"technology","lenient":null,"conjunction_mode":null}}}}]}}]}}
-(24 rows)
+(22 rows)
 
 SELECT title, author, paradedb.score(id) as relevance
 FROM score_test
@@ -688,7 +681,6 @@ ORDER BY a.title, a.author, a.rating, a.score, b.title;
                            ->  Custom Scan (ParadeDB Scan) on score_test score_test_2
                                  Table: score_test
                                  Index: score_test_idx
-                                 Segment Count: 1
                                  Exec Method: TopNScanExecState
                                  Scores: true
                                     Sort Field: paradedb.score()
@@ -699,7 +691,6 @@ ORDER BY a.title, a.author, a.rating, a.score, b.title;
                ->  Custom Scan (ParadeDB Scan) on score_test score_test_1
                      Table: score_test
                      Index: score_test_idx
-                     Segment Count: 1
                      Exec Method: StringFastFieldExecState
                      Fast Fields: author
                      String Agg Field: author
@@ -707,7 +698,7 @@ ORDER BY a.title, a.author, a.rating, a.score, b.title;
                         Sort Field: title
                         Sort Direction: asc
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(32 rows)
+(30 rows)
 
 SELECT a.title, a.author, a.rating, a.score, b.title as related_title
 FROM (
@@ -811,7 +802,6 @@ LIMIT 10;
          ->  Custom Scan (ParadeDB Scan) on score_test
                Table: score_test
                Index: score_test_idx
-               Segment Count: 1
                Exec Method: MixedFastFieldExecState
                Fast Fields: author, title, id, rating
                String Fast Fields: author, title
@@ -819,7 +809,7 @@ LIMIT 10;
                Scores: true
                   Top N Limit: 10
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research OR development","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+(13 rows)
 
 SELECT 
     title, 

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
@@ -529,7 +529,6 @@ ORDER BY level, name;
            ->  Custom Scan (ParadeDB Scan) on category
                  Table: category
                  Index: category_idx
-                 Segment Count: 1
                  Exec Method: NormalScanExecState
                  Scores: false
                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"books","lenient":null,"conjunction_mode":null}}}}
@@ -539,7 +538,7 @@ ORDER BY level, name;
                  ->  Hash
                        ->  Seq Scan on category c
    ->  CTE Scan on category_tree
-(17 rows)
+(16 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case with search
@@ -601,12 +600,11 @@ ORDER BY level, name;
                        ->  Custom Scan (ParadeDB Scan) on category c
                              Table: category
                              Index: category_idx
-                             Segment Count: 1
                              Exec Method: NormalScanExecState
                              Scores: false
                              Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"computer","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"item_count","lower_bound":{"excluded":30},"upper_bound":null,"is_datetime":false}}]}}
    ->  CTE Scan on category_tree
-(18 rows)
+(17 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_08_type_conversion.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_08_type_conversion.out
@@ -311,14 +311,13 @@ WHERE content @@@ 'conversion test';
  Custom Scan (ParadeDB Scan) on conversion_test
    Table: conversion_test
    Index: conversion_search
-   Segment Count: 1
    Exec Method: MixedFastFieldExecState
    Fast Fields: id, bigint_field, integer_field, smallint_field
    String Fast Fields: id
    Numeric Fast Fields: bigint_field, integer_field, smallint_field
    Scores: false
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"conversion test","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Check values for different integer types
 SELECT id, smallint_field, integer_field, bigint_field

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
@@ -448,14 +448,13 @@ LIMIT 10;
                      ->  Custom Scan (ParadeDB Scan) on products p
                            Table: products
                            Index: products_idx
-                           Segment Count: 1
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: name, id, price
                            String Fast Fields: name
                            Numeric Fast Fields: id, price
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+(21 rows)
 
 SELECT p.name, p.price, c.name as category
 FROM products p
@@ -499,14 +498,13 @@ LIMIT 5;
                      ->  Custom Scan (ParadeDB Scan) on products p
                            Table: products
                            Index: products_idx
-                           Segment Count: 1
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: name, id
                            String Fast Fields: name
                            Numeric Fast Fields: id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"product","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+(17 rows)
 
 SELECT p.name, r.rating, r.content
 FROM products p
@@ -597,14 +595,13 @@ ORDER BY pr.avg_rating DESC, paradedb.score(tp.id), tp.price DESC;
                            ->  Custom Scan (ParadeDB Scan) on products p
                                  Table: products
                                  Index: products_idx
-                                 Segment Count: 1
                                  Exec Method: TopNScanExecState
                                  Scores: false
                                     Sort Field: price
                                     Sort Direction: desc
                                     Top N Limit: 50
                                  Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":{"included":100.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"included":800.0},"is_datetime":false}},{"term":{"field":"is_available","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}]}}
-(32 rows)
+(31 rows)
 
 WITH top_products AS (
     SELECT p.id, p.name, p.price, p.stock_count
@@ -661,14 +658,12 @@ ORDER BY type, item_name;
          ->  Custom Scan (ParadeDB Scan) on products
                Table: products
                Index: products_idx
-               Segment Count: 1
                Exec Method: NormalScanExecState
                Scores: false
                Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"10","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"feature","lenient":null,"conjunction_mode":null}}}}]}}
          ->  Custom Scan (ParadeDB Scan) on categories
                Table: categories
                Index: categories_idx
-               Segment Count: 1
                Exec Method: NormalScanExecState
                Fast Fields: description, name
                String Fast Fields: description, name
@@ -677,11 +672,10 @@ ORDER BY type, item_name;
          ->  Custom Scan (ParadeDB Scan) on reviews
                Table: reviews
                Index: reviews_idx
-               Segment Count: 1
                Exec Method: NormalScanExecState
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"great","lenient":null,"conjunction_mode":null}}}}
-(26 rows)
+(23 rows)
 
 SELECT 'Product' as type, name as item_name, description as content
 FROM products
@@ -770,12 +764,11 @@ ORDER BY p.price;
                      ->  Custom Scan (ParadeDB Scan) on categories c
                            Table: categories
                            Index: categories_idx
-                           Segment Count: 1
                            Exec Method: NumericFastFieldExecState
                            Fast Fields: id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"electronics OR clothing","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+(19 rows)
 
 SELECT p.name, p.price, p.stock_count
 FROM products p
@@ -837,11 +830,10 @@ ORDER BY
                ->  Custom Scan (ParadeDB Scan) on products p
                      Table: products
                      Index: products_idx
-                     Segment Count: 1
                      Exec Method: NormalScanExecState
                      Scores: true
                      Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_available","value":true,"is_datetime":false}},{"range":{"field":"price","lower_bound":{"included":200.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"included":600.0},"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}]}}
-(15 rows)
+(14 rows)
 
 SELECT 
     p.name,
@@ -938,14 +930,13 @@ ORDER BY r.rating DESC, p.price DESC;
                            ->  Custom Scan (ParadeDB Scan) on products p
                                  Table: products
                                  Index: products_idx
-                                 Segment Count: 1
                                  Exec Method: MixedFastFieldExecState
                                  Fast Fields: name, id, price
                                  String Fast Fields: name
                                  Numeric Fast Fields: id, price
                                  Scores: false
                                  Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"is_available","value":true,"is_datetime":false}}]}}
-(27 rows)
+(26 rows)
 
 SELECT p.name, p.price, r.content, r.rating
 FROM products p

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_01_basic_mixed_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_01_basic_mixed_fields.out
@@ -51,14 +51,13 @@ WHERE content @@@ 'red';
  Custom Scan (ParadeDB Scan) on mixed_numeric_string_test
    Table: mixed_numeric_string_test
    Index: mixed_test_search
-   Segment Count: 1
    Exec Method: MixedFastFieldExecState
    Fast Fields: string_field1, string_field2, numeric_field1, numeric_field2
    String Fast Fields: string_field1, string_field2
    Numeric Fast Fields: numeric_field1, numeric_field2
    Scores: false
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, numeric_field2, string_field1, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_02_multiple_string_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_02_multiple_string_fields.out
@@ -54,13 +54,12 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on mixed_numeric_string_test
          Table: mixed_numeric_string_test
          Index: mixed_test_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, string_field1, string_field2, string_field3
          String Fast Fields: id, string_field1, string_field2, string_field3
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 -- Execute query and check results
 SELECT string_field1, string_field2, string_field3

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_03_multiple_numeric_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_03_multiple_numeric_fields.out
@@ -54,14 +54,13 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on mixed_numeric_string_test
          Table: mixed_numeric_string_test
          Index: mixed_test_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, numeric_field1, numeric_field2
          String Fast Fields: id
          Numeric Fast Fields: numeric_field1, numeric_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, numeric_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_04_mixed_field_types.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_04_mixed_field_types.out
@@ -54,14 +54,13 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on mixed_numeric_string_test
          Table: mixed_numeric_string_test
          Index: mixed_test_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, string_field1, string_field2, numeric_field1, numeric_field2
          String Fast Fields: id, string_field1, string_field2
          Numeric Fast Fields: numeric_field1, numeric_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, string_field1, numeric_field2, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_01_corner_cases.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_01_corner_cases.out
@@ -148,13 +148,12 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: empty_string, id
          String Fast Fields: empty_string, id
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 -- Test handling of empty strings
 SELECT id, empty_string
@@ -185,11 +184,10 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(8 rows)
 
 SELECT id, length(very_long_string) as long_string_length
 FROM corner_case_test
@@ -219,13 +217,12 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, special_chars
          String Fast Fields: id, special_chars
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 SELECT id, special_chars
 FROM corner_case_test
@@ -255,14 +252,13 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, extreme_large, extreme_small
          String Fast Fields: id
          Numeric Fast Fields: extreme_large, extreme_small
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Test handling of extreme numeric values
 SELECT id, extreme_large, extreme_small
@@ -293,14 +289,13 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, bool_field
          String Fast Fields: id
          Numeric Fast Fields: bool_field
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 SELECT id, bool_field
 FROM corner_case_test

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_02_null_handling.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_02_null_handling.out
@@ -146,14 +146,13 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on nullable_test
          Table: nullable_test
          Index: nullable_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, string_field, numeric_field
          String Fast Fields: id, string_field
          Numeric Fast Fields: numeric_field
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"null","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Test retrieval of NULL values
 SELECT id, string_field, numeric_field

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_03_string_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_03_string_edge_cases.out
@@ -146,13 +146,12 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on mixed_numeric_string_test
          Table: mixed_numeric_string_test
          Index: mixed_string_edge_search
-         Segment Count: 1
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, string_field1, string_field2
          String Fast Fields: id, string_field1, string_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"edge case","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 -- Test query
 SELECT id, string_field1, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_04_complex_string_patterns.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_04_complex_string_patterns.out
@@ -146,13 +146,12 @@ ORDER BY id;
    ->  Custom Scan (ParadeDB Scan) on corner_case_test
          Table: corner_case_test
          Index: corner_case_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: empty_string, id, special_chars
          String Fast Fields: empty_string, id, special_chars
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"complex pattern","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 -- Test query
 SELECT id, empty_string, special_chars 

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
@@ -127,7 +127,6 @@ ORDER BY d.id, f.id, p.id;
                      ->  Custom Scan (ParadeDB Scan) on documents d
                            Table: documents
                            Index: documents_search
-                           Segment Count: 2
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: id, parents
                            String Fast Fields: id, parents
@@ -138,7 +137,6 @@ ORDER BY d.id, f.id, p.id;
                      ->  Custom Scan (ParadeDB Scan) on files f
                            Table: files
                            Index: files_search
-                           Segment Count: 2
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: documentid, file_path, id, title
                            String Fast Fields: documentid, file_path, id, title
@@ -147,14 +145,13 @@ ORDER BY d.id, f.id, p.id;
          ->  Custom Scan (ParadeDB Scan) on pages p
                Table: pages
                Index: pages_search
-               Segment Count: 2
                Exec Method: MixedFastFieldExecState
                Fast Fields: fileid, id, page_number
                String Fast Fields: fileid, id
                Numeric Fast Fields: page_number
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(39 rows)
+(36 rows)
 
 -- Test complex join
 SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
@@ -204,7 +201,6 @@ LIMIT 10;
                            ->  Custom Scan (ParadeDB Scan) on files
                                  Table: files
                                  Index: files_search
-                                 Segment Count: 2
                                  Exec Method: MixedFastFieldExecState
                                  Fast Fields: documentid, id
                                  String Fast Fields: documentid, id
@@ -215,14 +211,12 @@ LIMIT 10;
                            ->  Custom Scan (ParadeDB Scan) on pages
                                  Table: pages
                                  Index: pages_search
-                                 Segment Count: 2
                                  Exec Method: NormalScanExecState
                                  Scores: false
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
                ->  Custom Scan (ParadeDB Scan) on documents
                      Table: documents
                      Index: documents_search
-                     Segment Count: 2
                      Exec Method: StringFastFieldExecState
                      Fast Fields: id
                      String Agg Field: id
@@ -230,7 +224,7 @@ LIMIT 10;
                         Sort Field: id
                         Sort Direction: asc
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-(39 rows)
+(36 rows)
 
 DROP TABLE IF EXISTS pages CASCADE;
 CREATE TABLE pages (
@@ -348,7 +342,6 @@ LIMIT 10;
                ->  Custom Scan (ParadeDB Scan) on pages
                      Table: pages
                      Index: pages_search
-                     Segment Count: 8
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: content, fileid, page_number
                      String Fast Fields: content, fileid
@@ -359,7 +352,6 @@ LIMIT 10;
                      ->  Custom Scan (ParadeDB Scan) on files
                            Table: files
                            Index: files_search
-                           Segment Count: 8
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: documentid, id
                            String Fast Fields: documentid, id
@@ -369,13 +361,12 @@ LIMIT 10;
                ->  Custom Scan (ParadeDB Scan) on documents
                      Table: documents
                      Index: documents_search
-                     Segment Count: 8
                      Exec Method: StringFastFieldExecState
                      Fast Fields: id
                      String Agg Field: id
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-(35 rows)
+(32 rows)
 
 \i common/mixedff_queries_cleanup.sql
 -- Cleanup for relational query tests (07-10)

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_02_order_by.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_02_order_by.out
@@ -116,14 +116,13 @@ ORDER BY fileid, page_number;
    ->  Custom Scan (ParadeDB Scan) on pages
          Table: pages
          Index: pages_search
-         Segment Count: 2
          Exec Method: MixedFastFieldExecState
          Fast Fields: fileid, page_number
          String Fast Fields: fileid
          Numeric Fast Fields: page_number
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 -- Execute query and verify results are ordered
 SELECT fileId, page_number

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
@@ -139,7 +139,6 @@ ORDER BY document_title, file_title, page_number;
      ->  Custom Scan (ParadeDB Scan) on documents d
            Table: documents
            Index: documents_search
-           Segment Count: 2
            Exec Method: NormalScanExecState
            Fast Fields: id, parents, title
            String Fast Fields: id, parents, title
@@ -151,7 +150,6 @@ ORDER BY document_title, file_title, page_number;
            ->  Custom Scan (ParadeDB Scan) on files f
                  Table: files
                  Index: files_search
-                 Segment Count: 2
                  Exec Method: NormalScanExecState
                  Scores: false
                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"CTE Test","lenient":null,"conjunction_mode":null}}}}
@@ -168,14 +166,13 @@ ORDER BY document_title, file_title, page_number;
          ->  Custom Scan (ParadeDB Scan) on pages p
                Table: pages
                Index: pages_search
-               Segment Count: 2
                Exec Method: MixedFastFieldExecState
                Fast Fields: fileid, page_number
                String Fast Fields: fileid
                Numeric Fast Fields: page_number
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"searchable OR testing","lenient":null,"conjunction_mode":null}}}}
-(42 rows)
+(39 rows)
 
 -- Test with CTE
 WITH searchable_docs AS (

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
@@ -121,7 +121,6 @@ ORDER BY invoice_file_count DESC, d.id;
    ->  Custom Scan (ParadeDB Scan) on documents d
          Table: documents
          Index: documents_search
-         Segment Count: 2
          Exec Method: NormalScanExecState
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
@@ -130,11 +129,10 @@ ORDER BY invoice_file_count DESC, d.id;
                  ->  Custom Scan (ParadeDB Scan) on files f
                        Table: files
                        Index: files_search
-                       Segment Count: 2
                        Exec Method: NormalScanExecState
                        Scores: false
                        Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Invoice","lenient":null,"conjunction_mode":null}}}},{}]}}
-(18 rows)
+(16 rows)
 
 -- Test with subquery
 SELECT d.id, d.title, d.parents,


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

This PR removes the "Segment Count" field from the ParadeDB scan's explainer output when the `COSTS` option is turned off, making the output more stable when used in our pgregress tests.

## Why

The "Segment Count" information is not stable and can differ from one execution to another.

## How

1. Added an `is_costs()` method to the `Explainer` struct to check if costs should be displayed
2. Modified the `explain_custom_scan` function to conditionally display "Segment Count" only when `explainer.is_costs()` returns true
3. Updated the regression test outputs to reflect the change

## Tests

All existing tests have been updated to reflect the new explainer output formatting. The tests verify that "Segment Count" is no longer shown when costs are turned off.