### PR TITLE
chore: Quiet down the proptests

### DIFF
--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -93,16 +93,8 @@ where
     .execute(conn);
 
     conn.deallocate_all()?;
-    let pg_explain = format!("EXPLAIN {pg_query}")
-        .fetch::<(String,)>(conn)
-        .into_iter()
-        .map(|(s,)| s)
-        .collect::<Vec<_>>()
-        .join("\n");
-    eprintln!("pg_explain: {pg_explain}");
 
     let pg_result = run_query(&pg_query, conn);
-    eprintln!("pg_result: {pg_result:?}");
 
     // and for the "bm25" query, we run it a number of times with more and more scan types disabled,
     // always ensuring that paradedb's custom scan is turned on
@@ -115,16 +107,8 @@ where
         scan_type.execute(conn);
 
         conn.deallocate_all()?;
-        let bm25_explain = format!("EXPLAIN {bm25_query}")
-            .fetch::<(String,)>(conn)
-            .into_iter()
-            .map(|(s,)| s)
-            .collect::<Vec<_>>()
-            .join("\n");
-        eprintln!("bm25_explain: {bm25_explain}");
 
         let bm25_result = run_query(&bm25_query, conn);
-        eprintln!("bm25_result: {bm25_result:?}");
 
         prop_assert_eq!(
             &pg_result,
@@ -133,7 +117,12 @@ where
             scan_type,
             pg_query,
             bm25_query,
-            bm25_explain
+            format!("EXPLAIN {bm25_query}")
+                .fetch::<(String,)>(conn)
+                .into_iter()
+                .map(|(s,)| s)
+                .collect::<Vec<_>>()
+                .join("\n")
         );
     }
 


### PR DESCRIPTION
## What

Remove extraneous debug output from proptests.

## Why

Proptests run many times in a loop: to reduce their cost and the amount that they output, it is recommended to put any information that would help debug a failure into a test macro like `prop_assert_eq!`: that way, it will only actually be computed and rendered for failing cases _after_ the framework has minimized to the smallest repro that it can find.

When it's time to debug the cases that are being run, you can use `PROPTEST_VERBOSE=3` to have the framework print debug information about the cases that it is trying.