### PR TITLE
perf: FSM conditional locking & other minor drive-bys

### DIFF
--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -66,11 +66,13 @@ pub unsafe fn save_new_metas(
         .map(|s| s.id())
         .collect::<HashSet<_>>();
 
-    pgrx::debug1!(
-        "entered save_new_metas with {} new ids and {} previous ids",
-        new_ids.len(),
-        previous_ids.len()
-    );
+    if pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) {
+        pgrx::debug1!(
+            "entered save_new_metas with {} new ids and {} previous ids",
+            new_ids.len(),
+            previous_ids.len()
+        );
+    }
 
     // first, reorganize the directory_entries by segment id
     let mut new_files =
@@ -284,12 +286,16 @@ pub unsafe fn save_new_metas(
             // ... and add it to somewhere in the list, starting on this page
             linked_list.add_items(&[entry], Some(buffer));
         }
-        pgrx::debug1!("MODIFY: {entry:?}");
+        if pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) {
+            pgrx::debug1!("MODIFY: {entry:?}");
+        }
     }
 
     // add the new entries -- happens via an index commit or the result of a merge
     if !created_entries.is_empty() {
-        pgrx::debug1!("CREATE: {created_entries:?}");
+        if pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) {
+            pgrx::debug1!("CREATE: {created_entries:?}");
+        }
         linked_list.add_items(&created_entries, None);
     }
 

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -33,7 +33,7 @@ impl MergePolicy for LayeredMergePolicy {
             if self.enable_logging {
                 if let Some(directory) = directory {
                     directory.log(message);
-                } else {
+                } else if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
                     pgrx::debug1!("{message}");
                 }
             }
@@ -175,9 +175,7 @@ impl MergePolicy for LayeredMergePolicy {
 impl LayeredMergePolicy {
     pub fn new(layer_sizes: Vec<u64>) -> LayeredMergePolicy {
         Self {
-            n: std::thread::available_parallelism()
-                .expect("your computer should have at least one CPU")
-                .get(),
+            n: crate::available_parallelism(),
             layer_sizes,
             min_merge_count: 2,
             enable_logging: unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) },

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -17,6 +17,7 @@
 
 use crate::api::{HashMap, HashSet};
 use anyhow::Result;
+use pgrx::pg_sys;
 use std::num::NonZeroUsize;
 use tantivy::index::SegmentId;
 use tantivy::indexer::{AddOperation, IndexWriterOptions, SegmentWriter};
@@ -130,12 +131,14 @@ impl SerialIndexWriter {
         config: IndexWriterConfig,
         worker_number: i32,
     ) -> Result<Self> {
-        pgrx::debug1!(
-            "writer {}: opening index writer with config: {:?}, satisfies: {:?}",
-            worker_number,
-            config,
-            mvcc_satisfies
-        );
+        if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
+            pgrx::debug1!(
+                "writer {}: opening index writer with config: {:?}, satisfies: {:?}",
+                worker_number,
+                config,
+                mvcc_satisfies
+            );
+        }
 
         let directory = mvcc_satisfies.directory(index_relation);
         let mut index = Index::open(directory)?;
@@ -181,27 +184,31 @@ impl SerialIndexWriter {
         let max_doc = pending_segment.max_doc();
 
         if mem_usage >= self.config.memory_budget.into() {
-            pgrx::debug1!(
-                "writer {}: finalizing segment {} with {} docs, mem_usage: {} (out of {}), has created {} segments so far",
-                self.id,
-                pending_segment.segment.id(),
-                max_doc,
-                mem_usage,
-                self.config.memory_budget.get(),
-                self.new_metas.len()
-            );
+            if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
+                pgrx::debug1!(
+                    "writer {}: finalizing segment {} with {} docs, mem_usage: {} (out of {}), has created {} segments so far",
+                    self.id,
+                    pending_segment.segment.id(),
+                    max_doc,
+                    mem_usage,
+                    self.config.memory_budget.get(),
+                    self.new_metas.len()
+                );
+            }
             return self.finalize_segment(on_finalize);
         }
 
         if let Some(max_docs_per_segment) = self.config.max_docs_per_segment {
             if max_doc >= max_docs_per_segment as usize {
-                pgrx::debug1!(
-                    "writer {}: finalizing segment {} with {} docs, has created {} segments so far",
-                    self.id,
-                    pending_segment.segment.id(),
-                    max_doc,
-                    self.new_metas.len()
-                );
+                if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
+                    pgrx::debug1!(
+                        "writer {}: finalizing segment {} with {} docs, has created {} segments so far",
+                        self.id,
+                        pending_segment.segment.id(),
+                        max_doc,
+                        self.new_metas.len()
+                    );
+                }
                 return self.finalize_segment(on_finalize);
             }
         }
@@ -237,7 +244,9 @@ impl SerialIndexWriter {
         &mut self,
         on_finalize: OnFinalize,
     ) -> Result<Option<SegmentMeta>> {
-        pgrx::debug1!("writer {}: finalizing segment", self.id);
+        if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
+            pgrx::debug1!("writer {}: finalizing segment", self.id);
+        }
         let Some(pending_segment) = self.pending_segment.take() else {
             // no docs were ever added
             return Ok(None);
@@ -249,11 +258,13 @@ impl SerialIndexWriter {
     }
 
     fn commit_segment(&mut self, finalized_segment: Segment) -> Result<SegmentMeta> {
-        pgrx::debug1!(
-            "writer {}: committing segment {}",
-            self.id,
-            finalized_segment.id()
-        );
+        if unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) } {
+            pgrx::debug1!(
+                "writer {}: committing segment {}",
+                self.id,
+                finalized_segment.id()
+            );
+        }
         let previous_metas = self.new_metas.clone();
         let new_meta = finalized_segment.meta().clone();
         self.new_metas.push(new_meta.clone());

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -61,6 +61,17 @@ extension_sql!(
     finalize
 );
 
+pub fn available_parallelism() -> usize {
+    use once_cell::sync::Lazy;
+
+    static AVAILABLE_PARALLELISM: Lazy<usize> = Lazy::new(|| {
+        std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1)
+    });
+    *AVAILABLE_PARALLELISM
+}
+
 /// Initializes option parsing
 #[allow(clippy::missing_safety_doc)]
 #[allow(non_snake_case)]

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -310,11 +310,7 @@ impl BM25IndexOptions {
         self.options_data()
             .target_segment_count()
             .map(|count| count as usize)
-            .unwrap_or_else(|| {
-                std::thread::available_parallelism()
-                    .expect("your computer should have at least one CPU")
-                    .get()
-            })
+            .unwrap_or_else(crate::available_parallelism)
     }
 
     pub fn key_field_name(&self) -> FieldName {

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -160,6 +160,21 @@ impl RelationBufferAccess {
         )
     }
 
+    /// Retrieve an existing [`pg_sys::Buffer`] by its number with an exclusive lock.  If the lock
+    /// cannot be acquired due to another backend (or this one!) already holding a lock on it, this
+    /// function returns `None`.
+    pub fn get_buffer_conditional(&self, blockno: pg_sys::BlockNumber) -> Option<pg_sys::Buffer> {
+        unsafe {
+            let pg_buffer = pg_sys::ReadBuffer(self.rel.as_ptr(), blockno);
+            if pg_sys::ConditionalLockBuffer(pg_buffer) {
+                Some(pg_buffer)
+            } else {
+                pg_sys::ReleaseBuffer(pg_buffer);
+                None
+            }
+        }
+    }
+
     pub fn get_buffer_extended(
         &self,
         blockno: pg_sys::BlockNumber,


### PR DESCRIPTION
## What

Teach the FSM how to conditionally upgrade its buffer lock to an exclusive lock, skipping the page if it can't be acquired (unless it's the last page, then we wait).

While here, centralize `std::thread::available_parallelism()` (it actually showed up on profiles!) and gate some `pgrx::debug!()` statements

## Why

Trying to remove some overhead that showed up during profiling.

## How

## Tests
