### PR TITLE
perf: allow our index to support parallel vacuum

### DIFF
--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -113,6 +113,7 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     amroutine.aminitparallelscan = Some(parallel::aminitparallelscan);
     amroutine.amestimateparallelscan = Some(parallel::amestimateparallelscan);
     amroutine.amparallelrescan = Some(parallel::amparallelrescan);
+    amroutine.amparallelvacuumoptions = pg_sys::VACUUM_OPTION_PARALLEL_BULKDEL as _;
 
     amroutine.into_pg_boxed()
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Per Postgres docs: when there are more than 2 indexes on a table, and the indexes support parallel workers, at most one parallel worker can be dedicated to vacuuming each index.

## Why

## How

## Tests
