### PR TITLE
fix: issue #2564 -- `NormalScanExecState` now properly resets on rescans

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods.rs
@@ -71,12 +71,13 @@ pub trait ExecMethod {
 
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState;
 
-    // This is called when the scan is rescanned.
-    // Implementations should override this if they need to reset their state
-    fn reset(&mut self, state: &mut PdbScanState) {
-        // Default implementation does nothing
-        // Note: SearchResults are handled by PdbScanState.reset() - don't clear them here.
-    }
+    /// This is called when the scan is rescanned.
+    ///
+    /// ## Implementor's Note
+    ///
+    /// `SearchResults` are reset for you by [`PdbScanState::reset()`], which is called by the
+    /// custom scan machinery.
+    fn reset(&mut self, state: &mut PdbScanState);
 }
 
 struct UnknownScanStyle;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
@@ -162,7 +162,7 @@ impl ExecMethod for MixedFastFieldExecState {
                 let searcher = MixedAggSearcher(state.search_reader.as_ref().unwrap());
                 self.mixed_results = searcher.mixed_agg_by_segment(
                     state.need_scores(),
-                    &state.search_query_input,
+                    state.search_query_input(),
                     &self.string_fields,
                     &self.numeric_fields,
                     segment_id,
@@ -182,7 +182,7 @@ impl ExecMethod for MixedFastFieldExecState {
             let searcher = MixedAggSearcher(state.search_reader.as_ref().unwrap());
             self.mixed_results = searcher.mixed_agg(
                 state.need_scores(),
-                &state.search_query_input,
+                state.search_query_input(),
                 &self.string_fields,
                 &self.numeric_fields,
             );

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -49,7 +49,7 @@ impl ExecMethod for NumericFastFieldExecState {
                 self.inner.search_results = state.search_reader.as_ref().unwrap().search_segment(
                     state.need_scores(),
                     segment_id,
-                    &state.search_query_input,
+                    state.search_query_input(),
                 );
                 return true;
             }
@@ -65,7 +65,7 @@ impl ExecMethod for NumericFastFieldExecState {
             self.inner.search_results = state.search_reader.as_ref().unwrap().search(
                 state.need_scores(),
                 false,
-                &state.search_query_input,
+                state.search_query_input(),
                 state.limit,
             );
             self.inner.did_query = true;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -62,7 +62,7 @@ impl ExecMethod for StringFastFieldExecState {
                 let searcher = StringAggSearcher(state.search_reader.as_ref().unwrap());
                 self.search_results = searcher.string_agg_by_segment(
                     state.need_scores(),
-                    &state.search_query_input,
+                    state.search_query_input(),
                     &self.field,
                     segment_id,
                 );
@@ -79,7 +79,7 @@ impl ExecMethod for StringFastFieldExecState {
             // not parallel, first time query
             let searcher = StringAggSearcher(state.search_reader.as_ref().unwrap());
             self.search_results =
-                searcher.string_agg(state.need_scores(), &state.search_query_input, &self.field);
+                searcher.string_agg(state.need_scores(), state.search_query_input(), &self.field);
             self.inner.did_query = true;
             true
         }

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -156,6 +156,7 @@ impl ExecMethod for NormalScanExecState {
 
     fn reset(&mut self, _state: &mut PdbScanState) {
         // Reset tracking state but don't clear search_results - that's handled by PdbScanState.reset()
+        self.did_query = false;
 
         // Reset the block visibility cache
         self.blockvis = (pg_sys::InvalidBlockNumber, false);

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/normal.rs
@@ -86,7 +86,7 @@ impl ExecMethod for NormalScanExecState {
                 self.search_results = state.search_reader.as_ref().unwrap().search_segment(
                     state.need_scores(),
                     segment_id,
-                    &state.search_query_input,
+                    state.search_query_input(),
                 );
                 return true;
             }
@@ -176,7 +176,7 @@ impl NormalScanExecState {
             .search(
                 state.need_scores(),
                 false,
-                &state.search_query_input,
+                state.search_query_input(),
                 state.limit,
             );
         self.did_query = true;

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -122,7 +122,7 @@ impl ExecMethod for TopNScanExecState {
     fn init(&mut self, state: &mut PdbScanState, _cstate: *mut pg_sys::CustomScanState) {
         let sort_field = state.sort_field.clone();
 
-        self.search_query_input = Some(state.search_query_input.clone());
+        self.search_query_input = Some(state.search_query_input().clone());
         self.sort_field = sort_field;
         self.search_reader = state.search_reader.clone();
     }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -27,11 +27,12 @@ use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::utils::u64_to_item_pointer;
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::postgres::ParallelScanState;
-use crate::query::SearchQueryInput;
+use crate::query::{AsHumanReadable, SearchQueryInput};
 use pgrx::heap_tuple::PgHeapTuple;
 use pgrx::{name_data_to_str, pg_sys, PgRelation, PgTupleDesc};
 use std::cell::UnsafeCell;
 use tantivy::snippet::SnippetGenerator;
+use tantivy::SegmentReader;
 
 #[derive(Default)]
 pub struct PdbScanState {
@@ -39,9 +40,8 @@ pub struct PdbScanState {
 
     pub rti: pg_sys::Index,
 
-    pub search_query_input: SearchQueryInput,
-    pub serialized_query: Vec<u8>,
-    pub nexprs: usize,
+    base_search_query_input: SearchQueryInput,
+    search_query_input: SearchQueryInput,
     pub search_reader: Option<SearchIndexReader>,
 
     pub search_results: SearchResults,
@@ -99,6 +99,30 @@ impl CustomScanState for PdbScanState {
 }
 
 impl PdbScanState {
+    pub fn set_base_search_query_input(&mut self, input: SearchQueryInput) {
+        self.base_search_query_input = input;
+    }
+
+    pub fn prepare_query_for_execution(
+        &mut self,
+        planstate: *mut pg_sys::PlanState,
+        expr_context: *mut pg_sys::ExprContext,
+    ) {
+        self.search_query_input = self.base_search_query_input.clone();
+        if self.search_query_input.has_postgres_expressions() {
+            self.search_query_input.init_postgres_expressions(planstate);
+            self.search_query_input
+                .solve_postgres_expressions(expr_context);
+        }
+    }
+
+    pub fn search_query_input(&self) -> &SearchQueryInput {
+        if matches!(self.search_query_input, SearchQueryInput::Uninitialized) {
+            panic!("search_query_input should be initialized");
+        }
+        &self.search_query_input
+    }
+
     #[inline(always)]
     pub fn assign_exec_method<T: ExecMethod + 'static>(&mut self, method: T) {
         self.exec_method = UnsafeCell::new(Box::new(method));
@@ -123,10 +147,35 @@ impl PdbScanState {
         &self.exec_method_name
     }
 
+    pub fn query_to_json(&self) -> serde_json::Result<serde_json::Value> {
+        serde_json::to_value(&self.base_search_query_input)
+    }
+
+    pub fn parallel_serialization_data(&self) -> (&[SegmentReader], Vec<u8>) {
+        let serialized_query = serde_json::to_vec(self.search_query_input())
+            .expect("should be able to serialize query");
+
+        let segment_readers = self
+            .search_reader
+            .as_ref()
+            .expect("search reader must be initialized to build parallel serialization data")
+            .segment_readers();
+
+        (segment_readers, serialized_query)
+    }
+
+    pub fn human_readable_query_string(&self) -> String {
+        self.base_search_query_input.as_human_readable()
+    }
+
+    pub fn has_postgres_expressions(&mut self) -> bool {
+        self.base_search_query_input.has_postgres_expressions()
+    }
+
     #[inline(always)]
     pub fn need_scores(&self) -> bool {
         self.need_scores
-            || self.search_query_input.need_scores()
+            || self.base_search_query_input.need_scores()
             || self
                 .quals
                 .as_ref()

--- a/pg_search/src/postgres/customscan/pdbscan/solve_expr.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/solve_expr.rs
@@ -3,6 +3,15 @@ use crate::query::{PostgresExpression, SearchQueryInput};
 use pgrx::{pg_sys, FromDatum, PgMemoryContexts};
 
 impl SearchQueryInput {
+    pub fn has_postgres_expressions(&mut self) -> bool {
+        for sqi in self {
+            if matches!(sqi, SearchQueryInput::PostgresExpression { .. }) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) -> usize {
         let mut cnt = 0;
         for sqi in self {

--- a/pg_search/tests/pg_regress/expected/issue_2564-parallel.out
+++ b/pg_search/tests/pg_regress/expected/issue_2564-parallel.out
@@ -101,8 +101,8 @@ INSERT INTO pages (id, fileId, page_number, content) VALUES
 ('page_cte2', 'file_cte1', 2, 'Page 2 with more content for testing'),
 ('page_cte3', 'file_cte2', 1, 'Another page with test terms to search'),
 ('page_cte4', 'file_cte3', 1, 'Final test page for CTE testing'); 
--- Disable parallel workers to avoid differences in plans
-SET max_parallel_workers_per_gather = 0;
+-- Enable parallel workers to ensure they work too
+SET max_parallel_workers_per_gather = 2;
 SET enable_indexscan to OFF;
 -- by turning off this GUC we're forcing pg_search to choose its "NormalScanExecState", which is the method under test
 SET paradedb.enable_mixed_fast_field_exec = false;
@@ -115,38 +115,37 @@ WHERE d.parents @@@ 'Factures'
   AND f.title @@@ 'Receipt'
   AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort
-   Sort Key: d.id, p.fileid, p.id
-   Presorted Key: d.id
-   ->  Nested Loop
-         Join Filter: (f.id = p.fileid)
-         ->  Merge Join
-               Merge Cond: (d.id = f.documentid)
-               ->  Sort
-                     Sort Key: d.id
-                     ->  Custom Scan (ParadeDB Scan) on documents d
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: d.id, p.fileid, p.id
+         ->  Parallel Hash Join
+               Hash Cond: (f.documentid = d.id)
+               ->  Parallel Hash Join
+                     Hash Cond: (p.fileid = f.id)
+                     ->  Parallel Custom Scan (ParadeDB Scan) on pages p
+                           Table: pages
+                           Index: pages_search
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+                     ->  Parallel Hash
+                           ->  Parallel Custom Scan (ParadeDB Scan) on files f
+                                 Table: files
+                                 Index: files_search
+                                 Exec Method: NormalScanExecState
+                                 Scores: false
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
+               ->  Parallel Hash
+                     ->  Parallel Custom Scan (ParadeDB Scan) on documents d
                            Table: documents
                            Index: documents_search
                            Exec Method: NormalScanExecState
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-               ->  Sort
-                     Sort Key: f.documentid
-                     ->  Custom Scan (ParadeDB Scan) on files f
-                           Table: files
-                           Index: files_search
-                           Exec Method: NormalScanExecState
-                           Scores: false
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
-         ->  Custom Scan (ParadeDB Scan) on pages p
-               Table: pages
-               Index: pages_search
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(29 rows)
+(28 rows)
 
 SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
 FROM documents d
@@ -173,28 +172,30 @@ EXPLAIN (COSTS OFF) SELECT d.id, d.title, d.parents,
 FROM documents d
 WHERE d.parents @@@ 'Factures'
 ORDER BY d.id;
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: d.id
-   ->  Custom Scan (ParadeDB Scan) on documents d
-         Table: documents
-         Index: documents_search
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-         SubPlan 1
-           ->  Limit
-                 ->  Custom Scan (ParadeDB Scan) on files f
-                       Table: files
-                       Index: files_search
-                       Exec Method: TopNScanExecState
-                       Scores: true
-                          Sort Field: paradedb.score()
-                          Sort Direction: desc
-                          Top N Limit: 1
-                       Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Invoice","lenient":null,"conjunction_mode":null}}}},{}]}}
-(19 rows)
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: d.id
+         ->  Parallel Custom Scan (ParadeDB Scan) on documents d
+               Table: documents
+               Index: documents_search
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
+   SubPlan 1
+     ->  Limit
+           ->  Custom Scan (ParadeDB Scan) on files f
+                 Table: files
+                 Index: files_search
+                 Exec Method: TopNScanExecState
+                 Scores: true
+                    Sort Field: paradedb.score()
+                    Sort Direction: desc
+                    Top N Limit: 1
+                 Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Invoice","lenient":null,"conjunction_mode":null}}}},{}]}}
+(21 rows)
 
 SELECT d.id, d.title, d.parents,
        (

--- a/pg_search/tests/pg_regress/expected/issue_2564.out
+++ b/pg_search/tests/pg_regress/expected/issue_2564.out
@@ -1,0 +1,237 @@
+-- uses the same schema as the mixed fast fields queries
+\i common/mixedff_queries_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+-- Drop any existing test tables from this group
+DROP TABLE IF EXISTS documents CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS pages CASCADE;
+-- Create document tables for testing relational queries
+CREATE TABLE documents (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT,
+    parents TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE TABLE files (
+    id TEXT NOT NULL UNIQUE,
+    documentId TEXT NOT NULL,
+    title TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    file_size INTEGER,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (id, documentId),
+    FOREIGN KEY (documentId) REFERENCES documents(id)
+);
+CREATE TABLE pages (
+    id TEXT NOT NULL UNIQUE,
+    fileId TEXT NOT NULL,
+    page_number INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (id, fileId),
+    FOREIGN KEY (fileId) REFERENCES files(id)
+);
+-- Create BM25 indexes with fast fields
+CREATE INDEX documents_search ON documents USING bm25 (
+    id,
+    title,
+    parents,
+    content
+) WITH (
+    key_field = 'id',
+    text_fields = '{"title": {"tokenizer": {"type": "default"}, "fast": true}, "parents": {"tokenizer": {"type": "default"}, "fast": true}, "content": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+psql:common/mixedff_queries_setup.sql:53: WARNING:  the `raw` tokenizer is deprecated
+CREATE INDEX files_search ON files USING bm25 (
+    id,
+    documentId,
+    title,
+    file_path
+) WITH (
+    key_field = 'id',
+    text_fields = '{"documentid": {"tokenizer": {"type": "keyword"}, "fast": true}, "title": {"tokenizer": {"type": "default"}, "fast": true}, "file_path": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+psql:common/mixedff_queries_setup.sql:63: WARNING:  the `raw` tokenizer is deprecated
+CREATE INDEX pages_search ON pages USING bm25 (
+    id,
+    fileId,
+    content,
+    page_number
+) WITH (
+    key_field = 'id',
+    text_fields = '{"fileid": {"tokenizer": {"type": "keyword"}, "fast": true}, "content": {"tokenizer": {"type": "default"}}}',
+    numeric_fields = '{"page_number": {"fast": true}}'
+);
+psql:common/mixedff_queries_setup.sql:74: WARNING:  the `raw` tokenizer is deprecated
+-- Insert sample data for documents
+INSERT INTO documents (id, title, content, parents) VALUES
+('doc1', 'Invoice 2023', 'This is an invoice for services rendered in 2023', 'Factures'),
+('doc2', 'Receipt 2023', 'This is a receipt for payment received in 2023', 'Factures'),
+('doc3', 'Contract 2023', 'This is a contract for services in 2023', 'Contracts');
+-- Insert sample data for files
+INSERT INTO files (id, documentId, title, file_path, file_size) VALUES
+('file1', 'doc1', 'Invoice PDF', '/invoices/2023.pdf', 1024),
+('file2', 'doc1', 'Invoice Receipt', '/invoices/2023_receipt.pdf', 512),
+('file3', 'doc2', 'Receipt', '/receipts/2023.pdf', 256),
+('file4', 'doc3', 'Contract Document', '/contracts/2023.pdf', 2048);
+-- Insert sample data for pages
+INSERT INTO pages (id, fileId, page_number, content) VALUES
+('page1', 'file1', 1, 'Page 1 of Invoice PDF with Socienty General details'),
+('page2', 'file1', 2, 'Page 2 of Invoice PDF with payment information'),
+('page3', 'file2', 1, 'Page 1 of Invoice Receipt with bank details'),
+('page4', 'file3', 1, 'Page 1 of Receipt with Socienty General information'),
+('page5', 'file3', 2, 'Page 2 of Receipt with transaction ID'),
+('page6', 'file4', 1, 'Page 1 of Contract Document with terms and conditions');
+-- Add data for CTE testing
+INSERT INTO documents (id, title, content, parents) VALUES
+('doc_cte1', 'CTE Test Doc 1', 'This document tests common table expressions', 'Reports'),
+('doc_cte2', 'CTE Test Doc 2', 'Another document for CTE testing', 'Reports');
+INSERT INTO files (id, documentId, title, file_path, file_size) VALUES
+('file_cte1', 'doc_cte1', 'CTE Test File 1', '/reports/cte1.pdf', 500),
+('file_cte2', 'doc_cte1', 'CTE Test File 2', '/reports/cte2.pdf', 600),
+('file_cte3', 'doc_cte2', 'CTE Test File 3', '/reports/cte3.pdf', 700);
+INSERT INTO pages (id, fileId, page_number, content) VALUES
+('page_cte1', 'file_cte1', 1, 'Page 1 with searchable content for CTE testing'),
+('page_cte2', 'file_cte1', 2, 'Page 2 with more content for testing'),
+('page_cte3', 'file_cte2', 1, 'Another page with test terms to search'),
+('page_cte4', 'file_cte3', 1, 'Final test page for CTE testing'); 
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+-- by turning off this GUC we're forcing pg_search to choose its "NormalScanExecState", which is the method under test
+SET paradedb.enable_mixed_fast_field_exec = false;
+-- this should return one row
+EXPLAIN (COSTS OFF) SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Incremental Sort
+   Sort Key: d.id, p.fileid, p.id
+   Presorted Key: d.id
+   ->  Nested Loop
+         Join Filter: (f.id = p.fileid)
+         ->  Merge Join
+               Merge Cond: (d.id = f.documentid)
+               ->  Sort
+                     Sort Key: d.id
+                     ->  Custom Scan (ParadeDB Scan) on documents d
+                           Table: documents
+                           Index: documents_search
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
+               ->  Sort
+                     Sort Key: f.documentid
+                     ->  Custom Scan (ParadeDB Scan) on files f
+                           Table: files
+                           Index: files_search
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
+         ->  Custom Scan (ParadeDB Scan) on pages p
+               Table: pages
+               Index: pages_search
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+(29 rows)
+
+SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+  id  | parents  |  title  |     file_path      | fileid | page_number 
+------+----------+---------+--------------------+--------+-------------
+ doc2 | Factures | Receipt | /receipts/2023.pdf | file3  |           1
+(1 row)
+
+-- this should return one row too, but through a parallel custom scan
+SET max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF) SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: d.id, p.fileid, p.id
+         ->  Parallel Hash Join
+               Hash Cond: (f.documentid = d.id)
+               ->  Parallel Hash Join
+                     Hash Cond: (p.fileid = f.id)
+                     ->  Parallel Custom Scan (ParadeDB Scan) on pages p
+                           Table: pages
+                           Index: pages_search
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+                     ->  Parallel Hash
+                           ->  Parallel Custom Scan (ParadeDB Scan) on files f
+                                 Table: files
+                                 Index: files_search
+                                 Exec Method: NormalScanExecState
+                                 Scores: false
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
+               ->  Parallel Hash
+                     ->  Parallel Custom Scan (ParadeDB Scan) on documents d
+                           Table: documents
+                           Index: documents_search
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
+(28 rows)
+
+SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+  id  | parents  |  title  |     file_path      | fileid | page_number 
+------+----------+---------+--------------------+--------+-------------
+ doc2 | Factures | Receipt | /receipts/2023.pdf | file3  |           1
+(1 row)
+
+-- be a good citizen
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+\i common/mixedff_queries_cleanup.sql
+-- Cleanup for relational query tests (07-10)
+-- Drop the tables used in these tests
+DROP TABLE IF EXISTS pages CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_mixed_fast_field_exec;
+SELECT 'Relational query tests cleanup complete' AS status; 
+                 status                  
+-----------------------------------------
+ Relational query tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
@@ -147,7 +147,7 @@ ORDER BY invoice_file_count DESC, d.id;
   id  |    title     | parents  | invoice_file_count 
 ------+--------------+----------+--------------------
  doc1 | Invoice 2023 | Factures |                  2
- doc2 | Receipt 2023 | Factures |                  2
+ doc2 | Receipt 2023 | Factures |                  0
 (2 rows)
 
 \i common/mixedff_queries_cleanup.sql

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
@@ -147,7 +147,7 @@ ORDER BY invoice_file_count DESC, d.id;
   id  |    title     | parents  | invoice_file_count 
 ------+--------------+----------+--------------------
  doc1 | Invoice 2023 | Factures |                  2
- doc2 | Receipt 2023 | Factures |                  0
+ doc2 | Receipt 2023 | Factures |                  2
 (2 rows)
 
 \i common/mixedff_queries_cleanup.sql

--- a/pg_search/tests/pg_regress/sql/issue_2564-parallel.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2564-parallel.sql
@@ -1,8 +1,8 @@
 -- uses the same schema as the mixed fast fields queries
 \i common/mixedff_queries_setup.sql
 
--- Disable parallel workers to avoid differences in plans
-SET max_parallel_workers_per_gather = 0;
+-- Enable parallel workers to ensure they work too
+SET max_parallel_workers_per_gather = 2;
 SET enable_indexscan to OFF;
 
 -- by turning off this GUC we're forcing pg_search to choose its "NormalScanExecState", which is the method under test

--- a/pg_search/tests/pg_regress/sql/issue_2564.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2564.sql
@@ -1,0 +1,51 @@
+-- uses the same schema as the mixed fast fields queries
+\i common/mixedff_queries_setup.sql
+
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+-- by turning off this GUC we're forcing pg_search to choose its "NormalScanExecState", which is the method under test
+SET paradedb.enable_mixed_fast_field_exec = false;
+
+-- this should return one row
+EXPLAIN (COSTS OFF) SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+
+-- this should return one row too, but through a parallel custom scan
+SET max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF) SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
+FROM documents d
+         JOIN files f ON d.id = f.documentId
+         JOIN pages p ON p.fileId = f.id
+WHERE d.parents @@@ 'Factures'
+  AND f.title @@@ 'Receipt'
+  AND p.content @@@ 'Socienty'
+ORDER BY d.id, f.id, p.id;
+
+-- be a good citizen
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+\i common/mixedff_queries_cleanup.sql


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2564

## What

`NormalScanExecState` was failing to reset enough of its internal state to realize that during a rescan it should actually execute the query again.

It's worth noting that the bug itself, despite the report in #2564, is not dependent on `ANALYZE` so much as post-ANALYZE, postgres would choose an entirely different query plan which didn't involve rescans, so this bug wasn't tickled.

## Why

## How

Fixed the bug and also removed the default implementation for `ExecMethod::reset()` so that implementors are kinda required to consider what they need to do.

## Tests

New regression test added based on the repro from #2564 (which shares common DDL with other regression tests).

It also introduced a change in expected output in an existing regression test/query and after some analysis, the change is correct.  It's unclear to me if #2572 didn't change more than it should have, but that's a different problem for a different day.