### PR TITLE
fix: Install `cargo machete` as locked.

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -71,7 +71,7 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
 
       - name: Install cargo-machete
-        run: cargo install cargo-machete --debug
+        run: cargo install cargo-machete --locked --debug
 
       - name: Install taplo
         run: cargo install taplo-cli --version ^0.9 --locked --debug


### PR DESCRIPTION
## What

Install `cargo machete` with `--locked`.

## Why

Otherwise its deps could shift in ways which break CI when we're trying to get other things done.