### PR TITLE
fix: add #[pg_guard] to extern C-unwind functions

### DIFF
--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -23,7 +23,7 @@ use crate::postgres::customscan::opexpr::OpExpr;
 use crate::postgres::customscan::qual_inspect::Qual;
 use crate::postgres::var::{fieldname_from_var, find_var_relation};
 use crate::schema::{SearchField, SearchIndexSchema};
-use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
+use pgrx::{direct_function_call, pg_guard, pg_sys, IntoDatum, PgList};
 use std::sync::OnceLock;
 
 #[derive(Debug, Clone)]
@@ -253,7 +253,11 @@ unsafe fn make_opexpr(
 }
 
 pub unsafe fn is_complex(root: *mut pg_sys::Node) -> bool {
-    unsafe extern "C-unwind" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        _data: *mut core::ffi::c_void,
+    ) -> bool {
         nodecast!(Var, T_Var, node).is_some()
             || nodecast!(Param, T_Param, node).is_some()
             || pg_sys::contain_volatile_functions(node)

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -25,7 +25,7 @@ use crate::query::heap_field_filter::HeapFieldFilter;
 use crate::query::SearchQueryInput;
 use crate::schema::SearchIndexSchema;
 use pg_sys::BoolExprType;
-use pgrx::{pg_sys, FromDatum, IntoDatum, PgList};
+use pgrx::{pg_guard, pg_sys, FromDatum, IntoDatum, PgList};
 use std::ops::Bound;
 use tantivy::schema::OwnedValue;
 
@@ -962,7 +962,11 @@ unsafe fn is_node_range_table_entry(node: *mut pg_sys::Node, rti: pg_sys::Index)
 }
 
 unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
-    unsafe extern "C-unwind" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        _data: *mut core::ffi::c_void,
+    ) -> bool {
         if let Some(param) = nodecast!(Param, T_Param, node) {
             if (*param).paramkind == pg_sys::ParamKind::PARAM_EXEC {
                 return true;
@@ -979,7 +983,11 @@ unsafe fn contains_exec_param(root: *mut pg_sys::Node) -> bool {
 }
 
 unsafe fn contains_var(root: *mut pg_sys::Node) -> bool {
-    unsafe extern "C-unwind" fn walker(node: *mut pg_sys::Node, _: *mut core::ffi::c_void) -> bool {
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        _data: *mut core::ffi::c_void,
+    ) -> bool {
         nodecast!(Var, T_Var, node).is_some()
             || pg_sys::expression_tree_walker(node, Some(walker), std::ptr::null_mut())
     }
@@ -1271,6 +1279,7 @@ unsafe fn contains_relation_reference(node: *mut pg_sys::Node, target_rti: pg_sy
         return false;
     }
 
+    #[pg_guard]
     unsafe extern "C-unwind" fn walker(
         node: *mut pg_sys::Node,
         context: *mut core::ffi::c_void,
@@ -1467,6 +1476,7 @@ unsafe fn contains_any_relation_reference(node: *mut pg_sys::Node) -> bool {
         return false;
     }
 
+    #[pg_guard]
     unsafe extern "C-unwind" fn walker(
         node: *mut pg_sys::Node,
         _context: *mut core::ffi::c_void,


### PR DESCRIPTION
## What

All `extern "C-unwind"` functions require the `#[pg_guard]` attribute.  We had a few that were missing it, which _could_ lead to a crash.

## Why

## How

## Tests
