### PR TITLE
fix: make incorrect configs not error

### DIFF
--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -27,7 +27,8 @@ use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{SearchNormalizer, SearchTokenizer};
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+// TODO: re-enable this once we are okay with a breaking change
+// #[serde(deny_unknown_fields)]
 pub enum SearchFieldConfig {
     Text {
         #[serde(default = "default_as_true")]

--- a/pg_search/tests/pg_regress/expected/misconfigured_configs.out
+++ b/pg_search/tests/pg_regress/expected/misconfigured_configs.out
@@ -1,0 +1,18 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+WITH (key_field='id', text_fields='{"description": {"unknown": "value", "tokenizer": {"type": "keyword"}}}');
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@ paradedb.term('description', 'Sleek running shoes')
+LIMIT 5;
+     description     | rating | category 
+---------------------+--------+----------
+ Sleek running shoes |      5 | Footwear
+(1 row)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/misconfigured_configs.sql
+++ b/pg_search/tests/pg_regress/sql/misconfigured_configs.sql
@@ -1,0 +1,17 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+WITH (key_field='id', text_fields='{"description": {"unknown": "value", "tokenizer": {"type": "keyword"}}}');
+
+SELECT description, rating, category
+FROM mock_items
+WHERE id @@@ paradedb.term('description', 'Sleek running shoes')
+LIMIT 5;
+
+DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In #2660 I made serde throw an error for invalid index configs. While this was an improvement for new indexes it unintenionally broke existing indexes. This PR reverts that change until we're ready for a breaking release.

## Why

## How

## Tests
Added a regression test