### PR TITLE
ci: Add generation of Stressgres results to CSV

### DIFF
--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Generate Stressgres Continuous Benchmarking Metrics
         working-directory: stressgres/
-        run: cargo run --release -- graph stressgres-${{ matrix.test_file }}.log output.csv
+        run: cargo run --release -- csv stressgres-${{ matrix.test_file }}.log output.csv
 
       - name: Create Stressgres Graph
         working-directory: stressgres/


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Added by Eric in https://github.com/paradedb/stressgres/pull/17. This will be the building block for doing continuous benchmarking on Stressgres.

## Why
^

## How
^

## Tests
CI