### PR TITLE
perf: Lazily load bitpacked columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "bitpacking",
 ]
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "nom",
 ]
@@ -4677,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3#55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "16740add9447330b133348448ce4988edcc8174f", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "16740add9447330b133348448ce4988edcc8174f" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "55bd31e3539e6d6df6a8b2a7e48a5c2342caeac3" }


### PR DESCRIPTION
## What

Incorporates https://github.com/paradedb/tantivy/pull/56.

## Why

As mentioned there:
> We would like to be able to lazily load `BitpackedCodec` columns (similar to what https://github.com/paradedb/tantivy/commit/020bdffd61365a140218643c49ba01c5043b2966 did for `BlockwiseLinearCodec`), because in the context of `pg_search`, immediately constructing `OwnedBytes` means copying the entire content of the column into memory.

## Tests

There are a few 2x speedups in the benchmark suite, as well as a 1.8x speedup on a representative customer query.

Unfortunately there are also some 13-19% slowdowns on aggregates with `solve_mvcc=false`: it looks like that is because aggregates use `get_vals`, for which the default implementation is to just call `get_val` in a loop. After discussion, we think that getting back that performance might require wider API changes to make batching more inherent.