### PR TITLE
fix: Fix error for invalid col in FF JSON

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -217,7 +217,7 @@ fn validate_field_config(
     let field_name = config.alias().unwrap_or(field_name);
     let field_type = options
         .get_field_type(&FieldName::from(field_name.to_string()))
-        .unwrap_or_else(|| panic!("the column `{field_name}` does not exist in the table"));
+        .unwrap_or_else(|| panic!("the column `{field_name}` does not exist in the USING clause"));
     if !matches(&field_type) {
         panic!("`{field_name}` was configured with the wrong type");
     }

--- a/pg_search/tests/pg_regress/expected/index_config_errors.out
+++ b/pg_search/tests/pg_regress/expected/index_config_errors.out
@@ -15,7 +15,7 @@ CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
         "some_wrong_key": {"tokenizer": {"type": "default"}}
     }'
     );
-ERROR:  the column `some_wrong_key` does not exist in the table
+ERROR:  the column `some_wrong_key` does not exist in the USING clause
 CREATE INDEX idx_chunks_bm25 ON test_index_config_errors
     USING bm25 (id, name)
     WITH (


### PR DESCRIPTION
The error used to say the column didn't exist in the table, but what it's actually trying to say is that the column isn't covered in the bm25 USING clause.

- If the column isn't in the table but is in the USING then Postgres will throw it's own error before this code is reached.
- If the column is in the table and is isn't in the USING we will get this error
- If the column isn't in **either** then I suppose we could throw a more accurate warning, but this way at least it will throw the new erro, fixing which will result in the PG error

```
pg_search=# create table tester(id int, words text);
CREATE TABLE

pg_search=# CREATE INDEX   
        ON tester USING bm25(id, words) WITH (
    key_field = 'id', 
    numeric_fields = '{
        "missing": {"fast": true}
    }'
) ;
ERROR:  the column `missing` does not exist in the USING clause

pg_search=# CREATE INDEX   
        ON tester USING bm25(id, words, missing) WITH (
    key_field = 'id', 
    numeric_fields = '{
        "missing": {"fast": true}
    }'
) ;
ERROR:  column "missing" does not exist
```

