### PR TITLE
feat: add `limit_fetch_multiplier` index setting to reduce Top N retries

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -156,7 +156,14 @@ impl ExecMethod for TopNScanExecState {
         state.increment_query_count();
 
         // Calculate the limit for this query, and what the offset will be for the next query.
-        let local_limit = self.limit.max(self.chunk_size);
+        let multiplier = state
+            .indexrel
+            .as_ref()
+            .unwrap()
+            .options()
+            .limit_fetch_multiplier();
+        let local_limit =
+            ((self.limit as f64 * multiplier).max(self.chunk_size as f64)).ceil() as usize;
         let next_offset = self.offset + local_limit;
 
         self.search_results = state

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -228,6 +228,7 @@ impl ExecMethod for TopNScanExecState {
             }
 
             // set the chunk size to the scaling factor times the limit
+            // on subsequent retries, multiply the chunk size by `SUBSEQUENT_RETRY_SCALE_FACTOR`
             self.chunk_size = (self.chunk_size * SUBSEQUENT_RETRY_SCALE_FACTOR)
                 .max((self.limit as f64 * self.scale_factor) as usize)
                 .min(MAX_CHUNK_SIZE);

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -183,7 +183,7 @@ fn cstr_to_rust_str(value: *const std::os::raw::c_char) -> String {
         .to_string()
 }
 
-const NUM_REL_OPTS: usize = 12;
+const NUM_REL_OPTS: usize = 11;
 #[pg_guard]
 pub unsafe extern "C-unwind" fn amoptions(
     reloptions: pg_sys::Datum,
@@ -244,11 +244,6 @@ pub unsafe extern "C-unwind" fn amoptions(
             optname: "background_layer_sizes".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
             offset: offset_of!(BM25IndexOptionsData, background_layer_sizes_offset) as i32,
-        },
-        pg_sys::relopt_parse_elt {
-            optname: "limit_fetch_multiplier".as_pg_cstr(),
-            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
-            offset: offset_of!(BM25IndexOptionsData, limit_fetch_multiplier) as i32,
         },
     ];
     build_relopts(reloptions, validate, options)
@@ -316,10 +311,6 @@ impl BM25IndexOptions {
             .target_segment_count()
             .map(|count| count as usize)
             .unwrap_or_else(crate::available_parallelism)
-    }
-
-    pub fn limit_fetch_multiplier(&self) -> f64 {
-        self.options_data().limit_fetch_multiplier()
     }
 
     pub fn key_field_name(&self) -> FieldName {
@@ -581,7 +572,6 @@ struct BM25IndexOptionsData {
     inet_fields_offset: i32,
     target_segment_count: i32,
     background_layer_sizes_offset: i32,
-    limit_fetch_multiplier: f64,
 }
 
 impl BM25IndexOptionsData {
@@ -659,10 +649,6 @@ impl BM25IndexOptionsData {
             self.datetime_fields_offset,
             &SearchFieldConfig::date_from_json,
         )
-    }
-
-    pub fn limit_fetch_multiplier(&self) -> f64 {
-        self.limit_fetch_multiplier
     }
 
     fn deserialize_configs(
@@ -780,15 +766,6 @@ pub unsafe fn init() {
         "The sizes of each layer to merge in the background".as_pg_cstr(),
         std::ptr::null(),
         Some(validate_layer_sizes),
-        pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
-    );
-    pg_sys::add_real_reloption(
-        RELOPT_KIND_PDB,
-        "limit_fetch_multiplier".as_pg_cstr(),
-        "The multiplier to apply to the limit when fetching results".as_pg_cstr(),
-        1.0,
-        1.0,
-        100.0,
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds a GUC that allows the user to control how many results we fetch per segment for a Top N query.

```
f = number of results fetched
n = limit specified by the query
d = number of dead tuples in the heap, estimated by Postgres
a = number of alive tuples in the heap, estimated by Postgres
m = GUC limit_fetch_multiplier setting

f = n * (1 + (1 + d) / (1 + a)) * m
```

## Why

Accelerate Top N queries that are bottlenecked by retries

## How

## Tests
