### PR TITLE
fix: Do not convert vars to external on a base relation

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -26,6 +26,10 @@ use std::num::NonZeroUsize;
 /// Allows the user to toggle the use of our "ParadeDB Custom Scan".  The default is `true`.
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
+/// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
+/// default is `true`.
+static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(true);
+
 /// Allows the user to enable or disable the FastFieldsExecState executor. Default is `true`.
 static ENABLE_FAST_FIELD_EXEC: GucSetting<bool> = GucSetting::<bool>::new(true);
 
@@ -67,6 +71,15 @@ pub fn init() {
         c"Enable ParadeDB's custom scan",
         c"Enable ParadeDB's custom scan",
         &ENABLE_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_custom_scan_without_operator",
+        c"Enable ParadeDB's custom scan to run without the `@@@` operator",
+        c"Enable ParadeDB's custom scan to run even when the `@@@` operator has not been used in a query, as long as the entire WHERE clause is able to be pushed down",
+        &ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -116,6 +129,10 @@ pub fn init() {
 
 pub fn enable_custom_scan() -> bool {
     ENABLE_CUSTOM_SCAN.get()
+}
+
+pub fn enable_custom_scan_without_operator() -> bool {
+    ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR.get()
 }
 
 pub fn is_fast_field_exec_enabled() -> bool {

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -388,6 +388,12 @@ impl From<&Qual> for SearchQueryInput {
     }
 }
 
+#[derive(Default)]
+pub struct QualExtractState {
+    pub uses_tantivy_to_query: bool,
+    pub uses_our_operator: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn extract_quals(
     root: *mut pg_sys::PlannerInfo,
@@ -397,7 +403,7 @@ pub unsafe fn extract_quals(
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
     convert_external_to_special_qual: bool,
-    uses_tantivy_to_query: &mut bool,
+    state: &mut QualExtractState,
 ) -> Option<Qual> {
     if node.is_null() {
         return None;
@@ -413,7 +419,7 @@ pub unsafe fn extract_quals(
                 ri_type,
                 schema,
                 convert_external_to_special_qual,
-                uses_tantivy_to_query,
+                state,
             )?;
             if quals.len() == 1 {
                 quals.pop()
@@ -437,7 +443,7 @@ pub unsafe fn extract_quals(
                 ri_type,
                 schema,
                 convert_external_to_special_qual,
-                uses_tantivy_to_query,
+                state,
             )
         }
 
@@ -449,7 +455,7 @@ pub unsafe fn extract_quals(
             ri_type,
             schema,
             convert_external_to_special_qual,
-            uses_tantivy_to_query,
+            state,
         ),
 
         pg_sys::NodeTag::T_ScalarArrayOpExpr => opexpr(
@@ -460,7 +466,7 @@ pub unsafe fn extract_quals(
             ri_type,
             schema,
             convert_external_to_special_qual,
-            uses_tantivy_to_query,
+            state,
         ),
 
         pg_sys::NodeTag::T_BoolExpr => {
@@ -474,7 +480,7 @@ pub unsafe fn extract_quals(
                 ri_type,
                 schema,
                 convert_external_to_special_qual,
-                uses_tantivy_to_query,
+                state,
             )?;
 
             match (*boolexpr).boolop {
@@ -510,11 +516,10 @@ pub unsafe fn extract_quals(
             root,
             rti,
             node,
-            pdbopoid,
             ri_type,
             schema,
             convert_external_to_special_qual,
-            uses_tantivy_to_query,
+            state,
         ),
 
         pg_sys::NodeTag::T_Const => {
@@ -546,7 +551,7 @@ unsafe fn list(
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
     convert_external_to_special_qual: bool,
-    uses_tantivy_to_query: &mut bool,
+    state: &mut QualExtractState,
 ) -> Option<Vec<Qual>> {
     let args = PgList::<pg_sys::Node>::from_pg(list);
     let mut quals = Vec::new();
@@ -559,7 +564,7 @@ unsafe fn list(
             ri_type,
             schema,
             convert_external_to_special_qual,
-            uses_tantivy_to_query,
+            state,
         )?)
     }
     Some(quals)
@@ -574,7 +579,7 @@ unsafe fn opexpr(
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
     convert_external_to_special_qual: bool,
-    uses_tantivy_to_query: &mut bool,
+    state: &mut QualExtractState,
 ) -> Option<Qual> {
     let args = opexpr.args();
     let mut lhs = args.get_ptr(0)?;
@@ -595,7 +600,7 @@ unsafe fn opexpr(
             pdbopoid,
             ri_type,
             schema,
-            uses_tantivy_to_query,
+            state,
             opexpr,
             lhs,
             rhs,
@@ -612,13 +617,15 @@ unsafe fn opexpr(
                     pdbopoid,
                     ri_type,
                     schema,
-                    uses_tantivy_to_query,
+                    state,
                     opexpr,
                     lhs,
                     rhs,
                     convert_external_to_special_qual,
                 );
             }
+
+            state.uses_our_operator = true;
 
             if is_complex(rhs) {
                 return None;
@@ -635,7 +642,7 @@ unsafe fn opexpr(
             pdbopoid,
             ri_type,
             schema,
-            uses_tantivy_to_query,
+            state,
             opexpr,
             lhs,
             rhs,
@@ -653,7 +660,7 @@ unsafe fn node_opexpr(
     pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
-    uses_tantivy_to_query: &mut bool,
+    state: &mut QualExtractState,
     opexpr: OpExpr,
     lhs: *mut pg_sys::Node,
     mut rhs: *mut pg_sys::Node,
@@ -666,6 +673,7 @@ unsafe fn node_opexpr(
     let rhs_as_const = nodecast!(Const, T_Const, rhs);
 
     let is_our_operator = opexpr.opno() == pdbopoid;
+    state.uses_our_operator = state.uses_our_operator || is_our_operator;
 
     if rhs_as_const.is_none() {
         // the rhs expression is not a Const, so it's some kind of expression
@@ -680,7 +688,7 @@ unsafe fn node_opexpr(
                 // it uses our operator, so we directly know how to handle it
                 // this is the case of:  field @@@ paradedb.xxx(EXPR) where EXPR likely includes something
                 // that's parameterized
-                *uses_tantivy_to_query = true;
+                state.uses_tantivy_to_query = true;
                 return Some(Qual::Expr {
                     node: rhs,
                     expr_state: std::ptr::null_mut(),
@@ -707,7 +715,7 @@ unsafe fn node_opexpr(
                         return None;
                     }
                 }
-                *uses_tantivy_to_query = true;
+                state.uses_tantivy_to_query = true;
                 return result;
             }
         }
@@ -718,7 +726,7 @@ unsafe fn node_opexpr(
         // the rhs expression is a Const, so we can use it directly
         if is_node_range_table_entry(lhs, rti) {
             // the node comes from this range table entry, so we can use the full expression directly
-            *uses_tantivy_to_query = true;
+            state.uses_tantivy_to_query = true;
             Some(Qual::OpExpr {
                 lhs,
                 opno: opexpr.opno(),
@@ -746,7 +754,7 @@ unsafe fn node_opexpr(
                 None
             }
         } else {
-            *uses_tantivy_to_query = true;
+            state.uses_tantivy_to_query = true;
             result
         }
     }
@@ -822,38 +830,37 @@ unsafe fn booltest(
     root: *mut pg_sys::PlannerInfo,
     rti: pg_sys::Index,
     node: *mut pg_sys::Node,
-    pdbopoid: pg_sys::Oid,
     ri_type: RestrictInfoType,
     schema: &SearchIndexSchema,
     convert_external_to_special_qual: bool,
-    uses_tantivy_to_query: &mut bool,
+    state: &mut QualExtractState,
 ) -> Option<Qual> {
     let booltest = nodecast!(BooleanTest, T_BooleanTest, node)?;
     let arg = (*booltest).arg;
 
     // We only support boolean test for simple field references (Var nodes)
     // For complex expressions, the optimizer will evaluate the condition later
-    if let Some(arg_var) = nodecast!(Var, T_Var, arg) {
-        if let Some(field) = PushdownField::try_new(root, arg_var, schema) {
-            // It's a simple field reference, handle as specific cases
-            match (*booltest).booltesttype {
-                pg_sys::BoolTestType::IS_TRUE => Some(Qual::PushdownVarIsTrue { field }),
-                pg_sys::BoolTestType::IS_NOT_FALSE => {
-                    Some(Qual::Not(Box::new(Qual::PushdownVarIsFalse { field })))
-                }
-                pg_sys::BoolTestType::IS_FALSE => Some(Qual::PushdownVarIsFalse { field }),
-                pg_sys::BoolTestType::IS_NOT_TRUE => {
-                    Some(Qual::Not(Box::new(Qual::PushdownVarIsTrue { field })))
-                }
-                _ => None,
-            }
-        } else {
-            None
+    let arg_var = nodecast!(Var, T_Var, arg)?;
+    let field = PushdownField::try_new(root, arg_var, schema)?;
+
+    // It's a simple field reference, handle as specific cases
+    let qual = match (*booltest).booltesttype {
+        pg_sys::BoolTestType::IS_TRUE => Some(Qual::PushdownVarIsTrue { field }),
+        pg_sys::BoolTestType::IS_NOT_FALSE => {
+            Some(Qual::Not(Box::new(Qual::PushdownVarIsFalse { field })))
         }
-    } else {
-        // Not a simple field reference - let the PostgreSQL executor handle it
-        None
+        pg_sys::BoolTestType::IS_FALSE => Some(Qual::PushdownVarIsFalse { field }),
+        pg_sys::BoolTestType::IS_NOT_TRUE => {
+            Some(Qual::Not(Box::new(Qual::PushdownVarIsTrue { field })))
+        }
+        _ => None,
+    };
+
+    if qual.is_some() {
+        state.uses_tantivy_to_query = true;
     }
+
+    qual
 }
 
 /// Extract join-level search predicates that are relevant for snippet generation
@@ -893,7 +900,7 @@ pub unsafe fn extract_join_predicates(
         if let Some(simplified_node) =
             simplify_join_clause_for_relation((*ri).clause.cast(), current_rti)
         {
-            let mut uses_tantivy_to_query = false;
+            let mut qual_extract_state = QualExtractState::default();
             // Extract search predicates from the simplified expression
             if let Some(qual) = extract_quals(
                 root,
@@ -903,9 +910,9 @@ pub unsafe fn extract_join_predicates(
                 RestrictInfoType::BaseRelation,
                 schema,
                 true,
-                &mut uses_tantivy_to_query,
+                &mut qual_extract_state,
             ) {
-                if uses_tantivy_to_query {
+                if qual_extract_state.uses_tantivy_to_query {
                     // Convert qual to SearchQueryInput and return the entire expression
                     let search_input = SearchQueryInput::from(&qual);
                     // Return the entire simplified expression for scoring

--- a/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/qual_inspect.rs
@@ -689,9 +689,13 @@ unsafe fn node_opexpr(
         } else {
             // it doesn't use our operator
             if contains_var(rhs) {
-                // the rhs is (or contains) a Var, which likely means its part of a join condition
-                // we choose to just select everything in this situation
-                return Some(Qual::ExternalVar);
+                // the rhs is (or contains) a Var. If it's part of a join condition,
+                // select everything in this situation
+                if convert_external_to_special_qual {
+                    return Some(Qual::ExternalVar);
+                } else {
+                    return None;
+                }
             } else {
                 // it doesn't use our operator.
                 // we'll try to convert it into a pushdown

--- a/pg_search/tests/pg_regress/expected/issue_2753.out
+++ b/pg_search/tests/pg_regress/expected/issue_2753.out
@@ -1,0 +1,32 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (id SERIAL PRIMARY KEY, domain_short TEXT, domain_long TEXT);
+INSERT INTO t (domain_short, domain_long)
+VALUES ('google.com', 'Google.com'), ('fb.com', 'facebook.com');
+CREATE INDEX ON t USING bm25 (id, domain_short, domain_long) WITH (key_field = 'id');
+SET enable_seqscan = OFF; SET enable_indexscan = OFF;
+SELECT * FROM t 
+WHERE lower(domain_short) = lower(domain_long)
+ORDER BY id
+LIMIT 5;
+ id | domain_short | domain_long 
+----+--------------+-------------
+  1 | google.com   | Google.com
+(1 row)
+
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_mixed_fast_field_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/issue_2753.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2753.sql
@@ -1,0 +1,18 @@
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (id SERIAL PRIMARY KEY, domain_short TEXT, domain_long TEXT);
+
+INSERT INTO t (domain_short, domain_long)
+VALUES ('google.com', 'Google.com'), ('fb.com', 'facebook.com');
+
+CREATE INDEX ON t USING bm25 (id, domain_short, domain_long) WITH (key_field = 'id');
+
+SET enable_seqscan = OFF; SET enable_indexscan = OFF;
+
+SELECT * FROM t 
+WHERE lower(domain_short) = lower(domain_long)
+ORDER BY id
+LIMIT 5;
+
+\i common/common_cleanup.sql


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2753

## What

When extracting quals from a join `RestrictInfo`, we will convert vars into external vars. But one of the cases of that conversion was not covered by a check that we were extracting quals for a join.

Additionally, add an enabled-by-default `paradedb.enable_custom_scan_without_operator` GUC to control whether the custom scan can be used when we've successfully found expressions to push down, but have _not_ found use of our operator.

## Why

See #2753.

## Tests

Added the repro from #2753, and added a test of the new GUC.