### PR TITLE
ci: Rm Ubuntu 20.04

### DIFF
--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -35,39 +35,6 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ubuntu 20.04
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-8-ubuntu-2004
-            pg_version: 14
-            arch: amd64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-4-arm-ubuntu-2004
-            pg_version: 14
-            arch: arm64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-8-ubuntu-2004
-            pg_version: 15
-            arch: amd64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-4-arm-ubuntu-2004
-            pg_version: 15
-            arch: arm64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-8-ubuntu-2004
-            pg_version: 16
-            arch: amd64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-4-arm-ubuntu-2004
-            pg_version: 16
-            arch: arm64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-8-ubuntu-2004
-            pg_version: 17
-            arch: amd64
-          - name: Ubuntu 20.04 (Focal)
-            runner: ubicloud-standard-4-arm-ubuntu-2004
-            pg_version: 17
-            arch: arm64
           # Ubuntu 22.04
           - name: Ubuntu 22.04 (Jammy)
             runner: ubicloud-standard-8-ubuntu-2204


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
> As you may know, GitHub officially deprecated Ubuntu 20.04 runners on April 15, 2025 (For more details, you can check GitHub's official [deprecation notice](https://github.com/actions/runner-images/issues/11101)). In line with this change and due to the deprecation of key dependencies of the Ubuntu 20.04 images, Ubicloud will discontinue support for Ubuntu 20.04 runner images.

## Why
^

## How
^

## Tests
^