### PR TITLE
fix: Incorrect scores when used with expressions

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
@@ -112,7 +112,11 @@ impl MixedFastFieldExecState {
     /// # Returns
     ///
     /// A new MixedFastFieldExecState instance
-    pub fn new(which_fast_fields: Vec<WhichFastField>, limit: Option<usize>, can_use_virtual: bool) -> Self {
+    pub fn new(
+        which_fast_fields: Vec<WhichFastField>,
+        limit: Option<usize>,
+        can_use_virtual: bool,
+    ) -> Self {
         // If there is a limit, then we use a batch size which is a small multiple of the limit, in
         // case of dead tuples.
         let batch_size = limit
@@ -351,7 +355,7 @@ impl ExecMethod for MixedFastFieldExecState {
                         self.inner.blockvis.1
                     };
 
-                    if is_visible {
+                    if is_visible && self.inner.can_use_virtual {
                         self.inner.blockvis = (blockno, true);
 
                         // Setup slot for returning data

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mixed.rs
@@ -112,14 +112,14 @@ impl MixedFastFieldExecState {
     /// # Returns
     ///
     /// A new MixedFastFieldExecState instance
-    pub fn new(which_fast_fields: Vec<WhichFastField>, limit: Option<usize>) -> Self {
+    pub fn new(which_fast_fields: Vec<WhichFastField>, limit: Option<usize>, can_use_virtual: bool) -> Self {
         // If there is a limit, then we use a batch size which is a small multiple of the limit, in
         // case of dead tuples.
         let batch_size = limit
             .map(|limit| std::cmp::min(limit * 2, JOIN_BATCH_SIZE))
             .unwrap_or(JOIN_BATCH_SIZE);
         Self {
-            inner: FastFieldExecState::new(which_fast_fields),
+            inner: FastFieldExecState::new(which_fast_fields, can_use_virtual),
             batch_size,
             search_results: None,
             batch: Batch::default(),

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -56,6 +56,7 @@ pub struct FastFieldExecState {
     blockvis: (pg_sys::BlockNumber, bool),
 
     did_query: bool,
+    can_use_virtual: bool
 }
 
 impl Drop for FastFieldExecState {
@@ -71,7 +72,7 @@ impl Drop for FastFieldExecState {
 }
 
 impl FastFieldExecState {
-    pub fn new(which_fast_fields: Vec<WhichFastField>) -> Self {
+    pub fn new(which_fast_fields: Vec<WhichFastField>, can_use_virtual: bool) -> Self {
         Self {
             heaprel: None,
             tupdesc: None,
@@ -81,6 +82,7 @@ impl FastFieldExecState {
             vmbuff: pg_sys::InvalidBuffer as pg_sys::Buffer,
             blockvis: (pg_sys::InvalidBlockNumber, false),
             did_query: false,
+            can_use_virtual,
         }
     }
 
@@ -289,7 +291,7 @@ pub unsafe fn pullup_fast_fields(
                 return None;
             }
             continue;
-        } else if uses_scores((*te).expr.cast(), score_funcoid(), rti) {
+        } else if uses_scores((*te).expr.cast(), score_funcoid(), rti).0 {
             matches.push(WhichFastField::Score);
             continue;
         } else if pgrx::is_a((*te).expr.cast(), pg_sys::NodeTag::T_Aggref)

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -56,7 +56,7 @@ pub struct FastFieldExecState {
     blockvis: (pg_sys::BlockNumber, bool),
 
     did_query: bool,
-    can_use_virtual: bool
+    can_use_virtual: bool,
 }
 
 impl Drop for FastFieldExecState {
@@ -135,7 +135,11 @@ pub unsafe fn non_string_ff_to_datum(
     } else if matches!(which_fast_field, WhichFastField::TableOid) {
         (*slot).tts_tableOid.into_datum()
     } else if matches!(which_fast_field, WhichFastField::Score) {
-        score.into_datum()
+        if typid == pg_sys::FLOAT4OID {
+            score.into_datum()
+        } else {
+            (score as f64).into_datum()
+        }
     } else if matches!(
         which_fast_field,
         WhichFastField::Named(_, FastFieldType::String)

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/numeric.rs
@@ -34,9 +34,9 @@ pub struct NumericFastFieldExecState {
 }
 
 impl NumericFastFieldExecState {
-    pub fn new(which_fast_fields: Vec<WhichFastField>) -> Self {
+    pub fn new(which_fast_fields: Vec<WhichFastField>, can_use_virtual: bool) -> Self {
         Self {
-            inner: FastFieldExecState::new(which_fast_fields),
+            inner: FastFieldExecState::new(which_fast_fields, can_use_virtual),
             search_results: None,
         }
     }
@@ -102,7 +102,7 @@ impl ExecMethod for NumericFastFieldExecState {
                         self.inner.blockvis.1
                     };
 
-                    if is_visible {
+                    if is_visible && self.inner.can_use_virtual {
                         self.inner.blockvis = (blockno, true);
 
                         (*slot).tts_flags &= !pg_sys::TTS_FLAG_EMPTY as u16;

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1113,8 +1113,7 @@ fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
 /// needed at execution time.
 ///
 fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
-    let can_use_virtual =
-        !builder.custom_state().need_scores() || builder.custom_state().is_raw_score;
+    let can_use_virtual = builder.custom_state().can_use_virtual();
     match builder.custom_state_ref().exec_method_type.clone() {
         ExecMethodType::Normal => builder
             .custom_state()

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -677,13 +677,13 @@ impl CustomScan for PdbScan {
             builder.custom_state().snippet_funcoid = snippet_funcoid;
             builder.custom_state().snippet_positions_funcoid = snippet_positions_funcoid;
 
-            let (uses_scores, is_raw_score) = uses_scores(
+            let (uses_scores, uses_raw_score) = uses_scores(
                 builder.target_list().as_ptr().cast(),
                 score_funcoid,
                 builder.custom_state().execution_rti,
             );
             builder.custom_state().need_scores = uses_scores;
-            builder.custom_state().is_raw_score = is_raw_score;
+            builder.custom_state().uses_raw_score = uses_raw_score;
 
             // Store join snippet predicates in the scan state
             builder.custom_state().join_predicates =

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1113,7 +1113,8 @@ fn choose_exec_method(privdata: &PrivateData) -> ExecMethodType {
 /// needed at execution time.
 ///
 fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>) {
-    let can_use_virtual = !builder.custom_state().need_scores() || builder.custom_state().is_raw_score;
+    let can_use_virtual =
+        !builder.custom_state().need_scores() || builder.custom_state().is_raw_score;
     match builder.custom_state_ref().exec_method_type.clone() {
         ExecMethodType::Normal => builder
             .custom_state()

--- a/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
@@ -57,7 +57,7 @@ pub unsafe fn uses_scores(
                 if let Some(var) = nodecast!(Var, T_Var, args.get_ptr(0).unwrap()) {
                     if (*var).varno as i32 == (*data).rti as i32 {
                         (*data).found_score = true;
-                        (*data).is_raw_score = (*data).is_root;
+                        (*data).uses_raw_score = (*data).is_root;
                         return true;
                     }
                 }
@@ -72,7 +72,7 @@ pub unsafe fn uses_scores(
         score_funcoid: pg_sys::Oid,
         rti: pg_sys::Index,
         found_score: bool,
-        is_raw_score: bool,
+        uses_raw_score: bool,
         is_root: bool,
     }
 
@@ -80,12 +80,12 @@ pub unsafe fn uses_scores(
         score_funcoid,
         rti,
         found_score: false,
-        is_raw_score: false,
+        uses_raw_score: false,
         is_root: true,
     };
 
     walker(node, addr_of_mut!(data).cast());
-    (data.found_score, data.is_raw_score)
+    (data.found_score, data.uses_raw_score)
 }
 
 pub unsafe fn is_score_func(node: *mut pg_sys::Node, rti: pg_sys::Index) -> bool {

--- a/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/projections/score.rs
@@ -56,16 +56,8 @@ pub unsafe fn uses_scores(
                 assert!(args.len() == 1, "score function must have 1 argument");
                 if let Some(var) = nodecast!(Var, T_Var, args.get_ptr(0).unwrap()) {
                     if (*var).varno as i32 == (*data).rti as i32 {
-                        // Found a score function call
                         (*data).found_score = true;
-
-                        // Check if this is the root node (raw score) or wrapped in other operations (transformed)
-                        if (*data).is_root {
-                            (*data).is_raw_score = true;
-                        } else {
-                            (*data).is_raw_score = false;
-                        }
-
+                        (*data).is_raw_score = (*data).is_root;
                         return true;
                     }
                 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -207,6 +207,11 @@ impl PdbScanState {
     }
 
     #[inline(always)]
+    pub fn can_use_virtual(&self) -> bool {
+        !self.need_scores() || self.is_raw_score
+    }
+
+    #[inline(always)]
     pub fn need_scores(&self) -> bool {
         self.need_scores
             || self.base_search_query_input.need_scores()

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -73,6 +73,7 @@ pub struct PdbScanState {
     pub quals: Option<Qual>,
 
     pub need_scores: bool,
+    pub is_raw_score: bool,
     pub const_score_node: Option<*mut pg_sys::Const>,
     pub score_funcoid: pg_sys::Oid,
 

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -73,7 +73,7 @@ pub struct PdbScanState {
     pub quals: Option<Qual>,
 
     pub need_scores: bool,
-    pub is_raw_score: bool,
+    pub uses_raw_score: bool,
     pub const_score_node: Option<*mut pg_sys::Const>,
     pub score_funcoid: pg_sys::Oid,
 
@@ -208,7 +208,7 @@ impl PdbScanState {
 
     #[inline(always)]
     pub fn can_use_virtual(&self) -> bool {
-        !self.need_scores() || self.is_raw_score
+        !self.need_scores() || self.uses_raw_score
     }
 
     #[inline(always)]

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -41,4 +41,39 @@ SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * ra
  White jogging shoes |      3 | 3.4849067 |  10.45472002029419
 (3 rows)
 
+-- this should use TopNExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, paradedb.score(id) AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: mock_items_id_description_rating_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            Sort Field: paradedb.score()
+            Sort Direction: desc
+            Top N Limit: 3
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
+
+-- this should use NumericFastFieldExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, paradedb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ((paradedb.score(id) * '2'::double precision)) DESC
+         ->  Custom Scan (ParadeDB Scan) on mock_items
+               Table: mock_items
+               Index: mock_items_id_description_rating_idx
+               Exec Method: NumericFastFieldExecState
+               Fast Fields: id, paradedb.score()
+               Scores: true
+                  Top N Limit: 3
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
 DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -1,0 +1,44 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX on mock_items USING bm25 (id, description, rating) WITH (key_field='id');
+SELECT description, paradedb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+     description     |       score       
+---------------------+-------------------
+ Generic shoes       | 5.754520416259766
+ Sleek running shoes | 4.969813346862793
+ White jogging shoes | 4.969813346862793
+(3 rows)
+
+SELECT description, rating, paradedb.score(id) * rating AS score FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC, rating LIMIT 3;
+     description     | rating |       score        
+---------------------+--------+--------------------
+ Sleek running shoes |      5 | 17.424533367156982
+ Generic shoes       |      4 | 15.509040832519531
+ White jogging shoes |      3 |  10.45472002029419
+(3 rows)
+
+SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score_times_rating DESC LIMIT 3;
+     description     | rating |   score   | score_times_rating 
+---------------------+--------+-----------+--------------------
+ Sleek running shoes |      5 | 3.4849067 | 17.424533367156982
+ Generic shoes       |      4 | 3.8772602 | 15.509040832519531
+ White jogging shoes |      3 | 3.4849067 |  10.45472002029419
+(3 rows)
+
+SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC LIMIT 3;
+     description     | rating |   score   | score_times_rating 
+---------------------+--------+-----------+--------------------
+ Generic shoes       |      4 | 3.8772602 | 15.509040832519531
+ Sleek running shoes |      5 | 3.4849067 | 17.424533367156982
+ White jogging shoes |      3 | 3.4849067 |  10.45472002029419
+(3 rows)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/issue_2932.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2932.sql
@@ -1,0 +1,15 @@
+\i common/common_setup.sql
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX on mock_items USING bm25 (id, description, rating) WITH (key_field='id');
+
+SELECT description, paradedb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+SELECT description, rating, paradedb.score(id) * rating AS score FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC, rating LIMIT 3;
+SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score_times_rating DESC LIMIT 3;
+SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC LIMIT 3;
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/issue_2932.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2932.sql
@@ -12,4 +12,12 @@ SELECT description, rating, paradedb.score(id) * rating AS score FROM mock_items
 SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score_times_rating DESC LIMIT 3;
 SELECT description, rating, paradedb.score(id) AS score, paradedb.score(id) * rating AS score_times_rating FROM mock_items WHERE description @@@ 'shoes' OR rating > 2 ORDER BY score DESC LIMIT 3;
 
+-- this should use TopNExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, paradedb.score(id) AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+
+-- this should use NumericFastFieldExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, paradedb.score(id) * 2 AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score DESC LIMIT 3;
+
 DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2931 

## What

A query like
 
```sql
SELECT paradedb.score(id) * 2  AS score FROM mock_items WHERE description @@@ 'shoes' ORDER BY score LIMIT 5
```

would go down the numeric fast field exec method, instead of top N. This leads to two issues:

1. In `non_string_ff_to_datum` where we convert the score to datum, we were not correctly casting `f32` vs `f64`.
2. The numeric and mixed scans can return the scores in a `ExecState::Virtual`, which basically tells Postgres to accept our tuple as-is. This causes expressions like `paradedb.score(id) * 2` to get lost.

## Why

Bug fix

## How

When we detect that scores are being used in an expression, we return `ExecState::RequiresVisibilityCheck` instead of `ExecState::Virtual` so that Postgres can apply the expression.

## Tests

Added regression test