### PR TITLE
fix: fix failing test

### DIFF
--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -460,7 +460,7 @@ mod tests {
             memory_budget: NonZeroUsize::new(15 * 1024 * 1024).unwrap(),
             max_docs_per_segment: None,
         };
-        let segment_ids = simulate_index_writer(config, relation_oid, 25000);
+        let segment_ids = simulate_index_writer(config, relation_oid, 75000);
         assert_eq!(segment_ids.len(), 5);
     }
 


### PR DESCRIPTION
## What

Our recent changes to tantivy have adjusted the default MemoryArena page size from 1MB to 512k, and this actually has a downstream effect of allowing indexers to fit more docs in the arena before tantivy calcuates that the indexer has exceeded its memory budget.

We have a test that exposed this, so this adjustes the number of documents to insert to generate 5 segments.

## Why

## How

## Tests
