### PR TITLE
fix: allow user to set TEXT `key_field`'s tokenizer to `keyword`

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -193,9 +193,15 @@ fn validate_field_config(
     }
 
     if field_name.root() == key_field_name.root() {
-        panic!(
-            "cannot override BM25 configuration for key_field '{field_name}', you must use an aliased field name and 'column' configuration key"
-        );
+        match config {
+            // we allow the user to change a TEXT key_field tokenizer to "keyword"
+            SearchFieldConfig::Text { tokenizer: SearchTokenizer::Keyword, .. } => {
+                // noop
+            }
+
+            // but not to anything else
+            _ => panic!("cannot override BM25 configuration for key_field '{field_name}', you must use an aliased field name and 'column' configuration key")
+        }
     }
 
     if let Some(alias) = config.alias() {

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -400,7 +400,13 @@ impl BM25IndexOptions {
         }
 
         if field_name.root() == data.key_field_name()?.root() {
-            return self.get_field_type(field_name).map(key_field_config);
+            return match self.text_config().as_ref().unwrap().get(field_name) {
+                // if the key_field is TEXT then we'll use the config for it
+                config @ Some(SearchFieldConfig::Text { .. }) => config.cloned(),
+
+                // otherwise we'll use the default config for key_fields in general
+                _ => self.get_field_type(field_name).map(key_field_config),
+            };
         }
 
         self.text_config()

--- a/pg_search/tests/pg_regress/expected/key-field-text-as-keyword.out
+++ b/pg_search/tests/pg_regress/expected/key-field-text-as-keyword.out
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS public.key_field_text_raw;
+CREATE TABLE public.key_field_text_raw
+(
+    id text not null primary key,
+    data text
+);
+CREATE INDEX idx_key_field_raw on public.key_field_text_raw USING bm25 (id, data)
+WITH (key_field = id, text_fields = '{"id": { "tokenizer": { "type": "keyword" } } }');
+SELECT * FROM paradedb.schema('idx_key_field_raw') ORDER BY name;
+ name | field_type | stored | indexed | fast | fieldnorms | expand_dots |                         tokenizer                         |  record  | normalizer 
+------+------------+--------+---------+------+------------+-------------+-----------------------------------------------------------+----------+------------
+ ctid | U64        | f      | t       | t    | f          |             |                                                           |          | 
+ data | Str        | f      | t       | f    | t          |             | default                                                   | position | 
+ id   | Str        | f      | t       | t    | t          |             | keyword[remove_long=18446744073709551615,lowercase=false] | position | raw
+(3 rows)
+

--- a/pg_search/tests/pg_regress/sql/key-field-text-as-keyword.sql
+++ b/pg_search/tests/pg_regress/sql/key-field-text-as-keyword.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS public.key_field_text_raw;
+CREATE TABLE public.key_field_text_raw
+(
+    id text not null primary key,
+    data text
+);
+
+CREATE INDEX idx_key_field_raw on public.key_field_text_raw USING bm25 (id, data)
+WITH (key_field = id, text_fields = '{"id": { "tokenizer": { "type": "keyword" } } }');
+SELECT * FROM paradedb.schema('idx_key_field_raw') ORDER BY name;


### PR DESCRIPTION
Closes: #2502

## What

This allows the user to change the key_field's tokenizer to `keyword` since until now we complain that `raw` is deprecated.

## Why

It's not right for us to complain that the `raw` tokenizer is deprecated and then not allow the user to change it.

In the case of key_field TEXT columns we long long ago made the wrong decision to use the `raw` tokenizer as the default tokenizer.  Then we decided to deprecate the `raw` tokenizer in favor of the `keyword` tokenizer, but we never actually let users change the key_field's tokenizer.  So now we do... for TEXT fields only.

## How

## Tests

A new regression test has been added.  All other tests pass.
