### PR TITLE
feat: ability to specify term "fuzzy"-ness via a cast to `::fuzzy(N)`

### DIFF
--- a/pg_search/sql/pg_search--0.17.2--0.18.0.sql
+++ b/pg_search/sql/pg_search--0.17.2--0.18.0.sql
@@ -2445,3 +2445,174 @@ AS 'MODULE_PATHNAME', 'prox_to_boost_wrapper';
 CREATE CAST (pdb.query AS pg_catalog.boost) WITH FUNCTION query_to_boost(pdb.query, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pdb.proximityclause AS pg_catalog.boost) WITH FUNCTION prox_to_boost(pdb.proximityclause, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pg_catalog.boost AS pg_catalog.boost) WITH FUNCTION boost_to_boost(pg_catalog.boost, integer, boolean) AS IMPLICIT;
+
+
+--
+-- fuzzy support
+--
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:120
+-- creates:
+--   Type(pg_search::api::operator::fuzzy::typedef::FuzzyType)
+CREATE TYPE pg_catalog.fuzzy;
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:128
+-- pg_search::api::operator::fuzzy::typedef::fuzzy_in
+CREATE  FUNCTION "fuzzy_in"(
+    "input" cstring, /* &core::ffi::c_str::CStr */
+    "_typoid" oid, /* pgrx_pg_sys::submodules::oids::Oid */
+    "typmod" INT /* i32 */
+) RETURNS fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_in_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:136
+-- pg_search::api::operator::fuzzy::typedef::fuzzy_out
+CREATE  FUNCTION "fuzzy_out"(
+    "input" fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+) RETURNS cstring /* alloc::ffi::c_str::CString */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_out_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:219
+-- pg_search::api::operator::fuzzy::fuzzy_to_boost
+CREATE  FUNCTION "fuzzy_to_boost"(
+    "input" fuzzy, /* pg_search::api::operator::fuzzy::FuzzyType */
+    "typmod" INT, /* i32 */
+    "is_explicit" bool /* bool */
+) RETURNS boost /* pg_search::api::operator::boost::BoostType */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_to_boost_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:238
+-- pg_search::api::operator::fuzzy::fuzzy_to_fuzzy
+CREATE  FUNCTION "fuzzy_to_fuzzy"(
+    "input" fuzzy, /* pg_search::api::operator::fuzzy::FuzzyType */
+    "typmod" INT, /* i32 */
+    "is_explicit" bool /* bool */
+) RETURNS fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_to_fuzzy_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:143
+-- pg_search::api::operator::fuzzy::typedef::fuzzy_typmod_in
+CREATE  FUNCTION "fuzzy_typmod_in"(
+    "typmod_parts" cstring[] /* pgrx::datum::array::Array<&core::ffi::c_str::CStr> */
+) RETURNS INT /* i32 */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_typmod_in_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:180
+-- pg_search::api::operator::fuzzy::typedef::fuzzy_typmod_out
+CREATE  FUNCTION "fuzzy_typmod_out"(
+    "typmod" INT /* i32 */
+) RETURNS cstring /* alloc::ffi::c_str::CString */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_typmod_out_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:186
+-- requires:
+--   FuzzyType_shell
+--   fuzzy_in
+--   fuzzy_out
+--   fuzzy_typmod_in
+--   fuzzy_typmod_out
+CREATE TYPE pg_catalog.fuzzy (
+                                 INPUT = fuzzy_in,
+                                 OUTPUT = fuzzy_out,
+                                 INTERNALLENGTH = VARIABLE,
+                                 LIKE = text,
+                                 TYPMOD_IN = fuzzy_typmod_in,
+                                 TYPMOD_OUT = fuzzy_typmod_out
+                             );
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/andandand.rs:53
+-- pg_search::api::operator::andandand::search_with_match_conjunction_fuzzy
+CREATE  FUNCTION "search_with_match_conjunction_fuzzy"(
+    "_field" TEXT, /* &str */
+    "terms_to_tokenize" fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+) RETURNS bool /* bool */
+    IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'search_with_match_conjunction_fuzzy_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/ororor.rs:50
+-- pg_search::api::operator::ororor::search_with_match_disjunction_fuzzy
+CREATE  FUNCTION "search_with_match_disjunction_fuzzy"(
+    "_field" TEXT, /* &str */
+    "terms_to_tokenize" fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+) RETURNS bool /* bool */
+    IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'search_with_match_disjunction_fuzzy_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/eqeqeq.rs:53
+-- pg_search::api::operator::eqeqeq::search_with_term_fuzzy
+CREATE  FUNCTION "search_with_term_fuzzy"(
+    "_field" TEXT, /* &str */
+    "term" fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+) RETURNS bool /* bool */
+    IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'search_with_term_fuzzy_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:208
+-- pg_search::api::operator::fuzzy::query_to_fuzzy
+CREATE  FUNCTION "query_to_fuzzy"(
+    "input" pdb.Query, /* pg_search::query::pdb_query::pdb::Query */
+    "typmod" INT, /* i32 */
+    "_is_explicit" bool /* bool */
+) RETURNS fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'query_to_fuzzy_wrapper';
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:243
+-- requires:
+--   query_to_fuzzy
+--   fuzzy_to_boost
+--   fuzzy_to_fuzzy
+--   FuzzyType_final
+CREATE CAST (pdb.query AS pg_catalog.fuzzy) WITH FUNCTION query_to_fuzzy(pdb.query, integer, boolean) AS ASSIGNMENT;
+CREATE CAST (pg_catalog.fuzzy AS pg_catalog.boost) WITH FUNCTION fuzzy_to_boost(pg_catalog.fuzzy, integer, boolean) AS IMPLICIT;
+CREATE CAST (pg_catalog.fuzzy AS pg_catalog.fuzzy) WITH FUNCTION fuzzy_to_fuzzy(pg_catalog.fuzzy, integer, boolean) AS IMPLICIT;
+/* </end connected objects> */
+/* <begin connected objects> */
+-- pg_search/src/api/operator/fuzzy.rs:214
+-- pg_search::api::operator::fuzzy::fuzzy_to_query
+CREATE  FUNCTION "fuzzy_to_query"(
+    "input" fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+) RETURNS pdb.Query /* pg_search::query::pdb_query::pdb::Query */
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuzzy_to_query_wrapper';
+-- pg_search/src/api/operator/fuzzy.rs:214
+-- pg_search::api::operator::fuzzy::fuzzy_to_query
+CREATE CAST (
+    fuzzy /* pg_search::api::operator::fuzzy::FuzzyType */
+    AS
+    pdb.Query /* pg_search::query::pdb_query::pdb::Query */
+    )
+    WITH FUNCTION fuzzy_to_query AS IMPLICIT;
+ALTER FUNCTION paradedb.search_with_match_conjunction_fuzzy SUPPORT paradedb.search_with_match_conjunction_support;
+ALTER FUNCTION paradedb.search_with_match_disjunction_fuzzy SUPPORT paradedb.search_with_match_disjunction_support;
+ALTER FUNCTION paradedb.search_with_term_fuzzy SUPPORT paradedb.search_with_term_support;

--- a/pg_search/src/api/builder_fns/pdb.rs
+++ b/pg_search/src/api/builder_fns/pdb.rs
@@ -113,6 +113,7 @@ mod pdb {
             query_string,
             lenient,
             conjunction_mode,
+            fuzzy_data: None,
         }
     }
 

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -514,9 +514,9 @@ where
 
             other if other == fuzzy_typoid() => {
                 let fuzzy = FuzzyType::from_datum((*const_).constvalue, (*const_).constisnull)
-                    .expect("rhs boost value must not be NULL");
-                let boost = fuzzy_to_fuzzy(fuzzy, (*const_).consttypmod, true);
-                RHSValue::PdbQuery(boost.into())
+                    .expect("rhs fuzzy value must not be NULL");
+                let fuzzy = fuzzy_to_fuzzy(fuzzy, (*const_).consttypmod, true);
+                RHSValue::PdbQuery(fuzzy.into())
             }
 
             other if other == pdb_proximityclause_typoid() => {

--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -19,12 +19,14 @@ mod andandand;
 mod atatat;
 mod boost;
 mod eqeqeq;
+mod fuzzy;
 mod hashhashhash;
 mod ororor;
 mod proximity;
 mod searchqueryinput;
 
 use crate::api::operator::boost::{boost_to_boost, BoostType};
+use crate::api::operator::fuzzy::{fuzzy_to_fuzzy, FuzzyType};
 use crate::api::FieldName;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
@@ -143,6 +145,20 @@ pub fn boost_typoid() -> pg_sys::Oid {
         .expect("type `pg_catalog.boost` should exist");
         if oid == pg_sys::Oid::INVALID {
             panic!("type `pg_catalog.boost` should exist");
+        }
+        oid
+    }
+}
+
+pub fn fuzzy_typoid() -> pg_sys::Oid {
+    unsafe {
+        let oid = direct_function_call::<pg_sys::Oid>(
+            pg_sys::regtypein,
+            &[c"pg_catalog.fuzzy".into_datum()],
+        )
+        .expect("type `pg_catalog.fuzzy` should exist");
+        if oid == pg_sys::Oid::INVALID {
+            panic!("type `pg_catalog.fuzzy` should exist");
         }
         oid
     }
@@ -493,6 +509,13 @@ where
                 let boost = BoostType::from_datum((*const_).constvalue, (*const_).constisnull)
                     .expect("rhs boost value must not be NULL");
                 let boost = boost_to_boost(boost, (*const_).consttypmod, true);
+                RHSValue::PdbQuery(boost.into())
+            }
+
+            other if other == fuzzy_typoid() => {
+                let fuzzy = FuzzyType::from_datum((*const_).constvalue, (*const_).constisnull)
+                    .expect("rhs boost value must not be NULL");
+                let boost = fuzzy_to_fuzzy(fuzzy, (*const_).consttypmod, true);
                 RHSValue::PdbQuery(boost.into())
             }
 

--- a/pg_search/src/api/operator/atatat.rs
+++ b/pg_search/src/api/operator/atatat.rs
@@ -59,7 +59,7 @@ pub fn atatat_support(arg: Internal) -> ReturnedNodePointer {
                     Some(field) => to_search_query_input(field, parse_with_field(query_string, None, None)),
                     None => parse(query_string, None, None),
                 }
-                RHSValue::PdbQuery(pdb::Query::UnclassifiedString {string}) => {
+                RHSValue::PdbQuery(pdb::Query::UnclassifiedString {string, ..}) => {
                     assert!(field.is_some());
                     let query = parse_with_field(string, None, None);
                     to_search_query_input(field.unwrap(), query)
@@ -67,7 +67,7 @@ pub fn atatat_support(arg: Internal) -> ReturnedNodePointer {
                 RHSValue::PdbQuery(pdb::Query::Boost { query, boost}) => {
                     assert!(field.is_some());
                     let mut query = *query;
-                    if let pdb::Query::UnclassifiedString {string} = query {
+                    if let pdb::Query::UnclassifiedString {string, ..} = query {
                         query = parse_with_field(string, None, None);
                     }
                     to_search_query_input(field.unwrap(), pdb::Query::Boost { query: Box::new(query), boost})

--- a/pg_search/src/api/operator/atatat.rs
+++ b/pg_search/src/api/operator/atatat.rs
@@ -59,16 +59,18 @@ pub fn atatat_support(arg: Internal) -> ReturnedNodePointer {
                     Some(field) => to_search_query_input(field, parse_with_field(query_string, None, None)),
                     None => parse(query_string, None, None),
                 }
-                RHSValue::PdbQuery(pdb::Query::UnclassifiedString {string, ..}) => {
+                RHSValue::PdbQuery(pdb::Query::UnclassifiedString {string, fuzzy_data}) => {
                     assert!(field.is_some());
-                    let query = parse_with_field(string, None, None);
+                    let mut query = parse_with_field(string, None, None);
+                    query.apply_fuzzy_data(fuzzy_data);
                     to_search_query_input(field.unwrap(), query)
                 }
                 RHSValue::PdbQuery(pdb::Query::Boost { query, boost}) => {
                     assert!(field.is_some());
                     let mut query = *query;
-                    if let pdb::Query::UnclassifiedString {string, ..} = query {
+                    if let pdb::Query::UnclassifiedString {string, fuzzy_data} = query {
                         query = parse_with_field(string, None, None);
+                        query.apply_fuzzy_data(fuzzy_data);
                     }
                     to_search_query_input(field.unwrap(), pdb::Query::Boost { query: Box::new(query), boost})
                 }

--- a/pg_search/src/api/operator/boost.rs
+++ b/pg_search/src/api/operator/boost.rs
@@ -139,9 +139,8 @@ mod typedef {
 
     #[pg_extern(immutable, parallel_safe)]
     fn boost_in(input: &CStr, _typoid: pg_sys::Oid, typmod: i32) -> BoostType {
-        let query = pdb::Query::UnclassifiedString {
-            string: input.to_str().expect("input must not be NULL").to_string(),
-        };
+        let query =
+            pdb::Query::unclassified_string(input.to_str().expect("input must not be NULL"));
         BoostType(pdb::Query::Boost {
             query: Box::new(query),
             boost: (typmod != -1).then(|| deserialize_i32_to_f32(typmod)),
@@ -202,7 +201,7 @@ mod typedef {
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn query_to_boost(input: pdb::Query, typmod: i32, _is_explicit: bool) -> BoostType {
+pub fn query_to_boost(input: pdb::Query, typmod: i32, _is_explicit: bool) -> BoostType {
     let boost = deserialize_i32_to_f32(typmod);
     BoostType(pdb::Query::Boost {
         query: Box::new(input),

--- a/pg_search/src/api/operator/fuzzy.rs
+++ b/pg_search/src/api/operator/fuzzy.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::api::operator::boost::{query_to_boost, BoostType};
+use crate::query::pdb_query::pdb;
+use pgrx::{extension_sql, pg_cast, pg_extern};
+
+/// [`FuzzyType`] is a user-facing type used in SQL queries to indicate that certain query predicates
+/// can have a "fuzzy" value applied to them.  Typically this is "term" and "match" queries.
+///
+/// While there's no indication on the Rust type, [`FuzzyType`] wants a Postgres type modifier (typmod)
+/// when constructed so that a [`pdb::Query::Fuzzy { fuzzy: $typemod, query }`] can be constructed.
+///
+/// Users would use this type like so:
+///
+/// ```sql
+/// SELECT * FROM t WHERE body @@@ 'beer'::fuzzy(3);
+/// ```
+///
+/// It's up to individual operators to decide if/how they support [`FuzzyType`]
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct FuzzyType(pdb::Query);
+
+// Contains all the boilerplate required by pgrx to make a custom type from scratch
+mod sql_datum_support {
+    use crate::api::operator::fuzzy::FuzzyType;
+    use crate::api::operator::fuzzy_typoid;
+    use crate::query::pdb_query::pdb;
+    use pgrx::callconv::{Arg, ArgAbi, BoxRet, FcInfo};
+    use pgrx::nullable::Nullable;
+    use pgrx::pgrx_sql_entity_graph::metadata::{
+        ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+    };
+    use pgrx::{pg_sys, FromDatum, IntoDatum};
+
+    impl From<FuzzyType> for pdb::Query {
+        fn from(value: FuzzyType) -> Self {
+            value.0
+        }
+    }
+
+    impl IntoDatum for FuzzyType {
+        fn into_datum(self) -> Option<pg_sys::Datum> {
+            self.0.into_datum()
+        }
+
+        fn type_oid() -> pg_sys::Oid {
+            fuzzy_typoid()
+        }
+    }
+
+    impl FromDatum for FuzzyType {
+        unsafe fn from_polymorphic_datum(
+            datum: pg_sys::Datum,
+            is_null: bool,
+            typoid: pg_sys::Oid,
+        ) -> Option<Self> {
+            pdb::Query::from_polymorphic_datum(datum, is_null, typoid).map(FuzzyType)
+        }
+    }
+
+    unsafe impl SqlTranslatable for FuzzyType {
+        fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+            Ok(SqlMapping::As("fuzzy".into()))
+        }
+
+        fn return_sql() -> Result<Returns, ReturnsError> {
+            Ok(Returns::One(SqlMapping::As("fuzzy".into())))
+        }
+    }
+
+    unsafe impl BoxRet for FuzzyType {
+        unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> pgrx::datum::Datum<'fcx> {
+            match self.into_datum() {
+                Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
+                None => fcinfo.return_null(),
+            }
+        }
+    }
+
+    unsafe impl<'fcx> ArgAbi<'fcx> for FuzzyType {
+        unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
+            let index = arg.index();
+            unsafe {
+                arg.unbox_arg_using_from_datum()
+                    .unwrap_or_else(|| panic!("argument {index} must not be null"))
+            }
+        }
+
+        unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+            unsafe { arg.unbox_arg_using_from_datum().into() }
+        }
+    }
+}
+
+// [`FuzzyType`]'s SQL type definition and necessary functions to support creating
+mod typedef {
+    use crate::api::operator::fuzzy::FuzzyType;
+    use crate::query::pdb_query::pdb;
+    use crate::query::pdb_query::pdb::{query_out, FuzzyData};
+    use pgrx::{extension_sql, pg_extern, pg_sys, Array};
+    use std::ffi::{CStr, CString};
+    use std::str::FromStr;
+
+    extension_sql!(
+        r#"
+            CREATE TYPE pg_catalog.fuzzy;
+        "#,
+        name = "FuzzyType_shell",
+        creates = [Type(FuzzyType)]
+    );
+
+    #[pg_extern(immutable, parallel_safe)]
+    fn fuzzy_in(input: &CStr, _typoid: pg_sys::Oid, typmod: i32) -> FuzzyType {
+        let mut query =
+            pdb::Query::unclassified_string(input.to_str().expect("input must not be NULL"));
+        query.apply_fuzzy_data((typmod != -1).then(|| typmod.into()));
+        FuzzyType(query)
+    }
+
+    #[pg_extern(immutable, parallel_safe)]
+    fn fuzzy_out(input: FuzzyType) -> CString {
+        query_out(input.0)
+    }
+
+    /// Parse the user-specified "typmod" value string and encode it into an i32 following the
+    /// `impl From<FuzzyData> for i32` implementation over on [`crate::query::pdb_query::pdb::FuzzyData`]
+    #[pg_extern(immutable, parallel_safe)]
+    fn fuzzy_typmod_in(typmod_parts: Array<&CStr>) -> i32 {
+        assert!(typmod_parts.len() <= 3);
+        let fuzzy_str = typmod_parts
+            .get(0)
+            .unwrap()
+            .expect("typmod cstring must not be NULL");
+        let is_prefix = typmod_parts
+            .get(1)
+            .unwrap_or(Some(c"false"))
+            .expect("prefix value cannot be NULL")
+            .to_str()
+            .unwrap()
+            .starts_with("t");
+        let transposition_cost_one = typmod_parts
+            .get(2)
+            .unwrap_or(Some(c"false"))
+            .expect("transposition cost value cannot be NULL")
+            .to_str()
+            .unwrap()
+            .starts_with("t");
+
+        let fuzzy = i8::from_str(fuzzy_str.to_str().unwrap())
+            .unwrap_or_else(|_| panic!("invalid fuzzy value: {}", fuzzy_str.to_str().unwrap()));
+
+        if !(0..=2).contains(&fuzzy) {
+            panic!("fuzzy value must be 0, 1, or 2");
+        }
+
+        FuzzyData {
+            distance: fuzzy as u8,
+            prefix: is_prefix,
+            transposition_cost_one,
+        }
+        .into()
+    }
+
+    #[pg_extern(immutable, parallel_safe)]
+    fn fuzzy_typmod_out(typmod: i32) -> CString {
+        let fuzzy_data: FuzzyData = typmod.into();
+        CString::from_str(&fuzzy_data.to_string()).unwrap()
+    }
+
+    extension_sql!(
+        r#"
+            CREATE TYPE pg_catalog.fuzzy (
+                INPUT = fuzzy_in,
+                OUTPUT = fuzzy_out,
+                INTERNALLENGTH = VARIABLE,
+                LIKE = text,
+                TYPMOD_IN = fuzzy_typmod_in,
+                TYPMOD_OUT = fuzzy_typmod_out
+            );
+        "#,
+        name = "FuzzyType_final",
+        requires = [
+            "FuzzyType_shell",
+            fuzzy_in,
+            fuzzy_out,
+            fuzzy_typmod_in,
+            fuzzy_typmod_out
+        ]
+    );
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn query_to_fuzzy(mut input: pdb::Query, typmod: i32, _is_explicit: bool) -> FuzzyType {
+    input.apply_fuzzy_data((typmod != -1).then(|| typmod.into()));
+    FuzzyType(input)
+}
+
+#[pg_cast(implicit, immutable, parallel_safe)]
+fn fuzzy_to_query(input: FuzzyType) -> pdb::Query {
+    input.0
+}
+
+#[pg_extern(immutable, parallel_safe)]
+fn fuzzy_to_boost(input: FuzzyType, typmod: i32, is_explicit: bool) -> BoostType {
+    query_to_boost(input.0, typmod, is_explicit)
+}
+
+/// SQL `CAST` function used by Postgres to apply the `typmod` value after the type has been constructed
+///
+/// One would think the type's input function, which also allows for a `typmod` argument would be
+/// able to do this, but alas, Postgres always sets that to `-1` for historical reasons.
+///
+/// In our case, a simple expression like:
+///
+/// ```sql
+/// SELECT 'foo'::fuzzy(3);
+/// ```
+///
+/// Will first go through the `fuzzy_in` function with a `-1` typmod, and then Postgres will call
+/// the `typmod_in`/`typmod_out` functions defined for [`FuzzyType`], then pass that output value
+/// to this function so that we can apply it.  Fun!
+#[pg_extern(immutable, parallel_safe)]
+pub fn fuzzy_to_fuzzy(input: FuzzyType, typmod: i32, is_explicit: bool) -> FuzzyType {
+    query_to_fuzzy(input.0, typmod, is_explicit)
+}
+
+extension_sql!(
+    r#"
+        CREATE CAST (pdb.query AS pg_catalog.fuzzy) WITH FUNCTION query_to_fuzzy(pdb.query, integer, boolean) AS ASSIGNMENT;
+        CREATE CAST (pg_catalog.fuzzy AS pg_catalog.boost) WITH FUNCTION fuzzy_to_boost(pg_catalog.fuzzy, integer, boolean) AS IMPLICIT;
+        CREATE CAST (pg_catalog.fuzzy AS pg_catalog.fuzzy) WITH FUNCTION fuzzy_to_fuzzy(pg_catalog.fuzzy, integer, boolean) AS IMPLICIT;
+    "#,
+    name = "cast_to_fuzzy",
+    requires = [
+        query_to_fuzzy,
+        fuzzy_to_boost,
+        fuzzy_to_fuzzy,
+        "FuzzyType_final"
+    ]
+);

--- a/pg_search/src/api/operator/hashhashhash.rs
+++ b/pg_search/src/api/operator/hashhashhash.rs
@@ -61,7 +61,7 @@ fn search_with_phrase_support(arg: Internal) -> ReturnedNodePointer {
                 },
                 RHSValue::PdbQuery(pdb::Query::Boost { query, boost}) => {
                     let mut query = *query;
-                    if let pdb::Query::UnclassifiedString {string} = query {
+                    if let pdb::Query::UnclassifiedString {string, ..} = query {
                         query = phrase_string(string);
                     }
                     to_search_query_input(field, pdb::Query::Boost { query: Box::new(query), boost})

--- a/pg_search/src/api/operator/ororor.rs
+++ b/pg_search/src/api/operator/ororor.rs
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 use crate::api::builder_fns::match_disjunction;
 use crate::api::operator::boost::BoostType;
+use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
     get_expr_result_type, request_simplify, searchqueryinput_typoid, RHSValue, ReturnedNodePointer,
 };
@@ -46,6 +47,13 @@ fn search_with_match_disjunction_boost(_field: &str, terms_to_tokenize: BoostTyp
         "query is incompatible with pg_search's `|||(field, boost)` operator: `{terms_to_tokenize:?}`"
     )
 }
+#[pg_operator(immutable, parallel_safe, cost = 1000000000)]
+#[opname(pg_catalog.|||)]
+fn search_with_match_disjunction_fuzzy(_field: &str, terms_to_tokenize: FuzzyType) -> bool {
+    panic!(
+        "query is incompatible with pg_search's `|||(field, fuzzy)` operator: `{terms_to_tokenize:?}`"
+    )
+}
 
 #[pg_extern(immutable, parallel_safe)]
 fn search_with_match_disjunction_support(arg: Internal) -> ReturnedNodePointer {
@@ -58,10 +66,16 @@ fn search_with_match_disjunction_support(arg: Internal) -> ReturnedNodePointer {
                 },
                 RHSValue::PdbQuery(pdb::Query::Boost { query, boost}) => {
                     let mut query = *query;
-                    if let pdb::Query::UnclassifiedString {string} = query {
+                    if let pdb::Query::UnclassifiedString {string, fuzzy_data} = query {
                         query = match_disjunction(string);
+                        query.apply_fuzzy_data(fuzzy_data);
                     }
                     to_search_query_input(field, pdb::Query::Boost { query: Box::new(query), boost})
+                }
+                RHSValue::PdbQuery(pdb::Query::UnclassifiedString {string, fuzzy_data}) => {
+                    let mut query = match_disjunction(string);
+                    query.apply_fuzzy_data(fuzzy_data);
+                    to_search_query_input(field, query)
                 }
 
                 _ => panic!("The right-hand side of the `|||(field, TEXT)` operator must be a text value."),
@@ -100,12 +114,14 @@ extension_sql!(
         ALTER FUNCTION paradedb.search_with_match_disjunction SUPPORT paradedb.search_with_match_disjunction_support;
         ALTER FUNCTION paradedb.search_with_match_disjunction_pdb_query SUPPORT paradedb.search_with_match_disjunction_support;
         ALTER FUNCTION paradedb.search_with_match_disjunction_boost SUPPORT paradedb.search_with_match_disjunction_support;
+        ALTER FUNCTION paradedb.search_with_match_disjunction_fuzzy SUPPORT paradedb.search_with_match_disjunction_support;
     "#,
     name = "search_with_match_disjunction_support_fn",
     requires = [
         search_with_match_disjunction,
         search_with_match_disjunction_pdb_query,
         search_with_match_disjunction_boost,
+        search_with_match_disjunction_fuzzy,
         search_with_match_disjunction_support
     ]
 );

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -283,14 +283,15 @@ impl SearchIndexReader {
 
         let need_scores = need_scores || search_query_input.need_scores();
         let query = {
-            let mut parser = QueryParser::for_index(
-                &index,
-                schema.fields().map(|(field, _)| field).collect::<Vec<_>>(),
-            );
             search_query_input
                 .into_tantivy_query(
                     &schema,
-                    &mut parser,
+                    &|| {
+                        QueryParser::for_index(
+                            &index,
+                            schema.fields().map(|(field, _)| field).collect::<Vec<_>>(),
+                        )
+                    },
                     &searcher,
                     index_relation.oid(),
                     index_relation.rel_oid(),
@@ -343,18 +344,19 @@ impl SearchIndexReader {
     }
 
     pub fn make_query(&self, search_query_input: SearchQueryInput) -> Box<dyn Query> {
-        let mut parser = QueryParser::for_index(
-            &self.underlying_index,
-            self.schema
-                .fields()
-                .map(|(field, _)| field)
-                .collect::<Vec<_>>(),
-        );
         search_query_input
             .clone()
             .into_tantivy_query(
                 &self.schema,
-                &mut parser,
+                &|| {
+                    QueryParser::for_index(
+                        &self.underlying_index,
+                        self.schema
+                            .fields()
+                            .map(|(field, _)| field)
+                            .collect::<Vec<_>>(),
+                    )
+                },
                 &self.searcher,
                 self.index_rel.oid(),
                 self.index_rel.rel_oid(),

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -403,10 +403,10 @@ fn coerce_bound_to_field_type(
 }
 
 impl SearchQueryInput {
-    pub fn into_tantivy_query(
+    pub fn into_tantivy_query<QueryParserCtor: Fn() -> QueryParser>(
         self,
         schema: &SearchIndexSchema,
-        parser: &mut QueryParser,
+        parser: &QueryParserCtor,
         searcher: &Searcher,
         index_oid: pg_sys::Oid,
         relation_oid: Option<pg_sys::Oid>,
@@ -569,6 +569,7 @@ impl SearchQueryInput {
                 lenient,
                 conjunction_mode,
             } => {
+                let mut parser = parser();
                 if let Some(true) = conjunction_mode {
                     parser.set_conjunction_by_default();
                 }

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -94,6 +94,22 @@ pub mod pdb {
         }
     }
 
+    #[test]
+    fn fuzzy_data_roundtrip() {
+        proptest::proptest!(|(distance in 0u8..=255u8, prefix in 0..=1, transposition_cost_one in 0..=1)| {
+            let original = FuzzyData {
+                distance,
+                prefix: prefix == 1,
+                transposition_cost_one: transposition_cost_one == 1,
+            };
+
+            let typmod_repr:i32 = original.clone().into();
+            assert!(typmod_repr >= 0);  // can't be negative
+            let from_typmod:FuzzyData = typmod_repr.into();
+            assert_eq!(original, from_typmod);
+        })
+    }
+
     #[derive(Debug, PostgresType, Deserialize, Serialize, Clone, PartialEq)]
     #[inoutfuncs]
     #[serde(rename_all = "snake_case")]

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -150,6 +150,7 @@ pub mod pdb {
             query_string: String,
             lenient: Option<bool>,
             conjunction_mode: Option<bool>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             fuzzy_data: Option<FuzzyData>,
         },
         Phrase {

--- a/pg_search/tests/pg_regress/expected/fuzzy.out
+++ b/pg_search/tests/pg_regress/expected/fuzzy.out
@@ -1,0 +1,136 @@
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ 'shoes'::fuzzy(2);
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: idxregress_mock_items
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null,"fuzzy_data":{"distance":2,"prefix":false,"transposition_cost_one":false}}}}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description &&& 'shoes'::fuzzy(2);
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: idxregress_mock_items
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"shoes","tokenizer":null,"distance":2,"transposition_cost_one":false,"prefix":false,"conjunction_mode":true}}}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description ||| 'shoes'::fuzzy(2);
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: idxregress_mock_items
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"shoes","tokenizer":null,"distance":2,"transposition_cost_one":false,"prefix":false,"conjunction_mode":false}}}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description === 'shoes'::fuzzy(2);
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: idxregress_mock_items
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"fuzzy_term":{"field":"description","value":"shoes","distance":2,"transposition_cost_one":false,"prefix":false}}}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ pdb.term('shoes')::fuzzy(2);
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: idxregress_mock_items
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"fuzzy_term":{"field":"description","value":"shoes","distance":2,"transposition_cost_one":false,"prefix":false}}}}
+(6 rows)
+
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(0) ORDER BY id; -- no results
+ id | description | rating | category | in_stock | metadata | created_at | last_updated_date | latest_available_time | weight_range | sku 
+----+-------------+--------+----------+----------+----------+------------+-------------------+-----------------------+--------------+-----
+(0 rows)
+
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(1) ORDER BY id; -- no results
+ id | description | rating | category | in_stock | metadata | created_at | last_updated_date | latest_available_time | weight_range | sku 
+----+-------------+--------+----------+----------+----------+------------+-------------------+-----------------------+--------------+-----
+(0 rows)
+
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(2) ORDER BY id; -- 3 rows
+ id |     description     | rating | category | in_stock |                    metadata                     |        created_at        | last_updated_date | latest_available_time | weight_range |                 sku                  
+----+---------------------+--------+----------+----------+-------------------------------------------------+--------------------------+-------------------+-----------------------+--------------+--------------------------------------
+  3 | Sleek running shoes |      5 | Footwear | t        | {"color": "Blue", "location": "China"}          | Fri Apr 28 10:55:43 2023 | 04-29-2023        | 10:55:43              | [2,10)       | da2fea21-0003-411b-9e8c-2cb64e471293
+  4 | White jogging shoes |      3 | Footwear | f        | {"color": "White", "location": "United States"} | Thu Apr 20 16:38:02 2023 | 04-22-2023        | 16:38:02              | (,11)        | da2fea21-0004-411b-9e8c-2cb64e471293
+  5 | Generic shoes       |      4 | Footwear | t        | {"color": "Brown", "location": "Canada"}        | Tue May 02 08:45:11 2023 | 05-03-2023        | 08:45:11              | [3,)         | da2fea21-0005-411b-9e8c-2cb64e471293
+(3 rows)
+
+--
+-- (currently) unsupported for phrase and proximity
+--
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description ### 'running shoes'::fuzzy(2);
+ERROR:  operator is not unique: text ### fuzzy at character 97
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ ('running' ##3## 'shoes')::fuzzy(2);
+ERROR:  cannot cast type pdb.proximityclause to fuzzy at character 126
+--
+-- validate json representation
+--
+SELECT 'beer'::fuzzy(2);
+                                                        fuzzy                                                        
+---------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":false,"transposition_cost_one":false}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, t, t);
+                                                       fuzzy                                                       
+-------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":true,"transposition_cost_one":true}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, t, f);
+                                                       fuzzy                                                        
+--------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":true,"transposition_cost_one":false}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, f, f);
+                                                        fuzzy                                                        
+---------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":false,"transposition_cost_one":false}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, f, t);
+                                                       fuzzy                                                        
+--------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":false,"transposition_cost_one":true}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, "true", "true");
+                                                       fuzzy                                                       
+-------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":true,"transposition_cost_one":true}}}
+(1 row)
+
+SELECT 'beer'::fuzzy(2, "false", "false");
+                                                        fuzzy                                                        
+---------------------------------------------------------------------------------------------------------------------
+ {"unclassified_string":{"string":"beer","fuzzy_data":{"distance":2,"prefix":false,"transposition_cost_one":false}}}
+(1 row)
+
+--
+-- error conditions
+--
+SELECT 'beer'::fuzzy(-1);
+ERROR:  fuzzy value must be 0, 1, or 2 at character 16
+SELECT 'beer'::fuzzy(3);
+ERROR:  fuzzy value must be 0, 1, or 2 at character 16
+SELECT 'beer'::fuzzy(hi_mom);
+ERROR:  invalid fuzzy value: hi_mom at character 16
+SELECT 'beer'::fuzzy(2, true, true);    -- thanks, Postgres!
+ERROR:  type modifiers must be simple constants or identifiers at character 16

--- a/pg_search/tests/pg_regress/sql/fuzzy.sql
+++ b/pg_search/tests/pg_regress/sql/fuzzy.sql
@@ -1,0 +1,35 @@
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ 'shoes'::fuzzy(2);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description &&& 'shoes'::fuzzy(2);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description ||| 'shoes'::fuzzy(2);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description === 'shoes'::fuzzy(2);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ pdb.term('shoes')::fuzzy(2);
+
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(0) ORDER BY id; -- no results
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(1) ORDER BY id; -- no results
+SELECT * FROM regress.mock_items WHERE description === 'sho'::fuzzy(2) ORDER BY id; -- 3 rows
+
+--
+-- (currently) unsupported for phrase and proximity
+--
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description ### 'running shoes'::fuzzy(2);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ ('running' ##3## 'shoes')::fuzzy(2);
+
+
+--
+-- validate json representation
+--
+SELECT 'beer'::fuzzy(2);
+SELECT 'beer'::fuzzy(2, t, t);
+SELECT 'beer'::fuzzy(2, t, f);
+SELECT 'beer'::fuzzy(2, f, f);
+SELECT 'beer'::fuzzy(2, f, t);
+SELECT 'beer'::fuzzy(2, "true", "true");
+SELECT 'beer'::fuzzy(2, "false", "false");
+
+--
+-- error conditions
+--
+SELECT 'beer'::fuzzy(-1);
+SELECT 'beer'::fuzzy(3);
+SELECT 'beer'::fuzzy(hi_mom);
+SELECT 'beer'::fuzzy(2, true, true);    -- thanks, Postgres!


### PR DESCRIPTION
## What

Introduces a new SQL type named `fuzzy(N, b, b)` that can be used in various query contexts to indicate that the term(s) being searched for should be "fuzzy terms".

Some examples:

```sql
SELECT * FROM t WHERE f === 'beer'::fuzzy(2);   -- FuzzyTerm query
SELECT * FROM t WHERE f @@@ 'beer wine cheese'::fuzzy(2); -- QueryParser query with fuzzy set for the field "f"
SELECT * FROM t WHERE f &&& 'beer wine cheese'::fuzzy(2); -- Match conjunction query with fuzzy
SELECT * FROM t WHERE f ||| 'beer wine cheese'::fuzzy(2); -- Match disjunction query with fuzzy
```

The type modifier can take 3 arguments: a distance calculation in the range `0..=2` and two booleans written as either `t`/`f` or (literally) `"true"`/`"false"` (this is a Postgres restriction -- `true` or `false` on their own don't work).  The first boolean, which defaults to `f` denotes if the fuzzy term should be a prefix and the second boolean, which also defaults to `f` denotes if the transaction cost should be 1 (true) or zero (false).

## Why

A continuation of improving our SQL UX.  This feature is similar to the recently committed `::boost(N)` feature in that the query rewriting happens through an SQL type cast.

## How

## Tests

New regression test specifically for fuzzy, a proptest for the conversion to/from the typmod `i32` and all other tests pass.