### PR TITLE
fix: Always use a shared expression context to execute HeapFilters.

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/solve_expr.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/solve_expr.rs
@@ -6,18 +6,13 @@ impl SearchQueryInput {
     pub fn has_heap_filters(&mut self) -> bool {
         let mut found = false;
         self.visit(&mut |sqi| {
-            if let SearchQueryInput::HeapFilter { field_filters, .. } = sqi {
-                // Check if any heap field filters contain subqueries
-                for filter in field_filters.iter() {
-                    if filter.contains_subqueries() {
-                        found = true;
-                        break;
-                    }
-                }
+            if let SearchQueryInput::HeapFilter { .. } = sqi {
+                found = true;
             }
         });
         found
     }
+
     pub fn has_postgres_expressions(&mut self) -> bool {
         let mut found = false;
         self.visit(&mut |sqi| {

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -827,6 +827,10 @@ impl SearchQueryInput {
                     planstate,
                 )?;
 
+                // Is initialized in `begin_custom_scan` if `has_heap_filters`.
+                let expr_context = expr_context
+                    .expect("An expression context must be provided when heap filtering.");
+
                 // Create combined query with heap field filters
                 Ok(Box::new(heap_field_filter::HeapFilterQuery::new(
                     indexed_tantivy_query,


### PR DESCRIPTION
## What

Evaluating heap filters was leaking a `CreateStandaloneExprContext` per execution, which could eventually lead to OOMs.

## Why

`PgBox::from_pg` does not free the resulting memory: it's expected to be freed by a memory context, since PG created it.

## How

Always use a global expression context created by `ExecAssignExprContext` in `begin_custom_scan`.

## Tests

A repro uses significantly less memory, and [a benchmark query added for this purpose](https://github.com/paradedb/paradedb/pull/3175) is faster.