### PR TITLE
chore: stabilize regression output

### DIFF
--- a/pg_search/tests/pg_regress/expected/parallel_build_large.out
+++ b/pg_search/tests/pg_regress/expected/parallel_build_large.out
@@ -9,7 +9,6 @@ INSERT INTO parallel_build_large (name)
 SELECT 'lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 FROM generate_series(1, 35000);
 SET max_parallel_workers = 8;
-SET client_min_messages TO INFO;
 -- This should return a "not enough memory" error
 SET maintenance_work_mem = '64MB';
 SET max_parallel_maintenance_workers = 8;
@@ -42,11 +41,15 @@ BEGIN
 
                     CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id');
 
-                    -- Check index info and display results
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_large_idx');
+                    IF ts = 4 THEN
+                        ASSERT count_val = 4, format('Expected index info count to be 4, but got %s', count_val);
+                    ELSIF ts = 32 THEN
+                        ASSERT count_val BETWEEN 28 AND 32, format('Expected index info count to be between 28 and 32, but got %s', count_val);
+                    END IF;
+
                     SELECT SUM(num_docs) INTO num_docs_val FROM paradedb.index_info('parallel_build_large_idx');
-                    RAISE INFO 'Config: workers=%, work_mem=%,leader_participation=%, segments=%-> Count: %, Num Docs: %',
-                        mw, mwm,lp, ts, count_val, num_docs_val;
+                    ASSERT num_docs_val = 35000, format('Expected num_docs to be 35000, but got %s', num_docs_val);
 
                     DROP INDEX parallel_build_large_idx;
                 END LOOP;
@@ -54,29 +57,13 @@ BEGIN
         END LOOP;
     END LOOP;
 END $$;
-INFO:  Config: workers=6, work_mem=2GB,leader_participation=t, segments=4-> Count: 4, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=128MB,leader_participation=t, segments=4-> Count: 4, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=2GB,leader_participation=t, segments=32-> Count: 32, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=128MB,leader_participation=t, segments=32-> Count: 32, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=2GB,leader_participation=f, segments=4-> Count: 4, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=128MB,leader_participation=f, segments=4-> Count: 4, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=2GB,leader_participation=f, segments=32-> Count: 32, Num Docs: 35000
-INFO:  Config: workers=6, work_mem=128MB,leader_participation=f, segments=32-> Count: 32, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=2GB,leader_participation=t, segments=4-> Count: 4, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=128MB,leader_participation=t, segments=4-> Count: 4, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=2GB,leader_participation=t, segments=32-> Count: 32, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=128MB,leader_participation=t, segments=32-> Count: 32, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=2GB,leader_participation=f, segments=4-> Count: 4, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=128MB,leader_participation=f, segments=4-> Count: 4, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=2GB,leader_participation=f, segments=32-> Count: 32, Num Docs: 35000
 WARNING:  only 2 parallel workers were available for index build
-INFO:  Config: workers=2, work_mem=128MB,leader_participation=f, segments=32-> Count: 32, Num Docs: 35000
 \i common/parallel_build_large_cleanup.sql
 DROP TABLE IF EXISTS parallel_build_large;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In CI, the parallel build regression test can sometimes create one or two segments fewer than the target. So loosen our constraints around that.

## Why

## How

## Tests
