### PR TITLE
ci: Add better logs for the `is_latest` in Publish Docker job

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -95,17 +95,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          # Get the upcoming and current latest release tag (without the "v")
-          current="${{ github.event.inputs.version }}"
+          current_tag_version="${{ github.event.inputs.version }}"
           latest_tag=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
-          echo "Current latest release is $latest_tag"
-          echo "Current version to be released is $current"
+          echo "Current latest release is $latest_tag_version"
+          echo "Current version to be released is $current_tag_version"
 
-          # Install semver CLI and compare versions according to semVer rules
+          echo ""
+          echo "Install semver CLI via npm to compare versions..."
           npm install semver
+
+          echo ""
+          echo "Comparing versions to determine if the current version is the latest..."
           if npx semver -r ">$latest_tag" "$current"; then
+            echo "is_latest=true"
             echo "is_latest=true" >> $GITHUB_OUTPUT
           else
+            echo "is_latest=false"
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -11,8 +11,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - phil/fix-docker-publish-latest
   workflow_dispatch:
     inputs:
       version:
@@ -137,33 +135,33 @@ jobs:
             type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest && !contains(github.ref, '-')}}
             type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest && !contains(github.ref, '-') }}
 
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ vars.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      # - name: Build and Push Docker Image to Docker Hub
-      #   id: build-push
-      #   uses: depot/build-push-action@v1
-      #   with:
-      #     context: .
-      #     build-args: |
-      #       PG_VERSION_MAJOR=${{ matrix.pg_version }}
-      #       COMMIT_SHA=${{ steps.version.outputs.commit_sha }}
-      #       PARADEDB_VERSION=${{ steps.version.outputs.version }}
-      #     platforms: linux/amd64,linux/arm64
-      #     file: docker/Dockerfile
-      #     push: true
-      #     sbom: true
-      #     provenance: mode=max
-      #     project: ${{ secrets.DEPOT_PROJECT }}
-      #     token: ${{ secrets.DEPOT_TOKEN }}
-      #     tags: ${{ steps.meta.outputs.tags }}
+      - name: Build and Push Docker Image to Docker Hub
+        id: build-push
+        uses: depot/build-push-action@v1
+        with:
+          context: .
+          build-args: |
+            PG_VERSION_MAJOR=${{ matrix.pg_version }}
+            COMMIT_SHA=${{ steps.version.outputs.commit_sha }}
+            PARADEDB_VERSION=${{ steps.version.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          file: docker/Dockerfile
+          push: true
+          sbom: true
+          provenance: mode=max
+          project: ${{ secrets.DEPOT_PROJECT }}
+          token: ${{ secrets.DEPOT_TOKEN }}
+          tags: ${{ steps.meta.outputs.tags }}
 
-      # - name: Sign and Attest Build Provenance
-      #   uses: actions/attest-build-provenance@v2
-      #   with:
-      #     subject-name: index.docker.io/paradedb/paradedb
-      #     subject-digest: ${{ steps.build-push.outputs.digest }}
-      #     push-to-registry: true
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/paradedb/paradedb
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -11,6 +11,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - phil/fix-docker-publish-latest
   workflow_dispatch:
     inputs:
       version:
@@ -91,17 +93,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GHA_CREATE_RELEASE_PAT }}
         run: |
-          # Get the upcoming and current latest release tag versions (without the "v")
           current_tag_version="${{ steps.version.outputs.version }}"
           latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
           echo "Current latest release is $latest_tag_version"
           echo "Current version to be released is $current_tag_version"
 
-          # Install semver CLI and compare versions according to semVer rules
+          echo ""
+          echo "Install semver CLI via npm to compare versions..."
           npm install semver
+
+          echo ""
+          echo "Comparing versions to determine if the current version is the latest..."
           if npx semver -r ">$latest_tag_version" "$current_tag_version"; then
+            echo "is_latest=true"
             echo "is_latest=true" >> $GITHUB_OUTPUT
           else
+            echo "is_latest=false"
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
@@ -130,33 +137,33 @@ jobs:
             type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest && !contains(github.ref, '-')}}
             type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest && !contains(github.ref, '-') }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ vars.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Build and Push Docker Image to Docker Hub
-        id: build-push
-        uses: depot/build-push-action@v1
-        with:
-          context: .
-          build-args: |
-            PG_VERSION_MAJOR=${{ matrix.pg_version }}
-            COMMIT_SHA=${{ steps.version.outputs.commit_sha }}
-            PARADEDB_VERSION=${{ steps.version.outputs.version }}
-          platforms: linux/amd64,linux/arm64
-          file: docker/Dockerfile
-          push: true
-          sbom: true
-          provenance: mode=max
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
-          tags: ${{ steps.meta.outputs.tags }}
+      # - name: Build and Push Docker Image to Docker Hub
+      #   id: build-push
+      #   uses: depot/build-push-action@v1
+      #   with:
+      #     context: .
+      #     build-args: |
+      #       PG_VERSION_MAJOR=${{ matrix.pg_version }}
+      #       COMMIT_SHA=${{ steps.version.outputs.commit_sha }}
+      #       PARADEDB_VERSION=${{ steps.version.outputs.version }}
+      #     platforms: linux/amd64,linux/arm64
+      #     file: docker/Dockerfile
+      #     push: true
+      #     sbom: true
+      #     provenance: mode=max
+      #     project: ${{ secrets.DEPOT_PROJECT }}
+      #     token: ${{ secrets.DEPOT_TOKEN }}
+      #     tags: ${{ steps.meta.outputs.tags }}
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: index.docker.io/paradedb/paradedb
-          subject-digest: ${{ steps.build-push.outputs.digest }}
-          push-to-registry: true
+      # - name: Sign and Attest Build Provenance
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-name: index.docker.io/paradedb/paradedb
+      #     subject-digest: ${{ steps.build-push.outputs.digest }}
+      #     push-to-registry: true


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
For some reason, it still published as `latest`. I don't know why, because I tested it and ran another branch with these logs, and it didn't tag as `latest`... Maybe the CI just needed to be updated in `main`? Anyways, dropping these logs in case this happens again.

## Why
^

## How
^

## Tests
^