### PR TITLE
feat: removed aggregation limitations re mix of aggregate functions and aggregation on group-by column.

### DIFF
--- a/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
@@ -1,0 +1,240 @@
+-- Test for aggregate function columns in GROUP BY clause limitation
+-- This tests the specific case where Tantivy cannot handle aggregate fields in GROUP BY
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan = ON;
+-- Create test table
+CREATE TABLE groupby_conflict_test (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    rating INTEGER,
+    price NUMERIC,
+    views INTEGER
+);
+-- Insert deterministic test data
+INSERT INTO groupby_conflict_test (title, category, rating, price, views) VALUES
+-- Various ratings to test GROUP BY on rating field
+('Product A1', 'electronics', 1, 100.00, 500),
+('Product A2', 'electronics', 1, 150.00, 600),
+('Product B1', 'electronics', 2, 200.00, 700),
+('Product B2', 'electronics', 2, 250.00, 800),
+('Product C1', 'books', 3, 30.00, 300),
+('Product C2', 'books', 3, 40.00, 400),
+('Product D1', 'books', 4, 50.00, 450),
+('Product D2', 'books', 4, 60.00, 500),
+('Product E1', 'clothing', 5, 80.00, 200),
+('Product E2', 'clothing', 5, 90.00, 250),
+-- More data with different price points for GROUP BY price tests
+('Product F1', 'electronics', 3, 299.99, 1000),
+('Product F2', 'electronics', 4, 299.99, 1100),
+('Product G1', 'books', 2, 299.99, 800),
+('Product G2', 'clothing', 1, 299.99, 300);
+-- Create BM25 index with fast fields
+CREATE INDEX groupby_conflict_idx ON groupby_conflict_test 
+USING bm25(id, title, category, rating, price, views)
+WITH (
+    key_field='id',
+    text_fields='{"title": {}, "category": {"fast": true}}',
+    numeric_fields='{"rating": {"fast": true}, "price": {"fast": true}, "views": {"fast": true}}'
+);
+-- =====================================================================
+-- Test 1: GROUP BY on rating field with AVG(rating)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT rating, AVG(rating) as avg_rating, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY rating
+ORDER BY rating;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.groupby_conflict_test
+   Output: rating, now(), now()
+   Index: groupby_conflict_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"rating"}}}}}
+(5 rows)
+
+-- Execute the query
+SELECT rating, AVG(rating) as avg_rating, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY rating
+ORDER BY rating;
+ rating | avg_rating | count 
+--------+------------+-------
+      1 |          1 |     3
+      2 |          2 |     3
+      3 |          3 |     3
+      4 |          4 |     3
+      5 |          5 |     2
+(5 rows)
+
+-- =====================================================================
+-- Test 2: GROUP BY on price field with SUM(price)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT price, SUM(price) as total_price, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY price
+ORDER BY price;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.groupby_conflict_test
+   Output: price, now(), now()
+   Index: groupby_conflict_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"price","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+(5 rows)
+
+-- Execute the query
+SELECT price, SUM(price) as total_price, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY price
+ORDER BY price;
+ price  | total_price | count 
+--------+-------------+-------
+     30 |          30 |     1
+     40 |          40 |     1
+     50 |          50 |     1
+     60 |          60 |     1
+     80 |          80 |     1
+     90 |          90 |     1
+    100 |         100 |     1
+    150 |         150 |     1
+    200 |         200 |     1
+    250 |         250 |     1
+ 299.99 |     1199.96 |     4
+(11 rows)
+
+-- =====================================================================
+-- Test 3: GROUP BY on views field with MAX(views)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT views, MAX(views) as max_views, MIN(views) as min_views
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY views
+ORDER BY views;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.groupby_conflict_test
+   Output: views, now(), now()
+   Index: groupby_conflict_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Product","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"views","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"max":{"field":"views"}},"agg_1":{"min":{"field":"views"}}}}}
+(5 rows)
+
+-- Execute the query
+SELECT views, MAX(views) as max_views, MIN(views) as min_views
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY views
+ORDER BY views;
+ views | max_views | min_views 
+-------+-----------+-----------
+   200 |       200 |       200
+   250 |       250 |       250
+   300 |       300 |       300
+   400 |       400 |       400
+   450 |       450 |       450
+   500 |       500 |       500
+   600 |       600 |       600
+   700 |       700 |       700
+   800 |       800 |       800
+  1000 |      1000 |      1000
+  1100 |      1100 |      1100
+(11 rows)
+
+-- =====================================================================
+-- Test 4: Multiple aggregate functions on same field as GROUP BY
+-- =====================================================================
+-- This should NOT use AggregateScan: rating used in both GROUP BY and multiple aggregates
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT rating, 
+       AVG(rating) as avg_rating,
+       MIN(rating) as min_rating, 
+       MAX(rating) as max_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY rating
+ORDER BY rating;
+                                                                                                                 QUERY PLAN                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.groupby_conflict_test
+   Output: rating, now(), now(), now(), now()
+   Index: groupby_conflict_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"rating"}},"agg_1":{"min":{"field":"rating"}},"agg_2":{"max":{"field":"rating"}}}}}
+(5 rows)
+
+-- Execute the query
+SELECT rating, 
+       AVG(rating) as avg_rating,
+       MIN(rating) as min_rating, 
+       MAX(rating) as max_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY rating
+ORDER BY rating;
+ rating | avg_rating | min_rating | max_rating | count 
+--------+------------+------------+------------+-------
+      1 |          1 |          1 |          1 |     2
+      2 |          2 |          2 |          2 |     2
+      3 |          3 |          3 |          3 |     1
+      4 |          4 |          4 |          4 |     1
+(4 rows)
+
+-- =====================================================================
+-- Edge case: GROUP BY on non-fast field with aggregates on fast fields
+-- =====================================================================
+-- Test 7: GROUP BY on title (not fast field) - should fall back anyway
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT title,
+       AVG(rating) as avg_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY title
+ORDER BY title;
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: title, avg(rating), count(*)
+   Group Key: groupby_conflict_test.title
+   ->  Sort
+         Output: title, rating
+         Sort Key: groupby_conflict_test.title
+         ->  Custom Scan (ParadeDB Scan) on public.groupby_conflict_test
+               Output: title, rating
+               Table: groupby_conflict_test
+               Index: groupby_conflict_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+(13 rows)
+
+-- Execute the query
+SELECT title,
+       AVG(rating) as avg_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY title
+ORDER BY title
+LIMIT 5;
+   title    |       avg_rating       | count 
+------------+------------------------+-------
+ Product A1 | 1.00000000000000000000 |     1
+ Product A2 | 1.00000000000000000000 |     1
+ Product B1 |     2.0000000000000000 |     1
+ Product B2 |     2.0000000000000000 |     1
+ Product F1 |     3.0000000000000000 |     1
+(5 rows)
+
+-- Clean up
+DROP TABLE groupby_conflict_test;

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -422,33 +422,25 @@ FROM type_test
 WHERE text_val @@@ 'test1 OR test2 OR test3'
 GROUP BY text_val
 ORDER BY text_val;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: text_val, sum(int_val), avg(numeric_val), min(float_val), max(bigint_val)
-   Group Key: type_test.text_val
-   ->  Sort
-         Output: text_val, int_val, numeric_val, float_val, bigint_val
-         Sort Key: type_test.text_val
-         ->  Custom Scan (ParadeDB Scan) on public.type_test
-               Output: text_val, int_val, numeric_val, float_val, bigint_val
-               Table: type_test
-               Index: type_test_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_val","query_string":"test1 OR test2 OR test3","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+                                                                                                                                          QUERY PLAN                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.type_test
+   Output: text_val, now(), now(), now(), now()
+   Index: type_test_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"text_val","query_string":"test1 OR test2 OR test3","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"text_val","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"int_val"}},"agg_1":{"avg":{"field":"numeric_val"}},"agg_2":{"min":{"field":"float_val"}},"agg_3":{"max":{"field":"bigint_val"}}}}}
+(5 rows)
 
 SELECT text_val, SUM(int_val), AVG(numeric_val), MIN(float_val), MAX(bigint_val)
 FROM type_test
 WHERE text_val @@@ 'test1 OR test2 OR test3'
 GROUP BY text_val
 ORDER BY text_val;
- text_val | sum |         avg          | min |   max   
-----------+-----+----------------------+-----+---------
- test1    | 100 |  99.9900000000000000 | 1.5 | 1000000
- test2    | 200 | 199.9900000000000000 | 2.5 | 2000000
- test3    | 300 | 299.9900000000000000 | 3.5 | 3000000
+ text_val | sum |  avg   | min |   max   
+----------+-----+--------+-----+---------
+ test1    | 100 |  99.99 | 1.5 | 1000000
+ test2    | 200 | 199.99 | 2.5 | 2000000
+ test3    | 300 | 299.99 | 3.5 | 3000000
 (3 rows)
 
 -- =====================================================================
@@ -495,23 +487,14 @@ SELECT rating, SUM(price), MAX(rating)
 FROM products
 WHERE description @@@ 'keyboard'
 GROUP BY rating;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: rating, sum(price), max(rating)
-   Group Key: products.rating
-   ->  Sort
-         Output: rating, price
-         Sort Key: products.rating
-         ->  Custom Scan (ParadeDB Scan) on public.products
-               Output: rating, price
-               Table: products
-               Index: products_idx
-               Exec Method: MixedFastFieldExecState
-               Fast Fields: price, rating
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
-(14 rows)
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: rating, now(), now()
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}},"agg_1":{"max":{"field":"rating"}}}}}
+(5 rows)
 
 SELECT rating, SUM(price), MAX(rating)
 FROM products
@@ -531,22 +514,14 @@ SELECT category, MIN(rating), MAX(rating), SUM(price)
 FROM products
 WHERE category @@@ 'Electronics'
 GROUP BY category;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: category, min(rating), max(rating), sum(price)
-   Group Key: products.category
-   ->  Sort
-         Output: category, rating, price
-         Sort Key: products.category
-         ->  Custom Scan (ParadeDB Scan) on public.products
-               Output: category, rating, price
-               Table: products
-               Index: products_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}
-(13 rows)
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: category, now(), now(), now()
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","size":65000,"segment_size":65000},"aggs":{"agg_0":{"min":{"field":"rating"}},"agg_1":{"max":{"field":"rating"}},"agg_2":{"sum":{"field":"price"}}}}}
+(5 rows)
 
 SELECT category, MIN(rating), MAX(rating), SUM(price)
 FROM products
@@ -627,23 +602,14 @@ WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics')
 GROUP BY rating
 ORDER BY rating;
-                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: rating, sum(price), count(*)
-   Group Key: products.rating
-   ->  Sort
-         Output: rating, price
-         Sort Key: products.rating
-         ->  Custom Scan (ParadeDB Scan) on public.products
-               Output: rating, price
-               Table: products
-               Index: products_idx
-               Exec Method: MixedFastFieldExecState
-               Fast Fields: price, rating
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}]}}]}}
-(14 rows)
+                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: rating, now(), now()
+   Index: products_idx
+   Tantivy Query: {"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}}]}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"rating","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"sum":{"field":"price"}}}}}
+(5 rows)
 
 SELECT rating, SUM(price), COUNT(*)
 FROM products
@@ -664,31 +630,23 @@ FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
-                                                                                                                                                                 QUERY PLAN                                                                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: category, avg(price), min(rating), max(rating)
-   Group Key: products.category
-   ->  Sort
-         Output: category, price, rating
-         Sort Key: products.category
-         ->  Custom Scan (ParadeDB Scan) on public.products
-               Output: category, price, rating
-               Table: products
-               Index: products_idx
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}]}}
-(13 rows)
+                                                                                                                                                           QUERY PLAN                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: category, now(), now(), now()
+   Index: products_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"Electronics","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR keyboard","lenient":null,"conjunction_mode":null}}}}]}}
+   Aggregate Definition: {"group_0":{"terms":{"field":"category","order":{"_key":"asc"},"size":65000,"segment_size":65000},"aggs":{"agg_0":{"avg":{"field":"price"}},"agg_1":{"min":{"field":"rating"}},"agg_2":{"max":{"field":"rating"}}}}}
+(5 rows)
 
 SELECT category, AVG(price), MIN(rating), MAX(rating)
 FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard')
 GROUP BY category
 ORDER BY category;
-  category   |         avg          | min | max 
--------------+----------------------+-----+-----
- Electronics | 632.4900000000000000 |   4 |   5
+  category   |  avg   | min | max 
+-------------+--------+-----+-----
+ Electronics | 632.49 |   4 |   5
 (1 row)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/aggregate-groupby-conflict.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate-groupby-conflict.sql
@@ -1,0 +1,147 @@
+-- Test for aggregate function columns in GROUP BY clause limitation
+-- This tests the specific case where Tantivy cannot handle aggregate fields in GROUP BY
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan = ON;
+
+-- Create test table
+CREATE TABLE groupby_conflict_test (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    rating INTEGER,
+    price NUMERIC,
+    views INTEGER
+);
+
+-- Insert deterministic test data
+INSERT INTO groupby_conflict_test (title, category, rating, price, views) VALUES
+-- Various ratings to test GROUP BY on rating field
+('Product A1', 'electronics', 1, 100.00, 500),
+('Product A2', 'electronics', 1, 150.00, 600),
+('Product B1', 'electronics', 2, 200.00, 700),
+('Product B2', 'electronics', 2, 250.00, 800),
+('Product C1', 'books', 3, 30.00, 300),
+('Product C2', 'books', 3, 40.00, 400),
+('Product D1', 'books', 4, 50.00, 450),
+('Product D2', 'books', 4, 60.00, 500),
+('Product E1', 'clothing', 5, 80.00, 200),
+('Product E2', 'clothing', 5, 90.00, 250),
+-- More data with different price points for GROUP BY price tests
+('Product F1', 'electronics', 3, 299.99, 1000),
+('Product F2', 'electronics', 4, 299.99, 1100),
+('Product G1', 'books', 2, 299.99, 800),
+('Product G2', 'clothing', 1, 299.99, 300);
+
+-- Create BM25 index with fast fields
+CREATE INDEX groupby_conflict_idx ON groupby_conflict_test 
+USING bm25(id, title, category, rating, price, views)
+WITH (
+    key_field='id',
+    text_fields='{"title": {}, "category": {"fast": true}}',
+    numeric_fields='{"rating": {"fast": true}, "price": {"fast": true}, "views": {"fast": true}}'
+);
+
+-- =====================================================================
+-- Test 1: GROUP BY on rating field with AVG(rating)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT rating, AVG(rating) as avg_rating, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY rating
+ORDER BY rating;
+
+-- Execute the query
+SELECT rating, AVG(rating) as avg_rating, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY rating
+ORDER BY rating;
+
+-- =====================================================================
+-- Test 2: GROUP BY on price field with SUM(price)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT price, SUM(price) as total_price, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY price
+ORDER BY price;
+
+-- Execute the query
+SELECT price, SUM(price) as total_price, COUNT(*) as count
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY price
+ORDER BY price;
+
+-- =====================================================================
+-- Test 3: GROUP BY on views field with MAX(views)
+-- =====================================================================
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT views, MAX(views) as max_views, MIN(views) as min_views
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY views
+ORDER BY views;
+
+-- Execute the query
+SELECT views, MAX(views) as max_views, MIN(views) as min_views
+FROM groupby_conflict_test
+WHERE title @@@ 'Product'
+GROUP BY views
+ORDER BY views;
+
+-- =====================================================================
+-- Test 4: Multiple aggregate functions on same field as GROUP BY
+-- =====================================================================
+-- This should NOT use AggregateScan: rating used in both GROUP BY and multiple aggregates
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT rating, 
+       AVG(rating) as avg_rating,
+       MIN(rating) as min_rating, 
+       MAX(rating) as max_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY rating
+ORDER BY rating;
+
+-- Execute the query
+SELECT rating, 
+       AVG(rating) as avg_rating,
+       MIN(rating) as min_rating, 
+       MAX(rating) as max_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY rating
+ORDER BY rating;
+
+-- =====================================================================
+-- Edge case: GROUP BY on non-fast field with aggregates on fast fields
+-- =====================================================================
+
+-- Test 7: GROUP BY on title (not fast field) - should fall back anyway
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT title,
+       AVG(rating) as avg_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY title
+ORDER BY title;
+
+-- Execute the query
+SELECT title,
+       AVG(rating) as avg_rating,
+       COUNT(*) as count
+FROM groupby_conflict_test
+WHERE category @@@ 'electronics'
+GROUP BY title
+ORDER BY title
+LIMIT 5;
+
+-- Clean up
+DROP TABLE groupby_conflict_test;

--- a/pg_search/tests/pg_regress/sql/test-fruit-types-issue.sql
+++ b/pg_search/tests/pg_regress/sql/test-fruit-types-issue.sql
@@ -1,0 +1,93 @@
+-- Test for "incompatible fruit types in tree" issue (#2963)
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan = ON;
+
+-- Create test table with mixed field types (exact reproduction)
+CREATE TABLE users (
+    id    SERIAL8 NOT NULL PRIMARY KEY,
+    uuid  UUID NOT NULL,
+    name  TEXT,
+    color VARCHAR,
+    age   INTEGER,
+    price NUMERIC(10,2),
+    rating INTEGER
+);
+
+-- Create BM25 index with fast fields (exact reproduction)
+CREATE INDEX idxusers ON users USING bm25 (id, uuid, name, color, age, price, rating)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "color": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{
+        "age": { "fast": true },
+        "price": { "fast": true },
+        "rating": { "fast": true }
+    }'
+);
+
+-- Insert test data (deterministic version instead of gen_random_uuid)
+INSERT INTO users (uuid, name, color, age, price, rating)
+SELECT
+    ('00000000-0000-0000-0000-' || lpad(i::text, 12, '0'))::uuid,
+    CASE (i % 3) WHEN 0 THEN 'alice' WHEN 1 THEN 'bob' ELSE 'charlie' END,
+    'blue',
+    20 + (i % 30),
+    (100 + i * 10)::numeric(10,2),
+    (i % 5) + 1
+FROM generate_series(1, 100) AS i;
+
+-- =====================================================================
+-- Test the specific failing query from the issue (#2963)
+-- =====================================================================
+-- This query was supposed to trigger "incompatible fruit types in tree" error
+-- if the issue still existed
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name;
+
+-- execute the failing query
+SELECT name, SUM(price), MAX(rating), AVG(age) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name
+ORDER BY name;
+
+-- =====================================================================
+-- Additional related test cases
+-- =====================================================================
+
+-- Test 4: COUNT + SUM + MAX (different combination)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT name, COUNT(*), SUM(price), MAX(rating) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name;
+
+SELECT name, COUNT(*), SUM(price), MAX(rating) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name
+ORDER BY name;
+
+-- Test 5: COUNT + MAX + AVG (different combination)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT name, COUNT(*), MAX(rating), AVG(age) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name;
+
+SELECT name, COUNT(*), MAX(rating), AVG(age) 
+FROM users 
+WHERE color @@@ 'blue' 
+GROUP BY name
+ORDER BY name;
+
+-- Clean up
+DROP TABLE users;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2963

## What

Removes aggregate limitations that prevented queries where the same field is used in both `GROUP BY` and aggregate functions (e.g., `SELECT rating, AVG(rating) FROM table GROUP BY rating`).

## Why

Previous safety checks blocked these queries due to Tantivy's "incompatible fruit types" errors, but testing shows the underlying issue is resolved. The limitations were overly restrictive and caused unnecessary fallbacks to slower PostgreSQL aggregation.

## How

- Removed `has_search_field_conflicts` function and field conflict validation
- Eliminated ~35 lines of restrictive code in `extract_and_validate_aggregates`
- Previously blocked queries now use faster `AggregateScan` instead of `GroupAggregate`

## Tests

- **`aggregate-groupby-conflict.sql`** - Tests `GROUP BY field` with aggregates on same field
- **`test-fruit-types-issue.sql`** - Validates #2963 issue resolution  
- **`groupby_aggregate.out`** - Updated expectations showing `AggregateScan` usage
