### PR TITLE
fix: fsm: allow rolling back fsm versions

### DIFF
--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -178,7 +178,10 @@ impl FreeSpaceManager {
 
             blockno = page.special::<BM25PageSpecialData>().next_blockno;
 
-            if !matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v1_uncompressed) {
+            if !matches!(
+                page.contents::<FSMBlockHeader>().kind,
+                FSMBlockKind::v1_uncompressed
+            ) {
                 // skip unknown blocks
                 continue;
             }
@@ -268,7 +271,10 @@ impl FreeSpaceManager {
 
             blockno = page.special::<BM25PageSpecialData>().next_blockno;
 
-            if !matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v1_uncompressed) {
+            if !matches!(
+                page.contents::<FSMBlockHeader>().kind,
+                FSMBlockKind::v1_uncompressed
+            ) {
                 // skip v0 blocks
                 continue;
             }


### PR DESCRIPTION

## Why

If we decide to move to a new FSM version, and it turns out to be buggy, we should have a working method to roll back to working code. Let's clobber newer as well as older FSM versions as we do this.

## How

We check for FSM block types when we open the FSM. To date, we checked if the block was v0, and dropped it. However, we should also drop v2 blocks when we're rolling back from v2, rather than trying to interpret them as v1 blocks.

## Tests

Current unit tests pass.