### PR TITLE
chore: cherry-pick action no longer passes labels to PRs

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           branch: "0.17.x"
           token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          inherit_labels: false
 
   cherry-pick-to-0-18:
     name: Cherry Pick to 0.18.x
@@ -40,3 +41,4 @@ jobs:
         with:
           branch: "0.18.x"
           token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          inherit_labels: false


### PR DESCRIPTION
## What

This sets the `inherit_labels` property for the `carloscastrojumo/github-cherry-pick-action` to `false` -- default is `true`

## Why

I find it very confusing that the cherry-pick PRs this action creates also contain the `[cherry-pick/...]` labels.

## How

## Tests
