### PR TITLE
fix: write all delete files atomically (#3178)

### DIFF
--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -15,19 +15,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use pgrx::{pg_sys::ItemPointerData, *};
-
 use crate::index::fast_fields_helper::FFType;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::metadata::MetaPage;
 
-use crate::postgres::rel::PgSearchRelation;
 use anyhow::Result;
-use pgrx::pg_sys;
-use tantivy::index::SegmentId;
+use pgrx::{pg_sys::ItemPointerData, *};
 use tantivy::indexer::delete_queue::DeleteQueue;
 use tantivy::indexer::{advance_deletes, DeleteOperation, SegmentEntry};
+use tantivy::SegmentMeta;
 use tantivy::{Directory, DocId, Index, IndexMeta, Opstamp};
 
 #[pg_guard]
@@ -79,7 +77,13 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     // It's important to drop the merge lock after the `vacuum_sentinel` is pinned
     drop(merge_lock);
 
-    let mut did_delete = false;
+    let mut old_metas = Vec::new();
+    let mut new_metas = Vec::new();
+
+    let directory = MvccSatisfies::Vacuum.directory(&index_relation);
+    let index = Index::open(directory).unwrap();
+    let searchable_segment_metas = index.searchable_segment_metas().unwrap();
+
     for segment_reader in reader.segment_readers() {
         let segment_id = segment_reader.segment_id();
         if !writer_segment_ids.contains(&segment_id) {
@@ -90,7 +94,12 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
             // need to concern ourselves with the ones the writer is aware of
             continue;
         }
-        let mut deleter = SegmentDeleter::open(&index_relation, segment_id)
+
+        let segment_meta = searchable_segment_metas
+            .iter()
+            .find(|meta| meta.id() == segment_id)
+            .unwrap_or_else(|| panic!("segment meta not found for segment_id: {segment_id:?}"));
+        let mut deleter = SegmentDeleter::open(segment_meta)
             .expect("ambulkdelete: should be able to open a SegmentDeleter");
         let ctid_ff = FFType::new_ctid(segment_reader.fast_fields());
         let mut needs_commit = false;
@@ -103,16 +112,17 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
 
             let ctid = ctid_ff.as_u64(doc_id).expect("ctid should be present");
             if callback(ctid) {
-                did_delete = true;
                 needs_commit = true;
                 deleter.delete_document(doc_id);
             }
         }
 
         if needs_commit {
-            deleter
-                .commit()
+            let (old_meta, new_meta) = deleter
+                .commit(&index)
                 .expect("ambulkdelete: segment deletercommit should succeed");
+            old_metas.push(old_meta);
+            new_metas.push(new_meta);
         }
     }
     // no need to keep the reader around.  Also, it holds a pin on the CLEANUP_LOCK, which
@@ -128,42 +138,40 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
         stats.pages_deleted = 0;
     }
 
-    // As soon as ambulkdelete returns, Postgres will update the visibility map
-    // This can cause concurrent scans that have just read ctids, which are dead but
-    // are about to be marked visible, to return wrong results. To guard against this,
-    // we acquire a cleanup lock that guarantees that there are no pins on the index,
-    // which means that all concurrent scans have completed.
-    //
-    // Effectively, we're blocking ambulkdelete from finishing until we know that concurrent
-    // scans have finished too
-    if did_delete {
+    if !old_metas.is_empty() {
+        // Save the new delete metas entries in one atomic operation
+        assert_eq!(old_metas.len(), new_metas.len());
+        save_delete_metas(&index, old_metas, new_metas)
+            .expect("ambulkdelete: should be able to save delete metas entries");
+
+        // As soon as ambulkdelete returns, Postgres will update the visibility map
+        // This can cause concurrent scans that have just read ctids, which are dead but
+        // are about to be marked visible, to return wrong results. To guard against this,
+        // we acquire a cleanup lock that guarantees that there are no pins on the index,
+        // which means that all concurrent scans have completed.
+        //
+        // Effectively, we're blocking ambulkdelete from finishing until we know that concurrent
+        // scans have finished too
         drop(metadata.cleanup_lock_for_cleanup());
     }
 
     // we're done, no need to hold onto the sentinel any longer
     drop(vacuum_sentinel);
+    drop(metadata);
+
     stats.into_pg()
 }
 
 struct SegmentDeleter {
     delete_queue: DeleteQueue,
     segment_entry: SegmentEntry,
-    index: Index,
     opstamp: Opstamp,
 }
 
 impl SegmentDeleter {
-    pub fn open(index_relation: &PgSearchRelation, segment_id: SegmentId) -> Result<Self> {
+    pub fn open(segment_meta: &SegmentMeta) -> Result<Self> {
         let delete_queue = DeleteQueue::new();
         let delete_cursor = delete_queue.cursor();
-
-        let directory = MvccSatisfies::Vacuum.directory(index_relation);
-        let index = Index::open(directory)?;
-        let searchable_segment_metas = index.searchable_segment_metas()?;
-        let segment_meta = searchable_segment_metas
-            .iter()
-            .find(|meta| meta.id() == segment_id)
-            .unwrap_or_else(|| panic!("segment meta not found for segment_id: {segment_id:?}"));
         let opstamp = segment_meta.delete_opstamp().unwrap_or_default();
 
         // It's important to set the entry/cursor at the beginning vs. when commit() is called,
@@ -173,7 +181,6 @@ impl SegmentDeleter {
         Ok(Self {
             delete_queue,
             segment_entry,
-            index,
             opstamp,
         })
     }
@@ -187,30 +194,30 @@ impl SegmentDeleter {
         });
     }
 
-    pub fn commit(mut self) -> Result<()> {
-        let segment = self.index.segment(self.segment_entry.meta().clone());
+    pub fn commit(mut self, index: &Index) -> Result<(SegmentMeta, SegmentMeta)> {
+        let old_meta = self.segment_entry.meta().clone();
+        let segment = index.segment(self.segment_entry.meta().clone());
         advance_deletes(segment, &mut self.segment_entry, self.opstamp + 1)?;
-
-        let current_metas = self.index.load_metas()?;
-        let modified_segments = current_metas
-            .segments
-            .clone()
-            .into_iter()
-            .map(|meta| {
-                if meta.id() == self.segment_entry.meta().id() {
-                    self.segment_entry.meta().clone()
-                } else {
-                    meta
-                }
-            })
-            .collect();
-        let new_metas = IndexMeta {
-            segments: modified_segments,
-            ..current_metas.clone()
-        };
-        self.index
-            .directory()
-            .save_metas(&new_metas, &current_metas, &mut ())?;
-        Ok(())
+        Ok((old_meta, self.segment_entry.meta().clone()))
     }
+}
+
+fn save_delete_metas(
+    index: &Index,
+    old_metas: Vec<SegmentMeta>,
+    new_metas: Vec<SegmentMeta>,
+) -> Result<()> {
+    let current_metas = index.load_metas()?;
+    let old_index_meta = IndexMeta {
+        segments: old_metas,
+        ..current_metas.clone()
+    };
+    let new_index_meta = IndexMeta {
+        segments: new_metas.clone(),
+        ..current_metas.clone()
+    };
+    index
+        .directory()
+        .save_metas(&new_index_meta, &old_index_meta, &mut ())?;
+    Ok(())
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In `ambulkdelete`, write all delete files to the meta list atomically, instead of one at a time.

## Why

Reduces the number of writes to the metas list.

## How

## Tests

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
