### PR TITLE
chore: more improvements to index/schema configuration and management

### DIFF
--- a/.github/stressgres/bulk-updates.toml
+++ b/.github/stressgres/bulk-updates.toml
@@ -88,7 +88,7 @@ title = "Bulk Update"
 log_tps = true
 log_count = true
 sql = """
-EXPLAIN UPDATE test
+UPDATE test
 SET severity = (severity + 1) % 5
 WHERE id < 10000;
 """

--- a/.github/stressgres/bulk-updates.toml
+++ b/.github/stressgres/bulk-updates.toml
@@ -82,12 +82,13 @@ SELECT count(*) FROM test where id @@@ 'message:cheese';
 assert = "3000000"
 
 [[jobs]]
+window_height = 25
 refresh_ms = 25
 title = "Bulk Update"
 log_tps = true
 log_count = true
 sql = """
-UPDATE test
+EXPLAIN UPDATE test
 SET severity = (severity + 1) % 5
 WHERE id < 10000;
 """

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -188,9 +188,8 @@ pub fn search_with_query_input(
         )
             .expect("search_with_query_input: should be able to open a SearchIndexReader");
         let schema = search_reader.schema();
-        let key_field = search_reader.key_field();
-        let key_field_name = key_field.field_name().root();
-        let key_field_type = schema.search_field(&key_field_name).unwrap().field_type().into();
+        let key_field_name = schema.key_field_name();
+        let key_field_type = schema.key_field_type().into();
         let ff_helper =
             FFHelper::with_fields(&search_reader, &[(key_field_name, key_field_type).into()]);
 

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -41,13 +41,14 @@ use serde_json::Value;
 #[pg_extern]
 pub unsafe fn index_fields(index: PgRelation) -> anyhow::Result<JsonB> {
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let options = BM25IndexOptions::from_relation(&index);
-    let schema = SearchIndexSchema::open(&index)?;
+    let schema = index.schema()?;
 
     let mut name_and_config = HashMap::default();
     for (_, field_entry) in schema.fields() {
         let field_name = field_entry.name();
-        let field_config = options.field_config_or_default(&FieldName::from(field_name));
+        let field_config = index
+            .options()
+            .field_config_or_default(&FieldName::from(field_name));
         name_and_config.insert(field_name, field_config);
     }
 
@@ -57,8 +58,8 @@ pub unsafe fn index_fields(index: PgRelation) -> anyhow::Result<JsonB> {
 #[pg_extern]
 pub unsafe fn layer_sizes(index: PgRelation) -> Vec<AnyNumeric> {
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let options = BM25IndexOptions::from_relation(&index);
-    options
+    index
+        .options()
         .layer_sizes()
         .into_iter()
         .map(|layer_size| layer_size.into())

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -22,7 +22,7 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::index::IndexKind;
 use crate::postgres::insert::merge_index_with_policy;
-use crate::postgres::options::SearchIndexOptions;
+use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{
     LinkedList, MVCCEntry, SegmentMetaEntry, SEGMENT_METAS_START,
@@ -41,7 +41,7 @@ use serde_json::Value;
 #[pg_extern]
 pub unsafe fn index_fields(index: PgRelation) -> anyhow::Result<JsonB> {
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let options = SearchIndexOptions::from_relation(&index);
+    let options = BM25IndexOptions::from_relation(&index);
     let schema = SearchIndexSchema::open(&index)?;
 
     let mut name_and_config = HashMap::default();
@@ -57,7 +57,7 @@ pub unsafe fn index_fields(index: PgRelation) -> anyhow::Result<JsonB> {
 #[pg_extern]
 pub unsafe fn layer_sizes(index: PgRelation) -> Vec<AnyNumeric> {
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let options = SearchIndexOptions::from_relation(&index);
+    let options = BM25IndexOptions::from_relation(&index);
     options
         .layer_sizes()
         .into_iter()

--- a/pg_search/src/bootstrap/create_bm25.rs
+++ b/pg_search/src/bootstrap/create_bm25.rs
@@ -22,7 +22,6 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::index::IndexKind;
 use crate::postgres::insert::merge_index_with_policy;
-use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{
     LinkedList, MVCCEntry, SegmentMetaEntry, SEGMENT_METAS_START,
@@ -31,7 +30,6 @@ use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::storage::LinkedItemList;
 use crate::postgres::utils::item_pointer_to_u64;
 use crate::query::SearchQueryInput;
-use crate::schema::SearchIndexSchema;
 use anyhow::Result;
 use pgrx::prelude::*;
 use pgrx::JsonB;

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -355,7 +355,15 @@ impl Directory for MVCCDirectory {
 
     fn load_metas(&self, inventory: &SegmentMetaInventory) -> tantivy::Result<IndexMeta> {
         let loaded_metas = self.loaded_metas.get_or_init(|| unsafe {
-            match load_metas(&self.indexrel, inventory, &self.mvcc_style) {
+            match load_metas(
+                &self.indexrel,
+                inventory,
+                &self.mvcc_style,
+                self.indexrel
+                    .schema()
+                    .unwrap_or_else(|e| panic!("{e}"))
+                    .tantivy_schema(),
+            ) {
                 Err(e) => Arc::new(Err(e)),
                 Ok(loaded) => {
                     *self.all_entries.lock() = loaded

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -458,3 +458,11 @@ pub unsafe fn load_metas(
         total_segments,
     })
 }
+
+pub fn load_index_schema(indexrel: &PgSearchRelation) -> tantivy::Result<Option<Schema>> {
+    let schema_bytes = unsafe { LinkedBytesList::open(indexrel, SCHEMA_START).read_all() };
+    if schema_bytes.is_empty() {
+        return Ok(None);
+    }
+    Ok(serde_json::from_slice(&schema_bytes)?)
+}

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -323,6 +323,7 @@ pub unsafe fn load_metas(
     indexrel: &PgSearchRelation,
     inventory: &SegmentMetaInventory,
     solve_mvcc: &MvccSatisfies,
+    tantivy_schema: &Schema,
 ) -> tantivy::Result<LoadedMetas> {
     let mut total_segments = 0;
     let mut alive_segments = vec![];
@@ -440,16 +441,14 @@ pub unsafe fn load_metas(
         }
     }
 
-    let schema = LinkedBytesList::open(indexrel, SCHEMA_START);
     let settings = LinkedBytesList::open(indexrel, SETTINGS_START);
-    let deserialized_schema = serde_json::from_slice(&schema.read_all())?;
     let deserialized_settings = serde_json::from_slice(&settings.read_all())?;
 
     Ok(LoadedMetas {
         entries: alive_entries,
         meta: IndexMeta {
             segments: alive_segments,
-            schema: deserialized_schema,
+            schema: tantivy_schema.clone(),
             index_settings: deserialized_settings,
             opstamp: opstamp.unwrap_or(0),
             payload: None,

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -285,8 +285,8 @@ impl SearchIndexReader {
 
         let directory = mvcc_style.directory(index_relation);
         let mut index = Index::open(directory)?;
-        let schema = SearchIndexSchema::from_index(index_relation, &index);
-        setup_tokenizers(index_relation, &mut index, &schema)?;
+        let schema = index_relation.schema()?;
+        setup_tokenizers(index_relation, &mut index)?;
 
         let reader = index
             .reader_builder()

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -25,7 +25,6 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::CLEANUP_LOCK;
 use crate::postgres::storage::buffer::{BufferManager, PinnedBuffer};
 use crate::query::SearchQueryInput;
-use crate::schema::SearchField;
 use crate::schema::SearchIndexSchema;
 use anyhow::Result;
 use std::cmp::Ordering;
@@ -330,10 +329,6 @@ impl SearchIndexReader {
             .iter()
             .map(|r| r.segment_id())
             .collect()
-    }
-
-    pub fn key_field(&self) -> SearchField {
-        self.schema.key_field()
     }
 
     pub fn need_scores(&self) -> bool {

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -15,32 +15,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::options::BM25IndexOptions;
-use crate::postgres::utils::categorize_fields;
-use crate::schema::SearchIndexSchema;
-
 use crate::postgres::rel::PgSearchRelation;
 use anyhow::Result;
 use tantivy::Index;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager, SearchTokenizer};
 
-pub fn setup_tokenizers(
-    index_relation: &PgSearchRelation,
-    index: &mut Index,
-    schema: &SearchIndexSchema,
-) -> Result<()> {
-    let options = BM25IndexOptions::from_relation(index_relation);
-    let categorized_fields = categorize_fields(index_relation, schema);
+pub fn setup_tokenizers(index_relation: &PgSearchRelation, index: &mut Index) -> Result<()> {
+    let schema = index_relation.schema()?;
+    let categorized_fields = schema.categorized_fields();
 
     let mut tokenizers: Vec<SearchTokenizer> = Vec::new();
-    for (search_field, _) in categorized_fields {
+    for (search_field, _) in categorized_fields.iter() {
         if search_field.is_ctid() {
             continue;
         }
 
-        let config = options.field_config_or_default(search_field.field_name());
-        if let Some(tokenizer) = config.tokenizer().cloned() {
-            tokenizers.push(tokenizer);
+        let config = search_field.field_config();
+        if let Some(tokenizer) = config.tokenizer() {
+            tokenizers.push(tokenizer.clone());
         }
     }
 

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::postgres::options::SearchIndexOptions;
+use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::utils::categorize_fields;
 use crate::schema::SearchIndexSchema;
 
@@ -29,7 +29,7 @@ pub fn setup_tokenizers(
     index: &mut Index,
     schema: &SearchIndexSchema,
 ) -> Result<()> {
-    let options = unsafe { SearchIndexOptions::from_relation(index_relation) };
+    let options = BM25IndexOptions::from_relation(index_relation);
     let categorized_fields = categorize_fields(index_relation, schema);
 
     let mut tokenizers: Vec<SearchTokenizer> = Vec::new();
@@ -38,7 +38,7 @@ pub fn setup_tokenizers(
             continue;
         }
 
-        let config = options.field_config_or_default(&search_field.field_name());
+        let config = options.field_config_or_default(search_field.field_name());
         if let Some(tokenizer) = config.tokenizer().cloned() {
             tokenizers.push(tokenizer);
         }

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -139,8 +139,8 @@ impl SerialIndexWriter {
 
         let directory = mvcc_satisfies.directory(index_relation);
         let mut index = Index::open(directory)?;
-        let schema = SearchIndexSchema::from_index(index_relation, &index);
-        setup_tokenizers(index_relation, &mut index, &schema)?;
+        let schema = index_relation.schema()?;
+        setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();
 
         Ok(Self {

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -18,7 +18,6 @@
 use crate::api::FieldName;
 use crate::index::mvcc::MvccSatisfies;
 use crate::postgres::build_parallel::build_index;
-use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{
     SegmentMetaEntry, CLEANUP_LOCK, METADATA, SCHEMA_START, SEGMENT_METAS_START, SETTINGS_START,
@@ -27,7 +26,7 @@ use crate::postgres::storage::buffer::BufferManager;
 use crate::postgres::storage::metadata::MetaPageMut;
 use crate::postgres::storage::{LinkedBytesList, LinkedItemList};
 use crate::postgres::utils::extract_field_attributes;
-use crate::schema::{SearchFieldType, SearchIndexSchema};
+use crate::schema::SearchFieldType;
 use anyhow::Result;
 use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::*;

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -216,7 +216,7 @@ fn validate_field_config(
     let field_name = config.alias().unwrap_or(field_name);
     let field_type = options
         .get_field_type(&FieldName::from(field_name.to_string()))
-        .unwrap_or_else(|| panic!("the column `{field_name}` does not exist"));
+        .unwrap_or_else(|| panic!("the column `{field_name}` does not exist in the table"));
     if !matches(&field_type) {
         panic!("`{field_name}` was configured with the wrong type");
     }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -325,7 +325,7 @@ impl WorkerBuildState {
         let writer = SerialIndexWriter::open(indexrel, config, worker_number)?;
         let schema = writer.schema();
         let categorized_fields = categorize_fields(indexrel, schema);
-        let key_field_name = schema.key_field().field_name();
+        let key_field_name = schema.key_field_name();
         Ok(Self {
             writer: Some(writer),
             categorized_fields,
@@ -614,7 +614,7 @@ pub(super) fn build_index(
 
 mod plan {
     use super::*;
-    use crate::postgres::options::SearchIndexOptions;
+    use crate::postgres::options::BM25IndexOptions;
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
     /// The number of workers is determined by max_parallel_maintenance_workers. However, if max_parallel_maintenance_workers
@@ -695,7 +695,7 @@ mod plan {
         indexrel: &PgSearchRelation,
     ) -> usize {
         // If there are fewer rows than number of CPUs, use 1 worker
-        let options = unsafe { SearchIndexOptions::from_relation(indexrel) };
+        let options = BM25IndexOptions::from_relation(indexrel);
         let reltuples = plan::estimate_heap_reltuples(heaprel);
         let target_segment_count = options.target_segment_count();
         if reltuples <= target_segment_count as f64 {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -614,7 +614,7 @@ pub(super) fn build_index(
 
 mod plan {
     use super::*;
-    use crate::postgres::options::BM25IndexOptions;
+
     /// Determine the number of workers to use for a given CREATE INDEX/REINDEX statement.
     ///
     /// The number of workers is determined by max_parallel_maintenance_workers. However, if max_parallel_maintenance_workers

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -333,7 +333,9 @@ impl CustomScan for PdbScan {
             let segment_count = directory.total_segment_count(); // return value only valid after the index has been opened
             let index = Index::open(directory).expect("custom_scan: should be able to open index");
             let segment_count = segment_count.load(Ordering::Relaxed);
-            let schema = SearchIndexSchema::from_index(&bm25_index, &index);
+            let schema = bm25_index
+                .schema()
+                .expect("custom_scan: should have a schema");
             let pathkey = pullup_orderby_pathkey(&mut builder, rti, &schema, root);
 
             #[cfg(any(feature = "pg14", feature = "pg15"))]
@@ -655,7 +657,7 @@ impl CustomScan for PdbScan {
             let directory = MvccSatisfies::Snapshot.directory(&indexrel);
             let index = Index::open(directory)
                 .expect("should be able to open index for snippet extraction");
-            let schema = SearchIndexSchema::from_index(&indexrel, &index);
+            let schema = indexrel.schema().expect("should have a schema");
 
             let base_query = builder
                 .custom_private()
@@ -1263,10 +1265,9 @@ fn compute_exec_which_fast_fields(
 ) -> Option<Vec<WhichFastField>> {
     let exec_which_fast_fields = unsafe {
         let indexrel = builder.custom_state().indexrel();
-        let directory = MvccSatisfies::Snapshot.directory(indexrel);
-        let index =
-            Index::open(directory).expect("create_custom_scan_state: should be able to open index");
-        let schema = SearchIndexSchema::from_index(indexrel, &index);
+        let schema = indexrel
+            .schema()
+            .expect("create_custom_scan_state: should have a schema");
 
         // Calculate the ordered set of fast fields which have actually been requested in
         // the target list.

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -22,7 +22,7 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{
     IndexWriterConfig, Mergeable, SearchIndexMerger, SerialIndexWriter,
 };
-use crate::postgres::options::SearchIndexOptions;
+use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{SegmentMetaEntry, CLEANUP_LOCK, SEGMENT_METAS_START};
 use crate::postgres::storage::buffer::BufferManager;
@@ -59,7 +59,7 @@ impl InsertState {
         )?;
         let schema = writer.schema();
         let categorized_fields = categorize_fields(indexrel, schema);
-        let key_field_name = schema.key_field().field_name();
+        let key_field_name = schema.key_field_name();
 
         let per_row_context = pg_sys::AllocSetContextCreateExtended(
             PgMemoryContexts::CurrentMemoryContext.value(),
@@ -230,7 +230,7 @@ unsafe fn do_merge(indexrel: PgSearchRelation) -> (NumCandidates, NumMerged) {
         indexrel
     };
 
-    let index_options = SearchIndexOptions::from_relation(&indexrel);
+    let index_options = BM25IndexOptions::from_relation(&indexrel);
     let merge_policy = LayeredMergePolicy::new(index_options.layer_sizes());
 
     merge_index_with_policy(&indexrel, merge_policy, false, false, false)

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -22,7 +22,6 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{
     IndexWriterConfig, Mergeable, SearchIndexMerger, SerialIndexWriter,
 };
-use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{SegmentMetaEntry, CLEANUP_LOCK, SEGMENT_METAS_START};
 use crate::postgres::storage::buffer::BufferManager;

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -23,7 +23,6 @@ use crate::schema::IndexRecordOption;
 use crate::schema::{SearchFieldConfig, SearchFieldType};
 use std::cell::{Ref, RefCell};
 
-use crate::postgres::rel::PgSearchRelation;
 use anyhow::Result;
 use memoffset::*;
 use pgrx::pg_sys::AsPgCStr;
@@ -436,9 +435,7 @@ impl BM25IndexOptions {
             // it's one we add directly, so we need to account for it here
             return Some(SearchFieldType::U64(pg_sys::TIDOID));
         }
-        self.attributes()
-            .get(field_name)
-            .map(|(_, typ)| typ.clone())
+        self.attributes().get(field_name).map(|(_, typ)| *typ)
     }
 
     pub fn attributes(&self) -> Ref<HashMap<FieldName, (usize, SearchFieldType)>> {

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -19,7 +19,7 @@ use crate::postgres::build::is_bm25_index;
 use crate::postgres::options::BM25IndexOptions;
 use crate::schema::SearchIndexSchema;
 use pgrx::{name_data_to_str, pg_sys, PgList, PgTupleDesc};
-use std::cell::{Ref, RefCell};
+use std::cell::RefCell;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -18,7 +18,7 @@
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
-use crate::postgres::options::SearchIndexOptions;
+use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::parallel::list_segment_ids;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::{parallel, ScanStrategy};
@@ -124,9 +124,9 @@ pub extern "C-unwind" fn amrescan(
     unsafe {
         parallel::maybe_init_parallel_scan(scan, &search_reader);
 
-        let options = SearchIndexOptions::from_relation(&indexrel);
+        let options = BM25IndexOptions::from_relation(&indexrel);
         let key_field = options.key_field_name();
-        let key_field_type = search_reader.key_field().field_type().into();
+        let key_field_type = options.key_field_type().into();
 
         let results = if (*scan).parallel_scan.is_null() {
             // not a parallel scan

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::index::fast_fields_helper::FFHelper;
+use crate::index::fast_fields_helper::{FFHelper, FastFieldType};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
 use crate::postgres::options::BM25IndexOptions;
@@ -124,10 +124,6 @@ pub extern "C-unwind" fn amrescan(
     unsafe {
         parallel::maybe_init_parallel_scan(scan, &search_reader);
 
-        let options = BM25IndexOptions::from_relation(&indexrel);
-        let key_field = options.key_field_name();
-        let key_field_type = options.key_field_type().into();
-
         let results = if (*scan).parallel_scan.is_null() {
             // not a parallel scan
             search_reader.search(None)
@@ -141,10 +137,15 @@ pub extern "C-unwind" fn amrescan(
 
         let natts = (*(*scan).xs_hitupdesc).natts as usize;
         let scan_state = if (*scan).xs_want_itup {
+            let schema = indexrel.schema().expect("indexrel should have a schema");
             Bm25ScanState {
                 fast_fields: FFHelper::with_fields(
                     &search_reader,
-                    &[(key_field, key_field_type).into()],
+                    &[(
+                        schema.key_field_name(),
+                        FastFieldType::from(schema.key_field_type()),
+                    )
+                        .into()],
                 ),
                 reader: search_reader,
                 results,

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -18,7 +18,6 @@
 use crate::index::fast_fields_helper::{FFHelper, FastFieldType};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::{SearchIndexReader, SearchResults};
-use crate::postgres::options::BM25IndexOptions;
 use crate::postgres::parallel::list_segment_ids;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::{parallel, ScanStrategy};

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -85,6 +85,7 @@ pub fn u64_to_item_pointer(value: u64, tid: &mut pg_sys::ItemPointerData) {
     item_pointer_set_all(tid, blockno, offno);
 }
 
+#[derive(Debug)]
 pub struct CategorizedFieldData {
     pub attno: usize,
     pub base_oid: PgOid,
@@ -189,7 +190,7 @@ pub unsafe fn row_to_search_document(
         let datum = *values.add(*attno);
         let isnull = *isnull.add(*attno);
 
-        if isnull && *key_field_name == search_field.field_name() {
+        if isnull && key_field_name == search_field.field_name() {
             return Err(IndexError::KeyIdNull(key_field_name.to_string()));
         }
 

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -21,7 +21,7 @@ use crate::index::writer::index::IndexError;
 use crate::postgres::build::is_bm25_index;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::types::TantivyValue;
-use crate::schema::{CategorizedFieldData, SearchField, SearchFieldType, SearchIndexSchema};
+use crate::schema::{CategorizedFieldData, SearchField, SearchFieldType};
 use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, NaiveTime};
 use pgrx::itemptr::{item_pointer_get_both, item_pointer_set_all};

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -1041,7 +1041,7 @@ impl SearchQueryInput {
                 let lower_bound = coerce_bound_to_field_type(lower_bound, field_type);
                 let upper_bound = coerce_bound_to_field_type(upper_bound, field_type);
                 let (lower_bound, upper_bound) =
-                    check_range_bounds(typeoid.into(), lower_bound, upper_bound)?;
+                    check_range_bounds(typeoid, lower_bound, upper_bound)?;
 
                 let lower_bound = match lower_bound {
                     Bound::Included(value) => Bound::Included(value_to_term(
@@ -1093,7 +1093,7 @@ impl SearchQueryInput {
                 let typeoid = search_field.field_type().typeoid();
                 let is_datetime = search_field.is_datetime() || is_datetime;
                 let (lower_bound, upper_bound) =
-                    check_range_bounds(typeoid.into(), lower_bound, upper_bound)?;
+                    check_range_bounds(typeoid, lower_bound, upper_bound)?;
                 let range_field = RangeField::new(search_field.field(), is_datetime);
 
                 let mut satisfies_lower_bound: Vec<(Occur, Box<dyn Query>)> = vec![];
@@ -1248,7 +1248,7 @@ impl SearchQueryInput {
                 let is_datetime = search_field.is_datetime() || is_datetime;
 
                 let (lower_bound, upper_bound) =
-                    check_range_bounds(typeoid.into(), lower_bound, upper_bound)?;
+                    check_range_bounds(typeoid, lower_bound, upper_bound)?;
                 let range_field = RangeField::new(search_field.field(), is_datetime);
 
                 let mut satisfies_lower_bound: Vec<(Occur, Box<dyn Query>)> = vec![];
@@ -1518,7 +1518,7 @@ impl SearchQueryInput {
                 let typeoid = search_field.field_type().typeoid();
                 let is_datetime = search_field.is_datetime() || is_datetime;
                 let (lower_bound, upper_bound) =
-                    check_range_bounds(typeoid.into(), lower_bound, upper_bound)?;
+                    check_range_bounds(typeoid, lower_bound, upper_bound)?;
 
                 let range_field = RangeField::new(search_field.field(), is_datetime);
 

--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -122,8 +122,7 @@ impl MoreLikeThisQueryBuilder {
             .expect("more_like_this: index should have a heap relation");
         let schema = SearchIndexSchema::open(&index_relation)
             .expect("more_like_this: should be able to open schema");
-        let key_field = schema.key_field();
-        let (key_field_name, key_oid) = (key_field.field_name(), key_field.field_type().typeoid());
+        let (key_field_name, key_field_type) = (schema.key_field_name(), schema.key_field_type());
         let categorized_fields = categorize_fields(&index_relation, &schema);
 
         let doc_fields: Vec<(Field, Vec<OwnedValue>)> = pgrx::Spi::connect(|client| {
@@ -139,7 +138,7 @@ impl MoreLikeThisQueryBuilder {
                     None,
                     unsafe {
                         &[TantivyValue(key_value)
-                            .try_into_datum(key_oid.into())
+                            .try_into_datum(key_field_type.typeoid())
                             .expect("more_like_this: should be able to convert key value to datum")
                             .into()]
                     },

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -105,9 +105,9 @@ impl TryFrom<PgOid> for SearchFieldType {
             .unwrap_or_else(|| pgrx::error!("Failed to resolve base type for type {:?}", pg_oid));
         match &base_oid {
             PgOid::BuiltIn(builtin) => match builtin {
-                PgBuiltInOids::TEXTOID
-                | PgBuiltInOids::VARCHAROID
-                | PgBuiltInOids::TEXTARRAYOID => Ok(SearchFieldType::Text((*builtin).into())),
+                PgBuiltInOids::TEXTOID | PgBuiltInOids::VARCHAROID => {
+                    Ok(SearchFieldType::Text((*builtin).into()))
+                }
                 PgBuiltInOids::UUIDOID => Ok(SearchFieldType::Uuid((*builtin).into())),
                 PgBuiltInOids::INETOID => Ok(SearchFieldType::Inet((*builtin).into())),
                 PgBuiltInOids::INT2OID | PgBuiltInOids::INT4OID | PgBuiltInOids::INT8OID => {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -36,7 +36,6 @@ use anyhow::Result;
 use derive_more::Into;
 use pgrx::{pg_sys, PgBuiltInOids, PgOid};
 use serde::{Deserialize, Serialize};
-use tantivy::index::Index;
 use tantivy::schema::{Field, FieldEntry, FieldType, OwnedValue, Schema};
 use thiserror::Error;
 use tokenizers::manager::SearchTokenizerFilters;
@@ -244,7 +243,7 @@ impl SearchIndexSchema {
                 let mut search_fields = alias_lookup.remove(attname.as_ref()).unwrap_or_default();
 
                 // If there's an indexed field with the same name as a this column, add it to the list.
-                if let Some(index_field) = self.search_field(&attname) {
+                if let Some(index_field) = self.search_field(attname) {
                     search_fields.push(index_field)
                 };
 

--- a/pg_search/tests/pg_regress/expected/index_config_errors.out
+++ b/pg_search/tests/pg_regress/expected/index_config_errors.out
@@ -15,7 +15,7 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
         "some_wrong_key": {"tokenizer": {"type": "default"}}
     }'
     );
-ERROR:  field type should have been set for `some_wrong_key`
+ERROR:  the column `some_wrong_key` does not exist in the table
 CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
     USING bm25 (id, name)
     WITH (
@@ -25,4 +25,17 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
     }'
     );
 ERROR:  field config should be valid for SearchFieldConfig::name: unknown tokenizer type: some_wrong_type
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
+    USING bm25 (id, name)
+    WITH (
+    key_field = 'id',
+    text_fields ='{
+        "id": {"tokenizer": {"type": "default"}}
+    }'
+    );
+ERROR:  cannot override BM25 configuration for key_field 'id', you must use an aliased field name and 'column' configuration key
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name);
+ERROR:  index should have a `WITH (key_field='...')` option
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name) WITH (text_fields ='{"id": {"tokenizer": {"type": "default"}}}');
+ERROR:  index should have a `WITH (key_field='...')` option
 DROP TABLE test_index_config_errors CASCADE;

--- a/pg_search/tests/pg_regress/expected/top_n_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_n_scan.out
@@ -95,7 +95,6 @@ USING bm25 (
         "metadata_words": { "fast": true, "normalizer": "lowercase", "tokenizer": { "type": "default" }, "column": "metadata" } 
     }'
 );
-WARNING:  the `raw` tokenizer is deprecated
 \echo '======== EXECUTION METHOD TESTS ========'
 ======== EXECUTION METHOD TESTS ========
 \echo 'Tests to identify when TopNScanExecState vs NormalScanExecState is used'

--- a/pg_search/tests/pg_regress/sql/index_config_errors.sql
+++ b/pg_search/tests/pg_regress/sql/index_config_errors.sql
@@ -29,4 +29,19 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
     );
 
 
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
+    USING bm25 (id, name)
+    WITH (
+    key_field = 'id',
+    text_fields ='{
+        "id": {"tokenizer": {"type": "default"}}
+    }'
+    );
+
+
+
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name);
+CREATE INDEX idx_chunks_bm25 ON test_index_config_errors USING bm25 (id, name) WITH (text_fields ='{"id": {"tokenizer": {"type": "default"}}}');
+
+
 DROP TABLE test_index_config_errors CASCADE;

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -42,7 +42,7 @@ fn invalid_create_index(mut conn: PgConnection) {
         Ok(_) => panic!("should fail with no key_field"),
         Err(err) => assert_eq!(
             err.to_string(),
-            "error returned from database: key_field WITH option should be configured"
+            "error returned from database: index should have a `WITH (key_field='...')` option"
         ),
     };
 }


### PR DESCRIPTION
## What

#2660 brought a much needed round of cleanups to how we manage index schemas.  Unfortunately, it introduced quite some overhead in reading/decoding/validating the schema.  This process was happening quite a bit throughout the execution paths of `aminsert` and other hot-spots.

#2176 brought the ability to essentially keep one heavy-weight `PgSearchRelation` instantiated and cheaply clone it when necessary.  This PR cleans up things further such that the `SearchIndexSchema` is now a lazily-evaluated property of `PgSearchRelation`.  This means `SearchIndexSchema` is only evaluated when needed, and then only once (at least per statement).

Furthermore, its internal properties are lazily-evaluated, ensuring any given code path doesn't do more work than it needs.

This also renames `SearchIndexOptions` to `BM25IndexOptions`, mainly because I kept getting confused about what `SearchIndexOptions` represented (it was too similarly named to `SearchIndexSchema` for my tastes).  And `BM25IndexOptions` is now a property of `PgSearchRelation` too.

This seems to have drastically improved the write throughput of the INSERT/UPDATE jobs in our `single-server.toml` stressgress test.  v0.15.26 was 176/s INSERTs and 154/s UPDATEs.  This PR clocks in at 275/s and 260/s, respectively.

# Other Notable Changes

- Index configuration validation now happens during CREATE INDEX/REINDEX in `ambuildempty()` rather than on every instantiation of `SearchIndexSchema`.

- The "raw" tokenizer deprecation warnings are now gone, unless somehow the "key_field" is configured with it -- which is no longer possible

## Why

Trying to rollback performance regressions that were introduced in 0.16.0

## How

## Tests

All existing tests pass, and a few were updated due to the "raw" tokenizer deprecation warning going away and a change in wording for a specific validation error.
