### PR TITLE
feat: always do pushdowns when we can

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -295,7 +295,6 @@ impl CustomScan for PdbScan {
             //
             // look for quals we can support
             //
-            let mut uses_our_operator = false;
             let quals = extract_quals(
                 root,
                 rti,
@@ -303,16 +302,7 @@ impl CustomScan for PdbScan {
                 anyelement_query_input_opoid(),
                 ri_type,
                 &schema,
-                &mut uses_our_operator,
             );
-
-            if !uses_our_operator {
-                // for now, we're not going to submit our custom scan for queries that don't also
-                // use our `@@@` operator.  Perhaps in the future we can do this, but we don't want to
-                // circumvent Postgres' other possible plans that might do index scans over a btree
-                // index or something
-                return None;
-            }
 
             let Some(quals) = quals else {
                 // if we are not able to push down all of the quals, then do not propose the custom

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -381,19 +381,10 @@ pub unsafe fn extract_quals(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_our_operator: &mut bool,
 ) -> Option<Qual> {
     match (*node).type_ {
         pg_sys::NodeTag::T_List => {
-            let mut quals = list(
-                root,
-                rti,
-                node.cast(),
-                pdbopoid,
-                ri_type,
-                schema,
-                uses_our_operator,
-            )?;
+            let mut quals = list(root, rti, node.cast(), pdbopoid, ri_type, schema)?;
             if quals.len() == 1 {
                 quals.pop()
             } else {
@@ -408,39 +399,15 @@ pub unsafe fn extract_quals(
             } else {
                 (*ri).clause
             };
-            extract_quals(
-                root,
-                rti,
-                clause.cast(),
-                pdbopoid,
-                ri_type,
-                schema,
-                uses_our_operator,
-            )
+            extract_quals(root, rti, clause.cast(), pdbopoid, ri_type, schema)
         }
 
-        pg_sys::NodeTag::T_OpExpr => opexpr(
-            root,
-            rti,
-            node,
-            pdbopoid,
-            ri_type,
-            schema,
-            uses_our_operator,
-        ),
+        pg_sys::NodeTag::T_OpExpr => opexpr(root, rti, node, pdbopoid, ri_type, schema),
 
         pg_sys::NodeTag::T_BoolExpr => {
             let boolexpr = nodecast!(BoolExpr, T_BoolExpr, node)?;
             let args = PgList::<pg_sys::Node>::from_pg((*boolexpr).args);
-            let mut quals = list(
-                root,
-                rti,
-                (*boolexpr).args,
-                pdbopoid,
-                ri_type,
-                schema,
-                uses_our_operator,
-            )?;
+            let mut quals = list(root, rti, (*boolexpr).args, pdbopoid, ri_type, schema)?;
 
             match (*boolexpr).boolop {
                 pg_sys::BoolExprType::AND_EXPR => Some(Qual::And(quals)),
@@ -472,15 +439,7 @@ pub unsafe fn extract_quals(
             }
         }
 
-        pg_sys::NodeTag::T_BooleanTest => booltest(
-            root,
-            rti,
-            node,
-            pdbopoid,
-            ri_type,
-            schema,
-            uses_our_operator,
-        ),
+        pg_sys::NodeTag::T_BooleanTest => booltest(root, rti, node, pdbopoid, ri_type, schema),
 
         // we don't understand this clause so we can't do anything
         _ => None,
@@ -494,20 +453,11 @@ unsafe fn list(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_our_operator: &mut bool,
 ) -> Option<Vec<Qual>> {
     let args = PgList::<pg_sys::Node>::from_pg(list);
     let mut quals = Vec::new();
     for child in args.iter_ptr() {
-        quals.push(extract_quals(
-            root,
-            rti,
-            child,
-            pdbopoid,
-            ri_type,
-            schema,
-            uses_our_operator,
-        )?)
+        quals.push(extract_quals(root, rti, child, pdbopoid, ri_type, schema)?)
     }
     Some(quals)
 }
@@ -519,7 +469,6 @@ unsafe fn opexpr(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_our_operator: &mut bool,
 ) -> Option<Qual> {
     let opexpr = nodecast!(OpExpr, T_OpExpr, node)?;
     let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
@@ -536,17 +485,9 @@ unsafe fn opexpr(
     }
 
     match (*lhs).type_ {
-        pg_sys::NodeTag::T_Var => var_opexpr(
-            root,
-            rti,
-            pdbopoid,
-            ri_type,
-            schema,
-            uses_our_operator,
-            opexpr,
-            lhs,
-            rhs,
-        ),
+        pg_sys::NodeTag::T_Var => {
+            var_opexpr(root, rti, pdbopoid, ri_type, schema, opexpr, lhs, rhs)
+        }
 
         pg_sys::NodeTag::T_FuncExpr => {
             // direct support for paradedb.score() in the WHERE clause
@@ -576,7 +517,6 @@ unsafe fn var_opexpr(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_our_operator: &mut bool,
     opexpr: *mut pg_sys::OpExpr,
     lhs: *mut pg_sys::Node,
     mut rhs: *mut pg_sys::Node,
@@ -602,7 +542,6 @@ unsafe fn var_opexpr(
                 // it uses our operator, so we directly know how to handle it
                 // this is the case of:  field @@@ paradedb.xxx(EXPR) where EXPR likely includes something
                 // that's parameterized
-                *uses_our_operator = true;
                 return Some(Qual::Expr {
                     node: rhs,
                     expr_state: std::ptr::null_mut(),
@@ -617,7 +556,7 @@ unsafe fn var_opexpr(
             } else {
                 // it doesn't use our operator.
                 // we'll try to convert it into a pushdown
-                return try_pushdown(root, opexpr, schema);
+                return try_pushdown(root, rti, opexpr, schema);
             }
         }
     }
@@ -628,7 +567,6 @@ unsafe fn var_opexpr(
 
         if (*lhs).varno as i32 == rti as i32 {
             // the var comes from this range table entry, so we can use the full expression directly
-            *uses_our_operator = true;
             Some(Qual::OpExpr {
                 var: lhs,
                 opno: (*opexpr).opno,
@@ -648,7 +586,7 @@ unsafe fn var_opexpr(
     } else {
         // it doesn't use our operator.
         // we'll try to convert it into a pushdown
-        try_pushdown(root, opexpr, schema)
+        try_pushdown(root, rti, opexpr, schema)
     }
 }
 
@@ -700,7 +638,6 @@ unsafe fn booltest(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_our_operator: &mut bool,
 ) -> Option<Qual> {
     let booltest = nodecast!(BooleanTest, T_BooleanTest, node)?;
     let arg = (*booltest).arg;

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -310,3 +310,23 @@ SELECT (SELECT COUNT(*)
     14 |    14
 (1 row)
 
+--
+-- removing the `uses_our_operator` code so that we always push down quals if we can exposed
+-- a bug where we'd confuse vars by their names if different tables in the query contain fields
+-- with the same names.  This tests for that
+--
+SELECT (SELECT COUNT(*)
+        FROM products
+                 JOIN orders ON products.name = orders.name
+        WHERE (NOT (products.id = '3'))
+           OR ((products.name = 'bob') AND (orders.id = '3'))),
+       (SELECT COUNT(*)
+        FROM products
+                 JOIN orders ON products.name = orders.name
+        WHERE (NOT (products.id @@@ '3'))
+           OR ((products.name @@@ 'bob') AND (orders.id @@@ '3')));
+ count | count 
+-------+-------
+    19 |    19
+(1 row)
+

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
@@ -446,30 +446,38 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT title, is_available, rating
 FROM limit_topn_test
 WHERE is_available = true
-ORDER BY rating DESC
+ORDER BY rating DESC, title ASC
 LIMIT 7;
-               QUERY PLAN                
------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: rating DESC
-         ->  Seq Scan on limit_topn_test
-               Filter: is_available
-(5 rows)
+   ->  Incremental Sort
+         Sort Key: rating DESC, title
+         Presorted Key: rating
+         ->  Custom Scan (ParadeDB Scan) on limit_topn_test
+               Table: limit_topn_test
+               Index: limit_topn_idx
+               Exec Method: TopNScanExecState
+               Scores: false
+                  Sort Field: rating
+                  Sort Direction: desc
+                  Top N Limit: 7
+               Tantivy Query: {"term":{"field":"is_available","value":true,"is_datetime":false}}
+(13 rows)
 
 SELECT title, is_available, rating
 FROM limit_topn_test
 WHERE is_available = true
-ORDER BY rating DESC
+ORDER BY rating DESC, title ASC
 LIMIT 7;
    title    | is_available | rating 
 ------------+--------------+--------
+ Product 14 | t            |      5
+ Product 24 | t            |      5
+ Product 34 | t            |      5
+ Product 4  | t            |      5
  Product 44 | t            |      5
  Product 54 | t            |      5
- Product 4  | t            |      5
- Product 34 | t            |      5
- Product 24 | t            |      5
- Product 14 | t            |      5
  Product 64 | t            |      5
 (7 rows)
 
@@ -480,14 +488,19 @@ FROM limit_topn_test
 WHERE rating > 3.0 AND price < 500
 ORDER BY price DESC
 LIMIT 12;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: price DESC
-         ->  Seq Scan on limit_topn_test
-               Filter: ((rating > '3'::double precision) AND (price < '500'::double precision))
-(5 rows)
+   ->  Custom Scan (ParadeDB Scan) on limit_topn_test
+         Table: limit_topn_test
+         Index: limit_topn_idx
+         Exec Method: TopNScanExecState
+         Scores: false
+            Sort Field: price
+            Sort Direction: desc
+            Top N Limit: 12
+         Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"excluded":500.0},"is_datetime":false}}]}}
+(10 rows)
 
 SELECT rating, price
 FROM limit_topn_test

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
@@ -590,8 +590,12 @@ ORDER BY pr.avg_rating DESC, paradedb.score(tp.id), tp.price DESC;
                                        ->  Seq Scan on reviews r
                                              Filter: (rating >= 3)
                ->  Hash
-                     ->  Seq Scan on categories c
-                           Filter: is_active
+                     ->  Custom Scan (ParadeDB Scan) on categories c
+                           Table: categories
+                           Index: categories_idx
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"term":{"field":"is_active","value":true,"is_datetime":false}}
          ->  Hash
                ->  Subquery Scan on tp
                      ->  Limit
@@ -604,7 +608,7 @@ ORDER BY pr.avg_rating DESC, paradedb.score(tp.id), tp.price DESC;
                                     Sort Direction: desc
                                     Top N Limit: 50
                                  Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":{"included":100.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"included":800.0},"is_datetime":false}},{"term":{"field":"is_available","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}]}}
-(31 rows)
+(35 rows)
 
 WITH top_products AS (
     SELECT p.id, p.name, p.price, p.stock_count

--- a/pg_search/tests/pg_regress/sql/issue_2533.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2533.sql
@@ -291,3 +291,19 @@ SELECT (SELECT COUNT(*)
               NOT ((orders.age @@@ '20') AND (orders.age @@@ '20'))
            OR (orders.color @@@ 'blue') AND NOT (users.age @@@ '20')
            OR ((users.name @@@ 'bob') AND (NOT (users.color @@@ 'blue'))));
+
+--
+-- removing the `uses_our_operator` code so that we always push down quals if we can exposed
+-- a bug where we'd confuse vars by their names if different tables in the query contain fields
+-- with the same names.  This tests for that
+--
+SELECT (SELECT COUNT(*)
+        FROM products
+                 JOIN orders ON products.name = orders.name
+        WHERE (NOT (products.id = '3'))
+           OR ((products.name = 'bob') AND (orders.id = '3'))),
+       (SELECT COUNT(*)
+        FROM products
+                 JOIN orders ON products.name = orders.name
+        WHERE (NOT (products.id @@@ '3'))
+           OR ((products.name @@@ 'bob') AND (orders.id @@@ '3')));

--- a/pg_search/tests/pg_regress/sql/mixedff_advanced_03_limit_topn.sql
+++ b/pg_search/tests/pg_regress/sql/mixedff_advanced_03_limit_topn.sql
@@ -84,13 +84,13 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT title, is_available, rating
 FROM limit_topn_test
 WHERE is_available = true
-ORDER BY rating DESC
+ORDER BY rating DESC, title ASC
 LIMIT 7;
 
 SELECT title, is_available, rating
 FROM limit_topn_test
 WHERE is_available = true
-ORDER BY rating DESC
+ORDER BY rating DESC, title ASC
 LIMIT 7;
 
 -- Test LIMIT with multiple numeric fields

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -153,8 +153,7 @@ fn pushdown(mut conn: PgConnection) {
                 EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
                 SELECT count(*)
                 FROM test
-                WHERE {sqlname} {operator} {default}::{sqltype}
-                  AND id @@@ '1';
+                WHERE {sqlname} {operator} {default}::{sqltype};
             "#
             );
 
@@ -177,8 +176,7 @@ fn pushdown(mut conn: PgConnection) {
                 EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
                 SELECT count(*)
                 FROM test
-                WHERE {sqlname} = true
-                  AND id @@@ '1';
+                WHERE {sqlname} = true;
             "#
         );
 
@@ -198,8 +196,7 @@ fn pushdown(mut conn: PgConnection) {
                 EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
                 SELECT count(*)
                 FROM test
-                WHERE {sqlname} = false
-                  AND id @@@ '1';
+                WHERE {sqlname} = false;
             "#
         );
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Until now, we would short-circuit out of our custom scan if the query didn't contain at least one `@@@` usage somewhere in the query, even if other quals, such as `field = 'value'` could be pushed down. Essentially this was a measure to only do pushdowns when the user made it clear they wanted/needed a custom scan.

This removes that short-circuit and will now send any query through our custom scan where every qual is either directly `@@@` or is otherwise pushdown-able.

## Why

We have enough test coverage now where we can confidently do this and ensure that the custom scan plan will produce the same results as the non-custom scan plan we'd have executed prior to this PR.

## How

## Tests

Two of the regression tests have changed plans b/c now they go through the custom scan path.  A third adds a new query to validate, which was the result of a bug this change uncovered related to confusing which relation a Var came from.

Additionally, we add some more logic on the qgen proptests to force Postgres to do various plans to make sure we always get the correct results.