### PR TITLE
feat: push down `group by ... order by ... limit`

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -298,7 +298,7 @@ pub struct OrderByInfo {
 
 pub trait ToTantivyJson {
     fn key(&self) -> String;
-    fn json_value(&self) -> serde_json::Value;
+    fn json_value(&self) -> Option<serde_json::Value>;
 }
 
 impl ToTantivyJson for OrderByInfo {
@@ -306,14 +306,14 @@ impl ToTantivyJson for OrderByInfo {
         "order".to_string()
     }
 
-    fn json_value(&self) -> serde_json::Value {
+    fn json_value(&self) -> Option<serde_json::Value> {
         match self.feature {
             OrderByFeature::Field(_) => match self.direction {
-                SortDirection::Asc => serde_json::json!({ "_key": "asc" }),
-                SortDirection::Desc => serde_json::json!({ "_key": "desc" }),
+                SortDirection::Asc => Some(serde_json::json!({ "_key": "asc" })),
+                SortDirection::Desc => Some(serde_json::json!({ "_key": "desc" })),
             },
             // it is the caller's responsibility to make sure that order by score is not pushed down
-            OrderByFeature::Score => panic!("order by score is not supported"),
+            OrderByFeature::Score => None,
         }
     }
 }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -295,3 +295,25 @@ pub struct OrderByInfo {
     pub feature: OrderByFeature,
     pub direction: SortDirection,
 }
+
+pub trait ToTantivyJson {
+    fn key(&self) -> String;
+    fn json_value(&self) -> serde_json::Value;
+}
+
+impl ToTantivyJson for OrderByInfo {
+    fn key(&self) -> String {
+        "order".to_string()
+    }
+
+    fn json_value(&self) -> serde_json::Value {
+        match self.feature {
+            OrderByFeature::Field(_) => match self.direction {
+                SortDirection::Asc => serde_json::json!({ "_key": "asc" }),
+                SortDirection::Desc => serde_json::json!({ "_key": "desc" }),
+            },
+            // it is the caller's responsibility to make sure that order by score is not pushed down
+            OrderByFeature::Score => panic!("order by score is not supported"),
+        }
+    }
+}

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -46,6 +46,9 @@ static ENABLE_MIXED_FAST_FIELD_EXEC: GucSetting<bool> = GucSetting::<bool>::new(
 /// In a TopN query, the limit is multiplied by this factor to determine the chunk size.
 static LIMIT_FETCH_MULTIPLIER: GucSetting<f64> = GucSetting::<f64>::new(1.0);
 
+/// The maximum number of buckets that can be returned by a TermsAggregation
+static MAX_TERM_AGG_BUCKETS: GucSetting<i32> = GucSetting::<i32>::new(10000);
+
 /// The number of fast-field columns below-which the MixedFastFieldExecState will be used, rather
 /// than the NormalExecState. The Mixed execution mode fetches data as column-oriented, whereas
 /// the Normal mode fetches data as row-oriented.
@@ -164,6 +167,17 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.max_term_agg_buckets",
+        c"Maximum number of buckets/groups that can be returned by a terms aggregation",
+        c"Maximum number of buckets/groups that can be returned by a terms aggregation",
+        &MAX_TERM_AGG_BUCKETS,
+        1,
+        tantivy::aggregation::DEFAULT_BUCKET_LIMIT as i32,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -261,6 +275,10 @@ pub fn adjust_work_mem() -> NonZeroUsize {
 
 pub fn limit_fetch_multiplier() -> f64 {
     LIMIT_FETCH_MULTIPLIER.get()
+}
+
+pub fn max_term_agg_buckets() -> i32 {
+    MAX_TERM_AGG_BUCKETS.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -172,7 +172,7 @@ pub fn init() {
     GucRegistry::define_int_guc(
         c"paradedb.max_term_agg_buckets",
         c"Maximum number of buckets/groups that can be returned by a terms aggregation",
-        c"Maximum number of buckets/groups that can be returned by a terms aggregation",
+        c"Mostly used for testing. If this number is exceeded, that means the result could be truncated and the query will be cancelled.",
         &MAX_TERM_AGG_BUCKETS,
         1,
         DEFAULT_BUCKET_LIMIT as i32,

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -22,6 +22,7 @@ use pgrx::{
 };
 use std::ffi::CStr;
 use std::num::NonZeroUsize;
+use tantivy::aggregation::DEFAULT_BUCKET_LIMIT;
 
 /// Allows the user to toggle the use of our "ParadeDB Scan".
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
@@ -47,7 +48,7 @@ static ENABLE_MIXED_FAST_FIELD_EXEC: GucSetting<bool> = GucSetting::<bool>::new(
 static LIMIT_FETCH_MULTIPLIER: GucSetting<f64> = GucSetting::<f64>::new(1.0);
 
 /// The maximum number of buckets that can be returned by a TermsAggregation
-static MAX_TERM_AGG_BUCKETS: GucSetting<i32> = GucSetting::<i32>::new(10000);
+static MAX_TERM_AGG_BUCKETS: GucSetting<i32> = GucSetting::<i32>::new(DEFAULT_BUCKET_LIMIT as i32);
 
 /// The number of fast-field columns below-which the MixedFastFieldExecState will be used, rather
 /// than the NormalExecState. The Mixed execution mode fetches data as column-oriented, whereas
@@ -174,7 +175,7 @@ pub fn init() {
         c"Maximum number of buckets/groups that can be returned by a terms aggregation",
         &MAX_TERM_AGG_BUCKETS,
         1,
-        tantivy::aggregation::DEFAULT_BUCKET_LIMIT as i32,
+        DEFAULT_BUCKET_LIMIT as i32,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -234,7 +234,7 @@ impl CustomScan for AggregateScan {
             has_order_by: false, // Will be set in plan_custom_path
             limit: limit.unwrap(),
             offset,
-            maybe_lossy: false, // Will be set in plan_custom_path
+            maybe_truncated: false, // Will be set in plan_custom_path
         }))
     }
 
@@ -291,7 +291,7 @@ impl CustomScan for AggregateScan {
         builder.custom_private_mut().orderby_info = orderby_info.clone();
 
         // If there are more sort fields than what we're able to push down, the GROUP BY could be lossy
-        builder.custom_private_mut().maybe_lossy =
+        builder.custom_private_mut().maybe_truncated =
             !builder.custom_private().grouping_columns.is_empty()
                 && orderby_info.len() != sort_clause.len();
 
@@ -338,7 +338,7 @@ impl CustomScan for AggregateScan {
             unsafe { (*builder.args().cscan).scan.scanrelid as pg_sys::Index };
         builder.custom_state().limit = builder.custom_private().limit;
         builder.custom_state().offset = builder.custom_private().offset;
-        builder.custom_state().maybe_lossy = builder.custom_private().maybe_lossy;
+        builder.custom_state().maybe_truncated = builder.custom_private().maybe_truncated;
         builder.build()
     }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -266,8 +266,8 @@ impl CustomScan for AggregateScan {
         builder.custom_private_mut().has_order_by = has_order_by;
 
         // Override orderby_info
-        // We are only able to handle GROUP BY ... ORDER BY ... LIMIT if it's a single field
-        let orderby_info = builder
+        // We are only able to handle GROUP BY ... ORDER BY ... LIMIT if the ORDER BY fields are indexed
+        builder.custom_private_mut().orderby_info = builder
             .custom_private()
             .orderby_info
             .clone()
@@ -280,13 +280,6 @@ impl CustomScan for AggregateScan {
                 }
             })
             .collect::<Vec<_>>();
-
-        if orderby_info.len() == 1 && !builder.custom_private().grouping_columns.is_empty() {
-            builder.custom_private_mut().orderby_info = orderby_info.clone();
-        } else {
-            builder.custom_private_mut().orderby_info = vec![];
-            builder.custom_private_mut().limit = None;
-        }
 
         if builder.custom_private().grouping_columns.is_empty()
             && builder.custom_private().orderby_info.is_empty()

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -22,7 +22,7 @@ use std::ffi::CStr;
 
 use crate::aggregate::execute_aggregate;
 use crate::api::operator::anyelement_query_input_opoid;
-use crate::api::{FieldName, HashSet, OrderByFeature};
+use crate::api::{HashSet, OrderByFeature};
 use crate::gucs;
 use crate::index::mvcc::MvccSatisfies;
 use crate::nodecast;
@@ -292,7 +292,8 @@ impl CustomScan for AggregateScan {
 
         // If there are more sort fields than what we're able to push down, the GROUP BY could be lossy
         builder.custom_private_mut().maybe_lossy =
-            !builder.custom_private().grouping_columns.is_empty() && orderby_info.len() != sort_clause.len();
+            !builder.custom_private().grouping_columns.is_empty()
+                && orderby_info.len() != sort_clause.len();
 
         if builder.custom_private().grouping_columns.is_empty()
             && builder.custom_private().orderby_info.is_empty()

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -322,12 +322,7 @@ impl CustomScan for AggregateScan {
         builder.custom_state().query = builder.custom_private().query.clone();
         builder.custom_state().execution_rti =
             unsafe { (*builder.args().cscan).scan.scanrelid as pg_sys::Index };
-
-        if !builder.custom_private().grouping_columns.is_empty()
-            && !builder.custom_private().orderby_info.is_empty()
-        {
-            builder.custom_state().limit = builder.custom_private().limit;
-        }
+        builder.custom_state().limit = builder.custom_private().limit;
 
         builder.build()
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -153,7 +153,6 @@ impl CustomScan for AggregateScan {
         if limit.is_none() || (limit.unwrap_or(0) + offset.unwrap_or(0) > max_term_agg_buckets) {
             return None;
         }
-
         // Can we handle all of the quals?
         let query = unsafe {
             let result = extract_quals(
@@ -233,7 +232,7 @@ impl CustomScan for AggregateScan {
             orderby_info,
             target_list_mapping,
             has_order_by: false, // Will be set in plan_custom_path
-            limit,
+            limit: limit.unwrap(),
             offset,
         }))
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -150,7 +150,7 @@ impl CustomScan for AggregateScan {
             (extract_const(limit_count), extract_const(offset_count))
         };
 
-        if offset.unwrap_or_default() > max_term_agg_buckets {
+        if limit.is_none() || (limit.unwrap_or(0) + offset.unwrap_or(0) > max_term_agg_buckets) {
             return None;
         }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -267,7 +267,6 @@ pub struct PrivateData {
     pub grouping_columns: Vec<GroupingColumn>,
     pub orderby_info: Vec<OrderByInfo>,
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
-    pub has_order_by: bool,                        // Whether the original query has ORDER BY clause
 }
 
 impl From<*mut pg_sys::List> for PrivateData {

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -270,7 +270,7 @@ pub struct PrivateData {
     pub has_order_by: bool,
     pub limit: u32,
     pub offset: Option<u32>,
-    pub maybe_lossy: bool,
+    pub maybe_truncated: bool,
 }
 
 impl From<*mut pg_sys::List> for PrivateData {

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -267,6 +267,7 @@ pub struct PrivateData {
     pub grouping_columns: Vec<GroupingColumn>,
     pub orderby_info: Vec<OrderByInfo>,
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
+    pub limit: Option<u32>,
 }
 
 impl From<*mut pg_sys::List> for PrivateData {

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -268,7 +268,7 @@ pub struct PrivateData {
     pub orderby_info: Vec<OrderByInfo>,
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
     pub has_order_by: bool,
-    pub limit: Option<u32>,
+    pub limit: u32,
     pub offset: Option<u32>,
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -268,7 +268,7 @@ pub struct PrivateData {
     pub orderby_info: Vec<OrderByInfo>,
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
     pub has_order_by: bool,
-    pub limit: u32,
+    pub limit: Option<u32>,
     pub offset: Option<u32>,
     pub maybe_truncated: bool,
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -267,6 +267,7 @@ pub struct PrivateData {
     pub grouping_columns: Vec<GroupingColumn>,
     pub orderby_info: Vec<OrderByInfo>,
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
+    pub has_order_by: bool,
     pub limit: Option<u32>,
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -270,6 +270,7 @@ pub struct PrivateData {
     pub has_order_by: bool,
     pub limit: u32,
     pub offset: Option<u32>,
+    pub maybe_lossy: bool,
 }
 
 impl From<*mut pg_sys::List> for PrivateData {

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -269,6 +269,7 @@ pub struct PrivateData {
     pub target_list_mapping: Vec<TargetListEntry>, // Maps target list position to data type
     pub has_order_by: bool,
     pub limit: Option<u32>,
+    pub offset: Option<u32>,
 }
 
 impl From<*mut pg_sys::List> for PrivateData {

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -80,7 +80,7 @@ pub struct AggregateScanState {
     pub limit: u32,
     // The OFFSET, if GROUP BY ... ORDER BY ... LIMIT is present
     pub offset: Option<u32>,
-    pub maybe_lossy: bool
+    pub maybe_lossy: bool,
 }
 
 impl AggregateScanState {

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -149,7 +149,12 @@ impl AggregateScanState {
             });
 
             if let Some(orderby_info) = orderby_info {
-                terms.insert(orderby_info.key(), orderby_info.json_value());
+                terms.insert(
+                    orderby_info.key(),
+                    orderby_info
+                        .json_value()
+                        .expect("ordering by score is not supported"),
+                );
             }
 
             if let Some(limit) = self.limit {

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -132,17 +132,15 @@ impl AggregateScanState {
                 serde_json::Value::String(group_col.field_name.clone()),
             );
 
-            if let [OrderByInfo {
-                feature: OrderByFeature::Field(field_name),
-                ..
-            }] = &self.orderby_info[..]
-            {
-                if FieldName::from(group_col.field_name.clone()) == *field_name {
-                    terms.insert(
-                        self.orderby_info[0].key(),
-                        self.orderby_info[0].json_value(),
-                    );
+            // insert ORDER BY info
+            if let Some(orderby_info) = self.orderby_info.iter().find(|info| {
+                if let OrderByFeature::Field(field_name) = &info.feature {
+                    *field_name == FieldName::from(group_col.field_name.clone())
+                } else {
+                    false
                 }
+            }) {
+                terms.insert(orderby_info.key(), orderby_info.json_value());
             }
 
             // if we remove this, we'd get the default size of 10, which means we receive 10 groups max from tantivy

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -80,6 +80,7 @@ pub struct AggregateScanState {
     pub limit: u32,
     // The OFFSET, if GROUP BY ... ORDER BY ... LIMIT is present
     pub offset: Option<u32>,
+    pub maybe_lossy: bool
 }
 
 impl AggregateScanState {
@@ -281,7 +282,7 @@ impl AggregateScanState {
         }
 
         self.extract_bucket_results(&result, 0, &mut Vec::new(), &mut rows);
-        if rows.len() == gucs::max_term_agg_buckets() as usize && self.limit.is_none() {
+        if rows.len() == gucs::max_term_agg_buckets() as usize && self.maybe_lossy {
             ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_PROGRAM_LIMIT_EXCEEDED,
                 "more than `paradedb.max_term_agg_buckets` buckets/groups were returned",

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -293,7 +293,7 @@ impl AggregateScanState {
                 "maximum number of buckets/groups may have been exceeded",
                 function_name!(),
             )
-            .set_detail("any buckets/groups beyond the first `paradedb.max_term_agg_buckets` will be truncated")
+            .set_detail("any buckets/groups beyond the first `paradedb.max_term_agg_buckets` were truncated")
             .set_hint("consider adding a lower `LIMIT` to the query or raising `paradedb.max_term_agg_buckets`")
             .report(PgLogLevel::WARNING);
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -378,8 +378,11 @@ impl AggregateScanState {
 
     fn sort_rows(&self, rows: &mut [GroupedAggregateRow]) {
         if self.orderby_info.is_empty() {
+            pgrx::info!("no order by info");
             return;
         }
+
+        pgrx::info!("sorting rows by {:?}", self.orderby_info);
 
         rows.sort_by(|a, b| {
             for order_info in &self.orderby_info {

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -80,6 +80,7 @@ pub struct AggregateScanState {
     pub limit: u32,
     // The OFFSET, if GROUP BY ... ORDER BY ... LIMIT is present
     pub offset: Option<u32>,
+    // Whether a GROUP BY could be lossy (i.e. some buckets truncated)
     pub maybe_lossy: bool,
 }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -60,7 +60,7 @@ use crate::postgres::customscan::{
 };
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
-use crate::postgres::var::find_var_relation;
+use crate::postgres::var::{find_one_var_and_fieldname, find_var_relation, VarContext};
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::query::pdb_query::pdb;
 use crate::query::SearchQueryInput;
@@ -1430,21 +1430,15 @@ where
                 }
             }
             // Check if this is a regular Var (column reference)
-            else if let Some(var) = nodecast!(Var, T_Var, expr) {
-                let (heaprelid, attno, _) = find_var_relation(var, root);
-                if heaprelid != pg_sys::InvalidOid {
-                    let heaprel =
-                        PgSearchRelation::with_lock(heaprelid, pg_sys::AccessShareLock as _);
-                    let tupdesc = heaprel.tuple_desc();
-                    if let Some(att) = tupdesc.get(attno as usize - 1) {
-                        if let Some(search_field) = schema.search_field(att.name()) {
-                            if regular_sortability_check(&search_field) {
-                                pathkey_styles
-                                    .push(OrderByStyle::Field(pathkey, att.name().into()));
-                                found_valid_member = true;
-                                break;
-                            }
-                        }
+            else if let Some((var, field_name)) = find_one_var_and_fieldname(
+                VarContext::from_planner(root),
+                expr as *mut pg_sys::Node,
+            ) {
+                if let Some(search_field) = schema.search_field(field_name.root()) {
+                    if regular_sortability_check(&search_field) {
+                        pathkey_styles.push(OrderByStyle::Field(pathkey, field_name));
+                        found_valid_member = true;
+                        break;
                     }
                 }
             }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1434,11 +1434,14 @@ where
                 VarContext::from_planner(root),
                 expr as *mut pg_sys::Node,
             ) {
-                if let Some(search_field) = schema.search_field(field_name.root()) {
-                    if regular_sortability_check(&search_field) {
-                        pathkey_styles.push(OrderByStyle::Field(pathkey, field_name));
-                        found_valid_member = true;
-                        break;
+                let (heaprelid, _, _) = find_var_relation(var, root);
+                if heaprelid != pg_sys::Oid::INVALID {
+                    if let Some(search_field) = schema.search_field(field_name.root()) {
+                        if regular_sortability_check(&search_field) {
+                            pathkey_styles.push(OrderByStyle::Field(pathkey, field_name));
+                            found_valid_member = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -187,7 +187,7 @@ pub unsafe fn fieldname_from_var(
     var: *mut pg_sys::Var,
     varattno: pg_sys::AttrNumber,
 ) -> Option<FieldName> {
-    if (*var).varattno == 0 {
+    if (*var).varattno == 0 || heaprelid == pg_sys::Oid::INVALID {
         return None;
     }
     // Check for InvalidOid before trying to open the relation

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -180,13 +180,13 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) FROM empty_test 
 WHERE id @@@ paradedb.all() 
 GROUP BY category;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.empty_test
    Output: category, now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT category, COUNT(*) FROM empty_test 
@@ -209,7 +209,7 @@ ORDER BY category;
    Output: category, now(), now(), now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(value), AVG(value) 
@@ -242,7 +242,7 @@ ORDER BY category, value;
    Output: category, value, now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"value","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"value","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 SELECT category, value, COUNT(*) FROM empty_test 

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -203,13 +203,13 @@ FROM empty_test
 WHERE id @@@ paradedb.all() 
 GROUP BY category 
 ORDER BY category;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.empty_test
    Output: category, now(), now(), now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(value), AVG(value) 
@@ -236,13 +236,13 @@ SELECT category, value, COUNT(*) FROM empty_test
 WHERE id @@@ paradedb.all() 
 GROUP BY category, value 
 ORDER BY category, value;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.empty_test
    Output: category, value, now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"group_1":{"terms":{"field":"value","size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"value","order":{"_key":"asc"},"size":10000}}}}}
 (5 rows)
 
 SELECT category, value, COUNT(*) FROM empty_test 

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -203,13 +203,13 @@ FROM empty_test
 WHERE id @@@ paradedb.all() 
 GROUP BY category 
 ORDER BY category;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.empty_test
    Output: category, now(), now(), now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"value"}},"agg_2":{"avg":{"field":"value"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(value), AVG(value) 
@@ -236,13 +236,13 @@ SELECT category, value, COUNT(*) FROM empty_test
 WHERE id @@@ paradedb.all() 
 GROUP BY category, value 
 ORDER BY category, value;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.empty_test
    Output: category, value, now()
    Index: empty_test_idx
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"value","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"value","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 SELECT category, value, COUNT(*) FROM empty_test 

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -26,7 +26,7 @@ INSERT INTO products (description, rating, category, price, in_stock) VALUES
     ('Running shoes for athletes', 5, 'Sports', 89.99, true),
     ('Winter jacket warm', 4, 'Clothing', 129.99, true),
     ('Summer jacket light', 3, 'Clothing', 59.99, true);
-CREATE INDEX products_idx ON products 
+CREATE INDEX products_idx ON products
 USING bm25 (id, description, rating, category, price)
 WITH (
     key_field='id',
@@ -38,9 +38,9 @@ WITH (
 -- =====================================================================
 -- Test 1.1: GROUP BY with COUNT(*)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT category, COUNT(*) 
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+SELECT category, COUNT(*)
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
                                                                             QUERY PLAN                                                                             
@@ -49,12 +49,12 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (5 rows)
 
-SELECT category, COUNT(*) 
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+SELECT category, COUNT(*)
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | count 
@@ -66,8 +66,8 @@ ORDER BY category;
 -- Test 1.2: GROUP BY with SUM
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) AS total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
                                                                             QUERY PLAN                                                                             
@@ -76,12 +76,12 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) AS total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | total_price 
@@ -93,8 +93,8 @@ ORDER BY category;
 -- Test 1.3: GROUP BY with AVG
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price) AS avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
                                                                             QUERY PLAN                                                                             
@@ -103,12 +103,12 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, AVG(price) AS avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | avg_price 
@@ -120,22 +120,22 @@ ORDER BY category;
 -- Test 1.4: GROUP BY with MIN and MAX
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | min_price | max_price 
@@ -146,33 +146,33 @@ ORDER BY category;
 
 -- Test 1.5: GROUP BY with all aggregate functions
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT category, 
-       COUNT(*) AS count, 
-       SUM(price) AS total, 
-       AVG(price) AS avg, 
-       MIN(price) AS min_price, 
+SELECT category,
+       COUNT(*) AS count,
+       SUM(price) AS total,
+       AVG(price) AS avg,
+       MIN(price) AS min_price,
        MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                                                            QUERY PLAN                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                       QUERY PLAN                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now(), now(), now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
 (5 rows)
 
-SELECT category, 
-       COUNT(*) AS count, 
-       SUM(price) AS total, 
-       AVG(price) AS avg, 
-       MIN(price) AS min_price, 
+SELECT category,
+       COUNT(*) AS count,
+       SUM(price) AS total,
+       AVG(price) AS avg,
+       MIN(price) AS min_price,
        MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | count |  total  |  avg   | min_price | max_price 
@@ -184,22 +184,22 @@ ORDER BY category;
 -- Test 1.6: GROUP BY with numeric field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT rating, COUNT(*), SUM(price), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop' 
+FROM products
+WHERE description @@@ 'laptop'
 GROUP BY rating
 ORDER BY rating;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: rating, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT rating, COUNT(*), SUM(price), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop' 
+FROM products
+WHERE description @@@ 'laptop'
 GROUP BY rating
 ORDER BY rating;
  rating | count |   sum   |   avg   
@@ -214,22 +214,22 @@ ORDER BY rating;
 -- Test 2.1: Two GROUP BY columns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, rating, COUNT(*), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
   category   | rating | count |       avg        
@@ -248,7 +248,7 @@ SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: now(), category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (5 rows)
 
 SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -266,7 +266,7 @@ SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (5 rows)
 
 SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -282,7 +282,7 @@ SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY 
 -- Test 3.1: GROUP BY with empty result set
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(price)
-FROM products 
+FROM products
 WHERE description @@@ 'nonexistent'
 GROUP BY category;
                                                                           QUERY PLAN                                                                          
@@ -295,7 +295,7 @@ GROUP BY category;
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(price)
-FROM products 
+FROM products
 WHERE description @@@ 'nonexistent'
 GROUP BY category;
  category | count | sum | avg 
@@ -305,22 +305,22 @@ GROUP BY category;
 -- Test 3.2: GROUP BY with grouping column in the middle
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: now(), category, now(), rating, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
  count |  category   |       avg        | rating |   sum   
@@ -333,7 +333,7 @@ ORDER BY category, rating;
 -- Test 3.3: GROUP BY with contradictory WHERE clauses
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) AND (description @@@ 'laptop'))
 GROUP BY category;
                                                                                                                                                                          QUERY PLAN                                                                                                                                                                          
@@ -346,9 +346,10 @@ GROUP BY category;
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) AND (description @@@ 'laptop'))
-GROUP BY category;
+GROUP BY category
+ORDER BY category;
  category | count | sum | avg 
 ----------+-------+-----+-----
 (0 rows)
@@ -357,7 +358,7 @@ GROUP BY category;
 -- WHERE (NOT (description @@@ 'laptop')) OR (description @@@ 'laptop') is always true
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) OR (description @@@ 'laptop'))
 GROUP BY category;
                                                                                                                                                                           QUERY PLAN                                                                                                                                                                           
@@ -370,9 +371,10 @@ GROUP BY category;
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) OR (description @@@ 'laptop'))
-GROUP BY category;
+GROUP BY category
+ORDER BY category;
   category   | count |   sum   | avg  
 -------------+-------+---------+------
  Clothing    |     2 |  189.98 |  3.5
@@ -399,7 +401,7 @@ INSERT INTO type_test (int_val, bigint_val, smallint_val, numeric_val, float_val
     (100, 1000000, 10, 99.99, 1.5, 3.14159, 'test1'),
     (200, 2000000, 20, 199.99, 2.5, 6.28318, 'test2'),
     (300, 3000000, 30, 299.99, 3.5, 9.42477, 'test3');
-CREATE INDEX type_test_idx ON type_test 
+CREATE INDEX type_test_idx ON type_test
 USING bm25 (id, text_val, int_val, bigint_val, smallint_val, numeric_val, float_val, double_val)
 WITH (
     key_field='id',
@@ -455,7 +457,7 @@ ORDER BY text_val;
 -- Test 5.1: GROUP BY with DISTINCT aggregates (should fall back to PostgreSQL)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(DISTINCT rating), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category;
                                                                                   QUERY PLAN                                                                                   
@@ -476,7 +478,7 @@ GROUP BY category;
 (13 rows)
 
 SELECT category, COUNT(DISTINCT rating), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
@@ -511,9 +513,9 @@ GROUP BY rating;
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
 (14 rows)
 
-SELECT rating, SUM(price), MAX(rating) 
-FROM products 
-WHERE description @@@ 'keyboard' 
+SELECT rating, SUM(price), MAX(rating)
+FROM products
+WHERE description @@@ 'keyboard'
 GROUP BY rating
 ORDER BY rating;
  rating |  sum   | max 
@@ -526,7 +528,7 @@ ORDER BY rating;
 -- (category is both searched and grouped - should fall back)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(rating), MAX(rating), SUM(price)
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics'
 GROUP BY category;
                                                                              QUERY PLAN                                                                              
@@ -547,7 +549,7 @@ GROUP BY category;
 (13 rows)
 
 SELECT category, MIN(rating), MAX(rating), SUM(price)
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics'
 GROUP BY category
 ORDER BY category;
@@ -562,8 +564,8 @@ ORDER BY category;
 -- Test 6.1: ORDER BY aggregate result
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
                                                                             QUERY PLAN                                                                             
@@ -572,12 +574,12 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
   category   | total_price 
@@ -589,24 +591,24 @@ ORDER BY category;
 -- Test 6.2: ORDER BY multiple columns including aggregates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
-ORDER BY category;
+ORDER BY category, rating;
   category   | rating | cnt |    avg_price     
 -------------+--------+-----+------------------
  Electronics |      4 |   1 |            79.99
@@ -620,8 +622,8 @@ ORDER BY category;
 -- Test 7.1: Complex boolean WHERE clauses with GROUP BY
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT rating, SUM(price), COUNT(*)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics')
 GROUP BY rating
 ORDER BY rating;
@@ -644,8 +646,8 @@ ORDER BY rating;
 (14 rows)
 
 SELECT rating, SUM(price), COUNT(*)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics')
 GROUP BY rating
 ORDER BY rating;
@@ -658,7 +660,7 @@ ORDER BY rating;
 -- Test 7.2: Nested boolean expressions with GROUP BY
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
@@ -680,7 +682,7 @@ ORDER BY category;
 (13 rows)
 
 SELECT category, AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
@@ -692,11 +694,11 @@ ORDER BY category;
 -- =====================================================================
 -- SECTION 8: ORDER BY Aggregate Functions (New Feature)
 -- =====================================================================
--- Test 8.1: ORDER BY COUNT(*) DESC - Customer's reported issue  
+-- Test 8.1: ORDER BY COUNT(*) DESC - Customer's reported issue
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 10;
@@ -711,12 +713,12 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10}}}
 (10 rows)
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 10;
@@ -729,8 +731,8 @@ LIMIT 10;
 -- Test 8.2: ORDER BY COUNT(field) DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
                                                                                QUERY PLAN                                                                                
@@ -746,8 +748,8 @@ ORDER BY COUNT(category) DESC;
 (8 rows)
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
   category   
@@ -756,11 +758,11 @@ ORDER BY COUNT(category) DESC;
  Toys
 (2 rows)
 
--- Test 8.3: ORDER BY SUM() DESC  
+-- Test 8.3: ORDER BY SUM() DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
                                                                                QUERY PLAN                                                                                
@@ -776,8 +778,8 @@ ORDER BY SUM(price) DESC;
 (8 rows)
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
   category   | total_price 
@@ -789,8 +791,8 @@ ORDER BY SUM(price) DESC;
 -- Test 8.4: ORDER BY AVG() ASC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
                                                                                QUERY PLAN                                                                                
@@ -806,8 +808,8 @@ ORDER BY AVG(price) ASC;
 (8 rows)
 
 SELECT category, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
   category   | avg_price 
@@ -819,8 +821,8 @@ ORDER BY AVG(price) ASC;
 -- Test 8.5: ORDER BY MIN() and MAX()
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
                                                                                QUERY PLAN                                                                                
@@ -836,8 +838,8 @@ ORDER BY MIN(price) DESC;
 (8 rows)
 
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
   category   | min_price | max_price 
@@ -849,8 +851,8 @@ ORDER BY MIN(price) DESC;
 -- Test 8.6: Multiple aggregate ORDER BY (first by COUNT, then by category)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt, SUM(price) as total
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
                                                                                QUERY PLAN                                                                                
@@ -862,12 +864,12 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now(), now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt, SUM(price) as total
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
   category   | cnt |  total  
@@ -879,8 +881,8 @@ ORDER BY COUNT(*) DESC, category ASC;
 -- Test 8.7: ORDER BY aggregate with LIMIT - real-world use case
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as product_count
-FROM products 
-WHERE description @@@ 'laptop OR keyboard OR jacket' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard OR jacket'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 2;
@@ -895,12 +897,12 @@ LIMIT 2;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard OR jacket","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":2}}}
 (10 rows)
 
 SELECT category, COUNT(*) as product_count
-FROM products 
-WHERE description @@@ 'laptop OR keyboard OR jacket' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard OR jacket'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 2;
@@ -916,8 +918,8 @@ LIMIT 2;
 -- Test 8.0: Named Aggregate ORDER BY (alias-based) - Should be simplest case
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as pcount
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY pcount DESC
 LIMIT 10;
@@ -932,12 +934,12 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10}}}
 (10 rows)
 
 SELECT category, COUNT(*) as pcount
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY pcount DESC
 LIMIT 10;
@@ -950,8 +952,8 @@ LIMIT 10;
 -- Test 8.2: ORDER BY COUNT(field) DESC - Aggregate on specific field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
                                                                                QUERY PLAN                                                                                
@@ -967,8 +969,8 @@ ORDER BY COUNT(category) DESC;
 (8 rows)
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
   category   
@@ -977,11 +979,11 @@ ORDER BY COUNT(category) DESC;
  Toys
 (2 rows)
 
--- Test 8.3: ORDER BY SUM() DESC  
+-- Test 8.3: ORDER BY SUM() DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
                                                                                QUERY PLAN                                                                                
@@ -997,8 +999,8 @@ ORDER BY SUM(price) DESC;
 (8 rows)
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
   category   | total_price 
@@ -1008,10 +1010,10 @@ ORDER BY SUM(price) DESC;
 (2 rows)
 
 -- Test 8.4: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
                                                                                QUERY PLAN                                                                                
@@ -1023,12 +1025,12 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, category ASC;
   category   | cnt 
@@ -1038,10 +1040,10 @@ ORDER BY cnt DESC, category ASC;
 (2 rows)
 
 -- Test 8.5: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
                                                                                QUERY PLAN                                                                                
@@ -1053,12 +1055,12 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: now(), category
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (8 rows)
 
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, category ASC;
  cnt 
@@ -1070,7 +1072,7 @@ ORDER BY cnt DESC, category ASC;
 -- Test 8.6: Multiple aggregates with mixed ORDER BY (cnt DESC, avg_price ASC)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
@@ -1087,7 +1089,7 @@ ORDER BY cnt DESC, avg_price ASC;
 (8 rows)
 
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
@@ -1098,10 +1100,10 @@ ORDER BY cnt DESC, avg_price ASC;
 (2 rows)
 
 -- Test 8.7: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category ASC;
                                                                             QUERY PLAN                                                                             
@@ -1110,12 +1112,12 @@ ORDER BY category ASC;
    Output: category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
 (5 rows)
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category ASC;
   category   
@@ -1125,10 +1127,10 @@ ORDER BY category ASC;
 (2 rows)
 
 -- Test 8.8: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 ORDER BY COUNT(*) DESC;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1143,8 +1145,8 @@ ORDER BY COUNT(*) DESC;
 (8 rows)
 
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 ORDER BY cnt DESC;
  cnt 
 -----

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -713,7 +713,7 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
 (10 rows)
 
 SELECT category
@@ -897,7 +897,7 @@ LIMIT 2;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard OR jacket","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":2}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
 (10 rows)
 
 SELECT category, COUNT(*) as product_count
@@ -934,7 +934,7 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
 (10 rows)
 
 SELECT category, COUNT(*) as pcount

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -49,7 +49,7 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT category, COUNT(*)
@@ -76,7 +76,7 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) AS total_price
@@ -103,7 +103,7 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, AVG(price) AS avg_price
@@ -130,7 +130,7 @@ ORDER BY category;
    Output: category, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
@@ -162,7 +162,7 @@ ORDER BY category;
    Output: category, now(), now(), now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category,
@@ -194,7 +194,7 @@ ORDER BY rating;
    Output: rating, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT rating, COUNT(*), SUM(price), AVG(price)
@@ -224,7 +224,7 @@ ORDER BY category, rating;
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*), AVG(price)
@@ -248,7 +248,7 @@ SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: now(), category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -266,7 +266,7 @@ SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -285,13 +285,13 @@ SELECT category, COUNT(*), SUM(price), AVG(price)
 FROM products
 WHERE description @@@ 'nonexistent'
 GROUP BY category;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"nonexistent","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(price)
@@ -315,7 +315,7 @@ ORDER BY category, rating;
    Output: now(), category, now(), rating, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
@@ -342,7 +342,7 @@ GROUP BY category;
    Output: category, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"rating"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"rating"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
@@ -367,7 +367,7 @@ GROUP BY category;
    Output: category, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"boolean":{"should":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"rating"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"rating"}}}}}
 (5 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
@@ -574,7 +574,7 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) as total_price
@@ -595,13 +595,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                        QUERY PLAN                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"rating","size":65000,"segment_size":65000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
@@ -713,7 +713,7 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (10 rows)
 
 SELECT category
@@ -744,7 +744,7 @@ ORDER BY COUNT(category) DESC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (8 rows)
 
 SELECT category
@@ -774,7 +774,7 @@ ORDER BY SUM(price) DESC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, SUM(price) as total_price
@@ -804,7 +804,7 @@ ORDER BY AVG(price) ASC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, AVG(price) as avg_price
@@ -825,8 +825,8 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: category, (now()), (now())
    Sort Key: (now()) DESC
@@ -834,7 +834,7 @@ ORDER BY MIN(price) DESC;
          Output: category, now(), now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
@@ -864,7 +864,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now(), now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt, SUM(price) as total
@@ -897,7 +897,7 @@ LIMIT 2;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard OR jacket","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (10 rows)
 
 SELECT category, COUNT(*) as product_count
@@ -934,7 +934,7 @@ LIMIT 10;
                Output: category, now()
                Index: products_idx
                Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (10 rows)
 
 SELECT category, COUNT(*) as pcount
@@ -965,7 +965,7 @@ ORDER BY COUNT(category) DESC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
 (8 rows)
 
 SELECT category
@@ -995,7 +995,7 @@ ORDER BY SUM(price) DESC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, SUM(price) as total_price
@@ -1025,7 +1025,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt
@@ -1055,7 +1055,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: now(), category
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (8 rows)
 
 SELECT COUNT(*) as cnt
@@ -1085,7 +1085,7 @@ ORDER BY cnt DESC, avg_price ASC;
          Output: category, now(), now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
@@ -1112,7 +1112,7 @@ ORDER BY category ASC;
    Output: category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT category

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -49,7 +49,7 @@ ORDER BY category;
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 SELECT category, COUNT(*)
@@ -70,13 +70,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) AS total_price
@@ -97,13 +97,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, AVG(price) AS avg_price
@@ -124,13 +124,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
@@ -156,13 +156,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                                                                       QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now(), now(), now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}},"agg_3":{"min":{"field":"price"}},"agg_4":{"max":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category,
@@ -188,13 +188,13 @@ FROM products
 WHERE description @@@ 'laptop'
 GROUP BY rating
 ORDER BY rating;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: rating, now(), now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}},"agg_2":{"avg":{"field":"price"}}}}}
 (5 rows)
 
 SELECT rating, COUNT(*), SUM(price), AVG(price)
@@ -218,13 +218,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
-                                                                                                              QUERY PLAN                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                   QUERY PLAN                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*), AVG(price)
@@ -248,7 +248,7 @@ SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: now(), category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 SELECT COUNT(*), category FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -266,7 +266,7 @@ SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY 
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY category ORDER BY category;
@@ -309,13 +309,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
-                                                                                                                               QUERY PLAN                                                                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                    QUERY PLAN                                                                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: now(), category, now(), rating, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}},"agg_2":{"sum":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
@@ -568,13 +568,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
 (5 rows)
 
 SELECT category, SUM(price) as total_price
@@ -595,13 +595,13 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category;
-                                                                                                   QUERY PLAN                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.products
    Output: category, rating, now(), now()
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"rating","size":10000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}}}
 (5 rows)
 
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
@@ -855,8 +855,8 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: category, (now()), (now())
    Sort Key: (now()) DESC, products.category
@@ -864,7 +864,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now(), now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt, SUM(price) as total
@@ -1025,7 +1025,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: category, now()
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (8 rows)
 
 SELECT category, COUNT(*) as cnt
@@ -1055,7 +1055,7 @@ ORDER BY COUNT(*) DESC, category ASC;
          Output: now(), category
          Index: products_idx
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (8 rows)
 
 SELECT COUNT(*) as cnt
@@ -1112,7 +1112,7 @@ ORDER BY category ASC;
    Output: category
    Index: products_idx
    Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 SELECT category

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -702,19 +702,28 @@ WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 10;
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: category, (now())
+   Output: category, (count(*))
    ->  Sort
-         Output: category, (now())
-         Sort Key: (now()) DESC
-         ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-               Output: category, now()
-               Index: products_idx
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
-(10 rows)
+         Output: category, (count(*))
+         Sort Key: (count(*)) DESC
+         ->  GroupAggregate
+               Output: category, count(*)
+               Group Key: products.category
+               ->  Sort
+                     Output: category
+                     Sort Key: products.category
+                     ->  Custom Scan (ParadeDB Scan) on public.products
+                           Output: category
+                           Table: products
+                           Index: products_idx
+                           Exec Method: MixedFastFieldExecState
+                           Fast Fields: category
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
 
 SELECT category
 FROM products
@@ -735,17 +744,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now()) DESC
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
-(8 rows)
+   Output: category, (count(category))
+   Sort Key: (count(products.category)) DESC
+   ->  GroupAggregate
+         Output: category, count(category)
+         Group Key: products.category
+         ->  Sort
+               Output: category
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category
 FROM products
@@ -765,17 +783,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now()) DESC
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (sum(price))
+   Sort Key: (sum(products.price)) DESC
+   ->  GroupAggregate
+         Output: category, sum(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, SUM(price) as total_price
 FROM products
@@ -795,27 +822,36 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now())
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (avg(price))
+   Sort Key: (avg(products.price))
+   ->  GroupAggregate
+         Output: category, avg(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, AVG(price) as avg_price
 FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
-  category   | avg_price 
--------------+-----------
- Toys        |    499.99
- Electronics |    632.49
+  category   |      avg_price       
+-------------+----------------------
+ Toys        | 499.9900000000000000
+ Electronics | 632.4900000000000000
 (2 rows)
 
 -- Test 8.5: ORDER BY MIN() and MAX()
@@ -825,17 +861,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now()), (now())
-   Sort Key: (now()) DESC
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now(), now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"min":{"field":"price"}},"agg_1":{"max":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (min(price)), (max(price))
+   Sort Key: (min(products.price)) DESC
+   ->  GroupAggregate
+         Output: category, min(price), max(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
 FROM products
@@ -855,17 +900,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
-                                                                                  QUERY PLAN                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now()), (now())
-   Sort Key: (now()) DESC, products.category
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now(), now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_1":{"sum":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (count(*)), (sum(price))
+   Sort Key: (count(*)) DESC, products.category
+   ->  GroupAggregate
+         Output: category, count(*), sum(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, COUNT(*) as cnt, SUM(price) as total
 FROM products
@@ -886,19 +940,25 @@ WHERE description @@@ 'laptop OR keyboard OR jacket'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 2;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: category, (now())
+   Output: category, (count(*))
    ->  Sort
-         Output: category, (now())
-         Sort Key: (now()) DESC
-         ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-               Output: category, now()
-               Index: products_idx
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard OR jacket","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
-(10 rows)
+         Output: category, (count(*))
+         Sort Key: (count(*)) DESC
+         ->  HashAggregate
+               Output: category, count(*)
+               Group Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard OR jacket","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
 
 SELECT category, COUNT(*) as product_count
 FROM products
@@ -923,19 +983,28 @@ WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY pcount DESC
 LIMIT 10;
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: category, (now())
+   Output: category, (count(*))
    ->  Sort
-         Output: category, (now())
-         Sort Key: (now()) DESC
-         ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-               Output: category, now()
-               Index: products_idx
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
-(10 rows)
+         Output: category, (count(*))
+         Sort Key: (count(*)) DESC
+         ->  GroupAggregate
+               Output: category, count(*)
+               Group Key: products.category
+               ->  Sort
+                     Output: category
+                     Sort Key: products.category
+                     ->  Custom Scan (ParadeDB Scan) on public.products
+                           Output: category
+                           Table: products
+                           Index: products_idx
+                           Exec Method: MixedFastFieldExecState
+                           Fast Fields: category
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
 
 SELECT category, COUNT(*) as pcount
 FROM products
@@ -956,17 +1025,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now()) DESC
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000}}}
-(8 rows)
+   Output: category, (count(category))
+   Sort Key: (count(products.category)) DESC
+   ->  GroupAggregate
+         Output: category, count(category)
+         Group Key: products.category
+         ->  Sort
+               Output: category
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category
 FROM products
@@ -986,17 +1064,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now()) DESC
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (sum(price))
+   Sort Key: (sum(products.price)) DESC
+   ->  GroupAggregate
+         Output: category, sum(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, SUM(price) as total_price
 FROM products
@@ -1016,17 +1103,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now())
-   Sort Key: (now()) DESC, products.category
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
-(8 rows)
+   Output: category, (count(*))
+   Sort Key: (count(*)) DESC, products.category
+   ->  GroupAggregate
+         Output: category, count(*)
+         Group Key: products.category
+         ->  Sort
+               Output: category
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, COUNT(*) as cnt
 FROM products
@@ -1046,17 +1142,26 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: (now()), category
-   Sort Key: (now()) DESC, products.category
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: now(), category
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
-(8 rows)
+   Output: (count(*)), category
+   Sort Key: (count(*)) DESC, products.category
+   ->  GroupAggregate
+         Output: count(*), category
+         Group Key: products.category
+         ->  Sort
+               Output: category
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT COUNT(*) as cnt
 FROM products
@@ -1076,27 +1181,36 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: category, (now()), (now())
-   Sort Key: (now()) DESC, (now())
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
-         Output: category, now(), now()
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_1":{"avg":{"field":"price"}}}}}
-(8 rows)
+   Output: category, (count(*)), (avg(price))
+   Sort Key: (count(*)) DESC, (avg(products.price))
+   ->  GroupAggregate
+         Output: category, count(*), avg(price)
+         Group Key: products.category
+         ->  Sort
+               Output: category, price
+               Sort Key: products.category
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: category, price
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: price, category
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
 FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
-  category   | cnt | avg_price 
--------------+-----+-----------
- Electronics |   4 |    632.49
- Toys        |   1 |    499.99
+  category   | cnt |      avg_price       
+-------------+-----+----------------------
+ Electronics |   4 | 632.4900000000000000
+ Toys        |   1 | 499.9900000000000000
 (2 rows)
 
 -- Test 8.7: Multiple ORDER BY expressions (aggregate + field)

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
@@ -9,6 +9,8 @@ CREATE TABLE products (
 INSERT INTO products (rating)
 SELECT rating
 FROM generate_series(1, 100) rating, generate_series(1, rating);
+INSERT INTO products (rating)
+VALUES (null);
 CREATE INDEX products_idx ON products
 USING bm25 (id, rating)
 WITH (key_field='id');
@@ -131,3 +133,168 @@ GROUP BY rating
 ORDER BY 2
 LIMIT 5;
 ERROR:  query cancelled because result was truncated due to more than 10 groups being returned
+-- Limit 0
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 0;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: rating, (now())
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
+         Output: rating, now()
+         Index: products_idx
+         Tantivy Query: {"with_index":{"query":"all"}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":0,"segment_size":0}}}
+(7 rows)
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 0;
+ rating | count 
+--------+-------
+(0 rows)
+
+-- High limit
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 10000;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Limit
+   Output: rating, (count(*))
+   ->  Sort
+         Output: rating, (count(*))
+         Sort Key: products.rating
+         ->  HashAggregate
+               Output: rating, count(*)
+               Group Key: products.rating
+               ->  Custom Scan (ParadeDB Scan) on public.products
+                     Output: rating
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: rating
+                     Scores: false
+                     Full Index Scan: true
+                     Tantivy Query: {"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 10000;
+ rating | count 
+--------+-------
+      1 |     1
+      2 |     2
+      3 |     3
+      4 |     4
+      5 |     5
+      6 |     6
+      7 |     7
+      8 |     8
+      9 |     9
+     10 |    10
+     11 |    11
+     12 |    12
+     13 |    13
+     14 |    14
+     15 |    15
+     16 |    16
+     17 |    17
+     18 |    18
+     19 |    19
+     20 |    20
+     21 |    21
+     22 |    22
+     23 |    23
+     24 |    24
+     25 |    25
+     26 |    26
+     27 |    27
+     28 |    28
+     29 |    29
+     30 |    30
+     31 |    31
+     32 |    32
+     33 |    33
+     34 |    34
+     35 |    35
+     36 |    36
+     37 |    37
+     38 |    38
+     39 |    39
+     40 |    40
+     41 |    41
+     42 |    42
+     43 |    43
+     44 |    44
+     45 |    45
+     46 |    46
+     47 |    47
+     48 |    48
+     49 |    49
+     50 |    50
+     51 |    51
+     52 |    52
+     53 |    53
+     54 |    54
+     55 |    55
+     56 |    56
+     57 |    57
+     58 |    58
+     59 |    59
+     60 |    60
+     61 |    61
+     62 |    62
+     63 |    63
+     64 |    64
+     65 |    65
+     66 |    66
+     67 |    67
+     68 |    68
+     69 |    69
+     70 |    70
+     71 |    71
+     72 |    72
+     73 |    73
+     74 |    74
+     75 |    75
+     76 |    76
+     77 |    77
+     78 |    78
+     79 |    79
+     80 |    80
+     81 |    81
+     82 |    82
+     83 |    83
+     84 |    84
+     85 |    85
+     86 |    86
+     87 |    87
+     88 |    88
+     89 |    89
+     90 |    90
+     91 |    91
+     92 |    92
+     93 |    93
+     94 |    94
+     95 |    95
+     96 |    96
+     97 |    97
+     98 |    98
+     99 |    99
+    100 |   100
+        |     1
+(101 rows)
+

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
@@ -116,23 +116,37 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY 2
 LIMIT 5;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Limit
    ->  Sort
-         Sort Key: (now())
-         ->  Custom Scan (ParadeDB Aggregate Scan) on products
-               Index: products_idx
-               Tantivy Query: {"with_index":{"query":"all"}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"rating","size":10,"segment_size":10}}}
-(7 rows)
+         Sort Key: (count(*))
+         ->  HashAggregate
+               Group Key: rating
+               ->  Custom Scan (ParadeDB Scan) on products
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: rating
+                     Scores: false
+                     Full Index Scan: true
+                     Tantivy Query: {"with_index":{"query":"all"}}
+(13 rows)
 
 SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY 2
 LIMIT 5;
-ERROR:  query cancelled because result was truncated due to more than 10 groups being returned
+ rating | count 
+--------+-------
+      1 |     1
+        |     1
+      2 |     2
+      3 |     3
+      4 |     4
+(5 rows)
+
 -- Limit 0
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT rating, COUNT(*) FROM products

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
@@ -1,0 +1,133 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.max_term_agg_buckets TO 10;
+DROP TABLE IF EXISTS products CASCADE;
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    rating INTEGER
+);
+INSERT INTO products (rating)
+SELECT rating
+FROM generate_series(1, 100) rating, generate_series(1, rating);
+CREATE INDEX products_idx ON products
+USING bm25 (id, rating)
+WITH (key_field='id');
+-- These should not be pushed down
+-- No LIMIT
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on products
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":"all"}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10,"segment_size":10}}}
+(4 rows)
+
+-- Limit + offset exceeds max_term_agg_buckets
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 6;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: rating
+         ->  HashAggregate
+               Group Key: rating
+               ->  Custom Scan (ParadeDB Scan) on products
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: rating
+                     Scores: false
+                     Full Index Scan: true
+                     Tantivy Query: {"with_index":{"query":"all"}}
+(13 rows)
+
+-- Ordering on a non grouping column
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating, id
+ORDER BY rating, id
+LIMIT 5 OFFSET 5;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: rating, id
+         ->  HashAggregate
+               Group Key: id
+               ->  Custom Scan (ParadeDB Scan) on products
+                     Table: products
+                     Index: products_idx
+                     Exec Method: MixedFastFieldExecState
+                     Fast Fields: id, rating
+                     Scores: false
+                     Full Index Scan: true
+                     Tantivy Query: {"with_index":{"query":"all"}}
+(13 rows)
+
+-- This should be pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 5;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: rating, (now())
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.products
+         Output: rating, now()
+         Index: products_idx
+         Tantivy Query: {"with_index":{"query":"all"}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":10,"segment_size":10}}}
+(7 rows)
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 5;
+ rating | count 
+--------+-------
+      6 |     6
+      7 |     7
+      8 |     8
+      9 |     9
+     10 |    10
+(5 rows)
+
+-- Ordering on a non-grouping column
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY 2
+LIMIT 5;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (now())
+         ->  Custom Scan (ParadeDB Aggregate Scan) on products
+               Index: products_idx
+               Tantivy Query: {"with_index":{"query":"all"}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"rating","size":10,"segment_size":10}}}
+(7 rows)
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY 2
+LIMIT 5;
+ERROR:  query cancelled because result was truncated due to more than 10 groups being returned

--- a/pg_search/tests/pg_regress/expected/issue_3050.out
+++ b/pg_search/tests/pg_regress/expected/issue_3050.out
@@ -56,17 +56,14 @@ WHERE id @@@ paradedb.all()
 GROUP BY id, metadata->>'color'
 ORDER BY id, metadata->>'color'
 LIMIT 5;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Incremental Sort
-         Sort Key: id, ((metadata ->> 'color'::text))
-         Presorted Key: id
-         ->  Custom Scan (ParadeDB Aggregate Scan) on mock_items
-               Index: mock_items_id_description_rating_category_metadata_idx
-               Tantivy Query: {"with_index":{"query":"all"}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"id","size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.color","size":10000}}}}}
-(8 rows)
+   ->  Custom Scan (ParadeDB Aggregate Scan) on mock_items
+         Index: mock_items_id_description_rating_category_metadata_idx
+         Tantivy Query: {"with_index":{"query":"all"}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"id","order":{"_key":"asc"},"size":5,"segment_size":5},"aggs":{"group_1":{"terms":{"field":"metadata.color","order":{"_key":"asc"},"size":5,"segment_size":5}}}}}
+(5 rows)
 
 SELECT id, metadata->>'color' AS color, COUNT(*)
 FROM mock_items

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -43,7 +43,7 @@ ORDER BY category;
    Output: (metadata ->> 'category'::text), now()
    Index: idx_json_single
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -96,7 +96,7 @@ ORDER BY category, brand;
    Output: (metadata ->> 'category'::text), (metadata ->> 'brand'::text), now()
    Index: idx_json_multiple
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"metadata.category"}}}},{"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -151,7 +151,7 @@ ORDER BY brand;
    Output: (metadata ->> 'brand'::text), now()
    Index: idx_json_aggregates
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -368,7 +368,7 @@ ORDER BY category NULLS FIRST;
    Output: (metadata ->> 'category'::text), now()
    Index: idx_json_nulls
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count
@@ -419,7 +419,7 @@ ORDER BY txn_key_value;
    Output: (metadata_json ->> 'reservation_id'::text), now()
    Index: idx_ledger_json
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata_json.reservation_id"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the original example query
@@ -475,7 +475,7 @@ ORDER BY theme, region;
    Output: ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text), ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text), now()
    Index: idx_json_deep
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.theme"}}}},{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.region"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -541,7 +541,7 @@ ORDER BY object_type;
    Output: (data ->> 'type'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"data.type"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.type","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.type","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -572,7 +572,7 @@ ORDER BY category, brand;
    Output: (data ->> 'category'::text), (data ->> 'brand'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"product","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.category"}}}},{"with_index":{"query":{"exists":{"field":"data.brand"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"data.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"data.brand","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -605,7 +605,7 @@ ORDER BY country;
    Output: (((data -> 'profile'::text) -> 'location'::text) ->> 'country'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"user","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.profile.location.country"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -658,7 +658,7 @@ ORDER BY priority_text;
    Output: ((payload -> 'metadata'::text) ->> 'priority'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -689,7 +689,7 @@ ORDER BY team;
    Output: (payload ->> 'team'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.team"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -720,7 +720,7 @@ ORDER BY priority_text, team;
    Output: ((payload -> 'metadata'::text) ->> 'priority'::text), (((payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}},{"with_index":{"query":{"exists":{"field":"payload.metadata.assignee.team"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -892,7 +892,7 @@ ORDER BY api_version;
    Output: ((config -> 'api'::text) ->> 'version'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"config.api.version"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query
@@ -926,7 +926,7 @@ ORDER BY db_host, api_version;
    Output: ((config -> 'database'::text) ->> 'host'::text), ((config -> 'api'::text) ->> 'version'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.database.host"}}}},{"with_index":{"query":{"exists":{"field":"config.api.version"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -963,7 +963,7 @@ ORDER BY users_endpoint, db_port;
    Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query  
@@ -1029,7 +1029,7 @@ ORDER BY department, role;
    Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), now()
    Index: idx_json_multi_subfields
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -1071,7 +1071,7 @@ ORDER BY department, role, location;
    Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), (user_profile ->> 'location'::text), now()
    Index: idx_json_multi_subfields
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.location"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}}}}}
 (5 rows)
 
 -- Execute the query
@@ -1241,7 +1241,7 @@ ORDER BY email_type;
    Output: ((content -> 'user-info'::text) ->> 'email@domain'::text), now()
    Index: idx_json_special
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"content.user-info.email@domain"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","order":{"_key":"asc"},"size":65000,"segment_size":65000}}}
 (5 rows)
 
 -- Execute the query

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -37,13 +37,13 @@ FROM json_test_single
 WHERE id @@@ paradedb.exists('metadata.category')
 GROUP BY metadata->>'category'
 ORDER BY category;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
    Output: (metadata ->> 'category'::text), now()
    Index: idx_json_single
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -90,13 +90,13 @@ WHERE id @@@ paradedb.exists('metadata.category')
   AND id @@@ paradedb.exists('metadata.brand')
 GROUP BY metadata->>'category', metadata->>'brand'
 ORDER BY category, brand;
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                      QUERY PLAN                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multiple
    Output: (metadata ->> 'category'::text), (metadata ->> 'brand'::text), now()
    Index: idx_json_multiple
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"metadata.category"}}}},{"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -145,13 +145,13 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.brand')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_aggregates
    Output: (metadata ->> 'brand'::text), now()
    Index: idx_json_aggregates
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -362,13 +362,13 @@ FROM json_test_nulls
 WHERE id @@@ paradedb.all()
 GROUP BY metadata->>'category'
 ORDER BY category NULLS FIRST;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_nulls
    Output: (metadata ->> 'category'::text), now()
    Index: idx_json_nulls
    Tantivy Query: {"with_index":{"query":"all"}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count
@@ -413,13 +413,13 @@ FROM ledger_transactions
 WHERE id @@@ paradedb.exists('metadata_json.reservation_id')
 GROUP BY metadata_json->>'reservation_id'
 ORDER BY txn_key_value;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.ledger_transactions
    Output: (metadata_json ->> 'reservation_id'::text), now()
    Index: idx_ledger_json
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata_json.reservation_id"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the original example query
@@ -469,13 +469,13 @@ WHERE id @@@ paradedb.exists('config.user.profile.settings.theme')
 GROUP BY config->'user'->'profile'->'settings'->>'theme',
          config->'user'->'profile'->'settings'->>'region'
 ORDER BY theme, region;
-                                                                                                                    QUERY PLAN                                                                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                         QUERY PLAN                                                                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_deep
    Output: ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text), ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text), now()
    Index: idx_json_deep
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.theme"}}}},{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.region"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -535,13 +535,13 @@ FROM json_test_mixed
 WHERE id @@@ paradedb.exists('data.type')
 GROUP BY data->>'type'
 ORDER BY object_type;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
    Output: (data ->> 'type'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"data.type"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.type","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.type","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -572,7 +572,7 @@ ORDER BY category, brand;
    Output: (data ->> 'category'::text), (data ->> 'brand'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"product","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.category"}}}},{"with_index":{"query":{"exists":{"field":"data.brand"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"data.brand","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.category","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"data.brand","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -605,7 +605,7 @@ ORDER BY country;
    Output: (((data -> 'profile'::text) -> 'location'::text) ->> 'country'::text), now()
    Index: idx_json_mixed
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"user","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.profile.location.country"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -652,13 +652,13 @@ FROM json_test_operators
 WHERE id @@@ paradedb.exists('payload.metadata.priority')
 GROUP BY payload->'metadata'->>'priority'
 ORDER BY priority_text;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
    Output: ((payload -> 'metadata'::text) ->> 'priority'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -683,13 +683,13 @@ FROM json_test_operators
 WHERE id @@@ paradedb.exists('payload.team')
 GROUP BY payload->>'team'
 ORDER BY team;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
    Output: (payload ->> 'team'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.team"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -714,13 +714,13 @@ WHERE id @@@ paradedb.exists('payload.metadata.priority')
   AND id @@@ paradedb.exists('payload.metadata.assignee.team')
 GROUP BY payload->'metadata'->>'priority', payload->'metadata'->'assignee'->>'team'
 ORDER BY priority_text, team;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
    Output: ((payload -> 'metadata'::text) ->> 'priority'::text), (((payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text), now()
    Index: idx_json_operators
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}},{"with_index":{"query":{"exists":{"field":"payload.metadata.assignee.team"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -886,13 +886,13 @@ FROM json_test_reconstruction
 WHERE id @@@ paradedb.exists('config.api.version')
 GROUP BY config->'api'->>'version'  -- Group by version string
 ORDER BY api_version;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
    Output: ((config -> 'api'::text) ->> 'version'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"config.api.version"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query
@@ -920,13 +920,13 @@ WHERE id @@@ paradedb.exists('config.database.host')
   AND id @@@ paradedb.exists('config.api.version')
 GROUP BY config->'database'->>'host', config->'api'->>'version'
 ORDER BY db_host, api_version;
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                          QUERY PLAN                                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
    Output: ((config -> 'database'::text) ->> 'host'::text), ((config -> 'api'::text) ->> 'version'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.database.host"}}}},{"with_index":{"query":{"exists":{"field":"config.api.version"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -957,13 +957,13 @@ WHERE id @@@ paradedb.exists('config.api.endpoints.users')
   AND id @@@ paradedb.exists('config.database.port')
 GROUP BY config->'api'->'endpoints'->>'users', config->'database'->>'port'
 ORDER BY users_endpoint, db_port;
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
    Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), now()
    Index: idx_json_reconstruction
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query  
@@ -1023,13 +1023,13 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('user_profile.role')
 GROUP BY user_profile->>'department', user_profile->>'role'
 ORDER BY department, role;
-                                                                                                      QUERY PLAN                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                           QUERY PLAN                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
    Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), now()
    Index: idx_json_multi_subfields
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}
 (5 rows)
 
 -- Execute the query
@@ -1065,13 +1065,13 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('user_profile.location')
 GROUP BY user_profile->>'department', user_profile->>'role', user_profile->>'location'
 ORDER BY department, role, location;
-                                                                                                                                                       QUERY PLAN                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
    Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), (user_profile ->> 'location'::text), now()
    Index: idx_json_multi_subfields
    Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.location"}}}}]}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","order":{"_key":"asc"},"size":10000}}}}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000,"segment_size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}}}}}
 (5 rows)
 
 -- Execute the query
@@ -1235,13 +1235,13 @@ FROM json_test_special
 WHERE id @@@ paradedb.exists('content.user-info.email@domain')
 GROUP BY content->'user-info'->>'email@domain'
 ORDER BY email_type;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_special
    Output: ((content -> 'user-info'::text) ->> 'email@domain'::text), now()
    Index: idx_json_special
    Tantivy Query: {"with_index":{"query":{"exists":{"field":"content.user-info.email@domain"}}}}
-   Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","order":{"_key":"asc"},"size":10000}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","order":{"_key":"asc"},"size":10000,"segment_size":10000}}}
 (5 rows)
 
 -- Execute the query

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -37,17 +37,14 @@ FROM json_test_single
 WHERE id @@@ paradedb.exists('metadata.category')
 GROUP BY metadata->>'category'
 ORDER BY category;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Sort
-   Output: ((metadata ->> 'category'::text)), (now())
-   Sort Key: ((json_test_single.metadata ->> 'category'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
-         Output: (metadata ->> 'category'::text), now()
-         Index: idx_json_single
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":10000}}}
-(8 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
+   Output: (metadata ->> 'category'::text), now()
+   Index: idx_json_single
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT metadata->>'category' AS category, COUNT(*) AS count
@@ -93,17 +90,14 @@ WHERE id @@@ paradedb.exists('metadata.category')
   AND id @@@ paradedb.exists('metadata.brand')
 GROUP BY metadata->>'category', metadata->>'brand'
 ORDER BY category, brand;
-                                                                                   QUERY PLAN                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((metadata ->> 'category'::text)), ((metadata ->> 'brand'::text)), (now())
-   Sort Key: ((json_test_multiple.metadata ->> 'category'::text)), ((json_test_multiple.metadata ->> 'brand'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multiple
-         Output: (metadata ->> 'category'::text), (metadata ->> 'brand'::text), now()
-         Index: idx_json_multiple
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"metadata.category"}}}},{"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","size":10000}}}}}
-(8 rows)
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multiple
+   Output: (metadata ->> 'category'::text), (metadata ->> 'brand'::text), now()
+   Index: idx_json_multiple
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"metadata.category"}}}},{"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT metadata->>'category' AS category,
@@ -151,17 +145,14 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.brand')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Sort
-   Output: ((metadata ->> 'brand'::text)), (now())
-   Sort Key: ((json_test_aggregates.metadata ->> 'brand'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_aggregates
-         Output: (metadata ->> 'brand'::text), now()
-         Index: idx_json_aggregates
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","size":10000}}}
-(8 rows)
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_aggregates
+   Output: (metadata ->> 'brand'::text), now()
+   Index: idx_json_aggregates
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.brand"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.brand","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT metadata->>'brand' AS brand, 
@@ -371,17 +362,14 @@ FROM json_test_nulls
 WHERE id @@@ paradedb.all()
 GROUP BY metadata->>'category'
 ORDER BY category NULLS FIRST;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Sort
-   Output: ((metadata ->> 'category'::text)), (now())
-   Sort Key: ((json_test_nulls.metadata ->> 'category'::text)) NULLS FIRST
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_nulls
-         Output: (metadata ->> 'category'::text), now()
-         Index: idx_json_nulls
-         Tantivy Query: {"with_index":{"query":"all"}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":10000}}}
-(8 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_nulls
+   Output: (metadata ->> 'category'::text), now()
+   Index: idx_json_nulls
+   Tantivy Query: {"with_index":{"query":"all"}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count
 FROM json_test_nulls
@@ -425,17 +413,14 @@ FROM ledger_transactions
 WHERE id @@@ paradedb.exists('metadata_json.reservation_id')
 GROUP BY metadata_json->>'reservation_id'
 ORDER BY txn_key_value;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((metadata_json ->> 'reservation_id'::text)), (now())
-   Sort Key: ((ledger_transactions.metadata_json ->> 'reservation_id'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.ledger_transactions
-         Output: (metadata_json ->> 'reservation_id'::text), now()
-         Index: idx_ledger_json
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata_json.reservation_id"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","size":10000}}}
-(8 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.ledger_transactions
+   Output: (metadata_json ->> 'reservation_id'::text), now()
+   Index: idx_ledger_json
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata_json.reservation_id"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"metadata_json.reservation_id","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the original example query
 SELECT metadata_json->>'reservation_id' AS txn_key_value,
@@ -484,17 +469,14 @@ WHERE id @@@ paradedb.exists('config.user.profile.settings.theme')
 GROUP BY config->'user'->'profile'->'settings'->>'theme',
          config->'user'->'profile'->'settings'->>'region'
 ORDER BY theme, region;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: (((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text)), (((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text)), (now())
-   Sort Key: (((((json_test_deep.config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text)), (((((json_test_deep.config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_deep
-         Output: ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text), ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text), now()
-         Index: idx_json_deep
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.theme"}}}},{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.region"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","size":10000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","size":10000}}}}}
-(8 rows)
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_deep
+   Output: ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'theme'::text), ((((config -> 'user'::text) -> 'profile'::text) -> 'settings'::text) ->> 'region'::text), now()
+   Index: idx_json_deep
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.theme"}}}},{"with_index":{"query":{"exists":{"field":"config.user.profile.settings.region"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.user.profile.settings.theme","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.user.profile.settings.region","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT config->'user'->'profile'->'settings'->>'theme' AS theme,
@@ -553,17 +535,14 @@ FROM json_test_mixed
 WHERE id @@@ paradedb.exists('data.type')
 GROUP BY data->>'type'
 ORDER BY object_type;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Sort
-   Output: ((data ->> 'type'::text)), (now())
-   Sort Key: ((json_test_mixed.data ->> 'type'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
-         Output: (data ->> 'type'::text), now()
-         Index: idx_json_mixed
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"data.type"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"data.type","size":10000}}}
-(8 rows)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
+   Output: (data ->> 'type'::text), now()
+   Index: idx_json_mixed
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"data.type"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.type","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT data->>'type' AS object_type, COUNT(*) AS count
@@ -587,17 +566,14 @@ WHERE id @@@ paradedb.term('data.type', 'product')
   AND id @@@ paradedb.exists('data.brand')
 GROUP BY data->>'category', data->>'brand'
 ORDER BY category, brand;
-                                                                                                                              QUERY PLAN                                                                                                                              
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((data ->> 'category'::text)), ((data ->> 'brand'::text)), (now())
-   Sort Key: ((json_test_mixed.data ->> 'category'::text)), ((json_test_mixed.data ->> 'brand'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
-         Output: (data ->> 'category'::text), (data ->> 'brand'::text), now()
-         Index: idx_json_mixed
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"product","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.category"}}}},{"with_index":{"query":{"exists":{"field":"data.brand"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"data.category","size":10000},"aggs":{"group_1":{"terms":{"field":"data.brand","size":10000}}}}}
-(8 rows)
+                                                                                                                           QUERY PLAN                                                                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
+   Output: (data ->> 'category'::text), (data ->> 'brand'::text), now()
+   Index: idx_json_mixed
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"product","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.category"}}}},{"with_index":{"query":{"exists":{"field":"data.brand"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.category","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"data.brand","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT data->>'category' AS category, data->>'brand' AS brand, COUNT(*) AS count
@@ -623,17 +599,14 @@ WHERE id @@@ paradedb.term('data.type', 'user')
   AND id @@@ paradedb.exists('data.profile.location.country')
 GROUP BY data->'profile'->'location'->>'country'
 ORDER BY country;
-                                                                                                       QUERY PLAN                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((((data -> 'profile'::text) -> 'location'::text) ->> 'country'::text)), (now())
-   Sort Key: ((((json_test_mixed.data -> 'profile'::text) -> 'location'::text) ->> 'country'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
-         Output: (((data -> 'profile'::text) -> 'location'::text) ->> 'country'::text), now()
-         Index: idx_json_mixed
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"user","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.profile.location.country"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","size":10000}}}
-(8 rows)
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_mixed
+   Output: (((data -> 'profile'::text) -> 'location'::text) ->> 'country'::text), now()
+   Index: idx_json_mixed
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"data.type","value":"user","is_datetime":false}}}},{"with_index":{"query":{"exists":{"field":"data.profile.location.country"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"data.profile.location.country","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT data->'profile'->'location'->>'country' AS country, 
@@ -679,17 +652,14 @@ FROM json_test_operators
 WHERE id @@@ paradedb.exists('payload.metadata.priority')
 GROUP BY payload->'metadata'->>'priority'
 ORDER BY priority_text;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Sort
-   Output: (((payload -> 'metadata'::text) ->> 'priority'::text)), (now())
-   Sort Key: (((json_test_operators.payload -> 'metadata'::text) ->> 'priority'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
-         Output: ((payload -> 'metadata'::text) ->> 'priority'::text), now()
-         Index: idx_json_operators
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","size":10000}}}
-(8 rows)
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
+   Output: ((payload -> 'metadata'::text) ->> 'priority'::text), now()
+   Index: idx_json_operators
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT payload->'metadata'->>'priority' AS priority_text,
@@ -713,17 +683,14 @@ FROM json_test_operators
 WHERE id @@@ paradedb.exists('payload.team')
 GROUP BY payload->>'team'
 ORDER BY team;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort
-   Output: ((payload ->> 'team'::text)), (now())
-   Sort Key: ((json_test_operators.payload ->> 'team'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
-         Output: (payload ->> 'team'::text), now()
-         Index: idx_json_operators
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.team"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","size":10000}}}
-(8 rows)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
+   Output: (payload ->> 'team'::text), now()
+   Index: idx_json_operators
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"payload.team"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.team","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT payload->>'team' AS team,
@@ -747,17 +714,14 @@ WHERE id @@@ paradedb.exists('payload.metadata.priority')
   AND id @@@ paradedb.exists('payload.metadata.assignee.team')
 GROUP BY payload->'metadata'->>'priority', payload->'metadata'->'assignee'->>'team'
 ORDER BY priority_text, team;
-                                                                                               QUERY PLAN                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: (((payload -> 'metadata'::text) ->> 'priority'::text)), ((((payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text)), (now())
-   Sort Key: (((json_test_operators.payload -> 'metadata'::text) ->> 'priority'::text)), ((((json_test_operators.payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
-         Output: ((payload -> 'metadata'::text) ->> 'priority'::text), (((payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text), now()
-         Index: idx_json_operators
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}},{"with_index":{"query":{"exists":{"field":"payload.metadata.assignee.team"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","size":10000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","size":10000}}}}}
-(8 rows)
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_operators
+   Output: ((payload -> 'metadata'::text) ->> 'priority'::text), (((payload -> 'metadata'::text) -> 'assignee'::text) ->> 'team'::text), now()
+   Index: idx_json_operators
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"payload.metadata.priority"}}}},{"with_index":{"query":{"exists":{"field":"payload.metadata.assignee.team"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"payload.metadata.priority","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"payload.metadata.assignee.team","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT payload->'metadata'->>'priority' AS priority_text,
@@ -922,17 +886,14 @@ FROM json_test_reconstruction
 WHERE id @@@ paradedb.exists('config.api.version')
 GROUP BY config->'api'->>'version'  -- Group by version string
 ORDER BY api_version;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Sort
-   Output: (((config -> 'api'::text) ->> 'version'::text)), (now())
-   Sort Key: (((json_test_reconstruction.config -> 'api'::text) ->> 'version'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
-         Output: ((config -> 'api'::text) ->> 'version'::text), now()
-         Index: idx_json_reconstruction
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"config.api.version"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","size":10000}}}
-(8 rows)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+   Output: ((config -> 'api'::text) ->> 'version'::text), now()
+   Index: idx_json_reconstruction
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"config.api.version"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT 
@@ -959,17 +920,14 @@ WHERE id @@@ paradedb.exists('config.database.host')
   AND id @@@ paradedb.exists('config.api.version')
 GROUP BY config->'database'->>'host', config->'api'->>'version'
 ORDER BY db_host, api_version;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: (((config -> 'database'::text) ->> 'host'::text)), (((config -> 'api'::text) ->> 'version'::text)), (now())
-   Sort Key: (((json_test_reconstruction.config -> 'database'::text) ->> 'host'::text)), (((json_test_reconstruction.config -> 'api'::text) ->> 'version'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
-         Output: ((config -> 'database'::text) ->> 'host'::text), ((config -> 'api'::text) ->> 'version'::text), now()
-         Index: idx_json_reconstruction
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.database.host"}}}},{"with_index":{"query":{"exists":{"field":"config.api.version"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","size":10000}}}}}
-(8 rows)
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+   Output: ((config -> 'database'::text) ->> 'host'::text), ((config -> 'api'::text) ->> 'version'::text), now()
+   Index: idx_json_reconstruction
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.database.host"}}}},{"with_index":{"query":{"exists":{"field":"config.api.version"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.database.host","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.api.version","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT 
@@ -999,17 +957,14 @@ WHERE id @@@ paradedb.exists('config.api.endpoints.users')
   AND id @@@ paradedb.exists('config.database.port')
 GROUP BY config->'api'->'endpoints'->>'users', config->'database'->>'port'
 ORDER BY users_endpoint, db_port;
-                                                                                          QUERY PLAN                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((config -> 'database'::text) ->> 'port'::text)), (now())
-   Sort Key: ((((json_test_reconstruction.config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((json_test_reconstruction.config -> 'database'::text) ->> 'port'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
-         Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), now()
-         Index: idx_json_reconstruction
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","size":10000}}}}}
-(8 rows)
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+   Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), now()
+   Index: idx_json_reconstruction
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query  
 SELECT 
@@ -1068,17 +1023,14 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('user_profile.role')
 GROUP BY user_profile->>'department', user_profile->>'role'
 ORDER BY department, role;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'role'::text)), (now())
-   Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'role'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
-         Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), now()
-         Index: idx_json_multi_subfields
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","size":10000}}}}}
-(8 rows)
+                                                                                                      QUERY PLAN                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
+   Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), now()
+   Index: idx_json_multi_subfields
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT 
@@ -1113,17 +1065,14 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('user_profile.location')
 GROUP BY user_profile->>'department', user_profile->>'role', user_profile->>'location'
 ORDER BY department, role, location;
-                                                                                                                          QUERY PLAN                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Output: ((user_profile ->> 'department'::text)), ((user_profile ->> 'role'::text)), ((user_profile ->> 'location'::text)), (now())
-   Sort Key: ((json_test_multi_subfields.user_profile ->> 'department'::text)), ((json_test_multi_subfields.user_profile ->> 'role'::text)), ((json_test_multi_subfields.user_profile ->> 'location'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
-         Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), (user_profile ->> 'location'::text), now()
-         Index: idx_json_multi_subfields
-         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.location"}}}}]}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","size":10000}}}}}}}
-(8 rows)
+                                                                                                                                                       QUERY PLAN                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_multi_subfields
+   Output: (user_profile ->> 'department'::text), (user_profile ->> 'role'::text), (user_profile ->> 'location'::text), now()
+   Index: idx_json_multi_subfields
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"user_profile.department"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.role"}}}},{"with_index":{"query":{"exists":{"field":"user_profile.location"}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"user_profile.department","order":{"_key":"asc"},"size":10000},"aggs":{"group_1":{"terms":{"field":"user_profile.role","order":{"_key":"asc"},"size":10000},"aggs":{"group_2":{"terms":{"field":"user_profile.location","order":{"_key":"asc"},"size":10000}}}}}}}
+(5 rows)
 
 -- Execute the query
 SELECT 
@@ -1286,17 +1235,14 @@ FROM json_test_special
 WHERE id @@@ paradedb.exists('content.user-info.email@domain')
 GROUP BY content->'user-info'->>'email@domain'
 ORDER BY email_type;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Sort
-   Output: (((content -> 'user-info'::text) ->> 'email@domain'::text)), (now())
-   Sort Key: (((json_test_special.content -> 'user-info'::text) ->> 'email@domain'::text))
-   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_special
-         Output: ((content -> 'user-info'::text) ->> 'email@domain'::text), now()
-         Index: idx_json_special
-         Tantivy Query: {"with_index":{"query":{"exists":{"field":"content.user-info.email@domain"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","size":10000}}}
-(8 rows)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.json_test_special
+   Output: ((content -> 'user-info'::text) ->> 'email@domain'::text), now()
+   Index: idx_json_special
+   Tantivy Query: {"with_index":{"query":{"exists":{"field":"content.user-info.email@domain"}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"content.user-info.email@domain","order":{"_key":"asc"},"size":10000}}}
+(5 rows)
 
 -- Execute the query
 SELECT content->'user-info'->>'email@domain' AS email_type,

--- a/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
@@ -69,19 +69,27 @@ WHERE id @@@ paradedb.exists('metadata.category')
 GROUP BY metadata->>'category'
 ORDER BY 2
 LIMIT 5;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Limit
-   Output: ((metadata ->> 'category'::text)), (now())
+   Output: ((metadata ->> 'category'::text)), (count(*))
    ->  Sort
-         Output: ((metadata ->> 'category'::text)), (now())
-         Sort Key: (now())
-         ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
-               Output: (metadata ->> 'category'::text), now()
-               Index: idx_json_single
-               Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":65000,"segment_size":65000}}}
-(10 rows)
+         Output: ((metadata ->> 'category'::text)), (count(*))
+         Sort Key: (count(*))
+         ->  GroupAggregate
+               Output: ((metadata ->> 'category'::text)), count(*)
+               Group Key: ((json_test_single.metadata ->> 'category'::text))
+               ->  Sort
+                     Output: ((metadata ->> 'category'::text))
+                     Sort Key: ((json_test_single.metadata ->> 'category'::text))
+                     ->  Custom Scan (ParadeDB Scan) on public.json_test_single
+                           Output: (metadata ->> 'category'::text)
+                           Table: json_test_single
+                           Index: idx_json_single
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
+(18 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count
 FROM json_test_single
@@ -91,8 +99,8 @@ ORDER BY 2
 LIMIT 5;
   category   | count 
 -------------+-------
- electronics |     3
  clothing    |     3
+ electronics |     3
 (2 rows)
 
 DROP TABLE json_test_single CASCADE;

--- a/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
@@ -69,8 +69,8 @@ WHERE id @@@ paradedb.exists('metadata.category')
 GROUP BY metadata->>'category'
 ORDER BY 2
 LIMIT 5;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: ((metadata ->> 'category'::text)), (now())
    ->  Sort
@@ -80,7 +80,7 @@ LIMIT 5;
                Output: (metadata ->> 'category'::text), now()
                Index: idx_json_single
                Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-               Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":10000}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":65000,"segment_size":65000}}}
 (10 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count

--- a/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
@@ -38,15 +38,15 @@ WHERE id @@@ paradedb.exists('metadata.category')
 GROUP BY metadata->>'category'
 ORDER BY 1
 LIMIT 5;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: ((metadata ->> 'category'::text)), (now())
    ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
          Output: (metadata ->> 'category'::text), now()
          Index: idx_json_single
          Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
-         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":5}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":5,"segment_size":5}}}
 (7 rows)
 
 SELECT metadata->>'category' AS category, COUNT(*) AS count

--- a/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_orderby_limit.out
@@ -1,0 +1,98 @@
+-- Test JSON field GROUP BY with aggregate custom scan
+-- Create extension
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Enable aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =========================================
+-- Test 1: Single JSON field GROUP BY
+-- =========================================
+-- Create test table
+CREATE TABLE json_test_single (
+    id SERIAL PRIMARY KEY,
+    metadata JSONB,
+    data JSONB
+);
+-- Insert test data
+INSERT INTO json_test_single (metadata, data) VALUES
+    ('{"category": "electronics", "brand": "Apple", "price": 999}', '{"color": "silver", "stock": 10}'),
+    ('{"category": "electronics", "brand": "Samsung", "price": 799}', '{"color": "black", "stock": 15}'),
+    ('{"category": "electronics", "brand": "Apple", "price": 1299}', '{"color": "gold", "stock": 5}'),
+    ('{"category": "clothing", "brand": "Nike", "price": 89}', '{"size": "M", "stock": 20}'),
+    ('{"category": "clothing", "brand": "Adidas", "price": 79}', '{"size": "L", "stock": 25}'),
+    ('{"category": "clothing", "brand": "Nike", "price": 99}', '{"size": "S", "stock": 30}');
+-- Create BM25 index
+CREATE INDEX idx_json_single ON json_test_single
+USING bm25 (id, metadata, data)
+WITH (
+    key_field = 'id',
+    json_fields = '{
+        "metadata": {"indexed": true, "fast": true, "expand_dots": true},
+        "data": {"indexed": true, "fast": true, "expand_dots": true}
+    }'
+);
+-- GROUP BY ... ORDER BY ... LIMIT pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 1
+LIMIT 5;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: ((metadata ->> 'category'::text)), (now())
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
+         Output: (metadata ->> 'category'::text), now()
+         Index: idx_json_single
+         Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
+         Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","order":{"_key":"asc"},"size":5}}}
+(7 rows)
+
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 1
+LIMIT 5;
+  category   | count 
+-------------+-------
+ clothing    |     3
+ electronics |     3
+(2 rows)
+
+-- Ordering by count should not be pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 2
+LIMIT 5;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Limit
+   Output: ((metadata ->> 'category'::text)), (now())
+   ->  Sort
+         Output: ((metadata ->> 'category'::text)), (now())
+         Sort Key: (now())
+         ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_single
+               Output: (metadata ->> 'category'::text), now()
+               Index: idx_json_single
+               Tantivy Query: {"with_index":{"query":{"exists":{"field":"metadata.category"}}}}
+               Aggregate Definition: {"group_0":{"terms":{"field":"metadata.category","size":10000}}}
+(10 rows)
+
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 2
+LIMIT 5;
+  category   | count 
+-------------+-------
+ electronics |     3
+ clothing    |     3
+(2 rows)
+
+DROP TABLE json_test_single CASCADE;

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate.sql
@@ -31,7 +31,7 @@ INSERT INTO products (description, rating, category, price, in_stock) VALUES
     ('Winter jacket warm', 4, 'Clothing', 129.99, true),
     ('Summer jacket light', 3, 'Clothing', 59.99, true);
 
-CREATE INDEX products_idx ON products 
+CREATE INDEX products_idx ON products
 USING bm25 (id, description, rating, category, price)
 WITH (
     key_field='id',
@@ -45,95 +45,95 @@ WITH (
 
 -- Test 1.1: GROUP BY with COUNT(*)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT category, COUNT(*) 
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+SELECT category, COUNT(*)
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
-SELECT category, COUNT(*) 
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+SELECT category, COUNT(*)
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 1.2: GROUP BY with SUM
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) AS total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 SELECT category, SUM(price) AS total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 1.3: GROUP BY with AVG
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price) AS avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 SELECT category, AVG(price) AS avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 1.4: GROUP BY with MIN and MAX
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 SELECT category, MIN(price) AS min_price, MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 1.5: GROUP BY with all aggregate functions
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT category, 
-       COUNT(*) AS count, 
-       SUM(price) AS total, 
-       AVG(price) AS avg, 
-       MIN(price) AS min_price, 
+SELECT category,
+       COUNT(*) AS count,
+       SUM(price) AS total,
+       AVG(price) AS avg,
+       MIN(price) AS min_price,
        MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
-SELECT category, 
-       COUNT(*) AS count, 
-       SUM(price) AS total, 
-       AVG(price) AS avg, 
-       MIN(price) AS min_price, 
+SELECT category,
+       COUNT(*) AS count,
+       SUM(price) AS total,
+       AVG(price) AS avg,
+       MIN(price) AS min_price,
        MAX(price) AS max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 1.6: GROUP BY with numeric field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT rating, COUNT(*), SUM(price), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop' 
+FROM products
+WHERE description @@@ 'laptop'
 GROUP BY rating
 ORDER BY rating;
 
 SELECT rating, COUNT(*), SUM(price), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop' 
+FROM products
+WHERE description @@@ 'laptop'
 GROUP BY rating
 ORDER BY rating;
 
@@ -144,14 +144,14 @@ ORDER BY rating;
 -- Test 2.1: Two GROUP BY columns
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, rating, COUNT(*), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
 
 SELECT category, rating, COUNT(*), AVG(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
 
@@ -173,53 +173,55 @@ SELECT category, COUNT(*) FROM products WHERE description @@@ 'laptop' GROUP BY 
 -- Test 3.1: GROUP BY with empty result set
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(price)
-FROM products 
+FROM products
 WHERE description @@@ 'nonexistent'
 GROUP BY category;
 
 SELECT category, COUNT(*), SUM(price), AVG(price)
-FROM products 
+FROM products
 WHERE description @@@ 'nonexistent'
 GROUP BY category;
 
 -- Test 3.2: GROUP BY with grouping column in the middle
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
 
 SELECT COUNT(*), category, AVG(price) , rating, SUM(price)
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category, rating;
 
 -- Test 3.3: GROUP BY with contradictory WHERE clauses
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) AND (description @@@ 'laptop'))
 GROUP BY category;
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) AND (description @@@ 'laptop'))
-GROUP BY category;
+GROUP BY category
+ORDER BY category;
 
 -- Test 3.4: Tautological WHERE clauses with GROUP BY
 -- WHERE (NOT (description @@@ 'laptop')) OR (description @@@ 'laptop') is always true
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) OR (description @@@ 'laptop'))
 GROUP BY category;
 
 SELECT category, COUNT(*), SUM(price), AVG(rating)
-FROM products 
+FROM products
 WHERE ((NOT (description @@@ 'laptop')) OR (description @@@ 'laptop'))
-GROUP BY category;
+GROUP BY category
+ORDER BY category;
 
 -- =====================================================================
 -- SECTION 4: GROUP BY with Different Data Types
@@ -242,7 +244,7 @@ INSERT INTO type_test (int_val, bigint_val, smallint_val, numeric_val, float_val
     (200, 2000000, 20, 199.99, 2.5, 6.28318, 'test2'),
     (300, 3000000, 30, 299.99, 3.5, 9.42477, 'test3');
 
-CREATE INDEX type_test_idx ON type_test 
+CREATE INDEX type_test_idx ON type_test
 USING bm25 (id, text_val, int_val, bigint_val, smallint_val, numeric_val, float_val, double_val)
 WITH (
     key_field='id',
@@ -278,12 +280,12 @@ ORDER BY text_val;
 -- Test 5.1: GROUP BY with DISTINCT aggregates (should fall back to PostgreSQL)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(DISTINCT rating), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category;
 
 SELECT category, COUNT(DISTINCT rating), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
@@ -296,9 +298,9 @@ FROM products
 WHERE description @@@ 'keyboard'
 GROUP BY rating;
 
-SELECT rating, SUM(price), MAX(rating) 
-FROM products 
-WHERE description @@@ 'keyboard' 
+SELECT rating, SUM(price), MAX(rating)
+FROM products
+WHERE description @@@ 'keyboard'
 GROUP BY rating
 ORDER BY rating;
 
@@ -306,12 +308,12 @@ ORDER BY rating;
 -- (category is both searched and grouped - should fall back)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(rating), MAX(rating), SUM(price)
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics'
 GROUP BY category;
 
 SELECT category, MIN(rating), MAX(rating), SUM(price)
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics'
 GROUP BY category
 ORDER BY category;
@@ -323,30 +325,30 @@ ORDER BY category;
 -- Test 6.1: ORDER BY aggregate result
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
 
 -- Test 6.2: ORDER BY multiple columns including aggregates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
 ORDER BY category;
 
 SELECT category, rating, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category, rating
-ORDER BY category;
+ORDER BY category, rating;
 
 -- =====================================================================
 -- SECTION 7: Complex GROUP BY Query Patterns
@@ -355,15 +357,15 @@ ORDER BY category;
 -- Test 7.1: Complex boolean WHERE clauses with GROUP BY
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT rating, SUM(price), COUNT(*)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics')
 GROUP BY rating
 ORDER BY rating;
 
 SELECT rating, SUM(price), COUNT(*)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics')
 GROUP BY rating
 ORDER BY rating;
@@ -371,13 +373,13 @@ ORDER BY rating;
 -- Test 7.2: Nested boolean expressions with GROUP BY
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
 
 SELECT category, AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
@@ -386,18 +388,18 @@ ORDER BY category;
 -- SECTION 8: ORDER BY Aggregate Functions (New Feature)
 -- =====================================================================
 
--- Test 8.1: ORDER BY COUNT(*) DESC - Customer's reported issue  
+-- Test 8.1: ORDER BY COUNT(*) DESC - Customer's reported issue
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 10;
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 10;
@@ -405,85 +407,85 @@ LIMIT 10;
 -- Test 8.2: ORDER BY COUNT(field) DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
 
--- Test 8.3: ORDER BY SUM() DESC  
+-- Test 8.3: ORDER BY SUM() DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
 
 -- Test 8.4: ORDER BY AVG() ASC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
 
 SELECT category, AVG(price) as avg_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY AVG(price) ASC;
 
 -- Test 8.5: ORDER BY MIN() and MAX()
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
 
 SELECT category, MIN(price) as min_price, MAX(price) as max_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY MIN(price) DESC;
 
 -- Test 8.6: Multiple aggregate ORDER BY (first by COUNT, then by category)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt, SUM(price) as total
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
 
 SELECT category, COUNT(*) as cnt, SUM(price) as total
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
 
 -- Test 8.7: ORDER BY aggregate with LIMIT - real-world use case
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as product_count
-FROM products 
-WHERE description @@@ 'laptop OR keyboard OR jacket' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard OR jacket'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 2;
 
 SELECT category, COUNT(*) as product_count
-FROM products 
-WHERE description @@@ 'laptop OR keyboard OR jacket' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard OR jacket'
 GROUP BY category
 ORDER BY COUNT(*) DESC
 LIMIT 2;
@@ -495,15 +497,15 @@ LIMIT 2;
 -- Test 8.0: Named Aggregate ORDER BY (alias-based) - Should be simplest case
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as pcount
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY pcount DESC
 LIMIT 10;
 
 SELECT category, COUNT(*) as pcount
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY pcount DESC
 LIMIT 10;
@@ -511,97 +513,97 @@ LIMIT 10;
 -- Test 8.2: ORDER BY COUNT(field) DESC - Aggregate on specific field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(category) DESC;
 
--- Test 8.3: ORDER BY SUM() DESC  
+-- Test 8.3: ORDER BY SUM() DESC
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
 
 SELECT category, SUM(price) as total_price
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY SUM(price) DESC;
 
 -- Test 8.4: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
 
 SELECT category, COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, category ASC;
 
 -- Test 8.5: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY COUNT(*) DESC, category ASC;
 
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, category ASC;
 
 -- Test 8.6: Multiple aggregates with mixed ORDER BY (cnt DESC, avg_price ASC)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
 
 SELECT category, COUNT(*) as cnt, AVG(price) as avg_price
-FROM products 
+FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY cnt DESC, avg_price ASC;
 
 -- Test 8.7: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category ASC;
 
 SELECT category
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category ASC;
 
 -- Test 8.8: Multiple ORDER BY expressions (aggregate + field)
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE) 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 ORDER BY COUNT(*) DESC;
 
 SELECT COUNT(*) as cnt
-FROM products 
-WHERE description @@@ 'laptop OR keyboard' 
+FROM products
+WHERE description @@@ 'laptop OR keyboard'
 ORDER BY cnt DESC;
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
@@ -13,6 +13,9 @@ INSERT INTO products (rating)
 SELECT rating
 FROM generate_series(1, 100) rating, generate_series(1, rating);
 
+INSERT INTO products (rating)
+VALUES (null);
+
 CREATE INDEX products_idx ON products
 USING bm25 (id, rating)
 WITH (key_field='id');
@@ -69,3 +72,31 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY 2
 LIMIT 5;
+
+-- Limit 0
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 0;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 0;
+
+-- High limit
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 10000;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 10000;

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
@@ -17,31 +17,30 @@ CREATE INDEX products_idx ON products
 USING bm25 (id, rating)
 WITH (key_field='id');
 
--- This should show a warning about the maximum number of buckets/groups being exceeded
+-- These should not be pushed down
+
+-- No LIMIT
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY rating;
 
-SELECT rating, COUNT(*) FROM products
-WHERE id @@@ paradedb.all()
-GROUP BY rating
-ORDER BY rating
-OFFSET 50;
-
--- This should not be pushed down
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+-- Limit + offset exceeds max_term_agg_buckets
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY rating
 LIMIT 5 OFFSET 6;
 
+-- Ordering on a non-grouping column
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
 GROUP BY rating
-ORDER BY rating
-LIMIT 5 OFFSET 6;
+ORDER BY 2
+LIMIT 5;
 
 -- This should be pushed down
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
@@ -1,0 +1,58 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.max_term_agg_buckets TO 10;
+
+DROP TABLE IF EXISTS products CASCADE;
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    rating INTEGER
+);
+
+INSERT INTO products (rating)
+SELECT rating
+FROM generate_series(1, 100) rating, generate_series(1, rating);
+
+CREATE INDEX products_idx ON products
+USING bm25 (id, rating)
+WITH (key_field='id');
+
+-- This should show a warning about the maximum number of buckets/groups being exceeded
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+OFFSET 50;
+
+-- This should not be pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 6;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 6;
+
+-- This should be pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 5;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY rating
+LIMIT 5 OFFSET 5;

--- a/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
+++ b/pg_search/tests/pg_regress/sql/groupby_aggregate_highcard.sql
@@ -34,13 +34,13 @@ GROUP BY rating
 ORDER BY rating
 LIMIT 5 OFFSET 6;
 
--- Ordering on a non-grouping column
+-- Ordering on a non grouping column
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
-GROUP BY rating
-ORDER BY 2
-LIMIT 5;
+GROUP BY rating, id
+ORDER BY rating, id
+LIMIT 5 OFFSET 5;
 
 -- This should be pushed down
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
@@ -55,3 +55,17 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY rating
 LIMIT 5 OFFSET 5;
+
+-- Ordering on a non-grouping column
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY 2
+LIMIT 5;
+
+SELECT rating, COUNT(*) FROM products
+WHERE id @@@ paradedb.all()
+GROUP BY rating
+ORDER BY 2
+LIMIT 5;

--- a/pg_search/tests/pg_regress/sql/json_groupby_orderby_limit.sql
+++ b/pg_search/tests/pg_regress/sql/json_groupby_orderby_limit.sql
@@ -1,0 +1,72 @@
+-- Test JSON field GROUP BY with aggregate custom scan
+
+-- Create extension
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- Enable aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =========================================
+-- Test 1: Single JSON field GROUP BY
+-- =========================================
+
+-- Create test table
+CREATE TABLE json_test_single (
+    id SERIAL PRIMARY KEY,
+    metadata JSONB,
+    data JSONB
+);
+
+-- Insert test data
+INSERT INTO json_test_single (metadata, data) VALUES
+    ('{"category": "electronics", "brand": "Apple", "price": 999}', '{"color": "silver", "stock": 10}'),
+    ('{"category": "electronics", "brand": "Samsung", "price": 799}', '{"color": "black", "stock": 15}'),
+    ('{"category": "electronics", "brand": "Apple", "price": 1299}', '{"color": "gold", "stock": 5}'),
+    ('{"category": "clothing", "brand": "Nike", "price": 89}', '{"size": "M", "stock": 20}'),
+    ('{"category": "clothing", "brand": "Adidas", "price": 79}', '{"size": "L", "stock": 25}'),
+    ('{"category": "clothing", "brand": "Nike", "price": 99}', '{"size": "S", "stock": 30}');
+
+-- Create BM25 index
+CREATE INDEX idx_json_single ON json_test_single
+USING bm25 (id, metadata, data)
+WITH (
+    key_field = 'id',
+    json_fields = '{
+        "metadata": {"indexed": true, "fast": true, "expand_dots": true},
+        "data": {"indexed": true, "fast": true, "expand_dots": true}
+    }'
+);
+
+-- GROUP BY ... ORDER BY ... LIMIT pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 1
+LIMIT 5;
+
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 1
+LIMIT 5;
+
+-- Ordering by count should not be pushed down
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 2
+LIMIT 5;
+
+SELECT metadata->>'category' AS category, COUNT(*) AS count
+FROM json_test_single
+WHERE id @@@ paradedb.exists('metadata.category')
+GROUP BY metadata->>'category'
+ORDER BY 2
+LIMIT 5;
+
+DROP TABLE json_test_single CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3131 
- Opens #3156 #3155 

## What

Pushes down `group by ... order by ... limit` to Tantivy

## Why

By pushing down the sort/limit to Tantivy, we can significantly speed up `group by` queries over high cardinality columns.

## How

- Before we were hard-coding a bucket size and sorting the results ourselves, now the bucket size is set to the limit and we push the sort down to the Tantivy term agg

## Tests