### PR TITLE
Fixed rt_fetch out-of-bounds error

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -500,14 +500,14 @@ fn extract_grouping_columns(
                 {
                     // JSON operator expression or complex field access
                     let (heaprelid, attno, _) = find_var_relation(var, root);
-                    if heaprelid == pg_sys::Oid::INVALID {
+                    if heaprelid == pg_sys::InvalidOid {
                         continue;
                     }
                     (field_name.to_string(), attno)
                 } else if let Some(var) = nodecast!(Var, T_Var, expr) {
                     // Simple Var - extract field name from attribute
                     let (heaprelid, attno, _) = find_var_relation(var, root);
-                    if heaprelid == pg_sys::Oid::INVALID {
+                    if heaprelid == pg_sys::InvalidOid {
                         continue;
                     }
 

--- a/pg_search/src/postgres/customscan/range_table.rs
+++ b/pg_search/src/postgres/customscan/range_table.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::pg_sys;
+use pgrx::{pg_sys, PgList};
 
 /// If the given Bitmapset has exactly one member, return it.
 pub unsafe fn bms_exactly_one_member(bms: *mut pg_sys::Bitmapset) -> Option<pg_sys::Index> {
@@ -61,11 +61,13 @@ pub unsafe fn is_partitioned_table_setup(
 
     // Get the rtable for relkind checks
     let rtable = (*(*root).parse).rtable;
+    let rtable_list = PgList::<pg_sys::RangeTblEntry>::from_pg(rtable);
 
     // For each relation in baserels
     for baserel_idx in bms_iter(baserels) {
         // Skip invalid indices
-        if baserel_idx == 0 || baserel_idx >= (*root).simple_rel_array_size as pg_sys::Index {
+        if baserel_idx == 0 || baserel_idx as usize > rtable_list.len() {
+            // Out of bounds, skip this entry
             continue;
         }
 

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -1,0 +1,256 @@
+-- Regression test for rt_fetch out-of-bounds error with OR EXISTS and multiple JOINs
+-- This test verifies the fix for the issue where complex nested queries with OR EXISTS
+-- and multiple JOINs cause an rt_fetch out-of-bounds error
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Setup
+DROP TABLE IF EXISTS details CASCADE;
+DROP TABLE IF EXISTS item_details CASCADE;
+DROP TABLE IF EXISTS task_items CASCADE;
+DROP TABLE IF EXISTS tasks CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    org_id INT NOT NULL,
+    name TEXT
+);
+CREATE TABLE tasks (
+    id SERIAL PRIMARY KEY,
+    user_id INT REFERENCES users(id),
+    status TEXT,
+    priority INT
+);
+CREATE TABLE task_items (
+    id SERIAL PRIMARY KEY,
+    task_id INT REFERENCES tasks(id),
+    item_type TEXT,
+    created_at TIMESTAMP
+);
+CREATE TABLE item_details (
+    id SERIAL PRIMARY KEY,
+    task_item_id INT REFERENCES task_items(id),
+    detail_id INT
+);
+CREATE TABLE details (
+    id SERIAL PRIMARY KEY,
+    content TEXT,
+    metadata JSONB
+);
+-- Insert test data
+INSERT INTO users (org_id, name) VALUES 
+(1, 'Alice'), 
+(1, 'Bob'), 
+(2, 'Charlie');
+INSERT INTO tasks (user_id, status, priority) VALUES 
+(1, 'completed', 1), 
+(2, 'pending', 2),
+(3, 'completed', 3);
+INSERT INTO task_items (task_id, item_type, created_at) VALUES 
+(1, 'typeA', '2024-01-01'),
+(2, 'typeB', '2024-01-02'),
+(3, 'typeA', '2024-01-03');
+INSERT INTO item_details (task_item_id, detail_id) VALUES 
+(1, 1),
+(2, 2),
+(3, 3);
+INSERT INTO details (content, metadata) VALUES 
+('test content 1', '{"processed": true}'),
+('test content 2', '{"processed": false}'),
+('test content 3', NULL);
+-- Create BM25 indexes
+CREATE INDEX ON users USING bm25 (id, org_id, name) WITH (key_field = 'id');
+CREATE INDEX ON tasks USING bm25 (id, user_id, status, priority) WITH (key_field = 'id');
+CREATE INDEX ON task_items USING bm25 (id, task_id, item_type) WITH (key_field = 'id');
+CREATE INDEX ON item_details USING bm25 (id, task_item_id, detail_id) WITH (key_field = 'id');
+CREATE INDEX ON details USING bm25 (id, content, metadata) WITH (key_field = 'id', json_fields = '{"metadata": {"fast": true}}');
+-- Test 1: Simple query without EXISTS - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+ORDER BY u.id;
+ id | name  
+----+-------
+  1 | Alice
+  2 | Bob
+(2 rows)
+
+-- Test 2: Query with simple EXISTS - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND t.id @@@ paradedb.term('status', 'completed')
+)
+ORDER BY u.id;
+ id | name  
+----+-------
+  1 | Alice
+(1 row)
+
+-- Test 3: Query with AND EXISTS and multiple JOINs - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND t.id @@@ paradedb.term('status', 'completed')
+    AND EXISTS (
+        SELECT ti.id
+        FROM task_items ti
+        JOIN item_details id ON ti.id = id.task_item_id
+        JOIN details d ON id.detail_id = d.id
+        WHERE t.id = ti.task_id
+        AND ti.id @@@ paradedb.term('item_type', 'typeA')
+        AND d.id @@@ paradedb.exists('metadata.processed')
+    )
+)
+ORDER BY u.id;
+ id | name 
+----+------
+(0 rows)
+
+-- Test 4: The problematic query - OR EXISTS with multiple JOINs
+-- This previously caused rt_fetch out-of-bounds error
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE t.id = ti.task_id
+            AND ti.id @@@ paradedb.term('item_type', 'typeA')
+            AND d.id @@@ paradedb.exists('metadata.processed')
+        )
+    )
+)
+ORDER BY u.id;
+ id | name  
+----+-------
+  1 | Alice
+(1 row)
+
+-- Test 5: Workaround - Using native PostgreSQL clause
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE t.id = ti.task_id
+            AND ti.id @@@ paradedb.term('item_type', 'typeA')
+            AND d.metadata->>'processed' = 'true'  -- Native PostgreSQL instead of ParadeDB
+        )
+    )
+)
+ORDER BY u.id;
+ id | name  
+----+-------
+  1 | Alice
+(1 row)
+
+-- Test 6: Another variation with different join order
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 2)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('priority', 3)
+        OR EXISTS (
+            SELECT d.id
+            FROM details d
+            JOIN item_details id ON d.id = id.detail_id
+            JOIN task_items ti ON id.task_item_id = ti.id
+            WHERE t.id = ti.task_id
+            AND d.id @@@ paradedb.term('content', 'test')
+        )
+    )
+)
+ORDER BY u.id;
+ id |  name   
+----+---------
+  3 | Charlie
+(1 row)
+
+-- Test 7: Minimal reproduction case - simplified version
+SELECT 1 as result
+WHERE EXISTS(
+    SELECT 1
+    WHERE (
+        FALSE  -- Force evaluation of OR branch
+        OR EXISTS (
+            SELECT 1
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE d.id @@@ paradedb.exists('metadata.processed')
+        )
+    )
+);
+ result 
+--------
+      1
+(1 row)
+
+-- Test 8: Edge case - deeply nested OR EXISTS
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            WHERE t.id = ti.task_id
+            AND (
+                ti.id @@@ paradedb.term('item_type', 'typeA')
+                OR EXISTS (
+                    SELECT d.id
+                    FROM details d
+                    JOIN item_details id ON d.id = id.detail_id
+                    WHERE ti.id = id.task_item_id
+                    AND d.id @@@ paradedb.exists('metadata.processed')
+                )
+            )
+        )
+    )
+)
+ORDER BY u.id;
+ id | name  
+----+-------
+  1 | Alice
+  2 | Bob
+(2 rows)
+
+-- Cleanup
+DROP TABLE details CASCADE;
+DROP TABLE item_details CASCADE;
+DROP TABLE task_items CASCADE;
+DROP TABLE tasks CASCADE;
+DROP TABLE users CASCADE;

--- a/pg_search/tests/pg_regress/sql/or_exists_join_bug.sql
+++ b/pg_search/tests/pg_regress/sql/or_exists_join_bug.sql
@@ -1,0 +1,237 @@
+-- Regression test for rt_fetch out-of-bounds error with OR EXISTS and multiple JOINs
+-- This test verifies the fix for the issue where complex nested queries with OR EXISTS
+-- and multiple JOINs cause an rt_fetch out-of-bounds error
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- Setup
+DROP TABLE IF EXISTS details CASCADE;
+DROP TABLE IF EXISTS item_details CASCADE;
+DROP TABLE IF EXISTS task_items CASCADE;
+DROP TABLE IF EXISTS tasks CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    org_id INT NOT NULL,
+    name TEXT
+);
+
+CREATE TABLE tasks (
+    id SERIAL PRIMARY KEY,
+    user_id INT REFERENCES users(id),
+    status TEXT,
+    priority INT
+);
+
+CREATE TABLE task_items (
+    id SERIAL PRIMARY KEY,
+    task_id INT REFERENCES tasks(id),
+    item_type TEXT,
+    created_at TIMESTAMP
+);
+
+CREATE TABLE item_details (
+    id SERIAL PRIMARY KEY,
+    task_item_id INT REFERENCES task_items(id),
+    detail_id INT
+);
+
+CREATE TABLE details (
+    id SERIAL PRIMARY KEY,
+    content TEXT,
+    metadata JSONB
+);
+
+-- Insert test data
+INSERT INTO users (org_id, name) VALUES 
+(1, 'Alice'), 
+(1, 'Bob'), 
+(2, 'Charlie');
+
+INSERT INTO tasks (user_id, status, priority) VALUES 
+(1, 'completed', 1), 
+(2, 'pending', 2),
+(3, 'completed', 3);
+
+INSERT INTO task_items (task_id, item_type, created_at) VALUES 
+(1, 'typeA', '2024-01-01'),
+(2, 'typeB', '2024-01-02'),
+(3, 'typeA', '2024-01-03');
+
+INSERT INTO item_details (task_item_id, detail_id) VALUES 
+(1, 1),
+(2, 2),
+(3, 3);
+
+INSERT INTO details (content, metadata) VALUES 
+('test content 1', '{"processed": true}'),
+('test content 2', '{"processed": false}'),
+('test content 3', NULL);
+
+-- Create BM25 indexes
+CREATE INDEX ON users USING bm25 (id, org_id, name) WITH (key_field = 'id');
+CREATE INDEX ON tasks USING bm25 (id, user_id, status, priority) WITH (key_field = 'id');
+CREATE INDEX ON task_items USING bm25 (id, task_id, item_type) WITH (key_field = 'id');
+CREATE INDEX ON item_details USING bm25 (id, task_item_id, detail_id) WITH (key_field = 'id');
+CREATE INDEX ON details USING bm25 (id, content, metadata) WITH (key_field = 'id', json_fields = '{"metadata": {"fast": true}}');
+
+-- Test 1: Simple query without EXISTS - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+ORDER BY u.id;
+
+-- Test 2: Query with simple EXISTS - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND t.id @@@ paradedb.term('status', 'completed')
+)
+ORDER BY u.id;
+
+-- Test 3: Query with AND EXISTS and multiple JOINs - should work
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND t.id @@@ paradedb.term('status', 'completed')
+    AND EXISTS (
+        SELECT ti.id
+        FROM task_items ti
+        JOIN item_details id ON ti.id = id.task_item_id
+        JOIN details d ON id.detail_id = d.id
+        WHERE t.id = ti.task_id
+        AND ti.id @@@ paradedb.term('item_type', 'typeA')
+        AND d.id @@@ paradedb.exists('metadata.processed')
+    )
+)
+ORDER BY u.id;
+
+-- Test 4: The problematic query - OR EXISTS with multiple JOINs
+-- This previously caused rt_fetch out-of-bounds error
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE t.id = ti.task_id
+            AND ti.id @@@ paradedb.term('item_type', 'typeA')
+            AND d.id @@@ paradedb.exists('metadata.processed')
+        )
+    )
+)
+ORDER BY u.id;
+
+-- Test 5: Workaround - Using native PostgreSQL clause
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE t.id = ti.task_id
+            AND ti.id @@@ paradedb.term('item_type', 'typeA')
+            AND d.metadata->>'processed' = 'true'  -- Native PostgreSQL instead of ParadeDB
+        )
+    )
+)
+ORDER BY u.id;
+
+-- Test 6: Another variation with different join order
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 2)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('priority', 3)
+        OR EXISTS (
+            SELECT d.id
+            FROM details d
+            JOIN item_details id ON d.id = id.detail_id
+            JOIN task_items ti ON id.task_item_id = ti.id
+            WHERE t.id = ti.task_id
+            AND d.id @@@ paradedb.term('content', 'test')
+        )
+    )
+)
+ORDER BY u.id;
+
+-- Test 7: Minimal reproduction case - simplified version
+SELECT 1 as result
+WHERE EXISTS(
+    SELECT 1
+    WHERE (
+        FALSE  -- Force evaluation of OR branch
+        OR EXISTS (
+            SELECT 1
+            FROM task_items ti
+            JOIN item_details id ON ti.id = id.task_item_id
+            JOIN details d ON id.detail_id = d.id
+            WHERE d.id @@@ paradedb.exists('metadata.processed')
+        )
+    )
+);
+
+-- Test 8: Edge case - deeply nested OR EXISTS
+SELECT u.id, u.name
+FROM users u
+WHERE u.id @@@ paradedb.term('org_id', 1)
+AND EXISTS(
+    SELECT t.id
+    FROM tasks t
+    WHERE u.id = t.user_id
+    AND (
+        t.id @@@ paradedb.term('status', 'completed')
+        OR EXISTS (
+            SELECT ti.id
+            FROM task_items ti
+            WHERE t.id = ti.task_id
+            AND (
+                ti.id @@@ paradedb.term('item_type', 'typeA')
+                OR EXISTS (
+                    SELECT d.id
+                    FROM details d
+                    JOIN item_details id ON d.id = id.detail_id
+                    WHERE ti.id = id.task_item_id
+                    AND d.id @@@ paradedb.exists('metadata.processed')
+                )
+            )
+        )
+    )
+)
+ORDER BY u.id;
+
+-- Cleanup
+DROP TABLE details CASCADE;
+DROP TABLE item_details CASCADE;
+DROP TABLE task_items CASCADE;
+DROP TABLE tasks CASCADE;
+DROP TABLE users CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3135

## What

Fixed `rt_fetch used out-of-bounds` and `Cannot open relation with oid=0` errors that occurred in complex SQL queries with nested `OR EXISTS` clauses, multiple `JOIN`s.

## Why

The issue occurred when PostgreSQL's query planner generated `Var` nodes referencing Range Table Entries (RTEs) that were valid in outer planning contexts but didn't exist in inner execution contexts. This happened specifically with:
- `OR EXISTS` subqueries (not `AND EXISTS`)  
- Multiple `JOIN`s within the `EXISTS` clause
- ParadeDB functions applied to joined tables

When ParadeDB's custom scan tried to access these out-of-bounds RTEs using `rt_fetch`, it caused crashes.

## How

Implemented bounds checking across the codebase:

1. **Early detection**: Added bounds checking in `find_var_relation()` to detect invalid `varno` values and return `pg_sys::InvalidOid`. This was the main fix for the issue.
2. **Graceful handling**: Modified all functions that receive relation OIDs to check for `InvalidOid` before attempting to open relations
3. **Safe fallbacks**: Updated query optimization logic to skip optimizations when relation information is unavailable rather than crashing

## Tests

Added regression test `or_exists_join_bug.sql` covering:
- Simple queries (baseline functionality)
- `AND EXISTS` with multiple `JOIN`s (should work)  
- `OR EXISTS` with multiple `JOIN`s (the problematic case, now fixed)
- Various edge cases and workarounds
- Minimal reproduction cases
