### PR TITLE
fix: relation extension cache invalidation

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -18,6 +18,7 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 icu = ["tokenizers/icu"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
+block_tracker = []                         # for debugging when blocks are acquired and released
 
 [dependencies]
 anyhow = { version = "1.0.98", features = ["backtrace"] }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -5,6 +5,149 @@ use crate::postgres::storage::block::{
 use crate::postgres::storage::utils::{BM25BufferCache, BM25Page};
 use pgrx::pg_sys;
 
+/// A module to help with tracking when/where blocks are acquired and released.
+///
+/// This has quite a bit of runtime overhead so it is only active when the `block_tracker`
+/// feature flag is enabled.
+#[cfg(feature = "block_tracker")]
+mod block_tracker {
+    use crate::api::HashMap;
+    use parking_lot::Mutex;
+    use pgrx::pg_sys;
+    use std::hash::{Hash, Hasher};
+    use std::sync::OnceLock;
+
+    #[derive(Debug, Copy, Clone)]
+    pub(super) enum TrackedBlock {
+        Pinned(pg_sys::BlockNumber),
+        Read(pg_sys::BlockNumber),
+        Write(pg_sys::BlockNumber),
+        Conditional(pg_sys::BlockNumber),
+        ConditionalCleanup(pg_sys::BlockNumber),
+        Cleanup(pg_sys::BlockNumber),
+
+        // used when a block is being dropped and removed from the tracker
+        Drop(pg_sys::BlockNumber),
+    }
+
+    impl TrackedBlock {
+        #[inline(always)]
+        fn number(&self) -> pg_sys::BlockNumber {
+            match self {
+                TrackedBlock::Pinned(blockno)
+                | TrackedBlock::Read(blockno)
+                | TrackedBlock::Write(blockno)
+                | TrackedBlock::Conditional(blockno)
+                | TrackedBlock::ConditionalCleanup(blockno)
+                | TrackedBlock::Cleanup(blockno)
+                | TrackedBlock::Drop(blockno) => *blockno,
+            }
+        }
+    }
+
+    impl Eq for TrackedBlock {}
+    impl PartialEq for TrackedBlock {
+        #[inline(always)]
+        fn eq(&self, other: &Self) -> bool {
+            self.number() == other.number()
+        }
+    }
+
+    impl Hash for TrackedBlock {
+        #[inline(always)]
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            state.write_u32(self.number());
+        }
+    }
+
+    pub(super) static BLOCK_TRACKER: OnceLock<
+        Mutex<HashMap<TrackedBlock, Option<std::backtrace::Backtrace>>>,
+    > = OnceLock::new();
+
+    macro_rules! track {
+        ($style:ident, $pg_buffer:expr) => {
+            use std::collections::hash_map::Entry;
+            let blockno = block_tracker::TrackedBlock::$style(
+                #[allow(unused_unsafe)]
+                unsafe {
+                    pg_sys::BufferGetBlockNumber($pg_buffer)
+                },
+            );
+            let map = block_tracker::BLOCK_TRACKER.get_or_init(|| Default::default());
+            let mut lock = map.lock();
+            match lock.entry(blockno) {
+                Entry::Occupied(existing) => {
+                    // having an existing block is okay if the existing block is Pinned and we're trying
+                    // to track another Pinned or Read version of the block.
+                    let existing_okay = matches!(existing.key(), block_tracker::TrackedBlock::Pinned(_))
+                            && (
+                                    matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                                    || matches!(blockno, block_tracker::TrackedBlock::Read(_))
+                            );
+
+                    if !existing_okay {
+                        // any other combination is illegal within this process and we'll either WARN or panic
+                        // depending on if we're already panicking or not
+                        if std::thread::panicking() {
+                            pgrx::warning!(
+                                "blockno {:?} already opened at {:#?}.\ntried to open {blockno:?} again at {:#?}",
+                                existing.key(),
+                                existing.get(),
+                                std::backtrace::Backtrace::force_capture()
+                            )
+
+                        } else {
+                            panic!(
+                                "blockno {:?} already opened at {:#?}.\ntried to open {blockno:?} again at {:#?}",
+                                existing.key(),
+                                existing.get(),
+                                std::backtrace::Backtrace::force_capture()
+                            )
+                        }
+                    }
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert(Some(std::backtrace::Backtrace::force_capture()));
+                }
+            }
+        };
+    }
+
+    macro_rules! forget {
+        ($pg_buffer:expr) => {
+            let blockno = {
+                #[allow(unused_unsafe)]
+                unsafe {
+                    pg_sys::BufferGetBlockNumber($pg_buffer)
+                }
+            };
+            let map = block_tracker::BLOCK_TRACKER.get_or_init(|| Default::default());
+            let mut lock = map.lock();
+            lock.remove(&block_tracker::TrackedBlock::Drop(blockno));
+        };
+    }
+
+    pub(super) use forget;
+    pub(super) use track;
+}
+
+/// A noop version of the above `block_tracker` module which is used when the feature flag is not enabled.
+///
+/// This has zero overhead as it doesn't do anything other than allow the code to compile
+#[cfg(not(feature = "block_tracker"))]
+mod block_tracker {
+    macro_rules! track {
+        ($style:ident, $pg_buffer:expr) => {};
+    }
+
+    macro_rules! forget {
+        ($pg_buffer:expr) => {};
+    }
+
+    pub(super) use forget;
+    pub(super) use track;
+}
+
 #[derive(Debug)]
 pub struct Buffer {
     pg_buffer: pg_sys::Buffer,
@@ -13,6 +156,7 @@ pub struct Buffer {
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
+            block_tracker::forget!(self.pg_buffer);
             if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer
                 && pg_sys::InterruptHoldoffCount > 0    // if it's not we're likely unwinding the stack due to a panic and unlocking buffers isn't possible anymore
                 && crate::postgres::utils::IsTransactionState()
@@ -136,6 +280,7 @@ pub struct PinnedBuffer {
 impl Drop for PinnedBuffer {
     fn drop(&mut self) {
         unsafe {
+            block_tracker::forget!(self.pg_buffer);
             if crate::postgres::utils::IsTransactionState() {
                 pg_sys::ReleaseBuffer(self.pg_buffer);
             }
@@ -457,11 +602,11 @@ impl BufferManager {
     #[must_use]
     pub fn new_buffer(&mut self) -> BufferMut {
         unsafe {
+            let pg_buffer = self.bcache.new_buffer();
+            block_tracker::track!(Write, pg_buffer);
             BufferMut {
                 dirty: false,
-                inner: Buffer {
-                    pg_buffer: self.bcache.new_buffer(),
-                },
+                inner: Buffer { pg_buffer },
             }
         }
     }
@@ -473,24 +618,32 @@ impl BufferManager {
         unsafe {
             let mut buffer_vec = self.bcache.new_buffers(npages);
             std::iter::from_fn(move || {
-                buffer_vec.next().map(|pg_buffer| BufferMut {
-                    dirty: false,
-                    inner: Buffer { pg_buffer },
+                buffer_vec.next().map(|(pg_buffer, _needs_lock)| {
+                    block_tracker::track!(Write, pg_buffer);
+                    BufferMut {
+                        dirty: false,
+                        inner: Buffer { pg_buffer },
+                    }
                 })
             })
         }
     }
 
     pub fn pinned_buffer(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {
-        unsafe { PinnedBuffer::new(self.bcache.get_buffer(blockno, None)) }
+        unsafe {
+            let pg_buffer = self.bcache.get_buffer(blockno, None);
+            block_tracker::track!(Pinned, pg_buffer);
+            PinnedBuffer::new(pg_buffer)
+        }
     }
 
     pub fn get_buffer(&self, blockno: pg_sys::BlockNumber) -> Buffer {
         unsafe {
-            Buffer::new(
-                self.bcache
-                    .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE)),
-            )
+            let pg_buffer = self
+                .bcache
+                .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
+            block_tracker::track!(Read, pg_buffer);
+            Buffer::new(pg_buffer)
         }
     }
 
@@ -508,12 +661,13 @@ impl BufferManager {
 
     pub fn get_buffer_mut(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
+            let pg_buffer = self
+                .bcache
+                .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
+            block_tracker::track!(Write, pg_buffer);
             BufferMut {
                 dirty: false,
-                inner: Buffer::new(
-                    self.bcache
-                        .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE)),
-                ),
+                inner: Buffer::new(pg_buffer),
             }
         }
     }
@@ -536,6 +690,7 @@ impl BufferManager {
         unsafe {
             let pg_buffer = self.bcache.get_buffer(blockno, None);
             if pg_sys::ConditionalLockBuffer(pg_buffer) {
+                block_tracker::track!(Conditional, pg_buffer);
                 Some(BufferMut {
                     dirty: false,
                     inner: Buffer::new(pg_buffer),
@@ -549,15 +704,16 @@ impl BufferManager {
 
     pub fn get_buffer_for_cleanup(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
-            let buffer = self.bcache.get_buffer_with_strategy(
+            let pg_buffer = self.bcache.get_buffer_with_strategy(
                 blockno,
                 pg_sys::ReadBufferMode::RBM_NORMAL as _,
                 None,
             );
-            pg_sys::LockBufferForCleanup(buffer);
+            pg_sys::LockBufferForCleanup(pg_buffer);
+            block_tracker::track!(Cleanup, pg_buffer);
             BufferMut {
                 dirty: false,
-                inner: Buffer::new(buffer),
+                inner: Buffer::new(pg_buffer),
             }
         }
     }
@@ -567,14 +723,15 @@ impl BufferManager {
         blockno: pg_sys::BlockNumber,
     ) -> Option<BufferMut> {
         unsafe {
-            let buffer = self.bcache.get_buffer(blockno, None);
-            if pg_sys::ConditionalLockBufferForCleanup(buffer) {
+            let pg_buffer = self.bcache.get_buffer(blockno, None);
+            if pg_sys::ConditionalLockBufferForCleanup(pg_buffer) {
+                block_tracker::track!(ConditionalCleanup, pg_buffer);
                 Some(BufferMut {
                     dirty: false,
-                    inner: Buffer::new(buffer),
+                    inner: Buffer::new(pg_buffer),
                 })
             } else {
-                pg_sys::ReleaseBuffer(buffer);
+                pg_sys::ReleaseBuffer(pg_buffer);
                 None
             }
         }

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -246,20 +246,14 @@ impl LinkedBytesList {
         let mut bman = BufferManager::new(rel);
         let mut buffers = bman.new_buffers(2);
 
-        let header_blockno = {
-            let mut header_buffer = buffers.next().unwrap();
-            header_buffer.init_page();
-            header_buffer.number()
-        };
+        let mut header_buffer = buffers.next().unwrap();
+        let header_blockno = header_buffer.number();
+        let mut start_buffer = buffers.next().unwrap();
+        let start_blockno = start_buffer.number();
 
-        let start_blockno = {
-            let mut start_buffer = buffers.next().unwrap();
-            start_buffer.init_page();
-            start_buffer.number()
-        };
+        let mut header_page = header_buffer.init_page();
+        start_buffer.init_page();
 
-        let mut header_buffer = bman.get_buffer_mut(header_blockno);
-        let mut header_page = header_buffer.page_mut();
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -189,7 +189,7 @@ impl MetaPageMut {
         let segment_ids_list = LinkedBytesList::create(self.bman.bm25cache().rel());
         let mut writer = segment_ids_list.writer();
         writer.write(&segment_id_bytes)?;
-        let segment_ids_list = writer.into_inner()?;
+        let segment_ids_list = writer.finalize_and_write()?;
 
         let mut page = self.buffer.page_mut();
         let metadata = page.contents_mut::<MetaPageData>();


### PR DESCRIPTION
When extending a relation the backend needs to clear the relation's `SMgrRelation`'s "SIZE_CACHE" so that it doesn't become confused about the size of a relation relative to other concurrent relation extensions that may have occurred.

Failure to do this can cause errors like the below under high read/write concurrency:

```
ERROR:  XX001: could not read blocks 10..10 in file "base/16384/16552": read only 0 of 8192 bytes
```

PR #2716 introduced this bug as it changed our approach of always calling `pg_sys::relation_open()` to the new `PgSearchRelation` which wraps an already-opened `pg_sys::Relation` pointer and is cheaply clone-able.  

Essentially, prior to #2716 we'd always get a new `SMgrRelation` and it would ask the kernel about the size of the relation on disk, whereas #2716 made us dependent on the internal size cache.

Fixing this necessitates calling the various `pg_sys::ExtendBufferedRel*()` functions with the `pg_sys::ExtendBufferedFlags::EB_CLEAR_SIZE_CACHE` flag set, which also means we need to use `pg_sys::ExtendedBufferedRel` directly when extending the relation by one block.  So `BM25BufferCache` has been refactored a bit to handle this.

It's also necessary, when extending the relation by a single buffer, to lock it using an `ExclusiveLock`, not an `AccessExclusiveLock`.

## Additional Changes

### `SegmentComponentWriter` flush/drop Behavior

As a drive-by, this PR adjusts `SegmentComponentWriter`'s flush/drop behavior to be less confusing and better aided by the Rust compiler.  This is related to the new `LInkedBytesListWriter::finalize_and_write()` function (see below).

The cleanup around flush & drop also ensures that we won't try to write any bit of a SegmentComponentWriter's buffers to disk if we're dropping during a panic-induced stack unwind.

### `LinkedBytesListWriter` Defers Updating `last_blockno`

`LinkedBytesListWriter` now has a `fn finalize_and_write(self)` which is where it records the `last_blockno` in the list's metadata and also where its `BlockList` is written to disk.  The `last_blockno` was previously being constantly updated by `LinkedBytesListWriter::write()` every time it linked a new buffer to the end. This wasn't necessarily incorrect, but it was inefficient and made analyzing the issues this PR aims to fix a bit more difficult. 

Moving the final assignment of `last_blockno` to `finalize_and_write()` is fine as if the writer is never finalized for whatever reason, the "last block number" won't matter anyways.

### `block_tracker` Feature & Module

There's a new feature called `block_tracker` that when enabled will transiently track all block numbers being opened/released and panic when it detects a block is about to be opened a second time in an incompatible manner with an already-open instance.  This is for internal debugging and clearly not meant for production use, which is why the feature is not included in the default feature flag set.
