### PR TITLE
perf: Skip computing scores if not requested for top-n field queries

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -540,10 +540,7 @@ impl SearchIndexReader {
             .order_by_u64_field(&sort_field, sortdir.into());
         let weight = self
             .query
-            .weight(tantivy::query::EnableScoring::Enabled {
-                searcher: &self.searcher,
-                statistics_provider: &self.searcher,
-            })
+            .weight(enable_scoring(self.need_scores, &self.searcher))
             .expect("creating a Weight from a Query should not fail");
 
         let top_docs = self.collect_segments(segment_ids, |segment_ord, segment_reader| {
@@ -589,10 +586,7 @@ impl SearchIndexReader {
             .order_by_string_fast_field(&sort_field, sortdir.into());
         let weight = self
             .query
-            .weight(tantivy::query::EnableScoring::Enabled {
-                searcher: &self.searcher,
-                statistics_provider: &self.searcher,
-            })
+            .weight(enable_scoring(self.need_scores, &self.searcher))
             .expect("creating a Weight from a Query should not fail");
 
         let top_docs = self.collect_segments(segment_ids, |segment_ord, segment_reader| {


### PR DESCRIPTION
## What

`SearchIndexReader::{top_by_field_in_segments, top_by_string_field_in_segments}` were not using `SearchIndexReader::need_scores`, and were instead universally enabling scores.

Use the `enable_scoring` helper and `self.need_scores` to skip computing scores where possible.

## Why

Computing scores requires field norms, which ([if they have not been disabled](https://docs.paradedb.com/documentation/indexing/record)) can take time to load and use.