### PR TITLE
ci: fix gh-pages link in slack messages

### DIFF
--- a/.github/actions/benchmark-benchmarks/action.yml
+++ b/.github/actions/benchmark-benchmarks/action.yml
@@ -80,7 +80,7 @@ runs:
           text: |
             ${{ github.repository }} Benchmark Results: `${{ inputs.dataset }}`
             ${{ inputs.pr_label }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>
-            <https://paradedb.github.io/paradedb/benchmarks/>
+            <https://paradedb.github.io/${{ github.repository }}/benchmarks/>
 
     - name: Notify Slack on Failure (push only)
       if: failure() && github.event_name == 'push'

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -173,7 +173,7 @@ runs:
           initial_comment: |
             ${{ github.repository }} Stressgres Results: `${{ inputs.test_file }}`
             ${{ inputs.pr_label }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.resolve_ref.outputs.sha }}>
-            <https://paradedb.github.io/paradedb/stressgres/>
+            <https://paradedb.github.io/${{ github.repository }}/stressgres/>
           file: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.png
           filename: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.png
 


### PR DESCRIPTION
This uses variables to form the important bits of the Slack message link to the github pages repo.  Will fix links for enterprise benchmark reports.