### PR TITLE
chore: Increase benchmark run count to reduce noise.

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -106,7 +106,7 @@ jobs:
             echo "Unknown dataset!"
             exit 1
           fi
-          cargo run -- --url postgresql://localhost:288${{ matrix.pg_version }}/postgres --rows ${NUM_ROWS} --type pg_search --dataset ${{ matrix.dataset }} --output json
+          cargo run -- --url postgresql://localhost:288${{ matrix.pg_version }}/postgres --rows ${NUM_ROWS} --type pg_search --dataset ${{ matrix.dataset }} --runs 10 --output json
 
       - name: Check and Publish Continuous Benchmarking Metrics
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## What

Increase the run count in for the readonly queries.

## Why

To reduce noise in https://paradedb.github.io/paradedb/benchmarks/
