### PR TITLE
chore: Fix unit for average runtime in the benchmarks

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -90,7 +90,7 @@ async fn main() {
 }
 
 struct IndexCreationResult {
-    duration_min_secs: f64,
+    duration_min_ms: f64,
     index_name: String,
     index_size: i64,
     segment_count: i64,
@@ -99,7 +99,7 @@ struct IndexCreationResult {
 struct QueryResult {
     query_type: String,
     query: String,
-    runtimes_secs: Vec<f64>,
+    runtimes_ms: Vec<f64>,
     num_results: usize,
 }
 
@@ -113,16 +113,16 @@ struct JSONBenchmarkResult {
 
 impl From<QueryResult> for JSONBenchmarkResult {
     fn from(res: QueryResult) -> Self {
-        let avg = if res.runtimes_secs.is_empty() {
+        let avg = if res.runtimes_ms.is_empty() {
             0.0
         } else {
-            let sum: f64 = res.runtimes_secs.iter().sum();
-            sum / res.runtimes_secs.len() as f64
+            let sum: f64 = res.runtimes_ms.iter().sum();
+            sum / res.runtimes_ms.len() as f64
         };
 
         Self {
             name: res.query_type,
-            unit: "avg secs",
+            unit: "avg ms",
             value: avg,
             extra: res.query,
         }
@@ -134,13 +134,13 @@ fn process_index_creation(args: &Args) -> impl Iterator<Item = IndexCreationResu
     queries(Path::new(&index_sql)).into_iter().map(|statement| {
         println!("{statement}");
 
-        let duration_min_secs = execute_sql_with_timing(&args.url, &statement);
+        let duration_min_ms = execute_sql_with_timing(&args.url, &statement);
         let index_name = extract_index_name(&statement).to_owned();
         let index_size = get_index_size(&args.url, &index_name);
         let segment_count = get_segment_count(&args.url, &index_name);
 
         IndexCreationResult {
-            duration_min_secs,
+            duration_min_ms,
             index_name,
             index_size,
             segment_count,
@@ -188,13 +188,13 @@ fn run_benchmarks(args: &Args) -> impl Iterator<Item = QueryResult> + '_ {
         })
         .map(|(query_type, query)| {
             println!("Query Type: {query_type}\nQuery: {query}");
-            let (runtimes_secs, num_results) =
+            let (runtimes_ms, num_results) =
                 execute_query_multiple_times(&args.url, &query, args.runs);
-            println!("Results: {runtimes_secs:?} | Rows Returned: {num_results}\n");
+            println!("Results: {runtimes_ms:?} | Rows Returned: {num_results}\n");
             QueryResult {
                 query_type,
                 query,
-                runtimes_secs,
+                runtimes_ms,
                 num_results,
             }
         })
@@ -290,14 +290,14 @@ fn process_index_creation_csv(args: &Args) {
 
     for result in process_index_creation(args) {
         let IndexCreationResult {
-            duration_min_secs,
+            duration_min_ms,
             index_name,
             index_size,
             segment_count,
         } = result;
         writeln!(
             file,
-            "{index_name},{duration_min_secs:.2},{index_size},{segment_count}"
+            "{index_name},{duration_min_ms:.2},{index_size},{segment_count}"
         )
         .unwrap();
     }
@@ -319,13 +319,13 @@ fn run_benchmarks_csv(args: &Args) {
         let QueryResult {
             query_type,
             query,
-            runtimes_secs,
+            runtimes_ms,
             num_results,
         } = result;
 
         let mut result_line = query_type;
-        for &runtime_secs in &runtimes_secs {
-            result_line.push_str(&format!(",{runtime_secs:.0}"));
+        for &runtime_ms in &runtimes_ms {
+            result_line.push_str(&format!(",{runtime_ms:.0}"));
         }
         result_line.push_str(&format!(
             ",{},\"{}\"",
@@ -417,7 +417,7 @@ fn process_index_creation_md(file: &mut File, args: &Args) {
 
     for result in process_index_creation(args) {
         let IndexCreationResult {
-            duration_min_secs,
+            duration_min_ms,
             index_name,
             index_size,
             segment_count,
@@ -425,7 +425,7 @@ fn process_index_creation_md(file: &mut File, args: &Args) {
 
         writeln!(
             file,
-            "| {index_name} | {duration_min_secs:.2} | {index_size} | {segment_count} |"
+            "| {index_name} | {duration_min_ms:.2} | {index_size} | {segment_count} |"
         )
         .unwrap();
     }
@@ -440,11 +440,11 @@ fn run_benchmarks_md(file: &mut File, args: &Args) {
         let QueryResult {
             query_type,
             query,
-            runtimes_secs,
+            runtimes_ms,
             num_results,
         } = result;
         let md_query = query.replace("|", "\\|");
-        write_benchmark_results_md(file, &query_type, &runtimes_secs, num_results, &md_query);
+        write_benchmark_results_md(file, &query_type, &runtimes_ms, num_results, &md_query);
     }
 }
 


### PR DESCRIPTION
## What

The benchmarks claim to be running in seconds, but are running in microseconds: fix that.

## Why

To make the benchmarks look 1000x faster.