### PR TITLE
docs: Remove GA4 integration since it's now a duplicate

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -426,9 +426,6 @@
     }
   },
   "integrations": {
-    "ga4": {
-      "measurementId": "G-GB3C03LVY5"
-    },
     "gtm": {
       "tagId": "GTM-KMGRG564"
     },


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We've consolidated GA4 reporting to be issued via Google Tag Manager, so we're now double-counting docs visits. This fixes that.

## Why
Double counting is no bueno.

## How
Configured in GTM.

## Tests
I am pretty sure it works.