### PR TITLE
ci: don't run benchmarks when the workflow files change

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -12,7 +12,6 @@ on:
       - main
     paths:
       - "benchmarks/**"
-      - ".github/workflows/benchmark-pg_search-benchmarks.yml"
       - "**/*.rs"
       - "**/*.toml"
   pull_request:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -13,7 +13,6 @@ on:
       - main
     paths:
       - ".github/stressgres/**"
-      - ".github/workflows/benchmark-pg_search-stressgres.yml"
       - "**/*.rs"
       - "**/*.toml"
   pull_request:


### PR DESCRIPTION
## What

If the only change in the PR being merged to main is to the benchmarks or stressgres benchmark workflows themselves then we don't actually need to run them.

## Why

Doing so just adds another point to the historical data that isn't representative of anything useful.

## How

YAML

## Tests
