### PR TITLE
chore: cherry pick #2975 into `0.17.x`

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - 0.*.x # Release branches
     paths:
       - "benchmarks/**"
       - "**/*.rs"
@@ -18,6 +19,7 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
+      - 0.*.x # Release branches
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - 0.*.x # Release branches
     paths:
       - ".github/stressgres/**"
       - "**/*.rs"
@@ -19,6 +20,7 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
+      - 0.*.x # Release branches
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
+      - 0.*.x # Release branches
     paths:
       - ".github/workflows/check-pg_search-schema-upgrade.yml"
       - "pg_search/**"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
+      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-docs.yml"
       - "docs/**"

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
+      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-docker.yml"
       - "docker/**"

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
+      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-upgrade.yml"
       - "pg_search/**"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - 0.*.x
+      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search.yml"
       - "pg_search/**"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Some workflows, like benchmarking, were not triggered for 0.*.x branches.

## Why
We run releases out of these branches.

## How
Add a new branch trigger in GHA.

## Tests
N/A

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
