### PR TITLE
chore: Upgrade to `0.17.12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.17.10"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.17.10"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.17.10"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "approx",
@@ -4895,7 +4895,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.17.10"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "lindera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["pg_search", "tests", "tokenizers", "benchmarks"]
 
 [workspace.package]
-version = "0.17.10"
+version = "0.17.12"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/docs/changelog/0.17.12.mdx
+++ b/docs/changelog/0.17.12.mdx
@@ -1,0 +1,10 @@
+---
+title: 0.17.12
+---
+
+## Stability Improvements 💪
+
+- Fixed an issue where vacuums could cause background merging to happen even if background merging is disabled
+- Added more verbose logging to `EXPLAIN ANALYZE VERBOSE` output of parallel custom scans
+
+The full changelog is available [here](https://github.com/paradedb/paradedb/releases/tag/v0.17.12).

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -43,7 +43,7 @@ Postgres 14, 15, 16, and 17 are available. If you are using a different version 
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
 
 <Note>
-  You can replace `0.17.10` with the `pg_search` version you wish to install and
+  You can replace `0.17.12` with the `pg_search` version you wish to install and
   `17` with the version of Postgres you are using.
 </Note>
 
@@ -51,43 +51,43 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/postgresql-17-pg-search_0.17.10-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/postgresql-17-pg-search_0.17.12-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/postgresql-17-pg-search_0.17.10-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/postgresql-17-pg-search_0.17.12-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/postgresql-17-pg-search_0.17.10-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/postgresql-17-pg-search_0.17.12-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/pg_search_17-0.17.10-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/pg_search_17-0.17.12-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 8
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/pg_search_17-0.17.10-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/pg_search_17-0.17.12-1PARADEDB.el8.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/pg_search@17--0.17.10.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/pg_search@17--0.17.12.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.10/pg_search@17--0.17.10.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.17.12/pg_search@17--0.17.12.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -35,7 +35,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.17.10`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.17.12`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -77,10 +77,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.17.10
+docker pull paradedb/paradedb:0.17.12
 ```
 
-The latest version of the Docker image should be `0.17.10`.
+The latest version of the Docker image should be `0.17.12`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -97,7 +97,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.17.10';
+ALTER EXTENSION pg_search UPDATE TO '0.17.12';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.17.10",
+        "version": "v0.17.12",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -246,6 +246,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.17.12",
                   "changelog/0.17.10",
                   "changelog/0.17.9",
                   "changelog/0.17.8",

--- a/pg_search/sql/pg_search--0.17.10--0.17.12.sql
+++ b/pg_search/sql/pg_search--0.17.10--0.17.12.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.17.12'" to load this file. \quit


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Note that `0.17.11` was skipped because it was a hotfix in enterprise.

## Why

## How

## Tests
