### PR TITLE
perf: Lazily load fast fields dictionaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "bitpacking",
 ]
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "nom",
 ]
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4689,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
+source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "bitpacking",
 ]
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "nom",
 ]
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4689,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d37e61e6b8ddb105cbdc3ab391633ca108de6b73#d37e61e6b8ddb105cbdc3ab391633ca108de6b73"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.avoid-owned-bytes-dictionary#73d0776bf76fbe9ea291bf1af62deaa6ff03cffd"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d37e61e6b8ddb105cbdc3ab391633ca108de6b73", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.avoid-owned-bytes-dictionary", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d37e61e6b8ddb105cbdc3ab391633ca108de6b73" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.avoid-owned-bytes-dictionary" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.avoid-owned-bytes-dictionary", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "16740add9447330b133348448ce4988edcc8174f", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.avoid-owned-bytes-dictionary" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "16740add9447330b133348448ce4988edcc8174f" }


### PR DESCRIPTION
## What

Lazily load fast field dictionaries from buffers: see https://github.com/paradedb/tantivy/pull/55

## Why

A customer reported slower-than-expected paging on a string/uuid column. 85% of the time for that query was being spent in _opening_ a fast fields string/bytes column, with a large fraction of that time spent fully consuming the column's `Dictionary`. 

## Tests

See the attached benchmark results:
* [`docs` dataset](https://github.com/paradedb/paradedb/pull/2842#pullrequestreview-3014379545)
    * No regressions.
    * 2x faster for `top_n-score`
    * 1.4x faster for `highlighting` 
* [`logs` dataset](https://github.com/paradedb/paradedb/pull/2842#pullrequestreview-3014350211)
    * No regressions.
    * 4.5x faster for `paging-string-max`
    * 1.7x faster for `paging-string-median`
    * 1.6x faster for `paging-string-min`

The `paging-string-*` benchmarks were added in #2834 to highlight this particular issue.