### PR TITLE
docs: Clarify message for enterprise

### DIFF
--- a/docs/deploy/enterprise.mdx
+++ b/docs/deploy/enterprise.mdx
@@ -2,6 +2,13 @@
 title: ParadeDB Enterprise
 ---
 
+<Note>
+  If you're a non-profit or a non-commercial open source project and are
+  interested in ParadeDB Enterprise, please contact [contact
+  sales](mailto:sales@paradedb.com). We provide complimentary access on a
+  case-by-case basis.
+</Note>
+
 ParadeDB ships in two versions: ParadeDB Community and ParadeDB Enterprise.
 
 [ParadeDB Community](https://github.com/paradedb/paradedb) is our open source product, licensed under [AGPL-3.0](https://github.com/paradedb/paradedb/blob/dev/LICENSE).
@@ -36,11 +43,11 @@ For access to ParadeDB Enterprise, please [contact sales](mailto:sales@paradedb.
 | Block storage integration            | ✅                 | ✅                  |
 | Buffer cache integration<sup>2</sup> | ✅                 | ✅                  |
 | **Deployment** <sup>3</sup>          |                    |
+| Maximum cluster size                 | 1                  | Unlimited           |
 | Physical (i.e. WAL) Replication      | ❌                 | ✅                  |
 | Crash Recovery                       | ❌                 | ✅                  |
 | Point in Time Recovery               | ❌                 | ✅                  |
 | Logical Replication                  | ❌                 | ✅                  |
-| CloudNativePG Compatibility          | ❌                 | ✅                  |
 
 <Info>
 **Footnotes**


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Suggested by a user, and I thought it was a good idea. This clarifies that you can't have more than 1 instance under ParadeDB Community, for people not familiar with the implications of no WAL replication, and adds a note for non-profits who might want access to ParadeDB Enterprise.

## Why
^

## How
^

## Tests
N/A