### PR TITLE
ci: remove the cancel-in-progress

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -29,7 +29,6 @@ permissions:
 
 concurrency:
   group: test-pg_search-benchmark-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   benchmark-pg_search:

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -30,7 +30,6 @@ permissions:
 
 concurrency:
   group: test-pg_search-stressgres-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   test-pg_search-stressgres:


### PR DESCRIPTION
let benchmark jobs run concurrently