### PR TITLE
perf: improve INSERT/UPDATE perf with `SerialIndexWriter`

### DIFF
--- a/docs/documentation/configuration/write.mdx
+++ b/docs/documentation/configuration/write.mdx
@@ -4,20 +4,6 @@ title: Throughput
 
 Several settings can be used to tune the throughput of `INSERT`/`UPDATE`/`COPY` statements to the BM25 index.
 
-## Statement Parallelism
-
-`paradedb.statement_parallelism` controls the number of indexing threads used during `INSERT/UPDATE/COPY`. The default is `1` which will generally ensure only one
-segment is created by the INSERT/UPDATE/COPY statement.
-
-A value of zero will detect the "available parallelism" of the host computer.
-
-If your typical update patterns are single/few-row atomic `INSERT`s or `UPDATE`s, then a value of `1` can prevent extra segments from being created that later must be merged.
-For bulk inserts and updates, a larger value is better.
-
-```sql
-SET paradedb.statement_parallelism = 1;
-```
-
 ## Statement Memory Budget
 
 `paradedb.statement_memory_budget` defaults to `1024MB`. It sets the amount of memory to dedicate per indexing thread before the index segment needs to be

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -21,7 +21,7 @@ use super::storage::block::CLEANUP_LOCK;
 use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
-use crate::index::writer::index::SearchIndexWriter;
+use crate::index::writer::index::SearchIndexDeleter;
 use crate::index::WriterResources;
 use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::metadata::MetaPage;
@@ -64,7 +64,7 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     );
     drop(cleanup_lock);
 
-    let mut index_writer = SearchIndexWriter::open(
+    let mut index_writer = SearchIndexDeleter::open(
         &index_relation,
         MvccSatisfies::Vacuum,
         WriterResources::Vacuum,

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -18,8 +18,8 @@
 use crate::api::index::FieldName;
 use crate::index::merge_policy::{LayeredMergePolicy, NumCandidates, NumMerged};
 use crate::index::mvcc::MvccSatisfies;
-use crate::index::writer::index::{Mergeable, SearchIndexMerger, SearchIndexWriter};
-use crate::index::WriterResources;
+use crate::index::writer::index::{Mergeable, SearchIndexMerger, SerialIndexWriter};
+use crate::index::{get_index_schema, WriterResources};
 use crate::postgres::options::SearchIndexCreateOptions;
 use crate::postgres::storage::block::{SegmentMetaEntry, CLEANUP_LOCK, SEGMENT_METAS_START};
 use crate::postgres::storage::buffer::BufferManager;
@@ -28,15 +28,15 @@ use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use crate::postgres::utils::{
     categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
 };
-use crate::schema::SearchField;
+use crate::schema::{SearchDocument, SearchField};
 use pgrx::{check_for_interrupts, pg_guard, pg_sys, PgMemoryContexts, PgRelation, PgTupleDesc};
 use std::panic::{catch_unwind, resume_unwind};
-use tantivy::SegmentMeta;
+use tantivy::{SegmentMeta, TantivyDocument};
 
 pub struct InsertState {
     #[allow(dead_code)] // field is used by pg<16 for the fakeaminsertcleanup stuff
     pub indexrelid: pg_sys::Oid,
-    pub writer: Option<SearchIndexWriter>,
+    pub writer: Option<SerialIndexWriter>,
     categorized_fields: Vec<(SearchField, CategorizedFieldData)>,
     key_field_name: FieldName,
     per_row_context: PgMemoryContexts,
@@ -47,10 +47,14 @@ impl InsertState {
         indexrel: &PgRelation,
         writer_resources: WriterResources,
     ) -> anyhow::Result<Self> {
-        let writer = SearchIndexWriter::open(indexrel, MvccSatisfies::Mergeable, writer_resources)?;
+        let (parallelism, memory_budget) = writer_resources.resources();
+        let memory_budget = memory_budget / parallelism;
+        let writer =
+            SerialIndexWriter::with_mvcc(indexrel, MvccSatisfies::Mergeable, memory_budget)?;
+        let schema = get_index_schema(indexrel)?;
         let tupdesc = unsafe { PgTupleDesc::from_pg_unchecked(indexrel.rd_att) };
-        let categorized_fields = categorize_fields(&tupdesc, &writer.schema);
-        let key_field_name = writer.schema.key_field().name;
+        let categorized_fields = categorize_fields(&tupdesc, &schema);
+        let key_field_name = schema.key_field().name;
 
         let per_row_context = pg_sys::AllocSetContextCreateExtended(
             PgMemoryContexts::CurrentMemoryContext.value(),
@@ -122,21 +126,10 @@ pub unsafe extern "C-unwind" fn aminsert(
     index_relation: pg_sys::Relation,
     values: *mut pg_sys::Datum,
     isnull: *mut bool,
-    heap_tid: pg_sys::ItemPointer,
+    ctid: pg_sys::ItemPointer,
     _heap_relation: pg_sys::Relation,
     _check_unique: pg_sys::IndexUniqueCheck::Type,
     _index_unchanged: bool,
-    index_info: *mut pg_sys::IndexInfo,
-) -> bool {
-    aminsert_internal(index_relation, values, isnull, heap_tid, index_info)
-}
-
-#[inline(always)]
-unsafe fn aminsert_internal(
-    index_relation: pg_sys::Relation,
-    values: *mut pg_sys::Datum,
-    isnull: *mut bool,
-    ctid: pg_sys::ItemPointer,
     index_info: *mut pg_sys::IndexInfo,
 ) -> bool {
     if pg_sys::IsLogicalWorker() {
@@ -157,7 +150,9 @@ unsafe fn aminsert_internal(
             let key_field_name = &state.key_field_name;
             let writer = state.writer.as_mut().expect("writer should not be null");
 
-            let mut search_document = writer.schema.new_document();
+            let mut search_document = SearchDocument {
+                doc: TantivyDocument::new(),
+            };
 
             row_to_search_document(
                 values,
@@ -196,9 +191,9 @@ pub unsafe extern "C-unwind" fn aminsertcleanup(
     paradedb_aminsertcleanup(state.as_mut().and_then(|state| state.writer.take()));
 }
 
-pub fn paradedb_aminsertcleanup(mut writer: Option<SearchIndexWriter>) {
+pub fn paradedb_aminsertcleanup(mut writer: Option<SerialIndexWriter>) {
     if let Some(writer) = writer.take() {
-        let indexrelid = writer.indexrelid;
+        let indexrelid = writer.index_oid();
 
         writer
             .commit()

--- a/tests/tests/aborted_xact.rs
+++ b/tests/tests/aborted_xact.rs
@@ -26,7 +26,6 @@ fn aborted_segments_not_visible(mut conn: PgConnection) {
     r#"
         SET max_parallel_maintenance_workers = 0;
         SET parallel_leader_participation = false;
-        SET paradedb.statement_parallelism = 1;
         DROP TABLE IF EXISTS test_table;
         CREATE TABLE test_table (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
         INSERT INTO test_table (value) VALUES ('committed');


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We now use the `SerialIndexWriter` to insert rows during `aminsert()`, which seems to essentially double INSERT/UPDATE performance of small, single-row statements.

This then led to `SearchIndexWriter` being renamed to `SearchIndexDeleter` because now it's only used by `ambulkdelete()`.

We're basically one step away from being able to completely delete the `ChannelDirectory` and all the complexity it contains!

As a result of all this, the `paradedb.statement_parallelism` GUC is now gone.  Internally we keep the concept, but it's hardcoded to 1 -- Postgres doesn't support parallel worker-based INSERT/UPDATE/COPY statements.


## Why

It's a clear performance win mostly by removing the `ChannelDirectory` from this code path.

## How

## Tests

All existing tests pass.  Stressgres locally looked good with a nearly 2x improvement on INSERT/UPDATE transaction throughput.