### PR TITLE
ci: Make benchmark Slack notifs be a link

### DIFF
--- a/.github/actions/benchmark-benchmarks/action.yml
+++ b/.github/actions/benchmark-benchmarks/action.yml
@@ -79,8 +79,7 @@ runs:
           channel: ${{ inputs.slack_channel }}
           text: |
             ${{ github.repository }} Benchmark Results: `${{ inputs.dataset }}`
-            ${{ inputs.pr_label }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>
-            <https://paradedb.github.io/${{ github.repository }}/benchmarks/>
+            <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.pr_label }}> @ <https://paradedb.github.io/${{ github.repository }}/benchmarks/>
 
     - name: Notify Slack on Failure (push only)
       if: failure() && github.event_name == 'push'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This will replace:

<img width="942" height="103" alt="Capture d’écran 2025-07-17 à 05 38 33" src="https://github.com/user-attachments/assets/fe6e384d-f1f0-4c0f-a239-62a0b7703807" />

by the same `PR #2870: chore: Upgrade to 0.17.0` but with the commit as a hyperlink to it, which I thought was cleaner and less noise.

## Why
^

## How
^

## Tests
^ 