### PR TITLE
chore: add git commit hash to stressgres-generated graph images

### DIFF
--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -80,6 +80,12 @@ jobs:
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
+      - name: Derive Short Commit
+        id: commit_info
+        run: |
+          short_commit=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
+
       - name: Install & Configure Supported PostgreSQL Version
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -115,14 +121,14 @@ jobs:
 
       - name: Create Stressgres Graph
         working-directory: stressgres/
-        run: cargo run --release -- graph stressgres-${{ matrix.test_file }}.log stressgres-${{ matrix.test_file }}.png
+        run: cargo run --release -- graph stressgres-${{ matrix.test_file }}.log stressgres-${{ matrix.test_file }}-${{ steps.commit_info.outputs.short_commit }}.png
 
       - name: Upload Stressgres Graph
         id: artifact-graph
         uses: actions/upload-artifact@v4
         with:
           name: stressgres-graph-${{ matrix.test_file }}
-          path: stressgres/stressgres-${{ matrix.test_file }}.png
+          path: stressgres/stressgres-${{ matrix.test_file }}-${{ steps.commit_info.outputs.short_commit }}.png
 
       - name: Upload Stressgres Logs
         id: artifact-logs
@@ -130,12 +136,6 @@ jobs:
         with:
           name: stressgres-logs-${{ matrix.test_file }}
           path: stressgres/stressgres-${{ matrix.test_file }}.log
-
-      - name: Derive Short Commit
-        id: commit_info
-        run: |
-          short_commit=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
 
       - name: Upload Stressgres Graphs to Slack
         uses: slackapi/slack-github-action@v2
@@ -147,8 +147,8 @@ jobs:
             initial_comment: |
               *Community Stressgres Results (${{ matrix.test_file }})*
               <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ steps.commit_info.outputs.short_commit }}> | <${{ steps.artifact-logs.outputs.artifact-url }} | Download Logs>
-            file: "stressgres/stressgres-${{ matrix.test_file }}.png"
-            filename: "stressgres-${{ matrix.test_file }}.png"
+            file: "stressgres/stressgres-${{ matrix.test_file }}-${{ steps.commit_info.outputs.short_commit }}.png"
+            filename: "stressgres-${{ matrix.test_file }}-${{ steps.commit_info.outputs.short_commit }}.png"
             request_file_info: true
           errors: true
           payload-templated: false


### PR DESCRIPTION
## What

This adds the short commit hash to the graph .png files generated by stressgres. 

## Why

Make it a little easier to manage them when downloaded locally as they'll have unique filenames.

## How

YAML

## Tests
