### PR TITLE
fix: custom fsm "MAX BLOCKS PER PAGE" calculation

### DIFF
--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -51,7 +51,7 @@ impl Default for FSMBlockHeader {
 }
 
 const UNCOMPRESSED_MAX_BLOCKS_PER_PAGE: usize =
-    (bm25_max_free_space() / size_of::<pg_sys::BlockNumber>()) - size_of::<FSMBlockHeader>();
+    (bm25_max_free_space() - size_of::<FSMBlockHeader>()) / size_of::<pg_sys::BlockNumber>();
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
## What

The static `UNCOMPRESSED_MAX_BLOCKS_PER_PAGE` value is calculated incorrectly.  It mixes units and would end up slightly smaller than it should be.

I don't believe this would have contributed to a correctness problem, only wasting a few bytes per FSM page.

## Why

## How

## Tests
