### PR TITLE
fix: don't ERROR if `paradedb.terms_with_operator` is missing

### DIFF
--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use pgrx::{pg_sys, IntoDatum};
+use std::ffi::CStr;
+
+/// Helper function to lookup a namespace's [`pg_sys::Oid`] (SQL schema) by name
+pub fn lookup_namespace(namespace: &CStr) -> Option<pg_sys::Oid> {
+    unsafe {
+        let namespace_oid = pg_sys::get_namespace_oid(namespace.as_ptr(), true);
+        (namespace_oid != pg_sys::InvalidOid).then_some(namespace_oid)
+    }
+}
+
+/// Helper function to lookup a type's [`pg_sys::Oid`] by name and namespace
+pub fn lookup_typoid(namespace: &CStr, typename: &CStr) -> Option<pg_sys::Oid> {
+    unsafe {
+        let typoid = pg_sys::GetSysCacheOid(
+            pg_sys::SysCacheIdentifier::TYPENAMENSP as _,
+            pg_sys::Anum_pg_type_oid as _,
+            pg_sys::Datum::from(typename.as_ptr()),
+            lookup_namespace(namespace).into_datum()?,
+            pg_sys::Datum::null(),
+            pg_sys::Datum::null(),
+        );
+        (typoid != pg_sys::InvalidOid).then_some(typoid)
+    }
+}
+
+/// Helper function to lookup a function's [`pg_sys::Oid`] by name, argument types, and namespace
+pub fn lookup_procoid(
+    namespace: &CStr,
+    fucname: &CStr,
+    argtypes: &[pg_sys::Oid],
+) -> Option<pg_sys::Oid> {
+    unsafe {
+        let argvec = pg_sys::buildoidvector(argtypes.as_ptr(), argtypes.len() as _);
+        let procoid = pg_sys::GetSysCacheOid(
+            pg_sys::SysCacheIdentifier::PROCNAMEARGSNSP as _,
+            pg_sys::Anum_pg_proc_oid as _,
+            pg_sys::Datum::from(fucname.as_ptr()),
+            pg_sys::Datum::from(argvec),
+            lookup_namespace(namespace).into_datum()?,
+            pg_sys::Datum::null(),
+        );
+        pg_sys::pfree(argvec.cast());
+        (procoid != pg_sys::InvalidOid).then_some(procoid)
+    }
+}

--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -18,6 +18,7 @@
 use crate::api::operator::searchqueryinput_typoid;
 use crate::api::{fieldname_typoid, FieldName, HashMap};
 use crate::nodecast;
+use crate::postgres::catalog::{lookup_procoid, lookup_typoid};
 use crate::postgres::customscan::operator_oid;
 use crate::postgres::customscan::opexpr::OpExpr;
 use crate::postgres::customscan::qual_inspect::Qual;
@@ -66,16 +67,16 @@ impl PushdownField {
 
 macro_rules! pushdown {
     ($attname:expr, $opexpr:expr, $operator:expr, $rhs:ident) => {{
-        let funcexpr = make_opexpr($attname, $opexpr, $operator, $rhs);
-
-        if !is_complex(funcexpr.cast()) {
-            Qual::PushdownExpr { funcexpr }
-        } else {
-            Qual::Expr {
-                node: funcexpr.cast(),
-                expr_state: std::ptr::null_mut(),
+        make_opexpr($attname, $opexpr, $operator, $rhs).map(|funcexpr| {
+            if !is_complex(funcexpr.cast()) {
+                Qual::PushdownExpr { funcexpr }
+            } else {
+                Qual::Expr {
+                    node: funcexpr.cast(),
+                    expr_state: std::ptr::null_mut(),
+                }
             }
-        }
+        })
     }};
 }
 
@@ -161,7 +162,7 @@ pub unsafe fn try_pushdown_inner(
         Some(pgsearch_operator) => {
             // the `opexpr` is one we can pushdown
             if (*var).varno as pg_sys::Index == rti {
-                let pushed_down_qual = pushdown!(&pushdown.attname(), opexpr, pgsearch_operator, rhs);
+                let pushed_down_qual = pushdown!(&pushdown.attname(), opexpr, pgsearch_operator, rhs)?;
                 // and it's in this RTI, so we can use it directly
                 Some(pushed_down_qual)
             } else {
@@ -186,13 +187,17 @@ unsafe fn term_with_operator_procid() -> pg_sys::Oid {
             .expect("the `paradedb.term_with_operator(paradedb.fieldname, text, anyelement)` function should exist")
 }
 
-unsafe fn terms_with_operator_procid() -> pg_sys::Oid {
-    direct_function_call::<pg_sys::Oid>(
-            pg_sys::regprocedurein,
-            // NB:  the SQL signature here needs to match our Rust implementation
-            &[c"paradedb.terms_with_operator(paradedb.fieldname, text, anyelement, bool)".into_datum()],
-        )
-            .expect("the `paradedb.terms_with_operator(paradedb.fieldname, text, anyelement, bool)` function should exist")
+unsafe fn terms_with_operator_procid() -> Option<pg_sys::Oid> {
+    lookup_procoid(
+        c"paradedb",
+        c"terms_with_operator",
+        &[
+            lookup_typoid(c"paradedb", c"fieldname")?,
+            pg_sys::TEXTOID,
+            pg_sys::ANYELEMENTOID,
+            pg_sys::BOOLOID,
+        ],
+    )
 }
 
 unsafe fn make_opexpr(
@@ -200,12 +205,12 @@ unsafe fn make_opexpr(
     orig_opexor: OpExpr,
     operator: &str,
     value: *mut pg_sys::Node,
-) -> *mut pg_sys::FuncExpr {
+) -> Option<*mut pg_sys::FuncExpr> {
     let paradedb_funcexpr: *mut pg_sys::FuncExpr =
         pg_sys::palloc0(size_of::<pg_sys::FuncExpr>()).cast();
     (*paradedb_funcexpr).xpr.type_ = pg_sys::NodeTag::T_FuncExpr;
     (*paradedb_funcexpr).funcid = match orig_opexor {
-        OpExpr::Array(_) => terms_with_operator_procid(),
+        OpExpr::Array(_) => terms_with_operator_procid()?,
         OpExpr::Single(_) => term_with_operator_procid(),
     };
     (*paradedb_funcexpr).funcresulttype = searchqueryinput_typoid();
@@ -249,7 +254,7 @@ unsafe fn make_opexpr(
         args.into_pg()
     };
 
-    paradedb_funcexpr
+    Some(paradedb_funcexpr)
 }
 
 pub unsafe fn is_complex(root: *mut pg_sys::Node) -> bool {

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -39,6 +39,7 @@ mod vacuum;
 mod validate;
 
 mod build_parallel;
+pub mod catalog;
 pub mod customscan;
 pub mod datetime;
 #[cfg(not(feature = "pg17"))]

--- a/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
+++ b/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
@@ -1,0 +1,52 @@
+DROP TABLE IF EXISTS missing_fn;
+CREATE TABLE missing_fn (id int);
+INSERT INTO missing_fn (id) SELECT generate_series(1, 1000);
+CREATE INDEX idxmissing_fn ON missing_fn USING bm25 (id) WITH (key_field = 'id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 1
+   ->  Sort
+         Sort Key: id
+         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
+               Table: missing_fn
+               Index: idxmissing_fn
+               Exec Method: NumericFastFieldExecState
+               Fast Fields: id
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"term_set":{"terms":[{"field":"id","value":3,"is_datetime":false}]}},{"with_index":{"query":"all"}}]}}
+(11 rows)
+
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ id 
+----
+  3
+(1 row)
+
+BEGIN;
+ALTER EXTENSION pg_search DROP FUNCTION paradedb.terms_with_operator;
+DROP FUNCTION paradedb.terms_with_operator;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 1
+   ->  Sort
+         Sort Key: id
+         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
+               Table: missing_fn
+               Index: idxmissing_fn
+               Exec Method: NumericFastFieldExecState
+               Fast Fields: id
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":"all"}}]}},"field_filters":[{"expr_node":"{SCALARARRAYOPEXPR :opno 96 :opfuncid 65 :hashfuncid 0 :negfuncid 0 :useOr true :inputcollid 0 :args ({VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 1007 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 28 [ 112 0 0 0 1 0 0 0 0 0 0 0 23 0 0 0 1 0 0 0 1 0 0 0 3 0 0 0 ]}) :location -1}","description":"OpExpr with operator OID 96"}]}}]}}
+(11 rows)
+
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ id 
+----
+  3
+(1 row)
+
+ABORT;

--- a/pg_search/tests/pg_regress/sql/missing_terms_with_operator_fn.sql
+++ b/pg_search/tests/pg_regress/sql/missing_terms_with_operator_fn.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS missing_fn;
+CREATE TABLE missing_fn (id int);
+INSERT INTO missing_fn (id) SELECT generate_series(1, 1000);
+CREATE INDEX idxmissing_fn ON missing_fn USING bm25 (id) WITH (key_field = 'id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+
+BEGIN;
+ALTER EXTENSION pg_search DROP FUNCTION paradedb.terms_with_operator;
+DROP FUNCTION paradedb.terms_with_operator;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ABORT;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

It's possible that when upgrading pg_search from `v0.15.26` to `v0.17.x` we could generate an ERROR complaining that
`paradedb.terms_with_operator(...)` doesn't exist if the user upgraded the extension binary but has not yet run `ALTER EXTENSION pg_search UPDATE;`.

This fixes that by inspecting the catalogs directly when it's necessary to lookup that function and plumbing through an `Option<pg_sys::Oid>` return value.

## Why

To help users/customers/partners better deal with upgrading from really old pg_search versions.

## How

## Tests

Existing tests pass, especially the ones added in #2730, and a new regress test has been added that explicitly removes the function from the schema and ensures the query still works (tho with a different plan, of course).
