### PR TITLE
fix: shouldn't panic if there was an interrupt

### DIFF
--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -161,6 +161,11 @@ impl<const CAPACITY: usize, W: Write> Drop for ExactBuffer<CAPACITY, W> {
                 pgrx::warning!(
                     "During stack unwinding due to a panic elsewhere, an ExactBuffer has {} unwritten bytes", self.len
                 );
+            } else if unsafe { pg_sys::InterruptPending } != 0 {
+                pgrx::warning!(
+                    "ExactBuffer still has {} unwritten bytes because of interrupt",
+                    self.len
+                );
             } else {
                 panic!(
                     "ExactBuffer should have been flushed before being dropped.  It still has {} unwritten bytes", self.len

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -376,7 +376,11 @@ unsafe fn merge_index(
         check_for_interrupts!();
 
         if let Err(e) = merge_result {
-            panic!("failed to merge: {e:?}");
+            if unsafe { pg_sys::InterruptPending } != 0 {
+                pgrx::warning!("failed to merge: {e:?} because of interrupt");
+            } else {
+                panic!("failed to merge: {e:?}");
+            }
         }
     } else {
         drop(merge_lock);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

There were two places we were panicking if there was an interrupt: one at the end of `merge_index`, and another in the `Drop` impl of `ExactBuffer`.

## Why

## How

## Tests
