### PR TITLE
chore: Add support to the benchmark tool for emitting JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "anyhow",
  "clap",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "sqlx",
  "tokio",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -17,6 +17,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 pretty_assertions = "1.4.1"
 tokio = { version = "1.45", features = ["full"] }
+serde = "1.0.219"
 
 [lib]
 name = "paradedb"


### PR DESCRIPTION
## What

Dedupe index creation and query running across `md`/`csv` output formats, and add support for emitting `json` from the query benchmark job.

## Why

In order to graph them in https://github.com/benchmark-action/github-action-benchmark

## Tests

Manually validated that all `--output` modes produce expected results.