### PR TITLE
ci: Check for `-` in tag rather than `-rc` in all our publish workflows

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
   publish-docs:
     name: Publish Docs to Mintlify
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -96,8 +96,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # The pg_version-tag Docker tag syntax is necessary for our CloudNativePG Helm chart. We only deploy
-      # the `latest` and `latest-pg` tags on production releases, not for beta releases. All other tags get
-      # deployed by both releases and will have a `-rc.X` suffix inherited from the GitHub tag.
+      # the `latest` and `latest-pg` tags on production releases, not for beta releases.
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -31,7 +31,7 @@ jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} arm64
     runs-on: ${{ matrix.runner }}
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -17,7 +17,7 @@ jobs:
   publish-pg_search:
     name: Publish pg_search to PGXN
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
     container: pgxn/pgxn-tools
 
     steps:

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
-    if: ${{ !contains(github.ref, '-rc') }}
+    if: ${{ !contains(github.ref, '-') }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Stu pointed out this is how semver operates. I fixed it at the Docker publish workflow a few days ago, but it was still assuming `-rc` elsewhere.

## Why
Semver compliance.

## How
Remove text.

## Tests
N/A