### PR TITLE
fix: excluded problematic aggregate query shapes from custom aggregate scan

### DIFF
--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -156,14 +156,25 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard' 
 GROUP BY category
 ORDER BY category;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.products
-   Output: category, now(), now(), now(), now(), now()
-   Index: products_idx
-   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
-(5 rows)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: category, count(*), sum(price), avg(price), min(price), max(price)
+   Group Key: products.category
+   ->  Sort
+         Output: category, price
+         Sort Key: products.category
+         ->  Custom Scan (ParadeDB Scan) on public.products
+               Output: category, price
+               Table: products
+               Index: products_idx
+               Exec Method: MixedFastFieldExecState
+               Fast Fields: category, price
+               String Fast Fields: category
+               Numeric Fast Fields: price
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
 
 SELECT category, 
        COUNT(*) AS count, 
@@ -175,10 +186,10 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard' 
 GROUP BY category
 ORDER BY category;
-  category   | count |  total  |  avg   | min_price | max_price 
--------------+-------+---------+--------+-----------+-----------
- Electronics |     4 | 2529.96 | 632.49 |     79.99 |   1299.99
- Toys        |     1 |  499.99 | 499.99 |    499.99 |    499.99
+  category   | count |  total  |         avg          | min_price | max_price 
+-------------+-------+---------+----------------------+-----------+-----------
+ Electronics |     4 | 2529.96 | 632.4900000000000000 |     79.99 |   1299.99
+ Toys        |     1 |  499.99 | 499.9900000000000000 |    499.99 |    499.99
 (2 rows)
 
 -- Test 1.6: GROUP BY with numeric field
@@ -814,40 +825,95 @@ SELECT name, SUM(price), MAX(rating), AVG(age)
 FROM users 
 WHERE (users.color @@@ 'blue') AND (NOT (users.age < '20')) 
 GROUP BY name;
-                                                                                                                             QUERY PLAN                                                                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.users
-   Output: name, now(), now(), now()
-   Index: idxusers
-   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"age","lower_bound":{"included":20},"upper_bound":null,"is_datetime":false}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"name","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}},"agg_2":{"avg":{"field":"age"}}}}}
-(5 rows)
+                                                                                                                                         QUERY PLAN                                                                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: name, sum(price), max(rating), avg(age)
+   Group Key: users.name
+   ->  Gather Merge
+         Output: name, (PARTIAL sum(price)), (PARTIAL max(rating)), (PARTIAL avg(age))
+         Workers Planned: 2
+         ->  Sort
+               Output: name, (PARTIAL sum(price)), (PARTIAL max(rating)), (PARTIAL avg(age))
+               Sort Key: users.name
+               ->  Partial HashAggregate
+                     Output: name, PARTIAL sum(price), PARTIAL max(rating), PARTIAL avg(age)
+                     Group Key: users.name
+                     ->  Parallel Custom Scan (ParadeDB Scan) on public.users
+                           Output: name, price, rating, age
+                           Table: users
+                           Index: idxusers
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"age","lower_bound":{"included":20},"upper_bound":null,"is_datetime":false}}]}}
+(19 rows)
 
 SELECT name, SUM(price), MAX(rating), AVG(age) 
 FROM users 
 WHERE (users.color @@@ 'blue') AND (NOT (users.age < '20')) 
 GROUP BY name;
-ERROR:  incompatible fruit types in tree or missing merge_fruits handler
+      name      |    sum     | max |         avg         
+----------------+------------+-----+---------------------
+ alice          | 1002425.51 |   5 | 52.2000000000000000
+ bob            |    2293.00 |   5 | 46.4000000000000000
+ charlie        | 1011542.00 |   5 | 44.4444444444444444
+ david          | 1012134.99 |   5 | 55.2000000000000000
+ duplicate_name |    1500.00 |   5 | 27.0000000000000000
+ edge_case_1    |       0.00 |   1 | 20.0000000000000000
+ edge_case_2    |  999999.99 |   5 | 21.0000000000000000
+ emma           | 1021900.98 |   5 | 46.9000000000000000
+ frank          | 1021502.98 |   5 | 45.6666666666666667
+ sally          |   13297.25 |   5 | 51.3846153846153846
+(10 rows)
+
 --- ----
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT name, SUM(price), MAX(rating), AVG(age) 
 FROM users 
 WHERE (users.color @@@ 'blue')
 GROUP BY name;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.users
-   Output: name, now(), now(), now()
-   Index: idxusers
-   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"name","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}},"agg_2":{"avg":{"field":"age"}}}}}
-(5 rows)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: name, sum(price), max(rating), avg(age)
+   Group Key: users.name
+   ->  Gather Merge
+         Output: name, (PARTIAL sum(price)), (PARTIAL max(rating)), (PARTIAL avg(age))
+         Workers Planned: 2
+         ->  Sort
+               Output: name, (PARTIAL sum(price)), (PARTIAL max(rating)), (PARTIAL avg(age))
+               Sort Key: users.name
+               ->  Partial HashAggregate
+                     Output: name, PARTIAL sum(price), PARTIAL max(rating), PARTIAL avg(age)
+                     Group Key: users.name
+                     ->  Parallel Custom Scan (ParadeDB Scan) on public.users
+                           Output: name, price, rating, age
+                           Table: users
+                           Index: idxusers
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
 
 SELECT name, SUM(price), MAX(rating), AVG(age) 
 FROM users 
 WHERE (users.color @@@ 'blue')
 GROUP BY name;
-ERROR:  incompatible fruit types in tree or missing merge_fruits handler
+      name      |    sum     | max |         avg         
+----------------+------------+-----+---------------------
+ alice          | 1003050.51 |   5 | 44.0000000000000000
+ bob            |    3224.01 |   5 | 36.1333333333333333
+ charlie        | 1013020.00 |   5 | 34.2142857142857143
+ david          | 1022915.98 |   5 | 46.1538461538461538
+ duplicate_name |    1500.00 |   5 | 27.0000000000000000
+ edge_case_1    |       0.00 |   1 | 20.0000000000000000
+ edge_case_2    |  999999.99 |   5 | 21.0000000000000000
+ edge_case_3    |       0.01 |   1 | 19.0000000000000000
+ emma           | 1022821.98 |   5 | 39.7692307692307692
+ frank          | 1021726.99 |   5 | 38.1666666666666667
+ sally          | 1013635.25 |   5 | 44.8750000000000000
+(11 rows)
+
 --- ----
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT name, SUM(price), MAX(rating)
@@ -889,18 +955,18 @@ SELECT name, COUNT(*), SUM(price), AVG(price), MIN(rating), MAX(rating)
 FROM users 
 WHERE color @@@ 'blue' AND age >= 20
 GROUP BY name;
-      name      | count |    sum     |       avg        | min | max 
-----------------+-------+------------+------------------+-----+-----
- alice          |    10 | 1002425.51 |       100242.551 |   1 |   5
- bob            |    10 |       2293 |            229.3 |   1 |   5
- charlie        |     9 |    1011542 | 112393.555555556 |   1 |   5
- david          |    10 | 1012134.99 |       101213.499 |   1 |   5
- duplicate_name |     5 |       1500 |              300 |   1 |   5
- edge_case_1    |     1 |          0 |                0 |   1 |   1
- edge_case_2    |     1 |  999999.99 |        999999.99 |   5 |   5
- emma           |    10 | 1021900.98 |       102190.098 |   1 |   5
- frank          |     9 | 1021502.98 | 113500.331111111 |   1 |   5
- sally          |    13 |   13297.25 | 1022.86538461538 |   1 |   5
+      name      | count |    sum     |          avg           | min | max 
+----------------+-------+------------+------------------------+-----+-----
+ alice          |    10 | 1002425.51 |    100242.551000000000 |   1 |   5
+ bob            |    10 |    2293.00 |   229.3000000000000000 |   1 |   5
+ charlie        |     9 | 1011542.00 |    112393.555555555556 |   1 |   5
+ david          |    10 | 1012134.99 |    101213.499000000000 |   1 |   5
+ duplicate_name |     5 |    1500.00 |   300.0000000000000000 |   1 |   5
+ edge_case_1    |     1 |       0.00 | 0.00000000000000000000 |   1 |   1
+ edge_case_2    |     1 |  999999.99 |    999999.990000000000 |   5 |   5
+ emma           |    10 | 1021900.98 |    102190.098000000000 |   1 |   5
+ frank          |     9 | 1021502.98 |    113500.331111111111 |   1 |   5
+ sally          |    13 |   13297.25 |  1022.8653846153846154 |   1 |   5
 (10 rows)
 
 -- Test with complex WHERE conditions

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -848,6 +848,40 @@ FROM users
 WHERE (users.color @@@ 'blue')
 GROUP BY name;
 ERROR:  incompatible fruit types in tree or missing merge_fruits handler
+--- ----
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT name, SUM(price), MAX(rating)
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.users
+   Output: name, now(), now()
+   Index: idxusers
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"name","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}}}}}
+(5 rows)
+
+SELECT name, SUM(price), MAX(rating)
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+      name      |    sum     | max 
+----------------+------------+-----
+ alice          | 1003050.51 |   5
+ bob            |    3224.01 |   5
+ charlie        |    1013020 |   5
+ david          | 1022915.98 |   5
+ duplicate_name |       1500 |   5
+ edge_case_1    |          0 |   1
+ edge_case_2    |  999999.99 |   5
+ edge_case_3    |       0.01 |   1
+ emma           | 1022821.98 |   5
+ frank          | 1021726.99 |   5
+ sally          | 1013635.25 |   5
+(11 rows)
+
 -- Additional test cases to explore the fruit types error boundary conditions
 -- Test with different combinations that might trigger the same issue
 -- Test with different aggregate combinations

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -693,6 +693,196 @@ ORDER BY category;
 -- Cleanup
 -- =====================================================================
 DROP TABLE IF EXISTS products CASCADE;
+-- =====================================================================
+-- SECTION 8: Reproduction case for fruit types error
+-- =====================================================================
+-- Test case to reproduce the "incompatible fruit types in tree" error
+-- This reproduces the specific failure from the generated test suite
+DROP TABLE IF EXISTS users CASCADE;
+CREATE TABLE users
+(
+    id    SERIAL8 NOT NULL PRIMARY KEY,
+    uuid  UUID NOT NULL,
+    name  TEXT,
+    color VARCHAR,
+    age   INTEGER,
+    price NUMERIC(10,2),
+    rating INTEGER
+);
+-- Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxusers ON users USING bm25 (id, uuid, name, color, age, price, rating)
+WITH (
+key_field = 'id',
+text_fields = '
+            {
+                "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+                "name": { "tokenizer": { "type": "keyword" }, "fast": true },
+                "color": { "tokenizer": { "type": "keyword" }, "fast": true }
+            }',
+numeric_fields = '
+            {
+                "age": { "fast": true },
+                "price": { "fast": true },
+                "rating": { "fast": true }
+            }'
+);
+-- Set seed for deterministic UUID generation (optional, for extra consistency)
+SELECT setseed(0.5);
+ setseed 
+---------
+ 
+(1 row)
+
+-- Insert test data specifically designed to trigger the "incompatible fruit types" error
+-- Strategy: Create data patterns that stress Tantivy's aggregation field type handling
+-- Based on the original failing pattern, we need:
+-- 1. Complex boolean queries with mixed field types (text + numeric)
+-- 2. Multiple aggregation functions on different numeric field types
+-- 3. Sufficient data volume to trigger Tantivy's internal aggregation conflicts
+-- First, add some regular data
+INSERT into users (uuid, name, color, age, price, rating) VALUES
+    (gen_random_uuid(), 'bob', 'blue', 20, 99.99, 4),
+    (gen_random_uuid(), 'alice', 'blue', 25, 150.50, 5),
+    (gen_random_uuid(), 'sally', 'blue', 22, 175.25, 4);
+-- Then add many more records with patterns that might trigger the error
+-- Use a mix of data that creates aggregation conflicts
+INSERT into users (uuid, name, color, age, price, rating)
+SELECT
+    gen_random_uuid(),
+    CASE (i % 7)
+        WHEN 0 THEN 'alice'
+        WHEN 1 THEN 'bob'
+        WHEN 2 THEN 'sally'
+        WHEN 3 THEN 'charlie'
+        WHEN 4 THEN 'david'
+        WHEN 5 THEN 'emma'
+        ELSE 'frank'
+    END,
+    CASE (i % 8)
+        WHEN 0 THEN 'blue'
+        WHEN 1 THEN 'blue'
+        WHEN 2 THEN 'blue'
+        WHEN 3 THEN 'red'
+        WHEN 4 THEN 'green'
+        WHEN 5 THEN 'blue'
+        WHEN 6 THEN 'yellow'
+        ELSE 'blue'
+    END,
+    -- Ages that will create complex boolean filtering
+    CASE 
+        WHEN i % 10 < 3 THEN 15 + (i % 5)  -- Some under 20
+        WHEN i % 10 < 7 THEN 20 + (i % 30) -- Many over 20
+        ELSE 50 + (i % 40)                 -- Some much older
+    END,
+    -- Prices with extreme variations to stress aggregation
+    CASE 
+        WHEN i % 15 = 0 THEN 0.01          -- Very small values
+        WHEN i % 13 = 0 THEN 9999.99       -- Very large values
+        WHEN i % 11 = 0 THEN 1000000.00    -- Extremely large values
+        ELSE (50 + (i * 37) % 500)::numeric(10,2)  -- Regular values
+    END,
+    -- Ratings that might cause type conflicts with prices
+    CASE 
+        WHEN i % 17 = 0 THEN 1
+        WHEN i % 13 = 0 THEN 5
+        ELSE ((i * 7) % 5) + 1
+    END
+FROM generate_series(1, 150) AS i;
+-- Add some edge case records that are more likely to trigger conflicts
+INSERT into users (uuid, name, color, age, price, rating) VALUES
+    -- Records with NULL-like characteristics that might confuse aggregation
+    (gen_random_uuid(), 'edge_case_1', 'blue', 20, 0.00, 1),
+    (gen_random_uuid(), 'edge_case_2', 'blue', 21, 999999.99, 5),
+    (gen_random_uuid(), 'edge_case_3', 'blue', 19, 0.01, 1),
+    -- Records that create many duplicates in grouping
+    (gen_random_uuid(), 'duplicate_name', 'blue', 25, 100.00, 3),
+    (gen_random_uuid(), 'duplicate_name', 'blue', 26, 200.00, 4),
+    (gen_random_uuid(), 'duplicate_name', 'blue', 27, 300.00, 5),
+    (gen_random_uuid(), 'duplicate_name', 'blue', 28, 400.00, 1),
+    (gen_random_uuid(), 'duplicate_name', 'blue', 29, 500.00, 2);
+CREATE INDEX idxusers_uuid ON users (uuid);
+CREATE INDEX idxusers_name ON users (name);
+CREATE INDEX idxusers_color ON users (color);
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_price ON users (price);
+CREATE INDEX idxusers_rating ON users (rating);
+ANALYZE;
+-- Test the specific failing query that caused the "incompatible fruit types" error
+-- This query combines text search with NOT operator and multiple aggregations
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE (users.color @@@ 'blue') AND (NOT (users.age < '20')) 
+GROUP BY name;
+                                                                                                                             QUERY PLAN                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.users
+   Output: name, now(), now(), now()
+   Index: idxusers
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"age","lower_bound":{"included":20},"upper_bound":null,"is_datetime":false}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"name","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}},"agg_2":{"avg":{"field":"age"}}}}}
+(5 rows)
+
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE (users.color @@@ 'blue') AND (NOT (users.age < '20')) 
+GROUP BY name;
+ERROR:  incompatible fruit types in tree or missing merge_fruits handler
+--- ----
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.users
+   Output: name, now(), now(), now()
+   Index: idxusers
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"name","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}},"agg_2":{"avg":{"field":"age"}}}}}
+(5 rows)
+
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+ERROR:  incompatible fruit types in tree or missing merge_fruits handler
+-- Additional test cases to explore the fruit types error boundary conditions
+-- Test with different combinations that might trigger the same issue
+-- Test with different aggregate combinations
+SELECT name, COUNT(*), SUM(price), AVG(price), MIN(rating), MAX(rating)
+FROM users 
+WHERE color @@@ 'blue' AND age >= 20
+GROUP BY name;
+      name      | count |    sum     |       avg        | min | max 
+----------------+-------+------------+------------------+-----+-----
+ alice          |    10 | 1002425.51 |       100242.551 |   1 |   5
+ bob            |    10 |       2293 |            229.3 |   1 |   5
+ charlie        |     9 |    1011542 | 112393.555555556 |   1 |   5
+ david          |    10 | 1012134.99 |       101213.499 |   1 |   5
+ duplicate_name |     5 |       1500 |              300 |   1 |   5
+ edge_case_1    |     1 |          0 |                0 |   1 |   1
+ edge_case_2    |     1 |  999999.99 |        999999.99 |   5 |   5
+ emma           |    10 | 1021900.98 |       102190.098 |   1 |   5
+ frank          |     9 | 1021502.98 | 113500.331111111 |   1 |   5
+ sally          |    13 |   13297.25 | 1022.86538461538 |   1 |   5
+(10 rows)
+
+-- Test with complex WHERE conditions
+SELECT color, COUNT(*), AVG(age) 
+FROM users 
+WHERE (name @@@ 'bob' OR name @@@ 'alice') AND price > 50
+GROUP BY color;
+ color  | count |         avg         
+--------+-------+---------------------
+ blue   |    25 | 41.1600000000000000
+ green  |     6 | 43.0000000000000000
+ red    |     5 | 44.0000000000000000
+ yellow |     6 | 35.6666666666666667
+(4 rows)
+
+DROP TABLE IF EXISTS users CASCADE;
 DROP TABLE IF EXISTS type_test CASCADE;
 DROP TABLE IF EXISTS groupby_test CASCADE;
 RESET paradedb.enable_aggregate_custom_scan;

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate.sql
@@ -532,6 +532,19 @@ FROM users
 WHERE (users.color @@@ 'blue')
 GROUP BY name;
 
+--- ----
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT name, SUM(price), MAX(rating)
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+
+SELECT name, SUM(price), MAX(rating)
+FROM users 
+WHERE (users.color @@@ 'blue')
+GROUP BY name;
+
 -- Additional test cases to explore the fruit types error boundary conditions
 -- Test with different combinations that might trigger the same issue
 


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

Proptests caught a strange query shape, where Tantivy fails to run the aggregate query: https://github.com/paradedb/paradedb/actions/runs/16770569293/job/47484536820#step:16:3232

Albeit, this is data-dependent, i.e., the data in the relations can cause the error to show up or not.
## Why

Probably, there's a bug in Tantivy.

## How

This PR excludes the problematic query shape from being processed by aggregate custom scan.

## Tests

Added some tests to regression tests.
