### PR TITLE
chore: move code around

### DIFF
--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -25,11 +25,113 @@ use crate::postgres::storage::block::{LinkedList, MVCCEntry, SegmentMetaEntry};
 use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::utils::item_pointer_to_u64;
 use crate::query::SearchQueryInput;
+use crate::schema::IndexRecordOption;
 use anyhow::Result;
 use pgrx::prelude::*;
 use pgrx::JsonB;
 use pgrx::PgRelation;
 use serde_json::Value;
+use tantivy::schema::FieldType;
+
+#[allow(clippy::type_complexity)]
+#[pg_extern]
+pub fn schema(
+    index: PgRelation,
+) -> TableIterator<
+    'static,
+    (
+        name!(name, String),
+        name!(field_type, String),
+        name!(stored, bool),
+        name!(indexed, bool),
+        name!(fast, bool),
+        name!(fieldnorms, bool),
+        name!(expand_dots, Option<bool>),
+        name!(tokenizer, Option<String>),
+        name!(record, Option<String>),
+        name!(normalizer, Option<String>),
+    ),
+> {
+    // # Safety
+    //
+    // Lock the index relation until the end of this function so it is not dropped or
+    // altered while we are reading it.
+    //
+    // Because we accept a PgRelation above, we have confidence that Postgres has already
+    // validated the existence of the relation. We are safe calling the function below as
+    // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+
+    // We only consider the first partition for the purposes of computing a schema.
+    let index = IndexKind::for_index(index)
+        .unwrap()
+        .partitions()
+        .next()
+        .expect("expected at least one partition of the index");
+
+    let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)
+        .expect("could not open search index reader");
+    let schema = search_reader.schema();
+
+    let mut field_rows = Vec::new();
+    for (_, field_entry) in schema.fields() {
+        let (field_type, tokenizer, record, normalizer, expand_dots) =
+            match field_entry.field_type() {
+                FieldType::I64(_) => ("I64".to_string(), None, None, None, None),
+                FieldType::U64(_) => ("U64".to_string(), None, None, None, None),
+                FieldType::F64(_) => ("F64".to_string(), None, None, None, None),
+                FieldType::Bool(_) => ("Bool".to_string(), None, None, None, None),
+                FieldType::Str(text_options) => {
+                    let indexing_options = text_options.get_indexing_options();
+                    let tokenizer = indexing_options.map(|opt| opt.tokenizer().to_string());
+                    let record = indexing_options
+                        .map(|opt| IndexRecordOption::from(opt.index_option()).to_string());
+                    let normalizer = text_options
+                        .get_fast_field_tokenizer_name()
+                        .map(|s| s.to_string());
+                    ("Str".to_string(), tokenizer, record, normalizer, None)
+                }
+                FieldType::JsonObject(json_options) => {
+                    let indexing_options = json_options.get_text_indexing_options();
+                    let tokenizer = indexing_options.map(|opt| opt.tokenizer().to_string());
+                    let record = indexing_options
+                        .map(|opt| IndexRecordOption::from(opt.index_option()).to_string());
+                    let normalizer = json_options
+                        .get_fast_field_tokenizer_name()
+                        .map(|s| s.to_string());
+                    let expand_dots = Some(json_options.is_expand_dots_enabled());
+                    (
+                        "JsonObject".to_string(),
+                        tokenizer,
+                        record,
+                        normalizer,
+                        expand_dots,
+                    )
+                }
+                FieldType::Date(_) => ("Date".to_string(), None, None, None, None),
+                _ => ("Other".to_string(), None, None, None, None),
+            };
+
+        let row = (
+            field_entry.name().to_string(),
+            field_type,
+            field_entry.is_stored(),
+            field_entry.is_indexed(),
+            field_entry.is_fast(),
+            field_entry.has_fieldnorms(),
+            expand_dots,
+            tokenizer,
+            record,
+            normalizer,
+        );
+
+        field_rows.push(row);
+    }
+
+    // Sort field rows for consistent ordering
+    field_rows.sort_by_key(|(name, _, _, _, _, _, _, _, _, _)| name.clone());
+    TableIterator::new(field_rows)
+}
 
 #[pg_extern]
 pub unsafe fn index_fields(index: PgRelation) -> anyhow::Result<JsonB> {

--- a/pg_search/src/api/builder_fns.rs
+++ b/pg_search/src/api/builder_fns.rs
@@ -16,122 +16,17 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use pgrx::datum::RangeBound;
-use pgrx::{iter::TableIterator, *};
+use pgrx::*;
 
 use crate::api::{FieldName, HashMap};
-use crate::index::mvcc::MvccSatisfies;
-use crate::index::reader::index::SearchIndexReader;
-use crate::postgres::index::IndexKind;
-use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::types::{TantivyValue, TantivyValueError};
 use crate::query::{SearchQueryInput, TermInput};
 use crate::schema::AnyEnum;
-use crate::schema::IndexRecordOption;
 use pgrx::nullable::IntoNullableIterator;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use std::ops::Bound;
-use tantivy::schema::{FieldType, OwnedValue, Value};
-
-#[allow(clippy::type_complexity)]
-#[pg_extern]
-pub fn schema(
-    index: PgRelation,
-) -> TableIterator<
-    'static,
-    (
-        name!(name, String),
-        name!(field_type, String),
-        name!(stored, bool),
-        name!(indexed, bool),
-        name!(fast, bool),
-        name!(fieldnorms, bool),
-        name!(expand_dots, Option<bool>),
-        name!(tokenizer, Option<String>),
-        name!(record, Option<String>),
-        name!(normalizer, Option<String>),
-    ),
-> {
-    // # Safety
-    //
-    // Lock the index relation until the end of this function so it is not dropped or
-    // altered while we are reading it.
-    //
-    // Because we accept a PgRelation above, we have confidence that Postgres has already
-    // validated the existence of the relation. We are safe calling the function below as
-    // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
-    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-
-    // We only consider the first partition for the purposes of computing a schema.
-    let index = IndexKind::for_index(index)
-        .unwrap()
-        .partitions()
-        .next()
-        .expect("expected at least one partition of the index");
-
-    let search_reader = SearchIndexReader::empty(&index, MvccSatisfies::Snapshot)
-        .expect("could not open search index reader");
-    let schema = search_reader.schema();
-
-    let mut field_rows = Vec::new();
-    for (_, field_entry) in schema.fields() {
-        let (field_type, tokenizer, record, normalizer, expand_dots) =
-            match field_entry.field_type() {
-                FieldType::I64(_) => ("I64".to_string(), None, None, None, None),
-                FieldType::U64(_) => ("U64".to_string(), None, None, None, None),
-                FieldType::F64(_) => ("F64".to_string(), None, None, None, None),
-                FieldType::Bool(_) => ("Bool".to_string(), None, None, None, None),
-                FieldType::Str(text_options) => {
-                    let indexing_options = text_options.get_indexing_options();
-                    let tokenizer = indexing_options.map(|opt| opt.tokenizer().to_string());
-                    let record = indexing_options
-                        .map(|opt| IndexRecordOption::from(opt.index_option()).to_string());
-                    let normalizer = text_options
-                        .get_fast_field_tokenizer_name()
-                        .map(|s| s.to_string());
-                    ("Str".to_string(), tokenizer, record, normalizer, None)
-                }
-                FieldType::JsonObject(json_options) => {
-                    let indexing_options = json_options.get_text_indexing_options();
-                    let tokenizer = indexing_options.map(|opt| opt.tokenizer().to_string());
-                    let record = indexing_options
-                        .map(|opt| IndexRecordOption::from(opt.index_option()).to_string());
-                    let normalizer = json_options
-                        .get_fast_field_tokenizer_name()
-                        .map(|s| s.to_string());
-                    let expand_dots = Some(json_options.is_expand_dots_enabled());
-                    (
-                        "JsonObject".to_string(),
-                        tokenizer,
-                        record,
-                        normalizer,
-                        expand_dots,
-                    )
-                }
-                FieldType::Date(_) => ("Date".to_string(), None, None, None, None),
-                _ => ("Other".to_string(), None, None, None, None),
-            };
-
-        let row = (
-            field_entry.name().to_string(),
-            field_type,
-            field_entry.is_stored(),
-            field_entry.is_indexed(),
-            field_entry.is_fast(),
-            field_entry.has_fieldnorms(),
-            expand_dots,
-            tokenizer,
-            record,
-            normalizer,
-        );
-
-        field_rows.push(row);
-    }
-
-    // Sort field rows for consistent ordering
-    field_rows.sort_by_key(|(name, _, _, _, _, _, _, _, _, _)| name.clone());
-    TableIterator::new(field_rows)
-}
+use tantivy::schema::{OwnedValue, Value};
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn all() -> SearchQueryInput {

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -18,6 +18,7 @@
 // TODO: See https://github.com/pgcentralfoundation/pgrx/pull/2089
 #![allow(for_loops_over_fallibles)]
 
+mod admin;
 pub mod aggregate;
 pub mod builder_fns;
 pub mod config;

--- a/pg_search/src/bootstrap/mod.rs
+++ b/pg_search/src/bootstrap/mod.rs
@@ -15,5 +15,4 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-mod create_bm25;
 mod test_table;


### PR DESCRIPTION
## What

This relocates the `src/boostrap/create_bm25.rs` source to `src/api/admin.rs`, which I believe is a more sensibile location and name.

Additionally it moves the `#[pg_extern] schema()` function from `src/api/builder_fns.rs` to this new(ly renamed) `admin.rs`, as it's an administrative function, not a query builder function.

## Why

Trying to better organize things

## How

## Tests

No functional changes here.