### PR TITLE
chore: update tantivy to latest revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "bitpacking",
 ]
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "nom",
 ]
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f#db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=1b9d98ad9c6f37ecaf5543987158dfb49b915fb8#1b9d98ad9c6f37ecaf5543987158dfb49b915fb8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "1b9d98ad9c6f37ecaf5543987158dfb49b915fb8", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "db3a04cb5212c5e799e2d1a6bd98dddf3e3bf00f" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "1b9d98ad9c6f37ecaf5543987158dfb49b915fb8" }


### PR DESCRIPTION
## What

Update our tantivy dependency to https://github.com/paradedb/tantivy/commit/1b9d98ad9c6f37ecaf5543987158dfb49b915fb8 so that we get the benefits of https://github.com/paradedb/tantivy/pull/47

## Why

This removes some bit of overhead during segment merging

## How

## Tests

Existing tests pass, including tantivy's