### PR TITLE
fix: the `LinkedListData::npages` field is dead code

### DIFF
--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -51,8 +51,9 @@ pub struct LinkedListData {
     /// Indicates the last BlockNumber of the linked list.
     pub last_blockno: pg_sys::BlockNumber,
 
-    /// Counts the total number of data pages in the linked list (excludes the header page)
-    pub npages: u32,
+    /// This once tracked the number of blocks in the linked list, but now it's just dead space
+    #[doc(hidden)]
+    _dead_space: u32,
 
     /// Indicates where the BlockList for this linked list starts;
     pub blocklist_start: pg_sys::BlockNumber,
@@ -63,7 +64,6 @@ impl Debug for LinkedListData {
         f.debug_struct("LinkedListData")
             .field("start_blockno", &{ self.start_blockno })
             .field("last_blockno", &{ self.last_blockno })
-            .field("npages", &{ self.npages })
             .field("blocklist_start", &{ self.blocklist_start })
             .finish()
     }

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -144,7 +144,6 @@ impl LinkedBytesListWriter {
         let mut header_page = header_buffer.page_mut();
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.last_blockno = self.last_blockno;
-        metadata.npages += 1;
 
         if let Some(blockno) = self.blocklist_builder.finish(&mut self.list.bman) {
             metadata.blocklist_start = blockno;
@@ -256,7 +255,6 @@ impl LinkedBytesList {
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;
-        metadata.npages = 1;
         metadata.blocklist_start = pg_sys::InvalidBlockNumber;
 
         header_blockno
@@ -279,7 +277,6 @@ impl LinkedBytesList {
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;
-        metadata.npages = 1;
         metadata.blocklist_start = pg_sys::InvalidBlockNumber;
 
         Self {

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -109,7 +109,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;
-        metadata.npages = 0;
 
         header_blockno
     }
@@ -127,7 +126,6 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         let metadata = header_page.contents_mut::<LinkedListData>();
         metadata.start_blockno = start_blockno;
         metadata.last_blockno = start_blockno;
-        metadata.npages = 0;
 
         _self
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This field was once used to track the number of pages contained in one of our linked lists, but it's no longer used.

We had a few code paths that updated it (one, incorrectly!) but the field was never read.

We leave the 4 bytes it occuppied in the `LinkedListData` struct so our layout remains backwards compatabile, but we no longer use it.

## Why

In trying to track down a strange bug in enterprise related to hot standby promotion I realized this field is actually dead code.

## How

## Tests
