### PR TITLE
chore: Add a benchmark query to cover both regexes and heap filters.

### DIFF
--- a/benchmarks/datasets/logs/queries/pg_search/regex-and-heap.sql
+++ b/benchmarks/datasets/logs/queries/pg_search/regex-and-heap.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) FROM benchmark_logs WHERE (country @@@ pdb.regex('united.*') AND country ILIKE '% States');


### PR DESCRIPTION
## What

Add a heap filter (and regex) benchmark query to cover the use case from #3174.

## Why

We don't have a benchmark query which covers a heap filter, or regex matching. Speeding up either step should speed up this query.