### PR TITLE
chore: Add the workflow that kickstarts from community's PR Merge

### DIFF
--- a/.github/workflows/dispatch-new-enterprise-sync.yml
+++ b/.github/workflows/dispatch-new-enterprise-sync.yml
@@ -14,7 +14,7 @@ jobs:
           curl --fail -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN}}" \
+            -H "Authorization: Bearer ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/json" \
             https://api.github.com/repos/paradedb/enterprise-as-branch/dispatches \

--- a/.github/workflows/dispatch-new-enterprise-sync.yml
+++ b/.github/workflows/dispatch-new-enterprise-sync.yml
@@ -1,0 +1,27 @@
+name: Dispatch Sync to New Enterprise Repository (Enterprise As Branch) on Main Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync in Enterprise Patch Repository
+        run: |
+          curl --fail -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.CROSS_REPO_PAT}}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/paradedb/enterprise-as-branch/dispatches \
+            -d '{
+              "event_type": "run-community-rebase",
+              "client_payload": {
+                "sha": "${{ github.sha }}",
+                "repo": "${{ github.repository }}",
+                "ref": "${{ github.ref }}"
+              }
+            }'

--- a/.github/workflows/dispatch-new-enterprise-sync.yml
+++ b/.github/workflows/dispatch-new-enterprise-sync.yml
@@ -14,8 +14,9 @@ jobs:
           curl --fail -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.CROSS_REPO_PAT}}" \
+            -H "Authorization: Bearer ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN}}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
             https://api.github.com/repos/paradedb/enterprise-as-branch/dispatches \
             -d '{
               "event_type": "run-community-rebase",


### PR DESCRIPTION
# Ticket(s) Closed
[TODO] Update the secret reference to use Github BOT's token. 
- Closes #
Adds a GitHub workflow that triggers a sync operation to the paradedb/enterprise-as-branch repository whenever changes are merged to the main branch. The workflow uses repository dispatch to notify the enterprise patch repository to  run a community rebase with the latest commit SHA and repository information.
## What

## Why

## How

## Tests
