### PR TITLE
ci: Update the SSH deploy key to a unified one in organization-wide secrets

### DIFF
--- a/.github/actions/benchmarks-from-main/action.yml
+++ b/.github/actions/benchmarks-from-main/action.yml
@@ -1,4 +1,4 @@
-name: benchmarks-from-main
+name: Fetch Benchmark Sources from Main
 description: Fetch latest benchmark code, suites, and actions from `main`
 
 inputs:

--- a/.github/actions/push-file/action.yml
+++ b/.github/actions/push-file/action.yml
@@ -1,5 +1,4 @@
-name: "Commit and Push File"
-
+name: Commit and Push File
 description: Checks out the specified remote repository, stages the provided file, commits it if there are changes, and pushes to the given branch.
 
 inputs:
@@ -40,7 +39,7 @@ runs:
       shell: bash
       working-directory: "${{ inputs.repo-path }}"
       run: |
-        git config user.name "ParadeDB push file action"
+        git config user.name "ParadeDB GitHub Actions"
         git config user.email "developers@paradedb.com"
 
     - name: Stage changes

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -225,7 +225,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          benchmark-deploy-secret: ${{ secrets.BENCHMARK_DATA_DEPLOY_KEY }}
+          benchmark-deploy-secret: ${{ secrets.PARADEDB_BENCHMARK_DATA_DEPLOY_SSH_KEY }}
 
       - name: Benchmark bulk-updates.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -237,7 +237,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          benchmark-deploy-secret: ${{ secrets.BENCHMARK_DATA_DEPLOY_KEY }}
+          benchmark-deploy-secret: ${{ secrets.PARADEDB_BENCHMARK_DATA_DEPLOY_SSH_KEY }}
 
       - name: Benchmark wide-table.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -249,7 +249,7 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          benchmark-deploy-secret: ${{ secrets.BENCHMARK_DATA_DEPLOY_KEY }}
+          benchmark-deploy-secret: ${{ secrets.PARADEDB_BENCHMARK_DATA_DEPLOY_SSH_KEY }}
 
       - name: Benchmark background-merge.toml
         uses: ./.github/actions/benchmark-stressgres
@@ -261,4 +261,4 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           slack_webhook_url: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_WEBHOOK_URL }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          benchmark-deploy-secret: ${{ secrets.BENCHMARK_DATA_DEPLOY_KEY }}
+          benchmark-deploy-secret: ${{ secrets.PARADEDB_BENCHMARK_DATA_DEPLOY_SSH_KEY }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I had some free time today. I had it on my backlog to unify the deploy key to not depend on Eric's, and put a universal one across our organization's secrets instead of a per-repo one, for ease of reuse over time. This is what this does.

## Why
Simpler cross-repo pushing infra.

## How
^

## Tests
CI