### PR TITLE
chore: upgrade to pgrx v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dffb5a99b514090574a668078a28394317d30bbb33a8b6d651342ebd945e81b"
+checksum = "bab5bc1d60d3bc3c966d307a3c7313b1ebfb49a0ec183be3f1a057df0bcc9988"
 dependencies = [
  "atomic-traits",
  "bitflags 2.9.1",
@@ -2984,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e43f241932f230af1ed713fac06133a074efb12a80705db7f679627551b5a8"
+checksum = "9804b74c211a9edd550cd974718f8cc407dec50d8e9cafb906e0b042ba434af0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -3003,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c97650c7bb75290fc0b7e1a80bc5cea74e541015369a6558f72fb3da0c0e95e"
+checksum = "f230769493bf567f137de23264d604d267dd72b8a77c596528e43cf423c6208e"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -3015,11 +3024,13 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a370f7f6127487e50be58aaf6544439352ff667e9ab6e5e6b24fb77f794315b"
+checksum = "49b64c071c2a46a19ab4521120a25b02b598f4abf6e9b4b1769a7922edeee3de"
 dependencies = [
  "cargo_toml",
+ "codepage",
+ "encoding_rs",
  "eyre",
  "home",
  "owo-colors",
@@ -3029,13 +3040,14 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
  "url",
+ "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa062f644530005641b5cdc4b5d1303c70ffa38bd1089699035ea46adac41b6d"
+checksum = "fcbfa98ec7a90252d13a78ac666541173dbb01a2fc1ba20131db6490c0711125"
 dependencies = [
  "cee-scape",
  "libc",
@@ -3048,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58ca1db80bc9b38e38be7d65e3dd6ba2813083410e7a81ed9db70147c40f86"
+checksum = "e79bbf5a33cff6cfdc6dda3a976cd931c995eaa2c073a7c59b8f8fe8f6faa073"
 dependencies = [
  "convert_case 0.8.0",
  "eyre",
@@ -3064,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec4957e116035f87c2fb475b7c95554b44400d66e25842d6edb2491ed6c883"
+checksum = "9791c709882f3af9545bcca71670fdd82768f67a428b416b6210eae3773dbd0d"
 dependencies = [
  "clap-cargo",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
   "stopwords",
   "lz4-compression",
 ], default-features = false }
-pgrx = "=0.14.3"
-pgrx-tests = "=0.14.3"
+pgrx = "=0.15.0"
+pgrx-tests = "=0.15.0"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]

--- a/pg_search/src/postgres/ps_status.rs
+++ b/pg_search/src/postgres/ps_status.rs
@@ -6,29 +6,14 @@ pub const INDEXING: &CStr = c"indexing";
 pub const MERGING: &CStr = c"merging";
 
 pub unsafe fn set_ps_display_suffix(suffix: *const c_char) {
-    #[cfg(any(feature = "pg16", feature = "pg17"))]
-    pg_sys::ffi::pg_guard_ffi_boundary(|| {
-        extern "C-unwind" {
-            pub fn set_ps_display_suffix(suffix: *const c_char);
-        }
-        set_ps_display_suffix(suffix);
-    });
-
     #[cfg(any(feature = "pg14", feature = "pg15"))]
-    pg_sys::ffi::pg_guard_ffi_boundary(|| {
-        extern "C-unwind" {
-            pub fn set_ps_display(suffix: *const c_char);
-        }
-        set_ps_display(suffix);
-    });
+    pg_sys::set_ps_display(suffix);
+
+    #[cfg(any(feature = "pg16", feature = "pg17"))]
+    pg_sys::set_ps_display_suffix(suffix);
 }
 
 pub unsafe fn set_ps_display_remove_suffix() {
     #[cfg(any(feature = "pg16", feature = "pg17"))]
-    pg_sys::ffi::pg_guard_ffi_boundary(|| {
-        extern "C-unwind" {
-            pub fn set_ps_display_remove_suffix();
-        }
-        set_ps_display_remove_suffix();
-    });
+    pg_sys::set_ps_display_remove_suffix();
 }


### PR DESCRIPTION
This upgrades us to pgrx v0.15.0. 

It does **NOT** add Postgres 18 support.  I briefly looked at this and it looks like it'll be a somewhat difficult lift as there's been changes to the planner/executor, so a lot of our custom scan stuff doesn't compile on 18.

We can prioritize this work and whatever other changes are necessary to support 18 in our CI down the road.  In my opinion we ought to wait until the first 18 release candidate -- whenever that is.
