### PR TITLE
docs: Fix broken Slack link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -387,7 +387,7 @@
     "links": [
       {
         "label": "Community",
-        "href": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ"
+        "href": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw"
       },
       {
         "label": "Blog",
@@ -402,7 +402,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/paradedb/paradedb",
-      "slack": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-2lkzdsetw-OiIgbyFeiibd1DG~6wFgTQ",
+      "slack": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw",
       "twitter": "https://twitter.com/paradedb"
     }
   },


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
A user reported that the link in our docs was outdated. Somehow all other links for Slack were this one, but the one in the docs was different. This fixes that.

## Why
People can join our Slack!

## How
Just used the same invite link as we do everywhere else.

## Tests
I verified it's correct in incognito.