### PR TITLE
chore: cleanup around `SearchIndexSchema::open()`

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -189,10 +189,6 @@ impl MVCCDirectory {
     pub(crate) fn all_entries(&self) -> HashMap<SegmentId, SegmentMetaEntry> {
         self.all_entries.lock().clone()
     }
-
-    pub(crate) fn indexrel(&self) -> &PgSearchRelation {
-        &self.indexrel
-    }
 }
 
 impl Directory for MVCCDirectory {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -259,8 +259,8 @@ impl SearchIndexReader {
 
         let directory = mvcc_style.directory(index_relation);
         let mut index = Index::open(directory)?;
-        let schema = SearchIndexSchema::open(index_relation)?;
-        setup_tokenizers(index_relation, &mut index)?;
+        let schema = SearchIndexSchema::from_index(index_relation, &index);
+        setup_tokenizers(index_relation, &mut index, &schema)?;
 
         let reader = index
             .reader_builder()

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -30,7 +30,7 @@ pub fn setup_tokenizers(
     schema: &SearchIndexSchema,
 ) -> Result<()> {
     let options = unsafe { SearchIndexOptions::from_relation(index_relation) };
-    let categorized_fields = categorize_fields(index_relation, &schema);
+    let categorized_fields = categorize_fields(index_relation, schema);
 
     let mut tokenizers: Vec<SearchTokenizer> = Vec::new();
     for (search_field, _) in categorized_fields {

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -24,9 +24,12 @@ use anyhow::Result;
 use tantivy::Index;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager, SearchTokenizer};
 
-pub fn setup_tokenizers(index_relation: &PgSearchRelation, index: &mut Index) -> Result<()> {
+pub fn setup_tokenizers(
+    index_relation: &PgSearchRelation,
+    index: &mut Index,
+    schema: &SearchIndexSchema,
+) -> Result<()> {
     let options = unsafe { SearchIndexOptions::from_relation(index_relation) };
-    let schema = SearchIndexSchema::open(index_relation)?;
     let categorized_fields = categorize_fields(index_relation, &schema);
 
     let mut tokenizers: Vec<SearchTokenizer> = Vec::new();

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -39,9 +39,14 @@ struct PendingSegment {
 }
 
 impl PendingSegment {
-    fn new(directory: MVCCDirectory, memory_budget: NonZeroUsize) -> Result<Self> {
-        let mut index = Index::open(directory.clone())?;
-        setup_tokenizers(directory.indexrel(), &mut index)?;
+    fn new(
+        indexrel: &PgSearchRelation,
+        directory: MVCCDirectory,
+        schema: &SearchIndexSchema,
+        memory_budget: NonZeroUsize,
+    ) -> Result<Self> {
+        let mut index = Index::open(directory)?;
+        setup_tokenizers(indexrel, &mut index, schema)?;
 
         let segment = index.new_segment();
         let writer = SegmentWriter::for_segment(memory_budget.into(), segment.clone())?;
@@ -111,6 +116,7 @@ pub struct SerialIndexWriter {
     directory: MVCCDirectory,
     pending_segment: Option<PendingSegment>,
     new_metas: Vec<SegmentMeta>,
+    schema: SearchIndexSchema,
 }
 
 impl SerialIndexWriter {
@@ -143,7 +149,7 @@ impl SerialIndexWriter {
         let directory = mvcc_satisfies.clone().directory(index_relation);
         let mut index = Index::open(directory.clone())?;
         let schema = SearchIndexSchema::open(index_relation)?;
-        setup_tokenizers(index_relation, &mut index)?;
+        setup_tokenizers(index_relation, &mut index, &schema)?;
         let ctid_field = schema.ctid_field();
 
         Ok(Self {
@@ -155,7 +161,12 @@ impl SerialIndexWriter {
             directory,
             pending_segment: Default::default(),
             new_metas: Default::default(),
+            schema,
         })
+    }
+
+    pub fn schema(&self) -> &SearchIndexSchema {
+        &self.schema
     }
 
     pub fn insert(
@@ -219,7 +230,12 @@ impl SerialIndexWriter {
     ///
     /// Otherwise, we create a MVCCDirectory-backed segment.
     fn new_segment(&mut self) -> Result<PendingSegment> {
-        PendingSegment::new(self.directory.clone(), self.config.memory_budget)
+        PendingSegment::new(
+            &self.indexrel,
+            self.directory.clone(),
+            &self.schema,
+            self.config.memory_budget,
+        )
     }
 
     /// Once the memory budget is reached, we "finalize" the segment:
@@ -403,7 +419,7 @@ mod tests {
         let index_relation = PgSearchRelation::open(relation_oid);
         let mut writer =
             SerialIndexWriter::open(&index_relation, config, Default::default()).unwrap();
-        let schema = SearchIndexSchema::open(&index_relation).unwrap();
+        let schema = writer.schema();
         let ctid_field = schema.ctid_field();
         let text_field = schema.search_field("data").unwrap().field();
         let mut segment_ids = HashSet::default();

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -395,7 +395,6 @@ mod tests {
     use super::*;
     use crate::api::HashSet;
     use crate::postgres::rel::PgSearchRelation;
-    use crate::schema::SearchIndexSchema;
     use pgrx::prelude::*;
     use std::num::NonZeroUsize;
 

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -35,7 +35,7 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::spinlock::Spinlock;
 use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::utils::{categorize_fields, row_to_search_document, CategorizedFieldData};
-use crate::schema::{SearchField, SearchIndexSchema};
+use crate::schema::SearchField;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{
     check_for_interrupts, function_name, pg_guard, pg_sys, PgLogLevel, PgMemoryContexts,
@@ -322,7 +322,7 @@ impl WorkerBuildState {
             max_docs_per_segment,
         };
         let writer = SerialIndexWriter::open(indexrel, config, worker_number)?;
-        let schema = SearchIndexSchema::open(indexrel)?;
+        let schema = writer.schema();
         let categorized_fields = categorize_fields(indexrel, &schema);
         let key_field_name = schema.key_field().field_name();
         Ok(Self {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -323,7 +323,7 @@ impl WorkerBuildState {
         };
         let writer = SerialIndexWriter::open(indexrel, config, worker_number)?;
         let schema = writer.schema();
-        let categorized_fields = categorize_fields(indexrel, &schema);
+        let categorized_fields = categorize_fields(indexrel, schema);
         let key_field_name = schema.key_field().field_name();
         Ok(Self {
             writer: Some(writer),

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -58,7 +58,7 @@ impl InsertState {
             Default::default(),
         )?;
         let schema = writer.schema();
-        let categorized_fields = categorize_fields(indexrel, &schema);
+        let categorized_fields = categorize_fields(indexrel, schema);
         let key_field_name = schema.key_field().field_name();
 
         let per_row_context = pg_sys::AllocSetContextCreateExtended(

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -31,7 +31,7 @@ use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use crate::postgres::utils::{
     categorize_fields, item_pointer_to_u64, row_to_search_document, CategorizedFieldData,
 };
-use crate::schema::{SearchField, SearchIndexSchema};
+use crate::schema::SearchField;
 use pgrx::{check_for_interrupts, pg_guard, pg_sys, PgMemoryContexts};
 use std::panic::{catch_unwind, resume_unwind};
 use tantivy::{SegmentMeta, TantivyDocument};
@@ -57,7 +57,7 @@ impl InsertState {
             config,
             Default::default(),
         )?;
-        let schema = SearchIndexSchema::open(indexrel)?;
+        let schema = writer.schema();
         let categorized_fields = categorize_fields(indexrel, &schema);
         let key_field_name = schema.key_field().field_name();
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -156,10 +156,7 @@ impl SearchIndexSchema {
     pub fn open(indexrel: &PgSearchRelation) -> Result<Self> {
         let directory = MVCCDirectory::snapshot(indexrel);
         let index = Index::open(directory)?;
-        Ok(Self {
-            schema: index.schema(),
-            relation_oid: indexrel.oid(),
-        })
+        Ok(Self::from_index(indexrel, &index))
     }
 
     pub fn ctid_field(&self) -> Field {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -146,12 +146,18 @@ pub struct SearchIndexSchema {
 }
 
 impl SearchIndexSchema {
+    pub fn from_index(indexrel: &PgSearchRelation, index: &Index) -> Self {
+        Self {
+            schema: index.schema(),
+            relation_oid: indexrel.oid(),
+        }
+    }
+
     pub fn open(indexrel: &PgSearchRelation) -> Result<Self> {
         let directory = MVCCDirectory::snapshot(indexrel);
         let index = Index::open(directory)?;
-        let schema = index.schema().clone();
         Ok(Self {
-            schema,
+            schema: index.schema(),
             relation_oid: indexrel.oid(),
         })
     }


### PR DESCRIPTION
## What

In nearly every case we have enough information to construct a `SearchIndexSchema` without also needing to instantiate a `MVCCDirectory` and a tantivy `Index`.

Invent a new function, `SearchIndexSchema::from_index()` to require the caller to pass the necessary information and update all the old compatible `SearchIndexSchema::open()` call points.

## Why

General code cleanup and also removes overhead of opening an Index and MVCCDirectory when we already have them.

## How

## Tests
