### PR TITLE
fix: Properly set a tag during a manual docker publish

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -79,6 +79,7 @@ jobs:
             fi
           else
             VERSION=${{ github.event.inputs.version }}
+            TAG=v${{ github.event.inputs.version }}
           fi
           echo "GitHub Tag Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

When a version was specified directly via a workflow run, the `TAG` was not being set, causing the publish to fail.

## Why

To allow direct publishes of images.