### PR TITLE
ci: Revert back to dtolnay for Rust installer

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -50,7 +50,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       # Caches from base branches are available to PRs, but not across unrelated branches, so we only
       # save the cache on the 'dev' branch, but load it on all branches.

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -137,7 +137,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, since
       # /bin/sh does not support the `[[` syntax.

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -205,7 +205,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -151,7 +151,7 @@ jobs:
           gh --version
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Retrieve OS & GitHub Tag Versions
         id: version

--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -54,7 +54,7 @@ jobs:
           path: paradedb
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0 # Fetch the entire history
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Extract pgrx Version
         id: pgrx
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Extract pgrx Version
         id: pgrx

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
It was changed for another action, which automatically caches the Rust build and broke our release workflows. While we can disable the cache function on that action, it is significantly less used than the `dtolnay` one, so I figured we should stay with the true and tested.

## Why
^

## How
^

## Tests
^