### PR TITLE
fix: "attempt to multiply with overflow" error in `paradedb.aggregate`

### DIFF
--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -152,7 +152,7 @@ impl<'a> ParallelAggregationWorker<'a> {
         let nsegments = self.config.total_segments;
 
         let mut segment_ids = FxHashSet::default();
-        let (_, many_segments) = chunk_range(nsegments, nworkers, worker_number as usize);
+        let (_, many_segments) = chunk_range(nsegments, nworkers, worker_number.max(0) as usize);
         while let Some(segment_id) = self.checkout_segment() {
             segment_ids.insert(segment_id);
 

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -5,7 +5,7 @@ use crate::index::reader::index::SearchIndexReader;
 use crate::launch_parallel_process;
 use crate::parallel_worker::mqueue::MessageQueueSender;
 use crate::parallel_worker::ParallelStateManager;
-use crate::parallel_worker::{chunk_range, WorkerStyle};
+use crate::parallel_worker::{chunk_range, QueryWorkerStyle, WorkerStyle};
 use crate::parallel_worker::{ParallelProcess, ParallelState, ParallelStateType, ParallelWorker};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::spinlock::Spinlock;
@@ -141,17 +141,6 @@ impl<'a> ParallelAggregationWorker<'a> {
     }
 
     fn checkout_segments(&mut self, worker_number: i32) -> FxHashSet<SegmentId> {
-        let worker_number =
-            // if max_parallel_workers = 0 and parallel_leader_participation = off,
-            // the leader will be -1 and we need to set it to 0 to work with `chunk_range`
-            if worker_number < 0 && !unsafe { pg_sys::parallel_leader_participation } {
-                0
-            } else if unsafe { pg_sys::parallel_leader_participation } {
-                worker_number + 1
-            } else {
-                worker_number
-            };
-
         let nworkers = self.state.launched_workers();
         let nsegments = self.config.total_segments;
 
@@ -179,9 +168,9 @@ impl<'a> ParallelAggregationWorker<'a> {
 
     fn execute_aggregate(
         &mut self,
-        worker_number: i32,
+        worker_style: QueryWorkerStyle,
     ) -> anyhow::Result<Option<IntermediateAggregationResults>> {
-        let segment_ids = self.checkout_segments(worker_number);
+        let segment_ids = self.checkout_segments(worker_style.worker_number());
         if segment_ids.is_empty() {
             return Ok(None);
         }
@@ -269,7 +258,9 @@ impl ParallelWorker for ParallelAggregationWorker<'_> {
             std::thread::yield_now();
         }
 
-        if let Some(intermediate_results) = self.execute_aggregate(worker_number)? {
+        if let Some(intermediate_results) =
+            self.execute_aggregate(QueryWorkerStyle::ParallelWorker(worker_number))?
+        {
             let bytes = postcard::to_allocvec(&intermediate_results)?;
             Ok(mq_sender.send(bytes)?)
         } else {
@@ -343,7 +334,7 @@ pub fn aggregate(
             if pg_sys::parallel_leader_participation {
                 let mut worker =
                     ParallelAggregationWorker::new_parallel_worker(*process.state_manager());
-                if let Some(result) = worker.execute_aggregate(-1)? {
+                if let Some(result) = worker.execute_aggregate(QueryWorkerStyle::ParallelLeader)? {
                     agg_results.push(Ok(result));
                 }
             }
@@ -393,7 +384,7 @@ pub fn aggregate(
                 bucket_limit as _,
                 &mut state,
             );
-            if let Some(agg_results) = worker.execute_aggregate(-1)? {
+            if let Some(agg_results) = worker.execute_aggregate(QueryWorkerStyle::NonParallel)? {
                 let result = agg_results.into_final_result(
                     agg_req,
                     AggregationLimitsGuard::new(

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -583,3 +583,27 @@ pub fn chunk_range(n: usize, m: usize, i: usize) -> (usize, usize) {
     let length = quotient + if i < remainder { 1 } else { 0 };
     (start, length)
 }
+
+/// For a (possibly parallel) query, describes the worker that is running the query
+#[derive(Debug, Copy, Clone)]
+pub enum QueryWorkerStyle {
+    ParallelLeader,
+    ParallelWorker(i32),
+    NonParallel,
+}
+
+impl QueryWorkerStyle {
+    pub fn worker_number(&self) -> i32 {
+        match self {
+            QueryWorkerStyle::ParallelWorker(worker_number) => {
+                if unsafe { pg_sys::parallel_leader_participation } {
+                    *worker_number + 1
+                } else {
+                    *worker_number
+                }
+            }
+            QueryWorkerStyle::ParallelLeader => 0,
+            QueryWorkerStyle::NonParallel => 0,
+        }
+    }
+}

--- a/pg_search/tests/pg_regress/expected/aggregate-udf.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-udf.out
@@ -1,10 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
 DROP TABLE IF EXISTS pr2625;
 CREATE TABLE pr2625 (
     id serial8,
     k text,
     v float8
 );
-CREATE INDEX idxpr2625 ON pr2625 USING bm25 (id, k, v) WITH (key_field = 'id');
+CREATE INDEX idxpr2625 ON pr2625 USING bm25 (id, k, v) WITH (key_field = 'id', target_segment_count = 8, layer_sizes = '1gb, 10gb');
 --
 -- test with 1 segment
 --

--- a/pg_search/tests/pg_regress/sql/aggregate-udf.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate-udf.sql
@@ -1,10 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
 DROP TABLE IF EXISTS pr2625;
 CREATE TABLE pr2625 (
     id serial8,
     k text,
     v float8
 );
-CREATE INDEX idxpr2625 ON pr2625 USING bm25 (id, k, v) WITH (key_field = 'id');
+CREATE INDEX idxpr2625 ON pr2625 USING bm25 (id, k, v) WITH (key_field = 'id', target_segment_count = 8, layer_sizes = '1gb, 10gb');
 
 --
 -- test with 1 segment


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We were passing `-1` to `chunk_range`, which takes `usize`, leading to an underflow -> wrapping around. Additionally, the existing `aggregate_udf` test thinks it's testing over multiple segments but actually isn't -- if it had, it would have triggered this error.

## Why

## How

## Tests
Updated existing test