### PR TITLE
fix: update tantivy dependency revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4819,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "bitpacking",
 ]
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "nom",
 ]
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -4963,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=5b5ea7576c68b7c949691c0cddef4539bb8be5ce#5b5ea7576c68b7c949691c0cddef4539bb8be5ce"
+source = "git+https://github.com/paradedb/tantivy.git?rev=7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58#7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "5b5ea7576c68b7c949691c0cddef4539bb8be5ce", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -34,4 +34,4 @@ tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
 rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "5b5ea7576c68b7c949691c0cddef4539bb8be5ce" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58" }


### PR DESCRIPTION
## What

Update tantivy to
https://github.com/paradedb/tantivy/commit/7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58 which fixes a bug that disallowed a segment, during indexing, to real the real memory limit of 4GB.

## Why

We had a bug in our tantivy fork that wouldn't allow a segment, during indexing, to cross over 2GB to reach the actual limit of 4GB. 

## How

## Tests
