### PR TITLE
chore: add a label to automated cherry picks

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -24,6 +24,7 @@ jobs:
           branch: "0.17.x"
           token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
           inherit_labels: false
+          labels: automated-cherry-pick
 
   cherry-pick-to-0-18:
     name: Cherry Pick to 0.18.x
@@ -42,3 +43,4 @@ jobs:
           branch: "0.18.x"
           token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
           inherit_labels: false
+          labels: automated-cherry-pick


### PR DESCRIPTION
## What

In #3095 I removed the `[cherry-pick/x.y.z]` labels from our automated cherry pick PRs, but after seeing that in action I think some kind of label will be helpful.  So this adds `[automated-cherry-pick]`, which is not a bright, burning red but a cool, neutral gray.

## Why

To make looking at the PR list a little easier

## How

## Tests
