### PR TITLE
fix: use correct xids when returning to the fsm

### DIFF
--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -501,7 +501,7 @@ fn merge_lock_garbage_collect(index: PgRelation) -> SetOfIterator<'static, i32> 
         let merge_lock = metadata.acquire_merge_lock();
         let mut merge_list = merge_lock.merge_list();
         let before = merge_list.list();
-        merge_list.garbage_collect();
+        merge_list.garbage_collect(pg_sys::ReadNextTransactionId());
         let after = merge_list.list();
         drop(merge_lock);
 

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -56,7 +56,9 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
 
     // garbage collecting the MergeList is necessary to remove any stale entries that may have
     // been leftover from a cancelled merge or crash during merge
-    merge_lock.merge_list().garbage_collect();
+    merge_lock
+        .merge_list()
+        .garbage_collect(pg_sys::ReadNextTransactionId());
 
     // and now we should not have any merges happening, and cannot
     assert!(

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -209,6 +209,7 @@ pub fn paradedb_aminsertcleanup(mut writer: Option<SerialIndexWriter>) {
                     &indexrel,
                     MergeStyle::Insert,
                     Some(pg_sys::GetCurrentTransactionId()),
+                    Some(pg_sys::ReadNextTransactionId()),
                 )
                 .expect("should be able to merge");
             }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -291,11 +291,16 @@ impl BufferMut {
 
     /// Return this [`BufferMut`] instance back to our' Free Space Map, making
     /// it available for future reuse as a new buffer.
-    pub fn return_to_fsm(self, bman: &mut BufferManager) {
+    pub fn return_to_fsm_with_when_recyclable(
+        self,
+        bman: &mut BufferManager,
+        when_recyclable: pg_sys::TransactionId,
+    ) {
         let blockno = self.number();
         drop(self);
 
-        bman.fsm().extend(bman, std::iter::once(blockno));
+        bman.fsm()
+            .extend_with_when_recyclable(bman, when_recyclable, std::iter::once(blockno));
     }
 }
 

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -189,9 +189,9 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
         true
     }
 
-    pub unsafe fn garbage_collect(&mut self) -> Vec<T> {
+    pub unsafe fn garbage_collect(&mut self, when_recyclable: pg_sys::TransactionId) -> Vec<T> {
         // Delete all items that are definitely dead
-        self.retain(|bman, entry| {
+        self.retain(when_recyclable, |bman, entry| {
             if entry.recyclable(bman) {
                 RetainItem::Remove(entry)
             } else {
@@ -209,6 +209,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
     ///
     pub unsafe fn retain(
         &mut self,
+        when_recyclable: pg_sys::TransactionId,
         mut f: impl FnMut(&mut BufferManager, T) -> RetainItem<T>,
     ) -> Vec<T> {
         let (mut blockno, mut previous_buffer) = self.get_start_blockno_mut();
@@ -257,7 +258,7 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> LinkedItemList<
 
                 // return it to the FSM. Doing so will also drop the lock, but we are still
                 // holding the lock on the previous page, so hand-over-hand is ensured.
-                buffer.return_to_fsm(&mut self.bman);
+                buffer.return_to_fsm_with_when_recyclable(&mut self.bman, when_recyclable);
             } else {
                 // this is either the start page, or a page containing valid data. move its buffer
                 // into previous_buffer to ensure that it is held hand-over-hand until we decide
@@ -519,7 +520,11 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone + MVCCEntry> AtomicGuard<'_,
             Some(recyclable_blockno)
         })
         .chain(std::iter::once(self.cloned.header_blockno));
-        self.bman.fsm().extend(&mut self.bman, recyclable_blocks);
+        self.bman.fsm().extend_with_when_recyclable(
+            &mut self.bman,
+            unsafe { pg_sys::ReadNextTransactionId() },
+            recyclable_blocks,
+        );
     }
 }
 
@@ -595,7 +600,7 @@ mod tests {
 
         list.add_items(&entries_to_delete, None);
         list.add_items(&entries_to_keep, None);
-        list.garbage_collect();
+        list.garbage_collect(delete_xid);
 
         assert!(list
             .lookup(|entry| entry.segment_id == entries_to_delete[0].segment_id)
@@ -630,7 +635,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             list.add_items(&entries, None);
-            list.garbage_collect();
+            list.garbage_collect(deleted_xid);
 
             for entry in entries {
                 if entry.xmax == not_deleted_xid {
@@ -677,7 +682,7 @@ mod tests {
             list.add_items(&entries_3, None);
 
             let pre_gc_blocks = linked_list_block_numbers(&list);
-            list.garbage_collect();
+            list.garbage_collect(deleted_xid);
 
             for entries in [entries_1, entries_2, entries_3] {
                 for entry in entries {

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -291,8 +291,8 @@ impl MergeList {
         self.entries.list()
     }
 
-    pub unsafe fn garbage_collect(&mut self) {
-        let recycled_entries = self.entries.garbage_collect();
+    pub unsafe fn garbage_collect(&mut self, when_recyclable: pg_sys::TransactionId) {
+        let recycled_entries = self.entries.garbage_collect(when_recyclable);
 
         let indexrel = self.bman.buffer_access().rel().clone();
         self.bman.fsm().extend(

--- a/pg_search/src/postgres/vacuum.rs
+++ b/pg_search/src/postgres/vacuum.rs
@@ -26,6 +26,6 @@ pub unsafe extern "C-unwind" fn amvacuumcleanup(
     stats: *mut pg_sys::IndexBulkDeleteResult,
 ) -> *mut pg_sys::IndexBulkDeleteResult {
     let index = PgSearchRelation::open((*(*info).index).rd_id);
-    do_merge(&index, MergeStyle::Vacuum, None).expect("should be able to merge");
+    do_merge(&index, MergeStyle::Vacuum, None, None).expect("should be able to merge");
     stats
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

There's a few places where we need to use a future xid when returning blocks to the FSM.

Specically blocks from the segment meta entries list when it's garbage collected.

## Why

To address some community reports of what appear to be corrupt index pages.  

## How

## Tests
