### PR TITLE
chore: Improve determinism of property tests.

### DIFF
--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -110,6 +110,7 @@ impl Column {
         self
     }
 
+    /// Note: should use only the `random()` function to generate random data.
     pub const fn random_generator_sql(mut self, random_generator_sql: &'static str) -> Self {
         self.random_generator_sql = random_generator_sql;
         self
@@ -125,7 +126,11 @@ pub fn generated_queries_setup(
     "SET log_error_verbosity TO VERBOSE;".execute(conn);
     "SET log_min_duration_statement TO 1000;".execute(conn);
 
-    let mut setup_sql = String::new();
+    let seed_sql = format!("SET seed TO {};\n", rand::rng().random_range(-1.0..=1.0));
+    seed_sql.as_str().execute(conn);
+
+    let mut setup_sql = seed_sql;
+
     let column_definitions = columns_def
         .iter()
         .map(|col| {

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -44,7 +44,7 @@ const COLUMNS: &[Column] = &[
             true
         })
         .bm25_text_field(r#""uuid": { "tokenizer": { "type": "keyword" } , "fast": true }"#)
-        .random_generator_sql("gen_random_uuid()"),
+        .random_generator_sql("rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid"),
     Column::new("name", "TEXT", "'bob'")
         .bm25_text_field(r#""name": { "tokenizer": { "type": "keyword" }, "fast": true }"#)
         .random_generator_sql(


### PR DESCRIPTION
## What

Set a seed to control what is generated by `random()` in the property tests, and render it in the reproduction script after a failure.

## Why

To make it easier to reproduce property test failures by running over reproducible data.