### PR TITLE
chore: fixed the run script not to pass all args to psql.

### DIFF
--- a/scripts/pg_search_run.sh
+++ b/scripts/pg_search_run.sh
@@ -19,6 +19,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 # Extract --release flag if present
 COMMON_ARGS=()
+OTHER_ARGS=()
 i=1
 while [ $i -le $# ]; do
   arg="${!i}"
@@ -30,6 +31,8 @@ while [ $i -le $# ]; do
     if [ $i -le $# ]; then
       COMMON_ARGS+=("${!i}")
     fi
+  else
+    OTHER_ARGS+=("$arg")
   fi
   i=$((i+1))
 done
@@ -41,4 +44,4 @@ source "${SCRIPT_DIR}/pg_search_common.sh" "${COMMON_ARGS[@]+"${COMMON_ARGS[@]}"
 cd "${CURRENT_DIR}"
 
 # Connect to the database with psql and pass any additional arguments
-psql "${DATABASE_URL}" "$@"
+psql "${DATABASE_URL}" "${OTHER_ARGS[@]+"${OTHER_ARGS[@]}"}"


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

Fixed the `pg_search_run.sh` script to properly handle command-line arguments by separating arguments meant for the script from those intended for `psql`.

## Why

The previous implementation incorrectly passed all arguments to `psql` using `$@`, which could cause issues when trying to pass arguments specifically to the script itself.

## How

- Added a new `OTHER_ARGS` array to store arguments intended for `psql`

## Tests

Manually verified that the script correctly handles arguments, passing only the relevant ones to `psql`.