### PR TITLE
fix: Fix the permissions in the ParadeDB Docker image

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -91,7 +91,7 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             -p 5432:5432 \
-            --tmpfs /tmp \
+            --tmpfs /var/lib/postgresql/data:size=1G \
             paradedb/paradedb:latest
 
       # We run the container in detached mode, and grep for the word ERROR to see if it failed to start correctly

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -247,5 +247,8 @@ WORKDIR /
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
 COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
-# Explicitly set non-root user (same as official image default)
-USER postgres
+# The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
+# starts as `root` and then switches to the `postgres` user after running chown and chmod
+# on the PostgreSQL data directory. To maintain compatibility with the upstream image and
+# ensure that the `postgres` user has the correct permissions on the data directory, we let
+# the upstream `entrypoint.sh` script run as the entrypoint and don't specify a custom user.

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,8 +13,8 @@ services:
         - type=local,src=./.docker_cache_dev
       cache_to:
         - type=local,dest=./.docker_cache_dev
-    container_name: paradedb-dev
     image: paradedb/paradedb:latest # Tag the image with `latest` to make it run in the `docker-compose.yml` file
+    container_name: paradedb-dev
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
One of our customers reported that specifying the PostgreSQL data directory with `tmpfs` fails, exposing a permission issue. Meanwhile, doing the same with the upstreasm `postgres:latest` Docker image works. I reproduced and that's true.

- [8b938fe](https://github.com/paradedb/paradedb/pull/2954/commits/8b938fe6a9ccdadb6bad71a70d2eb205f0d7add4) makes our CI test properly catch this issue. Previously, our CI test did use a `--tmpfs` but it used the `tmp/` folder. That commit shows the error being reproduced.
- [07245cc](https://github.com/paradedb/paradedb/pull/2954/commits/07245cc2148862bd5a9c8d3557f68272d72c4522) removes the manually specified `USER postgres`, and provides an explanation. In short, the official Postgres container starts as root, runs chmod/chown to properly work with `tmpfs`, and then drops to `USER postgres`. By overriding it, we were forcing it to start directly as `postgres`, breaking `tmpfs` support. Instead, we don't specify any `USER` and let the Postgres entrypoint script do its job.

## Why
Working Docker image that behaves identical to upstream Postgres

## How
^

## Tests
CI!