### PR TITLE
perf: update tantivy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4781,6 +4781,7 @@ dependencies = [
  "measure_time",
  "once_cell",
  "oneshot",
+ "parking_lot",
  "paste",
  "rayon",
  "regex",
@@ -4807,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "bitpacking",
 ]
@@ -4815,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4830,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4863,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "nom",
 ]
@@ -4871,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4884,9 +4885,12 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
+ "fixedbitset",
  "murmurhash32",
+ "once_cell",
+ "parking_lot",
  "rand_distr",
  "tantivy-common",
 ]
@@ -4894,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2#1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "3b5a6a84e06b41610531942a920fc7a70ebab3b7", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "1ff1fbdf06de241f6d02c682731dc4c4eef4fdc2" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "3b5a6a84e06b41610531942a920fc7a70ebab3b7" }


### PR DESCRIPTION
## What

Update our tantivy dependency to pick (mostly pg_search-specific) optimizations made in https://github.com/paradedb/tantivy/pull/60

This will be cherry-picked to v0.18.x.  A different PR will be for 0.17.x as our tantivy timeline has forked.

## Why

This drastically improves INSERT/UPDATE performance for single-row "atomic updates", especially if the connection doing it is persistent/long-lived.

## How

## Tests

All existing tests pass.