### PR TITLE
chore: Fix count query ordering in benchmarks

### DIFF
--- a/benchmarks/datasets/logs/queries/pg_search/count-filter.sql
+++ b/benchmarks/datasets/logs/queries/pg_search/count-filter.sql
@@ -1,11 +1,11 @@
 -- numeric fast field
 SELECT COUNT(*) FROM benchmark_logs WHERE message @@@ 'team';
 
--- aggregate custom scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM benchmark_logs WHERE message @@@ 'team';
-
 -- aggregate with mvcc
 SELECT * FROM paradedb.aggregate(index=>'benchmark_logs_idx', query=>paradedb.term('message', 'team'), agg=>'{"count": { "value_count": { "field": "ctid" }}}', solve_mvcc=>true);
 
 -- aggregate without mvcc
 SELECT * FROM paradedb.aggregate(index=>'benchmark_logs_idx', query=>paradedb.term('message', 'team'), agg=>'{"count": { "value_count": { "field": "ctid" }}}', solve_mvcc=>false);
+
+-- aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM benchmark_logs WHERE message @@@ 'team';

--- a/benchmarks/datasets/logs/queries/pg_search/count-nofilter.sql
+++ b/benchmarks/datasets/logs/queries/pg_search/count-nofilter.sql
@@ -1,11 +1,11 @@
 -- numeric fast field
 SELECT COUNT(*) FROM benchmark_logs WHERE id @@@ paradedb.all();
 
--- aggregate custom scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM benchmark_logs WHERE id @@@ paradedb.all();
-
 -- aggregate with mvcc
 SELECT * FROM paradedb.aggregate(index=>'benchmark_logs_idx', query=>paradedb.all(), agg=>'{"count": { "value_count": { "field": "ctid" }}}', solve_mvcc=>true);
 
 -- aggregate without mvcc
 SELECT * FROM paradedb.aggregate(index=>'benchmark_logs_idx', query=>paradedb.all(), agg=>'{"count": { "value_count": { "field": "ctid" }}}', solve_mvcc=>false);
+
+-- aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM benchmark_logs WHERE id @@@ paradedb.all();


### PR DESCRIPTION
## What

Reorder the count queries, since they were shuffled in #2763 and that caused some false positive performance alerts. 

## Why

Query alternatives are offset based: avoid inserting above existing queries (for now.)