### PR TITLE
chore: `always()` print the Postgres logs in CI

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -243,4 +243,5 @@ jobs:
           fi
 
       - name: Print the Postgres Logs
+        if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version}}.log


### PR DESCRIPTION
## What/Why

Currently if certain types of CI jobs fail, the Postgres logs will not be printed. We should print them so that we can triage failures.

## How

`always()` print them: this aligns with our other `Print the Postgres Logs` steps.