### PR TITLE
docs: Make parallel worker docs more correct

### DIFF
--- a/docs/documentation/configuration/parallel.mdx
+++ b/docs/documentation/configuration/parallel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Search Performance
+title: Read Throughput
 ---
 
 As a general rule of thumb, the performance of expensive search queries can be greatly improved
@@ -7,28 +7,26 @@ if they are able to access more parallel Postgres workers and more shared buffer
 
 ## Parallel Workers
 
-The number of parallel workers depends on the server's CPU count and certain
-Postgres settings in `postgresql.conf`.
+There are three settings that control how many parallel workers ultimately get assigned to a query.
 
-`max_parallel_workers` and `max_worker_processes` control how many workers are available to parallel scans.
-`max_worker_processes` is a global limit for the number of available workers across all connections, and
-`max_parallel_workers` specifies how many of those workers can be used for parallel scans.
-
-```init postgresql.conf
-max_worker_processes = 16
-max_parallel_workers = 16
-```
-
-Next, `max_parallel_workers_per_gather` must be set. This setting is a limit for the number of parallel workers that a single parallel query can use. The default is `2`.
-This setting can be set in `postgresql.conf` to apply to all connections, or within a connection to apply to a single
-session.
+First, `max_worker_processes` is a global limit for the number of workers.
+Next, `max_parallel_workers` is a subset of `max_worker_processes`, and sets the limit for workers used in
+parallel queries. Finally, `max_parallel_workers_per_gather` limits how many workers a *single query* can receive.
 
 ```init postgresql.conf
-max_parallel_workers_per_gather = 16
+max_worker_processes = 72
+max_parallel_workers = 64;
+max_parallel_workers_per_gather = 4;
 ```
 
-The number of parallel workers should not exceed the server's CPU count. `max_worker_processes` and `max_parallel_workers` must be changed inside `postgresql.conf`,
-and Postgres must be restarted afterward.
+In the above example, the maximum number of workers that a single query can receive is set to `4`. The `max_parallel_workers` pool
+is set to `64`, which means that `16` queries can execute simultaneously with `4` workers each. Finally, `max_worker_processes` is
+set to `72` to give headroom for other workers like autovacuum and replication.
+
+<Note>
+If all `max_parallel_workers` are in use, Postgres will still execute additional queries, but those queries will run without parallelism.
+This means that queries do not fail — they just may run slower due to lack of parallelism.
+</Note>
 
 ## Shared Buffers
 

--- a/docs/documentation/configuration/parallel.mdx
+++ b/docs/documentation/configuration/parallel.mdx
@@ -11,7 +11,7 @@ There are three settings that control how many parallel workers ultimately get a
 
 First, `max_worker_processes` is a global limit for the number of workers.
 Next, `max_parallel_workers` is a subset of `max_worker_processes`, and sets the limit for workers used in
-parallel queries. Finally, `max_parallel_workers_per_gather` limits how many workers a *single query* can receive.
+parallel queries. Finally, `max_parallel_workers_per_gather` limits how many workers a _single query_ can receive.
 
 ```init postgresql.conf
 max_worker_processes = 72
@@ -23,9 +23,14 @@ In the above example, the maximum number of workers that a single query can rece
 is set to `64`, which means that `16` queries can execute simultaneously with `4` workers each. Finally, `max_worker_processes` is
 set to `72` to give headroom for other workers like autovacuum and replication.
 
+In practice, we recommend experimenting with different settings, as the best configuration depends on the underlying hardware,
+query patterns, and volume of data.
+
 <Note>
-If all `max_parallel_workers` are in use, Postgres will still execute additional queries, but those queries will run without parallelism.
-This means that queries do not fail — they just may run slower due to lack of parallelism.
+  If all `max_parallel_workers` are in use, Postgres will still execute
+  additional queries, but those queries will run without parallelism. This means
+  that queries do not fail — they just may run slower due to lack of
+  parallelism.
 </Note>
 
 ## Shared Buffers


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Previous docs recommended setting `max_parallel_workers` equal to the per gather setting, and pinning to CPU count, both of which are usually not optimal.

## Why

## How

## Tests
