### PR TITLE
ci: Post "One-branch Release Model" Improvements

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   check-pg_search-schema-upgrade:
-    name: Post Schema Change to PR
+    name: SchemaBot
     runs-on: ubicloud-standard-8
     if: github.event.pull_request.draft == false
     strategy:
@@ -39,24 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history
-
-      # This step is used to check if the PR author is a member of the org, since
-      # posting a comment to the PR requires write access to the repo, which is limited
-      # to org members.
-      - name: Check if PR author is member of org
-        id: org-check
-        run: |
-          echo "Checking if ${{ github.actor }} is a member of the org..."
-          result=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: token ${{ secrets.GHA_CREATE_RELEASE_PAT }}" \
-            https://api.github.com/orgs/paradedb/members/${{ github.actor }})
-          if [ "$result" -eq 204 ]; then
-            echo "is_member=true" >> $GITHUB_OUTPUT
-            echo "PR author is a member of the org"
-          else
-            echo "is_member=false" >> $GITHUB_OUTPUT
-            echo "PR author is not a member of the org"
-          fi
 
       - name: Extract pgrx Version
         id: pgrx
@@ -166,7 +148,7 @@ jobs:
 
       - name: Attach Schema Diff to PR
         uses: actions/github-script@v7
-        if: steps.generate_commit_message.outputs.schema_diff_detected == 'true' && steps.org-check.outputs.is_member == 'true'
+        if: steps.generate_commit_message.outputs.schema_diff_detected == 'true'
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -48,11 +48,22 @@ jobs:
             echo "PR author is not a member of the org"
           fi
 
-      # We only login to Docker Hub if the PR author is a member of the org, since
-      # access to GitHub Actions secrets is limited to org members and this step
-      # is only used for comparing upcoming release Docker images via Docker Scout.
+      # To avoid spamming PRs with the Docker Scout comparison, we only run
+      # it if the PR modifies the Dockerfile or its related scripts
+      - name: Detect Dockerfile Changes
+        id: dockerfilter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+
+      # We only login to Docker Hub if the PR author is a member of the org and there
+      # are changes to the docker/ directory, since access to GitHub Actions secrets
+      # is limited to org members and we only want to compare upcoming release Docker
+      # images via Docker Scout when there are changes to the Dockerfile or its related scripts.
       - name: Login to Docker Hub
-        if: steps.org-check.outputs.is_member == 'true'
+        if: steps.org-check.outputs.is_member == 'true' && steps.dockerfilter.outputs.docker == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -109,7 +120,7 @@ jobs:
           fi
 
       - name: Compare the ParadeDB Docker Image to the ParadeDB Docker Image in Docker Hub via Docker Scout
-        if: steps.org-check.outputs.is_member == 'true'
+        if: steps.org-check.outputs.is_member == 'true' && steps.dockerfilter.outputs.docker == 'true'
         uses: docker/scout-action@v1
         with:
           command: compare


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
- Don't make Docker Scout post on PRs that don't modify the Dockerfile, not necessary.
- Make sure the SchemaBot workflow errors when community contributors make a PR, so we can catch needed changes to the SQL upgrade script.
- Rename it to SchemaBot

## Why
QoL

## How
^

## Tests
CI