### PR TITLE
chore: Cherry pick push down `COALESCE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,8 +6291,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "rust_icu_sys"
-version = "5.0.0"
-source = "git+https://github.com/google/rust_icu.git?rev=53e98c8#53e98c8af71a572c0bfc459b533f9ae7019dc73d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,4 @@ pgrx-tests = "=0.15.0"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-rust_icu_sys = { git = "https://github.com/google/rust_icu.git", rev = "53e98c8" }
 tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7c6c6fc6ac977382b19ae7fb9fd5b0c53b8f1b58" }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -644,10 +644,10 @@ fn extract_aggregates(args: &CreateUpperPathsHookArgs) -> Option<Vec<AggregateTy
 
                 if (*aggref).aggstar {
                     // COUNT(*) (aggstar)
-                    aggregate_types.push(AggregateType::Count);
+                    aggregate_types.push(AggregateType::CountAny);
                 } else {
                     // Check for other aggregate functions with arguments
-                    let agg_type = identify_aggregate_function(aggref, relation_oid)?;
+                    let agg_type = AggregateType::try_from(aggref, relation_oid)?;
                     aggregate_types.push(agg_type);
                 }
             } else {
@@ -663,99 +663,6 @@ fn extract_aggregates(args: &CreateUpperPathsHookArgs) -> Option<Vec<AggregateTy
     // an empty vector instead of rejecting the plan.
 
     Some(aggregate_types)
-}
-
-/// Identify an aggregate function by its OID and extract field name from its arguments
-unsafe fn identify_aggregate_function(
-    aggref: *mut pg_sys::Aggref,
-    relation_oid: pg_sys::Oid,
-) -> Option<AggregateType> {
-    let aggfnoid = (*aggref).aggfnoid;
-
-    // Get the function name to identify the aggregate
-    let func_name = get_aggregate_function_name(aggfnoid)?;
-
-    // Extract the field name from the first argument
-    let field_name = extract_field_name_from_aggref(aggref, relation_oid);
-
-    match func_name {
-        "count" => Some(AggregateType::Count),
-        "sum" => Some(AggregateType::Sum { field: field_name? }),
-        "avg" => Some(AggregateType::Avg { field: field_name? }),
-        "min" => Some(AggregateType::Min { field: field_name? }),
-        "max" => Some(AggregateType::Max { field: field_name? }),
-        _ => {
-            pgrx::debug1!("Unsupported aggregate function: {func_name}");
-            None
-        }
-    }
-}
-
-/// Get the name of an aggregate function from its OID
-unsafe fn get_aggregate_function_name(aggfnoid: pg_sys::Oid) -> Option<&'static str> {
-    use pgrx::pg_sys::{
-        F_AVG_FLOAT4, F_AVG_FLOAT8, F_AVG_INT2, F_AVG_INT4, F_AVG_INT8, F_AVG_NUMERIC, F_COUNT_ANY,
-        F_MAX_DATE, F_MAX_FLOAT4, F_MAX_FLOAT8, F_MAX_INT2, F_MAX_INT4, F_MAX_INT8, F_MAX_NUMERIC,
-        F_MAX_TIME, F_MAX_TIMESTAMP, F_MAX_TIMESTAMPTZ, F_MAX_TIMETZ, F_MIN_DATE, F_MIN_FLOAT4,
-        F_MIN_FLOAT8, F_MIN_INT2, F_MIN_INT4, F_MIN_INT8, F_MIN_MONEY, F_MIN_NUMERIC, F_MIN_TIME,
-        F_MIN_TIMESTAMP, F_MIN_TIMESTAMPTZ, F_MIN_TIMETZ, F_SUM_FLOAT4, F_SUM_FLOAT8, F_SUM_INT2,
-        F_SUM_INT4, F_SUM_INT8, F_SUM_NUMERIC,
-    };
-    // Use well-known PostgreSQL function OIDs for standard aggregates
-    // These are consistent across PostgreSQL versions
-    match aggfnoid.to_u32() {
-        F_AVG_INT8 | F_AVG_INT4 | F_AVG_INT2 | F_AVG_NUMERIC | F_AVG_FLOAT4 | F_AVG_FLOAT8 => {
-            Some("avg")
-        }
-        F_SUM_INT8 | F_SUM_INT4 | F_SUM_INT2 | F_SUM_FLOAT4 | F_SUM_FLOAT8 | F_SUM_NUMERIC => {
-            Some("sum")
-        }
-        F_MAX_INT8 | F_MAX_INT4 | F_MAX_INT2 | F_MAX_FLOAT4 | F_MAX_FLOAT8 | F_MAX_DATE
-        | F_MAX_TIME | F_MAX_TIMETZ | F_MAX_TIMESTAMP | F_MAX_TIMESTAMPTZ | F_MAX_NUMERIC => {
-            Some("max")
-        }
-        F_MIN_INT8 | F_MIN_INT4 | F_MIN_INT2 | F_MIN_FLOAT4 | F_MIN_FLOAT8 | F_MIN_DATE
-        | F_MIN_TIME | F_MIN_TIMETZ | F_MIN_MONEY | F_MIN_TIMESTAMP | F_MIN_TIMESTAMPTZ
-        | F_MIN_NUMERIC => Some("min"),
-        F_COUNT_ANY => Some("count"),
-        _ => {
-            // For unknown function OIDs, we'll reject them for now
-            pgrx::debug1!("Unknown aggregate function OID: {}", aggfnoid.to_u32());
-            None
-        }
-    }
-}
-
-/// Extract field name from the first argument of an aggregate function
-unsafe fn extract_field_name_from_aggref(
-    aggref: *mut pg_sys::Aggref,
-    relation_oid: pg_sys::Oid,
-) -> Option<String> {
-    let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
-    if args.is_empty() {
-        return None;
-    }
-
-    let first_arg = args.get_ptr(0)?;
-    if let Some(var) = nodecast!(Var, T_Var, (*first_arg).expr) {
-        return get_var_field_name(var, relation_oid);
-    }
-
-    None
-}
-
-/// Get the field name from a Var node
-unsafe fn get_var_field_name(var: *mut pg_sys::Var, relation_oid: pg_sys::Oid) -> Option<String> {
-    let varattno = (*var).varattno;
-
-    // Get the actual column name from the relation
-    let attname = pg_sys::get_attname(relation_oid, varattno, false);
-    if !attname.is_null() {
-        let name = std::ffi::CStr::from_ptr(attname).to_str().ok()?;
-        return Some(name.to_string());
-    }
-
-    None
 }
 
 /// Replace any T_Aggref expressions in the target list with T_FuncExpr placeholders

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -333,13 +333,13 @@ impl AggregateScanState {
         doc_count: Option<i64>,
     ) -> AggregateValue {
         let agg_result = match (aggregate, result_source) {
-            (AggregateType::Count, AggregateResultSource::ResultMap(result_map)) => {
+            (AggregateType::CountAny, AggregateResultSource::ResultMap(result_map)) => {
                 let raw_result = result_map
                     .get(&agg_idx.to_string())
                     .expect("missing aggregate result");
                 Self::extract_aggregate_value_from_json(raw_result)
             }
-            (AggregateType::Count, AggregateResultSource::BucketObj(bucket_obj)) => {
+            (AggregateType::CountAny, AggregateResultSource::BucketObj(bucket_obj)) => {
                 let raw_result = bucket_obj.get("doc_count").expect("missing doc_count");
                 Self::extract_aggregate_value_from_json(raw_result)
             }

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::nodecast;
 use crate::postgres::datetime::{datetime_components_to_tantivy_date, MICROSECONDS_IN_SECOND};
 use crate::postgres::range::RangeToTantivyValue;
 use crate::schema::{AnyEnum, SearchField};
@@ -1047,6 +1048,30 @@ impl TryFrom<TantivyValue> for pgrx::Inet {
             Err(TantivyValueError::UnsupportedIntoConversion(
                 "inet".to_string(),
             ))
+        }
+    }
+}
+
+/// A wrapper around a `pg_sys::Const` node
+pub struct ConstNode(*mut pg_sys::Const);
+
+impl ConstNode {
+    pub fn try_from(node: *mut pg_sys::Node) -> Option<Self> {
+        let const_node = unsafe { nodecast!(Const, T_Const, node)? };
+        Some(Self(const_node))
+    }
+}
+
+impl TryFrom<ConstNode> for TantivyValue {
+    type Error = TantivyValueError;
+
+    fn try_from(value: ConstNode) -> Result<Self, Self::Error> {
+        if unsafe { (*value.0).constisnull } {
+            return Ok(TantivyValue(OwnedValue::Null));
+        }
+
+        unsafe {
+            TantivyValue::try_from_datum((*value.0).constvalue, PgOid::from((*value.0).consttype))
         }
     }
 }

--- a/pg_search/tests/pg_regress/expected/aggregate.out
+++ b/pg_search/tests/pg_regress/expected/aggregate.out
@@ -1,7 +1,7 @@
 -- =====================================================================
 -- Aggregate Custom Scan (Non-GROUP BY) Functionality
 -- =====================================================================
--- This file tests aggregate functions (COUNT, SUM, AVG, MIN, MAX) 
+-- This file tests aggregate functions (COUNT, SUM, AVG, MIN, MAX)
 -- without GROUP BY clauses for the aggregate custom scan feature.
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_aggregate_custom_scan TO on;
@@ -26,7 +26,7 @@ INSERT INTO products (description, rating, category, price, in_stock) VALUES
     ('Running shoes for athletes', 5, 'Sports', 89.99, true),
     ('Winter jacket warm', 4, 'Clothing', 129.99, true),
     ('Summer jacket light', 3, 'Clothing', 59.99, true);
-CREATE INDEX products_idx ON products 
+CREATE INDEX products_idx ON products
 USING bm25 (id, description, rating, category, price)
 WITH (
     key_field='id',
@@ -125,7 +125,7 @@ SELECT MAX(price) FROM products WHERE description @@@ 'laptop';
 
 -- Test 1.6: Multiple aggregates in single query
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT COUNT(*), SUM(price), AVG(price), MIN(price), MAX(price) 
+SELECT COUNT(*), SUM(price), AVG(price), MIN(price), MAX(price)
 FROM products WHERE description @@@ 'laptop';
                                                                                                               QUERY PLAN                                                                                                              
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -136,7 +136,7 @@ FROM products WHERE description @@@ 'laptop';
    Aggregate Definition: {"0":{"value_count":{"field":"ctid"}},"1":{"sum":{"field":"price"}},"2":{"avg":{"field":"price"}},"3":{"min":{"field":"price"}},"4":{"max":{"field":"price"}},"_doc_count":{"value_count":{"field":"ctid"}}}
 (5 rows)
 
-SELECT COUNT(*), SUM(price), AVG(price), MIN(price), MAX(price) 
+SELECT COUNT(*), SUM(price), AVG(price), MIN(price), MAX(price)
 FROM products WHERE description @@@ 'laptop';
  count |   sum   |       avg        |  min   |   max   
 -------+---------+------------------+--------+---------
@@ -320,8 +320,8 @@ SELECT MAX(rating) FROM products WHERE ((NOT (category @@@ 'Electronics')) AND (
 
 -- Test 2.3: Complex contradictory conditions
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT COUNT(*), SUM(price) 
-FROM products 
+SELECT COUNT(*), SUM(price)
+FROM products
 WHERE (description @@@ 'laptop') AND ((NOT (rating < 4)) AND (rating < 4));
                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                   
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -332,8 +332,8 @@ WHERE (description @@@ 'laptop') AND ((NOT (rating < 4)) AND (rating < 4));
    Aggregate Definition: {"0":{"value_count":{"field":"ctid"}},"1":{"sum":{"field":"price"}},"_doc_count":{"value_count":{"field":"ctid"}}}
 (5 rows)
 
-SELECT COUNT(*), SUM(price) 
-FROM products 
+SELECT COUNT(*), SUM(price)
+FROM products
 WHERE (description @@@ 'laptop') AND ((NOT (rating < 4)) AND (rating < 4));
  count | sum 
 -------+-----
@@ -358,7 +358,7 @@ INSERT INTO type_test (int_val, bigint_val, smallint_val, numeric_val, float_val
     (100, 1000000, 10, 99.99, 1.5, 3.14159, 'test1'),
     (200, 2000000, 20, 199.99, 2.5, 6.28318, 'test2'),
     (300, 3000000, 30, 299.99, 3.5, 9.42477, 'test3');
-CREATE INDEX type_test_idx ON type_test 
+CREATE INDEX type_test_idx ON type_test
 USING bm25 (id, text_val, int_val, bigint_val, smallint_val, numeric_val, float_val, double_val)
 WITH (
     key_field='id',
@@ -374,14 +374,14 @@ WITH (
 );
 -- Test 3.1: Aggregates on different numeric types
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
-SELECT 
+SELECT
     SUM(int_val), AVG(int_val), MIN(int_val), MAX(int_val),
     SUM(bigint_val), AVG(bigint_val), MIN(bigint_val), MAX(bigint_val),
     SUM(smallint_val), AVG(smallint_val), MIN(smallint_val), MAX(smallint_val),
     SUM(numeric_val), AVG(numeric_val), MIN(numeric_val), MAX(numeric_val),
     SUM(float_val), AVG(float_val), MIN(float_val), MAX(float_val),
     SUM(double_val), AVG(double_val), MIN(double_val), MAX(double_val)
-FROM type_test 
+FROM type_test
 WHERE text_val @@@ 'test1 OR test2';
                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -392,14 +392,14 @@ WHERE text_val @@@ 'test1 OR test2';
    Aggregate Definition: {"0":{"sum":{"field":"int_val"}},"1":{"avg":{"field":"int_val"}},"2":{"min":{"field":"int_val"}},"3":{"max":{"field":"int_val"}},"4":{"sum":{"field":"bigint_val"}},"5":{"avg":{"field":"bigint_val"}},"6":{"min":{"field":"bigint_val"}},"7":{"max":{"field":"bigint_val"}},"8":{"sum":{"field":"smallint_val"}},"9":{"avg":{"field":"smallint_val"}},"10":{"min":{"field":"smallint_val"}},"11":{"max":{"field":"smallint_val"}},"12":{"sum":{"field":"numeric_val"}},"13":{"avg":{"field":"numeric_val"}},"14":{"min":{"field":"numeric_val"}},"15":{"max":{"field":"numeric_val"}},"16":{"sum":{"field":"float_val"}},"17":{"avg":{"field":"float_val"}},"18":{"min":{"field":"float_val"}},"19":{"max":{"field":"float_val"}},"20":{"sum":{"field":"double_val"}},"21":{"avg":{"field":"double_val"}},"22":{"min":{"field":"double_val"}},"23":{"max":{"field":"double_val"}},"_doc_count":{"value_count":{"field":"ctid"}}}
 (5 rows)
 
-SELECT 
+SELECT
     SUM(int_val), AVG(int_val), MIN(int_val), MAX(int_val),
     SUM(bigint_val), AVG(bigint_val), MIN(bigint_val), MAX(bigint_val),
     SUM(smallint_val), AVG(smallint_val), MIN(smallint_val), MAX(smallint_val),
     SUM(numeric_val), AVG(numeric_val), MIN(numeric_val), MAX(numeric_val),
     SUM(float_val), AVG(float_val), MIN(float_val), MAX(float_val),
     SUM(double_val), AVG(double_val), MIN(double_val), MAX(double_val)
-FROM type_test 
+FROM type_test
 WHERE text_val @@@ 'test1 OR test2';
  sum | avg | min | max |   sum   |   avg   |   min   |   max   | sum | avg | min | max |  sum   |  avg   |  min  |  max   | sum | avg | min | max |        sum        |        avg        |   min   |   max   
 -----+-----+-----+-----+---------+---------+---------+---------+-----+-----+-----+-----+--------+--------+-------+--------+-----+-----+-----+-----+-------------------+-------------------+---------+---------
@@ -412,7 +412,7 @@ WHERE text_val @@@ 'test1 OR test2';
 -- Test 4.1: DISTINCT aggregates (should fall back to PostgreSQL)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(DISTINCT category), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop';
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -432,7 +432,7 @@ WHERE description @@@ 'laptop';
 (13 rows)
 
 SELECT COUNT(DISTINCT category), SUM(price)
-FROM products 
+FROM products
 WHERE description @@@ 'laptop';
  count |   sum   
 -------+---------
@@ -443,7 +443,7 @@ WHERE description @@@ 'laptop';
 -- Note: description field is not marked as "fast" in the index
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG(LENGTH(description))
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics';
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -459,7 +459,7 @@ WHERE category @@@ 'Electronics';
 (9 rows)
 
 SELECT AVG(LENGTH(description))
-FROM products 
+FROM products
 WHERE category @@@ 'Electronics';
          avg         
 ---------------------
@@ -472,8 +472,8 @@ WHERE category @@@ 'Electronics';
 -- Test 6.1: Complex boolean WHERE clauses with aggregates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), SUM(price), AVG(rating)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics');
                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -485,8 +485,8 @@ WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
 (5 rows)
 
 SELECT COUNT(*), SUM(price), AVG(rating)
-FROM products 
-WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard')) 
+FROM products
+WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
   AND (rating >= 4 OR category @@@ 'Electronics');
  count |   sum   | avg  
 -------+---------+------
@@ -496,7 +496,7 @@ WHERE ((description @@@ 'laptop') OR (description @@@ 'keyboard'))
 -- Test 6.2: Nested boolean expressions
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard');
                                                                                                                                                            QUERY PLAN                                                                                                                                                            
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -508,11 +508,93 @@ WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR k
 (5 rows)
 
 SELECT COUNT(*), AVG(price), MIN(rating), MAX(rating)
-FROM products 
+FROM products
 WHERE (NOT (NOT (category @@@ 'Electronics'))) AND (description @@@ 'laptop OR keyboard');
  count |  avg   | min | max 
 -------+--------+-----+-----
      4 | 632.49 |   4 |   5
+(1 row)
+
+-- =====================================================================
+-- SECTION 7: COALESCE Null Values
+-- =====================================================================
+INSERT INTO products (description, rating, category, price, in_stock) VALUES
+    (NULL, NULL, NULL, NULL, NULL);
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), AVG(price), MIN(rating), MAX(rating)
+FROM products
+WHERE id @@@ paradedb.all();
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: now(), now(), now(), now()
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":"all"}}
+   Aggregate Definition: {"0":{"value_count":{"field":"ctid"}},"1":{"avg":{"field":"price"}},"2":{"min":{"field":"rating"}},"3":{"max":{"field":"rating"}}}
+(5 rows)
+
+SELECT COUNT(*), AVG(price), MIN(rating), MAX(rating)
+FROM products
+WHERE id @@@ paradedb.all();
+ count |  avg   | min | max 
+-------+--------+-----+-----
+     9 | 413.74 |   3 |   5
+(1 row)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), AVG(COALESCE(price, 0)), MIN(COALESCE(rating, 0)), MAX(COALESCE(rating, 0))
+FROM products
+WHERE id @@@ paradedb.all();
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: now(), now(), now(), now()
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":"all"}}
+   Aggregate Definition: {"0":{"value_count":{"field":"ctid"}},"1":{"avg":{"field":"price","missing":0.0}},"2":{"min":{"field":"rating","missing":0.0}},"3":{"max":{"field":"rating","missing":0.0}}}
+(5 rows)
+
+SELECT COUNT(*), AVG(COALESCE(price, 0)), MIN(COALESCE(rating, 0)), MAX(COALESCE(rating, 0))
+FROM products
+WHERE id @@@ paradedb.all();
+ count |       avg        | min | max 
+-------+------------------+-----+-----
+     9 | 367.768888888889 |   0 |   5
+(1 row)
+
+SELECT COUNT(*), AVG(COALESCE(price, 0)), MIN(COALESCE(rating, 0)), MAX(COALESCE(rating, 0))
+FROM products;
+ count |         avg          | min | max 
+-------+----------------------+-----+-----
+     9 | 367.7688888888888889 |   0 |   5
+(1 row)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), AVG(COALESCE(price, 1)), MIN(COALESCE(rating, 1)), MAX(COALESCE(rating, 1))
+FROM products
+WHERE id @@@ paradedb.all();
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.products
+   Output: now(), now(), now(), now()
+   Index: products_idx
+   Tantivy Query: {"with_index":{"query":"all"}}
+   Aggregate Definition: {"0":{"value_count":{"field":"ctid"}},"1":{"avg":{"field":"price","missing":1.0}},"2":{"min":{"field":"rating","missing":1.0}},"3":{"max":{"field":"rating","missing":1.0}}}
+(5 rows)
+
+SELECT COUNT(*), AVG(COALESCE(price, 1)), MIN(COALESCE(rating, 1)), MAX(COALESCE(rating, 1))
+FROM products
+WHERE id @@@ paradedb.all();
+ count |  avg   | min | max 
+-------+--------+-----+-----
+     9 | 367.88 |   1 |   5
+(1 row)
+
+SELECT COUNT(*), AVG(COALESCE(price, 1)), MIN(COALESCE(rating, 1)), MAX(COALESCE(rating, 1))
+FROM products;
+ count |         avg          | min | max 
+-------+----------------------+-----+-----
+     9 | 367.8800000000000000 |   1 |   5
 (1 row)
 
 -- =====================================================================


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3172 

## What

Pushes down `SUM`, `MIN`, `MAX`, and `AVG` with `COALESCE` to the aggregate custom scan.

## Why

## How

## Tests

Added regression test
