### PR TITLE
feat: Port `ambulkdelete_epoch` to community

### DIFF
--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -60,6 +60,7 @@ use crate::postgres::customscan::{
 };
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
+use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::var::{find_one_var_and_fieldname, find_var_relation, VarContext};
 use crate::postgres::visibility_checker::VisibilityChecker;
 use crate::query::pdb_query::pdb;
@@ -654,6 +655,11 @@ impl CustomScan for PdbScan {
             builder
                 .custom_private_mut()
                 .set_var_attname_lookup(attname_lookup);
+
+            builder
+                .custom_private_mut()
+                .set_ambulkdelete_epoch(MetaPage::open(&indexrel).ambulkdelete_epoch());
+
             builder.build()
         }
     }
@@ -765,6 +771,9 @@ impl CustomScan for PdbScan {
             .into_iter()
             .map(|field| (field, None))
             .collect();
+
+            builder.custom_state().ambulkdelete_epoch =
+                builder.custom_private().ambulkdelete_epoch();
 
             assign_exec_method(&mut builder);
 

--- a/pg_search/src/postgres/customscan/pdbscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/privdat.rs
@@ -49,6 +49,7 @@ pub struct PrivateData {
     // Additional search predicates from join filters that are relevant for snippet/score generation
     // Stores the entire simplified Boolean expression to preserve OR structures like (TRUE OR name:"Rowling")
     join_predicates: Option<SearchQueryInput>,
+    ambulkdelete_epoch: u32,
 }
 
 mod var_attname_lookup_serializer {
@@ -184,6 +185,10 @@ impl PrivateData {
         self.var_attname_lookup = Some(var_attname_lookup);
     }
 
+    pub fn set_ambulkdelete_epoch(&mut self, epoch: u32) {
+        self.ambulkdelete_epoch = epoch;
+    }
+
     pub fn set_segment_count(&mut self, segment_count: usize) {
         self.segment_count = segment_count;
     }
@@ -277,5 +282,9 @@ impl PrivateData {
 
     pub fn join_predicates(&self) -> &Option<SearchQueryInput> {
         &self.join_predicates
+    }
+
+    pub fn ambulkdelete_epoch(&self) -> u32 {
+        self.ambulkdelete_epoch
     }
 }

--- a/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/scan_state.rs
@@ -88,6 +88,8 @@ pub struct PdbScanState {
     pub join_predicates: Option<SearchQueryInput>,
 
     pub exec_method_type: ExecMethodType,
+    pub ambulkdelete_epoch: u32,
+
     exec_method: UnsafeCell<Box<dyn ExecMethod>>,
     exec_method_name: String,
 }

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -138,7 +138,8 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
         stats.pages_deleted = 0;
     }
 
-    if !old_metas.is_empty() {
+    let did_delete = !old_metas.is_empty();
+    if did_delete {
         // Save the new delete metas entries in one atomic operation
         assert_eq!(old_metas.len(), new_metas.len());
         save_delete_metas(&index, old_metas, new_metas)

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -19,7 +19,7 @@ use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::storage::metadata::{MetaPage, MetaPageMut};
+use crate::postgres::storage::metadata::MetaPage;
 
 use anyhow::Result;
 use pgrx::{pg_sys::ItemPointerData, *};
@@ -158,10 +158,8 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
 
     // we're done, no need to hold onto the sentinel any longer
     drop(vacuum_sentinel);
-    drop(metadata);
 
     if did_delete {
-        let metadata = MetaPageMut::open(&index_relation);
         metadata.increment_ambulkdelete_epoch();
     }
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -19,7 +19,7 @@ use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::storage::metadata::MetaPage;
+use crate::postgres::storage::metadata::{MetaPage, MetaPageMut};
 
 use anyhow::Result;
 use pgrx::{pg_sys::ItemPointerData, *};
@@ -158,6 +158,11 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     // we're done, no need to hold onto the sentinel any longer
     drop(vacuum_sentinel);
     drop(metadata);
+
+    if did_delete {
+        let metadata = MetaPageMut::open(&index_relation);
+        metadata.increment_ambulkdelete_epoch();
+    }
 
     stats.into_pg()
 }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -486,13 +486,13 @@ pub struct ParallelExplainData {
     workers: BTreeMap<i32, ParallelExplainWorkerData>,
 }
 
-#[derive(Default, serde::Deserialize, serde::Serialize)]
+#[derive(Default, serde::Deserialize, serde::Serialize, Debug)]
 pub struct ParallelExplainWorkerData {
     query_count: Option<u16>,
     claimed_segments: Vec<ClaimedSegmentData>,
 }
 
-#[derive(Default, serde::Deserialize, serde::Serialize)]
+#[derive(Default, serde::Deserialize, serde::Serialize, Debug)]
 pub struct ClaimedSegmentData {
     id: String,
     deleted_docs: u32,

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -486,13 +486,13 @@ pub struct ParallelExplainData {
     workers: BTreeMap<i32, ParallelExplainWorkerData>,
 }
 
-#[derive(Default, serde::Deserialize, serde::Serialize, Debug)]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct ParallelExplainWorkerData {
     query_count: Option<u16>,
     claimed_segments: Vec<ClaimedSegmentData>,
 }
 
-#[derive(Default, serde::Deserialize, serde::Serialize, Debug)]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct ClaimedSegmentData {
     id: String,
     deleted_docs: u32,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Add `ambulkdelete_epoch` to the index metadata and make sure it's passed down to all scans. In enterprise, this value is used to detect query conflicts with concurrent vacuums on the primary.

## Why

## How

## Tests
