### PR TITLE
fix: Clarify v2 API docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -198,7 +198,7 @@
             "icon": "sparkles",
             "groups": [
               {
-                "group": "Documentation",
+                "group": "Documentation (v2)",
                 "pages": [
                   "v2/overview",
                   {

--- a/docs/v2/aggregates/overview.mdx
+++ b/docs/v2/aggregates/overview.mdx
@@ -2,4 +2,4 @@
 title: Overview
 ---
 
-The `v2` interface for aggregates is still in progress. Please continue to use `v1` for this capability.
+The `v2` interface for aggregates is still in progress. Please continue to use [`v1` for this capability](/documentation/aggregates/overview).

--- a/docs/v2/full-text/phrase.mdx
+++ b/docs/v2/full-text/phrase.mdx
@@ -62,4 +62,4 @@ Slop allows phrase queries to be relaxed a bit. It specifies how many changes â€
 For example, searching for `sleek shoes` with a slop of `1` would match `sleek running shoes` because there is one word, `running`, between
 `sleek` and `shoes`.
 
-Slop has not yet been implemented in `v2`. Please continue to use `v1` for this capability.
+Slop has not yet been implemented in `v2`. Please continue to use [`v1` for this capability](/documentation/full-text/phrase).

--- a/docs/v2/indexing/create_index.mdx
+++ b/docs/v2/indexing/create_index.mdx
@@ -2,4 +2,4 @@
 title: Create an Index
 ---
 
-The `v2` interface for creating and configuring index is still in progress. Please refer to the `v1` docs.
+The `v2` interface for creating and configuring indexes is still in progress. Please refer to the [`v1` docs](/documentation/indexing/create_index).

--- a/docs/v2/overview.mdx
+++ b/docs/v2/overview.mdx
@@ -9,6 +9,8 @@ title: Overview
 ParadeDB is undergoing a revamp to make its SQL interface more intuitive and ORM-friendly.
 This new experience is being introduced as `v2` of the API.
 
+To move back to the v1 API at any time click `Documentation` in the left navigation bar.
+
 `v1` will remain fully supported — there’s no need to change existing integrations.
 `v2` focuses on improving developer experience across three key areas:
 


### PR DESCRIPTION
Small fixes to make sure people don't get lost or stuck in the v2 docs.

- Add link back to v1 from v2 overview
- Add links back to correct page in v1 when v2 isn't implemented
- Change the sidebar anchor for v2 to be "Documentation (v2)"