### PR TITLE
feat: move query benchmarks to reporting median, not average

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -16,3 +16,17 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod micro_benchmarks;
+
+pub fn median<'a>(data: impl Iterator<Item = &'a f64>) -> f64 {
+    let mut sorted = data.copied().collect::<Vec<_>>();
+    sorted.sort_unstable_by(|a, b| a.total_cmp(b));
+    let n = sorted.len();
+    if n == 0 {
+        return f64::NAN;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+}

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use paradedb::median;
 use paradedb::micro_benchmarks::benchmark_mixed_fast_fields;
 use sqlx::{Connection, PgConnection};
 use std::fs::File;
@@ -113,17 +114,12 @@ struct JSONBenchmarkResult {
 
 impl From<QueryResult> for JSONBenchmarkResult {
     fn from(res: QueryResult) -> Self {
-        let avg = if res.runtimes_ms.is_empty() {
-            0.0
-        } else {
-            let sum: f64 = res.runtimes_ms.iter().sum();
-            sum / res.runtimes_ms.len() as f64
-        };
+        let median = median(res.runtimes_ms.iter());
 
         Self {
             name: res.query_type,
-            unit: "avg ms",
-            value: avg,
+            unit: "median ms",
+            value: median,
             extra: res.query,
         }
     }


### PR DESCRIPTION
## What

Internal discussions have led to us wanting to track the "median" query execution times in our benchmarks.

The primary heavyweight query benchmarks, they now calculate/report "median ms" instead of "avg ms".

The benches in `micro_benchmarks/` _also_ calculate the median and report it as another data point.

## Why

To try and remove some noise in our CI benchmark reporting
