### PR TITLE
chore: Make commit be hyperlink on its name for stressgres Slack notifs

### DIFF
--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -172,8 +172,7 @@ runs:
           channel_id: ${{ inputs.slack_channel }}
           initial_comment: |
             ${{ github.repository }} Stressgres Results: `${{ inputs.test_file }}`
-            ${{ inputs.pr_label }} @ <${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.resolve_ref.outputs.sha }}>
-            <https://paradedb.github.io/${{ github.event.repository.name }}/stressgres/>
+            <${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.resolve_ref.outputs.sha }}|${{ inputs.pr_label }}> @ <https://paradedb.github.io/${{ github.event.repository.name }}/stressgres/>
           file: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.png
           filename: stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.png
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We did this for benchmarks, but had forgotten for stressgres. Just easier to read.

## Why
^

## How
^

## Tests
^