### PR TITLE
ci: Fix benchmark-backfill-auto (#2942)

### DIFF
--- a/.github/workflows/benchmark-backfill-auto.yml
+++ b/.github/workflows/benchmark-backfill-auto.yml
@@ -4,24 +4,30 @@ name: Automatically backfill benchmarks using existing commit hashes
 on:
   workflow_dispatch:
 
-# the token must be allowed to start other workflows
+# The token must be allowed to start other workflows
 permissions:
   actions: write
   contents: write
 
+# We don't specify a concurrency group here, as we want all jobs to complete.
+
 jobs:
   reset:
+    name: Reset the `gh-pages` data.js Files
     runs-on: ubuntu-latest
+    outputs:
+      ids: ${{ steps.extract_commits.outputs.ids }}
+
     steps:
       - name: Load and extract commit IDs from benchmark data
         id: extract_commits
         run: |
-          # fetch the existing benchmark data.  we only get the stressgres data as
+          # Fetch the existing benchmark data. We only get the stressgres data as
           # all benchmark styles should have the same commits
           curl -sSL https://paradedb.github.io/paradedb/stressgres/data.js \
             -o data.js
 
-          # run a tiny Node script to eval and extract distinct commit IDs
+          # Run a tiny Node script to eval and extract distinct commit IDs
           ids=$(node -e "
             const fs = require('fs');
             global.window = {};
@@ -35,18 +41,17 @@ jobs:
                 ids.add(item.commit.id);
               }
             }
-
             console.log(JSON.stringify([...ids]));   # <-- JSON array
           ")
 
-          # set as an output; for newer GH Actions syntaxes
           echo "ids=$ids" >> $GITHUB_OUTPUT
 
-      - name: Checkout gh-pages
+      - name: Checkout Git Repository at ref=gh-pages
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-      - name: Reset data.js files
+
+      - name: Reset data.js Files
         run: |
           git config user.name "Benchmark Backfill Job"
           git config user.email "developers@paradedb.com"
@@ -57,16 +62,17 @@ jobs:
             git push
           fi
 
+  # We run one job per commit
   dispatch:
-    # one job per commit
+    name: Dispatch All Benchmark Jobs
+    runs-on: ubuntu-latest
     needs: reset
     strategy:
       matrix:
-        sha: ${{ fromJSON(steps.extract_commits.outputs.ids) }} # → ["…","…"]
-    runs-on: ubuntu-latest
+        sha: ${{ fromJSON(needs.reset.outputs.ids) }} # → ["…","…"]
 
     steps:
-      - name: Fire benchmark & stressgres for ${{ matrix.sha }}
+      - name: Fire Benchmark &Stressgres Jobs for ${{ matrix.sha }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +81,7 @@ jobs:
             const repo  = context.repo.repo;
             const sha   = '${{ matrix.sha }}';
 
-            // Workflows you want to queue
+            // Workflows to queue
             const targets = ['benchmark-pg_search-benchmarks.yml', 'benchmark-pg_search-stressgres.yml'];
 
             for (const wf of targets) {

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -11,7 +11,7 @@ on:
           Commits to re-run, written as a JSON array.
           Example: ["6d3c1f0", "a1b2c3d", "deadbeef"]
 
-          Using one hash still requires the JSON array syntax, ie ["6d3c1f0"].
+          Using one hash still requires the JSON array syntax, i.e. ["6d3c1f0"].
         required: true
         type: string
       reset_data:
@@ -19,21 +19,25 @@ on:
         type: boolean
         default: true
 
-# the token must be allowed to start other workflows
+# The token must be allowed to start other workflows
 permissions:
   actions: write
   contents: write
 
+# We don't specify a concurrency group here, as we want all jobs to complete.
+
 jobs:
   reset:
+    name: Reset the `gh-pages` data.js Files
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout gh-pages
+      - name: Checkout Git Repository at ref=gh-pages
         if: ${{ inputs.reset_data }}
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-      - name: Reset data.js files
+
+      - name: Reset data.js Files
         if: ${{ inputs.reset_data }}
         run: |
           git config user.name "Benchmark Backfill Job"
@@ -45,16 +49,17 @@ jobs:
             git push
           fi
 
+  # We run one job per commit
   dispatch:
-    # one job per commit
+    name: Dispatch All Benchmark Jobs
+    runs-on: ubuntu-latest
     needs: reset
     strategy:
       matrix:
         sha: ${{ fromJSON(github.event.inputs.commits) }} # → ["…","…"]
-    runs-on: ubuntu-latest
 
     steps:
-      - name: Fire benchmark & stressgres for ${{ matrix.sha }}
+      - name: Fire Benchmark & Stressgres for ${{ matrix.sha }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +68,7 @@ jobs:
             const repo  = context.repo.repo;
             const sha   = '${{ matrix.sha }}';
 
-            // Workflows you want to queue
+            // Workflows to queue
             const targets = ['benchmark-pg_search-benchmarks.yml', 'benchmark-pg_search-stressgres.yml'];
 
             for (const wf of targets) {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This job was always failing with a syntax error:

- https://github.com/paradedb/paradedb/actions/runs/16760995847
- https://github.com/paradedb/paradedb/actions/runs/16761014333
- https://github.com/paradedb/paradedb/actions/runs/16760952900

I fixed it by making it properly depend on the `ids` from the `reset` step. I also did some nitpicky cleanup.

## Why
Working workflow^

## How
^

## Tests
CI!