### PR TITLE
fix: parallel vacuum process now runs correctly (#2987)

### DIFF
--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -270,7 +270,10 @@ extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
 
         let current_xid = unsafe { pg_sys::GetCurrentTransactionId() };
         let args = unsafe { BackgroundMergeArgs::from_datum(arg, false) }.unwrap();
-        let index = PgSearchRelation::try_open(args.index_oid());
+        let index = PgSearchRelation::try_open(
+            args.index_oid(),
+            pg_sys::AccessShareLock as pg_sys::LOCKMODE,
+        );
         if index.is_none() {
             pgrx::debug1!(
                 "{}: index not found, suggesting it was just dropped",

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -145,11 +145,11 @@ impl PgSearchRelation {
 
     /// Open a relation with the specified [`pg_sys::Oid`]
     ///
-    /// Like `open`, but fallible
-    pub fn try_open(oid: pg_sys::Oid) -> Option<Self> {
+    /// Like [`Self::with_lock`], but fallible
+    pub fn try_open(oid: pg_sys::Oid, lockmode: pg_sys::LOCKMODE) -> Option<Self> {
         // SAFETY: See `open`
         unsafe {
-            let relation = pg_sys::RelationIdGetRelation(oid);
+            let relation = pg_sys::try_relation_open(oid, lockmode);
             if relation.is_null() {
                 None
             } else {

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -587,8 +587,12 @@ impl BufferManager {
             .fsm()
             .pop(self)
             .map(|blockno| {
-                self.rbufacc
-                    .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE))
+                self.rbufacc.get_buffer_extended(
+                    blockno,
+                    std::ptr::null_mut(),
+                    pg_sys::ReadBufferMode::RBM_ZERO_AND_LOCK,
+                    None,
+                )
             })
             .unwrap_or_else(|| self.rbufacc.new_buffer());
 

--- a/pg_search/tests/pg_regress/expected/parallel_vacuum.out
+++ b/pg_search/tests/pg_regress/expected/parallel_vacuum.out
@@ -1,0 +1,67 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+DROP TABLE IF EXISTS benchmark_logs CASCADE;
+CREATE TABLE benchmark_logs (
+    id SERIAL PRIMARY KEY,
+    message TEXT,
+    country VARCHAR(255),
+    severity INTEGER,
+    timestamp TIMESTAMP,
+    metadata JSONB
+);
+INSERT INTO benchmark_logs (message, country, severity, timestamp, metadata)
+SELECT
+  (ARRAY[
+    'The research team discovered a new species of deep-sea creature while conducting experiments near hydrothermal vents in the dark ocean depths.',
+    'The research facility analyzed samples from ancient artifacts, revealing breakthrough findings about civilizations lost to the depths of time.',
+    'The research station monitored weather patterns across mountain peaks, collecting data about atmospheric changes in the remote depths below.',
+    'The research observatory captured images of stellar phenomena, peering into the cosmic depths to understand the mysteries of distant galaxies.',
+    'The research laboratory processed vast amounts of genetic data, exploring the molecular depths of DNA to unlock biological secrets.',
+    'The research center studied rare organisms found in ocean depths, documenting new species thriving in extreme underwater environments.',
+    'The research institute developed quantum systems to probe subatomic depths, advancing our understanding of fundamental particle physics.',
+    'The research expedition explored underwater depths near volcanic vents, discovering unique ecosystems adapted to extreme conditions.',
+    'The research facility conducted experiments in the depths of space, testing how different materials behave in zero gravity environments.',
+    'The research team engineered crops that could grow in the depths of drought conditions, helping communities facing climate challenges.'
+  ])[1 + MOD(s.id - 1, 10)],
+  (ARRAY[
+    'United States',
+    'Canada',
+    'United Kingdom',
+    'France',
+    'Germany',
+    'Japan',
+    'Australia',
+    'Brazil',
+    'India',
+    'China'
+  ])[1 + MOD(s.id - 1, 10)],
+  1 + MOD(s.id - 1, 5),
+  timestamp '2020-01-01' +
+    make_interval(days => MOD(s.id - 1, 731)), -- 731 days = 2 years (including leap year)
+  jsonb_build_object(
+    'value', 1 + MOD(s.id - 1, 1000),
+    'label', (ARRAY[
+      'critical system alert',
+      'routine maintenance',
+      'security notification',
+      'performance metric',
+      'user activity',
+      'system status',
+      'network event',
+      'application log',
+      'database operation',
+      'authentication event'
+    ])[1 + MOD(s.id - 1, 10)]
+  )
+FROM generate_series(1, 100000) s(id);
+CREATE INDEX benchmark_logs_idx ON benchmark_logs USING bm25 (id, message, country, severity, timestamp, metadata) WITH (key_field = 'id', text_fields = '{"country": {"fast": true, "tokenizer": {"type": "raw", "lowercase": true} }}', json_fields = '{"metadata": { "fast": true, "tokenizer": {"type": "raw", "lowercase": true}}}');
+WARNING:  only 2 parallel workers were available for index build
+CREATE INDEX ON benchmark_logs USING btree (severity);
+CREATE INDEX ON benchmark_logs USING btree (timestamp);
+UPDATE benchmark_logs SET severity = severity + 1 WHERE id > 90000;
+VACUUM benchmark_logs;
+DROP TABLE benchmark_logs;

--- a/pg_search/tests/pg_regress/sql/parallel_vacuum.sql
+++ b/pg_search/tests/pg_regress/sql/parallel_vacuum.sql
@@ -1,0 +1,65 @@
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS benchmark_logs CASCADE;
+CREATE TABLE benchmark_logs (
+    id SERIAL PRIMARY KEY,
+    message TEXT,
+    country VARCHAR(255),
+    severity INTEGER,
+    timestamp TIMESTAMP,
+    metadata JSONB
+);
+
+INSERT INTO benchmark_logs (message, country, severity, timestamp, metadata)
+SELECT
+  (ARRAY[
+    'The research team discovered a new species of deep-sea creature while conducting experiments near hydrothermal vents in the dark ocean depths.',
+    'The research facility analyzed samples from ancient artifacts, revealing breakthrough findings about civilizations lost to the depths of time.',
+    'The research station monitored weather patterns across mountain peaks, collecting data about atmospheric changes in the remote depths below.',
+    'The research observatory captured images of stellar phenomena, peering into the cosmic depths to understand the mysteries of distant galaxies.',
+    'The research laboratory processed vast amounts of genetic data, exploring the molecular depths of DNA to unlock biological secrets.',
+    'The research center studied rare organisms found in ocean depths, documenting new species thriving in extreme underwater environments.',
+    'The research institute developed quantum systems to probe subatomic depths, advancing our understanding of fundamental particle physics.',
+    'The research expedition explored underwater depths near volcanic vents, discovering unique ecosystems adapted to extreme conditions.',
+    'The research facility conducted experiments in the depths of space, testing how different materials behave in zero gravity environments.',
+    'The research team engineered crops that could grow in the depths of drought conditions, helping communities facing climate challenges.'
+  ])[1 + MOD(s.id - 1, 10)],
+  (ARRAY[
+    'United States',
+    'Canada',
+    'United Kingdom',
+    'France',
+    'Germany',
+    'Japan',
+    'Australia',
+    'Brazil',
+    'India',
+    'China'
+  ])[1 + MOD(s.id - 1, 10)],
+  1 + MOD(s.id - 1, 5),
+  timestamp '2020-01-01' +
+    make_interval(days => MOD(s.id - 1, 731)), -- 731 days = 2 years (including leap year)
+  jsonb_build_object(
+    'value', 1 + MOD(s.id - 1, 1000),
+    'label', (ARRAY[
+      'critical system alert',
+      'routine maintenance',
+      'security notification',
+      'performance metric',
+      'user activity',
+      'system status',
+      'network event',
+      'application log',
+      'database operation',
+      'authentication event'
+    ])[1 + MOD(s.id - 1, 10)]
+  )
+FROM generate_series(1, 100000) s(id);
+
+CREATE INDEX benchmark_logs_idx ON benchmark_logs USING bm25 (id, message, country, severity, timestamp, metadata) WITH (key_field = 'id', text_fields = '{"country": {"fast": true, "tokenizer": {"type": "raw", "lowercase": true} }}', json_fields = '{"metadata": { "fast": true, "tokenizer": {"type": "raw", "lowercase": true}}}');
+CREATE INDEX ON benchmark_logs USING btree (severity);
+CREATE INDEX ON benchmark_logs USING btree (timestamp);
+
+UPDATE benchmark_logs SET severity = severity + 1 WHERE id > 90000;
+VACUUM benchmark_logs;
+DROP TABLE benchmark_logs;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2986

## What

This fixes issue #2986. The primary problem here is that parallel vacuum processes can't create a transaction id via
`pg_sys::GetCurrentTransactionId()` so we instead teach the FSM to use `pg_sys::GetCurrentTransactionIdIfAny()` and in the case of a parallel vacuum process we'll fall back to the
`pg_sys::FirstNormalTransactionId`.

A subtle difference is here that parallel vacuum processes won't be able to reuse blocks from the FSM in the case where `ambulkdelete()` adds a ".deletes" file to a segment. This is better than not being able to vacuum at all.

Thanks to @rebasedming for getting a test case together.

Additionally, that test case uncovered a race condition with the background merge process because it turns out it didn't hold a relation lock on the index at all. Now it holds a `pg_sys::AccessShareLock`, which is sufficient for the work it's doing and to prevent concurrent DDL like `DROP TABLE` from changing things out from under it.

## Why

Fixing bugs.

## How

## Tests

A new regression test has been added and some local stressgres tests look good.

---------

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
