### PR TITLE
fix: cherry pick excluded sub-queries from filter-pushdown (on non-indexed fields…

### DIFF
--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -913,6 +913,12 @@ unsafe fn try_pushdown(
                 return None;
             }
 
+            // Check if the expression contains subqueries (EXEC params)
+            // Subqueries require proper executor context which we don't have in HeapFieldFilter
+            if contains_exec_param(opexpr_node) {
+                return None;
+            }
+
             // We do use search (with heap filtering)
             state.uses_heap_expr = true;
             state.uses_tantivy_to_query = true;

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -978,3 +978,34 @@ ORDER BY score DESC;
   1 | Apple iPhone 14 | 999.99 | t        |    4.5 | 2.5521502
 (1 row)
 
+SET paradedb.enable_filter_pushdown = true;
+-- Test Case 19.1: Test that subqueries on the RHS of a heap filter which don't match anything don't
+-- result in an error.
+SELECT
+  products.id
+FROM products
+WHERE
+  (products.id @@@ paradedb.all())
+  AND (products.name ILIKE ANY (array['%Socks%']))
+  AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 1978) OR products.id < 1978 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 1978))
+ORDER BY products.created_at DESC, products.id DESC
+LIMIT 100;
+ id 
+----
+(0 rows)
+
+-- Test Case 19.2: Test that nested heap filters are solved.
+SELECT
+  products.id
+FROM products
+WHERE
+  (products.id @@@ paradedb.all())
+  AND (products.name ILIKE ANY (array['%Socks%']))
+  AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 7) OR products.id < 7 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 7))
+ORDER BY products.created_at DESC, products.id DESC
+LIMIT 100;
+ id 
+----
+(0 rows)
+
+RESET paradedb.enable_filter_pushdown;

--- a/pg_search/tests/pg_regress/sql/unified_expression_comprehensive.sql
+++ b/pg_search/tests/pg_regress/sql/unified_expression_comprehensive.sql
@@ -614,3 +614,29 @@ WHERE (name @@@ 'Apple' OR description @@@ 'smartphone')
     (category_name = 'Electronics' AND rating > 4.5)
   )
 ORDER BY score DESC; 
+
+SET paradedb.enable_filter_pushdown = true;
+-- Test Case 19.1: Test that subqueries on the RHS of a heap filter which don't match anything don't
+-- result in an error.
+SELECT
+  products.id
+FROM products
+WHERE
+  (products.id @@@ paradedb.all())
+  AND (products.name ILIKE ANY (array['%Socks%']))
+  AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 1978) OR products.id < 1978 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 1978))
+ORDER BY products.created_at DESC, products.id DESC
+LIMIT 100;
+
+-- Test Case 19.2: Test that nested heap filters are solved.
+SELECT
+  products.id
+FROM products
+WHERE
+  (products.id @@@ paradedb.all())
+  AND (products.name ILIKE ANY (array['%Socks%']))
+  AND (products.created_at < (SELECT created_at FROM products WHERE products.id = 7) OR products.id < 7 AND products.created_at = (SELECT created_at FROM products WHERE products.id = 7))
+ORDER BY products.created_at DESC, products.id DESC
+LIMIT 100;
+
+RESET paradedb.enable_filter_pushdown;


### PR DESCRIPTION
…). (#3045)

# Ticket(s) Closed

- Closes #3043 

## What

Prevents system crashes when `paradedb.enable_filter_pushdown` is enabled and heap filter expressions contain subqueries.

## Why

When `enable_filter_pushdown` is enabled, expressions that cannot be pushed down to the index are converted to `Qual::HeapExpr` for heap-based evaluation. However, `HeapFieldFilter` uses `CreateStandaloneExprContext()` which lacks the infrastructure needed for subquery evaluation (subplans, proper executor state), causing system crashes when subqueries are present.

## How

Added subquery detection in `try_pushdown()` using the existing `contains_exec_param()` function to identify expressions containing EXEC parameters (subqueries). When subqueries are detected, the function returns `None` instead of creating a `Qual::HeapExpr`, causing PostgreSQL's regular executor to handle the expression safely.

## Tests

- Added test cases in `unified_expression_comprehensive.sql` with subqueries in heap filter expressions

---------

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
