### PR TITLE
ci: Add missing code from SchemaBot Workflow

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -39,6 +39,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch the entire history
+          token: ${{ secrets.GHA_CREATE_RELEASE_PAT }} # Required with fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract pgrx Version
         id: pgrx


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
While doing a quick audit of the CI, I noticed this code is in our enterprise version, which is running well, and isn't in our community version. Somehow the community SchemaBot runs aren't even displaying in the Actions tab.

## Why
I think this code should be there (?)

## How
Compare community and enterprise

## Tests
CI