### PR TITLE
chore: proptest for our pg_sys::TransactionIdPrecedesOrEquals function

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -94,14 +94,12 @@ mod tests {
 
     #[pg_test]
     fn xid_precedes_or_equals_test() {
-        use proptest::proptest;
+        use proptest::prelude::*;
 
         proptest!(|(xid1 in 0..u32::MAX, xid2 in 0..u32::MAX)| {
-            if xid1 <= xid2 {
-                let us = TransactionIdPrecedesOrEquals(pg_sys::TransactionId::from(xid1), pg_sys::TransactionId::from(xid2));
-                let pg = unsafe { pg_sys::TransactionIdPrecedesOrEquals(pg_sys::TransactionId::from(xid1), pg_sys::TransactionId::from(xid2)) };
-                assert_eq!(us, pg);
-            }
+            let us = TransactionIdPrecedesOrEquals(pg_sys::TransactionId::from(xid1), pg_sys::TransactionId::from(xid2));
+            let pg = unsafe { pg_sys::TransactionIdPrecedesOrEquals(pg_sys::TransactionId::from(xid1), pg_sys::TransactionId::from(xid2)) };
+            prop_assert_eq!(us, pg);
         });
     }
 }


### PR DESCRIPTION
## What

Add a proptest for our port of `pg_sys::TransactionIdPrecedesOrEquals()`.

## Why

There was a moment of internal confusion around if it was actually correct or not.

## How

## Tests

This is a test.