### PR TITLE
fix: teach `push-file.yaml` how to retry

### DIFF
--- a/.github/actions/push-file/action.yml
+++ b/.github/actions/push-file/action.yml
@@ -1,4 +1,5 @@
-name: Commit and Push File
+name: "Commit and Push File"
+
 description: Checks out the specified remote repository, stages the provided file, commits it if there are changes, and pushes to the given branch.
 
 inputs:
@@ -60,11 +61,34 @@ runs:
           echo "no_changes=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Push changes
+    - name: Push changes with retry
       if: steps.commit.outputs.no_changes == 'false'
       shell: bash
       working-directory: "${{ inputs.repo-path }}"
-      run: git push origin HEAD:${{ inputs.branch }}
+      run: |
+        set -euo pipefail
+        max_attempts=10
+        delay=5
+
+        for attempt in $(seq 1 $max_attempts); do
+          echo "Attempt $attempt to push changes..."
+          if git push origin HEAD:${{ inputs.branch }}; then
+            echo "Push succeeded"
+            break
+          else
+            echo "Push failed (attempt $attempt)."
+            if [ $attempt -lt $max_attempts ]; then
+              echo "Fetching and rebasing before retry..."
+              git fetch origin "${{ inputs.branch }}"
+              git rebase "origin/${{ inputs.branch }}" || git rebase --abort
+              echo "Retrying in $delay seconds..."
+              sleep $delay
+            else
+              echo "All $max_attempts attempts to retry the push failed."
+              exit 1
+            fi
+          fi
+        done
 
     - name: Cleanup
       shell: bash

--- a/.github/actions/push-file/action.yml
+++ b/.github/actions/push-file/action.yml
@@ -67,8 +67,7 @@ runs:
       working-directory: "${{ inputs.repo-path }}"
       run: |
         set -euo pipefail
-        max_attempts=10
-        delay=5
+        max_attempts=5
 
         for attempt in $(seq 1 $max_attempts); do
           echo "Attempt $attempt to push changes..."
@@ -81,6 +80,8 @@ runs:
               echo "Fetching and rebasing before retry..."
               git fetch origin "${{ inputs.branch }}"
               git rebase "origin/${{ inputs.branch }}" || git rebase --abort
+
+              delay=$(( (RANDOM % 60) + 1 ))
               echo "Retrying in $delay seconds..."
               sleep $delay
             else

--- a/.github/actions/push-file/action.yml
+++ b/.github/actions/push-file/action.yml
@@ -1,5 +1,4 @@
-name: "Commit and Push File"
-
+name: Commit and Push File
 description: Checks out the specified remote repository, stages the provided file, commits it if there are changes, and pushes to the given branch.
 
 inputs:


### PR DESCRIPTION
## What

This teaches our `push-file.yml` action how to retry. 

## Why

At least in large benchmark backfills, concurrent jobs can end up trying to push to the same repo at the same time, and that means their local git state isn't up-to-date, so a retry is required.

## How

## Tests
