### PR TITLE
fix: Allow UUID columns to be used in fast field execution

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -227,6 +227,7 @@ fn collect_fast_field_try_for_attno(
                     if search_field.is_fast() {
                         let ff_type = if att.type_oid().value() == pg_sys::TEXTOID
                             || att.type_oid().value() == pg_sys::VARCHAROID
+                            || att.type_oid().value() == pg_sys::UUIDOID
                         {
                             FastFieldType::String
                         } else {

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -607,7 +607,7 @@ fn key_field_config(field_type: &SearchFieldType) -> SearchFieldConfig {
                 fast: true,
             }
         }
-        SearchFieldType::Text(_) => SearchFieldConfig::Text {
+        SearchFieldType::Text(_) | SearchFieldType::Uuid(_) => SearchFieldConfig::Text {
             indexed: true,
             fast: true,
             fieldnorms: false,
@@ -621,7 +621,6 @@ fn key_field_config(field_type: &SearchFieldType) -> SearchFieldConfig {
             normalizer: SearchNormalizer::Raw,
             column: None,
         },
-        SearchFieldType::Uuid(_) => SearchFieldConfig::default_uuid(),
         SearchFieldType::Json(_) => SearchFieldConfig::Json {
             indexed: true,
             fast: true,

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
@@ -55,7 +55,12 @@ SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
 
 -- And that non-key UUID fields do too.
 SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
-ERROR:  Unrecognized numeric fast field type for: uuid
+ name 
+------
+ bob
+ bob
+(2 rows)
+
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
                                                                     QUERY PLAN                                                                     
@@ -67,11 +72,10 @@ SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
          Index: idxproducts
          Exec Method: MixedFastFieldExecState
          Fast Fields: name, uuid
-         String Fast Fields: name
-         Numeric Fast Fields: uuid
+         String Fast Fields: name, uuid
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 \i common/common_cleanup.sql
 -- Reset parallel workers setting to default

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
@@ -48,10 +48,12 @@ SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
    ->  Custom Scan (ParadeDB Scan) on products
          Table: products
          Index: idxproducts
-         Exec Method: NormalScanExecState
+         Exec Method: MixedFastFieldExecState
+         Fast Fields: name, uuid_key
+         String Fast Fields: name, uuid_key
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+(10 rows)
 
 -- And that non-key UUID fields do too.
 SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
@@ -1,0 +1,86 @@
+-- Tests that MixedFF is used for UUIDs in the key field or in other fields.
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+\echo 'Test: Mixed field types in the same query'
+Test: Mixed field types in the same query
+DROP TABLE IF EXISTS products CASCADE;
+CREATE TABLE products
+(
+    uuid_key  UUID NOT NULL PRIMARY KEY,
+    uuid  UUID NOT NULL,
+    name  TEXT
+);
+INSERT into products
+    (uuid_key, uuid, name)
+VALUES
+    (gen_random_uuid(), gen_random_uuid(), 'alice'),
+    (gen_random_uuid(), gen_random_uuid(), 'bob'),
+    (gen_random_uuid(), gen_random_uuid(), 'bob'),
+    (gen_random_uuid(), gen_random_uuid(), 'cloe'),
+    (gen_random_uuid(), gen_random_uuid(), 'sally');
+CREATE INDEX idxproducts ON products USING bm25 (uuid_key, uuid, name)
+WITH (
+    key_field = 'uuid_key',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }'
+);
+WARNING:  the `raw` tokenizer is deprecated
+-- Confirm that the UUID key_field is fast and gets MixedFF.
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
+ name 
+------
+ bob
+ bob
+(2 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: uuid_key
+   ->  Custom Scan (ParadeDB Scan) on products
+         Table: products
+         Index: idxproducts
+         Exec Method: NormalScanExecState
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
+-- And that non-key UUID fields do too.
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
+ERROR:  Unrecognized numeric fast field type for: uuid
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: uuid
+   ->  Custom Scan (ParadeDB Scan) on products
+         Table: products
+         Index: idxproducts
+         Exec Method: MixedFastFieldExecState
+         Fast Fields: name, uuid
+         String Fast Fields: name
+         Numeric Fast Fields: uuid
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_mixed_fast_field_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/mixedff_basic_05_uuid.sql
+++ b/pg_search/tests/pg_regress/sql/mixedff_basic_05_uuid.sql
@@ -1,0 +1,45 @@
+-- Tests that MixedFF is used for UUIDs in the key field or in other fields.
+
+\i common/common_setup.sql
+
+\echo 'Test: Mixed field types in the same query'
+
+DROP TABLE IF EXISTS products CASCADE;
+CREATE TABLE products
+(
+    uuid_key  UUID NOT NULL PRIMARY KEY,
+    uuid  UUID NOT NULL,
+    name  TEXT
+);
+
+INSERT into products
+    (uuid_key, uuid, name)
+VALUES
+    (gen_random_uuid(), gen_random_uuid(), 'alice'),
+    (gen_random_uuid(), gen_random_uuid(), 'bob'),
+    (gen_random_uuid(), gen_random_uuid(), 'bob'),
+    (gen_random_uuid(), gen_random_uuid(), 'cloe'),
+    (gen_random_uuid(), gen_random_uuid(), 'sally');
+
+CREATE INDEX idxproducts ON products USING bm25 (uuid_key, uuid, name)
+WITH (
+    key_field = 'uuid_key',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }'
+);
+
+-- Confirm that the UUID key_field is fast and gets MixedFF.
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
+
+-- And that non-key UUID fields do too.
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
+
+\i common/common_cleanup.sql


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2703

## What

As described in #2703, UUID columns which are indexed as `fast` are incorrectly interpreted as numeric fast fields during `collect_fast_fields`. This fails at execution time for `Mixed` and `String` fast field execution modes.

Relatedly: a `UUID` `key_field` was not correctly being configured as `fast` at index creation time, meaning that scans using it would not use the fast field execution methods.

## Why

To fix the crash described on #2703, and to allow fast-field execution to be used in more cases.

## How

In two commits:
1. fix the `FastFieldType` which is extracted for a UUID
2. fix the `key_field` configuration that is used for a UUID

The latter change is backwards compatible, but gaining the advantage of the fast UUID field will require a reindex.

## Tests

Added a repro test which now shows `Mixed` execution used for both a `key_field` UUID, and a normal UUID field.

Regarding backwards compatibility: I manually created the table/index from the regression test (which has both a UUID `key_field` and a fast non-`key` UUID field) before this commit, and then upgraded to this commit. I confirmed that the `key_field` schema was [unchanged before/after the upgrade](https://gist.github.com/stuhood/cdf0976909f888645c0269c748392858), confirming that its schema was persisted. To actually get the benefit of a `fast` `key_field` for a UUID column, users will need to reindex, but the other bug fix in this change will take effect without a reindex.