### PR TITLE
fix: Fall back to Postgres when sorting by range field

### DIFF
--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -329,9 +329,8 @@ impl SearchField {
             FieldType::F64(options) => options.is_fast(),
             FieldType::Bool(options) => options.is_fast(),
             FieldType::Date(options) => options.is_fast(),
-            FieldType::JsonObject(options) => {
-                options.is_fast() && matches!(self.field_type, SearchFieldType::Range(_))
-            }
+            // TODO: Neither JSON nor range fields are not yet sortable by us
+            FieldType::JsonObject(_) => false,
             _ => false,
         }
     }

--- a/pg_search/tests/pg_regress/expected/fast_fields_options.out
+++ b/pg_search/tests/pg_regress/expected/fast_fields_options.out
@@ -171,18 +171,18 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on data_records
-         Table: data_records
-         Index: records_no_fast_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: valid_period
-            Sort Direction: asc
-            Top N Limit: 10
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Sort
+         Sort Key: valid_period
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_no_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (10 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -289,18 +289,18 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on data_records
-         Table: data_records
-         Index: records_with_fast_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: valid_period
-            Sort Direction: asc
-            Top N Limit: 10
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Sort
+         Sort Key: valid_period
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_with_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (10 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -407,18 +407,18 @@ FROM data_records
 WHERE title @@@ 'product'
 ORDER BY valid_period
 LIMIT 10;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on data_records
-         Table: data_records
-         Index: records_with_fast_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: valid_period
-            Sort Direction: asc
-            Top N Limit: 10
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+   ->  Sort
+         Sort Key: valid_period
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_with_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
 (10 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/expected/issue_2688.out
+++ b/pg_search/tests/pg_regress/expected/issue_2688.out
@@ -1,0 +1,202 @@
+DROP TABLE IF EXISTS data_records;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE TABLE data_records (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    price NUMERIC,
+    in_stock BOOLEAN,
+    created_at TIMESTAMP,
+    valid_period TSTZRANGE,
+    quantity_range NUMRANGE,
+    tags TEXT[]
+);
+INSERT INTO data_records (title, category, price, in_stock, created_at, valid_period, quantity_range, tags)
+SELECT
+    'Product ' || i,
+    CASE WHEN i % 4 = 0 THEN 'Electronics'
+         WHEN i % 4 = 1 THEN 'Clothing'
+         WHEN i % 4 = 2 THEN 'Books'
+         ELSE 'Home'
+    END,
+    (i * 1000)::numeric(10,2),
+    i % 3 = 0,
+    '2023-01-01'::timestamp + ((i % 365) || ' days')::interval,
+    tstzrange(
+        '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval,
+        '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval + '1 month'::interval
+    ),
+    numrange((i % 10) * 10, (i % 10 + 1) * 10),
+    ARRAY[
+        'tag' || (i % 5),
+        'tag' || (i % 7),
+        'tag' || (i % 3)
+    ]
+FROM generate_series(1, 20) i;
+DROP INDEX IF EXISTS records_no_fast_idx;
+CREATE INDEX records_no_fast_idx ON data_records
+USING bm25 (
+    id, title, category, price, in_stock, created_at, valid_period, quantity_range, tags
+) WITH (
+    key_field = 'id'
+);
+SELECT id, title, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY valid_period
+LIMIT 10;
+ id |   title    |                          valid_period                           
+----+------------+-----------------------------------------------------------------
+  1 | Product 1  | ["Mon Jan 02 00:00:00 2023 PST","Thu Feb 02 00:00:00 2023 PST")
+  2 | Product 2  | ["Tue Jan 03 00:00:00 2023 PST","Fri Feb 03 00:00:00 2023 PST")
+  3 | Product 3  | ["Wed Jan 04 00:00:00 2023 PST","Sat Feb 04 00:00:00 2023 PST")
+  4 | Product 4  | ["Thu Jan 05 00:00:00 2023 PST","Sun Feb 05 00:00:00 2023 PST")
+  5 | Product 5  | ["Fri Jan 06 00:00:00 2023 PST","Mon Feb 06 00:00:00 2023 PST")
+  6 | Product 6  | ["Sat Jan 07 00:00:00 2023 PST","Tue Feb 07 00:00:00 2023 PST")
+  7 | Product 7  | ["Sun Jan 08 00:00:00 2023 PST","Wed Feb 08 00:00:00 2023 PST")
+  8 | Product 8  | ["Mon Jan 09 00:00:00 2023 PST","Thu Feb 09 00:00:00 2023 PST")
+  9 | Product 9  | ["Tue Jan 10 00:00:00 2023 PST","Fri Feb 10 00:00:00 2023 PST")
+ 10 | Product 10 | ["Wed Jan 11 00:00:00 2023 PST","Sat Feb 11 00:00:00 2023 PST")
+(10 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY valid_period
+LIMIT 10;
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: valid_period
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_no_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
+
+SELECT id, title, quantity_range
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range
+LIMIT 10;
+ id |   title    | quantity_range 
+----+------------+----------------
+ 10 | Product 10 | [0,10)
+ 20 | Product 20 | [0,10)
+ 11 | Product 11 | [10,20)
+  1 | Product 1  | [10,20)
+ 12 | Product 12 | [20,30)
+  2 | Product 2  | [20,30)
+  3 | Product 3  | [30,40)
+ 13 | Product 13 | [30,40)
+  4 | Product 4  | [40,50)
+ 14 | Product 14 | [40,50)
+(10 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, quantity_range
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range
+LIMIT 10;
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: quantity_range
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_no_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
+
+SELECT id, title, quantity_range, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range, valid_period
+LIMIT 10;
+ id |   title    | quantity_range |                          valid_period                           
+----+------------+----------------+-----------------------------------------------------------------
+ 10 | Product 10 | [0,10)         | ["Wed Jan 11 00:00:00 2023 PST","Sat Feb 11 00:00:00 2023 PST")
+ 20 | Product 20 | [0,10)         | ["Sat Jan 21 00:00:00 2023 PST","Tue Feb 21 00:00:00 2023 PST")
+  1 | Product 1  | [10,20)        | ["Mon Jan 02 00:00:00 2023 PST","Thu Feb 02 00:00:00 2023 PST")
+ 11 | Product 11 | [10,20)        | ["Thu Jan 12 00:00:00 2023 PST","Sun Feb 12 00:00:00 2023 PST")
+  2 | Product 2  | [20,30)        | ["Tue Jan 03 00:00:00 2023 PST","Fri Feb 03 00:00:00 2023 PST")
+ 12 | Product 12 | [20,30)        | ["Fri Jan 13 00:00:00 2023 PST","Mon Feb 13 00:00:00 2023 PST")
+  3 | Product 3  | [30,40)        | ["Wed Jan 04 00:00:00 2023 PST","Sat Feb 04 00:00:00 2023 PST")
+ 13 | Product 13 | [30,40)        | ["Sat Jan 14 00:00:00 2023 PST","Tue Feb 14 00:00:00 2023 PST")
+  4 | Product 4  | [40,50)        | ["Thu Jan 05 00:00:00 2023 PST","Sun Feb 05 00:00:00 2023 PST")
+ 14 | Product 14 | [40,50)        | ["Sun Jan 15 00:00:00 2023 PST","Wed Feb 15 00:00:00 2023 PST")
+(10 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, quantity_range, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range, valid_period
+LIMIT 10;
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: quantity_range, valid_period
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_no_fast_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
+
+SELECT id, title, price, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY price ASC, valid_period ASC
+LIMIT 10;
+ id |   title    |  price   |                          valid_period                           
+----+------------+----------+-----------------------------------------------------------------
+  1 | Product 1  |  1000.00 | ["Mon Jan 02 00:00:00 2023 PST","Thu Feb 02 00:00:00 2023 PST")
+  2 | Product 2  |  2000.00 | ["Tue Jan 03 00:00:00 2023 PST","Fri Feb 03 00:00:00 2023 PST")
+  3 | Product 3  |  3000.00 | ["Wed Jan 04 00:00:00 2023 PST","Sat Feb 04 00:00:00 2023 PST")
+  4 | Product 4  |  4000.00 | ["Thu Jan 05 00:00:00 2023 PST","Sun Feb 05 00:00:00 2023 PST")
+  5 | Product 5  |  5000.00 | ["Fri Jan 06 00:00:00 2023 PST","Mon Feb 06 00:00:00 2023 PST")
+  6 | Product 6  |  6000.00 | ["Sat Jan 07 00:00:00 2023 PST","Tue Feb 07 00:00:00 2023 PST")
+  7 | Product 7  |  7000.00 | ["Sun Jan 08 00:00:00 2023 PST","Wed Feb 08 00:00:00 2023 PST")
+  8 | Product 8  |  8000.00 | ["Mon Jan 09 00:00:00 2023 PST","Thu Feb 09 00:00:00 2023 PST")
+  9 | Product 9  |  9000.00 | ["Tue Jan 10 00:00:00 2023 PST","Fri Feb 10 00:00:00 2023 PST")
+ 10 | Product 10 | 10000.00 | ["Wed Jan 11 00:00:00 2023 PST","Sat Feb 11 00:00:00 2023 PST")
+(10 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, price, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY price ASC, valid_period ASC
+LIMIT 10;
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: price, valid_period
+         Presorted Key: price
+         ->  Custom Scan (ParadeDB Scan) on data_records
+               Table: data_records
+               Index: records_no_fast_idx
+               Exec Method: TopNScanExecState
+               Scores: false
+                  Sort Field: price
+                  Sort Direction: asc
+                  Top N Limit: 10
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"product","lenient":null,"conjunction_mode":null}}}}
+(13 rows)
+
+DROP TABLE data_records;

--- a/pg_search/tests/pg_regress/expected/top_n_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_n_scan.out
@@ -138,18 +138,18 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.all())
 ORDER BY time_period DESC
 LIMIT 25;
-                                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on records
-         Table: records
-         Index: records_search_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: time_period
-            Sort Direction: desc
-            Top N Limit: 25
-         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
+   ->  Sort
+         Sort Key: time_period DESC
+         ->  Custom Scan (ParadeDB Scan) on records
+               Table: records
+               Index: records_search_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 25
+               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (10 rows)
 
 -- Test 3: Same query without paradedb.all() operator
@@ -166,18 +166,18 @@ WHERE tenant_id = 'tenant-1'
   AND (NOT id @@@ paradedb.exists('removed_at'))
 ORDER BY time_period DESC
 LIMIT 25;
-                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on records
-         Table: records
-         Index: records_search_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: time_period
-            Sort Direction: desc
-            Top N Limit: 25
-         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
+   ->  Sort
+         Sort Key: time_period DESC
+         ->  Custom Scan (ParadeDB Scan) on records
+               Table: records
+               Index: records_search_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 25
+               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (10 rows)
 
 -- Test 4: Testing the impact of paradedb.all() alone
@@ -260,18 +260,18 @@ WHERE tenant_id = 'tenant-1'
   AND id @@@ paradedb.match('notes', 'check')
 ORDER BY time_period DESC
 LIMIT 25;
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on records
-         Table: records
-         Index: records_search_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: time_period
-            Sort Direction: desc
-            Top N Limit: 25
-         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
+   ->  Sort
+         Sort Key: time_period DESC
+         ->  Custom Scan (ParadeDB Scan) on records
+               Table: records
+               Index: records_search_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 25
+               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (10 rows)
 
 -- Test 8: Testing with each complex component isolated
@@ -317,18 +317,18 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.all())
 ORDER BY time_period DESC
 LIMIT 25;
-                                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on records
-         Table: records
-         Index: records_search_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: time_period
-            Sort Direction: desc
-            Top N Limit: 25
-         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
+   ->  Sort
+         Sort Key: time_period DESC
+         ->  Custom Scan (ParadeDB Scan) on records
+               Table: records
+               Index: records_search_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 25
+               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"source_id","query_string":"IN [source-1 source-2 source-3]","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":{"type":"ngram","max_gram":3,"min_gram":3,"lowercase":true,"prefix_only":false,"remove_long":255},"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"exists":{"field":"removed_at"}}}}]}},{"with_index":{"query":"all"}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (10 rows)
 
 -- Test 10: Fast-field only solution - selecting only indexed fast fields
@@ -342,18 +342,18 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.match('notes', 'check'))
 ORDER BY time_period DESC
 LIMIT 25;
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on records
-         Table: records
-         Index: records_search_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: time_period
-            Sort Direction: desc
-            Top N Limit: 25
-         Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
+   ->  Sort
+         Sort Key: time_period DESC
+         ->  Custom Scan (ParadeDB Scan) on records
+               Table: records
+               Index: records_search_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+                  Top N Limit: 25
+               Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (10 rows)
 
 -- Cleanup

--- a/pg_search/tests/pg_regress/sql/issue_2688.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2688.sql
@@ -1,0 +1,99 @@
+DROP TABLE IF EXISTS data_records;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CREATE TABLE data_records (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    price NUMERIC,
+    in_stock BOOLEAN,
+    created_at TIMESTAMP,
+    valid_period TSTZRANGE,
+    quantity_range NUMRANGE,
+    tags TEXT[]
+);
+
+INSERT INTO data_records (title, category, price, in_stock, created_at, valid_period, quantity_range, tags)
+SELECT
+    'Product ' || i,
+    CASE WHEN i % 4 = 0 THEN 'Electronics'
+         WHEN i % 4 = 1 THEN 'Clothing'
+         WHEN i % 4 = 2 THEN 'Books'
+         ELSE 'Home'
+    END,
+    (i * 1000)::numeric(10,2),
+    i % 3 = 0,
+    '2023-01-01'::timestamp + ((i % 365) || ' days')::interval,
+    tstzrange(
+        '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval,
+        '2023-01-01'::timestamptz + ((i % 365) || ' days')::interval + '1 month'::interval
+    ),
+    numrange((i % 10) * 10, (i % 10 + 1) * 10),
+    ARRAY[
+        'tag' || (i % 5),
+        'tag' || (i % 7),
+        'tag' || (i % 3)
+    ]
+FROM generate_series(1, 20) i;
+
+DROP INDEX IF EXISTS records_no_fast_idx;
+CREATE INDEX records_no_fast_idx ON data_records
+USING bm25 (
+    id, title, category, price, in_stock, created_at, valid_period, quantity_range, tags
+) WITH (
+    key_field = 'id'
+);
+
+SELECT id, title, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY valid_period
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY valid_period
+LIMIT 10;
+
+SELECT id, title, quantity_range
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, quantity_range
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range
+LIMIT 10;
+
+SELECT id, title, quantity_range, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range, valid_period
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, quantity_range, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY quantity_range, valid_period
+LIMIT 10;
+
+SELECT id, title, price, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY price ASC, valid_period ASC
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, title, price, valid_period
+FROM data_records
+WHERE title @@@ 'product'
+ORDER BY price ASC, valid_period ASC
+LIMIT 10;
+
+DROP TABLE data_records;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes (partially) #2688 

## What

`is_sortable` was erroneously emitting `true` when the field was a range field -- we have not implemented support for this so it should return `false`.

## Why

## How

## Tests
