### PR TITLE
perf: update tantivy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4588,6 +4588,7 @@ dependencies = [
  "measure_time",
  "once_cell",
  "oneshot",
+ "parking_lot",
  "rayon",
  "regex",
  "rust-stemmers",
@@ -4613,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "bitpacking",
 ]
@@ -4621,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4636,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4669,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "nom",
 ]
@@ -4677,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4690,9 +4691,12 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
+ "fixedbitset",
  "murmurhash32",
+ "once_cell",
+ "parking_lot",
  "rand_distr",
  "tantivy-common",
 ]
@@ -4700,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=16740add9447330b133348448ce4988edcc8174f#16740add9447330b133348448ce4988edcc8174f"
+source = "git+https://github.com/paradedb/tantivy.git?branch=pg_search-0.17.x-compatible#9f9d48dbc3128d426b45e0da499df792e27dc73c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "16740add9447330b133348448ce4988edcc8174f", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "pg_search-0.17.x-compatible", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "16740add9447330b133348448ce4988edcc8174f" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "pg_search-0.17.x-compatible" }


### PR DESCRIPTION
## What

This is the 0.17.x-specific version of PR #3081.

## Why

Our tantivy timeline has forked and so has our dependency points.

## How

## Tests
