### PR TITLE
Warnings in v1 docs for phrase features with ngram

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -198,7 +198,7 @@
             "icon": "sparkles",
             "groups": [
               {
-                "group": "Documentation",
+                "group": "Documentation (v2)",
                 "pages": [
                   "v2/overview",
                   {

--- a/docs/documentation/advanced/phrase/phrase.mdx
+++ b/docs/documentation/advanced/phrase/phrase.mdx
@@ -1,6 +1,11 @@
 ---
 title: Phrase
 ---
+<Note>
+Phrase features may not behave as expected with tokenizers that have multiple tokens
+per phrase (such as ngram). Consider using a different tokenizer or switch to 
+parse/match
+</Note>
 
 ## Basic Usage
 

--- a/docs/documentation/advanced/phrase/phrase_prefix.mdx
+++ b/docs/documentation/advanced/phrase/phrase_prefix.mdx
@@ -2,10 +2,17 @@
 title: Phrase Prefix
 ---
 
+<Note>
+Phrase features may not behave as expected with tokenizers that have multiple tokens
+per phrase (such as ngram). Consider using a different tokenizer or switch to 
+parse/match
+</Note>
+
 ## Basic Usage
 
 Identifies documents containing a [phrase](/documentation/concepts/phrase) followed by a term prefix. The field must be indexed with a
 [record](/documentation/indexing/record) of `position`.
+
 
 <CodeGroup>
 ```sql Function Syntax

--- a/docs/documentation/advanced/phrase/regex_phrase.mdx
+++ b/docs/documentation/advanced/phrase/regex_phrase.mdx
@@ -2,6 +2,12 @@
 title: Regex Phrase
 ---
 
+<Note>
+Phrase features may not behave as expected with tokenizers that have multiple tokens
+per phrase (such as ngram). Consider using a different tokenizer or switch to 
+parse/match
+</Note>
+
 ## Basic Usage
 
 `regex_phrase` matches a specific sequence of regex queries. It is similar to `phrase` but allows for more flexibility in the query.

--- a/docs/documentation/full-text/phrase.mdx
+++ b/docs/documentation/full-text/phrase.mdx
@@ -2,6 +2,12 @@
 title: Phrase
 ---
 
+<Note>
+Phrase features may not behave as expected with tokenizers that have multiple tokens
+per phrase (such as ngram). Consider using a different tokenizer or switch to 
+parse/match
+</Note>
+
 Searches for the presence of a [phrase](/documentation/concepts/phrase). The field must be indexed with [record](/documentation/indexing/record) of `position`.
 For more granular controls, see the [phrase query](/documentation/advanced/phrase).
 

--- a/docs/v2/aggregates/overview.mdx
+++ b/docs/v2/aggregates/overview.mdx
@@ -2,4 +2,4 @@
 title: Overview
 ---
 
-The `v2` interface for aggregates is still in progress. Please continue to use `v1` for this capability.
+The `v2` interface for aggregates is still in progress. Please continue to use [`v1` for this capability](/documentation/aggregates/overview).

--- a/docs/v2/full-text/phrase.mdx
+++ b/docs/v2/full-text/phrase.mdx
@@ -62,4 +62,4 @@ Slop allows phrase queries to be relaxed a bit. It specifies how many changes â€
 For example, searching for `sleek shoes` with a slop of `1` would match `sleek running shoes` because there is one word, `running`, between
 `sleek` and `shoes`.
 
-Slop has not yet been implemented in `v2`. Please continue to use `v1` for this capability.
+Slop has not yet been implemented in `v2`. Please continue to use [`v1` for this capability](/documentation/full-text/phrase).

--- a/docs/v2/indexing/create_index.mdx
+++ b/docs/v2/indexing/create_index.mdx
@@ -2,4 +2,4 @@
 title: Create an Index
 ---
 
-The `v2` interface for creating and configuring index is still in progress. Please refer to the `v1` docs.
+The `v2` interface for creating and configuring indexes is still in progress. Please refer to the [`v1` docs](/documentation/indexing/create_index).

--- a/docs/v2/overview.mdx
+++ b/docs/v2/overview.mdx
@@ -9,6 +9,8 @@ title: Overview
 ParadeDB is undergoing a revamp to make its SQL interface more intuitive and ORM-friendly.
 This new experience is being introduced as `v2` of the API.
 
+To move back to the v1 API at any time click `Documentation` in the left navigation bar.
+
 `v1` will remain fully supported — there’s no need to change existing integrations.
 `v2` focuses on improving developer experience across three key areas:
 


### PR DESCRIPTION
Adds warning to the v1 API docs on phrase features that unexpected behaviour may be observed with
tokenizers that have multiple tokens per phrase (such as ngram).

v2 needs to addressed seperately, as it's a bit harder.

# Ticket(s) Closed
- Closes #2592 

