### PR TITLE
test: Add generated subquery tests, and generate paging expressions.

### DIFF
--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -14,7 +14,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 pub mod joingen;
+pub mod pagegen;
 pub mod wheregen;
 
 use std::fmt::Debug;

--- a/tests/tests/fixtures/querygen/pagegen.rs
+++ b/tests/tests/fixtures/querygen/pagegen.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::fmt::{Debug, Display};
+
+use proptest::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct PagingExprs {
+    order_by: Vec<String>,
+    offset: Option<usize>,
+    limit: Option<usize>,
+}
+
+impl PagingExprs {
+    pub fn to_sql(&self) -> String {
+        let mut sql = String::new();
+
+        let mut order_bys = self.order_by.iter();
+        if let Some(order_by) = order_bys.next() {
+            sql.push_str("ORDER BY ");
+            sql.push_str(order_by);
+        }
+        for order_by in order_bys {
+            sql.push_str(", ");
+            sql.push_str(order_by);
+        }
+
+        if let Some(offset) = &self.offset {
+            if !sql.is_empty() {
+                sql.push(' ');
+            }
+            sql.push_str("OFFSET ");
+            sql.push_str(&offset.to_string());
+        }
+
+        if let Some(limit) = &self.limit {
+            if !sql.is_empty() {
+                sql.push(' ');
+            }
+            sql.push_str("LIMIT ");
+            sql.push_str(&limit.to_string());
+        }
+        sql
+    }
+}
+
+/// Generate arbitrary `ORDER BY`, `OFFSET`, and `LIMIT` expressions.
+///
+/// This strategy is intentionally limited to combinations which allow for deterministic
+/// comparison:
+/// * If an `ORDER BY` is generated, the given tiebreaker will be appended to give a
+/// stable sort order.
+/// * `LIMIT` and `OFFSET` will only be generated if there is an `ORDER BY`.
+pub fn arb_paging_exprs(
+    table: impl AsRef<str>,
+    order_by_tiebreaker: impl AsRef<str>,
+    columns: Vec<impl AsRef<str>>,
+) -> impl Strategy<Value = String> {
+    let columns = columns
+        .into_iter()
+        .map(|col| format!("{}.{}", table.as_ref(), col.as_ref()))
+        .collect::<Vec<_>>();
+    let columns_len = columns.len();
+
+    // Choose `order_by`.
+    proptest::sample::subsequence(columns, 0..columns_len)
+        .prop_flat_map(move |mut order_by| {
+            let (offset, limit) = if order_by.is_empty() {
+                // If there is no `ORDER BY`, then we cannot deterministically LIMIT or OFFSET.
+                (Just(None).boxed(), Just(None).boxed())
+            } else {
+                // Add the tiebreaker, and then generate OFFSET and LIMIT.
+                order_by.push(order_by_tiebreaker.as_ref().to_owned());
+                (
+                    prop_oneof![Just(None), Just(Some(0usize)), Just(Some(10usize))].boxed(),
+                    prop_oneof![Just(None), Just(Some(10usize))].boxed(),
+                )
+            };
+            (Just(order_by), offset, limit)
+        })
+        .prop_map(|(order_by, offset, limit)| {
+            PagingExprs {
+                order_by,
+                offset,
+                limit,
+            }
+            .to_sql()
+        })
+}

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -19,6 +19,7 @@ mod fixtures;
 
 use crate::fixtures::querygen::arb_joins_and_wheres;
 use crate::fixtures::querygen::joingen::JoinType;
+use crate::fixtures::querygen::pagegen::arb_paging_exprs;
 use crate::fixtures::querygen::wheregen::arb_wheres;
 
 use fixtures::*;
@@ -81,6 +82,15 @@ ANALYZE;
     setup_sql
 }
 
+fn explain(query: impl AsRef<str>, conn: &mut PgConnection) -> String {
+    format!("EXPLAIN ANALYZE {}", query.as_ref())
+        .fetch::<(String,)>(conn)
+        .into_iter()
+        .map(|(s,)| s)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 ///
 /// Tests all JoinTypes against small tables (which are particularly important for joins which
 /// result in e.g. the cartesian product).
@@ -123,7 +133,7 @@ async fn generated_joins_small(database: Db) {
             "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
             pg,
             bm25,
-            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+            explain(&bm25, &mut pool.pull()),
         );
     });
 }
@@ -178,7 +188,7 @@ async fn generated_joins_large_limit(database: Db) {
             "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
             pg,
             bm25,
-            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+            explain(&bm25, &mut pool.pull()),
         );
     });
 }
@@ -192,19 +202,68 @@ async fn generated_single_relation(database: Db) {
     );
 
     let table_name = "users";
-    generated_queries_setup(&mut pool.pull(), &[(table_name, 10)]);
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 10)]);
+    eprintln!("{setup_sql}");
 
     proptest!(|(
         where_expr in arb_wheres(
             vec![table_name],
             vec![("name", "bob"), ("color", "blue"), ("age", "20")]
         ),
+        paging_exprs in arb_paging_exprs(table_name, "id", vec!["name", "color", "age"]),
     )| {
-        let where_clause = where_expr.to_sql(" = ");
-        let pg = format!("SELECT COUNT(*) FROM {table_name} WHERE {where_clause}");
-        let bm25 = format!(
-            "SELECT COUNT(*) FROM {table_name} WHERE ({where_clause}) AND id @@@ paradedb.all()"
-        ); // force a pushdown
+        let pg = format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = "));
+        let bm25 = format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@"));
+
+        let pg_res = (&pg).fetch::<(i64,)>(&mut pool.pull());
+        let bm25_res = (&bm25).fetch::<(i64,)>(&mut pool.pull());
+        prop_assert_eq!(
+            pg_res.len(),
+            bm25_res.len(),
+            "\npg:\n  {:?}\nbm25:\n  {:?}\nexplain:\n{}\n",
+            pg,
+            bm25,
+            explain(&bm25, &mut pool.pull()),
+        );
+    });
+}
+
+#[rstest]
+#[tokio::test]
+async fn generated_subquery(database: Db) {
+    let pool = MutexObjectPool::<PgConnection>::new(
+        move || block_on(async { database.connection().await }),
+        |_| {},
+    );
+
+    let outer_table_name = "products";
+    let inner_table_name = "orders";
+    let setup_sql = generated_queries_setup(
+        &mut pool.pull(),
+        &[(outer_table_name, 10), (inner_table_name, 10)],
+    );
+    eprintln!("{setup_sql}");
+
+    proptest!(|(
+        outer_where_expr in arb_wheres(
+            vec![outer_table_name],
+            vec![("name", "bob"), ("color", "blue"), ("age", "20")]
+        ),
+        inner_where_expr in arb_wheres(
+            vec![inner_table_name],
+            vec![("name", "bob"), ("color", "blue"), ("age", "20")]
+        ),
+        subquery_column in proptest::sample::select(&["name", "color", "age"]),
+        paging_exprs in arb_paging_exprs(inner_table_name, "id", vec!["name", "color", "age"]),
+    )| {
+        let pg = format!("SELECT COUNT(*) FROM {outer_table_name} \
+            WHERE {outer_table_name}.{subquery_column} IN (\
+                SELECT {subquery_column} FROM {inner_table_name} WHERE {} {paging_exprs}\
+            ) AND {}", inner_where_expr.to_sql(" = "), outer_where_expr.to_sql(" = "));
+        let bm25 = format!("SELECT COUNT(*) FROM {outer_table_name} \
+            WHERE {outer_table_name}.{subquery_column} IN (\
+                SELECT {subquery_column} FROM {inner_table_name} WHERE {} {paging_exprs}\
+            ) AND {}", inner_where_expr.to_sql("@@@"), outer_where_expr.to_sql("@@@"));
 
         let (pg_cnt,) = (&pg).fetch_one::<(i64,)>(&mut pool.pull());
         let (bm25_cnt,) = (&bm25).fetch_one::<(i64,)>(&mut pool.pull());
@@ -214,7 +273,7 @@ async fn generated_single_relation(database: Db) {
             "\npg:\n  {}\nbm25:\n  {}\nexplain:\n{}\n",
             pg,
             bm25,
-            format!("EXPLAIN {bm25}").fetch::<(String,)>(&mut pool.pull()).into_iter().map(|(s,)| s).collect::<Vec<_>>().join("\n"),
+            explain(&bm25, &mut pool.pull()),
         );
     });
 }


### PR DESCRIPTION
## What

Expands the proptests to add a test of subqueries, and to add "paging" expressions (`ORDER BY`, `LIMIT`, `OFFSET`) to the single query and subquery tests.

## Why

To increase test coverage: particularly around subqueries (which seemingly hit re-scan cases more frequently) and top-n.