### PR TITLE
Improved the JSON aggregation support: non-string JSON group-by column

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -48,7 +48,7 @@ use crate::postgres::customscan::{
 };
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
-use crate::postgres::types::TantivyValue;
+use crate::postgres::types::{TantivyValue, TantivyValueError};
 use crate::postgres::var::{find_one_var_and_fieldname, find_var_relation, VarContext};
 use crate::query::SearchQueryInput;
 use crate::schema::SearchIndexSchema;
@@ -397,10 +397,17 @@ unsafe fn convert_group_value_to_datum(
     typoid: pg_sys::Oid,
 ) -> (pg_sys::Datum, bool) {
     let oid = pgrx::PgOid::from(typoid);
-    let tantivy_value = TantivyValue(group_val);
+    let tantivy_value = TantivyValue(group_val.clone());
     match tantivy_value.try_into_datum(oid) {
         Ok(Some(datum)) => (datum, false),
         Ok(None) => (pg_sys::Datum::from(0), true),
+        Err(TantivyValueError::UnsupportedIntoConversion(target_type))
+            if target_type == "String" =>
+        {
+            // Handle conversions to String type for JSON GROUP BY aggregates
+            let converted_string = TantivyValue(group_val).to_string();
+            (converted_string.into_datum().unwrap(), false)
+        }
         Err(e) => {
             panic!("Failed to convert TantivyValue to datum: {e:?}");
         }

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -892,7 +892,373 @@ ORDER BY metric_category;
 (3 rows)
 
 -- =========================================
--- Test 10: Edge cases with special characters
+-- Test 10: Complex JSON reconstruction
+-- =========================================
+-- Create test table for JSON reconstruction scenarios
+CREATE TABLE json_test_reconstruction (
+    id SERIAL PRIMARY KEY,
+    config JSONB
+);
+-- Insert test data with nested objects that need reconstruction
+INSERT INTO json_test_reconstruction (config) VALUES
+    ('{"api": {"version": "v1", "endpoints": {"users": "/api/v1/users", "orders": "/api/v1/orders"}}, "database": {"host": "db1", "port": 5432}}'),
+    ('{"api": {"version": "v2", "endpoints": {"users": "/api/v2/users", "orders": "/api/v2/orders"}}, "database": {"host": "db2", "port": 5432}}'),
+    ('{"api": {"version": "v1", "endpoints": {"users": "/api/v1/users", "products": "/api/v1/products"}}, "database": {"host": "db1", "port": 3306}}'),
+    ('{"api": {"version": "v2", "endpoints": {"users": "/api/v2/users", "products": "/api/v2/products"}}, "database": {"host": "db3", "port": 5432}}'),
+    ('{"api": {"version": "v1", "endpoints": {"users": "/api/v1/users", "orders": "/api/v1/orders"}}, "database": {"host": "db1", "port": 5432}}');
+-- Create BM25 index
+CREATE INDEX idx_json_reconstruction ON json_test_reconstruction
+USING bm25 (id, config)
+WITH (
+    key_field = 'id',
+    json_fields = '{"config": {"indexed": true, "fast": true, "expand_dots": true}}'
+);
+-- GROUP BY intermediate JSON object
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    config->'api'->>'version' AS api_version,  -- Simpler: extract version string
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.api.version')
+GROUP BY config->'api'->>'version'  -- Group by version string
+ORDER BY api_version;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Output: (((config -> 'api'::text) ->> 'version'::text)), (now())
+   Sort Key: (((json_test_reconstruction.config -> 'api'::text) ->> 'version'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+         Output: ((config -> 'api'::text) ->> 'version'::text), now()
+         Index: idx_json_reconstruction
+         Tantivy Query: {"with_index":{"query":{"exists":{"field":"config.api.version"}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","size":10000}}}
+(8 rows)
+
+-- Execute the query
+SELECT 
+    config->'api'->>'version' AS api_version,
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.api.version')
+GROUP BY config->'api'->>'version'
+ORDER BY api_version;
+ api_version | count 
+-------------+-------
+ v1          |     3
+ v2          |     2
+(2 rows)
+
+-- Another example: GROUP BY multiple nested fields
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    config->'database'->>'host' AS db_host,  -- Extract host string
+    config->'api'->>'version' AS api_version,
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.database.host')
+  AND id @@@ paradedb.exists('config.api.version')
+GROUP BY config->'database'->>'host', config->'api'->>'version'
+ORDER BY db_host, api_version;
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: (((config -> 'database'::text) ->> 'host'::text)), (((config -> 'api'::text) ->> 'version'::text)), (now())
+   Sort Key: (((json_test_reconstruction.config -> 'database'::text) ->> 'host'::text)), (((json_test_reconstruction.config -> 'api'::text) ->> 'version'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+         Output: ((config -> 'database'::text) ->> 'host'::text), ((config -> 'api'::text) ->> 'version'::text), now()
+         Index: idx_json_reconstruction
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.database.host"}}}},{"with_index":{"query":{"exists":{"field":"config.api.version"}}}}]}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","size":10000}}}}}
+(8 rows)
+
+-- Execute the query
+SELECT 
+    config->'database'->>'host' AS db_host,
+    config->'api'->>'version' AS api_version,
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.database.host')
+  AND id @@@ paradedb.exists('config.api.version')
+GROUP BY config->'database'->>'host', config->'api'->>'version'
+ORDER BY db_host, api_version;
+ db_host | api_version | count 
+---------+-------------+-------
+ db1     | v1          |     3
+ db2     | v2          |     1
+ db3     | v2          |     1
+(3 rows)
+
+-- Test case demonstrating deep nested path grouping
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    config->'api'->'endpoints'->>'users' AS users_endpoint,  -- Extract specific endpoint
+    config->'database'->>'port' AS db_port,
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.api.endpoints.users')
+  AND id @@@ paradedb.exists('config.database.port')
+GROUP BY config->'api'->'endpoints'->>'users', config->'database'->>'port'
+ORDER BY users_endpoint, db_port;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: ((((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((config -> 'database'::text) ->> 'port'::text)), (now())
+   Sort Key: ((((json_test_reconstruction.config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((json_test_reconstruction.config -> 'database'::text) ->> 'port'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+         Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), now()
+         Index: idx_json_reconstruction
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","size":10000}}}}}
+(8 rows)
+
+-- Execute the query  
+SELECT 
+    config->'api'->'endpoints'->>'users' AS users_endpoint,
+    config->'database'->>'port' AS db_port,
+    COUNT(*) AS count
+FROM json_test_reconstruction
+WHERE id @@@ paradedb.exists('config.api.endpoints.users')
+  AND id @@@ paradedb.exists('config.database.port')
+GROUP BY config->'api'->'endpoints'->>'users', config->'database'->>'port'
+ORDER BY users_endpoint, db_port;
+ users_endpoint | db_port | count 
+----------------+---------+-------
+ /api/v1/users  | 3306    |     1
+ /api/v1/users  | 5432    |     2
+ /api/v2/users  | 5432    |     2
+(3 rows)
+
+-- =========================================
+-- Test 11: Multiple subfields from same JSON field as GROUP BY columns
+-- =========================================
+-- Create test table demonstrating multiple subfields from same JSON object
+CREATE TABLE json_test_multi_subfields (
+    id SERIAL PRIMARY KEY,
+    user_profile JSONB,
+    order_details JSONB
+);
+-- Insert test data with multiple subfields in the same JSON objects
+INSERT INTO json_test_multi_subfields (user_profile, order_details) VALUES
+    ('{"name": "Alice", "department": "Engineering", "role": "Senior", "location": "SF"}', '{"product": "laptop", "category": "electronics", "quantity": 2, "price": 1200}'),
+    ('{"name": "Bob", "department": "Engineering", "role": "Junior", "location": "NYC"}', '{"product": "mouse", "category": "electronics", "quantity": 5, "price": 25}'),
+    ('{"name": "Carol", "department": "Marketing", "role": "Senior", "location": "SF"}', '{"product": "desk", "category": "furniture", "quantity": 1, "price": 300}'),
+    ('{"name": "David", "department": "Marketing", "role": "Manager", "location": "LA"}', '{"product": "chair", "category": "furniture", "quantity": 3, "price": 150}'),
+    ('{"name": "Eve", "department": "Engineering", "role": "Senior", "location": "SF"}', '{"product": "monitor", "category": "electronics", "quantity": 2, "price": 400}'),
+    ('{"name": "Frank", "department": "Sales", "role": "Junior", "location": "NYC"}', '{"product": "laptop", "category": "electronics", "quantity": 1, "price": 1200}'),
+    ('{"name": "Grace", "department": "Marketing", "role": "Senior", "location": "LA"}', '{"product": "tablet", "category": "electronics", "quantity": 1, "price": 500}'),
+    ('{"name": "Henry", "department": "Engineering", "role": "Manager", "location": "SF"}', '{"product": "desk", "category": "furniture", "quantity": 2, "price": 300}');
+-- Create BM25 index
+CREATE INDEX idx_json_multi_subfields ON json_test_multi_subfields
+USING bm25 (id, user_profile, order_details)
+WITH (
+    key_field = 'id',
+    json_fields = '{
+        "user_profile": {"indexed": true, "fast": true, "expand_dots": true},
+        "order_details": {"indexed": true, "fast": true, "expand_dots": true}
+    }'
+);
+-- Test 1: Two subfields from the same JSON field (user_profile)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'role' AS role,
+    COUNT(*) AS employee_count
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('user_profile.role')
+GROUP BY user_profile->>'department', user_profile->>'role'
+ORDER BY department, role;
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'role'::text)), (now())
+   Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'role'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
+         Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), now()
+         Index: idx_json_multi_subfields
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}}]}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","size":10000}}}}}
+(8 rows)
+
+-- Execute the query
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'role' AS role,
+    COUNT(*) AS employee_count
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('user_profile.role')
+GROUP BY user_profile->>'department', user_profile->>'role'
+ORDER BY department, role;
+ department  |  role   | employee_count 
+-------------+---------+----------------
+ Engineering | Junior  |              1
+ Engineering | Manager |              1
+ Engineering | Senior  |              2
+ Marketing   | Manager |              1
+ Marketing   | Senior  |              2
+ Sales       | Junior  |              1
+(6 rows)
+
+-- Test 2: Three subfields from the same JSON field 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'role' AS role,
+    user_profile->>'location' AS location,
+    COUNT(*) AS employee_count
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('user_profile.role')
+  AND id @@@ paradedb.exists('user_profile.location')
+GROUP BY user_profile->>'department', user_profile->>'role', user_profile->>'location'
+ORDER BY department, role, location;
+                                                                                                                          QUERY PLAN                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'role'::text)), ((user_profile ->> 'location'::text)), (now())
+   Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'role'::text)), ((json_test_multi_subfields.user_profile ->> 'location'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
+         Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), (user_profile ->> 'location'::text), now()
+         Index: idx_json_multi_subfields
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.location"}}}}]}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","size":10000}}}}}}}
+(8 rows)
+
+-- Execute the query
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'role' AS role,
+    user_profile->>'location' AS location,
+    COUNT(*) AS employee_count
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('user_profile.role')
+  AND id @@@ paradedb.exists('user_profile.location')
+GROUP BY user_profile->>'department', user_profile->>'role', user_profile->>'location'
+ORDER BY department, role, location;
+ department  |  role   | location | employee_count 
+-------------+---------+----------+----------------
+ Engineering | Junior  | NYC      |              1
+ Engineering | Manager | SF       |              1
+ Engineering | Senior  | SF       |              2
+ Marketing   | Manager | LA       |              1
+ Marketing   | Senior  | LA       |              1
+ Marketing   | Senior  | SF       |              1
+ Sales       | Junior  | NYC      |              1
+(7 rows)
+
+-- Test 3: Mix subfields from different JSON fields (NOT SUPPORTED BY CUSTOM AGGREGATE SCAN YET)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    user_profile->>'department' AS department,
+    order_details->>'category' AS product_category,
+    COUNT(*) AS order_count,
+    SUM((order_details->>'quantity')::int) AS total_quantity
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('order_details.category')
+GROUP BY user_profile->>'department', order_details->>'category'
+ORDER BY department, product_category;
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: ((user_profile ->> 'department'::text)), ((order_details ->> 'category'::text)), count(*), sum(((order_details ->> 'quantity'::text))::integer)
+   Group Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.order_details ->> 'category'::text))
+   ->  Sort
+         Output: ((user_profile ->> 'department'::text)), ((order_details ->> 'category'::text)), order_details
+         Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.order_details ->> 'category'::text))
+         ->  Custom Scan (ParadeDB Scan) on public.json_test_multi_subfields
+               Output: (user_profile ->> 'department'::text), (order_details ->> 'category'::text), order_details
+               Table: json_test_multi_subfields
+               Index: idx_json_multi_subfields
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"order_details.category"}}}}]}}
+(13 rows)
+
+-- Execute the query
+SELECT 
+    user_profile->>'department' AS department,
+    order_details->>'category' AS product_category,
+    COUNT(*) AS order_count,
+    SUM((order_details->>'quantity')::int) AS total_quantity
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('order_details.category')
+GROUP BY user_profile->>'department', order_details->>'category'
+ORDER BY department, product_category;
+ department  | product_category | order_count | total_quantity 
+-------------+------------------+-------------+----------------
+ Engineering | electronics      |           3 |              9
+ Engineering | furniture        |           1 |              2
+ Marketing   | electronics      |           1 |              1
+ Marketing   | furniture        |           2 |              4
+ Sales       | electronics      |           1 |              1
+(5 rows)
+
+-- Test 4: Complex query with subfields from both JSON fields plus aggregates (NOT SUPPORTED BY CUSTOM AGGREGATE SCAN YET)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'location' AS location,
+    order_details->>'product' AS product,
+    order_details->>'category' AS category,
+    COUNT(*) AS order_count,
+    AVG((order_details->>'price')::numeric) AS avg_price,
+    SUM((order_details->>'quantity')::int) AS total_quantity
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('order_details.category')
+GROUP BY user_profile->>'department', user_profile->>'location', 
+         order_details->>'product', order_details->>'category'
+ORDER BY department, location, product;
+                                                                                                                                         QUERY PLAN                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'location'::text)), ((order_details ->> 'product'::text)), ((order_details ->> 'category'::text)), count(*), avg(((order_details ->> 'price'::text))::numeric), sum(((order_details ->> 'quantity'::text))::integer)
+   Group Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'location'::text)), ((json_test_multi_subfields.order_details ->> 'product'::text)), ((json_test_multi_subfields.order_details ->> 'category'::text))
+   ->  Sort
+         Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'location'::text)), ((order_details ->> 'product'::text)), ((order_details ->> 'category'::text)), order_details
+         Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'location'::text)), ((json_test_multi_subfields.order_details ->> 'product'::text)), ((json_test_multi_subfields.order_details ->> 'category'::text))
+         ->  Custom Scan (ParadeDB Scan) on public.json_test_multi_subfields
+               Output: (user_profile ->> 'department'::text), (user_profile ->> 'location'::text), (order_details ->> 'product'::text), (order_details ->> 'category'::text), order_details
+               Table: json_test_multi_subfields
+               Index: idx_json_multi_subfields
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"order_details.category"}}}}]}}
+(13 rows)
+
+-- Execute the query
+SELECT 
+    user_profile->>'department' AS department,
+    user_profile->>'location' AS location,
+    order_details->>'product' AS product,
+    order_details->>'category' AS category,
+    COUNT(*) AS order_count,
+    AVG((order_details->>'price')::numeric) AS avg_price,
+    SUM((order_details->>'quantity')::int) AS total_quantity
+FROM json_test_multi_subfields
+WHERE id @@@ paradedb.exists('user_profile.department')
+  AND id @@@ paradedb.exists('order_details.category')
+GROUP BY user_profile->>'department', user_profile->>'location', 
+         order_details->>'product', order_details->>'category'
+ORDER BY department, location, product;
+ department  | location | product |  category   | order_count |       avg_price       | total_quantity 
+-------------+----------+---------+-------------+-------------+-----------------------+----------------
+ Engineering | NYC      | mouse   | electronics |           1 |   25.0000000000000000 |              5
+ Engineering | SF       | desk    | furniture   |           1 |  300.0000000000000000 |              2
+ Engineering | SF       | laptop  | electronics |           1 | 1200.0000000000000000 |              2
+ Engineering | SF       | monitor | electronics |           1 |  400.0000000000000000 |              2
+ Marketing   | LA       | chair   | furniture   |           1 |  150.0000000000000000 |              3
+ Marketing   | LA       | tablet  | electronics |           1 |  500.0000000000000000 |              1
+ Marketing   | SF       | desk    | furniture   |           1 |  300.0000000000000000 |              1
+ Sales       | NYC      | laptop  | electronics |           1 | 1200.0000000000000000 |              1
+(8 rows)
+
+-- =========================================
+-- Test 12: Edge cases with special characters
 -- =========================================
 -- Create test table with special JSON keys
 CREATE TABLE json_test_special (
@@ -955,4 +1321,6 @@ DROP TABLE json_test_deep;
 DROP TABLE json_test_mixed;
 DROP TABLE json_test_operators;
 DROP TABLE json_test_complex;
+DROP TABLE json_test_reconstruction;
+DROP TABLE json_test_multi_subfields;
 DROP TABLE json_test_special;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Fixes `UnsupportedIntoConversion("String")` error when grouping by non-string JSON fields in aggregate custom scan.

## Why

When grouping by JSON fields that contain non-string values (integers, booleans, etc.), Tantivy returns `OwnedValue` types like `I64`, `U64`, `Bool`, etc., but PostgreSQL expects string output for JSON extraction operators (`->>` always returns text). The generic `TryFrom<TantivyValue> for String` implementation only handles `OwnedValue::Str`, causing conversion failures.

## How

Added targeted error handling in `convert_group_value_to_datum()` to catch `UnsupportedIntoConversion("String")` errors and route them through `TantivyValue(group_val).to_string()` for JSON GROUP BY aggregates.

## Tests

- Added deep nested JSON path tests in `json_groupby_aggregate.sql`
- Nested query now returns proper results instead of conversion errors

```sql
-- Example: GROUP BY JSON field containing integers
SELECT config->'database'->>'port' AS db_port, COUNT(*) 
FROM table 
GROUP BY config->'database'->>'port';

-- Before: ERROR: Failed to convert TantivyValue to datum: UnsupportedIntoConversion("String")  
-- After:  
 db_port | count 
---------+-------
 3306    |     1
 5432    |     4
```
