### PR TITLE
feat: TopN scan can emit scores for any `ORDER BY`

### DIFF
--- a/docs/documentation/full-text/sorting.mdx
+++ b/docs/documentation/full-text/sorting.mdx
@@ -27,35 +27,6 @@ ORDER BY rating DESC
 LIMIT 5;
 ```
 
-<Note>
-If `paradedb.score` is present in the query, but the `ORDER BY` is not on `paradedb.score`, the query will be executed less
-efficiently. This is due to the performance overhead of both computing scores and sorting by another field.
-
-```sql
--- Less efficient: paradedb.score present
--- but ORDER BY rating
-SELECT description, rating, category, paradedb.score(id)
-FROM mock_items
-WHERE description @@@ 'shoes'
-ORDER BY rating DESC
-LIMIT 5;
-
--- More efficient: ORDER BY paradedb.score
-SELECT description, rating, category, paradedb.score(id)
-FROM mock_items
-WHERE description @@@ 'shoes'
-ORDER BY paradedb.score(id) DESC
-LIMIT 5;
-
--- More efficient: No paradedb.score
-SELECT description, rating, category
-FROM mock_items
-WHERE description @@@ 'shoes'
-ORDER BY rating DESC
-LIMIT 5;
-```
-</Note>
-
 ## Tiebreaking
 
 Postgres can `ORDER BY` multiple columns to break ties in BM25 scores. In the following query, rows with the same

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -296,6 +296,12 @@ pub struct OrderByInfo {
     pub direction: SortDirection,
 }
 
+impl OrderByInfo {
+    pub fn is_score(&self) -> bool {
+        matches!(self.feature, OrderByFeature::Score)
+    }
+}
+
 pub trait ToTantivyJson {
     fn key(&self) -> String;
     fn json_value(&self) -> Option<serde_json::Value>;

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -950,7 +950,7 @@ pub(super) fn enable_scoring(need_scores: bool, searcher: &Searcher) -> EnableSc
 #[derive(Default)]
 pub struct ErasedFeatures {
     features: Vec<(ErasedFeature, SortDirection)>,
-    score_index: Option<usize>,
+    score_index: Option<usize>, // which, if any, of the erased features is the score feature
 }
 
 impl ErasedFeatures {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -683,14 +683,17 @@ impl SearchIndexReader {
                 )
                 .into_iter()
                 .map(|((f, erased1), doc)| {
-                    let maybe_score = if erased_features.score_index() == Some(0) {
-                        match erased1 {
+                    let maybe_score = match erased_features.score_index() {
+                        Some(0) => match erased1 {
                             OwnedValue::F64(f) => Some(f as Score),
                             OwnedValue::Null => None,
                             _ => panic!("expected a f64 for the score"),
-                        }
-                    } else {
-                        None
+                        },
+                        None => None,
+                        x => panic!(
+                            "cannot have a score index of {:?} for a single erased feature",
+                            x
+                        ),
                     };
                     ((f, maybe_score), doc)
                 })
@@ -710,7 +713,26 @@ impl SearchIndexReader {
                     offset,
                 )
                 .into_iter()
-                .map(|((f, _, _), doc)| ((f, None), doc))
+                .map(|((f, erased1, erased2), doc)| {
+                    let maybe_score = match erased_features.score_index() {
+                        Some(0) => match erased1 {
+                            OwnedValue::F64(f) => Some(f as Score),
+                            OwnedValue::Null => None,
+                            _ => panic!("expected a f64 for the score"),
+                        },
+                        Some(1) => match erased2 {
+                            OwnedValue::F64(f) => Some(f as Score),
+                            OwnedValue::Null => None,
+                            _ => panic!("expected a f64 for the score"),
+                        },
+                        None => None,
+                        x => panic!(
+                            "cannot have a score index of {:?} for two erased features",
+                            x
+                        ),
+                    };
+                    ((f, maybe_score), doc)
+                })
                 .collect()
             }
             x => {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -75,7 +75,6 @@ pub type FastFieldCache = HashMap<SegmentOrdinal, FFType>;
 type ErasedFeature = Arc<dyn Feature<Output = OwnedValue, SegmentOutput = Option<u64>>>;
 
 /// A known-size iterator of results for Top-N.
-#[derive(Debug)]
 pub struct TopNSearchResults {
     results_original_len: usize,
     results: std::vec::IntoIter<(SearchIndexScore, DocAddress)>,
@@ -127,7 +126,7 @@ impl TopNSearchResults {
     ///
     /// TODO: We could in theory actually render that field using a virtual tuple (for the right
     /// query), similar to what we do in fast-fields execution.
-    fn new_for_discarded_field<T: Debug>(
+    fn new_for_discarded_field<T>(
         searcher: &Searcher,
         results: impl IntoIterator<Item = ((Option<T>, Option<Score>), DocAddress)>,
     ) -> Self {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -709,10 +709,17 @@ impl SearchIndexReader {
                 .collect()
             }
             x => {
-                panic!(
-                    "Unsupported sort-field count: {}. At most {MAX_TOPN_FEATURES} are supported.",
-                    x + 1,
-                )
+                if erased_features.score_index() == Some(x - 1) {
+                    panic!(
+                        "Unsupported sort-field count: {}. At most {} are supported when `paradedb.score` is requested.",
+                        x, MAX_TOPN_FEATURES - 1
+                    )
+                } else {
+                    panic!(
+                        "Unsupported sort-field count: {}. At most {MAX_TOPN_FEATURES} are supported.",
+                        x + 1,
+                    )
+                }
             }
         }
     }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -633,6 +633,7 @@ impl SearchIndexReader {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     /// Called by `search_top_n_in_segments`.
     ///
     /// `search_top_n_in_segments` is specialized for all combinations of:
@@ -903,6 +904,8 @@ impl SearchIndexReader {
             }
         }
 
+        // if we need scores, but there's no score feature in the order by list,
+        // we push an erased score feature to the end of the list for the purpose of holding scores
         if self.need_scores
             && erased_features.score_index().is_none()
             && !orderby_infos

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -860,6 +860,9 @@ impl SearchIndexReader {
     /// Create erased Features for the given OrderByInfo.
     ///
     /// See `top_in_segments` and `sort_features!`.
+    ///
+    /// Additionally, if we need scores, this method will ensure that at least one of these features is a ScoreFeature
+    /// (see comment within function below)
     fn erased_features(&self, orderby_infos: Option<&Vec<OrderByInfo>>) -> ErasedFeatures {
         let remainder = orderby_infos.and_then(|oi| oi.get(1..)).unwrap_or(&[]);
         let mut erased_features = ErasedFeatures::default();
@@ -950,7 +953,10 @@ pub(super) fn enable_scoring(need_scores: bool, searcher: &Searcher) -> EnableSc
 #[derive(Default)]
 pub struct ErasedFeatures {
     features: Vec<(ErasedFeature, SortDirection)>,
-    score_index: Option<usize>, // which, if any, of the erased features is the score feature
+    // which, if any, of the erased features is the score feature
+    // note: once https://github.com/quickwit-oss/tantivy/pull/2681#issuecomment-3340222261 is resolved,
+    // this will be unnecessary
+    score_index: Option<usize>,
 }
 
 impl ErasedFeatures {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -130,16 +130,7 @@ impl TopNSearchResults {
         searcher: &Searcher,
         results: impl IntoIterator<Item = ((Option<T>, Option<Score>), DocAddress)>,
     ) -> Self {
-        Self::new_for_score(
-            searcher,
-            results.into_iter().map(|(output, doc)| {
-                if let (_, Some(score)) = output {
-                    (score, doc)
-                } else {
-                    (1.0, doc)
-                }
-            }),
-        )
+        Self::new_for_score(searcher, results.into_iter().map(|(_, doc)| (1.0, doc)))
     }
 
     pub fn original_len(&self) -> usize {

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -48,6 +48,8 @@ pub struct TopNScanExecState {
     // If parallel, the segments which have been claimed by this worker.
     claimed_segments: RefCell<Option<Vec<SegmentId>>>,
     scale_factor: f64,
+
+    need_scores: bool,
 }
 
 impl TopNScanExecState {
@@ -55,6 +57,7 @@ impl TopNScanExecState {
         heaprelid: pg_sys::Oid,
         limit: usize,
         orderby_info: Option<Vec<OrderByInfo>>,
+        need_scores: bool,
     ) -> Self {
         if matches!(&orderby_info, Some(orderby_info) if orderby_info.len() > MAX_TOPN_FEATURES) {
             panic!("Cannot sort by more than {MAX_TOPN_FEATURES} features.");
@@ -93,6 +96,7 @@ impl TopNScanExecState {
             chunk_size: 0,
             claimed_segments: RefCell::default(),
             scale_factor,
+            need_scores,
         }
     }
 

--- a/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/exec_methods/top_n.rs
@@ -48,8 +48,6 @@ pub struct TopNScanExecState {
     // If parallel, the segments which have been claimed by this worker.
     claimed_segments: RefCell<Option<Vec<SegmentId>>>,
     scale_factor: f64,
-
-    need_scores: bool,
 }
 
 impl TopNScanExecState {
@@ -57,7 +55,6 @@ impl TopNScanExecState {
         heaprelid: pg_sys::Oid,
         limit: usize,
         orderby_info: Option<Vec<OrderByInfo>>,
-        need_scores: bool,
     ) -> Self {
         if matches!(&orderby_info, Some(orderby_info) if orderby_info.len() > MAX_TOPN_FEATURES) {
             panic!("Cannot sort by more than {MAX_TOPN_FEATURES} features.");
@@ -96,7 +93,6 @@ impl TopNScanExecState {
             chunk_size: 0,
             claimed_segments: RefCell::default(),
             scale_factor,
-            need_scores,
         }
     }
 

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -487,14 +487,7 @@ impl CustomScan for PdbScan {
             // Determine whether we might be able to sort.
             if is_maybe_topn && topn_pathkey_info.pathkeys().is_some() {
                 let pathkeys = topn_pathkey_info.pathkeys().unwrap();
-                // we can only (currently) do const projections if the first sort field is a score,
-                // because we currently discard all but the first sort field, and so will not
-                // produce a valid Score value. see TopNSearchResults.
-                let orderby_supported = !maybe_needs_const_projections
-                    || matches!(pathkeys.first(), Some(OrderByStyle::Score(..)));
-                if orderby_supported {
-                    custom_private.set_maybe_orderby_info(Some(pathkeys));
-                }
+                custom_private.set_maybe_orderby_info(Some(pathkeys));
             }
 
             // Choose the exec method type, and make claims about whether it is sorted.

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1190,18 +1190,11 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>
             heaprelid,
             limit,
             orderby_info,
-        } => {
-            let need_scores = builder.custom_state().need_scores();
-            builder.custom_state().assign_exec_method(
-                exec_methods::top_n::TopNScanExecState::new(
-                    heaprelid,
-                    limit,
-                    orderby_info,
-                    need_scores,
-                ),
-                None,
-            )
-        }
+        } => builder.custom_state().assign_exec_method(
+            exec_methods::top_n::TopNScanExecState::new(heaprelid, limit, orderby_info),
+            None,
+        ),
+
         ExecMethodType::FastFieldMixed {
             which_fast_fields,
             limit,

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -1190,10 +1190,18 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<PdbScan, PrivateData>
             heaprelid,
             limit,
             orderby_info,
-        } => builder.custom_state().assign_exec_method(
-            exec_methods::top_n::TopNScanExecState::new(heaprelid, limit, orderby_info),
-            None,
-        ),
+        } => {
+            let need_scores = builder.custom_state().need_scores();
+            builder.custom_state().assign_exec_method(
+                exec_methods::top_n::TopNScanExecState::new(
+                    heaprelid,
+                    limit,
+                    orderby_info,
+                    need_scores,
+                ),
+                None,
+            )
+        }
         ExecMethodType::FastFieldMixed {
             which_fast_fields,
             limit,

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -487,7 +487,7 @@ impl CustomScan for PdbScan {
             // Determine whether we might be able to sort.
             if is_maybe_topn && topn_pathkey_info.pathkeys().is_some() {
                 let pathkeys = topn_pathkey_info.pathkeys().unwrap();
-                custom_private.set_maybe_orderby_info(Some(pathkeys));
+                custom_private.set_maybe_orderby_info(topn_pathkey_info.pathkeys());
             }
 
             // Choose the exec method type, and make claims about whether it is sorted.

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
@@ -356,19 +356,18 @@ FROM score_test
 WHERE content @@@ 'technology'
 ORDER BY title, paradedb.score(id), rating DESC
 LIMIT 10;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: title, (paradedb.score(id)), rating DESC
-         ->  Custom Scan (ParadeDB Scan) on score_test
-               Table: score_test
-               Index: score_test_idx
-               Exec Method: MixedFastFieldExecState
-               Fast Fields: id, rating, title
-               Scores: true
-               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-(10 rows)
+   ->  Custom Scan (ParadeDB Scan) on score_test
+         Table: score_test
+         Index: score_test_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: title asc, paradedb.score() asc, rating desc
+            TopN Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+(9 rows)
 
 SELECT title, paradedb.score(id), rating
 FROM score_test
@@ -471,19 +470,18 @@ FROM scored_posts
 WHERE rating > 3
 ORDER BY title, author, relevance DESC
 LIMIT 10;
-                                                                                                                                             QUERY PLAN                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                          QUERY PLAN                                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: score_test.title, score_test.author, (paradedb.score(score_test.id)) DESC
-         ->  Custom Scan (ParadeDB Scan) on score_test
-               Table: score_test
-               Index: score_test_idx
-               Exec Method: MixedFastFieldExecState
-               Fast Fields: author, id, rating, title
-               Scores: true
-               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science OR research","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}
-(10 rows)
+   ->  Custom Scan (ParadeDB Scan) on score_test
+         Table: score_test
+         Index: score_test_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: title asc, author asc, paradedb.score() desc
+            TopN Limit: 10
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"science OR research","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3},"upper_bound":null,"is_datetime":false}}]}}
+(9 rows)
 
 WITH scored_posts AS (
     SELECT title, author, rating, paradedb.score(id) as relevance

--- a/pg_search/tests/pg_regress/expected/topn_scores.out
+++ b/pg_search/tests/pg_regress/expected/topn_scores.out
@@ -1,0 +1,192 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX search_idx on mock_items
+USING bm25 (id, description, rating, category, metadata)
+WITH (key_field='id', text_fields = '{"category": {"fast": true}}', json_fields = '{"metadata": {"fast": true, "tokenizer": {"type": "raw", "lowercase": true}}}');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating DESC
+LIMIT 5;
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: rating desc
+            TopN Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating DESC
+LIMIT 5;
+ id |       description        | rating |   score   
+----+--------------------------+--------+-----------
+  3 | Sleek running shoes      |      5 | 3.4849067
+  5 | Generic shoes            |      4 | 3.8772602
+  2 | Plastic Keyboard         |      4 | 3.2668595
+  1 | Ergonomic metal keyboard |      4 | 2.8213787
+  4 | White jogging shoes      |      3 | 3.4849067
+(5 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC
+LIMIT 5;
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: rating asc, id asc
+            TopN Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC
+LIMIT 5;
+ id |       description        | rating |   score   
+----+--------------------------+--------+-----------
+  4 | White jogging shoes      |      3 | 3.4849067
+  1 | Ergonomic metal keyboard |      4 | 2.8213787
+  2 | Plastic Keyboard         |      4 | 3.2668595
+  5 | Generic shoes            |      4 | 3.8772602
+  3 | Sleek running shoes      |      5 | 3.4849067
+(5 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC, category
+LIMIT 5;
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: rating asc, id asc, category asc
+            TopN Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC, category
+LIMIT 5;
+ERROR:  Unsupported sort-field count: 3. At most 2 are supported when `paradedb.score` is requested.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id) DESC
+LIMIT 5;
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: rating asc, paradedb.score() desc
+            TopN Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id) DESC
+LIMIT 5;
+ id |       description        | rating |   score   
+----+--------------------------+--------+-----------
+  4 | White jogging shoes      |      3 | 3.4849067
+  5 | Generic shoes            |      4 | 3.8772602
+  2 | Plastic Keyboard         |      4 | 3.2668595
+  1 | Ergonomic metal keyboard |      4 | 2.8213787
+  3 | Sleek running shoes      |      5 | 3.4849067
+(5 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id DESC
+LIMIT 5;
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Scan) on mock_items
+         Table: mock_items
+         Index: search_idx
+         Exec Method: TopNScanExecState
+         Scores: true
+            TopN Order By: rating asc, paradedb.score() asc, id desc
+            TopN Limit: 5
+         Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id DESC
+LIMIT 5;
+ id |       description        | rating |   score   
+----+--------------------------+--------+-----------
+  4 | White jogging shoes      |      3 | 3.4849067
+  1 | Ergonomic metal keyboard |      4 | 2.8213787
+  2 | Plastic Keyboard         |      4 | 3.2668595
+  5 | Generic shoes            |      4 | 3.8772602
+  3 | Sleek running shoes      |      5 | 3.4849067
+(5 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id, category DESC
+LIMIT 5;
+                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: rating, (paradedb.score(id)), id, category DESC
+         ->  Custom Scan (ParadeDB Scan) on mock_items
+               Table: mock_items
+               Index: search_idx
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"shoes","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":2},"upper_bound":null,"is_datetime":false}}]}}]}}
+(9 rows)
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id, category DESC
+LIMIT 5;
+ id |       description        | rating |   score   
+----+--------------------------+--------+-----------
+  4 | White jogging shoes      |      3 | 3.4849067
+  1 | Ergonomic metal keyboard |      4 | 2.8213787
+  2 | Plastic Keyboard         |      4 | 3.2668595
+  5 | Generic shoes            |      4 | 3.8772602
+  3 | Sleek running shoes      |      5 | 3.4849067
+(5 rows)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/topn_scores.sql
+++ b/pg_search/tests/pg_regress/sql/topn_scores.sql
@@ -1,0 +1,78 @@
+\i common/common_setup.sql
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX search_idx on mock_items
+USING bm25 (id, description, rating, category, metadata)
+WITH (key_field='id', text_fields = '{"category": {"fast": true}}', json_fields = '{"metadata": {"fast": true, "tokenizer": {"type": "raw", "lowercase": true}}}');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating DESC
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating DESC
+LIMIT 5;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC
+LIMIT 5;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC, category
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, id ASC, category
+LIMIT 5;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id) DESC
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id) DESC
+LIMIT 5;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id DESC
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id DESC
+LIMIT 5;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id, category DESC
+LIMIT 5;
+
+SELECT id, description, rating, paradedb.score(id) FROM mock_items
+WHERE description @@@ 'keyboard' OR description @@@ 'shoes' AND rating > 2
+ORDER BY rating, paradedb.score(id), id, category DESC
+LIMIT 5;
+
+DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3227 

## What

Allows the `TopNScanState` to return scores.

## Why

Avoid falling back to the normal exec state, which can be very slow.

## How

## Tests

Added regression test.