### PR TITLE
fix: should be able to construct a `SearchField` for `ctid`

### DIFF
--- a/pg_search/tests/pg_regress/expected/find_ctid.out
+++ b/pg_search/tests/pg_regress/expected/find_ctid.out
@@ -1,0 +1,11 @@
+CREATE TABLE tblfind_ctid (id bigint);
+ERROR:  relation "tblfind_ctid" already exists
+CREATE INDEX idxfind_ctid ON tblfind_ctid USING bm25 (id) WITH (key_field = 'id');
+ERROR:  relation "idxfind_ctid" already exists
+INSERT INTO tblfind_ctid (id) VALUES (1);
+SELECT count(*) FROM paradedb.find_ctid('idxfind_ctid', '(0, 1)');
+ count 
+-------
+     1
+(1 row)
+

--- a/pg_search/tests/pg_regress/expected/find_ctid.out
+++ b/pg_search/tests/pg_regress/expected/find_ctid.out
@@ -1,7 +1,6 @@
+DROP TABLE IF EXISTS tblfind_ctid;
 CREATE TABLE tblfind_ctid (id bigint);
-ERROR:  relation "tblfind_ctid" already exists
 CREATE INDEX idxfind_ctid ON tblfind_ctid USING bm25 (id) WITH (key_field = 'id');
-ERROR:  relation "idxfind_ctid" already exists
 INSERT INTO tblfind_ctid (id) VALUES (1);
 SELECT count(*) FROM paradedb.find_ctid('idxfind_ctid', '(0, 1)');
  count 

--- a/pg_search/tests/pg_regress/sql/find_ctid.sql
+++ b/pg_search/tests/pg_regress/sql/find_ctid.sql
@@ -1,0 +1,4 @@
+CREATE TABLE tblfind_ctid (id bigint);
+CREATE INDEX idxfind_ctid ON tblfind_ctid USING bm25 (id) WITH (key_field = 'id');
+INSERT INTO tblfind_ctid (id) VALUES (1);
+SELECT count(*) FROM paradedb.find_ctid('idxfind_ctid', '(0, 1)');

--- a/pg_search/tests/pg_regress/sql/find_ctid.sql
+++ b/pg_search/tests/pg_regress/sql/find_ctid.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS tblfind_ctid;
 CREATE TABLE tblfind_ctid (id bigint);
 CREATE INDEX idxfind_ctid ON tblfind_ctid USING bm25 (id) WITH (key_field = 'id');
 INSERT INTO tblfind_ctid (id) VALUES (1);


### PR DESCRIPTION
## What

Like the title says, we also need to be able to construct a `SearchField` instance for the postgres "ctid" system column.  This was a minor regression from #2660, because now we only rely on the index's TupleDescriptor to lookup attributes.

## Why

Specifically, the `paradedb.find_ctid()` was broken due to this, which is something used in some stressgres test suites.

## How

## Tests

Yes, yes there's a new one to assert that `paradedb.find_ctid()` works.