### PR TITLE
chore: Formalize stable branches (cherry-pick of #2848)

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -10,7 +10,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
     paths:
       - ".github/workflows/check-pg_search-schema-upgrade.yml"
       - "pg_search/**"

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -10,8 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
-      - dev
+      - 0.*.x
     paths:
       - ".github/workflows/check-pg_search-schema-upgrade.yml"
       - "pg_search/**"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,8 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
-      - dev
+      - 0.*.x
     paths:
       - ".github/workflows/test-docs.yml"
       - "docs/**"

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -50,20 +50,11 @@ jobs:
         working-directory: docker/
         run: docker compose -f docker-compose.dev.yml build
 
-      # On PRs to `dev`, we start the ParadeDB Docker image using Docker Compose to test the
-      # compose file. The docker-compose.yml file will use the local ParadeDB image that we
-      # just built since we tagged it with `latest` in docker-compose.dev.yml.
-      - name: Start the ParadeDB Docker Image via Docker Compose (dev only)
-        if: github.event.pull_request.base.ref == 'dev'
-        working-directory: docker/
-        run: docker compose -f docker-compose.yml up -d && sleep 10
-
-      # On PRs to `main` or `staging`, we start the ParadeDB Docker image using `docker run` to test the
+      # On PRs, we start the ParadeDB Docker image using `docker run` to test the
       # standalone Docker image. We add a --tmpfs mount as a test of compatibility with the
       # upstream `postgres` image. The `docker run` command will use the local ParadeDB image
       # that we just built since we tagged it with `latest` in docker-compose.dev.yml.
-      - name: Start the ParadeDB Docker Image via Docker Run (main only)
-        if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'staging'
+      - name: Start the ParadeDB Docker Image via Docker Run (stable branches only)
         working-directory: docker/
         run: |
           docker run -d \

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -10,8 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
-      - dev
+      - 0.*.x
     paths:
       - ".github/workflows/test-pg_search-docker.yml"
       - "docker/**"

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
+      - 0.*.x
     paths:
       - ".github/workflows/test-pg_search-upgrade.yml"
       - "pg_search/**"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -10,8 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - staging
-      - dev
+      - 0.*.x
     paths:
       - ".github/workflows/test-pg_search.yml"
       - "pg_search/**"


### PR DESCRIPTION
## What

Run most `main` CI jobs on PRs to stable branches (named `0.*.x`), and formalize them a bit in `RELEASE.md`.