### PR TITLE
perf: Make fast field execution lazier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "bitpacking",
 ]
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "nom",
 ]
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
+source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "bitpacking",
 ]
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "nom",
 ]
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b#e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b"
+source = "git+https://github.com/stuhood/tantivy.git?branch=stuhood.public-dict#a684ed4c42fc6119a883ffda6e6c2eeb5a90c350"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/stuhood/tantivy.git", package = "tantivy", branch = "stuhood.public-dict", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "657cedc19af403b33392841e2cc3e639ddc84211", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/stuhood/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.public-dict" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "657cedc19af403b33392841e2cc3e639ddc84211" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b", features = [
+tantivy = { git = "https://github.com/stuhood/tantivy.git", package = "tantivy", branch = "stuhood.public-dict", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "e7b32ae0e9f44a2ed8b82683fb0c6527eff7002b" }
+tantivy-tokenizer-api = { git = "https://github.com/stuhood/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.public-dict" }

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -89,20 +89,6 @@ impl FFHelper {
             .get_or_init(|| FFType::new(&entry.0, &entry.1))
             .as_i64(doc_address.doc_id)
     }
-
-    #[track_caller]
-    pub fn string(
-        &self,
-        field: FFIndex,
-        doc_address: DocAddress,
-        value: &mut String,
-    ) -> Option<()> {
-        let entry = &self.0[doc_address.segment_ord as usize][field];
-        entry
-            .2
-            .get_or_init(|| FFType::new(&entry.0, &entry.1))
-            .string(doc_address.doc_id, value)
-    }
 }
 
 /// Helper for working with different "fast field" types as if they're all one type

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -356,7 +356,7 @@ fn fast_field_capable_prereqs(privdata: &PrivateData) -> bool {
 
     if is_all_special_or_junk_fields(which_fast_fields) {
         // if all the fast fields we have are Junk fields, then we're not actually
-        // projecting fast fields
+        // projecting fast fields, and we're better off using a Normal scan.
         return false;
     }
 
@@ -474,8 +474,10 @@ pub fn is_mixed_fast_field_capable(privdata: &PrivateData) -> bool {
     0 < named_field_count && named_field_count < gucs::mixed_fast_field_exec_column_threshold()
 }
 
-fn is_all_special_or_junk_fields(which_fast_fields: &HashSet<WhichFastField>) -> bool {
-    which_fast_fields.iter().all(|ff| {
+pub fn is_all_special_or_junk_fields<'a>(
+    which_fast_fields: impl IntoIterator<Item = &'a WhichFastField>,
+) -> bool {
+    which_fast_fields.into_iter().all(|ff| {
         matches!(
             ff,
             WhichFastField::Junk(_)

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/string.rs
@@ -15,37 +15,50 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::api::HashMap;
-use crate::index::fast_fields_helper::WhichFastField;
+use std::rc::Rc;
+
+use crate::index::fast_fields_helper::{FFIndex, WhichFastField};
 use crate::index::reader::index::{SearchIndexReader, SearchIndexScore, SearchResults};
 use crate::postgres::customscan::pdbscan::exec_methods::fast_fields::{
-    sorted_ords_to_terms, FastFieldExecState,
+    non_string_ff_to_datum, ords_to_sorted_terms, FastFieldExecState,
 };
 use crate::postgres::customscan::pdbscan::exec_methods::{ExecMethod, ExecState};
+use crate::postgres::customscan::pdbscan::fast_fields::StrColumn;
 use crate::postgres::customscan::pdbscan::is_block_all_visible;
 use crate::postgres::customscan::pdbscan::parallel::checkout_segment;
 use crate::postgres::customscan::pdbscan::scan_state::PdbScanState;
 use crate::query::SearchQueryInput;
+
 use pgrx::itemptr::item_pointer_get_block_number;
 use pgrx::pg_sys;
 use pgrx::pg_sys::CustomScanState;
+use pgrx::IntoDatum;
 use tantivy::collector::Collector;
 use tantivy::index::SegmentId;
 use tantivy::query::Query;
+use tantivy::termdict::TermOrdinal;
 use tantivy::{DocAddress, Executor, SegmentOrdinal};
 
 pub struct StringFastFieldExecState {
     inner: FastFieldExecState,
     search_results: StringAggResults,
     field: String,
+    field_idx: FFIndex,
 }
 
 impl StringFastFieldExecState {
     pub fn new(field: String, which_fast_fields: Vec<WhichFastField>) -> Self {
+        let field_idx = which_fast_fields
+            .iter()
+            .position(|wff| matches!(wff, WhichFastField::Named(name, _) if name == &field))
+            .unwrap_or_else(|| {
+                panic!("No string fast field named {field} in {which_fast_fields:?}")
+            });
         Self {
             inner: FastFieldExecState::new(which_fast_fields),
-            search_results: StringAggResults::None,
+            search_results: StringAggResults::new(vec![]),
             field,
+            field_idx,
         }
     }
 }
@@ -85,15 +98,10 @@ impl ExecMethod for StringFastFieldExecState {
     }
 
     fn internal_next(&mut self, state: &mut PdbScanState) -> ExecState {
-        if matches!(self.search_results, StringAggResults::None) {
-            return ExecState::Eof;
-        }
-
         unsafe {
-            // SAFETY:  .next() can't be called with self.search_results being set to Some(...)
             match self.search_results.next() {
                 None => ExecState::Eof,
-                Some((scored, doc_address, mut term)) => {
+                Some((scored, doc_address, term)) => {
                     let slot = self.inner.slot;
                     let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
 
@@ -122,18 +130,35 @@ impl ExecMethod for StringFastFieldExecState {
                         (*slot).tts_flags |= pg_sys::TTS_FLAG_SHOULDFREE as u16;
                         (*slot).tts_nvalid = natts as _;
 
-                        // Use the shared extract_data_from_fast_fields function
                         let tupdesc = self.inner.tupdesc.as_ref().unwrap();
-                        crate::postgres::customscan::pdbscan::exec_methods::fast_fields::extract_data_from_fast_fields(
-                            natts,
-                            tupdesc,
-                            &self.inner.which_fast_fields,
-                            &mut self.inner.ffhelper,
-                            slot,
-                            scored,
-                            doc_address,
-                            &mut term,
-                        );
+                        let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
+                        let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
+
+                        for (i, att) in tupdesc.iter().enumerate() {
+                            if i == self.field_idx {
+                                isnull[i] = term.is_null();
+                                datums[i] = term;
+                                continue;
+                            }
+
+                            match non_string_ff_to_datum(
+                                (&self.inner.which_fast_fields[i], i),
+                                att.atttypid,
+                                scored.bm25,
+                                doc_address,
+                                &mut self.inner.ffhelper,
+                                slot,
+                            ) {
+                                None => {
+                                    datums[i] = pg_sys::Datum::null();
+                                    isnull[i] = true;
+                                }
+                                Some(datum) => {
+                                    datums[i] = datum;
+                                    isnull[i] = false;
+                                }
+                            }
+                        }
 
                         ExecState::Virtual { slot }
                     } else {
@@ -154,36 +179,49 @@ impl ExecMethod for StringFastFieldExecState {
     }
 }
 
-type SearchResultsIter = std::vec::IntoIter<(SearchIndexScore, DocAddress)>;
-type BatchedResultsIter = std::vec::IntoIter<(Option<String>, SearchResultsIter)>;
-type MergedResultsMap = HashMap<Option<String>, Vec<(SearchIndexScore, DocAddress)>>;
-#[derive(Default)]
-enum StringAggResults {
-    #[default]
-    None,
-    Batched {
-        current: (Option<String>, SearchResultsIter),
-        set: BatchedResultsIter,
-    },
-    SingleSegment(std::vec::IntoIter<(SearchIndexScore, DocAddress, Option<String>)>),
+/// The result of searching one segment: a column, and vec of matches with TermOrdinals for that
+/// column.
+type SegmentResult = (StrColumn, Vec<(TermOrdinal, SearchIndexScore, DocAddress)>);
+
+struct StringAggResults {
+    /// Per-segment results which have yet to be emitted.
+    per_segment: std::vec::IntoIter<SegmentResult>,
+    /// An iterator for the current segment.
+    current_segment: Box<dyn Iterator<Item = (SearchIndexScore, DocAddress, Option<Rc<str>>)>>,
+}
+
+impl StringAggResults {
+    #[allow(clippy::type_complexity)]
+    fn new(per_segment: Vec<SegmentResult>) -> Self {
+        Self {
+            per_segment: per_segment.into_iter(),
+            current_segment: Box::new(std::iter::empty()),
+        }
+    }
 }
 
 impl Iterator for StringAggResults {
-    type Item = (SearchIndexScore, DocAddress, Option<String>);
+    type Item = (SearchIndexScore, DocAddress, pg_sys::Datum);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            StringAggResults::None => None,
-            StringAggResults::Batched { current, set } => loop {
-                if let Some(next) = current.1.next() {
-                    return Some((next.0, next.1, current.0.clone()));
-                } else if let Some(next_set) = set.next() {
-                    *current = next_set;
-                } else {
-                    return None;
-                }
-            },
-            StringAggResults::SingleSegment(iter) => iter.next(),
+        loop {
+            // See if there are more results from the current segment.
+            if let Some((score, doc_address, term)) = self.current_segment.next() {
+                let datum = term
+                    .map(|term| {
+                        term.into_datum()
+                            .expect("String fast field must be a datum.")
+                    })
+                    .unwrap_or_else(pg_sys::Datum::null);
+                return Some((score, doc_address, datum));
+            }
+
+            // Get results from the next segment, if any.
+            let (str_ff, results) = self.per_segment.next()?;
+            self.current_segment = Box::new(
+                ords_to_sorted_terms(str_ff, results, |(term_ordinal, _, _)| *term_ordinal)
+                    .map(|((_, scored, doc_address), term)| (scored, doc_address, Some(term))),
+            );
         }
     }
 }
@@ -224,39 +262,7 @@ impl StringAggSearcher<'_> {
             )
             .expect("failed to search");
 
-        let field = field.to_string();
-        let searcher = self.0.searcher().clone();
-
-        let mut merged: MergedResultsMap = HashMap::default();
-
-        results
-            .into_iter()
-            .for_each(|(str_ff, mut segment_results)| {
-                // Resolve all term ordinals to their string values.
-                segment_results.sort_unstable_by_key(|(term_ordinal, _, _)| *term_ordinal);
-                let terms = sorted_ords_to_terms(
-                    &str_ff,
-                    segment_results
-                        .iter()
-                        .map(|(term_ordinal, _, _)| *term_ordinal),
-                );
-                for (term, (_, score, doc_addr)) in terms.into_iter().zip(segment_results) {
-                    merged
-                        .entry(Some(term))
-                        .or_default()
-                        .push((score, doc_addr));
-                }
-            });
-
-        let set = merged
-            .into_iter()
-            .map(|(term, docs)| (term, docs.into_iter()))
-            .collect::<Vec<_>>()
-            .into_iter();
-        StringAggResults::Batched {
-            current: (None, vec![].into_iter()),
-            set,
-        }
+        StringAggResults::new(results)
     }
 
     pub fn string_agg_by_segment(
@@ -294,7 +300,7 @@ impl StringAggSearcher<'_> {
             })
             .expect("weight should be constructable");
 
-        let (str_ff, mut results) = collector
+        let results = collector
             .collect_segment(
                 weight.as_ref(),
                 segment_ord as SegmentOrdinal,
@@ -302,20 +308,7 @@ impl StringAggSearcher<'_> {
             )
             .expect("single segment collection should succeed");
 
-        let searcher = self.0.searcher().clone();
-        results.sort_unstable_by_key(|(term_ordinal, _, _)| *term_ordinal);
-        let terms = sorted_ords_to_terms(
-            &str_ff,
-            results.iter().map(|(term_ordinal, _, _)| *term_ordinal),
-        );
-        StringAggResults::SingleSegment(
-            terms
-                .into_iter()
-                .zip(results)
-                .map(|(term, (_, scored, doc_address))| (scored, doc_address, Some(term)))
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
+        StringAggResults::new(vec![results])
     }
 }
 
@@ -334,7 +327,7 @@ mod term_ord_collector {
     }
 
     impl Collector for TermOrdCollector {
-        type Fruit = Vec<(StrColumn, Vec<(TermOrdinal, SearchIndexScore, DocAddress)>)>;
+        type Fruit = Vec<super::SegmentResult>;
         type Child = TermOrdSegmentCollector;
 
         fn for_segment(
@@ -371,7 +364,7 @@ mod term_ord_collector {
     }
 
     impl SegmentCollector for TermOrdSegmentCollector {
-        type Fruit = (StrColumn, Vec<(TermOrdinal, SearchIndexScore, DocAddress)>);
+        type Fruit = super::SegmentResult;
 
         fn collect(&mut self, doc: DocId, score: Score) {
             let doc_address = DocAddress::new(self.segment_ord, doc);

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -649,8 +649,6 @@ mod pushdown_is_null {
     }
 
     #[rstest]
-    // TODO: See https://github.com/paradedb/paradedb/issues/2619.
-    #[should_panic]
     fn with_join(#[from(setup_test_table)] mut conn: PgConnection) {
         // Verify that JOIN works
         "CREATE TABLE test2 (id SERIAL8 NOT NULL PRIMARY KEY, ref_id int8, ref_text text);"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2619.

## What

Builds atop #2610 to make fast field execution lazier. `StringFF` and `MixedFF` were both merging _across_ segments, but that will almost never show a benefit, because a `DocAddress` can only come from one segment, and if we _were_ going to merge across segments, we'd want to do so via lazy, sorted order iterators (as introduced here).

## Why

Make fast fields faster, and prepare to enable sorting of fast fields (#2623).

## How

* Replace `sorted_ords_to_terms` with a `ords_to_sorted_terms` function which produces an iterator of sorted terms.
* Remove the cross-segment batching/grouping that `StringFF` and `MixedFF` were doing.
    * `StringFF` now lazily emits results from each segment in sorted order, meaning that it never has the full set of strings for a segment in memory (only the `TermOrdinal`s).
    * `MixedFF` no longer buffers all segments, but will still buffer any non-sort columns of each segment to execute a hash join of those columns on the `DocAddress`.
* Inline the `extract_data_from_fast_fields` function and rename `ff_to_datum => non_string_ff_to_datum`.
* Fix fetching of `Numeric` `Date` columns in `Mixed`.

## Tests

Makes the [hierarchical_content.1.scores-mixedff.sql query](https://github.com/paradedb/paradedb/blob/54324d2f0e3689a20f86e817d603bcad65b2cd84/benchmarks/datasets/join/queries/pg_search/hierarchical_content.sql#L19-L30) another 1.12x faster.