### PR TITLE
feat: `CREATE INDEX` uses Postgres parallel workers

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -226,7 +226,11 @@ pub fn log_create_index_progress() -> bool {
 }
 
 pub fn create_index_parallelism() -> NonZeroUsize {
-    adjust_nthreads(CREATE_INDEX_PARALLELISM.get())
+    if enable_parallel_index_build() {
+        unsafe { NonZeroUsize::new_unchecked(1) }
+    } else {
+        adjust_nthreads(CREATE_INDEX_PARALLELISM.get())
+    }
 }
 
 pub fn create_index_memory_budget() -> usize {

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -71,6 +71,9 @@ static STATEMENT_PARALLELISM: GucSetting<i32> = GucSetting::<i32>::new(1);
 /// thread.  So if there's 10 threads and this value is 100MB, then a total of 1GB will be allocated.
 static STATEMENT_MEMORY_BUDGET: GucSetting<i32> = GucSetting::<i32>::new(1024);
 
+/// Should we enable parallel index build?
+static ENABLE_PARALLEL_INDEX_BUILD: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -182,6 +185,15 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_MB,
     );
+
+    GucRegistry::define_bool_guc(
+        "paradedb.enable_parallel_index_build",
+        "Enable parallel index build",
+        "Enable parallel index build",
+        &ENABLE_PARALLEL_INDEX_BUILD,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -227,6 +239,10 @@ pub fn statement_parallelism() -> NonZeroUsize {
 
 pub fn statement_memory_budget() -> usize {
     adjust_budget(STATEMENT_MEMORY_BUDGET.get(), statement_parallelism())
+}
+
+pub fn enable_parallel_index_build() -> bool {
+    ENABLE_PARALLEL_INDEX_BUILD.get()
 }
 
 fn adjust_nthreads(nthreads: i32) -> NonZeroUsize {

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -535,9 +535,9 @@ unsafe fn record_create_index_segment_ids(index_relation: &PgRelation) {
     let reader = SearchIndexReader::open(index_relation, MvccSatisfies::Snapshot)
         .expect("do_heap_scan: should be able to open a SearchIndexReader");
 
-    // record the segment ids created in the merge lock
-    let merge_lock = MergeLock::init(index_relation.oid());
-    merge_lock
+    // record the segment ids created by ambuild
+    let metadata = MetaPageMut::new(index_relation.oid());
+    metadata
         .record_create_index_segment_ids(reader.segment_ids().iter())
         .expect("do_heap_scan: should be able to record segment ids in merge lock");
 }

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -94,7 +94,12 @@ pub extern "C-unwind" fn ambuild(
         }
     }
 
-    let tuple_count = do_heap_scan(index_info, &heap_relation, &index_relation);
+    let tuple_count = if crate::gucs::enable_parallel_index_build() {
+        todo!("parallel index build");
+    } else {
+        do_heap_scan(index_info, &heap_relation, &index_relation)
+    };
+
     unsafe { pg_sys::FlushRelationBuffers(indexrel) };
 
     let mut result = unsafe { PgBox::<pg_sys::IndexBuildResult>::alloc0() };

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -445,9 +445,7 @@ unsafe fn begin_parallel_index_build(
         );
     }
 
-    pgrx::log!("waiting for workers to attach");
     pg_sys::WaitForParallelWorkersToAttach(parallel_context);
-    pgrx::log!("workers attached");
 }
 
 #[no_mangle]
@@ -515,11 +513,6 @@ unsafe fn parallel_heap_scan(build_state: *mut BuildState) {
             pg_sys::SpinLockRelease(&mut (*shared_state).mutex);
             break;
         }
-        pgrx::log!(
-            "n_participants_done: {} need {}",
-            (*shared_state).n_participants_done,
-            n_participant_tuple_sorts
-        );
         pg_sys::SpinLockRelease(&mut (*shared_state).mutex);
         pg_sys::ConditionVariableSleep(
             &mut (*shared_state).workers_done,

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -95,6 +95,10 @@ pub extern "C-unwind" fn ambuild(
     }
 
     let tuple_count = if crate::gucs::enable_parallel_index_build() {
+        if !heaprel.is_null() {
+            let nworkers = unsafe { compute_nworkers(&heap_relation, &index_relation) };
+            pgrx::info!("parallel index build with {} workers", nworkers);
+        }
         todo!("parallel index build");
     } else {
         do_heap_scan(index_info, &heap_relation, &index_relation)

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -88,6 +88,7 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     amroutine.aminsert = Some(insert::aminsert);
     #[cfg(feature = "pg17")]
     {
+        amroutine.amcanbuildparallel = true;
         amroutine.aminsertcleanup = Some(insert::aminsertcleanup);
     }
     amroutine.ambulkdelete = Some(delete::ambulkdelete);

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod anyenum;
-mod document;
+pub mod document;
 pub mod range;
 
 use crate::api::HashMap;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`ambuild` now uses Postgres parallel workers, which divide the table up amongst themselves and index in parallel. In my testing I saw anywhere between a 20% to 300% speedup in `CREATE INDEX`, depending on the dataset, setting `max_maintenance_parallel_workers` equal to the current `paradedb.create_index_parallelism` setting (which will go away).

## Why

The current `ambuild` implementation uses threads to achieve parallelism. However, the table is still scanned serially top to bottom -- only the indexing itself (i.e. tokenization, serialization, etc.) is parallelized.

With Postgres parallel workers, we can also scan in parallel. This means we no longer need to use threads to achieve parallelism and can do everything in the foreground within a parallel process. 

The downstream effect of this change is that `CREATE INDEX` can perform better with fewer workers, meaning that more memory can be allocated per worker, meaning larger segments can be created by default (and force merging doesn't need to happen after).

## How

- Implemented Postgres parallel workers
- Implemented a `SerialIndexWriter` that writes in the foreground

## Tests
