### PR TITLE
test: Enable long-running-statement logging in tests

### DIFF
--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -63,6 +63,11 @@ pub fn conn(database: Db) -> PgConnection {
             .await
             .expect("could not adjust log_error_verbosity");
 
+        sqlx::query("SET log_min_duration_statement TO 1000;")
+            .execute(&mut conn)
+            .await
+            .expect("could not set long-running-statement logging");
+
         conn
     })
 }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -32,6 +32,7 @@ use sqlx::PgConnection;
 fn generated_queries_setup(conn: &mut PgConnection, tables: &[(&str, usize)]) -> String {
     "CREATE EXTENSION pg_search;".execute(conn);
     "SET log_error_verbosity TO VERBOSE;".execute(conn);
+    "SET log_min_duration_statement TO 1000;".execute(conn);
 
     let mut setup_sql = String::new();
 


### PR DESCRIPTION
## What

Enable `log_min_duration_statement` for our integration tests.

## Why

Our CI job reports the Postgres logs at the end of the run, and we occasionally have long running queries produced by the proptests -- reporting long running statements will help us track down and reduce the cost of those tests.