### PR TITLE
chore: fix schema upgrade scripts

### DIFF
--- a/pg_search/sql/pg_search--0.16.3--0.16.4.sql
+++ b/pg_search/sql/pg_search--0.16.3--0.16.4.sql
@@ -1,9 +1,1 @@
-CREATE  FUNCTION "fsm_info"(
-    "index" regclass /* pgrx::rel::PgRelation */
-) RETURNS TABLE (
-                    "fsm_blockno" NUMERIC,  /* pgrx::datum::numeric::AnyNumeric */
-                    "free_blockno" NUMERIC  /* pgrx::datum::numeric::AnyNumeric */
-                )
-    STRICT
-    LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'fsm_info_wrapper';
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.16.4'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.16.4--0.17.0.sql
+++ b/pg_search/sql/pg_search--0.16.4--0.17.0.sql
@@ -1,0 +1,9 @@
+CREATE  FUNCTION "fsm_info"(
+    "index" regclass /* pgrx::rel::PgRelation */
+) RETURNS TABLE (
+                    "fsm_blockno" NUMERIC,  /* pgrx::datum::numeric::AnyNumeric */
+                    "free_blockno" NUMERIC  /* pgrx::datum::numeric::AnyNumeric */
+                )
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fsm_info_wrapper';


### PR DESCRIPTION
This fixes the upgrade script paths in light of today's 0.16.4 patch release.

There were no schema changes from 0.16.3 to 0.16.4, but there are going to be some from 0.16.4 to whenever we release 0.17.0