### PR TITLE
fix: bucket aggregates can serialize to/from json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "bitpacking",
 ]
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "nom",
 ]
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4780,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=657cedc19af403b33392841e2cc3e639ddc84211#657cedc19af403b33392841e2cc3e639ddc84211"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0d48d870f55b093a14888d3643aad6dd87af8e44#0d48d870f55b093a14888d3643aad6dd87af8e44"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "657cedc19af403b33392841e2cc3e639ddc84211", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "0d48d870f55b093a14888d3643aad6dd87af8e44", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "657cedc19af403b33392841e2cc3e639ddc84211" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "0d48d870f55b093a14888d3643aad6dd87af8e44" }

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -372,7 +372,7 @@ macro_rules! launch_parallel_process {
 
                 <$parallel_worker_type>::new(state_manager)
                     .run(&mq_sender, unsafe { pgrx::pg_sys::ParallelWorkerNumber })
-                    .unwrap_or_else(|e| ::std::panic::panic_any(e));
+                    .unwrap_or_else(|e| panic!("{e}"));
             }
         }
 

--- a/tests/tests/aggregate.rs
+++ b/tests/tests/aggregate.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+mod fixtures;
+
+use fixtures::db::Query;
+use fixtures::*;
+use rstest::*;
+use sqlx::PgConnection;
+
+#[rstest]
+fn test_aggregate_with_mvcc(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CREATE INDEX idxbm25_search ON paradedb.bm25_search
+    USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "category": {"fast": true, "normalizer": "raw"}
+        }',
+        numeric_fields='{"rating": {"fast": true}}'
+    );
+    INSERT INTO paradedb.bm25_search (description, category, rating) VALUES
+        ('keyboard', 'Electronics', 4.5),
+        ('keyboard', 'Electronics', 3.8),
+        ('keyboard', 'Accessories', 4.2);
+
+    DELETE FROM paradedb.bm25_search WHERE category = 'Accessories';
+    "#
+        .execute(&mut conn);
+
+    // Test with MVCC enabled (default)
+    let result = r#"
+    SELECT paradedb.aggregate(
+        'paradedb.idxbm25_search',
+        paradedb.parse('description:keyboard'),
+        '{
+            "category": {
+                "terms": {
+                    "field": "category",
+                    "size": 10
+                }
+            }
+        }'::json
+    )
+    "#
+    .fetch_one::<(serde_json::Value,)>(&mut conn);
+
+    // Verify the aggregation results
+    let buckets = result
+        .0
+        .pointer("/category/buckets")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert_eq!(buckets.len(), 1); // Should have 1 category
+}
+
+#[rstest]
+fn test_aggregate_without_mvcc(mut conn: PgConnection) {
+    r#"
+    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
+    CREATE INDEX idxbm25_search ON paradedb.bm25_search
+    USING bm25 (id, description, category, rating, in_stock, metadata, created_at, last_updated_date, latest_available_time)
+    WITH (
+        key_field='id',
+        text_fields='{
+            "description": {},
+            "category": {"fast": true, "normalizer": "raw"}
+        }',
+        numeric_fields='{"rating": {"fast": true}}',
+        boolean_fields='{"in_stock": {}}',
+        json_fields='{"metadata": {}}',
+        datetime_fields='{
+            "created_at": {},
+            "last_updated_date": {},
+            "latest_available_time": {}
+        }'
+    );
+    INSERT INTO paradedb.bm25_search (description, category, rating) VALUES
+        ('keyboard', 'Electronics', 4.5),
+        ('keyboard', 'Electronics', 3.8),
+        ('keyboard', 'Accessories', 4.2);
+
+    DELETE FROM paradedb.bm25_search WHERE category = 'Accessories';
+    "#
+        .execute(&mut conn);
+
+    // Test with MVCC disabled
+    let result = r#"
+    SELECT paradedb.aggregate(
+        'paradedb.idxbm25_search',
+        paradedb.parse('description:keyboard'),
+        '{
+            "category": {
+                "terms": {
+                    "field": "category",
+                    "size": 10
+                }
+            }
+        }'::json,
+        false
+    )
+    "#
+    .fetch_one::<(serde_json::Value,)>(&mut conn);
+
+    // Verify the aggregation results
+    let buckets = result
+        .0
+        .pointer("/category/buckets")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert_eq!(buckets.len(), 2); // Should have 2 categories
+}


### PR DESCRIPTION
## What

Updates our tantivy dependency to
https://github.com/paradedb/tantivy/pull/44/commits/0d48d870f55b093a14888d3643aad6dd87af8e44 so that we can serialize intermediate aggregate results through the new parallel worker machinery.

Also fixes a little bug where certain errors in a parallel worker could be obscured as `ERROR: Box<Any>`.

## Why

## How

## Tests

There's 2 more unit tests for the new `paradedb.aggregate()` function which exposed this problem.