### PR TITLE
ci: benchmark workflow cleanups

### DIFF
--- a/.github/actions/benchmark-benchmarks/action.yml
+++ b/.github/actions/benchmark-benchmarks/action.yml
@@ -20,6 +20,9 @@ inputs:
   slack_webhook_url:
     description: "Slack webhook URL to post results to"
     required: true
+  pr_label:
+    description: "The human readable version of the commit being tested"
+    required: true
 
 runs:
   using: "composite"
@@ -75,7 +78,9 @@ runs:
         payload: |
           channel: ${{ inputs.slack_channel }}
           text: |
-            *<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.ref }}>*: Community \`${{ inputs.dataset }}\` Query Results available: <https://paradedb.github.io/paradedb/benchmarks/>
+            ${{ github.repository }} Benchmark Results
+            ${{ inputs.pr_title }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>
+            <https://paradedb.github.io/paradedb/benchmarks/>
 
     - name: Notify Slack on Failure (push only)
       if: failure() && github.event_name == 'push'

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -24,6 +24,9 @@ inputs:
   slack_webhook_url:
     description: "Slack webhook URL to post results to"
     required: true
+  pr_label:
+    description: "The human readable version of the commit being tested"
+    required: true
 
 runs:
   using: "composite"
@@ -139,7 +142,7 @@ runs:
 
     - name: Create Stressgres Graph
       shell: bash
-      run: stressgres graph "stressgres-${{ steps.sanitize-inputs.outputs.jobname }}.log" "stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.sanitize-inputs.outputs.safe_ref }}.png"
+      run: stressgres graph "stressgres-${{ steps.sanitize-inputs.outputs.jobname }}.log" "stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ github.sha }}.png"
 
     - name: Upload Stressgres Results to Slack (push only)
       if: github.event_name != 'pull_request'
@@ -150,9 +153,11 @@ runs:
         payload: |
           channel_id: ${{ inputs.slack_channel }}
           initial_comment: |
-            *<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.ref }}>*: Community Stressgres "${{ inputs.test_file }}" Results (<${{ steps.artifact-logs.outputs.artifact-url }} | logs>): <https://paradedb.github.io/paradedb/stressgres/>
-          file: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.sanitize-inputs.outputs.safe_ref }}.png
-          filename: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.sanitize-inputs.outputs.safe_ref }}.png
+            ${{ github.repository }} Stressgres Results: `${{ inputs.test_file }}`
+            ${{ inputs.pr_title }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>
+            <https://paradedb.github.io/paradedb/stressgres/>
+          file: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ github.sha }}}.png
+          filename: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ github.sha }}.png
 
     - name: Print Postgres Logs
       shell: bash

--- a/.github/actions/benchmarks-from-main/action.yml
+++ b/.github/actions/benchmarks-from-main/action.yml
@@ -1,0 +1,35 @@
+name: benchmarks-from-main
+description: Fetch latest benchmark code, suites, and actions from `main`
+
+# We manually fetch the benchmark queries *and* our custom actions from `main` to make sure all are available
+# when backfilling old commits potentially created before new queries were added.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Fetch the Latest Benchmark Queries
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository }}
+        path: bench-temp
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
+        ref: main
+
+    - name: Copy latest benchmarks into place
+      shell: bash
+      run: |
+        rm -rf benchmarks
+        cp -rv bench-temp/benchmarks .
+
+        echo "Copied benchmark files to benchmarks/:"
+        ls -la benchmarks/
+
+    - name: Copy latest actions into place
+      shell: bash
+      run: |
+        cp -rv bench-temp/.github/actions .github/
+
+    - name: Cleanup temporary checkout
+      shell: bash
+      run: rm -rf bench-temp

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -70,17 +70,34 @@ jobs:
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
 
-      # We manually fetch the benchmark queries from `main` to make sure all are available when backfilling
-      # old commits potentially created before new queries were added.
-      - name: Fetch the Latest Benchmark Queries
-        run: |
-          git clone --depth 1 --branch main https://github.com/paradedb/paradedb.git paradedb-temp
-          rm -rf benchmarks
-          cp -rv paradedb-temp/benchmarks .
-          rm -rf paradedb-temp/
+      - name: Fetch latest benchmark code, suites, and actions
+        uses: ./.github/actions/benchmarks-from-main
 
-          echo "Copied benchmark files to benchmarks/:"
-          ls -la benchmarks/
+      - name: Find PR for this commit
+        id: find_pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: sha
+            });
+
+            if (pulls.length) {
+              return `PR #${pulls[0].number}: ${pulls[0].title}`;
+            } else {
+              // fall back to the raw SHA
+              return sha;
+            }
+
+      - name: Running for ${{ steps.find_pr.outputs.result }}"
+        shell: bash
+        run: |
+          echo ${{ steps.find_pr.outputs.result }}"
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -144,12 +161,6 @@ jobs:
           short_commit=$(echo "${GITHUB_SHA}" | cut -c1-7)
           echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
 
-      - name: Fetch Benchmark Actions from main
-        run: |
-          git clone --depth 1 --branch main https://github.com/paradedb/paradedb.git tmp
-          cp -r tmp/.github/actions .github/
-          rm -rf tmp
-
       - name: Benchmark "logs" Dataset
         uses: ./.github/actions/benchmark-benchmarks
         with:
@@ -159,6 +170,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
+          pr_label: ${{ steps.find_pr.outputs.result }}"
 
       - name: Benchmark "docs" Dataset
         uses: ./.github/actions/benchmark-benchmarks
@@ -169,3 +181,4 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
+          pr_label: ${{ steps.find_pr.outputs.result }}"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -71,16 +71,34 @@ jobs:
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
 
-      # We manually fetch the stressgres queries from `main` to make sure all are available when backfilling
-      # old commits potentially created before new queries were added.
-      - name: Fetch the Latest Stressgres Jobs
-        run: |
-          git clone --depth 1 --branch main https://github.com/paradedb/paradedb.git paradedb-temp
-          cp -rv paradedb-temp/.github/stressgres .github/
-          rm -rf paradedb-temp
+      - name: Fetch latest benchmark code, suites, and actions
+        uses: ./.github/actions/benchmarks-from-main
 
-          echo "Files copied to .github/stressgres/:"
-          ls -la .github/stressgres/
+      - name: Find PR for this commit
+        id: find_pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: sha
+            });
+
+            if (pulls.length) {
+              return `PR #${pulls[0].number}: ${pulls[0].title}`;
+            } else {
+              // fall back to the raw SHA
+              return sha;
+            }
+
+      - name: Running for ${{ steps.find_pr.outputs.result }}"
+        shell: bash
+        run: |
+          echo ${{ steps.find_pr.outputs.result }}"
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -139,12 +157,6 @@ jobs:
       - name: Remove stressgres repo
         run: rm -rf stressgres
 
-      - name: Fetch Benchmark Actions from main
-        run: |
-          git clone --depth 1 --branch main https://github.com/paradedb/paradedb.git tmp
-          cp -r tmp/.github/actions .github/
-          rm -rf tmp
-
       # Runs default to 10 minutes, but can be configured to run for longer with the `duration` input.
       - name: Benchmark single-server.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -155,6 +167,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
+          pr_label: ${{ steps.find_pr.outputs.result }}"
 
       - name: Benchmark bulk-updates.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -165,6 +178,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
+          pr_label: ${{ steps.find_pr.outputs.result }}"
 
       - name: Benchmark wide-table.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -175,3 +189,4 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
+          pr_label: ${{ steps.find_pr.outputs.result }}"


### PR DESCRIPTION
This is an attempt to cleanup the benchmark workflows a little bit.  

- Centralizes checking out the latest benchmark code/suites/actions into a composite action.
- figures out the PR #/title being tested
- Changes the slack notification messages to be dynamic to hopefully avoid conflicts with -enterprise
