### PR TITLE
ci: (temporarily) disable concurrency controls on benchmark workflows

### DIFF
--- a/.github/workflows/test-pg_search-benchmark.yml
+++ b/.github/workflows/test-pg_search-benchmark.yml
@@ -32,13 +32,13 @@ permissions:
   deployments: write
   pull-requests: write
 
-concurrency:
-  # If this is a manual backfill run, use the commit SHA.
-  # Otherwise (push/PR) fall back to the branch name.
-  group: ${{ format('query-benchmarks-{0}',
-    (github.event_name == 'workflow_dispatch' && inputs.commit) || github.ref) }}
-  # Keep auto-cancellation for normal CI, switch it off for backfills.
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+#concurrency:
+#  # If this is a manual backfill run, use the commit SHA.
+#  # Otherwise (push/PR) fall back to the branch name.
+#  group: ${{ format('query-benchmarks-{0}',
+#    (github.event_name == 'workflow_dispatch' && inputs.commit) || github.ref) }}
+#  # Keep auto-cancellation for normal CI, switch it off for backfills.
+#  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   benchmark-pg_search:

--- a/.github/workflows/test-pg_search-stressgres.yml
+++ b/.github/workflows/test-pg_search-stressgres.yml
@@ -31,13 +31,13 @@ permissions:
   deployments: write
   pull-requests: write
 
-concurrency:
-  # If this is a manual backfill run, use the commit SHA.
-  # Otherwise (push/PR) fall back to the branch name.
-  group: ${{ format('stressgres-benchmarks-{0}',
-    (github.event_name == 'workflow_dispatch' && inputs.commit) || github.ref) }}
-  # Keep auto-cancellation for normal CI, switch it off for backfills.
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+#concurrency:
+#  # If this is a manual backfill run, use the commit SHA.
+#  # Otherwise (push/PR) fall back to the branch name.
+#  group: ${{ format('stressgres-benchmarks-{0}',
+#    (github.event_name == 'workflow_dispatch' && inputs.commit) || github.ref) }}
+#  # Keep auto-cancellation for normal CI, switch it off for backfills.
+#  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   test-pg_search-stressgres:


### PR DESCRIPTION
I've commented out the `concurrency:` block in these two jobs b/c I need to run the same hash a bunch of times, concurrently.