### PR TITLE
perf: optimize merging heuristics to prefer background merging

### DIFF
--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -54,36 +54,25 @@ impl TryFrom<u8> for MergeStyle {
 #[derive(Debug, Copy, Clone)]
 struct BackgroundMergeArgs {
     index_oid: pg_sys::Oid,
-    merge_style: MergeStyle,
 }
 
 impl BackgroundMergeArgs {
-    pub fn new(index_oid: pg_sys::Oid, merge_style: MergeStyle) -> Self {
-        Self {
-            index_oid,
-            merge_style,
-        }
+    pub fn new(index_oid: pg_sys::Oid) -> Self {
+        Self { index_oid }
     }
 
     pub fn index_oid(&self) -> pg_sys::Oid {
         self.index_oid
     }
-
-    pub fn merge_style(&self) -> MergeStyle {
-        self.merge_style
-    }
 }
 
 impl IntoDatum for BackgroundMergeArgs {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let oid = u32::from(self.index_oid) as u64;
-        let style = self.merge_style as u8 as u64;
-        let raw: u64 = (oid << 8) | style;
-        Some(pg_sys::Datum::from(raw as i64))
+        self.index_oid().into_datum()
     }
 
     fn type_oid() -> pg_sys::Oid {
-        pg_sys::INT8OID
+        pg_sys::OIDOID
     }
 }
 
@@ -91,19 +80,14 @@ impl FromDatum for BackgroundMergeArgs {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
-        typoid: pg_sys::Oid,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self> {
         if is_null {
             return None;
         }
 
-        let raw = i64::from_polymorphic_datum(datum, is_null, typoid).unwrap() as u64;
-        let index_oid = pg_sys::Oid::from((raw >> 8) as u32);
-        let merge_style = MergeStyle::try_from((raw & 0xFF) as u8).ok()?;
-        Some(BackgroundMergeArgs {
-            index_oid,
-            merge_style,
-        })
+        let index_oid = pg_sys::Oid::from_datum(datum, is_null)?;
+        Some(BackgroundMergeArgs { index_oid })
     }
 }
 
@@ -116,15 +100,18 @@ struct IndexLayerSizes {
 impl From<&PgSearchRelation> for IndexLayerSizes {
     fn from(index: &PgSearchRelation) -> Self {
         let index_options = index.options();
-        let all_entries = unsafe { MetaPage::open(index).segment_metas().list() };
-        let index_byte_size = all_entries
-            .iter()
-            .map(|entry| entry.byte_size())
-            .sum::<u64>();
-        let target_segment_count = index_options.target_segment_count();
-        let target_byte_size = index_byte_size / target_segment_count as u64;
 
-        // clamp the highest layer size to be less than the following:
+        let mut index_byte_size = 0;
+        unsafe {
+            MetaPage::open(index)
+                .segment_metas()
+                .for_each(|_, entry| index_byte_size += entry.byte_size());
+        }
+
+        let target_segment_count = index_options.target_segment_count();
+        let target_segment_byte_size = index_byte_size / target_segment_count as u64;
+
+        // clamp the highest layer size to be less than `target_segment_byte_size`:
         //
         // `index_byte_size` / `target_segment_count`
         //
@@ -139,18 +126,23 @@ impl From<&PgSearchRelation> for IndexLayerSizes {
         // - [1mb, 10mb]
         //
         // why? the 100mb layer gets excluded because the target segment size is 20mb
-        pgrx::debug1!("target_byte_size for merge: {target_byte_size}");
 
         let foreground_layer_sizes = index_options.foreground_layer_sizes();
-        pgrx::debug1!("foreground_layer_sizes: {foreground_layer_sizes:?}");
-
         let mut background_layer_sizes = index_options.background_layer_sizes();
-        let max_foreground_layer_size = foreground_layer_sizes.iter().max().unwrap_or(&0);
-        // additionally, ensure the background layer sizes are greater than the foreground ones
-        background_layer_sizes.retain(|&layer_size| {
-            layer_size < target_byte_size && layer_size > *max_foreground_layer_size
-        });
-        pgrx::debug1!("adjusted background_layer_sizes {background_layer_sizes:?}");
+
+        if !background_layer_sizes.is_empty() {
+            // additionally, ensure that the background layer sizes are <= to the target segment size
+            background_layer_sizes.retain(|&layer_size| layer_size <= target_segment_byte_size);
+
+            // ensure the background layer sizes can merge down to the target segment size
+            background_layer_sizes.push(target_segment_byte_size);
+        }
+
+        // NB:  it's possible a user could configure "layer_sizes = '10TB'" or something ridiculous
+        //      and that would cause us to merge the entire index into a single segment
+        //      uncommenting this would prevent that, but light up some unit tests
+        // // ensure the foreground layer sizes are <= to the target segment size
+        // foreground_layer_sizes.retain(|&layer_size| layer_size <= target_segment_byte_size);
 
         Self {
             foreground_layer_sizes,
@@ -159,12 +151,20 @@ impl From<&PgSearchRelation> for IndexLayerSizes {
     }
 }
 impl IndexLayerSizes {
-    fn foreground(&self) -> Vec<u64> {
-        self.foreground_layer_sizes.clone()
+    fn foreground(&self) -> &[u64] {
+        &self.foreground_layer_sizes
     }
 
-    fn background(&self) -> Vec<u64> {
-        self.background_layer_sizes.clone()
+    fn background(&self) -> &[u64] {
+        &self.background_layer_sizes
+    }
+
+    fn combined(&self) -> Vec<u64> {
+        let mut combined = self.foreground_layer_sizes.clone();
+        combined.extend_from_slice(&self.background_layer_sizes);
+        combined.sort_unstable();
+        combined.dedup();
+        combined
     }
 }
 
@@ -179,52 +179,46 @@ pub unsafe fn do_merge(
 ) -> anyhow::Result<()> {
     let merger = SearchIndexMerger::open(MvccSatisfies::Mergeable.directory(index))?;
     let layer_sizes = IndexLayerSizes::from(index);
-    let foreground_layers = layer_sizes.foreground();
-    let background_layers = layer_sizes.background();
 
     let metadata = MetaPage::open(index);
     let cleanup_lock = metadata.cleanup_lock_shared();
     let merge_lock = metadata.acquire_merge_lock();
 
-    let needs_background_merge = !background_layers.is_empty() && {
-        let mut background_merge_policy = LayeredMergePolicy::new(background_layers.clone());
-        background_merge_policy.set_mergeable_segment_entries(&metadata, &merge_lock, &merger);
-        let merge_candidates = background_merge_policy.simulate();
-        !merge_candidates.is_empty()
-    };
+    let needs_background_merge = style == MergeStyle::Vacuum
+        || (!layer_sizes.background().is_empty() && { merge_lock.merge_list().is_empty() } && {
+            let combined_layers = layer_sizes.combined();
+            let mut background_merge_policy = LayeredMergePolicy::new(combined_layers);
+            background_merge_policy.set_mergeable_segment_entries(&metadata, &merge_lock, &merger);
+            let merge_candidates = background_merge_policy.simulate();
+            !merge_candidates.is_empty()
+        });
 
-    // first merge down the foreground layers
-    if !foreground_layers.is_empty() && style == MergeStyle::Insert {
-        let foreground_merge_policy = LayeredMergePolicy::new(foreground_layers);
-        unsafe {
-            merge_index(
-                index,
-                foreground_merge_policy,
-                merge_lock,
-                cleanup_lock,
-                false,
-                current_xid.expect("foreground merging requires a current transaction id"),
-            )
-        };
-    } else {
+    if needs_background_merge {
+        // if we need (and think we can do) a background merge then we prefer to do that
         // we no longer need to hold the [`MergeLock`] as we're not merging in the foreground
         drop(merge_lock);
+        drop(cleanup_lock);
+
+        try_launch_background_merger(index);
+    } else if style == MergeStyle::Insert && !layer_sizes.foreground().is_empty() {
+        let foreground_merge_policy = LayeredMergePolicy::new(layer_sizes.foreground_layer_sizes);
+        merge_index(
+            index,
+            foreground_merge_policy,
+            merge_lock,
+            cleanup_lock,
+            false,
+            current_xid.expect("foreground merging requires a current transaction id"),
+        );
     }
 
-    pgrx::debug1!("foreground merge complete, needs_background_merge: {needs_background_merge}");
-
-    // then launch a background process to merge down the background layers
-    // only if we determine that there are enough segments to merge in the background
-    if needs_background_merge || style == MergeStyle::Vacuum {
-        try_launch_background_merger(index, style);
-    }
-
+    // merge_lock is dropped here
     Ok(())
 }
 
 /// Try to launch a background process to merge down the index.
 /// Is not guaranteed to launch the process if there are not enough `max_worker_processes` available.
-unsafe fn try_launch_background_merger(index: &PgSearchRelation, style: MergeStyle) {
+unsafe fn try_launch_background_merger(index: &PgSearchRelation) {
     let dbname = CStr::from_ptr(pg_sys::get_database_name(pg_sys::MyDatabaseId))
         .to_string_lossy()
         .into_owned();
@@ -240,7 +234,7 @@ unsafe fn try_launch_background_merger(index: &PgSearchRelation, style: MergeSty
         .enable_shmem_access(None)
         .set_library("pg_search")
         .set_function("background_merge")
-        .set_argument(BackgroundMergeArgs::new(index.oid(), style).into_datum())
+        .set_argument(BackgroundMergeArgs::new(index.oid()).into_datum())
         .set_extra(&dbname)
         .set_notify_pid(unsafe { pg_sys::MyProcPid })
         .load_dynamic()
@@ -254,22 +248,20 @@ unsafe fn try_launch_background_merger(index: &PgSearchRelation, style: MergeSty
 /// This function is called by the background worker.
 #[pg_guard]
 #[no_mangle]
-extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
+unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
     BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
     BackgroundWorker::connect_worker_to_spi(Some(BackgroundWorker::get_extra()), None);
     BackgroundWorker::transaction(|| {
-        unsafe {
-            set_ps_display_suffix(MERGING.as_ptr());
-            pg_sys::pgstat_report_activity(pg_sys::BackendState::STATE_RUNNING, MERGING.as_ptr());
-        };
+        set_ps_display_suffix(MERGING.as_ptr());
+        pg_sys::pgstat_report_activity(pg_sys::BackendState::STATE_RUNNING, MERGING.as_ptr());
 
         pgrx::debug1!(
             "{}: starting background merge",
             BackgroundWorker::get_name()
         );
 
-        let current_xid = unsafe { pg_sys::GetCurrentTransactionId() };
-        let args = unsafe { BackgroundMergeArgs::from_datum(arg, false) }.unwrap();
+        let current_xid = pg_sys::GetCurrentTransactionId();
+        let args = BackgroundMergeArgs::from_datum(arg, false).unwrap();
         let index = PgSearchRelation::try_open(
             args.index_oid(),
             pg_sys::AccessShareLock as pg_sys::LOCKMODE,
@@ -284,48 +276,18 @@ extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         let index = index.unwrap();
         let metadata = MetaPage::open(&index);
         let layer_sizes = IndexLayerSizes::from(&index);
+        let merge_policy = LayeredMergePolicy::new(layer_sizes.combined());
 
-        if args.merge_style() == MergeStyle::Vacuum {
-            pgrx::debug1!(
-                "{}: merging foreground layers",
-                BackgroundWorker::get_name()
-            );
-
-            let foreground_layers = layer_sizes.foreground();
-            let merge_policy = LayeredMergePolicy::new(foreground_layers);
-            let cleanup_lock = metadata.cleanup_lock_shared();
-            let merge_lock = unsafe { metadata.acquire_merge_lock() };
-            unsafe {
-                merge_index(
-                    &index,
-                    merge_policy,
-                    merge_lock,
-                    cleanup_lock,
-                    true,
-                    current_xid,
-                )
-            };
-        }
-
-        pgrx::debug1!(
-            "{}: merging background layers",
-            BackgroundWorker::get_name()
-        );
-
-        let background_layers = layer_sizes.background();
-        let merge_policy = LayeredMergePolicy::new(background_layers);
         let cleanup_lock = metadata.cleanup_lock_shared();
-        let merge_lock = unsafe { metadata.acquire_merge_lock() };
-        unsafe {
-            merge_index(
-                &index,
-                merge_policy,
-                merge_lock,
-                cleanup_lock,
-                true,
-                current_xid,
-            )
-        };
+        let merge_lock = metadata.acquire_merge_lock();
+        merge_index(
+            &index,
+            merge_policy,
+            merge_lock,
+            cleanup_lock,
+            true,
+            current_xid,
+        )
     });
 }
 
@@ -363,7 +325,7 @@ unsafe fn merge_index(
         // could be merged
         let merge_entry = merge_lock
             .merge_list()
-            .add_segment_ids(merge_policy.mergeable_segments())
+            .add_segment_ids(merge_policy.mergeable_segments(), current_xid)
             .expect("should be able to write current merge segment_id list");
         drop(merge_lock);
 
@@ -444,7 +406,6 @@ pub unsafe fn garbage_collect_index(
     segment_metas.commit();
     free_entries(indexrel, entries, current_xid);
 }
-
 /// Chase down all the files in a segment and return them to the FSM
 pub fn free_entries(
     indexrel: &PgSearchRelation,

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -306,6 +306,7 @@ impl MergeList {
     pub unsafe fn add_segment_ids<'a>(
         &mut self,
         segment_ids: impl IntoIterator<Item = &'a SegmentId>,
+        current_xid: pg_sys::TransactionId,
     ) -> anyhow::Result<MergeEntry> {
         assert!(pg_sys::IsTransactionState());
 
@@ -319,10 +320,9 @@ impl MergeList {
         segment_ids_list.writer().write(&segment_id_bytes)?;
 
         // fabricate and write the [`MergeEntry`] itself
-        let xid = pg_sys::GetCurrentTransactionId();
         let merge_entry = MergeEntry {
             pid: pg_sys::MyProcPid,
-            xmin: xid,
+            xmin: current_xid,
             _unused: pg_sys::InvalidTransactionId,
             segment_ids_start_blockno,
         };

--- a/tests/tests/layered_merge.rs
+++ b/tests/tests/layered_merge.rs
@@ -25,7 +25,7 @@ use sqlx::PgConnection;
 fn merges_to_1_100k_segment(mut conn: PgConnection) {
     r#"
         CREATE TABLE layer_sizes (id bigint);
-        CREATE INDEX idxlayer_sizes ON layer_sizes USING bm25(id) WITH (key_field='id', layer_sizes = '100kb, 1mb, 100mb');
+        CREATE INDEX idxlayer_sizes ON layer_sizes USING bm25(id) WITH (key_field='id', layer_sizes = '100kb, 1mb, 100mb', background_layer_sizes = '0');
     "#
     .execute_result(&mut conn).expect("creating table/index should not fail");
 
@@ -52,7 +52,7 @@ fn merge_with_no_positions(mut conn: PgConnection) {
             id serial8,
             message text
         );
-        CREATE INDEX idxtest ON test USING bm25 (id, message) WITH (key_field = 'id', target_segment_count = 8, layer_sizes = '10kb, 100kb, 1mb');
+        CREATE INDEX idxtest ON test USING bm25 (id, message) WITH (key_field = 'id', target_segment_count = 8, layer_sizes = '10kb, 100kb, 1mb', background_layer_sizes = '0');
     "#
     .execute(&mut conn);
 


### PR DESCRIPTION
We change the decisions around when/how/what to merge such that we prefer to merge in the background if we can.  That is defined as all of these being true:

- the user has either a default or non-zero configuration for `background_layer_sizes`
- no other merge (foreground or background) is currently happening
- the layer policy simulation indicates there is merging work to do 
 
 or

- the request to merge came from a VACUUM

Otherwise we'll merge in the foreground if:

- the request to merge came from `aminsert`
- the user has either a default or non-zero configuration for `layer_sizes`

Additionally, when merging in the background we now consider the combined/unique set of layer sizes from both `layer_sizes` and `background_layer_sizes`, and ensure the maximum layer size is clamped to our estimate of what an ideal segment size would be based on the current index size and the `target_segment_count`.

This still allows concurrent backends to merge into layers defined in `layer_sizes` in the foreground, but they'll prefer to launch that work in the background if it looks possible.

It does not necessarily ensure there'll only ever be one background merger per index at any given time, but in practice it's pretty close.
