### PR TITLE
ci: Don't tag Docker images as `latest` if there's a `-` in the tag

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -42,8 +42,8 @@ jobs:
         id: set-matrix
         run: |
           echo "Evaluating tag: $GITHUB_REF"
-          if [[ "$GITHUB_REF" == *"-rc"* ]]; then
-            echo "Release candidate tag detected; using only PostgreSQL version 17."
+          if [[ "$GITHUB_REF" == *"-"* ]]; then
+            echo "GitHub ref contains a dash. Release candidate tag detected; using only PostgreSQL version 17."
             echo "matrix=[17]" >> $GITHUB_OUTPUT
           else
             echo "Regular promotion tag detected; using provided PostgreSQL version(s)."
@@ -109,8 +109,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ !contains(github.ref, '-rc')}}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && !contains(github.ref, '-rc') }}
+            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ !contains(github.ref, '-')}}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && !contains(github.ref, '-') }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We tried to make pre-releases recently that were not correctly marked as pre-releases. In semVer, anything with a `-` is a pre-release, so mark it as such.

## Why
Don't push official releases when we do mean to!

## How
Instead of filtering out official releases via `-rc`, we do it via `-` only.

## Tests
CI