### PR TITLE
fix: `paradedb.aggregate()` won't crash if it couldn't launch workers

### DIFF
--- a/pg_search/src/parallel_worker/mqueue.rs
+++ b/pg_search/src/parallel_worker/mqueue.rs
@@ -27,7 +27,9 @@ struct MessageQueueHandle {
 impl Drop for MessageQueueHandle {
     fn drop(&mut self) {
         unsafe {
-            pg_sys::shm_mq_detach(self.handle.as_ptr());
+            if pg_sys::IsInParallelMode() {
+                pg_sys::shm_mq_detach(self.handle.as_ptr());
+            }
         }
     }
 }

--- a/pg_search/tests/pg_regress/expected/aggregate-udf.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-udf.out
@@ -59,11 +59,15 @@ SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=
 (1 row)
 
 --
--- this one should generate an ERROR
+-- this one will execute serially in the current backend
 --
 SET parallel_leader_participation = false;
 SET max_parallel_workers = 0;
 SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=>'{"average": { "avg": { "field": "v" }}}', solve_mvcc=>true);
-ERROR:  should be able to launch parallel process
+           aggregate           
+-------------------------------
+ {"average": {"value": 500.5}}
+(1 row)
+
 RESET parallel_leader_participation;
 RESET max_parallel_workers;

--- a/pg_search/tests/pg_regress/sql/aggregate-udf.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate-udf.sql
@@ -36,7 +36,7 @@ SELECT * FROM paradedb.aggregate(index=>'idxpr2625', query=>paradedb.all(), agg=
 
 
 --
--- this one should generate an ERROR
+-- this one will execute serially in the current backend
 --
 SET parallel_leader_participation = false;
 SET max_parallel_workers = 0;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`paradedb.aggregate()` had the potential to crash if no parallel workers were available.

This fixes that bug (in `mqueue.rs`) and then addresses the situation of not being able to spawn workers in `aggregate()` by just running the aggregate right there in the calling backend.

## Why

customer report and crashing is bad!

## How

## Tests

Existing tests pass.  It's a little difficult to write a test to expose this as it requires concurrent backends where one has consumed all available parallel worker slots.

I can at least confirm my manual test to recreate this now works as expected.