### PR TITLE
perf: Batch field lookups in MVCC-aware aggregates

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -235,7 +235,7 @@ impl FFType {
 
     /// Given [`DocId`]s, what are their u64 "fast field" values?
     ///
-    /// The given `output` sluce must be the same length as the docs slice.
+    /// The given `output` slice must be the same length as the docs slice.
     #[inline(always)]
     pub fn as_u64s(&self, docs: &[DocId], output: &mut [Option<u64>]) {
         let FFType::U64(ff) = self else {

--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -232,6 +232,17 @@ impl FFType {
             None
         }
     }
+
+    /// Given [`DocId`]s, what are their u64 "fast field" values?
+    ///
+    /// The given `output` sluce must be the same length as the docs slice.
+    #[inline(always)]
+    pub fn as_u64s(&self, docs: &[DocId], output: &mut [Option<u64>]) {
+        let FFType::U64(ff) = self else {
+            panic!("Expected a u64 column.");
+        };
+        ff.first_vals(docs, output);
+    }
 }
 
 #[derive(Debug, Clone, Ord, Eq, PartialOrd, PartialEq, Serialize, Deserialize, Hash)]


### PR DESCRIPTION
## What

Use batch lookups for the `ctid` in aggregates, and re-use buffers.

## Why

Although fast fields do not have optimized decoding for batch lookups, they do have a small amount of loop unrolling for batch lookups via the [`first_vals` and `get_vals_opt` methods](https://github.com/paradedb/tantivy/blob/3ffaeb8e0c44e07e03a5d27423eee843bf87a0bc/columnar/src/column_values/mod.rs#L84-L109).

## Tests

Adjustments to the benchmark suite to use `paradedb.aggregate` show a 5% to 20% performance improvement for MVCC-aware aggregates.