### PR TITLE
ci: use the custom/composite actions from @main

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -144,7 +144,7 @@ jobs:
           echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
 
       - name: Benchmark "single" Dataset
-        uses: ./.github/actions/benchmark-benchmarks
+        uses: paradedb/pg_search/.github/actions/benckmark-benchmarks@main
         with:
           dataset: single
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
@@ -154,7 +154,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
 
       - name: Benchmark "join" Dataset
-        uses: ./.github/actions/benchmark-benchmarks
+        uses: paradedb/pg_search/.github/actions/benckmark-benchmarks@main
         with:
           dataset: join
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -141,7 +141,7 @@ jobs:
 
       # Runs default to 10 minutes, but can be configured to run for longer with the `duration` input.
       - name: Benchmark single-server.toml
-        uses: ./.github/actions/benchmark-stressgres
+        uses: paradedb/pg_search/.github/actions/benckmark-stressgres@main
         with:
           test_file: single-server.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
@@ -151,7 +151,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
 
       - name: Benchmark bulk-updates.toml
-        uses: ./.github/actions/benchmark-stressgres
+        uses: paradedb/pg_search/.github/actions/benckmark-stressgres@main
         with:
           test_file: bulk-updates.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
@@ -161,7 +161,7 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
 
       - name: Benchmark wide-table.toml
-        uses: ./.github/actions/benchmark-stressgres
+        uses: paradedb/pg_search/.github/actions/benckmark-stressgres@main
         with:
           test_file: wide-table.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}


### PR DESCRIPTION
The new benchmark `action.yaml` files don't exist in historical commits, which is what the benchmarks also test during a backfill.

So always use whatever is at `main`.
