### PR TITLE
fix: Only mark Docker images as `latest` if they actually are the latest ones

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -86,6 +86,25 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Determine if Release Should be Marked as Latest
+        id: release_latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
+        run: |
+          # Get the upcoming and current latest release tag versions (without the "v")
+          current_tag_version="${{ steps.version.outputs.version }}"
+          latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
+          echo "Current latest release is $latest_tag_version"
+          echo "Current version to be released is $current_tag_version"
+
+          # Install semver CLI and compare versions according to semVer rules
+          npm install semver
+          if npx semver -r ">$latest_tag_version" "$current_tag_version"; then
+            echo "is_latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_latest=false" >> $GITHUB_OUTPUT
+          fi
+
       # Cross-compilation is incredibly slow, so we use an external service called Depot to
       # speed up container builds for universal images. We could eventually replace this with
       # Docker Build Cloud once they add support for multiple concurrent builders.
@@ -108,8 +127,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ !contains(github.ref, '-')}}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && !contains(github.ref, '-') }}
+            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest && !contains(github.ref, '-')}}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest && !contains(github.ref, '-') }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -123,6 +123,15 @@ jobs:
             exit 1
           fi
 
+      # Useful for debugging discrepancies between local and remote ParadeDB Docker images
+      - name: Print the ParadeDB Docker Image History
+        run: docker history paradedb/paradedb:latest
+
+      - name: Print the ParadeDB Docker Image Permissions
+        run: |
+          docker run --name temp-inspect-paradedb --entrypoint /bin/bash paradedb/paradedb:latest -c "ls -la /var/lib/postgresql"
+          docker rm temp-inspect-paradedb
+
       - name: Compare the ParadeDB Docker Image to the ParadeDB Docker Image in Docker Hub via Docker Scout
         if: steps.org-check.outputs.is_member == 'true' && steps.dockerfilter.outputs.docker == 'true'
         uses: docker/scout-action@v1

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -1,7 +1,7 @@
 # workflows/test-pg_search-docker.yml
 #
 # Test pg_search Docker
-# Test building the ParadeDB Docker Image using Docker Compose.
+# Test building and running the ParadeDB Docker Image using Docker Compose.
 
 name: Test pg_search Docker
 

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -104,6 +104,10 @@ jobs:
           echo "Container status: $CONTAINER_STATUS"
 
           echo ""
+          echo "Sleeping 30 seconds to give Postgres the time to fully initialize and run initdb..."
+          sleep 30
+
+          echo ""
           echo "Printing logs for the ParadeDB Docker container..."
           docker logs $CONTAINER_ID
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This PR fixes two issues:

- We were unconditionally marking any non-beta release Docker images as being `latest`. This means despite having released `0.18.0` before, now releasing `0.17.7` marked it as latest. This PR fixes this by comparing the semver versions and creating a flag based on the output, which is used in the Docker Tag step. This is mostly the same code as in the `publish-github-release.yml`, where we had a similar issue before.

- I also added some more logs to our `Test ParadeDB Docker` job to help verify why some users reported permission errors. It seems that the PR #2954 simply wasn't porteed over to the `0.17.x` release branch.

## Why
Properly tag Docker releases.

## How
^

## Tests
All tested manually.