### PR TITLE
fix: replace fixed-size array with Vec to avoid stack overflow with large BLCKSZ

### DIFF
--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -98,7 +98,7 @@ impl InnerSegmentComponentWriter {
             total_bytes: Default::default(),
             buffer: ExactBuffer {
                 writer: Some(segment_component.writer()),
-                buffer: [0; BUFWRITER_CAPACITY],
+                buffer: Box::new([0; BUFWRITER_CAPACITY]),
                 len: 0,
             },
         }
@@ -147,7 +147,7 @@ impl TerminatingWrite for InnerSegmentComponentWriter {
 /// capacity.  Except on `flush()` where any remaining bytes are written.
 struct ExactBuffer<const CAPACITY: usize, W: Write> {
     writer: Option<W>,
-    buffer: [u8; CAPACITY],
+    buffer: Box<[u8; CAPACITY]>,
     len: usize,
 }
 
@@ -201,7 +201,7 @@ impl<const CAPACITY: usize, W: Write> Write for ExactBuffer<CAPACITY, W> {
 
         if self.len == CAPACITY {
             // buffer is full -- write it out
-            let _ = writer.write(&self.buffer)?;
+            let _ = writer.write(&*self.buffer)?;
             self.len = 0;
         }
 


### PR DESCRIPTION

ExactBuffer previously used a fixed-size array [u8; CAPACITY] on the stack. When CAPACITY depends on pg_sys::BLCKSZ (e.g., configured to 32KB), this can cause excessive stack allocation and potential stack overflow.

Switch to using Vec<u8> instead, which allocates the buffer on the heap and avoids the problem while keeping the interface unchanged.

# Ticket(s) Closed

- Closes #2973

## What

## Why

## How

## Tests
