### PR TITLE
fix: writer doesn't crash on abort

### DIFF
--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -144,7 +144,10 @@ struct ExactBuffer<const CAPACITY: usize, W: Write> {
 
 impl<const CAPACITY: usize, W: Write> Drop for ExactBuffer<CAPACITY, W> {
     fn drop(&mut self) {
-        self.flush().ok();
+        // self.flush() creates buffers -- don't do this if we are not in a transaction i.e. have aborted
+        if unsafe { pg_sys::IsTransactionState() } {
+            self.flush().ok();
+        }
     }
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

All credit to @stuhood for diagnosing the problem!

We had a problem where aborting during an insert would trip up a Postgres assert that a lock was being held on a buffer whose locks should have been freed.

## Why

## How

## Tests
