### PR TITLE
chore: Add workflows to automatically cherry-pick from `main` to stable branches

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,42 @@
+name: Cherry Pick
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cherry-pick-to-0-17:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base_branch == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'cherry-pick/0.17.x')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cherry Pick
+        uses: carloscastrojumo/github-cherry-pick-action@v1
+        with:
+          branch: "0.17.x"
+          commit: ${{ github.event.pull_request.merge_commit_sha }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  cherry-pick-to-0-18:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base_branch == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'cherry-pick/0.18.x')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cherry Pick
+        uses: carloscastrojumo/github-cherry-pick-action@v1
+        with:
+          branch: "0.18.x"
+          commit: ${{ github.event.pull_request.merge_commit_sha }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   cherry-pick-to-0-17:
+    name: Cherry Pick to 0.17.x
     if: |
       github.event.pull_request.merged == true &&
       github.event.pull_request.base_branch == 'main' &&
@@ -24,6 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   cherry-pick-to-0-18:
+    name: Cherry Pick to 0.18.x
     if: |
       github.event.pull_request.merged == true &&
       github.event.pull_request.base_branch == 'main' &&


### PR DESCRIPTION
## What

Add Github workflows which use https://github.com/marketplace/actions/github-cherry-pick-action to automatically open cherry-picks to stable branches for appropriately labeled PRs.

## Why

This eliminates some annoying manual/local steps when a fix is landing on `main` which needs to be propagated to stable branches.

## How

To automatically open cherry-pick PRs to `0.17.x` and/or `0.18.x`, use the `cherry-pick/0.17.x` and `cherry-pick/0.18.x` labels, respectively.