### PR TITLE
chore: Enable running CI for drafts.

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -30,7 +30,6 @@ jobs:
   check-pg_search-schema-upgrade:
     name: SchemaBot
     runs-on: ubicloud-standard-8
-    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         pg_version: [14] # pg_search's minimum supported Postgres version

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -18,7 +18,6 @@ jobs:
   check-typo:
     name: Check Typo using codespell
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -21,7 +21,6 @@ jobs:
   lint-bash:
     name: Lint Bash Scripts
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -21,7 +21,6 @@ jobs:
   lint-docker:
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -18,7 +18,6 @@ jobs:
   lint-format:
     name: Lint File Endings & Trailing Whitespaces
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -22,7 +22,6 @@ jobs:
   lint-markdown:
     name: Lint Markdown Files
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -20,7 +20,6 @@ jobs:
   lint-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,7 +22,6 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -22,7 +22,6 @@ jobs:
   lint-yaml:
     name: Lint YAML Files
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -24,7 +24,6 @@ jobs:
   test-docs:
     name: Test Docs for Broken Links
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -26,7 +26,6 @@ jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image
     runs-on: ubicloud-standard-8
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -31,7 +31,6 @@ jobs:
   test-pg_search-upgrade:
     name: Test upgrading pg_search via ALTER EXTENSION
     runs-on: ubicloud-standard-8
-    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -27,7 +27,7 @@ jobs:
   set-matrix:
     name: Define the PostgreSQL Version Matrix
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && github.event.pull_request.draft == false }}
+    if: ${{ !cancelled() }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -45,7 +45,7 @@ jobs:
   test-pg_search-postgres:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubicloud-standard-8
-    if: ${{ !cancelled() && github.event.pull_request.draft == false }}
+    if: ${{ !cancelled() }}
     needs: set-matrix
     strategy:
       matrix:
@@ -138,8 +138,8 @@ jobs:
         if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version}}.log
 
-  # Don't run pgrx-managed Postgres tests on push events, since they are only used to fill the Rust cache, which
-  # is already handled in the test-pg_search-postgres job.
+  # Don't run pgrx-managed Postgres tests on drafts or push events, since they are only used to
+  # fill the Rust cache, which is already handled in the test-pg_search-postgres job.
   test-pg_search-pgrx-postgres:
     name: Test pg_search on pgrx PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubicloud-standard-8

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -138,12 +138,9 @@ jobs:
         if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version}}.log
 
-  # Don't run pgrx-managed Postgres tests on drafts or push events, since they are only used to
-  # fill the Rust cache, which is already handled in the test-pg_search-postgres job.
   test-pg_search-pgrx-postgres:
     name: Test pg_search on pgrx PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubicloud-standard-8
-    if: github.event.pull_request.draft == false || github.event_name == 'push'
     strategy:
       matrix:
         pg_version: [17]


### PR DESCRIPTION
## What

Enable CI on PR drafts.

## Why

It is good to be able to run CI _before_ notifying your teammates that something is reviewable. Because we additionally use required-reviewers/owners, it is currently impossible to run CI without beginning to email all reviewers.

Moving forward: we should usually only post something as a Draft if we would like CI to run: for simply sharing a branch with someone, or for self-review without CI, we can use the [compare](https://github.com/paradedb/paradedb/compare) view. And we should only actually mark something reviewable when we would like the mentioned users to review it.