### PR TITLE
chore: cherry-pick PR3013 to main

### DIFF
--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use pgrx::{pg_sys, IntoDatum};
+use std::ffi::CStr;
+
+/// Helper function to lookup a namespace's [`pg_sys::Oid`] (SQL schema) by name
+pub fn lookup_namespace(namespace: &CStr) -> Option<pg_sys::Oid> {
+    unsafe {
+        let namespace_oid = pg_sys::get_namespace_oid(namespace.as_ptr(), true);
+        (namespace_oid != pg_sys::InvalidOid).then_some(namespace_oid)
+    }
+}
+
+/// Helper function to lookup a type's [`pg_sys::Oid`] by name and namespace
+pub fn lookup_typoid(namespace: &CStr, typename: &CStr) -> Option<pg_sys::Oid> {
+    unsafe {
+        let typoid = pg_sys::GetSysCacheOid(
+            pg_sys::SysCacheIdentifier::TYPENAMENSP as _,
+            pg_sys::Anum_pg_type_oid as _,
+            pg_sys::Datum::from(typename.as_ptr()),
+            lookup_namespace(namespace).into_datum()?,
+            pg_sys::Datum::null(),
+            pg_sys::Datum::null(),
+        );
+        (typoid != pg_sys::InvalidOid).then_some(typoid)
+    }
+}
+
+/// Helper function to lookup a function's [`pg_sys::Oid`] by name, argument types, and namespace
+pub fn lookup_procoid(
+    namespace: &CStr,
+    fucname: &CStr,
+    argtypes: &[pg_sys::Oid],
+) -> Option<pg_sys::Oid> {
+    unsafe {
+        let argvec = pg_sys::buildoidvector(argtypes.as_ptr(), argtypes.len() as _);
+        let procoid = pg_sys::GetSysCacheOid(
+            pg_sys::SysCacheIdentifier::PROCNAMEARGSNSP as _,
+            pg_sys::Anum_pg_proc_oid as _,
+            pg_sys::Datum::from(fucname.as_ptr()),
+            pg_sys::Datum::from(argvec),
+            lookup_namespace(namespace).into_datum()?,
+            pg_sys::Datum::null(),
+        );
+        pg_sys::pfree(argvec.cast());
+        (procoid != pg_sys::InvalidOid).then_some(procoid)
+    }
+}

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -38,6 +38,7 @@ mod vacuum;
 mod validate;
 
 mod build_parallel;
+pub mod catalog;
 pub mod customscan;
 pub mod datetime;
 #[cfg(not(feature = "pg17"))]

--- a/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
+++ b/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
@@ -3,20 +3,18 @@ CREATE TABLE missing_fn (id int);
 INSERT INTO missing_fn (id) SELECT generate_series(1, 1000);
 CREATE INDEX idxmissing_fn ON missing_fn USING bm25 (id) WITH (key_field = 'id');
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Merge
-   Workers Planned: 1
-   ->  Sort
-         Sort Key: id
-         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
-               Table: missing_fn
-               Index: idxmissing_fn
-               Exec Method: NumericFastFieldExecState
-               Fast Fields: id
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"term_set":{"terms":[{"field":"id","value":3,"is_datetime":false}]}},{"with_index":{"query":"all"}}]}}
-(11 rows)
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Custom Scan (ParadeDB Scan) on missing_fn
+         Table: missing_fn
+         Index: idxmissing_fn
+         Exec Method: MixedFastFieldExecState
+         Fast Fields: id
+         Scores: false
+         Tantivy Query: {"boolean":{"must":[{"term_set":{"terms":[{"field":"id","value":3,"is_datetime":false}]}},{"with_index":{"query":"all"}}]}}
+(9 rows)
 
 SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
  id 
@@ -28,20 +26,19 @@ BEGIN;
 ALTER EXTENSION pg_search DROP FUNCTION paradedb.terms_with_operator;
 DROP FUNCTION paradedb.terms_with_operator;
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
-                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Merge
-   Workers Planned: 1
-   ->  Sort
-         Sort Key: id
-         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
-               Table: missing_fn
-               Index: idxmissing_fn
-               Exec Method: NumericFastFieldExecState
-               Fast Fields: id
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":"all"}}]}},"field_filters":[{"expr_node":"{SCALARARRAYOPEXPR :opno 96 :opfuncid 65 :hashfuncid 0 :negfuncid 0 :useOr true :inputcollid 0 :args ({VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 1007 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 28 [ 112 0 0 0 1 0 0 0 0 0 0 0 23 0 0 0 1 0 0 0 1 0 0 0 3 0 0 0 ]}) :location -1}","description":"OpExpr with operator OID 96"}]}}]}}
-(11 rows)
+                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Custom Scan (ParadeDB Scan) on missing_fn
+         Table: missing_fn
+         Index: idxmissing_fn
+         Exec Method: MixedFastFieldExecState
+         Fast Fields: id
+         Scores: false
+         Full Index Scan: true
+         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":"all"}}]}},"field_filters":[{"expr_node":"{SCALARARRAYOPEXPR :opno 96 :opfuncid 65 :hashfuncid 0 :negfuncid 0 :useOr true :inputcollid 0 :args ({VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 1007 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 28 [ 112 0 0 0 1 0 0 0 0 0 0 0 23 0 0 0 1 0 0 0 1 0 0 0 3 0 0 0 ]}) :location -1}","description":"OpExpr with operator OID 96"}]}}]}}
+(10 rows)
 
 SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
  id 

--- a/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
+++ b/pg_search/tests/pg_regress/expected/missing_terms_with_operator_fn.out
@@ -1,0 +1,52 @@
+DROP TABLE IF EXISTS missing_fn;
+CREATE TABLE missing_fn (id int);
+INSERT INTO missing_fn (id) SELECT generate_series(1, 1000);
+CREATE INDEX idxmissing_fn ON missing_fn USING bm25 (id) WITH (key_field = 'id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 1
+   ->  Sort
+         Sort Key: id
+         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
+               Table: missing_fn
+               Index: idxmissing_fn
+               Exec Method: NumericFastFieldExecState
+               Fast Fields: id
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"term_set":{"terms":[{"field":"id","value":3,"is_datetime":false}]}},{"with_index":{"query":"all"}}]}}
+(11 rows)
+
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ id 
+----
+  3
+(1 row)
+
+BEGIN;
+ALTER EXTENSION pg_search DROP FUNCTION paradedb.terms_with_operator;
+DROP FUNCTION paradedb.terms_with_operator;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 1
+   ->  Sort
+         Sort Key: id
+         ->  Parallel Custom Scan (ParadeDB Scan) on missing_fn
+               Table: missing_fn
+               Index: idxmissing_fn
+               Exec Method: NumericFastFieldExecState
+               Fast Fields: id
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":"all"}}]}},"field_filters":[{"expr_node":"{SCALARARRAYOPEXPR :opno 96 :opfuncid 65 :hashfuncid 0 :negfuncid 0 :useOr true :inputcollid 0 :args ({VAR :varno 1 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varnosyn 1 :varattnosyn 1 :location -1} {CONST :consttype 1007 :consttypmod -1 :constcollid 0 :constlen -1 :constbyval false :constisnull false :location -1 :constvalue 28 [ 112 0 0 0 1 0 0 0 0 0 0 0 23 0 0 0 1 0 0 0 1 0 0 0 3 0 0 0 ]}) :location -1}","description":"OpExpr with operator OID 96"}]}}]}}
+(11 rows)
+
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ id 
+----
+  3
+(1 row)
+
+ABORT;

--- a/pg_search/tests/pg_regress/sql/missing_terms_with_operator_fn.sql
+++ b/pg_search/tests/pg_regress/sql/missing_terms_with_operator_fn.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS missing_fn;
+CREATE TABLE missing_fn (id int);
+INSERT INTO missing_fn (id) SELECT generate_series(1, 1000);
+CREATE INDEX idxmissing_fn ON missing_fn USING bm25 (id) WITH (key_field = 'id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+
+BEGIN;
+ALTER EXTENSION pg_search DROP FUNCTION paradedb.terms_with_operator;
+DROP FUNCTION paradedb.terms_with_operator;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+SELECT * FROM missing_fn WHERE id = ANY(ARRAY[3]) AND id @@@ paradedb.all() ORDER BY id;
+ABORT;


### PR DESCRIPTION
Cherry picks PR #3013, which only landed in 0.17.x, to `main` and `0.18.x` via the label.