### PR TITLE
fix: reverted "feat: always do pushdowns when we can"

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -27,8 +27,8 @@ use std::num::NonZeroUsize;
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
-/// default is `true`.
-static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(true);
+/// default is `false`.
+static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 /// Allows the user to enable or disable the FastFieldsExecState executor. Default is `true`.
 static ENABLE_FAST_FIELD_EXEC: GucSetting<bool> = GucSetting::<bool>::new(true);

--- a/pg_search/tests/pg_regress/expected/issue_2745.out
+++ b/pg_search/tests/pg_regress/expected/issue_2745.out
@@ -37,19 +37,15 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT contact_name FROM contacts_companies
 WHERE contact_name SIMILAR TO 'Alice'
 AND NOT EXISTS (SELECT 1 FROM contact_list WHERE contact_id = contact_list.id);
-                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  Hash Right Anti Join
    Hash Cond: (contact_list.id = contacts_companies.contact_id)
    ->  Seq Scan on contact_list
    ->  Hash
-         ->  Custom Scan (ParadeDB Scan) on contacts_companies
-               Table: contacts_companies
-               Index: contacts_companies_contact_id_company_id_contact_name_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 641 :opfuncid 1254 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 3 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 3 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 15 [ 60 0 0 0 94 40 63 58 65 108 105 99 101 41 36 ]}) :location -1}","description":"OpExpr with operator OID 641"}]}}
-(10 rows)
+         ->  Index Scan using contacts_companies_pkey on contacts_companies
+               Filter: (contact_name ~ '^(?:Alice)$'::text)
+(6 rows)
 
 SET paradedb.enable_custom_scan = off;
 SELECT contact_name FROM contacts_companies

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_03_limit_topn.out
@@ -448,22 +448,14 @@ FROM limit_topn_test
 WHERE is_available = true
 ORDER BY rating DESC, title ASC
 LIMIT 7;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+               QUERY PLAN                
+-----------------------------------------
  Limit
-   ->  Incremental Sort
+   ->  Sort
          Sort Key: rating DESC, title
-         Presorted Key: rating
-         ->  Custom Scan (ParadeDB Scan) on limit_topn_test
-               Table: limit_topn_test
-               Index: limit_topn_idx
-               Exec Method: TopNScanExecState
-               Scores: false
-                  Sort Field: rating
-                  Sort Direction: desc
-                  Top N Limit: 7
-               Tantivy Query: {"term":{"field":"is_available","value":true,"is_datetime":false}}
-(13 rows)
+         ->  Seq Scan on limit_topn_test
+               Filter: is_available
+(5 rows)
 
 SELECT title, is_available, rating
 FROM limit_topn_test
@@ -488,19 +480,14 @@ FROM limit_topn_test
 WHERE rating > 3.0 AND price < 500
 ORDER BY price DESC
 LIMIT 12;
-                                                                                                                      QUERY PLAN                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Scan) on limit_topn_test
-         Table: limit_topn_test
-         Index: limit_topn_idx
-         Exec Method: TopNScanExecState
-         Scores: false
-            Sort Field: price
-            Sort Direction: desc
-            Top N Limit: 12
-         Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"excluded":500.0},"is_datetime":false}}]}}
-(10 rows)
+   ->  Sort
+         Sort Key: price DESC
+         ->  Seq Scan on limit_topn_test
+               Filter: ((rating > '3'::double precision) AND (price < '500'::double precision))
+(5 rows)
 
 SELECT rating, price
 FROM limit_topn_test

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
@@ -378,28 +378,21 @@ WITH RECURSIVE category_tree AS (
 SELECT name, level, item_count
 FROM category_tree
 ORDER BY level, name;
-                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Sort
    Sort Key: category_tree.level, category_tree.name
    CTE category_tree
      ->  Recursive Union
-           ->  Custom Scan (ParadeDB Scan) on category
-                 Table: category
-                 Index: category_idx
-                 Exec Method: MixedFastFieldExecState
-                 Fast Fields: name, id, is_active, item_count, level, parent_id
-                 String Fast Fields: name
-                 Numeric Fast Fields: id, is_active, item_count, level, parent_id
-                 Scores: false
-                 Tantivy Query: {"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 2 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 2 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 15 [ 60 0 0 0 69 108 101 99 116 114 111 110 105 99 115 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}}
+           ->  Seq Scan on category
+                 Filter: (name = 'Electronics'::text)
            ->  Hash Join
                  Hash Cond: (c.parent_id = ct.id)
                  ->  Seq Scan on category c
                  ->  Hash
                        ->  WorkTable Scan on category_tree ct
    ->  CTE Scan on category_tree
-(19 rows)
+(12 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case: start with parent category
@@ -598,21 +591,14 @@ WITH RECURSIVE category_tree AS (
 SELECT name, level, description, item_count
 FROM category_tree
 ORDER BY level, name;
-                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                    QUERY PLAN                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: category_tree.level, category_tree.name
    CTE category_tree
      ->  Recursive Union
-           ->  Custom Scan (ParadeDB Scan) on category
-                 Table: category
-                 Index: category_idx
-                 Exec Method: MixedFastFieldExecState
-                 Fast Fields: description, name, id, item_count, level, parent_id
-                 String Fast Fields: description, name
-                 Numeric Fast Fields: id, item_count, level, parent_id
-                 Scores: false
-                 Tantivy Query: {"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 2 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 2 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 15 [ 60 0 0 0 69 108 101 99 116 114 111 110 105 99 115 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}}
+           ->  Seq Scan on category
+                 Filter: (name = 'Electronics'::text)
            ->  Hash Join
                  Hash Cond: (ct.id = c.parent_id)
                  ->  WorkTable Scan on category_tree ct
@@ -627,7 +613,7 @@ ORDER BY level, name;
                              Scores: false
                              Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"computer","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"item_count","lower_bound":{"excluded":30},"upper_bound":null,"is_datetime":false}}]}}
    ->  CTE Scan on category_tree
-(27 rows)
+(20 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
@@ -590,12 +590,8 @@ ORDER BY pr.avg_rating DESC, paradedb.score(tp.id), tp.price DESC;
                                        ->  Seq Scan on reviews r
                                              Filter: (rating >= 3)
                ->  Hash
-                     ->  Custom Scan (ParadeDB Scan) on categories c
-                           Table: categories
-                           Index: categories_idx
-                           Exec Method: NormalScanExecState
-                           Scores: false
-                           Tantivy Query: {"term":{"field":"is_active","value":true,"is_datetime":false}}
+                     ->  Seq Scan on categories c
+                           Filter: is_active
          ->  Hash
                ->  Subquery Scan on tp
                      ->  Limit
@@ -608,7 +604,7 @@ ORDER BY pr.avg_rating DESC, paradedb.score(tp.id), tp.price DESC;
                                     Sort Direction: desc
                                     Top N Limit: 50
                                  Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":{"included":100.0},"upper_bound":null,"is_datetime":false}},{"range":{"field":"price","lower_bound":null,"upper_bound":{"included":800.0},"is_datetime":false}},{"term":{"field":"is_available","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}]}}
-(35 rows)
+(31 rows)
 
 WITH top_products AS (
     SELECT p.id, p.name, p.price, p.stock_count
@@ -913,20 +909,15 @@ WHERE p.name @@@ 'Product'
   AND c.name = 'Electronics'
   AND p.is_available = true
 ORDER BY r.rating DESC, p.price DESC;
-                                                                                                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: r.rating DESC, p.price DESC
    ->  Hash Join
          Hash Cond: (pc.product_id = p.id)
          ->  Nested Loop
-               ->  Custom Scan (ParadeDB Scan) on categories c
-                     Table: categories
-                     Index: categories_idx
-                     Exec Method: NumericFastFieldExecState
-                     Fast Fields: id
-                     Scores: false
-                     Tantivy Query: {"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 6 :varattno 2 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 6 :varattnosyn 2 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 15 [ 60 0 0 0 69 108 101 99 116 114 111 110 105 99 115 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}}
+               ->  Seq Scan on categories c
+                     Filter: (name = 'Electronics'::text)
                ->  Bitmap Heap Scan on product_categories pc
                      Recheck Cond: (category_id = c.id)
                      ->  Bitmap Index Scan on product_categories_pkey
@@ -946,7 +937,7 @@ ORDER BY r.rating DESC, p.price DESC;
                                  Numeric Fast Fields: id, price
                                  Scores: false
                                  Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"is_available","value":true,"is_datetime":false}}]}}
-(31 rows)
+(26 rows)
 
 SELECT p.name, p.price, r.content, r.rating
 FROM products p

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_04_subquery.out
@@ -179,25 +179,20 @@ SELECT d.id, d.title, d.parents,
 FROM documents d
 WHERE d.parents = 'Factures'
 ORDER BY invoice_file_count DESC, d.id;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Sort
    Sort Key: ((SubPlan 1)) DESC, d.id
-   ->  Custom Scan (ParadeDB Scan) on documents d
-         Table: documents
-         Index: documents_search
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 4 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 4 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 12 [ 48 0 0 0 70 97 99 116 117 114 101 115 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}}
+   ->  Seq Scan on documents d
+         Filter: (parents = 'Factures'::text)
          SubPlan 1
            ->  Aggregate
-                 ->  Custom Scan (ParadeDB Scan) on files f
-                       Table: files
-                       Index: files_search
-                       Exec Method: NormalScanExecState
-                       Scores: false
-                       Tantivy Query: {"boolean":{"must":[{"boolean":{"should":[{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 3 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 3 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 19 [ 76 0 0 0 73 110 118 111 105 99 101 32 82 101 99 101 105 112 116 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}},{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 98 :opfuncid 67 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 100 :args ({VAR :varno 1 :varattno 3 :vartype 25 :vartypmod -1 :varcollid 100 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 3 :location -1} {CONST :consttype 25 :consttypmod -1 :constcollid 100 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 15 [ 60 0 0 0 73 110 118 111 105 99 101 32 80 68 70 ]}) :location -1}","description":"OpExpr with operator OID 98"}]}}]}},{}]}}
-(16 rows)
+                 ->  Bitmap Heap Scan on files f
+                       Recheck Cond: (documentid = d.id)
+                       Filter: ((title = 'Invoice Receipt'::text) OR (title = 'Invoice PDF'::text))
+                       ->  Bitmap Index Scan on files_pkey
+                             Index Cond: (documentid = d.id)
+(11 rows)
 
 \i common/mixedff_queries_cleanup.sql
 -- Cleanup for relational query tests (07-10)

--- a/pg_search/tests/pg_regress/expected/pushdown_scalar_array_opexr.out
+++ b/pg_search/tests/pg_regress/expected/pushdown_scalar_array_opexr.out
@@ -4,6 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_mixed_fast_field_exec = true;
+SET paradedb.enable_custom_scan_without_operator = on;
 CREATE TABLE scalar_array_pushdown(
     id SERIAL PRIMARY KEY,
     uuid_col UUID,
@@ -191,5 +192,6 @@ LIMIT 10;
          Tantivy Query: {"boolean":{"should":[{"boolean":{"must":[{"term_set":{"terms":[{"field":"uuid_col","value":"550e8400-e29b-41d4-a716-446655440000","is_datetime":false},{"field":"uuid_col","value":"550e8400-e29b-41d4-a716-446655440001","is_datetime":false}]}},{"term_set":{"terms":[{"field":"text_col","value":"Alice","is_datetime":false},{"field":"text_col","value":"Bob","is_datetime":false}]}}]}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_col","query_string":"Alice","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"int_col","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
 (10 rows)
 
+RESET paradedb.enable_custom_scan_without_operator;
 DROP INDEX scalar_array_pushdown_idx;
 DROP TABLE scalar_array_pushdown;

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -124,7 +124,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70;
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
-       2 | Stephen King |    2.5308118 |  0.7432616
+       2 | Stephen King |              |  0.7432616
 (1 row)
 
 SELECT
@@ -151,7 +151,7 @@ JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60;
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
-       2 | Stephen King |    2.5308118 |  0.7432616
+       2 | Stephen King |              |  0.7432616
 (1 row)
 
 SELECT
@@ -226,8 +226,8 @@ RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60;
  author_id |   author_name   | author_score | book_score 
 -----------+-----------------+--------------+------------
-         2 | Stephen King    |            1 | 0.13515766
-         3 | Agatha Christie |    2.5308118 |          0
+         2 | Stephen King    |              | 0.13515766
+         3 | Agatha Christie |              |          0
 (2 rows)
 
 -- Test multiple score functions in same query

--- a/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
@@ -90,11 +90,11 @@ WHERE category_name = 'Electronics'
 ORDER BY id;
  id |      name       | category_name | score 
 ----+-----------------+---------------+-------
-  2 | MacBook Pro     | Electronics   |     0
-  4 | Samsung Galaxy  | Electronics   |     0
-  7 | Apple Watch     | Electronics   |     0
-  8 | Sony Headphones | Electronics   |     0
- 10 | Budget Phone    | Electronics   |     0
+  2 | MacBook Pro     | Electronics   |      
+  4 | Samsung Galaxy  | Electronics   |      
+  7 | Apple Watch     | Electronics   |      
+  8 | Sony Headphones | Electronics   |      
+ 10 | Budget Phone    | Electronics   |      
 (5 rows)
 
 -- Test Case 1.6: Simple test with just non-indexed predicate to isolate the issue
@@ -777,17 +777,13 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Sort
    Sort Key: (paradedb.score(id)) DESC
-   ->  Custom Scan (ParadeDB Scan) on products
-         Table: products
-         Index: products_bm25_idx
-         Exec Method: NormalScanExecState
-         Scores: true
-         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 1757 :opfuncid 1721 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 4 :location -1} {CONST :consttype 1700 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 8 [ 32 0 0 0 0 -127 100 0 ]}) :location -1}","description":"OpExpr with operator OID 1757"}]}},{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 1755 :opfuncid 1723 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 4 :location -1} {CONST :consttype 1700 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 8 [ 32 0 0 0 0 -127 44 1 ]}) :location -1}","description":"OpExpr with operator OID 1755"}]}},{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{VAR :varno 1 :varattno 7 :vartype 16 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 7 :location -1}","description":"Boolean field_7 = true"}]}}]}}
-(8 rows)
+   ->  Seq Scan on products
+         Filter: (in_stock AND (price >= 100.00) AND (price <= 300.00))
+(4 rows)
 
 SELECT 
     id,
@@ -801,9 +797,9 @@ WHERE price BETWEEN 100.00 AND 300.00
 ORDER BY score DESC;
  id |       name        | price  | in_stock | score 
 ----+-------------------+--------+----------+-------
-  3 | Nike Air Max      | 149.99 | t        |     0
-  5 | Adidas Ultraboost | 179.99 | t        |     0
-  8 | Sony Headphones   | 299.99 | t        |     0
+  3 | Nike Air Max      | 149.99 | t        |      
+  5 | Adidas Ultraboost | 179.99 | t        |      
+  8 | Sony Headphones   | 299.99 | t        |      
 (3 rows)
 
 -- Test Case 14: Array operations (if supported)

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -741,17 +741,13 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Sort
    Sort Key: (paradedb.score(id)) DESC
-   ->  Custom Scan (ParadeDB Scan) on products
-         Table: products
-         Index: products_bm25_idx
-         Exec Method: NormalScanExecState
-         Scores: true
-         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 1757 :opfuncid 1721 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 4 :location -1} {CONST :consttype 1700 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 8 [ 32 0 0 0 0 -127 100 0 ]}) :location -1}","description":"OpExpr with operator OID 1757"}]}},{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{OPEXPR :opno 1755 :opfuncid 1723 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 4 :location -1} {CONST :consttype 1700 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 8 [ 32 0 0 0 0 -127 44 1 ]}) :location -1}","description":"OpExpr with operator OID 1755"}]}},{"heap_filter":{"indexed_query":"all","field_filters":[{"expr_node":"{VAR :varno 1 :varattno 7 :vartype 16 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 7 :location -1}","description":"Boolean field_7 = true"}]}}]}}
-(8 rows)
+   ->  Seq Scan on products
+         Filter: (in_stock AND (price >= 100.00) AND (price <= 300.00))
+(4 rows)
 
 SELECT 
     id,
@@ -765,9 +761,9 @@ WHERE price BETWEEN 100.00 AND 300.00
 ORDER BY score DESC;
  id |       name        | price  | in_stock | score 
 ----+-------------------+--------+----------+-------
-  3 | Nike Air Max      | 149.99 | t        |     0
-  5 | Adidas Ultraboost | 179.99 | t        |     0
-  8 | Sony Headphones   | 299.99 | t        |     0
+  3 | Nike Air Max      | 149.99 | t        |      
+  5 | Adidas Ultraboost | 179.99 | t        |      
+  8 | Sony Headphones   | 299.99 | t        |      
 (3 rows)
 
 -- Test Case 14: Array operations (if supported)

--- a/pg_search/tests/pg_regress/sql/pushdown_scalar_array_opexr.sql
+++ b/pg_search/tests/pg_regress/sql/pushdown_scalar_array_opexr.sql
@@ -1,5 +1,9 @@
 \i common/common_setup.sql
 
+-- This flag is set to off by default, so we need to enable it to
+-- test the pushdown of scalar array expressions.
+SET paradedb.enable_custom_scan_without_operator = on;
+
 CREATE TABLE scalar_array_pushdown(
     id SERIAL PRIMARY KEY,
     uuid_col UUID,
@@ -87,6 +91,8 @@ OR text_col @@@ 'Alice'
 AND int_col > 2
 ORDER BY id
 LIMIT 10;
+
+RESET paradedb.enable_custom_scan_without_operator;
 
 DROP INDEX scalar_array_pushdown_idx;
 DROP TABLE scalar_array_pushdown;

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -98,7 +98,11 @@ where
 
     // and for the "bm25" query, we run it a number of times with more and more scan types disabled,
     // always ensuring that paradedb's custom scan is turned on
-    "SET paradedb.enable_custom_scan TO ON;".execute(conn);
+    r#"
+        SET paradedb.enable_custom_scan TO ON;
+        SET paradedb.enable_custom_scan_without_operator TO ON;
+    "#
+    .execute(conn);
     for scan_type in [
         "SET enable_seqscan TO OFF",
         "SET enable_indexscan TO OFF",

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -144,6 +144,7 @@ fn pushdown(mut conn: PgConnection) {
     "SET enable_indexscan TO off;".execute(&mut conn);
     "SET enable_bitmapscan TO off;".execute(&mut conn);
     "SET max_parallel_workers TO 0;".execute(&mut conn);
+    "SET enable_custom_scan_without_operator TO on;".execute(&mut conn);
 
     for operator in OPERATORS {
         for [sqltype, default] in TYPES {


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

PR #2639 was causing write throughput regression.

## Why

## How

We will disable the `paradedb.enable_custom_scan_without_operator` GUC by default.

## Tests
