### PR TITLE
fix: fsm: we have space if any slots are invalid, no need for all (#3015)

### DIFF
--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -98,6 +98,12 @@ impl FSMBlock {
             .iter()
             .all(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
     }
+    #[inline]
+    fn any_invalid(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
+    }
 }
 
 /// The [`FreeSpaceManager`] is our version of Postgres' "free space map".  We need to track free space
@@ -221,7 +227,7 @@ impl FreeSpaceManager {
 
             let page = buffer.page();
             let contents = page.contents_ref::<FSMBlock>();
-            let space_available = contents.header.empty || contents.all_invalid();
+            let space_available = contents.header.empty || contents.any_invalid();
 
             if space_available {
                 let mut page = buffer.page_mut();


### PR DESCRIPTION
## What

When walking the free space map looking for blocks with open slots, we want to pick a block with any empty slots, not all open slots, so that we don't end up with a long, low occupancy list.

## Why

Performance.

## How

Add a function to query whether any slots in the fsm block are empty, and then use it.

## Tests

Ran unit tests.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
