### PR TITLE
fix: Fix handling of nulls in TopN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "bitpacking",
 ]
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "nom",
 ]
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "bitpacking",
 ]
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "nom",
 ]
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=3b5a6a84e06b41610531942a920fc7a70ebab3b7#3b5a6a84e06b41610531942a920fc7a70ebab3b7"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.top-orderable-null-handling#bf16ca4fa6e5d6160d958c7c7f3e58799659b246"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.top-orderable-null-handling", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "5b5ea7576c68b7c949691c0cddef4539bb8be5ce", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.top-orderable-null-handling" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "5b5ea7576c68b7c949691c0cddef4539bb8be5ce" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "3b5a6a84e06b41610531942a920fc7a70ebab3b7", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.top-orderable-null-handling", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "3b5a6a84e06b41610531942a920fc7a70ebab3b7" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.top-orderable-null-handling" }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -71,7 +71,7 @@ impl PartialOrd for SearchIndexScore {
 pub type FastFieldCache = HashMap<SegmentOrdinal, FFType>;
 
 /// See `SearchIndexReader::erased_features`.
-type ErasedFeature = Arc<dyn Feature<Output = OwnedValue, SegmentOutput = u64>>;
+type ErasedFeature = Arc<dyn Feature<Output = OwnedValue, SegmentOutput = Option<u64>>>;
 
 /// A known-size iterator of results for Top-N.
 pub struct TopNSearchResults {

--- a/pg_search/tests/pg_regress/expected/top_n_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_n_scan.out
@@ -357,7 +357,21 @@ WHERE id @@@ paradedb.all()
   AND state IS NULL
 ORDER BY state, id
 LIMIT 10000;
-ERROR:  Not all terms were matched in segment.
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=2500 loops=1)
+   ->  Custom Scan (ParadeDB Scan) on records (actual rows=2500 loops=1)
+         Table: records
+         Index: records_search_idx
+         Heap Fetches: 2500
+         Exec Method: TopNScanExecState
+         Scores: false
+            TopN Order By: state asc, id asc
+            TopN Limit: 10000
+            Queries: 1
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":"all"}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"state"}}]}}]}}
+(11 rows)
+
 -- Cleanup
 DROP INDEX IF EXISTS records_search_idx;
 DROP TABLE IF EXISTS records;

--- a/pg_search/tests/pg_regress/expected/top_n_scan.out
+++ b/pg_search/tests/pg_regress/expected/top_n_scan.out
@@ -63,7 +63,7 @@ SELECT
     ),
     CASE WHEN i % 7 = 0 THEN '2023-06-01'::timestamp + ((i % 30) || ' days')::interval ELSE NULL END,
     CASE WHEN i % 4 = 0 THEN 'USD' WHEN i % 4 = 1 THEN 'EUR' WHEN i % 4 = 2 THEN 'GBP' ELSE 'JPY' END,
-    CASE WHEN i % 3 = 0 THEN 'pending' WHEN i % 3 = 1 THEN 'completed' ELSE 'failed' END,
+    CASE WHEN i % 4 = 0 THEN 'pending' WHEN i % 4 = 1 THEN 'completed' WHEN i % 4 = 2 THEN 'failed' ELSE NULL END,
     CASE WHEN i % 2 = 0 THEN 'inbound' ELSE 'outbound' END
 FROM generate_series(1, 10000) i;
 -- Create a search index with various field types
@@ -347,6 +347,17 @@ LIMIT 25;
                Tantivy Query: {"boolean":{"must":[{"term":{"field":"is_active","value":true,"is_datetime":false}},{"with_index":{"query":{"match":{"field":"notes","value":"check","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}},{"term":{"field":"tenant_id","value":"tenant-1","is_datetime":false}}]}}
 (9 rows)
 
+-- Test 11: ORDER BY on column containing NULL.
+\echo 'Test 11: ORDER BY on column containing NULL.'
+Test 11: ORDER BY on column containing NULL.
+EXPLAIN (ANALYZE, COSTS OFF, BUFFERS OFF, TIMING OFF, SUMMARY OFF)
+SELECT state, id
+FROM records
+WHERE id @@@ paradedb.all()
+  AND state IS NULL
+ORDER BY state, id
+LIMIT 10000;
+ERROR:  Not all terms were matched in segment.
 -- Cleanup
 DROP INDEX IF EXISTS records_search_idx;
 DROP TABLE IF EXISTS records;

--- a/pg_search/tests/pg_regress/sql/top_n_scan.sql
+++ b/pg_search/tests/pg_regress/sql/top_n_scan.sql
@@ -61,7 +61,7 @@ SELECT
     ),
     CASE WHEN i % 7 = 0 THEN '2023-06-01'::timestamp + ((i % 30) || ' days')::interval ELSE NULL END,
     CASE WHEN i % 4 = 0 THEN 'USD' WHEN i % 4 = 1 THEN 'EUR' WHEN i % 4 = 2 THEN 'GBP' ELSE 'JPY' END,
-    CASE WHEN i % 3 = 0 THEN 'pending' WHEN i % 3 = 1 THEN 'completed' ELSE 'failed' END,
+    CASE WHEN i % 4 = 0 THEN 'pending' WHEN i % 4 = 1 THEN 'completed' WHEN i % 4 = 2 THEN 'failed' ELSE NULL END,
     CASE WHEN i % 2 = 0 THEN 'inbound' ELSE 'outbound' END
 FROM generate_series(1, 10000) i;
 
@@ -215,6 +215,16 @@ WHERE tenant_id = 'tenant-1'
   AND (id @@@ paradedb.match('notes', 'check'))
 ORDER BY time_period DESC
 LIMIT 25;
+
+-- Test 11: ORDER BY on column containing NULL.
+\echo 'Test 11: ORDER BY on column containing NULL.'
+EXPLAIN (ANALYZE, COSTS OFF, BUFFERS OFF, TIMING OFF, SUMMARY OFF)
+SELECT state, id
+FROM records
+WHERE id @@@ paradedb.all()
+  AND state IS NULL
+ORDER BY state, id
+LIMIT 10000;
 
 -- Cleanup
 DROP INDEX IF EXISTS records_search_idx;

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -49,6 +49,7 @@ pub struct Column {
     pub sample_value: &'static str,
     pub is_primary_key: bool,
     pub is_groupable: bool,
+    pub is_whereable: bool,
     pub is_indexed: bool,
     pub bm25_options: Option<BM25Options>,
     pub random_generator_sql: &'static str,
@@ -66,6 +67,7 @@ impl Column {
             sample_value,
             is_primary_key: false,
             is_groupable: true,
+            is_whereable: true,
             is_indexed: true,
             bm25_options: None,
             random_generator_sql: "NULL",
@@ -79,6 +81,11 @@ impl Column {
 
     pub const fn groupable(mut self, is_groupable: bool) -> Self {
         self.is_groupable = is_groupable;
+        self
+    }
+
+    pub const fn whereable(mut self, is_whereable: bool) -> Self {
+        self.is_whereable = is_whereable;
         self
     }
 

--- a/tests/tests/fixtures/querygen/wheregen.rs
+++ b/tests/tests/fixtures/querygen/wheregen.rs
@@ -64,6 +64,7 @@ pub fn arb_wheres(tables: Vec<impl AsRef<str>>, columns: &[Column]) -> impl Stra
         .collect::<Vec<_>>();
     let columns = columns
         .iter()
+        .filter(|c| c.is_whereable)
         .map(|c| (c.name.to_owned(), c.sample_value.to_owned(), c.is_indexed))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
## What

TopN was not handling nulls properly: instead, they were filled in with a default, which would cause an error when the limit was high enough to include them.

## How

See https://github.com/paradedb/tantivy/pull/61.

## Tests

Added a regression test and property tests (which exposed a related issue in pushdown: https://github.com/paradedb/paradedb/pull/3110).