### PR TITLE
ci: workflow to automatically backfill

### DIFF
--- a/.github/workflows/benchmark-backfill-auto.yml
+++ b/.github/workflows/benchmark-backfill-auto.yml
@@ -16,8 +16,9 @@ jobs:
       - name: Load and extract commit IDs from benchmark data
         id: extract_commits
         run: |
-          # fetch the remote data.js
-          curl -sSL https://raw.githubusercontent.com/paradedb/benchmark-data/refs/heads/main/data.js \
+          # fetch the existing benchmark data.  we only get the stressgres data as
+          # all benchmark styles should have the same commits
+          curl -sSL https://paradedb.github.io/paradedb/stressgres/data.js \
             -o data.js
 
           # run a tiny Node script to eval and extract distinct commit IDs


### PR DESCRIPTION
This workflow can be run manually from the "[Actions]" tab without any inputs.  It will automatically detect all the hashes we've already benchmarked, reset the data, then do a backfill of those hashes.