### PR TITLE
chore: Configure `max_parallel_maintenance_workers` , add tiebreak query to benchmarks

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -83,6 +83,7 @@ jobs:
           sed -i "s/^shared_buffers = .*/shared_buffers = '12GB'/" postgresql.conf
           sed -i "s/^#max_parallel_workers = .*/max_parallel_workers = 8/" postgresql.conf
           sed -i "s/^#max_worker_processes = .*/max_worker_processes = 8/" postgresql.conf
+          sed -i "s/^#max_parallel_maintenance_workers = .*/max_parallel_maintenance_workers = 8/" postgresql.conf
           sed -i "s/^#max_parallel_workers_per_gather = .*/max_parallel_workers_per_gather = 8/" postgresql.conf
 
       - name: Restart Postgres

--- a/benchmarks/datasets/single/queries/pg_search/top_n.sql
+++ b/benchmarks/datasets/single/queries/pg_search/top_n.sql
@@ -2,3 +2,4 @@ SELECT *, paradedb.score(id) FROM benchmark_logs WHERE message @@@ 'research' OR
 SELECT * FROM benchmark_logs WHERE message @@@ 'research' AND country @@@ 'Canada' ORDER BY severity LIMIT 10;
 SELECT * FROM benchmark_logs WHERE message @@@ 'research' AND country @@@ 'Canada' ORDER BY country LIMIT 10;
 SELECT * FROM benchmark_logs WHERE message @@@ 'research' AND country @@@ 'Canada' ORDER BY timestamp LIMIT 10;
+SELECT * FROM benchmark_logs WHERE message @@@ 'research' AND country @@@ 'Canada' ORDER BY severity, timestamp LIMIT 10;

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -147,6 +147,7 @@ fn write_postgres_settings_csv(url: &str, test_type: &str) {
         "max_parallel_workers",
         "max_worker_processes",
         "max_parallel_workers_per_gather",
+        "max_parallel_maintenance_workers",
     ];
 
     for setting in settings {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Some benchmark improvements:

- Set `max_parallel_maintenance_workers` to 8 now that we have parallel index builds
- Add a Top N tiebreak query

## Why

## How

## Tests
