### PR TITLE
ci: if running from backfill use input commit in slack message

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -187,7 +187,7 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
             text: |
-              *<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ steps.commit_info.outputs.short_commit }}>*: Community "${{ matrix.dataset}}" Query Results available:
+              *<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.commit || steps.commit_info.outputs.short_commit }}>*: Community "${{ matrix.dataset}}" Query Results available:
               <https://paradedb.github.io/paradedb/benchmarks/>
           errors: true
           retries: 5


### PR DESCRIPTION
Just some cleanup to the Slack message links to show the commit benchmarked, not necessarily the commit containing the workflow file.