### PR TITLE
fix: Remove the string/numeric classification from fast fields explain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,7 +3115,6 @@ dependencies = [
  "derive_more",
  "env_logger 0.11.8",
  "half 2.6.0",
- "itertools 0.14.0",
  "json5",
  "lazy_static",
  "macros",

--- a/docs/documentation/aggregates/overview.mdx
+++ b/docs/documentation/aggregates/overview.mdx
@@ -111,7 +111,6 @@ You can verify if a query will be accelerated by running `EXPLAIN`. Accelerated 
                      Segment Count: 1
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: rating
-                     Numeric Fast Fields: rating
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}}
 (14 rows)

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -29,7 +29,6 @@ bitpacking = "0.9.2"
 chrono = "0.4.41"
 derive_more = { version = "2.0.1", features = ["full"] }
 env_logger = "0.11.8"
-itertools = "0.14.0"
 json5 = "0.4.1"
 memoffset = "0.9.1"
 once_cell = "1.21.3"

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/fast_fields/mod.rs
@@ -35,7 +35,6 @@ use crate::postgres::var::{find_one_var, find_one_var_and_fieldname, VarContext}
 
 use arrow_array::builder::StringViewBuilder;
 use arrow_array::ArrayRef;
-use itertools::Itertools;
 use pgrx::pg_sys::CustomScanState;
 use pgrx::{pg_sys, IntoDatum, PgList, PgOid, PgTupleDesc};
 use tantivy::columnar::StrColumn;
@@ -435,31 +434,13 @@ pub fn explain(state: &CustomScanStateWrapper<PdbScan>, explainer: &mut Explaine
     } = &state.custom_state().exec_method_type
     {
         // Get all fast fields used
-        let string_fields: Vec<_> = which_fast_fields
+        let fields: Vec<_> = which_fast_fields
             .iter()
-            .filter(|ff| matches!(ff, WhichFastField::Named(_, FastFieldType::String)))
+            .filter(|ff| matches!(ff, WhichFastField::Named(_, _)))
             .map(|ff| ff.name())
-            .sorted()
             .collect();
 
-        let numeric_fields: Vec<_> = which_fast_fields
-            .iter()
-            .filter(|ff| matches!(ff, WhichFastField::Named(_, FastFieldType::Numeric)))
-            .map(|ff| ff.name())
-            .sorted()
-            .collect();
-
-        let all_fields = [string_fields.clone(), numeric_fields.clone()].concat();
-
-        explainer.add_text("Fast Fields", all_fields.join(", "));
-
-        if !string_fields.is_empty() {
-            explainer.add_text("String Fast Fields", string_fields.join(", "));
-        }
-
-        if !numeric_fields.is_empty() {
-            explainer.add_text("Numeric Fast Fields", numeric_fields.join(", "));
-        }
+        explainer.add_text("Fast Fields", fields.join(", "));
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/aggregate.out
+++ b/pg_search/tests/pg_regress/expected/aggregate.out
@@ -426,12 +426,10 @@ WHERE description @@@ 'laptop';
                Table: products
                Index: products_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: category, price
-               String Fast Fields: category
-               Numeric Fast Fields: price
+               Fast Fields: price, category
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+(13 rows)
 
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products 

--- a/pg_search/tests/pg_regress/expected/custom_scan_is_numeric_fast_field_capable.out
+++ b/pg_search/tests/pg_regress/expected/custom_scan_is_numeric_fast_field_capable.out
@@ -51,10 +51,9 @@ select assert(count(*), 8), count(*) from (select id from test where message @@@
                      Index: idxtest
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: severity
-                     Numeric Fast Fields: severity
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 select assert(count(*), 8), count(*) from (select id from test where message @@@ 'beer' order by severity) x limit 8;
  assert | count 
@@ -75,10 +74,9 @@ select assert(count(*), 8), count(*), max(id) from (select id from test where me
                      Index: idxtest
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: id, severity
-                     Numeric Fast Fields: id, severity
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 select assert(count(*), 8), count(*), max(id) from (select id from test where message @@@ 'beer' order by severity) x limit 8;
  assert | count | max 
@@ -99,10 +97,9 @@ select assert(count(*), 8), count(*), max(myid) from (select 12 as myid from tes
                      Index: idxtest
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: severity
-                     Numeric Fast Fields: severity
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"message","query_string":"beer","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(11 rows)
 
 select assert(count(*), 8), count(*), max(myid) from (select 12 as myid from test where message @@@ 'beer' order by severity) x limit 8;
  assert | count | max 

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -507,10 +507,9 @@ GROUP BY rating;
                Index: products_idx
                Exec Method: MixedFastFieldExecState
                Fast Fields: price, rating
-               Numeric Fast Fields: price, rating
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+(14 rows)
 
 SELECT rating, SUM(price), MAX(rating) 
 FROM products 
@@ -640,10 +639,9 @@ ORDER BY rating;
                Index: products_idx
                Exec Method: MixedFastFieldExecState
                Fast Fields: price, rating
-               Numeric Fast Fields: price, rating
                Scores: false
                Tantivy Query: {"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}]}}]}}
-(15 rows)
+(14 rows)
 
 SELECT rating, SUM(price), COUNT(*)
 FROM products 

--- a/pg_search/tests/pg_regress/expected/issue_2932.out
+++ b/pg_search/tests/pg_regress/expected/issue_2932.out
@@ -68,9 +68,8 @@ SELECT id, paradedb.score(id) * 2 AS score FROM mock_items WHERE description @@@
                Index: mock_items_id_description_rating_idx
                Exec Method: MixedFastFieldExecState
                Fast Fields: id
-               Numeric Fast Fields: id
                Scores: true
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(10 rows)
 
 DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/expected/mixed_fast_fields_bug.out
+++ b/pg_search/tests/pg_regress/expected/mixed_fast_fields_bug.out
@@ -115,11 +115,10 @@ ORDER BY numeric_field1;
          Table: benchmark_data
          Index: benchmark_data_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: numeric_field1, numeric_field2, numeric_field3
-         Numeric Fast Fields: numeric_field1, numeric_field2, numeric_field3
+         Fast Fields: numeric_field3, numeric_field2, numeric_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"string_field1","query_string":"IN [alpha beta gamma delta epsilon]","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"string_field2","query_string":"IN [red blue green]","lenient":null,"conjunction_mode":null}}}}]}}
-(10 rows)
+(9 rows)
 
 -- Run the query with MixedFastFieldExec (should return same data)
 SELECT

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_01_aggregation.out
@@ -346,10 +346,9 @@ WHERE content @@@ 'Socienty';
          Index: pages_search
          Exec Method: MixedFastFieldExecState
          Fast Fields: page_number
-         Numeric Fast Fields: page_number
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(8 rows)
 
 -- Test other aggregations
 SELECT 

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_02_mixed_fast_non_fast.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_02_mixed_fast_non_fast.out
@@ -318,12 +318,10 @@ ORDER BY fileId, page_number;
          Table: pages
          Index: pages_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: fileid, page_number
-         String Fast Fields: fileid
-         Numeric Fast Fields: page_number
+         Fast Fields: page_number, fileid
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Query with only fast fields
 SELECT fileId, page_number

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_04_execution_method_selection.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_04_execution_method_selection.out
@@ -365,10 +365,9 @@ ORDER BY text_field1, text_field2;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, text_field2
-         String Fast Fields: text_field1, text_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 SELECT text_field1, text_field2
 FROM exec_method_test
@@ -443,11 +442,9 @@ ORDER BY text_field1, num_field1, num_field2;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1, num_field2
-         String Fast Fields: text_field1
-         Numeric Fast Fields: num_field1, num_field2
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"excluded":10},"upper_bound":null,"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT text_field1, num_field1, num_field2
 FROM exec_method_test
@@ -511,12 +508,10 @@ ORDER BY text_field1, text_field2, num_field1, bool_field;
          Table: exec_method_test
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: text_field1, text_field2, bool_field, num_field1
-         String Fast Fields: text_field1, text_field2
-         Numeric Fast Fields: bool_field, num_field1
+         Fast Fields: text_field2, text_field1, bool_field, num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"bool_field","value":true,"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT text_field1, text_field2, num_field1, bool_field
 FROM exec_method_test
@@ -566,10 +561,9 @@ ORDER BY text_field1;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1
-         String Fast Fields: text_field1
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 SELECT text_field1
 FROM exec_method_test
@@ -644,10 +638,9 @@ ORDER BY num_field1, num_field2;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: num_field1, num_field2
-         Numeric Fast Fields: num_field1, num_field2
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"range":{"field":"num_field1","lower_bound":{"excluded":25},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}]}}
-(10 rows)
+(9 rows)
 
 SELECT num_field1, num_field2
 FROM exec_method_test
@@ -773,11 +766,9 @@ ORDER BY text_field1, num_field1 DESC;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1
-         String Fast Fields: text_field1
-         Numeric Fast Fields: num_field1
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 SELECT text_field1, num_field1
 FROM exec_method_test
@@ -854,12 +845,10 @@ ORDER BY text_field1, text_field2, num_field1, bool_field;
          Table: exec_method_test
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: text_field1, text_field2, bool_field, num_field1
-         String Fast Fields: text_field1, text_field2
-         Numeric Fast Fields: bool_field, num_field1
+         Fast Fields: text_field2, text_field1, bool_field, num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"text_field2","query_string":"Sample","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"included":10},"upper_bound":null,"is_datetime":false}},{"range":{"field":"num_field1","lower_bound":null,"upper_bound":{"included":40},"is_datetime":false}},{"term":{"field":"bool_field","value":true,"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT text_field1, text_field2, num_field1, bool_field
 FROM exec_method_test
@@ -907,11 +896,9 @@ ORDER BY t.text_field1, t.num_field1;
          Index: exec_method_idx
          Exec Method: MixedFastFieldExecState
          Fast Fields: text_field1, num_field1
-         String Fast Fields: text_field1
-         Numeric Fast Fields: num_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"text_field1","query_string":"Text","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"num_field1","lower_bound":{"excluded":10},"upper_bound":null,"is_datetime":false}},{"range":{"field":"num_field1","lower_bound":null,"upper_bound":{"excluded":30},"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT t.text_field1, t.num_field1
 FROM (

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
@@ -325,21 +325,17 @@ ORDER BY rating DESC, title;
                      Table: union_test_a
                      Index: union_test_a_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, price, rating
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: price, rating
+                     Fast Fields: author, price, rating, title
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}}]}}
                ->  Custom Scan (ParadeDB Scan) on union_test_b
                      Table: union_test_b
                      Index: union_test_b_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, price, rating
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: price, rating
+                     Fast Fields: author, price, rating, title
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}}]}}
-(23 rows)
+(19 rows)
 
 SELECT title, author, rating, price
 FROM union_test_a
@@ -409,21 +405,17 @@ ORDER BY price;
                Table: union_test_a
                Index: union_test_a_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: title, price, year
-               String Fast Fields: title
-               Numeric Fast Fields: price, year
+               Fast Fields: price, year, title
                Scores: false
                Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":null,"upper_bound":{"excluded":30.0},"is_datetime":false}},{"range":{"field":"year","lower_bound":{"excluded":2000},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
          ->  Custom Scan (ParadeDB Scan) on union_test_b
                Table: union_test_b
                Index: union_test_b_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: title, price, year
-               String Fast Fields: title
-               Numeric Fast Fields: price, year
+               Fast Fields: price, year, title
                Scores: false
                Tantivy Query: {"boolean":{"must":[{"range":{"field":"price","lower_bound":null,"upper_bound":{"excluded":45.0},"is_datetime":false}},{"range":{"field":"year","lower_bound":{"excluded":1982},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}}]}}
-(21 rows)
+(17 rows)
 
 SELECT title, price, year
 FROM union_test_a
@@ -465,12 +457,10 @@ ORDER BY title, author, author_rank;
                      Table: union_test_a
                      Index: union_test_a_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, price, rating
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: price, rating
+                     Fast Fields: author, price, title, rating
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+(12 rows)
 
 SELECT title, author, price, rating,
        ROW_NUMBER() OVER (PARTITION BY author, price ORDER BY rating DESC) as author_rank
@@ -549,12 +539,10 @@ ORDER BY title, author, price;
                      Table: union_test_a
                      Index: union_test_a_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, price
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: price
+                     Fast Fields: author, price, title
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+(12 rows)
 
 SELECT title, author, price,
        AVG(price) OVER (PARTITION BY author ORDER BY price) as running_avg_price
@@ -759,9 +747,7 @@ ORDER BY author, title;
                            Table: union_test_a
                            Index: union_test_a_idx
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: author, title, is_published
-                           String Fast Fields: author, title
-                           Numeric Fast Fields: is_published
+                           Fast Fields: author, is_published, title
                            Scores: false
                            Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_published","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author 1","lenient":null,"conjunction_mode":null}}}}]}}
                ->  Sort
@@ -770,12 +756,10 @@ ORDER BY author, title;
                            Table: union_test_b
                            Index: union_test_b_idx
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: author, title, is_published
-                           String Fast Fields: author, title
-                           Numeric Fast Fields: is_published
+                           Fast Fields: author, is_published, title
                            Scores: false
                            Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_published","value":true,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author 1","lenient":null,"conjunction_mode":null}}}}]}}
-(27 rows)
+(23 rows)
 
 SELECT title, author, is_published
 FROM union_test_a
@@ -888,11 +872,9 @@ ORDER BY avg_rating DESC;
                                  Index: union_test_a_idx
                                  Exec Method: MixedFastFieldExecState
                                  Fast Fields: author, price, rating
-                                 String Fast Fields: author
-                                 Numeric Fast Fields: price, rating
                                  Scores: false
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+(15 rows)
 
 SELECT author, 
        AVG(rating) as avg_rating,
@@ -933,7 +915,6 @@ INTERSECT
                      Index: union_test_b_idx
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: author
-                     String Fast Fields: author
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
          ->  Subquery Scan on "*SELECT* 1"
@@ -942,10 +923,9 @@ INTERSECT
                      Index: union_test_a_idx
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: author
-                     String Fast Fields: author
                      Scores: false
                      Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(20 rows)
+(18 rows)
 
 (SELECT author FROM union_test_a WHERE rating > 4.5 and title @@@ 'Book A')
 INTERSECT

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
@@ -365,12 +365,10 @@ LIMIT 10;
                Table: score_test
                Index: score_test_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: title, id, rating
-               String Fast Fields: title
-               Numeric Fast Fields: id, rating
+               Fast Fields: id, rating, title
                Scores: true
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(10 rows)
 
 SELECT title, paradedb.score(id), rating
 FROM score_test
@@ -407,12 +405,10 @@ LIMIT 5;
                Table: score_test
                Index: score_test_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: author, title, id, rating, views
-               String Fast Fields: author, title
-               Numeric Fast Fields: id, rating, views
+               Fast Fields: author, id, views, rating, title
                Scores: true
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research","lenient":null,"conjunction_mode":null}}}}
-(12 rows)
+(10 rows)
 
 SELECT title, author, rating, views, paradedb.score(id)
 FROM score_test
@@ -442,12 +438,10 @@ ORDER BY title, author, paradedb.score(id) DESC;
          Table: score_test
          Index: score_test_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: author, title, id
-         String Fast Fields: author, title
-         Numeric Fast Fields: id
+         Fast Fields: author, id, title
          Scores: true
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"term":{"field":"is_featured","value":true,"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT title, author, paradedb.score(id)
 FROM score_test
@@ -486,12 +480,10 @@ LIMIT 10;
                Table: score_test
                Index: score_test_idx
                Exec Method: MixedFastFieldExecState
-               Fast Fields: author, title, id, rating
-               String Fast Fields: author, title
-               Numeric Fast Fields: id, rating
+               Fast Fields: author, id, rating, title
                Scores: true
                Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science OR research","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}
-(12 rows)
+(10 rows)
 
 WITH scored_posts AS (
     SELECT title, author, rating, paradedb.score(id) as relevance
@@ -535,12 +527,10 @@ ORDER BY sp.title, sp.author, sp.relevance DESC;
          Table: score_test
          Index: score_test_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: author, title, id
-         String Fast Fields: author, title
-         Numeric Fast Fields: id
+         Fast Fields: author, id, title
          Scores: true
          Tantivy Query: {"score_filter":{"bounds":[[{"Excluded":0.5},"Unbounded"]],"query":{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}}}
-(11 rows)
+(9 rows)
 
 SELECT sp.title, sp.author, sp.relevance
 FROM (
@@ -617,21 +607,17 @@ LIMIT 10;
                      Table: score_test
                      Index: score_test_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, id
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: id
+                     Fast Fields: author, id, title
                      Scores: true
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
                ->  Custom Scan (ParadeDB Scan) on score_test score_test_1
                      Table: score_test
                      Index: score_test_idx
                      Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, title, id
-                     String Fast Fields: author, title
-                     Numeric Fast Fields: id
+                     Fast Fields: author, id, title
                      Scores: true
                      Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"technology","lenient":null,"conjunction_mode":null}}}}]}}]}}
-(22 rows)
+(18 rows)
 
 SELECT title, author, paradedb.score(id) as relevance
 FROM score_test
@@ -698,10 +684,9 @@ ORDER BY a.title, a.author, a.rating, a.score, b.title;
                      Index: score_test_idx
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: author
-                     String Fast Fields: author
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(27 rows)
+(26 rows)
 
 SELECT a.title, a.author, a.rating, a.score, b.title as related_title
 FROM (
@@ -804,12 +789,10 @@ ORDER BY title, author, paradedb.score(id) DESC;
          Table: score_test
          Index: score_test_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: author, title, id, rating
-         String Fast Fields: author, title
-         Numeric Fast Fields: id, rating
+         Fast Fields: author, id, rating, title
          Scores: true
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"research OR development","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":4},"upper_bound":null,"is_datetime":false}}]}}
-(11 rows)
+(9 rows)
 
 SELECT
     title,

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_07_recursive_cte.out
@@ -533,9 +533,7 @@ ORDER BY level, name;
                  Table: category
                  Index: category_idx
                  Exec Method: MixedFastFieldExecState
-                 Fast Fields: description, name, id, item_count, level, parent_id
-                 String Fast Fields: description, name
-                 Numeric Fast Fields: id, item_count, level, parent_id
+                 Fast Fields: level, id, name, description, item_count, parent_id
                  Scores: false
                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"books","lenient":null,"conjunction_mode":null}}}}
            ->  Hash Join
@@ -544,7 +542,7 @@ ORDER BY level, name;
                  ->  Hash
                        ->  Seq Scan on category c
    ->  CTE Scan on category_tree
-(19 rows)
+(17 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case with search
@@ -607,13 +605,11 @@ ORDER BY level, name;
                              Table: category
                              Index: category_idx
                              Exec Method: MixedFastFieldExecState
-                             Fast Fields: description, name, id, item_count, level, parent_id
-                             String Fast Fields: description, name
-                             Numeric Fast Fields: id, item_count, level, parent_id
+                             Fast Fields: level, id, name, description, item_count, parent_id
                              Scores: false
                              Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"computer","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"item_count","lower_bound":{"excluded":30},"upper_bound":null,"is_datetime":false}}]}}
    ->  CTE Scan on category_tree
-(20 rows)
+(18 rows)
 
 WITH RECURSIVE category_tree AS (
     -- Base case

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_08_type_conversion.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_08_type_conversion.out
@@ -315,12 +315,10 @@ WHERE content @@@ 'conversion test';
    Table: conversion_test
    Index: conversion_search
    Exec Method: MixedFastFieldExecState
-   Fast Fields: id, bigint_field, integer_field, smallint_field
-   String Fast Fields: id
-   Numeric Fast Fields: bigint_field, integer_field, smallint_field
+   Fast Fields: bigint_field, id, smallint_field, integer_field
    Scores: false
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"conversion test","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(7 rows)
 
 -- Check values for different integer types
 SELECT id, smallint_field, integer_field, bigint_field

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_09_multi_index_search.out
@@ -452,12 +452,10 @@ LIMIT 10;
                            Table: products
                            Index: products_idx
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: name, id, price
-                           String Fast Fields: name
-                           Numeric Fast Fields: id, price
+                           Fast Fields: name, price, id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+(19 rows)
 
 SELECT p.name, p.price, c.name as category
 FROM products p
@@ -503,11 +501,9 @@ LIMIT 5;
                            Index: products_idx
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: name, id
-                           String Fast Fields: name
-                           Numeric Fast Fields: id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"product","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+(15 rows)
 
 SELECT p.name, r.rating, r.content
 FROM products p
@@ -766,10 +762,9 @@ ORDER BY p.price;
                            Index: categories_idx
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: id
-                           Numeric Fast Fields: id
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"electronics OR clothing","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+(19 rows)
 
 SELECT p.name, p.price, p.stock_count
 FROM products p
@@ -932,12 +927,10 @@ ORDER BY r.rating DESC, p.price DESC;
                                  Table: products
                                  Index: products_idx
                                  Exec Method: MixedFastFieldExecState
-                                 Fast Fields: name, id, price
-                                 String Fast Fields: name
-                                 Numeric Fast Fields: id, price
+                                 Fast Fields: name, price, id
                                  Scores: false
                                  Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Product","lenient":null,"conjunction_mode":null}}}},{"term":{"field":"is_available","value":true,"is_datetime":false}}]}}
-(26 rows)
+(24 rows)
 
 SELECT p.name, p.price, r.content, r.rating
 FROM products p

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_01_basic_mixed_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_01_basic_mixed_fields.out
@@ -55,12 +55,10 @@ WHERE content @@@ 'red';
    Table: mixed_numeric_string_test
    Index: mixed_test_search
    Exec Method: MixedFastFieldExecState
-   Fast Fields: string_field1, string_field2, numeric_field1, numeric_field2
-   String Fast Fields: string_field1, string_field2
-   Numeric Fast Fields: numeric_field1, numeric_field2
+   Fast Fields: string_field1, numeric_field2, numeric_field1, string_field2
    Scores: false
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(9 rows)
+(7 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, numeric_field2, string_field1, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_02_multiple_string_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_02_multiple_string_fields.out
@@ -58,11 +58,10 @@ ORDER BY id;
          Table: mixed_numeric_string_test
          Index: mixed_test_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, string_field1, string_field2, string_field3
-         String Fast Fields: id, string_field1, string_field2, string_field3
+         Fast Fields: string_field1, id, string_field3, string_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Execute query and check results
 SELECT string_field1, string_field2, string_field3

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_03_multiple_numeric_fields.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_03_multiple_numeric_fields.out
@@ -58,12 +58,10 @@ ORDER BY id;
          Table: mixed_numeric_string_test
          Index: mixed_test_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, numeric_field1, numeric_field2
-         String Fast Fields: id
-         Numeric Fast Fields: numeric_field1, numeric_field2
+         Fast Fields: numeric_field2, numeric_field1, id
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, numeric_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_04_mixed_field_types.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_04_mixed_field_types.out
@@ -58,12 +58,10 @@ ORDER BY id;
          Table: mixed_numeric_string_test
          Index: mixed_test_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, string_field1, string_field2, numeric_field1, numeric_field2
-         String Fast Fields: id, string_field1, string_field2
-         Numeric Fast Fields: numeric_field1, numeric_field2
+         Fast Fields: numeric_field1, string_field1, id, numeric_field2, string_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"red","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Execute query and check results
 SELECT numeric_field1, string_field1, numeric_field2, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
@@ -49,11 +49,10 @@ SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
          Table: products
          Index: idxproducts
          Exec Method: MixedFastFieldExecState
-         Fast Fields: name, uuid_key
-         String Fast Fields: name, uuid_key
+         Fast Fields: uuid_key, name
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- And that non-key UUID fields do too.
 SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
@@ -73,11 +72,10 @@ SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid;
          Table: products
          Index: idxproducts
          Exec Method: MixedFastFieldExecState
-         Fast Fields: name, uuid
-         String Fast Fields: name, uuid
+         Fast Fields: uuid, name
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 \i common/common_cleanup.sql
 -- Reset parallel workers setting to default

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_01_corner_cases.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_01_corner_cases.out
@@ -152,11 +152,10 @@ ORDER BY id;
          Table: corner_case_test
          Index: corner_case_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: empty_string, id
-         String Fast Fields: empty_string, id
+         Fast Fields: id, empty_string
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Test handling of empty strings
 SELECT id, empty_string
@@ -222,10 +221,9 @@ ORDER BY id;
          Index: corner_case_search
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, special_chars
-         String Fast Fields: id, special_chars
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 SELECT id, special_chars
 FROM corner_case_test
@@ -256,12 +254,10 @@ ORDER BY id;
          Table: corner_case_test
          Index: corner_case_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, extreme_large, extreme_small
-         String Fast Fields: id
-         Numeric Fast Fields: extreme_large, extreme_small
+         Fast Fields: extreme_small, id, extreme_large
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Test handling of extreme numeric values
 SELECT id, extreme_large, extreme_small
@@ -294,11 +290,9 @@ ORDER BY id;
          Index: corner_case_search
          Exec Method: MixedFastFieldExecState
          Fast Fields: id, bool_field
-         String Fast Fields: id
-         Numeric Fast Fields: bool_field
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"test","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 SELECT id, bool_field
 FROM corner_case_test

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_02_null_handling.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_02_null_handling.out
@@ -150,12 +150,10 @@ ORDER BY id;
          Table: nullable_test
          Index: nullable_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, string_field, numeric_field
-         String Fast Fields: id, string_field
-         Numeric Fast Fields: numeric_field
+         Fast Fields: numeric_field, id, string_field
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"null","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Test retrieval of NULL values
 SELECT id, string_field, numeric_field

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_03_string_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_03_string_edge_cases.out
@@ -150,11 +150,10 @@ ORDER BY id;
          Table: mixed_numeric_string_test
          Index: mixed_string_edge_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: id, string_field1, string_field2
-         String Fast Fields: id, string_field1, string_field2
+         Fast Fields: string_field1, id, string_field2
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"edge case","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Test query
 SELECT id, string_field1, string_field2

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_04_complex_string_patterns.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_04_complex_string_patterns.out
@@ -150,11 +150,10 @@ ORDER BY id;
          Table: corner_case_test
          Index: corner_case_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: empty_string, id, special_chars
-         String Fast Fields: empty_string, id, special_chars
+         Fast Fields: id, empty_string, special_chars
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"complex pattern","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+(9 rows)
 
 -- Test query
 SELECT id, empty_string, special_chars 

--- a/pg_search/tests/pg_regress/expected/mixedff_edgecases_05_numeric_handling.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_edgecases_05_numeric_handling.out
@@ -117,11 +117,10 @@ ORDER BY numeric_field1;
          Table: benchmark_data
          Index: benchmark_data_idx
          Exec Method: MixedFastFieldExecState
-         Fast Fields: numeric_field1, numeric_field2, numeric_field3
-         Numeric Fast Fields: numeric_field1, numeric_field2, numeric_field3
+         Fast Fields: numeric_field3, numeric_field2, numeric_field1
          Scores: false
          Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"string_field1","query_string":"IN [alpha beta gamma delta epsilon]","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"string_field2","query_string":"IN [red blue green]","lenient":null,"conjunction_mode":null}}}}]}}
-(12 rows)
+(11 rows)
 
 -- Run the query with MixedFastFieldExec (should return same data)
 SELECT

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_01_complex_join.out
@@ -133,7 +133,6 @@ ORDER BY d.id, f.id, p.id;
                            Index: documents_search
                            Exec Method: MixedFastFieldExecState
                            Fast Fields: id, parents
-                           String Fast Fields: id, parents
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
                ->  Sort
@@ -142,20 +141,17 @@ ORDER BY d.id, f.id, p.id;
                            Table: files
                            Index: files_search
                            Exec Method: MixedFastFieldExecState
-                           Fast Fields: documentid, file_path, id, title
-                           String Fast Fields: documentid, file_path, id, title
+                           Fast Fields: file_path, id, documentid, title
                            Scores: false
                            Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
          ->  Custom Scan (ParadeDB Scan) on pages p
                Table: pages
                Index: pages_search
                Exec Method: MixedFastFieldExecState
-               Fast Fields: fileid, id, page_number
-               String Fast Fields: fileid, id
-               Numeric Fast Fields: page_number
+               Fast Fields: page_number, id, fileid
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(36 rows)
+(32 rows)
 
 -- Test complex join
 SELECT d.id, d.parents, f.title, f.file_path, p.fileId, p.page_number
@@ -206,8 +202,7 @@ LIMIT 10;
                                  Table: files
                                  Index: files_search
                                  Exec Method: MixedFastFieldExecState
-                                 Fast Fields: documentid, id
-                                 String Fast Fields: documentid, id
+                                 Fast Fields: id, documentid
                                  Scores: false
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
                      ->  Sort
@@ -216,9 +211,7 @@ LIMIT 10;
                                  Table: pages
                                  Index: pages_search
                                  Exec Method: MixedFastFieldExecState
-                                 Fast Fields: content, fileid, page_number
-                                 String Fast Fields: content, fileid
-                                 Numeric Fast Fields: page_number
+                                 Fast Fields: page_number, fileid, content
                                  Scores: false
                                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
                ->  Custom Scan (ParadeDB Scan) on documents
@@ -226,10 +219,9 @@ LIMIT 10;
                      Index: documents_search
                      Exec Method: MixedFastFieldExecState
                      Fast Fields: id
-                     String Fast Fields: id
                      Scores: false
                      Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-(37 rows)
+(33 rows)
 
 \i common/mixedff_queries_cleanup.sql
 -- Cleanup for relational query tests (07-10)

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_02_order_by.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_02_order_by.out
@@ -121,12 +121,10 @@ ORDER BY fileid, page_number;
          Table: pages
          Index: pages_search
          Exec Method: MixedFastFieldExecState
-         Fast Fields: fileid, page_number
-         String Fast Fields: fileid
-         Numeric Fast Fields: page_number
+         Fast Fields: page_number, fileid
          Scores: false
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-(11 rows)
+(9 rows)
 
 -- Execute query and verify results are ordered
 SELECT fileId, page_number

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_03_cte_test.out
@@ -144,8 +144,7 @@ ORDER BY document_title, file_title, page_number;
            Table: documents
            Index: documents_search
            Exec Method: MixedFastFieldExecState
-           Fast Fields: id, parents, title
-           String Fast Fields: id, parents, title
+           Fast Fields: parents, id, title
            Scores: false
            Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"CTE Test","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Reports","lenient":null,"conjunction_mode":null}}}}]}}
    CTE matching_files
@@ -155,9 +154,7 @@ ORDER BY document_title, file_title, page_number;
                  Table: files
                  Index: files_search
                  Exec Method: MixedFastFieldExecState
-                 Fast Fields: documentid, file_path, id, title, file_size
-                 String Fast Fields: documentid, file_path, id, title
-                 Numeric Fast Fields: file_size
+                 Fast Fields: file_path, title, id, documentid, file_size
                  Scores: false
                  Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"CTE Test","lenient":null,"conjunction_mode":null}}}}
            ->  CTE Scan on searchable_docs sd_1
@@ -174,12 +171,10 @@ ORDER BY document_title, file_title, page_number;
                Table: pages
                Index: pages_search
                Exec Method: MixedFastFieldExecState
-               Fast Fields: fileid, page_number
-               String Fast Fields: fileid
-               Numeric Fast Fields: page_number
+               Fast Fields: page_number, fileid
                Scores: false
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"searchable OR testing","lenient":null,"conjunction_mode":null}}}}
-(42 rows)
+(37 rows)
 
 -- Test with CTE
 WITH searchable_docs AS (

--- a/pg_search/tests/pg_regress/expected/mixedff_queries_05_join2.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_queries_05_join2.out
@@ -244,15 +244,13 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT users.color FROM users JOIN 
                Index: idxusers
                Exec Method: MixedFastFieldExecState
                Fast Fields: color, id
-               String Fast Fields: color
-               Numeric Fast Fields: id
                Scores: false
                Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
          ->  Bitmap Heap Scan on orders
                Recheck Cond: (users.id = id)
                ->  Bitmap Index Scan on orders_pkey
                      Index Cond: (id = users.id)
-(15 rows)
+(13 rows)
 
 SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.color @@@ 'blue') AND (users.name @@@ 'bob') LIMIT 10;
  color 

--- a/tests/tests/fast_fields.rs
+++ b/tests/tests/fast_fields.rs
@@ -147,7 +147,7 @@ WITH (
     let (plan, ) = "EXPLAIN (ANALYZE, FORMAT JSON) SELECT category, count(*) FROM paradedb.bm25_search WHERE id @@@ 'description:keyboard' GROUP BY category".fetch_one::<(Value,)>(&mut conn);
     assert_eq!(
         Some(&Value::String("category".into())),
-        plan.pointer("/0/Plan/Plans/0/Plans/0/String Fast Fields")
+        plan.pointer("/0/Plan/Plans/0/Plans/0/Fast Fields")
     )
 }
 


### PR DESCRIPTION
## What

Remove the string/numeric classification from MixedFastFields explain.

## Why

The distinction is no longer actually used in the scan implementation, and it can be confusing when the field being projected from is actually e.g. a JSON field with nested/dynamic columns for the subtypes.