### PR TITLE
feat: add `target_segment_count` as an index `WITH` option

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,7 @@
                               "documentation/configuration/overview",
                               "documentation/configuration/index",
                               "documentation/configuration/index_size",
+                              "documentation/configuration/segment_count",
                               "documentation/configuration/segment_size",
                               "documentation/configuration/write",
                               "documentation/configuration/parallel"

--- a/docs/documentation/configuration/index.mdx
+++ b/docs/documentation/configuration/index.mdx
@@ -22,16 +22,3 @@ SET max_parallel_maintenance_workers = 8;
 ```
 
 In order for `max_parallel_maintenance_workers` to take effect, it must be less than or equal to both `max_parallel_workers` and `max_worker_processes`.
-
-### Target Segment Count
-
-By default, `CREATE INDEX`/`REINDEX` will create as many segments as there are CPUs on the host machine. This can be changed with
-`paradedb.target_segment_count`.
-
-For optimal performance, the segment count should equal the number of parallel workers that a query can receive, which is controlled by
-[`max_parallel_workers_per_gather`](/documentation/configuration/parallel#parallel-workers). If `max_parallel_workers_per_gather` is greater than the number of CPUs on the host machine, then increasing the target segment count to match `max_parallel_workers_per_gather` can improve query
-performance.
-
-```sql
-SET paradedb.target_segment_count = 32;
-```

--- a/docs/documentation/configuration/segment_count.mdx
+++ b/docs/documentation/configuration/segment_count.mdx
@@ -1,0 +1,33 @@
+---
+title: Segment Count
+---
+
+By default, `CREATE INDEX`/`REINDEX` will create as many segments as there are CPUs on the host machine. This can be changed using the
+`target_segment_count` index option.
+
+```sql
+CREATE INDEX search_idx ON mock_items USING bm25 (id, description, rating) WITH (key_field = 'id', target_segment_count = 32, ...);
+```
+
+This property is attached to the index so that during `REINDEX`, the same value will be used.
+
+It can be changed with ALTER INDEX, like so:
+
+```sql
+ALTER INDEX search_idx SET (target_segment_count = 8);
+```
+
+However, a `REINDEX` is required to rebalance the index to that segment count.
+
+For optimal performance, the segment count should equal the number of parallel workers that a query can receive, which is controlled by
+[`max_parallel_workers_per_gather`](/documentation/configuration/parallel#parallel-workers). If `max_parallel_workers_per_gather` is greater than the number of CPUs on the host machine, then increasing the target segment count to match `max_parallel_workers_per_gather` can improve query
+performance.
+
+<Note>
+`target_segment_count` is merely a suggestion.
+
+While `pg_search` will endeavor to ensure the created index will have exactly this many segments, it is possible for it
+to have less or more. Mostly this depends on the distribution of work across parallel builder processes, memory
+constraints, and heap size.
+
+</Note>

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -57,8 +57,6 @@ static MIXED_FAST_FIELD_EXEC_COLUMN_THRESHOLD_NAME: &str =
 /// it logically can.
 static PER_TUPLE_COST: GucSetting<f64> = GucSetting::<f64>::new(100_000_000.0);
 
-static TARGET_SEGMENT_COUNT: GucSetting<i32> = GucSetting::<i32>::new(0);
-
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -110,17 +108,6 @@ pub fn init() {
         &PER_TUPLE_COST,
         0.0,
         f64::MAX,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_int_guc(
-        "paradedb.target_segment_count",
-        "Set the target segment count for a CREATE INDEX/REINDEX statement",
-        "Defaults to 0, which means the number of CPU cores will be used as the target segment count. Increasing the target segment count can be useful if max_parallel_workers_per_gather is greater than the CPU count.",
-        &TARGET_SEGMENT_COUNT,
-        0,
-        1024,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -200,14 +187,6 @@ pub fn adjust_work_mem() -> NonZeroUsize {
     );
 
     NonZeroUsize::new(wm_as_bytes).unwrap()
-}
-
-pub fn target_segment_count() -> usize {
-    if TARGET_SEGMENT_COUNT.get() > 0 {
-        TARGET_SEGMENT_COUNT.get() as usize
-    } else {
-        std::thread::available_parallelism().unwrap().get()
-    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -697,9 +697,7 @@ mod plan {
         // If there are fewer rows than number of CPUs, use 1 worker
         let options = unsafe { SearchIndexOptions::from_relation(indexrel) };
         let reltuples = plan::estimate_heap_reltuples(heaprel);
-        let target_segment_count = options
-            .target_segment_count()
-            .unwrap_or_else(gucs::target_segment_count);
+        let target_segment_count = options.target_segment_count();
         if reltuples <= target_segment_count as f64 {
             pgrx::debug1!("number of reltuples ({reltuples}) is less than target segment count ({target_segment_count}), creating a single segment");
             return 1;

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -235,7 +235,8 @@ impl<'a> BuildWorker<'a> {
             let nlaunched = self.coordination.nlaunched();
             let per_worker_memory_budget =
                 gucs::adjust_maintenance_work_mem(nlaunched).get() / nlaunched;
-            let target_segment_count = plan::adjusted_target_segment_count(&self.heaprel);
+            let target_segment_count =
+                plan::adjusted_target_segment_count(&self.heaprel, &self.indexrel);
             let (_, worker_segment_target) =
                 chunk_range(target_segment_count, nlaunched, worker_number as usize);
 
@@ -525,7 +526,7 @@ pub(super) fn build_index(
     });
 
     let process = ParallelBuild::new(&heaprel, &indexrel, snapshot.0, concurrent);
-    let nworkers = plan::create_index_nworkers(&heaprel);
+    let nworkers = plan::create_index_nworkers(&heaprel, &indexrel);
     pgrx::debug1!("build_index: asked for {nworkers} workers");
 
     let total_tuples = if let Some(mut process) = launch_parallel_process!(
@@ -613,15 +614,19 @@ pub(super) fn build_index(
 
 mod plan {
     use super::*;
+    use crate::postgres::options::SearchIndexOptions;
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
     /// The number of workers is determined by max_parallel_maintenance_workers. However, if max_parallel_maintenance_workers
     /// is greater than available parallelism, we use available parallelism.
     ///
     /// If the leader is participating, we subtract 1 from the number of workers because the leader also counts as a worker.
-    pub(super) fn create_index_nworkers(heaprel: &PgSearchRelation) -> usize {
+    pub(super) fn create_index_nworkers(
+        heaprel: &PgSearchRelation,
+        indexrel: &PgSearchRelation,
+    ) -> usize {
         // We don't want a parallel build to happen if we're creating a single segment
-        let target_segment_count = plan::adjusted_target_segment_count(heaprel);
+        let target_segment_count = plan::adjusted_target_segment_count(heaprel, indexrel);
         if target_segment_count == 1 {
             return 0;
         }
@@ -685,10 +690,16 @@ mod plan {
     }
 
     /// If we determine that the table is very small, we should just create a single segment
-    pub(super) fn adjusted_target_segment_count(heaprel: &PgSearchRelation) -> usize {
+    pub(super) fn adjusted_target_segment_count(
+        heaprel: &PgSearchRelation,
+        indexrel: &PgSearchRelation,
+    ) -> usize {
         // If there are fewer rows than number of CPUs, use 1 worker
+        let options = unsafe { SearchIndexOptions::from_relation(indexrel) };
         let reltuples = plan::estimate_heap_reltuples(heaprel);
-        let target_segment_count = gucs::target_segment_count();
+        let target_segment_count = options
+            .target_segment_count()
+            .unwrap_or_else(gucs::target_segment_count);
         if reltuples <= target_segment_count as f64 {
             pgrx::debug1!("number of reltuples ({reltuples}) is less than target segment count ({target_segment_count}), creating a single segment");
             return 1;

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -338,8 +338,14 @@ impl SearchIndexOptions {
         self.layer_sizes.clone()
     }
 
-    pub fn target_segment_count(&self) -> Option<usize> {
-        self.target_segment_count.map(|count| count as usize)
+    pub fn target_segment_count(&self) -> usize {
+        self.target_segment_count
+            .map(|count| count as usize)
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .expect("your computer should have at least one CPU")
+                    .get()
+            })
     }
 
     pub fn key_field_name(&self) -> FieldName {

--- a/pg_search/tests/pg_regress/expected/parallel_build_empty.out
+++ b/pg_search/tests/pg_regress/expected/parallel_build_empty.out
@@ -31,10 +31,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     -- Check index info and display results
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_small_idx');

--- a/pg_search/tests/pg_regress/expected/parallel_build_large.out
+++ b/pg_search/tests/pg_regress/expected/parallel_build_large.out
@@ -12,8 +12,7 @@ SET max_parallel_workers = 8;
 -- This should return a "not enough memory" error
 SET maintenance_work_mem = '64MB';
 SET max_parallel_maintenance_workers = 8;
-SET paradedb.target_segment_count = 16;
-CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id');
+CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id', target_segment_count = 16);
 ERROR:  `maintenance_work_mem` is not high enough to give each parallel worker 15MB
 -- These should complete and create the target segment count
 DO $$
@@ -36,10 +35,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_large_idx');
                     IF ts = 4 THEN

--- a/pg_search/tests/pg_regress/expected/parallel_build_small.out
+++ b/pg_search/tests/pg_regress/expected/parallel_build_small.out
@@ -30,10 +30,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     -- Check index info and display results
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_small_idx');

--- a/pg_search/tests/pg_regress/sql/parallel_build_empty.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_build_empty.sql
@@ -23,10 +23,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     -- Check index info and display results
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_small_idx');

--- a/pg_search/tests/pg_regress/sql/parallel_build_large.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_build_large.sql
@@ -5,8 +5,7 @@ SET max_parallel_workers = 8;
 -- This should return a "not enough memory" error
 SET maintenance_work_mem = '64MB';
 SET max_parallel_maintenance_workers = 8;
-SET paradedb.target_segment_count = 16;
-CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id');
+CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id', target_segment_count = 16);
 
 -- These should complete and create the target segment count
 DO $$
@@ -29,10 +28,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_large_idx ON parallel_build_large USING bm25 (id, name) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_large_idx');
                     IF ts = 4 THEN

--- a/pg_search/tests/pg_regress/sql/parallel_build_small.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_build_small.sql
@@ -22,10 +22,9 @@ BEGIN
                     -- Set configuration
                     EXECUTE format('SET max_parallel_maintenance_workers = %s', mw);
                     EXECUTE format('SET parallel_leader_participation = %s', lp);
-                    EXECUTE format('SET paradedb.target_segment_count = %s', ts);
                     EXECUTE format('SET maintenance_work_mem = %L', mwm);
 
-                    CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = 'id');
+                    EXECUTE format('CREATE INDEX parallel_build_small_idx ON parallel_build_small USING bm25 (id, name, age) WITH (key_field = ''id'', target_segment_count = %s)', ts);
 
                     -- Check index info and display results
                     SELECT COUNT(*) INTO count_val FROM paradedb.index_info('parallel_build_small_idx');


### PR DESCRIPTION
## What

Adds a new index `WITH` option to let users set the `target_segment_count`.

It probably makes sense to have this value as a property of the index itself so that the same value can be reused during REINDEX.  If unspecified it defaults to the  number of CPUs on the host system.

After discussions with @rebasedming, we have decided to remove the `paradedb.target_segment_count` GUC.

## Why

## How

## Tests

Existing tests that used the old GUC have been updated to use this new index option.  Docs updated too.