### PR TITLE
chore: upgrade to pgrx v0.15.0

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -113,7 +113,7 @@ Then, install and initialize `pgrx`:
 
 ```bash
 # Note: Replace --pg17 with your version of Postgres, if different (i.e. --pg16, etc.)
-cargo install --locked cargo-pgrx --version 0.13.0
+cargo install --locked cargo-pgrx --version 0.15.0
 
 # macOS arm64
 cargo pgrx init --pg17=/opt/homebrew/opt/postgresql@17/bin/pg_config


### PR DESCRIPTION
Because 0.13 is outdated.

https://github.com/paradedb/paradedb/blob/main/Cargo.toml#L31

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
