### PR TITLE
fix: zero worker threads (#2959)

### DIFF
--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use pgrx::pg_sys;
 use std::num::NonZeroUsize;
 use tantivy::index::SegmentId;
-use tantivy::indexer::{AddOperation, SegmentWriter};
+use tantivy::indexer::{AddOperation, IndexWriterOptions, SegmentWriter};
 use tantivy::schema::Field;
 use tantivy::{
     Directory, Index, IndexMeta, IndexWriter, Opstamp, Segment, SegmentMeta, TantivyDocument,
@@ -362,7 +362,13 @@ impl Mergeable for SearchIndexMerger {
             "segment was already merged by this merger instance"
         );
 
-        let mut writer: IndexWriter = self.index.writer(15 * 1024 * 1024)?;
+        let mut writer: IndexWriter = self.index.writer_with_options(
+            IndexWriterOptions::builder()
+                .memory_budget_per_thread(15 * 1024 * 1024)
+                .num_merge_threads(0)
+                .num_worker_threads(0)
+                .build(),
+        )?;
         let new_segment = writer.merge_foreground(segment_ids, true)?;
         unsafe {
             // SAFETY:  The important thing here is that these segments are not used in any way


### PR DESCRIPTION
We don't use any of Tantivy's threading features, and as of https://github.com/paradedb/tantivy/pull/59 it's now possible to set the number of merge and worker threads to zero.

Doing so saves overhead of making threads that we never use, and joining on them, for every segment merge operation.


🍒 This is a cherry pick of 98d7dcdc33169d31d80e13ef39aa7242e1a09710 from `main/0.18.x`
