### PR TITLE
chore: don't warn about `raw` tokenizer on UUID key fields

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -25,6 +25,7 @@ use crate::postgres::utils::{extract_field_attributes, ExtractedFieldAttribute};
 use crate::schema::{SearchFieldConfig, SearchFieldType};
 use anyhow::Result;
 use pgrx::pg_sys::panic::ErrorReport;
+use pgrx::pg_sys::BuiltinOid;
 use pgrx::*;
 use tantivy::schema::Schema;
 use tantivy::{Index, IndexSettings};
@@ -106,13 +107,16 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
     let options = index_relation.options();
     let key_field_name = options.key_field_name();
     let key_field_config = options.field_config_or_default(&key_field_name);
+    let key_field_is_uuid = options.get_field_type(&key_field_name).unwrap().typeoid()
+        == PgOid::BuiltIn(BuiltinOid::UUIDOID);
 
-    // warn when the `raw` tokenizer is used for the key_field
+    // warn when the `raw` tokenizer is used for the key_field, so long as the key field is not of type UUID
     #[allow(deprecated)]
     if key_field_config
         .tokenizer()
         .map(|tokenizer| matches!(tokenizer, SearchTokenizer::Raw(_)))
         .unwrap_or(false)
+        && !key_field_is_uuid
     {
         ErrorReport::new(
             PgSqlErrorCode::ERRCODE_WARNING_DEPRECATED_FEATURE,

--- a/pg_search/tests/pg_regress/expected/key-field-uuid-raw-warning.out
+++ b/pg_search/tests/pg_regress/expected/key-field-uuid-raw-warning.out
@@ -1,0 +1,13 @@
+create table public.key_field_uuid_raw
+(
+    id uuid default gen_random_uuid() not null primary key,
+    metadata_json jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+CREATE INDEX test_search_index on public.key_field_uuid_raw
+    USING bm25 (id, metadata_json)
+    WITH (
+    key_field = id,
+    json_fields='{
+"metadata_json": { "fast": true, "normalizer": "lowercase", "tokenizer": { "type": "raw" } },
+"metadata_json_new": { "fast": true, "tokenizer": { "type": "keyword", "lowercase": true }, "column": "metadata_json" }
+}', numeric_fields = '{}');

--- a/pg_search/tests/pg_regress/expected/keys_snippet_score.out
+++ b/pg_search/tests/pg_regress/expected/keys_snippet_score.out
@@ -93,7 +93,6 @@ INSERT INTO uuid_test (id, value) VALUES ('40bc9216-66d0-4ae8-87ee-ddb02e3e1b33'
 INSERT INTO uuid_test (id, value) VALUES ('02f9789d-4963-47d5-a189-d9c114f5cba4', 'rainbow');
 CREATE INDEX uuid_test_idx ON uuid_test USING bm25 (id, value)
 WITH (key_field='id', text_fields='{"value": {"tokenizer": {"type": "ngram", "min_gram": 4, "max_gram": 4, "prefix_only": false}}}');
-WARNING:  the `raw` tokenizer is deprecated
 -- Test stable sort (sorted by score)
 \echo 'Query with ORDER BY score DESC for UUID key'
 Query with ORDER BY score DESC for UUID key

--- a/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_basic_05_uuid.out
@@ -30,7 +30,6 @@ WITH (
         "name": { "tokenizer": { "type": "keyword" }, "fast": true }
     }'
 );
-WARNING:  the `raw` tokenizer is deprecated
 -- Confirm that the UUID key_field is fast and gets MixedFF.
 SELECT name FROM products WHERE name @@@ 'bob' ORDER BY uuid_key;
  name 

--- a/pg_search/tests/pg_regress/sql/key-field-uuid-raw-warning.sql
+++ b/pg_search/tests/pg_regress/sql/key-field-uuid-raw-warning.sql
@@ -1,0 +1,14 @@
+create table public.key_field_uuid_raw
+(
+    id uuid default gen_random_uuid() not null primary key,
+    metadata_json jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+
+CREATE INDEX test_search_index on public.key_field_uuid_raw
+    USING bm25 (id, metadata_json)
+    WITH (
+    key_field = id,
+    json_fields='{
+"metadata_json": { "fast": true, "normalizer": "lowercase", "tokenizer": { "type": "raw" } },
+"metadata_json_new": { "fast": true, "tokenizer": { "type": "keyword", "lowercase": true }, "column": "metadata_json" }
+}', numeric_fields = '{}');


### PR DESCRIPTION
## What

Remove the warning about using the `raw` tokenizer when the `key_field` is a UUID field.

The drama here is that we (pg_search) assign the `raw` tokenizer to UUID fields used as the key_field so there's nothing a user can do about it.  Warning about our own bad decisions is not cool.

## Why

Many user and customer complaints.

## How

## Tests

Existing tests pass but a couple of the regression test expected output is now different.