### PR TITLE
fix: estimate improvements

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -28,11 +28,17 @@ pub mod gucs;
 use self::postgres::customscan;
 use pgrx::*;
 
+/// Postgres' value for a `norm_selec` that hasn't been assigned
+const UNASSIGNED_SELECTIVITY: f64 = -1.0;
+
 /// A hardcoded value when we can't figure out a good selectivity value
 const UNKNOWN_SELECTIVITY: f64 = 0.00001;
 
 /// A hardcoded value for parameterized plan queries
 const PARAMETERIZED_SELECTIVITY: f64 = 0.10;
+
+/// The selectivity value indicating the entire relation will be returned
+const FULL_RELATION_SELECTIVITY: f64 = 1.0;
 
 /// An arbitrary value for what it costs for a plan with one of our operators (@@@) to do whatever
 /// initial work it needs to do (open tantivy index, start the query, etc).  The value is largely

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -359,6 +359,10 @@ impl<P: Into<*mut pg_sys::List> + Default> CustomPathBuilder<P> {
         self
     }
 
+    pub fn is_parallel(&self) -> bool {
+        self.custom_path_node.path.parallel_workers > 0
+    }
+
     pub fn build(mut self) -> pg_sys::CustomPath {
         self.custom_path_node.custom_paths = self.custom_paths.into_pg();
         self.custom_path_node.custom_private = self.custom_private.into();

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -338,8 +338,8 @@ impl CustomScan for PdbScan {
                 // we can use the norm_selec that already happened
                 norm_selec
             } else if quals.contains_external_var() {
-                // if the query has external vars (references to another relation) then we end up
-                // returning *everything* from _this_ relation
+                // if the query has external vars (references to other relations which decide whether the rows in this
+                // relation are visible) then we end up returning *everything* from _this_ relation
                 FULL_RELATION_SELECTIVITY
             } else if quals.contains_exprs() {
                 // if the query has expressions then it's parameterized and we have to guess something

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -325,9 +325,8 @@ impl CustomScan for PdbScan {
                 .then(|| (*restrict_info.get_ptr(0).unwrap()).norm_selec)
                 .unwrap_or(UNASSIGNED_SELECTIVITY);
 
-            pgrx::warning!("query={query:?}");
             let has_expressions = quals.contains_exprs();
-            let selectivity = if let Some(limit) = limit {
+            let mut selectivity = if let Some(limit) = limit {
                 // use the limit
                 limit
                     / table
@@ -340,11 +339,7 @@ impl CustomScan for PdbScan {
             } else if quals.contains_external_var() {
                 // if the query has external vars (references to another relation) then we end up
                 // returning *everything* from _this_ relation
-                // FULL_RELATION_SELECTIVITY
-
-                // TODO:  make this a little smarter if we can -- we're mostly concerned about "<ALL>" nodes
-                // in the plan and if they'd end up selecting the entire set
-                estimate_selectivity(&bm25_index, &query).unwrap_or(UNKNOWN_SELECTIVITY)
+                FULL_RELATION_SELECTIVITY
             } else if has_expressions {
                 // if the query has expressions then it's parameterized and we have to guess something
                 PARAMETERIZED_SELECTIVITY
@@ -364,6 +359,12 @@ impl CustomScan for PdbScan {
             builder.custom_private().set_range_table_index(rti);
             builder.custom_private().set_query(query);
             builder.custom_private().set_limit(limit);
+            builder.custom_private().set_segment_count(
+                index
+                    .searchable_segments()
+                    .map(|segments| segments.len())
+                    .unwrap_or(0),
+            );
 
             if is_topn && pathkey.is_some() {
                 let pathkey = pathkey.as_ref().unwrap();
@@ -393,48 +394,14 @@ impl CustomScan for PdbScan {
                     .set_sort_direction(Some(SortDirection::None));
             }
 
-            let reltuples = table.reltuples().unwrap_or(1.0) as f64;
-            let rows = (reltuples * selectivity).max(1.0);
-
-            let per_tuple_cost = {
-                // if we think we need scores, we need a much cheaper plan so that Postgres will
-                // prefer it over all the others.
-                if is_join || maybe_needs_const_projections {
-                    0.0
-                } else if maybe_ff {
-                    // returns fields from fast fields
-                    pg_sys::cpu_index_tuple_cost / 100.0
-                } else {
-                    // requires heap access to return fields
-                    pg_sys::cpu_tuple_cost * 200.0
-                }
-            };
-
-            let startup_cost = if is_join || maybe_needs_const_projections {
-                0.0
-            } else {
-                DEFAULT_STARTUP_COST
-            };
-
-            let total_cost = startup_cost + (rows * per_tuple_cost);
-            let segment_count = index.searchable_segments().unwrap_or_default().len();
             let nworkers = if (*builder.args().rel).consider_parallel {
+                let segment_count = index.searchable_segments().unwrap_or_default().len();
                 compute_nworkers(limit, segment_count, builder.custom_private().is_sorted())
             } else {
                 0
             };
 
-            builder.custom_private().set_segment_count(
-                index
-                    .searchable_segments()
-                    .map(|segments| segments.len())
-                    .unwrap_or(0),
-            );
-            builder = builder.set_rows(rows);
-            builder = builder.set_startup_cost(startup_cost);
-            builder = builder.set_total_cost(total_cost);
-            builder = builder.set_flag(Flags::Projection);
-
+            let mut set_parallel = false;
             if pathkey.is_some()
                 && !is_topn
                 && fast_fields::is_string_agg_capable_with_prereqs(builder.custom_private())
@@ -470,12 +437,14 @@ impl CustomScan for PdbScan {
                     // See the TODO below about being able to claim sorting for parallel
                     // workers.
                     builder = builder.set_parallel(nworkers);
+                    set_parallel = true;
                 } else {
                     // otherwise we'll do a regular scan
                     builder.custom_private().set_sort_info(pathkey);
                 }
             } else if !quals.contains_external_var() && nworkers > 0 {
                 builder = builder.set_parallel(nworkers);
+                set_parallel = true;
             }
 
             let exec_method_type = choose_exec_method(builder.custom_private());
@@ -494,6 +463,42 @@ impl CustomScan for PdbScan {
                     builder = builder.add_path_key(pathkey);
                 }
             }
+
+            //
+            // finally, we have enough information to set the cost and estimation information
+            //
+
+            if set_parallel {
+                // if we're likely to do a parallel scan, divide the selectivity up by the number of
+                // workers we're likely to use.  this lets Postgres make better decisions based on what
+                // an individual parallel scan is actually going to return
+                selectivity /= (nworkers
+                    + pg_sys::parallel_leader_participation
+                        .then_some(1)
+                        .unwrap_or(0)) as f64;
+            }
+
+            let reltuples = table.reltuples().unwrap_or(1.0) as f64;
+            let rows = (reltuples * selectivity).max(1.0);
+            let per_tuple_cost = {
+                if maybe_ff {
+                    // returning fields from fast fields
+                    pg_sys::cpu_index_tuple_cost
+                } else {
+                    // requires heap access to return fields
+                    pg_sys::cpu_tuple_cost
+                }
+            };
+
+            let startup_cost = DEFAULT_STARTUP_COST;
+            let total_cost = startup_cost + (rows * per_tuple_cost);
+
+            builder = builder.set_rows(rows);
+            builder = builder.set_startup_cost(startup_cost);
+            builder = builder.set_total_cost(total_cost);
+
+            // indicate that we'll be doing projection ourselves
+            builder = builder.set_flag(Flags::Projection);
 
             Some(builder.build())
         }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -207,7 +207,7 @@ impl CustomScan for PdbScan {
             }
 
             let rti = builder.args().rti;
-            let (table, bm25_index, is_join) = {
+            let (table, bm25_index) = {
                 let rte = builder.args().rte();
 
                 // we only support plain relation and join rte's
@@ -226,7 +226,7 @@ impl CustomScan for PdbScan {
                 // and that relation must have a `USING bm25` index
                 let (table, bm25_index) = rel_get_bm25_index(rte.relid)?;
 
-                (table, bm25_index, rte.rtekind == pg_sys::RTEKind::RTE_JOIN)
+                (table, bm25_index)
             };
 
             let root = builder.args().root;
@@ -320,7 +320,6 @@ impl CustomScan for PdbScan {
                 return None;
             };
             let query = SearchQueryInput::from(&quals);
-            let is_join = is_join || quals.contains_external_var();
             let norm_selec = if restrict_info.len() == 1 {
                 (*restrict_info.get_ptr(0).unwrap()).norm_selec
             } else {

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -102,6 +102,25 @@ impl Qual {
         }
     }
 
+    pub fn contains_external_var(&self) -> bool {
+        match self {
+            Qual::All => false,
+            Qual::ExternalVar => true,
+            Qual::OpExpr { .. } => false,
+            Qual::Expr { .. } => false,
+            Qual::PushdownExpr { .. } => false,
+            Qual::PushdownVarEqTrue { .. } => false,
+            Qual::PushdownVarEqFalse { .. } => false,
+            Qual::PushdownVarIsTrue { .. } => false,
+            Qual::PushdownVarIsFalse { .. } => false,
+            Qual::PushdownIsNotNull { .. } => false,
+            Qual::ScoreExpr { .. } => false,
+            Qual::And(quals) => quals.iter().any(|q| q.contains_external_var()),
+            Qual::Or(quals) => quals.iter().any(|q| q.contains_external_var()),
+            Qual::Not(qual) => qual.contains_external_var(),
+        }
+    }
+
     pub unsafe fn contains_exec_param(&self) -> bool {
         match self {
             Qual::All => false,
@@ -125,7 +144,7 @@ impl Qual {
         match self {
             Qual::All => false,
             Qual::ExternalVar => false,
-            Qual::OpExpr { .. } => false,
+            Qual::OpExpr { .. } => true,
             Qual::Expr { .. } => true,
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarEqTrue { .. } => true,

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -144,7 +144,7 @@ impl Qual {
         match self {
             Qual::All => false,
             Qual::ExternalVar => false,
-            Qual::OpExpr { .. } => true,
+            Qual::OpExpr { .. } => false,
             Qual::Expr { .. } => true,
             Qual::PushdownExpr { .. } => false,
             Qual::PushdownVarEqTrue { .. } => true,

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -98,7 +98,8 @@ async fn generated_joins_small(database: Db) {
         .iter()
         .map(|(table, _)| table)
         .collect::<Vec<_>>();
-    generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
+    eprintln!("{setup_sql}");
 
     proptest!(|(
         (join, where_expr) in arb_joins_and_wheres(
@@ -143,7 +144,8 @@ async fn generated_joins_large_limit(database: Db) {
         .iter()
         .map(|(table, _)| table)
         .collect::<Vec<_>>();
-    generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes);
+    eprintln!("{setup_sql}");
 
     proptest!(|(
         (join, where_expr) in arb_joins_and_wheres(


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This is improves (and in some cases corrects) our custom scan's cost and selectivity estimation.

## Why

Providing more accurate costs can allow Postgres to choose better plans for any given query.

## How

A few things:

- when a query contains a `Qual::ExternalVar`, then our scan will output all rows, so the selectivity in that case now gets set to `1.0`
- when parallel workers are to be used, we need to divide the selectivity by the number of workers so that we can better indicate the number of tuples any given worker will emit
- fix a bug where we'd use an existing `norm_selc` of -1.0 on accident!
- we also had situations where the "total cost" would be calculated as `0.0`, which is, of course, incorrect too

This is all (mostly) isolated to the custom scan's `callback` function and necessitated reordering some of the code.

## Tests

All the existing tests pass, both unit and regression -- no plan changes at all.

EDIT:  Looking at some complex JOIN queries, the improved correctness here actually makes significant improvements around how Postgres plans out Parallel Hash Joins and the bucketing strategies it wants to use, which leads to some great perf improvements.

We purposely don't EXPLAIN queries with COSTS, so it's a little difficult to specifically test for the changes here.