### PR TITLE
fix: `keyword` text fields should always be fast

### DIFF
--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -96,12 +96,21 @@ pub enum SearchFieldConfig {
 
 impl SearchFieldConfig {
     pub fn text_from_json(value: serde_json::Value) -> Result<Self> {
-        let config: Self = serde_json::from_value(json!({
+        let mut config: Self = serde_json::from_value(json!({
             "Text": value
         }))?;
 
         match config {
-            SearchFieldConfig::Text { .. } => Ok(config),
+            SearchFieldConfig::Text {
+                ref tokenizer,
+                ref mut fast,
+                ..
+            } => {
+                if matches!(tokenizer, SearchTokenizer::Keyword) {
+                    *fast = true;
+                }
+                Ok(config)
+            }
             _ => Err(anyhow::anyhow!("Expected Text configuration")),
         }
     }
@@ -113,7 +122,7 @@ impl SearchFieldConfig {
 
         match config {
             SearchFieldConfig::Inet { .. } => Ok(config),
-            _ => Err(anyhow::anyhow!("Expected Text configuration")),
+            _ => Err(anyhow::anyhow!("Expected Inet configuration")),
         }
     }
 

--- a/pg_search/tests/pg_regress/expected/keyword_defaults_fast.out
+++ b/pg_search/tests/pg_regress/expected/keyword_defaults_fast.out
@@ -1,0 +1,38 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "keyword"}}}');
+SELECT * FROM paradedb.schema('search_idx');
+     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots |                         tokenizer                         |  record  | normalizer 
+--------------+------------+--------+---------+------+------------+-------------+-----------------------------------------------------------+----------+------------
+ category     | Str        | f      | t       | f    | t          |             | default                                                   | position | 
+ created_at   | Date       | f      | t       | t    | f          |             |                                                           |          | 
+ ctid         | U64        | f      | t       | t    | f          |             |                                                           |          | 
+ description  | Str        | f      | t       | t    | t          |             | keyword[remove_long=18446744073709551615,lowercase=false] | position | raw
+ id           | I64        | f      | t       | t    | f          |             |                                                           |          | 
+ in_stock     | Bool       | f      | t       | t    | f          |             |                                                           |          | 
+ metadata     | JsonObject | f      | t       | f    | f          | t           | default                                                   | position | 
+ rating       | I64        | f      | t       | t    | f          |             |                                                           |          | 
+ weight_range | JsonObject | f      | t       | t    | f          | t           | default                                                   | position | raw
+(9 rows)
+
+SELECT * FROM mock_items WHERE id @@@ paradedb.exists('description') ORDER BY id LIMIT 5;
+ id |       description        | rating |  category   | in_stock |                     metadata                     |        created_at        | last_updated_date | latest_available_time | weight_range 
+----+--------------------------+--------+-------------+----------+--------------------------------------------------+--------------------------+-------------------+-----------------------+--------------
+  1 | Ergonomic metal keyboard |      4 | Electronics | t        | {"color": "Silver", "location": "United States"} | Mon May 01 09:12:34 2023 | 05-03-2023        | 09:12:34              | [1,10)
+  2 | Plastic Keyboard         |      4 | Electronics | f        | {"color": "Black", "location": "Canada"}         | Sat Apr 15 13:27:09 2023 | 04-16-2023        | 13:27:09              | (,10)
+  3 | Sleek running shoes      |      5 | Footwear    | t        | {"color": "Blue", "location": "China"}           | Fri Apr 28 10:55:43 2023 | 04-29-2023        | 10:55:43              | [2,10)
+  4 | White jogging shoes      |      3 | Footwear    | f        | {"color": "White", "location": "United States"}  | Thu Apr 20 16:38:02 2023 | 04-22-2023        | 16:38:02              | (,11)
+  5 | Generic shoes            |      4 | Footwear    | t        | {"color": "Brown", "location": "Canada"}         | Tue May 02 08:45:11 2023 | 05-03-2023        | 08:45:11              | [3,)
+(5 rows)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/keyword_defaults_fast.sql
+++ b/pg_search/tests/pg_regress/sql/keyword_defaults_fast.sql
@@ -1,0 +1,15 @@
+\i common/common_setup.sql
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "keyword"}}}');
+
+SELECT * FROM paradedb.schema('search_idx');
+SELECT * FROM mock_items WHERE id @@@ paradedb.exists('description') ORDER BY id LIMIT 5;
+
+DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In order for `<>` predicates over text fields to be pushed down to our index, the text field must be "keyword" tokenized AND fast. This means that if a field is "keyword" tokenized we should just make it fast by default.

## Why

## How

## Tests
