### PR TITLE
ci: option (default true) for backfill to reset the data

### DIFF
--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -9,18 +9,44 @@ on:
       commits: # JSON array of SHAs
         description: >
           Commits to re-run, written as a JSON array.
-          Example: ["6d3c1f0", "a1b2c3d", "deadbeef"]
+          Example: `["6d3c1f0", "a1b2c3d", "deadbeef"]`
+
+          Using one hash still requires the JSON array syntax, ie `["6d3c1f0"]`.
         required: true
         type: string
+      reset_data:
+        description: Set to `true` to reset the data before running the benchmarks.  The default is `true`.
+        type: boolean
+        default: true
 
 # the token must be allowed to start other workflows
 permissions:
   actions: write
-  contents: read
+  contents: write
 
 jobs:
+  reset:
+    if: ${{ inputs.reset_data }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Reset data.js files
+        run: |
+          git config user.name "Benchmark Backfill Job"
+          git config user.email "info@paradedb.com"
+          files=$(git ls-files '**/data.js')
+          if [ -n "$files" ]; then
+            echo "$files" | xargs git rm
+            git commit -m "Reset data.js files"
+            git push
+          fi
+
   dispatch:
     # one job per commit
+    needs: reset
     strategy:
       matrix:
         sha: ${{ fromJSON(github.event.inputs.commits) }} # → ["…","…"]
@@ -42,7 +68,7 @@ jobs:
             for (const wf of targets) {
               /*  createWorkflowDispatch must point at a branch or tag, not a
                   bare SHA, so we send `ref:"main"` and hand the commit SHA
-                  through an input named `commit`  */                       // :contentReference[oaicite:0]{index=0}
+                  through an input named `commit`  */
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,


### PR DESCRIPTION
This adds a boolean option to the `benchmark-backfill` workflow to reset the existing `gh-pages` benchmark data.

This is accomplished by checking out the `gh-pages` branch, deleting whatever `**/data.js` files we find (if any) and pushd that change.