### PR TITLE
chore: suffix process title in `ps`/`top` during parallel index build

### DIFF
--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -30,6 +30,7 @@ mod delete;
 pub mod expression;
 pub mod insert;
 pub mod options;
+mod ps_status;
 mod range;
 mod scan;
 mod vacuum;

--- a/pg_search/src/postgres/ps_status.rs
+++ b/pg_search/src/postgres/ps_status.rs
@@ -1,0 +1,34 @@
+use pgrx::pg_sys;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+pub const INDEXING: &CStr = c"indexing";
+pub const MERGING: &CStr = c"merging";
+
+pub unsafe fn set_ps_display_suffix(suffix: *const c_char) {
+    #[cfg(any(feature = "pg16", feature = "pg17"))]
+    pg_sys::ffi::pg_guard_ffi_boundary(|| {
+        extern "C-unwind" {
+            pub fn set_ps_display_suffix(suffix: *const c_char);
+        }
+        set_ps_display_suffix(suffix);
+    });
+
+    #[cfg(any(feature = "pg14", feature = "pg15"))]
+    pg_sys::ffi::pg_guard_ffi_boundary(|| {
+        extern "C-unwind" {
+            pub fn set_ps_display(suffix: *const c_char);
+        }
+        set_ps_display(suffix);
+    });
+}
+
+pub unsafe fn set_ps_display_remove_suffix() {
+    #[cfg(any(feature = "pg16", feature = "pg17"))]
+    pg_sys::ffi::pg_guard_ffi_boundary(|| {
+        extern "C-unwind" {
+            pub fn set_ps_display_remove_suffix();
+        }
+        set_ps_display_remove_suffix();
+    });
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Suffixes the title of a process with either "writing" or "merging" during parallel index build, so that `ps`/`top` can see what each worker is doing.

## Why

## How

## Tests
