### PR TITLE
ci: Fix benchmark-backfill-auto

### DIFF
--- a/.github/workflows/benchmark-backfill-auto.yml
+++ b/.github/workflows/benchmark-backfill-auto.yml
@@ -77,7 +77,7 @@ jobs:
         sha: ${{ fromJSON(needs.reset.outputs.ids) }} # → ["…","…"]
 
     steps:
-      - name: Fire Benchmark &Sstressgres Jobs for ${{ matrix.sha }}
+      - name: Fire Benchmark &Stressgres Jobs for ${{ matrix.sha }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -61,7 +61,7 @@ jobs:
         sha: ${{ fromJSON(github.event.inputs.commits) }} # → ["…","…"]
 
     steps:
-      - name: Fire benchmark & stressgres for ${{ matrix.sha }}
+      - name: Fire Benchmark & Stressgres for ${{ matrix.sha }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This job was always failing with a syntax error:

- https://github.com/paradedb/paradedb/actions/runs/16760995847
- https://github.com/paradedb/paradedb/actions/runs/16761014333
- https://github.com/paradedb/paradedb/actions/runs/16760952900

I fixed it by making it properly depend on the `ids` from the `reset` step. I also did some nitpicky cleanup.

## Why
Working workflow^

## How
^

## Tests
CI!