### PR TITLE
fix: bugs with 0.17.x exposed by the custom FSM

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -66,6 +66,12 @@ pub unsafe fn save_new_metas(
         .map(|s| s.id())
         .collect::<HashSet<_>>();
 
+    pgrx::debug1!(
+        "entered save_new_metas with {} new ids and {} previous ids",
+        new_ids.len(),
+        previous_ids.len()
+    );
+
     // first, reorganize the directory_entries by segment id
     let mut new_files =
         HashMap::<SegmentId, HashMap<SegmentComponent, (FileEntry, PathBuf)>>::default();
@@ -278,10 +284,12 @@ pub unsafe fn save_new_metas(
             // ... and add it to somewhere in the list, starting on this page
             linked_list.add_items(&[entry], Some(buffer));
         }
+        pgrx::debug1!("MODIFY: {entry:?}");
     }
 
     // add the new entries -- happens via an index commit or the result of a merge
     if !created_entries.is_empty() {
+        pgrx::debug1!("CREATE: {created_entries:?}");
         linked_list.add_items(&created_entries, None);
     }
 
@@ -329,111 +337,95 @@ pub unsafe fn load_metas(
     // Collect segments from each relevant list.
     let metapage = MetaPage::open(indexrel);
     let mut segment_metas = metapage.segment_metas();
-    let mut exhausted_metas_lists = false;
 
     let is_largest_only = &MvccSatisfies::LargestSegment == solve_mvcc;
     let mut largest_doc_count = 0;
-    loop {
-        // Find all relevant segments in this list.
-        segment_metas.for_each(|bman, entry| {
-            // nobody sees recyclable segments
-            let accept = !entry.recyclable(bman) && (
-                // parallel workers only see a specific set of segments.  This relies on the leader having kept a pin on them
-                matches!(solve_mvcc, MvccSatisfies::ParallelWorker(only_these) if only_these.contains(&entry.segment_id))
+    // Find all relevant segments in this list.
+    segment_metas.for_each(|bman, entry| {
+        // nobody sees recyclable segments
+        let accept = !entry.recyclable(bman) && (
+            // parallel workers only see a specific set of segments.  This relies on the leader having kept a pin on them
+            matches!(solve_mvcc, MvccSatisfies::ParallelWorker(only_these) if only_these.contains(&entry.segment_id))
 
-                    // vacuum sees everything that hasn't been deleted by a merge
-                    || (matches!(solve_mvcc, MvccSatisfies::Vacuum) && entry.xmax == pg_sys::InvalidTransactionId)
+                // vacuum sees everything that hasn't been deleted by a merge
+                || (matches!(solve_mvcc, MvccSatisfies::Vacuum) && entry.xmax == pg_sys::InvalidTransactionId)
 
-                    // a snapshot or ::LargestSegment can see any that are visible in its snapshot
-                    || (matches!(solve_mvcc, MvccSatisfies::Snapshot | MvccSatisfies::LargestSegment) && entry.visible())
+                // a snapshot or ::LargestSegment can see any that are visible in its snapshot
+                || (matches!(solve_mvcc, MvccSatisfies::Snapshot | MvccSatisfies::LargestSegment) && entry.visible())
 
-                    // mergeable can see any that are known to be mergeable
-                    || (matches!(solve_mvcc, MvccSatisfies::Mergeable) && entry.mergeable())
-            );
-            if !accept {
-                return;
+                // mergeable can see any that are known to be mergeable
+                || (matches!(solve_mvcc, MvccSatisfies::Mergeable) && entry.mergeable())
+        );
+        if !accept {
+            return;
+        };
+
+        total_segments += 1;
+
+        let mut need_entry = true;
+        if is_largest_only {
+            if entry.num_docs() > largest_doc_count {
+                largest_doc_count = entry.num_docs();
+
+                // the entry we're processing right now is known to be the largest so far
+                // and it's the only one we want
+                alive_segments.clear();
+                alive_entries.clear();
+                pin_cushion.clear();
+            } else {
+                // we already have the largest so we don't need this entry
+                need_entry = false;
+            }
+        }
+
+        if need_entry {
+            pin_cushion.push(bman, &entry);
+            let inner_segment_meta = InnerSegmentMeta {
+                max_doc: entry.max_doc,
+                segment_id: entry.segment_id,
+                deletes: entry.delete.map(|delete_entry| DeleteMeta {
+                    num_deleted_docs: delete_entry.num_deleted_docs,
+                    opstamp: 0, // hardcode zero as the entry's opstamp as it's not used
+                }),
+                include_temp_doc_store: Arc::new(AtomicBool::new(false)),
             };
 
-            total_segments += 1;
+            alive_segments.push(inner_segment_meta.track(inventory));
+            alive_entries.push(entry);
 
-            let mut need_entry = true;
-            if is_largest_only {
-                if entry.num_docs() > largest_doc_count {
-                    largest_doc_count = entry.num_docs();
+            opstamp = opstamp.max(Some(entry.opstamp()));
+        }
+    });
 
-                    // the entry we're processing right now is known to be the largest so far
-                    // and it's the only one we want
-                    alive_segments.clear();
-                    alive_entries.clear();
-                    pin_cushion.clear();
-                } else {
-                    // we already have the largest so we don't need this entry
-                    need_entry = false;
-                }
-            }
+    match solve_mvcc {
+        MvccSatisfies::ParallelWorker(only_these) if alive_entries.len() != only_these.len() => {
+            let missing = only_these
+                .difference(&alive_entries.iter().map(|s| s.segment_id).collect())
+                .cloned()
+                .collect::<HashSet<SegmentId>>();
+            let found = only_these.difference(&missing).collect::<HashSet<_>>();
 
-            if need_entry {
-                pin_cushion.push(bman, &entry);
-                let inner_segment_meta = InnerSegmentMeta {
-                    max_doc: entry.max_doc,
-                    segment_id: entry.segment_id,
-                    deletes: entry.delete.map(|delete_entry| DeleteMeta {
-                        num_deleted_docs: delete_entry.num_deleted_docs,
-                        opstamp: 0, // hardcode zero as the entry's opstamp as it's not used
-                    }),
-                    include_temp_doc_store: Arc::new(AtomicBool::new(false)),
-                };
-
-                alive_segments.push(inner_segment_meta.track(inventory));
-                alive_entries.push(entry);
-
-                opstamp = opstamp.max(Some(entry.opstamp()));
-            }
-        });
-
-        match solve_mvcc {
-            MvccSatisfies::ParallelWorker(only_these)
-                if alive_entries.len() != only_these.len() =>
-            {
-                // If we haven't tried the `segment_metas_garbage` list, try that next.
-                if !exhausted_metas_lists {
-                    if let Some(garbage) = MetaPage::open(indexrel).segment_metas_garbage() {
-                        segment_metas = garbage;
-                        exhausted_metas_lists = true;
-                        continue;
-                    }
-                }
-
-                let missing = only_these
-                    .difference(&alive_entries.iter().map(|s| s.segment_id).collect())
-                    .cloned()
-                    .collect::<HashSet<SegmentId>>();
-                let found = only_these.difference(&missing).collect::<HashSet<_>>();
-
-                panic!(
-                    "load_metas: MvccSatisfies::ParallelWorker didn't load the correct segments. \
+            panic!(
+                "load_metas: MvccSatisfies::ParallelWorker didn't load the correct segments. \
                     found={found:?}, missing={missing:?}",
-                );
-            }
-            #[cfg(debug_assertions)]
-            MvccSatisfies::ParallelWorker(only_these) => {
-                // In debug mode only, actually do a set comparison to determine that we got the
-                // exact expected segments.
-                let actual = alive_entries
-                    .iter()
-                    .map(|s| s.segment_id)
-                    .collect::<HashSet<_>>();
-                assert_eq!(
-                    &actual, only_these,
-                    "Got the wrong segments in parallel worker: \
+            );
+        }
+        #[cfg(debug_assertions)]
+        MvccSatisfies::ParallelWorker(only_these) => {
+            // In debug mode only, actually do a set comparison to determine that we got the
+            // exact expected segments.
+            let actual = alive_entries
+                .iter()
+                .map(|s| s.segment_id)
+                .collect::<HashSet<_>>();
+            assert_eq!(
+                &actual, only_these,
+                "Got the wrong segments in parallel worker: \
                      actual: {actual:?}, expected: {only_these:?}"
-                );
-                break;
-            }
-            _ => {
-                // We've successfully collected all of the relevant entries.
-                break;
-            }
+            );
+        }
+        _ => {
+            // We've successfully collected all of the relevant entries.
         }
     }
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -201,7 +201,6 @@ impl SegmentMetaEntry {
     /// This function returns true if the `SegmentMetaEntry` is a "fake" `DeleteEntry`
     pub fn is_orphaned_delete(&self) -> bool {
         self.segment_id == SegmentId::from_bytes([0; 16])
-            && self.xmax == pg_sys::FrozenTransactionId
     }
 
     /// Fake an `Opstamp` that's always zero

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -255,6 +255,8 @@ impl BufferMut {
     /// it available for future reuse as a new buffer.
     pub fn return_to_fsm(self, bman: &mut BufferManager) {
         let blockno = self.number();
+        drop(self);
+
         bman.fsm().extend(bman, std::iter::once(blockno));
     }
 }
@@ -458,10 +460,6 @@ impl PageMut<'_> {
         header
     }
 
-    pub fn special<T>(&self) -> &T {
-        unsafe { &*(pg_sys::PageGetSpecialPointer(self.pg_page) as *const T) }
-    }
-
     pub fn special_mut<T>(&mut self) -> &mut T {
         let special = unsafe { &mut *(pg_sys::PageGetSpecialPointer(self.pg_page) as *mut T) };
         self.buffer.dirty = true;
@@ -518,10 +516,6 @@ impl PageMut<'_> {
         self.header_mut().pd_lower += len;
         self.buffer.dirty = true;
         true
-    }
-
-    pub fn contents<T: Copy>(&self) -> T {
-        unsafe { (pg_sys::PageGetContents(self.pg_page) as *const T).read_unaligned() }
     }
 
     pub fn contents_mut<T>(&mut self) -> &mut T {
@@ -604,29 +598,56 @@ impl BufferManager {
     /// Like [`new_buffer`], but returns an iterator of buffers instead.
     /// This is better than calling [`new_buffer`] multiple times because it avoids potentially
     /// locking the relation for every new buffer.
-    pub fn new_buffers(&mut self, npages: usize) -> impl Iterator<Item = BufferMut> {
-        let fsm_blocknos = self.fsm().pop_many(self, npages);
-        let needed = npages - fsm_blocknos.len();
-        let new_buffers = self.rbufacc.new_buffers(needed);
+    pub fn new_buffers(&mut self, npages: usize) -> Box<dyn Iterator<Item = BufferMut>> {
+        if npages == 0 {
+            return Box::new(std::iter::empty());
+        } else if npages == 1 {
+            return Box::new(std::iter::once(self.new_buffer()));
+        }
 
-        let rbufacc = self.rbufacc.clone();
-        fsm_blocknos
-            .into_iter()
-            .map(move |blockno| {
-                let pg_buffer = rbufacc.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-                block_tracker::track!(Write, pg_buffer);
-                BufferMut {
-                    dirty: false,
-                    inner: Buffer { pg_buffer },
-                }
-            })
-            .chain(new_buffers.map(|pg_buffer| {
-                block_tracker::track!(Write, pg_buffer);
-                BufferMut {
-                    dirty: false,
-                    inner: Buffer { pg_buffer },
-                }
-            }))
+        let buffer_access = self.buffer_access().clone();
+
+        let mut fsm_blocknos = self.fsm().drain(self, npages).map(move |blockno| {
+            let pg_buffer = buffer_access.get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
+            block_tracker::track!(Write, pg_buffer);
+            BufferMut {
+                dirty: false,
+                inner: Buffer { pg_buffer },
+            }
+        });
+
+        let bman = self.clone();
+        let mut remaining_from_fsm = npages;
+        let mut new_buffers = None;
+        let buffers = std::iter::from_fn(move || {
+            if remaining_from_fsm == 0 {
+                // got all we wanted from the fsm
+                return None;
+            }
+
+            if let Some(from_fsm) = fsm_blocknos.next() {
+                remaining_from_fsm -= 1;
+                return Some(from_fsm);
+            }
+
+            if new_buffers.is_none() {
+                // the fsm didn't give us all the buffers we asked for, so we need to get the rest
+                // by extending the relation with brand new buffers
+                new_buffers = Some(bman.buffer_access().new_buffers(remaining_from_fsm).map(
+                    move |pg_buffer| {
+                        block_tracker::track!(Write, pg_buffer);
+                        BufferMut {
+                            dirty: false,
+                            inner: Buffer { pg_buffer },
+                        }
+                    },
+                ));
+            }
+
+            new_buffers.as_mut().unwrap().next()
+        });
+
+        Box::new(buffers)
     }
 
     pub fn pinned_buffer(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -17,79 +17,127 @@
 
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{bm25_max_free_space, BM25PageSpecialData};
-use crate::postgres::storage::buffer::{init_new_buffer, BufferManager};
+use crate::postgres::storage::buffer::{init_new_buffer, BufferManager, BufferMut};
 use crate::postgres::storage::metadata::MetaPage;
 use pgrx::iter::TableIterator;
 use pgrx::{name, pg_extern, pg_sys, AnyNumeric, PgRelation};
 
-// NB:  As of the initial implementation, we only have "Uncompressed" but I (@eeeebbbbrrrr) could
-//      imagine bit-packed blocks, variable-width blocks, etc
 /// Denotes what the data on an FSM block looks like
-#[derive(Debug, Copy, Clone)]
+#[allow(non_camel_case_types)]
+#[derive(Default, Debug, Copy, Clone)]
 #[repr(u32)]
 enum FSMBlockKind {
-    Uncompressed = 0,
+    /// This variant represents the original FSM format in pg_search versions 0.17.0 through 0.17.3
+    /// It is not meant to be used for making new pages, only for detecting old pages so they can
+    /// be converted
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    v0 = 0,
+
+    /// This represents the current FSM format and is the default for new FSM pages
+    #[default]
+    v1_uncompressed = 1,
 }
 
-#[derive(Debug, Copy, Clone)]
+/// A short header for the FSM block, stored at the beginning of each page, which allows us to quickly
+/// identify what kind of block we're about to work with
+#[derive(Default, Debug, Copy, Clone)]
 #[repr(C)]
 struct FSMBlockHeader {
     /// Denotes how the block data is stored on this page
     kind: FSMBlockKind,
-
-    /// Specifies the number of *free* blocks managed by this page
-    len: u32,
 }
 
-impl Default for FSMBlockHeader {
-    fn default() -> Self {
-        Self {
-            kind: FSMBlockKind::Uncompressed,
-            len: 0,
-        }
-    }
-}
-
-const UNCOMPRESSED_MAX_BLOCKS_PER_PAGE: usize =
-    (bm25_max_free_space() / size_of::<pg_sys::BlockNumber>()) - size_of::<FSMBlockHeader>();
-
+/// The header information for the current FSM block format.  Its first field is purposely the [`FSMBlockHeader`]
+/// so that the block header can be read as that type.  `#[repr(C)]` ensures this is correct
+#[derive(Default, Debug, Copy, Clone)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-struct FSMBlock {
+struct V1Header {
     header: FSMBlockHeader,
 
-    // with different [`FSMBlockKind`]s this might need to become a `[u8; bm25_max_free_space() - size_of::<FSMBlockInner>()]`
-    // and treated differently by each kind
-    blocks: [pg_sys::BlockNumber; UNCOMPRESSED_MAX_BLOCKS_PER_PAGE],
+    /// Denotes if this block is completely empty, meaning all its entries reference the
+    /// [`pg_sys::InvalidBlockNumber`].
+    ///
+    /// Empty blocks can be skipped without needing to read the entire entry data.  This is just a
+    /// hint towards `true`.  If it's `false` but all the entries are invalid, that's okay --
+    /// we only wasted some CPU cycles scanning the empty block.
+    empty: bool,
+}
+
+/// An individual entry on a [`FSMBlock`].  Represented as a pair of [`pg_sys::BlockNumber`] and
+/// [`pg_sys::TransactionId`].  The transaction id is the [`pg_sys::GetCurrentTransactionId()`] (or perhaps caller-provided)
+/// of the transaction that added the entry to the FSM.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct FSMEntry(pg_sys::BlockNumber, pg_sys::TransactionId);
+
+const MAX_ENTRIES_PER_PAGE: usize =
+    (bm25_max_free_space() - size_of::<V1Header>()) / size_of::<FSMEntry>();
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+struct FSMBlock {
+    header: V1Header,
+    entries: [FSMEntry; MAX_ENTRIES_PER_PAGE],
 }
 
 impl Default for FSMBlock {
     fn default() -> Self {
         Self {
             header: Default::default(),
-            blocks: [pg_sys::InvalidBlockNumber; UNCOMPRESSED_MAX_BLOCKS_PER_PAGE],
+            entries: [FSMEntry(pg_sys::InvalidBlockNumber, pg_sys::InvalidTransactionId);
+                MAX_ENTRIES_PER_PAGE],
         }
     }
 }
 
-/// The [`FreeSpaceManager`] our version of Postgres' "free space map".  We need to track free space
-/// as whole blocks and we'd prefer to not have to mark pages we return to a FSM as deleted.  Our
-/// own implementation allows us to do that.
+impl FSMBlock {
+    #[inline]
+    fn all_invalid(&self) -> bool {
+        self.entries
+            .iter()
+            .all(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
+    }
+}
+
+/// The [`FreeSpaceManager`] is our version of Postgres' "free space map".  We need to track free space
+/// as whole blocks and we'd prefer to not have to mark pages as deleted when giving them to the FSM.
 ///
-/// The design of this structure is simply a linked list of blocks where each block, a [`FSMBlock`],
-/// is (currently) a fixed-sized array of [`pg_sys::BlockNumber`]s.  Each block contains a small
-/// [`FSMBlockHeader`] that stores the list of free blocks it contains along with bookkeeping data
-/// and a [`FSMBlockKind`] flag indicating how the blocks are stored on that page.
+/// We also have a requirement that blocks be recycled in the future, after the transaction which
+/// marked them free is known to no longer be overlapping with other concurrent transactions, including
+/// those from hot-standby servers.  Reusing a block before all nodes in the cluster and/or all
+/// concurrent backends are aware that it's been deleted can cause race conditions and data corruption.
 ///
-/// Outside of per-page exclusive locking when mutating a page, no special locking requirements exist
-/// to manage concurrency.  The intent is that the [`FreeSpaceManager`]'s linked block list can grow
+/// The on-disk structure is simply a linked list of blocks where each block, a [`FSMBlock`],
+/// is a fixed-sized array of ([`pg_sys::BlockNumber`], [`pg_sys::TransactionId`]) pairs.
+///
+/// Each block starts with a small [`FSMBlockHeader`] indicating the type of block (we've had a few
+/// styles so far).  This is denoted by the [`FSMBlockHeader::kind`] flag.
+///
+/// Outside per-page exclusive locking when mutating a page, no special locking requirements exist
+/// to manage concurrency.  The intent is that the [`FreeSpaceManager`]'s linked list can grow
 /// unbounded, with the hope that it actually won't grow to be very large in practice.
 ///
 /// Any other kind of structure will likely need a more sophisticated approach to concurrency control.
 ///
 /// The user-facing API is meant to _kinda_ mimic a `Vec` in that the [`FreeSpaceManager`] can be
-/// popped and extended.  From where in the FSM popped blocks come, or where in the FSM new blocks
-/// are added, is an implementation detail.
+/// popped, drained, and extended.
+///
+/// There is a [`FSMBlockKind::v0`] variant which is used to represent the original FSM format, used
+/// prior to pg_search 0.17.4.  This variant is not meant to be used for making new pages, and if
+/// found on disk, we will immediately convert it to the new format, with the caveat that any data
+/// the `v0` block contains will be lost.  This will effectively orphan blocks that it referenced.
+///
+/// # V1
+///
+/// A `v1` block's content layout disk layout is:
+///
+/// ```text
+/// [kind (4 bytes)] [empty (1 byte)] [ [blockno (4 bytes)] [xid (4 bytes)] ][ ... ] (up to MAX_ENTRIES_PER_PAGE)
+/// ```
+///
+/// And blocks are linked together with the `next_blockno` field in the [`BM25PageSpecialData`].
+///
 #[derive(Debug)]
 pub struct FreeSpaceManager {
     start_blockno: pg_sys::BlockNumber,
@@ -109,129 +157,92 @@ impl FreeSpaceManager {
         Self { start_blockno }
     }
 
-    /// Retrieve a single free [`pg_sys::BlockNumber`], which can be acquired and re-initialized.
+    /// Retrieve a single recyclable [`pg_sys::BlockNumber`], which can be acquired and re-initialized.
     ///
-    /// If no free blocks are available, this returns `None`.
+    /// Returns `None` if no recyclable blocks are available.
     ///
     /// Upon return, the block is removed from the [`FreeSpaceManager`]'s control.  It is the caller's
-    /// responsibility to ensure the block is soon properly used or else it will be lost forever as
+    /// responsibility to ensure the block is properly used, or else it will be lost forever as
     /// dead space in the underlying relation.
-    ///
-    /// # Implementation Note
-    ///
-    /// The FSM is traversed from head to tail.  The requested block is "popped" from the first page
-    /// that has a free block.  This is done by decrementing its header `len` property by one.
-    pub fn pop(&self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
-        let mut blockno = self.start_blockno;
-
-        loop {
-            if blockno == pg_sys::InvalidBlockNumber {
-                // the FSM is empty
-                return None;
-            }
-            let mut buffer = bman.get_buffer_mut(blockno);
-            let mut page = buffer.page_mut();
-            let block = page.contents::<FSMBlock>();
-            if block.header.len == 0 {
-                // go to the next block
-                blockno = page.special::<BM25PageSpecialData>().next_blockno;
-                continue;
-            }
-
-            // found a block to return
-            let block = page.contents_mut::<FSMBlock>();
-            block.header.len -= 1;
-            return Some(block.blocks[block.header.len as usize]);
-        }
+    pub fn pop(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
+        self.drain(bman, 1).next()
     }
 
-    /// The returned Vec will contain as many free blocks as possible, up to `npages`.
+    /// Drain `n` recyclable blocks from this [`FreeSpaceManager`] instance, using the specified
+    /// [`BufferManager`] for underlying disk access.
     ///
-    /// Upon return, these blocks are now removed from the [`FreeSpaceManager`]'s control.  If the caller
-    /// loses these blocks then they're lost forever as dead space in the underlying relation.
+    /// As [`pg_sys::BlockNumber`]s are yielded from the returned iterator, they are removed from the
+    /// FSM.  The returned iterator will never return more than `n`, but it could return fewer.
     ///
-    /// # Implementation Note
-    ///
-    /// The FSM is traversed from head to tail.  During traversal, if the current page has at least
-    /// `npages` free blocks, they're consumed (and queued for return) by decrementing the page's
-    /// `len` property by the number of blocks consumed from that page.
-    pub fn pop_many(&self, bman: &mut BufferManager, npages: usize) -> Vec<pg_sys::BlockNumber> {
-        if npages == 0 {
-            return Vec::new();
-        }
-        let mut result = Vec::with_capacity(npages);
-        let mut remaining = npages;
-        let mut blockno = self.start_blockno;
-
-        while remaining > 0 && blockno != pg_sys::InvalidBlockNumber {
-            let mut buffer = bman.get_buffer_mut(blockno);
-            let mut page = buffer.page_mut();
-            let block = page.contents::<FSMBlock>();
-
-            if block.header.len > 0 {
-                let chunk_size = remaining.min(block.header.len as usize);
-                let new_len = block.header.len - chunk_size as u32;
-
-                result
-                    .extend_from_slice(&block.blocks[new_len as usize..block.header.len as usize]);
-                page.contents_mut::<FSMBlock>().header.len = new_len;
-                remaining -= chunk_size;
-            }
-
-            // this block is now empty
-            // go to the next page
-            blockno = page.special::<BM25PageSpecialData>().next_blockno
-        }
-
-        // TODO:  it might make sense to sort this
-        // result.sort_unstable();
-
-        result
+    /// It is the caller's responsibility to ensure each yielded block is properly used, or else it will
+    /// be lost forever as dead space in the underlying relation.  Unyielded blocks are unaffected.
+    pub fn drain(
+        &mut self,
+        bman: &mut BufferManager,
+        n: usize,
+    ) -> impl Iterator<Item = pg_sys::BlockNumber> {
+        FSMDrainIter::new(self, bman)
+            .take(n)
+            .map(|FSMEntry(blockno, _)| blockno)
     }
 
     /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`FreeSpaceManager`].
     ///
-    /// # Implementation Note
-    ///
-    /// The FSM is traversed head to tail and empty space on each page is filled with the results
-    /// of the provided `extend_with` iterator.  If the whole FSM is full then a new block is allocated
-    /// and linked to the end as the new tail.
+    /// The added blocks will be recyclable in the future based on the current [`pg_sys::GetCurrentTransactionId`].
     pub fn extend(
         &self,
         bman: &mut BufferManager,
+        extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
+    ) {
+        self.extend_with_when_recyclable(
+            bman,
+            unsafe { pg_sys::GetCurrentTransactionId() },
+            extend_with,
+        );
+    }
+
+    /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`FreeSpaceManager`].
+    ///
+    /// The added blocks will be recyclable in the future based on the provided `when_recyclable` transaction id.
+    pub fn extend_with_when_recyclable(
+        &self,
+        bman: &mut BufferManager,
+        when_recyclable: pg_sys::TransactionId,
         extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
     ) {
         let mut extend_with = extend_with.peekable();
         let mut blockno = self.start_blockno;
         loop {
             let mut buffer = bman.get_buffer_mut(blockno);
-            let mut page = buffer.page_mut();
+            let header = buffer.page().contents::<FSMBlockHeader>();
 
-            let mut len = page.contents::<FSMBlock>().header.len as usize;
-            while len < UNCOMPRESSED_MAX_BLOCKS_PER_PAGE {
-                match extend_with.peek() {
-                    // we've added every block from the iterator
-                    None => {
-                        return;
-                    }
-
-                    // add the next block
-                    Some(blockno) => {
-                        let block = page.contents_mut::<FSMBlock>();
-                        block.blocks[block.header.len as usize] = *blockno;
-                        block.header.len += 1;
-                        len = block.header.len as usize;
-                        extend_with.next(); // burn it
-                    }
-                }
+            if matches!(header.kind, FSMBlockKind::v0) {
+                // convert the block to the new format and we'll just overwrite it
+                *buffer.page_mut().contents_mut::<FSMBlock>() = FSMBlock::default();
             }
 
-            // TODO:  it might make sense to sort `block.blocks` in reverse order
-            //        so that when blocks are popped off they're returned smallest-to-largest
+            let blocks = buffer.page().contents::<FSMBlock>();
+            blocks
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, FSMEntry(blockno, _))| *blockno == pg_sys::InvalidBlockNumber)
+                .zip(&mut extend_with)
+                .for_each(|((i, _), blockno)| {
+                    let mut page = buffer.page_mut();
+                    let contents = page.contents_mut::<FSMBlock>();
+                    contents.header.empty = false;
+                    contents.entries[i].0 = blockno;
+                    contents.entries[i].1 = when_recyclable;
+                });
+            if extend_with.peek().is_none() {
+                // no more blocks to add to the FSM
+                return;
+            }
 
             // we still have blocks to apply
             // move to the next block and apply them there
-            blockno = page.special::<BM25PageSpecialData>().next_blockno;
+            blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
 
             // however, if there is no next block we need to make one and link it in
             if blockno == pg_sys::InvalidBlockNumber {
@@ -243,9 +254,141 @@ impl FreeSpaceManager {
 
                 // move to this new block
                 let new_blockno = new_buffer.number();
-                page.special_mut::<BM25PageSpecialData>().next_blockno = new_blockno;
+                buffer
+                    .page_mut()
+                    .special_mut::<BM25PageSpecialData>()
+                    .next_blockno = new_blockno;
                 blockno = new_blockno;
             }
+        }
+    }
+}
+
+/// The "visibility horizon" is the oldest transaction id, across the Postgres cluster, that can see
+/// blocks in the FSM.
+///
+/// We use the current transaction id.
+///
+/// When being drained, the FSM compares each block's stored xid with this value, ensuring the stored
+/// value precedes or equals this one, before it is considered recyclable.
+#[inline(always)]
+fn visibility_horizon() -> pg_sys::TransactionId {
+    unsafe { pg_sys::GetCurrentTransactionId() }
+}
+
+/// Draining iterator over FSM entries. As entries are yielded, they are
+/// removed from the FSM (on-disk) and the page's `empty` flag is updated
+/// if it becomes fully invalid.
+struct FSMDrainIter {
+    bman: BufferManager,
+    current_blockno: pg_sys::BlockNumber,
+    // hold the current page buffer locked until we finish scanning it
+    current_buffer: Option<(BufferMut, Option<FSMBlock>)>,
+    entry_idx: usize,
+    xid_horizon: pg_sys::TransactionId,
+}
+
+impl FSMDrainIter {
+    #[inline]
+    fn new(fsm: &FreeSpaceManager, bman: &BufferManager) -> Self {
+        let xid_horizon = visibility_horizon();
+        Self {
+            bman: bman.clone(),
+            current_blockno: fsm.start_blockno,
+            current_buffer: None,
+            entry_idx: 0,
+            xid_horizon,
+        }
+    }
+
+    #[inline]
+    fn next_block(&mut self) {
+        debug_assert!(self.current_buffer.is_some());
+
+        let (buffer, _) = self.current_buffer.take().unwrap();
+        let next_blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
+        self.current_buffer = None;
+        self.current_blockno = next_blockno;
+        self.entry_idx = 0;
+    }
+}
+
+impl Iterator for FSMDrainIter {
+    type Item = FSMEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.current_buffer.is_none() {
+                if self.current_blockno == pg_sys::InvalidBlockNumber {
+                    return None;
+                }
+                let buffer = self.bman.get_buffer_mut(self.current_blockno);
+                self.current_buffer = Some((buffer, None));
+            }
+
+            // SAFETY:  the above ensures that self.current_buffer is Some(T)
+            let (buffer, block) = unsafe { self.current_buffer.as_mut().unwrap_unchecked() };
+
+            // if we haven't read the block contents for this page yet, we need to inspect the header...
+            if block.is_none() {
+                // ... legacy v0 pages are converted to the new format
+                let header = buffer.page().contents::<FSMBlockHeader>();
+                if matches!(header.kind, FSMBlockKind::v0) {
+                    // convert old v0 pages into the new format.  this overwrites the old page, purposely
+                    // losing any data in the v0 block -- unclear how it could be correctly preserved/migrated
+                    *buffer.page_mut().contents_mut::<FSMBlock>() = FSMBlock::default();
+
+                    // and we know it's empty so we can skip it
+                    self.next_block();
+                    continue;
+                }
+
+                // ... and we can skip pages we know are empty
+                let v1_header = buffer.page().contents::<V1Header>();
+                if v1_header.empty {
+                    self.next_block();
+                    continue;
+                }
+            }
+
+            // make a (or get the current) copy of the block contents so we can elide going to disk
+            // unless we find a recyclable block to use.
+            //
+            // We still keep the backing `buffer` locked with a BufferMut
+            let block = block.get_or_insert_with(|| buffer.page().contents::<FSMBlock>());
+
+            // find the next valid entry in the page.  a valid entry is one that doesn't reference
+            // the invalid block number and also has a transaction id that precedes or equals the visibility horizon
+            while self.entry_idx < MAX_ENTRIES_PER_PAGE {
+                let i = self.entry_idx;
+                let FSMEntry(ref mut blockno, xid) = block.entries[i];
+
+                // whether this entry is valid or not we're still going to eventually move to the next entry
+                self.entry_idx += 1;
+
+                if *blockno != pg_sys::InvalidBlockNumber
+                    && crate::postgres::utils::TransactionIdPrecedesOrEquals(xid, self.xid_horizon)
+                {
+                    let returned = FSMEntry(*blockno, xid);
+
+                    // mark it as used on-disk
+                    buffer.page_mut().contents_mut::<FSMBlock>().entries[i].0 =
+                        pg_sys::InvalidBlockNumber;
+
+                    // and in our local view
+                    *blockno = pg_sys::InvalidBlockNumber;
+
+                    return Some(returned);
+                }
+            }
+
+            if block.all_invalid() {
+                // if we have drained the page fully, set the empty hint now.
+                buffer.page_mut().contents_mut::<V1Header>().empty = true;
+            }
+
+            // done with this page -- move to the next one
+            self.next_block();
         }
     }
 }
@@ -265,7 +408,7 @@ unsafe fn fsm_info(
     let meta = MetaPage::open(&index);
     let fsm_start = meta.fsm();
     let bman = BufferManager::new(&index);
-    let mut mapping = Vec::<(pg_sys::BlockNumber, Vec<pg_sys::BlockNumber>)>::default();
+    let mut mapping = Vec::<(pg_sys::BlockNumber, Vec<FSMEntry>)>::default();
 
     let mut blockno = fsm_start;
 
@@ -273,14 +416,17 @@ unsafe fn fsm_info(
         let buffer = bman.get_buffer(blockno);
         let page = buffer.page();
         let block = page.contents::<FSMBlock>();
-        let free_blocks = block.blocks[..block.header.len as usize].to_vec();
-        mapping.push((blockno, free_blocks));
+        if !block.header.empty {
+            let free_blocks = block.entries.to_vec();
+            mapping.push((blockno, free_blocks));
+        }
         blockno = page.special::<BM25PageSpecialData>().next_blockno;
     }
 
     TableIterator::new(mapping.into_iter().flat_map(|(fsm_blockno, blocks)| {
         blocks
             .into_iter()
-            .map(move |blockno| (fsm_blockno.into(), blockno.into()))
+            .filter(|FSMEntry(blockno, _)| *blockno != pg_sys::InvalidBlockNumber)
+            .map(move |blockno| (fsm_blockno.into(), blockno.0.into()))
     }))
 }

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -489,29 +489,29 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> AtomicGuard<'_,
 
         // Update our header page to point to the new start block, and return the old one.
         let mut blockno = {
-            // Open both header pages.
-            let mut original_header_page = original_header_lock.page_mut();
-            let mut cloned_header_buffer =
-                self.cloned.bman.get_buffer_mut(self.cloned.header_blockno);
-            let mut cloned_header_page = cloned_header_buffer.page_mut();
+            // The metadata from the cloned header is the one we want to become the new header for everyone
+            let cloned_header_metadata = self
+                .cloned
+                .bman
+                .get_buffer(self.cloned.header_blockno)
+                .page()
+                .contents::<LinkedListData>();
 
             // Capture our old start page, then overwrite our metadata.
+            let mut original_header_page = original_header_lock.page_mut();
             let original_metadata = original_header_page.contents_mut::<LinkedListData>();
-            let old_start_blockno = original_metadata.start_blockno;
-            *original_metadata = *cloned_header_page.contents_mut::<LinkedListData>();
+            let original_start_blockno = original_metadata.start_blockno;
 
-            // Finally, garbage collect the cloned header block.
-            cloned_header_buffer.return_to_fsm(&mut self.cloned.bman);
+            // Here we replace the original header with the cloned header and drop the original header lock
+            // ensuring it is written to disk, which includes the WAL.
+            *original_metadata = cloned_header_metadata;
+            std::mem::drop(original_header_lock);
 
-            old_start_blockno
+            original_start_blockno
         };
 
-        // Drop the header, to ensure that the new header content is written to the WAL before
-        // we begin cleaning up its old pages.
-        std::mem::drop(original_header_lock);
-
         // And then collect our old contents, which are no longer reachable.
-        let recyclable_block = std::iter::from_fn(move || {
+        let recyclable_blocks = std::iter::from_fn(move || {
             if blockno == pg_sys::InvalidBlockNumber {
                 return None;
             }
@@ -519,8 +519,9 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> AtomicGuard<'_,
             let buffer = original.bman.get_buffer(blockno);
             blockno = buffer.page().next_blockno();
             Some(recyclable_blockno)
-        });
-        self.bman.fsm().extend(&mut self.bman, recyclable_block);
+        })
+        .chain(std::iter::once(self.cloned.header_blockno));
+        self.bman.fsm().extend(&mut self.bman, recyclable_blocks);
     }
 }
 
@@ -532,35 +533,13 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> Drop for Atomic
         };
 
         unsafe {
-            if !pg_sys::IsTransactionState() {
+            if !pg_sys::IsTransactionState() || std::thread::panicking() {
                 // we are not in a transaction, so we can't release buffers
                 return;
             }
         }
 
-        // The guard was dropped without a call to commit: return its pages.
-        let header_blockno = self.cloned.header_blockno;
-        let bman = self.cloned.bman().clone();
-        let header_buffer = bman.get_buffer(header_blockno);
-        let mut blockno = header_buffer
-            .page()
-            .contents::<LinkedListData>()
-            .start_blockno;
-        drop(header_buffer);
-
-        let recyclable_blocks =
-            std::iter::once(header_blockno).chain(std::iter::from_fn(move || {
-                if blockno == pg_sys::InvalidBlockNumber {
-                    return None;
-                }
-
-                let recyable_blockno = blockno;
-                let buffer = bman.get_buffer(blockno);
-                blockno = buffer.page().next_blockno();
-                Some(recyable_blockno)
-            }));
-        let fsm = self.bman.fsm();
-        fsm.extend(&mut self.bman, recyclable_blocks);
+        panic!("internal error: failed to call `AtomicGuard::commit()`");
     }
 }
 
@@ -659,7 +638,9 @@ mod tests {
                 if entry.xmax == not_deleted_xid {
                     assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_ok());
                 } else {
-                    assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_err());
+                    assert!(list
+                        .lookup_ex(|el| el.segment_id == entry.segment_id)
+                        .is_err());
                 }
             }
         }
@@ -703,9 +684,13 @@ mod tests {
             for entries in [entries_1, entries_2, entries_3] {
                 for entry in entries {
                     if entry.xmax == not_deleted_xid {
-                        assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_ok());
+                        assert!(list
+                            .lookup_ex(|el| el.segment_id == entry.segment_id)
+                            .is_ok());
                     } else {
-                        assert!(list.lookup(|el| el.segment_id == entry.segment_id).is_err());
+                        assert!(list
+                            .lookup_ex(|el| el.segment_id == entry.segment_id)
+                            .is_err());
                     }
                 }
             }

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -40,10 +40,13 @@ pub struct MetaPageData {
     ambulkdelete_sentinel: pg_sys::BlockNumber,
 
     #[allow(dead_code)]
+    #[doc(hidden)]
     _dead_space_2: [u32; 2],
 
-    /// The header block for a [`LinkedItemsList<SegmentMergeEntry>]`
-    segment_meta_garbage: pg_sys::BlockNumber,
+    /// This used to be the header block for a [`LinkedItemsList<SegmentMergeEntry>]`
+    #[allow(dead_code)]
+    #[doc(hidden)]
+    _dead_space_3: pg_sys::BlockNumber,
 
     /// Merge lock block number
     merge_lock: pg_sys::BlockNumber,
@@ -82,8 +85,6 @@ impl MetaPage {
         unsafe {
             metadata.active_vacuum_list = init_new_buffer(indexrel).number();
             metadata.ambulkdelete_sentinel = init_new_buffer(indexrel).number();
-            metadata.segment_meta_garbage =
-                LinkedItemList::<SegmentMetaEntry>::create_without_fsm(indexrel);
             metadata.merge_lock = init_new_buffer(indexrel).number();
             metadata.fsm = FreeSpaceManager::create(indexrel);
 
@@ -113,7 +114,6 @@ impl MetaPage {
         // our old hardcoded values
         let may_need_init = !block_number_is_valid(metadata.active_vacuum_list)
             || !block_number_is_valid(metadata.ambulkdelete_sentinel)
-            || !block_number_is_valid(metadata.segment_meta_garbage)
             || !block_number_is_valid(metadata.merge_lock)
             || !block_number_is_valid(metadata.fsm);
 
@@ -133,11 +133,6 @@ impl MetaPage {
 
                 if !block_number_is_valid(metadata.ambulkdelete_sentinel) {
                     metadata.ambulkdelete_sentinel = init_new_buffer(indexrel).number();
-                }
-
-                if !block_number_is_valid(metadata.segment_meta_garbage) {
-                    metadata.segment_meta_garbage =
-                        LinkedItemList::<SegmentMetaEntry>::create_without_fsm(indexrel);
                 }
 
                 if !block_number_is_valid(metadata.merge_lock) {
@@ -165,26 +160,6 @@ impl MetaPage {
     pub unsafe fn acquire_merge_lock(&self) -> MergeLock {
         assert!(block_number_is_valid(self.data.merge_lock));
         MergeLock::acquire(self.bman.buffer_access().rel(), self.data.merge_lock)
-    }
-
-    ///
-    /// A LinkedItemList<SegmentMetaEntry> containing segments which are no longer visible from the
-    /// live `SEGMENT_METAS_START` list, and which will be recyclable when no transactions might still
-    /// be reading them on physical replicas.
-    ///
-    /// Deferring recycling avoids readers needing to hold a lock all the way from when
-    /// `SEGMENT_METAS_START` is first opened for reading until when they finish consuming the files
-    /// for the segments it references.
-    ///
-    pub fn segment_metas_garbage(&self) -> Option<LinkedItemList<SegmentMetaEntry>> {
-        if !block_number_is_valid(self.data.segment_meta_garbage) {
-            return None;
-        }
-
-        Some(LinkedItemList::<SegmentMetaEntry>::open(
-            self.bman.buffer_access().rel(),
-            self.data.segment_meta_garbage,
-        ))
     }
 
     pub fn vacuum_list(&self) -> VacuumList {

--- a/pg_search/src/postgres/storage/mod.rs
+++ b/pg_search/src/postgres/storage/mod.rs
@@ -93,7 +93,7 @@
 pub mod block;
 mod blocklist;
 pub mod buffer;
-mod fsm;
+pub mod fsm;
 pub mod linked_bytes;
 pub mod linked_items;
 pub mod merge;

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -49,7 +49,9 @@ impl BM25Page for pg_sys::Page {
     unsafe fn read_item(&self, offno: OffsetNumber) -> Option<PgItem> {
         let item_id = pg_sys::PageGetItemId(*self, offno);
 
-        if (*item_id).lp_flags() != pg_sys::LP_NORMAL {
+        // in order for a page to have an item it must have normal line pointers and be non-empty
+        // the lp_len() is effectively Postgres' `#define ItemIdHasStorage(itemId)` macro
+        if (*item_id).lp_flags() != pg_sys::LP_NORMAL || (*item_id).lp_len() == 0 {
             return None;
         }
 


### PR DESCRIPTION
This PR starts off fixing three distinct bugs that we've had for awhile but the new custom FSM brought to light:

- failed to properly identify an orphaned ".deletes" files, which could lead to adding the same block to the FSM multiple times
- `BufferMut.return_to_fsm()` needs to unlock/release the buffer before giving the block number to the FSM
- `AtomicGuard::commit()` was returning a block to the FSM prematurely

We also retool the FSM so that it will only return blocks when they're known to be all visible by all concurrent transactions.  Here on community that is actually "immediately" but is more sophsicated on our -enterprise product.

This also allows us to completely remove the concept of the "segment_meta_garbage" list.  Now that the FSM ensures blocks don't get reused until they're allowed, we don't need a separate way of tracking that.

The FSM is also largely rewritten to be centered around a "draining iterator".

Another minor change is that if we forget to call `AtomicGuard::commit()` its Drop impl now panics