### PR TITLE
chore: Use explicit components in the lint job.

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
 
       - name: Extract pgrx Version
         id: pgrx


### PR DESCRIPTION
## What

Explicitly request the `clippy` and `rustfmt` components for the `lint` CI job.

## Why

In some cases, the `lint` CI job does not already have the `rustfmt` component installed.