### PR TITLE
feat: A Free Space Manager fronted by an AVL tree

### DIFF
--- a/.github/stressgres/wide-table.toml
+++ b/.github/stressgres/wide-table.toml
@@ -271,20 +271,3 @@ log_tps = false
 refresh_ms = 5
 title = "Background Merging?"
 sql = "select pid, (case when state = 'Running' then 1 else 0 end) as running from paradedb.bgmerger_state('wide_table_idx');"
-
-[[jobs]]
-window_height = 5
-log_columns = ["byte_size:MB", "merge_count"]
-log_tps = false
-refresh_ms = 5
-title = "Merge Byte Size"
-sql = """
-select pid, sum(byte_size), (count(*) - 1) merge_count
-from (select byte_size, pid
-      from paradedb.merge_info('wide_table_idx') mi
-               inner join paradedb.index_info('wide_table_idx') ii on mi.segno = ii.segno
-      union
-      select 0, 0) x
-where pid <> 0
-group by pid;
-"""

--- a/.github/stressgres/wide-table.toml
+++ b/.github/stressgres/wide-table.toml
@@ -264,10 +264,3 @@ log_tps = false
 refresh_ms = 5
 title = "Background Merger"
 sql = "select count(*) background_merging from pg_stat_activity where query = 'merging';"
-
-[[jobs]]
-log_columns = ["running"]
-log_tps = false
-refresh_ms = 5
-title = "Background Merging?"
-sql = "select pid, (case when state = 'Running' then 1 else 0 end) as running from paradedb.bgmerger_state('wide_table_idx');"

--- a/.github/stressgres/wide-table.toml
+++ b/.github/stressgres/wide-table.toml
@@ -249,13 +249,6 @@ SELECT COUNT(*) FROM (
     LIMIT 100
 );
 """
-#
-#[[jobs]]
-#refresm_ms = 100
-#title = "FSM Size"
-#log_tps = false
-#log_columns = ["nfsm_blocks", "n_xids", "nfree"]
-#sql = "SELECT paradedb.fsm_size('wide_table_idx') as nfsm_blocks, count(distinct xid::text) as n_xids, count(*) nfree from paradedb.fsm_info('wide_table_idx')"
 
 [[jobs]]
 window_height = 5

--- a/.github/stressgres/wide-table.toml
+++ b/.github/stressgres/wide-table.toml
@@ -156,9 +156,10 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION update_random_data(num_rows INTEGER)
-RETURNS VOID AS $$
+RETURNS int AS $$
 DECLARE
     max_val bigint;
+    many int;
 BEGIN
     -- 1. Get the maximum ID value once.
     SELECT max(id) INTO max_val FROM wide_table;
@@ -174,6 +175,9 @@ BEGIN
         FROM generate_series(1, num_rows * 2)
         LIMIT num_rows
     );
+
+    GET DIAGNOSTICS many = ROW_COUNT;
+    RETURN many;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/.github/stressgres/wide-table.toml
+++ b/.github/stressgres/wide-table.toml
@@ -249,3 +249,42 @@ SELECT COUNT(*) FROM (
     LIMIT 100
 );
 """
+#
+#[[jobs]]
+#refresm_ms = 100
+#title = "FSM Size"
+#log_tps = false
+#log_columns = ["nfsm_blocks", "n_xids", "nfree"]
+#sql = "SELECT paradedb.fsm_size('wide_table_idx') as nfsm_blocks, count(distinct xid::text) as n_xids, count(*) nfree from paradedb.fsm_info('wide_table_idx')"
+
+[[jobs]]
+window_height = 5
+log_columns = ["background_merging"]
+log_tps = false
+refresh_ms = 5
+title = "Background Merger"
+sql = "select count(*) background_merging from pg_stat_activity where query = 'merging';"
+
+[[jobs]]
+log_columns = ["running"]
+log_tps = false
+refresh_ms = 5
+title = "Background Merging?"
+sql = "select pid, (case when state = 'Running' then 1 else 0 end) as running from paradedb.bgmerger_state('wide_table_idx');"
+
+[[jobs]]
+window_height = 5
+log_columns = ["byte_size:MB", "merge_count"]
+log_tps = false
+refresh_ms = 5
+title = "Merge Byte Size"
+sql = """
+select pid, sum(byte_size), (count(*) - 1) merge_count
+from (select byte_size, pid
+      from paradedb.merge_info('wide_table_idx') mi
+               inner join paradedb.index_info('wide_table_idx') ii on mi.segno = ii.segno
+      union
+      select 0, 0) x
+where pid <> 0
+group by pid;
+"""

--- a/pg_search/proptest-regressions/postgres/storage/avl.txt
+++ b/pg_search/proptest-regressions/postgres/storage/avl.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc dbca55a46d30969fe6e67e5035647cd4a6be9c94f0aa41ed83e639b6addb68d3 # shrinks to ops = [(0, -4), (0, 63), (0, -4), (0, 64), (0, 0), (1, 63)]
+cc 5badd8f640e653e6ff51115e2a916eadff003ea5dfd83230bd158bb64292adfb # shrinks to ops = [(0, -28), (0, 13), (0, -27), (0, 14), (0, 15), (0, 1), (0, 0), (0, -31), (0, -1), (0, -29), (0, -30), (0, 2), (0, -27), (1, -27)]

--- a/pg_search/sql/pg_search--0.18.11--0.18.12.sql
+++ b/pg_search/sql/pg_search--0.18.11--0.18.12.sql
@@ -1,0 +1,32 @@
+-- pg_search/src/postgres/storage/metadata.rs:404
+-- pg_search::postgres::storage::metadata::bgmerger_state
+CREATE  FUNCTION "bgmerger_state"(
+    "index" regclass /* pgrx::rel::PgRelation */
+) RETURNS TABLE (
+                    "pid" INT,  /* i32 */
+                    "state" TEXT  /* alloc::string::String */
+                )
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bgmerger_state_wrapper';
+
+-- pg_search/src/postgres/storage/metadata.rs:397
+-- pg_search::postgres::storage::metadata::reset_bgworker_state
+CREATE  FUNCTION "reset_bgworker_state"(
+    "index" regclass /* pgrx::rel::PgRelation */
+) RETURNS void
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reset_bgworker_state_wrapper';
+
+-- pg_search/src/postgres/storage/fsm.rs:1358
+-- pg_search::postgres::storage::fsm::fsm_size
+CREATE  FUNCTION "fsm_size"(
+    "index" regclass /* pgrx::rel::PgRelation */
+) RETURNS bigint /* i64 */
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fsm_size_wrapper';
+
+DROP FUNCTION IF EXISTS fsm_info(index regclass);
+CREATE OR REPLACE FUNCTION fsm_info(index regclass) RETURNS TABLE(xid xid, fsm_blockno pg_catalog.int8, tag pg_catalog.int8, free_blockno pg_catalog.int8) AS 'MODULE_PATHNAME', 'fsm_info_wrapper' LANGUAGE c STRICT;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -501,7 +501,7 @@ fn merge_lock_garbage_collect(index: PgRelation) -> SetOfIterator<'static, i32> 
         let merge_lock = metadata.acquire_merge_lock();
         let mut merge_list = merge_lock.merge_list();
         let before = merge_list.list();
-        merge_list.garbage_collect(pg_sys::ReadNextTransactionId());
+        merge_list.garbage_collect(pg_sys::ReadNextFullTransactionId());
         let after = merge_list.list();
         drop(merge_lock);
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -82,6 +82,9 @@ static MIXED_FAST_FIELD_EXEC_COLUMN_THRESHOLD_NAME: &CStr =
 /// it logically can.
 static PER_TUPLE_COST: GucSetting<f64> = GucSetting::<f64>::new(100_000_000.0);
 
+static GLOBAL_TARGET_SEGMENT_COUNT: GucSetting<i32> = GucSetting::<i32>::new(0);
+static GLOBAL_ENABLE_BACKGROUND_MERGING: GucSetting<bool> = GucSetting::<bool>::new(true);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -207,6 +210,26 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.global_target_segment_count",
+        c"a global target segment count override",
+        c"Setting this to a non-zero value ignore the `target_segment_count` property on all indexes in favor of this value",
+        &GLOBAL_TARGET_SEGMENT_COUNT,
+        0,
+        8192,
+        GucContext::Sighup,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.global_enable_background_merging",
+        c"Enable background merging",
+        c"Enable background merging",
+        &GLOBAL_ENABLE_BACKGROUND_MERGING,
+        GucContext::Sighup,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -253,6 +276,14 @@ pub fn per_tuple_cost() -> f64 {
 
 pub fn max_topn_chunk_size() -> i32 {
     MAX_TOPN_CHUNK_SIZE.get()
+}
+
+pub fn global_target_segment_count() -> i32 {
+    GLOBAL_TARGET_SEGMENT_COUNT.get()
+}
+
+pub fn global_enable_background_merging() -> bool {
+    GLOBAL_ENABLE_BACKGROUND_MERGING.get()
 }
 
 // NB:  These limits come from [`tantivy::index_writer::MEMORY_BUDGET_NUM_BYTES_MAX`], which is not publicly exposed

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -214,7 +214,7 @@ pub fn init() {
     GucRegistry::define_int_guc(
         c"paradedb.global_target_segment_count",
         c"a global target segment count override",
-        c"Setting this to a non-zero value ignore the `target_segment_count` property on all indexes in favor of this value",
+        c"Setting this to a non-zero value ignores the `target_segment_count` property on all indexes in favor of this value",
         &GLOBAL_TARGET_SEGMENT_COUNT,
         0,
         8192,

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -54,8 +54,8 @@ struct WorkerConfig {
     heaprelid: pg_sys::Oid,
     indexrelid: pg_sys::Oid,
     concurrent: bool,
-    current_xid: pg_sys::TransactionId,
-    next_xid: pg_sys::TransactionId,
+    current_xid: pg_sys::FullTransactionId,
+    next_xid: pg_sys::FullTransactionId,
 }
 impl ParallelStateType for WorkerConfig {}
 
@@ -119,8 +119,8 @@ impl ParallelBuild {
         indexrel: &PgSearchRelation,
         snapshot: pg_sys::Snapshot,
         concurrent: bool,
-        current_xid: pg_sys::TransactionId,
-        next_xid: pg_sys::TransactionId,
+        current_xid: pg_sys::FullTransactionId,
+        next_xid: pg_sys::FullTransactionId,
     ) -> Self {
         let scandesc = unsafe {
             let size = size_of::<pg_sys::ParallelTableScanDescData>()
@@ -288,8 +288,8 @@ struct WorkerBuildState {
     categorized_fields: Vec<(SearchField, CategorizedFieldData)>,
     key_field_name: FieldName,
     per_row_context: PgMemoryContexts,
-    current_xid: pg_sys::TransactionId,
-    next_xid: pg_sys::TransactionId,
+    current_xid: pg_sys::FullTransactionId,
+    next_xid: pg_sys::FullTransactionId,
     indexrel: PgSearchRelation,
     heaprel: PgSearchRelation,
     // the following statistics are used to determine when and what to merge:
@@ -318,8 +318,8 @@ impl WorkerBuildState {
         heaprel: &PgSearchRelation,
         indexrel: &PgSearchRelation,
         per_worker_memory_budget: NonZeroUsize,
-        current_xid: pg_sys::TransactionId,
-        next_xid: pg_sys::TransactionId,
+        current_xid: pg_sys::FullTransactionId,
+        next_xid: pg_sys::FullTransactionId,
         worker_segment_target: usize,
         nlaunched: usize,
         worker_number: i32,
@@ -552,8 +552,8 @@ pub(super) fn build_index(
         }
     });
 
-    let current_xid = unsafe { pg_sys::GetCurrentTransactionId() };
-    let next_xid = unsafe { pg_sys::ReadNextTransactionId() };
+    let current_xid = unsafe { pg_sys::GetCurrentFullTransactionId() };
+    let next_xid = unsafe { pg_sys::ReadNextFullTransactionId() };
     let process = ParallelBuild::new(
         &heaprel,
         &indexrel,

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     // been leftover from a cancelled merge or crash during merge
     merge_lock
         .merge_list()
-        .garbage_collect(pg_sys::ReadNextTransactionId());
+        .garbage_collect(pg_sys::ReadNextFullTransactionId());
 
     // and now we should not have any merges happening, and cannot
     assert!(

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -208,8 +208,8 @@ pub fn paradedb_aminsertcleanup(mut writer: Option<SerialIndexWriter>) {
                 do_merge(
                     &indexrel,
                     MergeStyle::Insert,
-                    Some(pg_sys::GetCurrentTransactionId()),
-                    Some(pg_sys::ReadNextTransactionId()),
+                    Some(pg_sys::GetCurrentFullTransactionId()),
+                    Some(pg_sys::ReadNextFullTransactionId()),
                 )
                 .expect("should be able to merge");
             }

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -21,15 +21,17 @@ use crate::index::writer::index::{Mergeable, SearchIndexMerger};
 use crate::postgres::ps_status::{set_ps_display_suffix, MERGING};
 use crate::postgres::storage::block::{MVCCEntry, SegmentMetaEntry};
 use crate::postgres::storage::buffer::{Buffer, BufferManager};
+use crate::postgres::storage::fsm::FreeSpaceManager;
 use crate::postgres::storage::merge::MergeLock;
 use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::storage::LinkedBytesList;
 use crate::postgres::PgSearchRelation;
 
 use pgrx::bgworkers::*;
-use pgrx::{check_for_interrupts, pg_sys};
+use pgrx::{check_for_interrupts, pg_sys, PgTryBuilder};
 use pgrx::{pg_guard, FromDatum, IntoDatum};
 use std::ffi::CStr;
+use std::panic::AssertUnwindSafe;
 use tantivy::index::SegmentMeta;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,8 +203,8 @@ impl IndexLayerSizes {
 pub unsafe fn do_merge(
     index: &PgSearchRelation,
     style: MergeStyle,
-    current_xid: Option<pg_sys::TransactionId>,
-    next_xid: Option<pg_sys::TransactionId>,
+    current_xid: Option<pg_sys::FullTransactionId>,
+    next_xid: Option<pg_sys::FullTransactionId>,
 ) -> anyhow::Result<()> {
     let layer_sizes = IndexLayerSizes::from(index);
     let metadata = MetaPage::open(index);
@@ -248,6 +250,10 @@ pub unsafe fn do_merge(
 /// Try to launch a background process to merge down the index.
 /// Is not guaranteed to launch the process if there are not enough `max_worker_processes` available.
 unsafe fn try_launch_background_merger(index: &PgSearchRelation) {
+    if !MetaPage::open(index).bgmerger().try_starting() {
+        return;
+    }
+
     let dbname = CStr::from_ptr(pg_sys::get_database_name(pg_sys::MyDatabaseId))
         .to_string_lossy()
         .into_owned();
@@ -265,10 +271,10 @@ unsafe fn try_launch_background_merger(index: &PgSearchRelation) {
         .set_function("background_merge")
         .set_argument(BackgroundMergeArgs::new(index.oid()).into_datum())
         .set_extra(&dbname)
-        .set_notify_pid(unsafe { pg_sys::MyProcPid })
         .load_dynamic()
         .is_err()
     {
+        MetaPage::open(index).bgmerger().set_stopped();
         pgrx::log!("not enough available `max_worker_processes` to launch a background merger");
     }
 }
@@ -289,7 +295,7 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
             BackgroundWorker::get_name()
         );
 
-        let current_xid = pg_sys::GetCurrentTransactionId();
+        let current_xid = pg_sys::GetCurrentFullTransactionId();
         let next_xid = current_xid;
         let args = BackgroundMergeArgs::from_datum(arg, false).unwrap();
         let index = PgSearchRelation::try_open(
@@ -305,20 +311,27 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         }
         let index = index.unwrap();
         let metadata = MetaPage::open(&index);
+        metadata.bgmerger().set_running();
+
         let layer_sizes = IndexLayerSizes::from(&index);
         let merge_policy = LayeredMergePolicy::new(layer_sizes.combined());
 
         let cleanup_lock = metadata.cleanup_lock_shared();
         let merge_lock = metadata.acquire_merge_lock();
-        merge_index(
-            &index,
-            merge_policy,
-            merge_lock,
-            cleanup_lock,
-            true,
-            current_xid,
-            next_xid,
-        )
+
+        PgTryBuilder::new(AssertUnwindSafe(|| {
+            merge_index(
+                &index,
+                merge_policy,
+                merge_lock,
+                cleanup_lock,
+                true,
+                current_xid,
+                next_xid,
+            )
+        }))
+        .finally(|| metadata.bgmerger().set_stopped())
+        .execute();
     });
 }
 
@@ -329,8 +342,8 @@ unsafe fn merge_index(
     merge_lock: MergeLock,
     cleanup_lock: Buffer,
     gc_after_merge: bool,
-    current_xid: pg_sys::TransactionId,
-    next_xid: pg_sys::TransactionId,
+    current_xid: pg_sys::FullTransactionId,
+    next_xid: pg_sys::FullTransactionId,
 ) {
     // take a shared lock on the CLEANUP_LOCK and hold it until this function is done.  We keep it
     // locked here so we can cause `ambulkdelete()` to block, waiting for all merging to finish
@@ -420,8 +433,8 @@ unsafe fn merge_index(
 ///
 pub unsafe fn garbage_collect_index(
     indexrel: &PgSearchRelation,
-    current_xid: pg_sys::TransactionId,
-    next_xid: pg_sys::TransactionId,
+    current_xid: pg_sys::FullTransactionId,
+    next_xid: pg_sys::FullTransactionId,
 ) {
     // Remove items which are no longer visible to active local transactions from SEGMENT_METAS,
     // and place them in SEGMENT_METAS_RECYLCABLE until they are no longer visible to remote
@@ -443,7 +456,7 @@ pub unsafe fn garbage_collect_index(
 pub fn free_entries(
     indexrel: &PgSearchRelation,
     freeable_entries: Vec<SegmentMetaEntry>,
-    current_xid: pg_sys::TransactionId,
+    current_xid: pg_sys::FullTransactionId,
 ) {
     let mut bman = BufferManager::new(indexrel);
     bman.fsm().extend_with_when_recyclable(

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -22,6 +22,7 @@ use crate::schema::IndexRecordOption;
 use crate::schema::{SearchFieldConfig, SearchFieldType};
 use std::cell::{Ref, RefCell};
 
+use crate::gucs::{global_enable_background_merging, global_target_segment_count};
 use anyhow::Result;
 use memoffset::*;
 use pgrx::pg_sys::AsPgCStr;
@@ -303,10 +304,19 @@ impl BM25IndexOptions {
     }
 
     pub fn background_layer_sizes(&self) -> Vec<u64> {
+        if !global_enable_background_merging() {
+            return vec![];
+        }
+
         self.options_data().background_layer_sizes()
     }
 
     pub fn target_segment_count(&self) -> usize {
+        let global_tsc = global_target_segment_count();
+        if global_tsc != 0 {
+            return global_tsc as usize;
+        }
+
         self.options_data()
             .target_segment_count()
             .map(|count| count as usize)

--- a/pg_search/src/postgres/storage/avl.rs
+++ b/pg_search/src/postgres/storage/avl.rs
@@ -685,7 +685,6 @@ impl<'a, K: Ord + Copy, V: Copy, T: Copy> Iterator for AvlIter<'a, K, V, T> {
     }
 }
 
-// Optional ergonomic IntoIterator for &AvlMap
 impl<'a, K: Ord + Copy, V: Copy, T: Copy> IntoIterator for &'a AvlTreeMapView<'a, K, V, T> {
     type Item = (K, V);
     type IntoIter = AvlIter<'a, K, V, T>;
@@ -964,24 +963,6 @@ mod tests {
     }
 
     proptest! {
-        #[test]
-        fn test_avl_map_prop(operations: Vec<(i32, i32)>) {
-            let mut header = AvlTreeMapHeader::default();
-            let mut buf = vec![Slot::<i32, i32>::default(); 1024];
-            let mut m = AvlTreeMap::new(&mut header, &mut buf);
-
-            for (k, v) in operations {
-                if m.view().len() >= m.view().capacity() {
-                    break;
-                }
-                prop_assert_eq!(m.insert(k, v), Ok((None, ())));
-                prop_assert_eq!(m.view().get(&k), Some((v, ())));
-
-                #[cfg(debug_assertions)]
-                m.view().assert_ok();
-            }
-        }
-
         #[test]
         fn test_avl_map_random_ops(ops in prop::collection::vec((0..3i32, -100i32..100i32), 1..100)) {
             let mut header = AvlTreeMapHeader::default();

--- a/pg_search/src/postgres/storage/avl.rs
+++ b/pg_search/src/postgres/storage/avl.rs
@@ -1,0 +1,1230 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(clippy::too_many_arguments)]
+use std::num::NonZeroU16;
+
+/// Index type for slots. You can switch to u16 if capacity <= 65_535 by
+/// replacing NonZeroU32 with NonZeroU16 and casts below.
+type Idx = u16;
+type NzIdx = NonZeroU16;
+
+#[inline]
+fn ix_some(i: usize) -> Option<NzIdx> {
+    NzIdx::new((i as Idx) + 1) // store i+1 so 0 encodes None
+}
+#[inline]
+fn ix_to_usize(o: Option<NzIdx>) -> Option<usize> {
+    o.map(|nz| (nz.get() - 1) as usize)
+}
+
+#[inline]
+fn meta_height(meta: u8) -> u8 {
+    meta & 0x7F
+}
+#[inline]
+fn meta_set_used(meta: &mut u8, used: bool) {
+    *meta = (*meta & 0x7F) | ((used as u8) << 7);
+}
+
+#[inline]
+fn meta_is_used(meta: u8) -> bool {
+    (meta & 0x80) != 0
+}
+
+#[inline]
+fn meta_set_height(meta: &mut u8, h: u8) {
+    *meta = (*meta & 0x80) | (h & 0x7F);
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Slot<K: Copy, V: Copy, T: Copy = ()> {
+    left: Option<NzIdx>,  // 2 bytes (None = 0)
+    right: Option<NzIdx>, // 2 bytes
+    pub tag: T,
+    pub key: K,
+    pub val: V,
+    meta: u8, // used bit + height (0 means empty)
+              // padding depends on K/V alignment; layout stays compact & linear
+}
+
+impl<K: Copy, V: Copy, T: Copy> Slot<K, V, T> {
+    #[inline]
+    pub fn is_used(&self) -> bool {
+        meta_is_used(self.meta)
+    }
+    #[inline]
+    fn set_used(&mut self, u: bool) {
+        meta_set_used(&mut self.meta, u)
+    }
+    #[inline]
+    fn height(&self) -> u8 {
+        meta_height(self.meta)
+    }
+    #[inline]
+    fn set_height(&mut self, h: u8) {
+        meta_set_height(&mut self.meta, h)
+    }
+    #[inline]
+    fn l(&self) -> Option<usize> {
+        ix_to_usize(self.left)
+    }
+    #[inline]
+    fn r(&self) -> Option<usize> {
+        ix_to_usize(self.right)
+    }
+    #[inline]
+    fn set_l(&mut self, i: Option<usize>) {
+        self.left = i.and_then(ix_some);
+    }
+    #[inline]
+    fn set_r(&mut self, i: Option<usize>) {
+        self.right = i.and_then(ix_some);
+    }
+}
+
+impl<K: Copy, V: Copy, T: Copy> Default for Slot<K, V, T> {
+    fn default() -> Self {
+        // Keys/values in unused slots are ignored. We avoid reading them when used=false.
+        // Zeroing is fine for common PODs; if your K/V cannot be zeroed, just ensure you never
+        // read key/val unless `is_used()` is true.
+        Self {
+            key: unsafe { core::mem::zeroed() },
+            val: unsafe { core::mem::zeroed() },
+            tag: unsafe { core::mem::zeroed() },
+            left: None,
+            right: None,
+            meta: 0, // used=false, height=0
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+pub enum Error {
+    #[error("AVL map is full")]
+    Full,
+}
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[derive(Default, Debug, Copy, Clone)]
+#[repr(C)]
+pub struct AvlTreeMapHeader {
+    root: Option<usize>,
+    free_head: Option<usize>,
+    len: usize,
+}
+
+/// Read-only view of an Array-backed AVL Tree living inside a borrowed [`&[Slot<K,V>]`]
+#[repr(C)]
+pub struct AvlTreeMapView<'a, K: Ord + Copy, V: Copy, T: Copy = ()> {
+    header: &'a AvlTreeMapHeader,
+    pub(crate) arena: &'a [Slot<K, V, T>],
+}
+
+/// Array-backed mutable AVL Tree living inside a borrowed [`&mut [Slot<K,V>]`]
+#[repr(C)]
+pub struct AvlTreeMap<'a, K: Ord + Copy, V: Copy, T: Copy = ()> {
+    header: &'a mut AvlTreeMapHeader,
+    arena: &'a mut [Slot<K, V, T>],
+}
+
+impl<'a, K: Ord + Copy, V: Copy, T: Copy> AvlTreeMapView<'a, K, V, T> {
+    /// Use the provided `header` and `arena` as pre-existing structures
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe as it cannot guarantee that the provided `header` and `arena` represent
+    /// a valid AVLTree and header information
+    pub unsafe fn with_header_and_arena(
+        header: &'a AvlTreeMapHeader,
+        arena: &'a [Slot<K, V, T>],
+    ) -> Self {
+        Self { header, arena }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.header.len
+    }
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.arena.len()
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.header.len == 0
+    }
+
+    /// Returns a copy of the value for `key`, if present.
+    pub fn get(&self, key: &K) -> Option<(V, T)> {
+        let mut cur = self.header.root;
+        while let Some(i) = cur {
+            let n = &self.arena[i];
+            use core::cmp::Ordering::*;
+            match key.cmp(&{ n.key }) {
+                Equal => return Some((n.val, n.tag)),
+                Less => cur = n.l(),
+                Greater => cur = n.r(),
+            }
+        }
+        None
+    }
+
+    #[inline]
+    pub fn contains(&self, key: &K) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Returns the entry with the greatest key `<= key`.
+    /// If no such key exists, returns `None`.
+    #[inline]
+    pub fn get_lte(&self, key: &K) -> Option<(K, V, T)> {
+        let mut cur = self.header.root;
+        let mut best: Option<usize> = None;
+
+        while let Some(i) = cur {
+            use core::cmp::Ordering::*;
+            let n = &self.arena[i];
+            match key.cmp(&{ n.key }) {
+                Equal => return Some((n.key, n.val, n.tag)),
+                Less => {
+                    // Must be in the left subtree (all keys there are < n.key)
+                    cur = n.l();
+                }
+                Greater => {
+                    // n.key is a candidate (<= key). Go right to try to get closer.
+                    best = Some(i);
+                    cur = n.r();
+                }
+            }
+        }
+
+        best.map(|i| {
+            let n = &self.arena[i];
+            (n.key, n.val, n.tag)
+        })
+    }
+
+    #[inline]
+    fn height(&self, i: Option<usize>) -> i16 {
+        i.map(|ix| self.arena[ix].height() as i16).unwrap_or(0)
+    }
+
+    #[inline]
+    fn balance_factor(&self, i: usize) -> i16 {
+        let lh = self.height(self.arena[i].l());
+        let rh = self.height(self.arena[i].r());
+        lh - rh
+    }
+
+    fn min_index(&self, mut i: usize) -> usize {
+        while let Some(l) = self.arena[i].l() {
+            i = l;
+        }
+        i
+    }
+
+    // Optional safety check (debug only)
+    #[cfg(debug_assertions)]
+    pub fn assert_ok(&self)
+    where
+        K: Ord + Copy + core::fmt::Debug,
+    {
+        fn dfs<K: Ord + Copy + core::fmt::Debug, V: Copy, T: Copy>(
+            t: &AvlTreeMapView<'_, K, V, T>,
+            i: Option<usize>,
+        ) -> (i8, K, K) {
+            let ix = i.expect("dfs called with None");
+            let n = &t.arena[ix];
+
+            // Left subtree
+            let (lh, lmin, lmax) = if let Some(li) = n.l() {
+                let (h, min_k, max_k) = dfs(t, Some(li));
+                assert!(
+                    max_k <= { n.key },
+                    "BST violation: left max {:?} > node {:?}",
+                    max_k,
+                    { n.key }
+                );
+                (h, min_k, max_k)
+            } else {
+                (0, n.key, n.key)
+            };
+
+            // Right subtree
+            let (rh, rmin, rmax) = if let Some(ri) = n.r() {
+                let (h, min_k, max_k) = dfs(t, Some(ri));
+                assert!(
+                    { n.key } <= min_k,
+                    "BST violation: node {:?} > right min {:?}",
+                    { n.key },
+                    min_k
+                );
+                (h, min_k, max_k)
+            } else {
+                (0, n.key, n.key)
+            };
+
+            // Check height and balance
+            let h = 1 + lh.max(rh);
+            assert_eq!(n.height() as i8, h, "Height mismatch at {:?}", { n.key });
+            assert!(
+                (lh - rh).abs() <= 1,
+                "Balance factor out of range at {:?}",
+                { n.key }
+            );
+
+            // Return overall min/max for this subtree
+            (h, lmin.min(n.key).min(rmin), rmax.max(n.key).max(lmax))
+        }
+
+        if let Some(r) = self.header.root {
+            let _ = dfs(self, Some(r));
+        }
+        assert!(self.header.len <= self.capacity());
+    }
+}
+
+impl<'a, K: Ord + Copy, V: Copy, T: Copy> AvlTreeMap<'a, K, V, T> {
+    /// Initialize over the given linear memory; marks all slots as free.
+    pub fn new(header: &'a mut AvlTreeMapHeader, arena: &'a mut [Slot<K, V, T>]) -> Self {
+        // Build free list by chaining `left` as the "next" pointer.
+        header.free_head = None;
+        for i in (0..arena.len()).rev() {
+            arena[i].set_used(false);
+            arena[i].set_height(0);
+            arena[i].set_r(None);
+            // push i on free list
+            arena[i].set_l(header.free_head);
+            header.free_head = Some(i);
+        }
+        header.root = None;
+        header.len = 0;
+        Self { header, arena }
+    }
+
+    /// Use the provided `header` and `arena` as pre-existing structures
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe as it cannot guarantee that the provided `header` and `arena` represent
+    /// a valid AVLTree and header information
+    pub unsafe fn with_header_and_arena(
+        header: &'a mut AvlTreeMapHeader,
+        arena: &'a mut [Slot<K, V, T>],
+    ) -> Self {
+        Self { header, arena }
+    }
+
+    #[inline(always)]
+    pub fn view(&self) -> AvlTreeMapView<'_, K, V, T> {
+        AvlTreeMapView {
+            header: self.header,
+            arena: self.arena,
+        }
+    }
+
+    /// Insert or update.
+    /// - If key exists: replaces its value and returns `Some(old_value)`.
+    /// - If key does not exist: inserts and returns `None`.
+    pub fn insert(&mut self, key: K, val: V) -> Result<(Option<V>, T)> {
+        let mut out_old: Option<V> = None;
+        let mut out_tag: Option<T> = None;
+        let mut inserted_new = false;
+        let mut occupied_at = 0;
+        self.header.root = self.insert_rec(
+            self.header.root,
+            key,
+            Some(val),
+            &mut out_old,
+            &mut out_tag,
+            &mut inserted_new,
+            &mut occupied_at,
+        )?;
+        if inserted_new {
+            self.header.len += 1;
+        }
+        Ok((out_old, out_tag.unwrap()))
+    }
+
+    /// Remove by key; returns value if found.
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        let mut removed_val: Option<V> = None;
+        let mut did_remove = false;
+        self.header.root =
+            self.delete_rec(self.header.root, key, &mut removed_val, &mut did_remove);
+        if did_remove {
+            self.header.len -= 1;
+        }
+        removed_val
+    }
+
+    /// Returns a mutable reference to the value if the `key` exists
+    pub fn get_slot_mut(&mut self, key: &K) -> Option<&mut Slot<K, V, T>> {
+        let mut cur = self.header.root;
+        while let Some(i) = cur {
+            let n = &self.arena[i];
+            use core::cmp::Ordering::*;
+            match key.cmp(&{ n.key }) {
+                Equal => return Some(&mut self.arena[i]),
+                Less => cur = n.l(),
+                Greater => cur = n.r(),
+            }
+        }
+        None
+    }
+
+    /// Returns a mutable reference to the slot with the maximum key in the tree.
+    /// If the tree is empty, returns `None`.
+    pub fn get_max_slot(&mut self) -> Option<&mut Slot<K, V, T>> {
+        let mut cur = self.header.root;
+        let mut max = None;
+
+        while let Some(i) = cur {
+            max = Some(i);
+            cur = self.arena[i].r();
+        }
+
+        max.map(|i| &mut self.arena[i])
+    }
+
+    #[inline]
+    fn update_height(&mut self, i: usize) {
+        let view = self.view();
+        let lh = view.height(view.arena[i].l());
+        let rh = view.height(view.arena[i].r());
+        self.arena[i].set_height((1 + lh.max(rh)) as u8);
+    }
+
+    fn rotate_right(&mut self, y: usize) -> usize {
+        // y's left must exist
+        let x = self.arena[y].l().expect("rotate_right requires left child");
+        let t2 = self.arena[x].r();
+
+        // Perform rotation
+        self.arena[x].set_r(Some(y));
+        self.arena[y].set_l(t2);
+
+        // Update heights
+        self.update_height(y);
+        self.update_height(x);
+        x
+    }
+
+    fn rotate_left(&mut self, x: usize) -> usize {
+        // x's right must exist
+        let y = self.arena[x].r().expect("rotate_left requires right child");
+        let t2 = self.arena[y].l();
+
+        self.arena[y].set_l(Some(x));
+        self.arena[x].set_r(t2);
+
+        self.update_height(x);
+        self.update_height(y);
+        y
+    }
+
+    fn rebalance(&mut self, i: usize) -> usize {
+        self.update_height(i);
+        let bf = self.view().balance_factor(i);
+
+        if bf > 1 {
+            // Left heavy
+            let l = self.arena[i].l().unwrap();
+            if self.view().balance_factor(l) < 0 {
+                // LR
+                let nl = self.rotate_left(l);
+                self.arena[i].set_l(Some(nl));
+            }
+            return self.rotate_right(i);
+        } else if bf < -1 {
+            // Right heavy
+            let r = self.arena[i].r().unwrap();
+            if self.view().balance_factor(r) > 0 {
+                // RL
+                let nr = self.rotate_right(r);
+                self.arena[i].set_r(Some(nr));
+            }
+            return self.rotate_left(i);
+        }
+        i
+    }
+
+    fn alloc_slot(&mut self, key: K, val: Option<V>) -> Result<usize> {
+        let idx = self.header.free_head.ok_or(Error::Full)?;
+        // pop from free list (stored in `left`)
+        self.header.free_head = self.arena[idx].l();
+        let n = &mut self.arena[idx];
+        n.key = key;
+        if let Some(val) = val {
+            n.val = val;
+        }
+        n.set_l(None);
+        n.set_r(None);
+        n.set_height(1);
+        n.set_used(true);
+        Ok(idx)
+    }
+
+    fn free_slot(&mut self, idx: usize) {
+        let n = &mut self.arena[idx];
+        n.set_used(false);
+        n.set_height(0);
+        n.set_r(None);
+        // push to free list via left
+        n.set_l(self.header.free_head);
+        self.header.free_head = Some(idx);
+    }
+
+    fn insert_rec(
+        &mut self,
+        root: Option<usize>,
+        key: K,
+        val: Option<V>,
+        out_old: &mut Option<V>,
+        out_tag: &mut Option<T>,
+        inserted_new: &mut bool,
+        occupied_at: &mut usize,
+    ) -> Result<Option<usize>> {
+        match root {
+            None => {
+                // insert a new value
+                *inserted_new = true;
+                let slot = self.alloc_slot(key, val)?;
+                *out_tag = Some(self.arena[slot].tag);
+                *occupied_at = slot;
+                Ok(Some(slot))
+            }
+            Some(i) => {
+                use core::cmp::Ordering::*;
+                match key.cmp(&{ self.arena[i].key }) {
+                    Equal => {
+                        // Update value, return old
+                        let old = self.arena[i].val;
+                        if let Some(val) = val {
+                            self.arena[i].val = val;
+                        }
+                        *out_old = Some(old);
+                        *out_tag = Some(self.arena[i].tag);
+                        *occupied_at = i;
+                        return Ok(Some(i));
+                    }
+                    Less => {
+                        let left = self.insert_rec(
+                            self.arena[i].l(),
+                            key,
+                            val,
+                            out_old,
+                            out_tag,
+                            inserted_new,
+                            occupied_at,
+                        )?;
+                        self.arena[i].set_l(left);
+                    }
+                    Greater => {
+                        let right = self.insert_rec(
+                            self.arena[i].r(),
+                            key,
+                            val,
+                            out_old,
+                            out_tag,
+                            inserted_new,
+                            occupied_at,
+                        )?;
+                        self.arena[i].set_r(right);
+                    }
+                }
+                let new_i = self.rebalance(i);
+                Ok(Some(new_i))
+            }
+        }
+    }
+
+    fn delete_rec(
+        &mut self,
+        root: Option<usize>,
+        key: &K,
+        removed_val: &mut Option<V>,
+        did_remove: &mut bool,
+    ) -> Option<usize> {
+        let i = root?;
+        use core::cmp::Ordering::*;
+        match key.cmp(&{ self.arena[i].key }) {
+            Less => {
+                let left = self.delete_rec(self.arena[i].l(), key, removed_val, did_remove);
+                self.arena[i].set_l(left);
+                Some(self.rebalance(i))
+            }
+            Greater => {
+                let right = self.delete_rec(self.arena[i].r(), key, removed_val, did_remove);
+                self.arena[i].set_r(right);
+                Some(self.rebalance(i))
+            }
+            Equal => {
+                *did_remove = true;
+                let retv = self.arena[i].val;
+                match (self.arena[i].l(), self.arena[i].r()) {
+                    (None, None) => {
+                        self.free_slot(i);
+                        *removed_val = Some(retv);
+                        None
+                    }
+                    (Some(c), None) | (None, Some(c)) => {
+                        self.free_slot(i);
+                        *removed_val = Some(retv);
+                        Some(c)
+                    }
+                    (Some(_), Some(_)) => {
+                        // Record the value being removed BEFORE overwriting the node.
+                        *removed_val = Some(retv);
+
+                        // In-order successor in right subtree
+                        let view = self.view();
+                        let succ = view.min_index(view.arena[i].r().unwrap());
+                        let (succ_key, succ_val, succ_tag) = {
+                            let s = &self.arena[succ];
+                            (s.key, s.val, s.tag)
+                        };
+
+                        // Overwrite this node with successor's key/val and swap tags
+                        self.arena[i].key = succ_key;
+                        self.arena[i].val = succ_val;
+                        let temp_tag = self.arena[i].tag; // Save original tag of slot i
+                        self.arena[i].tag = succ_tag; // Move successor's tag to slot i
+                        self.arena[succ].tag = temp_tag; // Move original tag to successor's slot
+
+                        // Delete successor, but do NOT overwrite removed_val
+                        let mut ignored_val: Option<V> = None;
+                        let mut ignored_flag = false;
+                        let right = self.delete_rec(
+                            self.arena[i].r(),
+                            &succ_key,
+                            &mut ignored_val,
+                            &mut ignored_flag,
+                        );
+                        self.arena[i].set_r(right);
+
+                        Some(self.rebalance(i))
+                    }
+                }
+            }
+        }
+    }
+}
+
+const MAX_HEIGHT: usize = 128;
+
+pub struct AvlIter<'a, K: Copy, V: Copy, T: Copy> {
+    arena: &'a [Slot<K, V, T>],
+    stack: [usize; MAX_HEIGHT],
+    sp: usize,
+    cursor: Option<usize>,
+}
+
+impl<'a, K: Ord + Copy, V: Copy, T: Copy> AvlTreeMapView<'a, K, V, T> {
+    /// In-order iterator over (&copy) (K, V) pairs.
+    #[inline]
+    pub fn iter(&'a self) -> AvlIter<'a, K, V, T> {
+        AvlIter {
+            arena: self.arena,
+            stack: [0; MAX_HEIGHT],
+            sp: 0,
+            cursor: self.header.root,
+        }
+    }
+}
+
+impl<'a, K: Copy, V: Copy, T: Copy> AvlIter<'a, K, V, T> {
+    #[inline]
+    fn push_left_chain(&mut self) {
+        // Descend left from `cursor`, pushing nodes onto the fixed stack.
+        while let Some(i) = self.cursor {
+            debug_assert!(self.sp < MAX_HEIGHT, "AVL height exceeded MAX_HEIGHT");
+            self.stack[self.sp] = i;
+            self.sp += 1;
+            self.cursor = self.arena[i].l();
+        }
+    }
+}
+
+impl<'a, K: Ord + Copy, V: Copy, T: Copy> Iterator for AvlIter<'a, K, V, T> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Go as far left as possible from the current cursor.
+        self.push_left_chain();
+
+        // Pop the top of the stack = next in-order node.
+        if self.sp == 0 {
+            return None;
+        }
+        self.sp -= 1;
+        let i = self.stack[self.sp];
+        let n = &self.arena[i];
+
+        // After visiting `i`, the next subtree to process is its right child.
+        self.cursor = n.r();
+
+        Some((n.key, n.val))
+    }
+}
+
+// Optional ergonomic IntoIterator for &AvlMap
+impl<'a, K: Ord + Copy, V: Copy, T: Copy> IntoIterator for &'a AvlTreeMapView<'a, K, V, T> {
+    type Item = (K, V);
+    type IntoIter = AvlIter<'a, K, V, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::postgres::storage::avl::{AvlTreeMap, AvlTreeMapHeader, Error, Slot};
+    use proptest::prelude::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_avl_map_basics() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32>::default(); 32];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+        assert_eq!(m.insert(10, 100), Ok((None, ())));
+        assert_eq!(m.insert(5, 50), Ok((None, ())));
+        assert_eq!(m.insert(15, 150), Ok((None, ())));
+        assert_eq!(m.view().get(&10), Some((100, ())));
+        assert_eq!(m.view().get(&7), None);
+
+        // update existing key
+        assert_eq!(m.insert(10, 111), Ok((Some(100), ())));
+        assert_eq!(m.view().get(&10), Some((111, ())));
+
+        // remove
+        assert_eq!(m.remove(&5), Some(50));
+        assert_eq!(m.view().get(&5), None);
+
+        // fill more and ensure balanced behavior
+        for k in [3, 7, 13, 17, 6, 8, 12, 14, 16, 18] {
+            let _ = m.insert(k, k * 10);
+        }
+        assert!(m.view().contains(&16));
+        assert_eq!(m.remove(&16), Some(160));
+        assert!(!m.view().contains(&16));
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+
+        for (k, v) in m.view().iter() {
+            eprintln!("{k}: {v}");
+        }
+
+        eprintln!("{}", size_of::<Slot<u32, u32>>())
+    }
+
+    #[test]
+    fn test_avl_map_full() {
+        const SIZE: usize = 8192 / size_of::<Slot<i32, i32>>();
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32>::default(); SIZE];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+        for i in 0..SIZE {
+            assert_eq!(m.insert(i as i32, i as i32), Ok((None, ())));
+        }
+
+        assert_eq!(m.insert((SIZE + 1) as i32, 0), Err(Error::Full));
+
+        assert_eq!(m.remove(&32), Some(32));
+        assert_eq!(m.insert((SIZE + 1) as i32, 0), Ok((None, ())));
+        assert_eq!(m.view().get(&((SIZE + 1) as i32)), Some((0, ())));
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    #[test]
+    fn test_avl_map_delete_returns_original_value_minimal_case() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32>::default(); 32];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+        // Minimal failing sequence from the prop-test
+        assert_eq!(m.insert(-4, -8), Ok((None, ()))); // left subtree
+        assert_eq!(m.insert(63, 126), Ok((None, ()))); // target node
+        assert_eq!(m.insert(-4, -8), Ok((Some(-8), ()))); // update same key (no-op on structure)
+        assert_eq!(m.insert(64, 128), Ok((None, ()))); // right child of 63
+        assert_eq!(m.insert(0, 0), Ok((None, ()))); // right child of -4 -> gives 63 two children
+
+        // Deleting 63 should return its ORIGINAL value (126), not the successor’s (128)
+        assert_eq!(m.remove(&63), Some(126));
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    #[test]
+    fn test_avl_map_delete_returns_original_value_two_children_general() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32>::default(); 64];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+        // Build a standard BST shape where the root has two children
+        for &(k, v) in &[
+            (50, 500),
+            (30, 300),
+            (70, 700),
+            (20, 200),
+            (40, 400),
+            (60, 600),
+            (80, 800),
+        ] {
+            assert_eq!(m.insert(k, v), Ok((None, ())));
+        }
+
+        // Delete node with two children (50). Must return the original value stored at 50.
+        assert_eq!(m.remove(&50), Some(500));
+
+        // Structure and inorder remain valid and match a reference BTreeMap after the delete.
+        let mut reference = std::collections::BTreeMap::new();
+        for &(k, v) in &[
+            (30, 300),
+            (70, 700),
+            (20, 200),
+            (40, 400),
+            (60, 600),
+            (80, 800),
+        ] {
+            reference.insert(k, v);
+        }
+        assert!(Iterator::eq(
+            m.view().iter(),
+            reference.iter().map(|(&k, &v)| (k, v))
+        ));
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    #[test]
+    fn test_avl_map_get_lte_basic() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32>::default(); 64];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+        for &(k, v) in &[(10, 100), (20, 200), (30, 300), (40, 400)] {
+            assert_eq!(m.insert(k, v), Ok((None, ())));
+        }
+
+        // Exact hits
+        assert_eq!(m.view().get_lte(&10), Some((10, 100, ())));
+        assert_eq!(m.view().get_lte(&40), Some((40, 400, ())));
+
+        // Between keys -> greatest smaller
+        assert_eq!(m.view().get_lte(&35), Some((30, 300, ())));
+        assert_eq!(m.view().get_lte(&21), Some((20, 200, ())));
+        assert_eq!(m.view().get_lte(&11), Some((10, 100, ())));
+
+        // Below minimum
+        assert_eq!(m.view().get_lte(&-1), None);
+
+        // Above maximum
+        assert_eq!(m.view().get_lte(&99), Some((40, 400, ())));
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    #[test]
+    fn test_avl_map_delete_tag_preservation() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32, i32>::default(); 32];
+        // Initialize the tree with a proper free list
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+        // Set unique tags after initialization
+        for (i, slot) in m.arena.iter_mut().enumerate() {
+            slot.tag = i as i32;
+        }
+        // Insert nodes: 50 (two children), 30 (left), 60 (right, successor)
+        assert_eq!(m.insert(50, 500), Ok((None, 0)));
+        assert_eq!(m.insert(30, 300), Ok((None, 1)));
+        assert_eq!(m.insert(60, 600), Ok((None, 2)));
+        // Before delete, key=60 has tag=2
+        assert_eq!(m.view().get(&60), Some((600, 2)));
+        // Delete 50 (two children)
+        assert_eq!(m.remove(&50), Some(500));
+        // After delete, key=60 should still have tag=2, now in slot 0
+        assert_eq!(m.view().get(&60), Some((600, 2)));
+        // Slot 2 (successor) is free, but its tag remains (e.g., for reuse)
+        assert_eq!(m.arena[2].tag, 0);
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    #[test]
+    fn test_avl_map_deep_tree_and_iterator() {
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32, i32>::default(); 128];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+        let mut reference = BTreeMap::new();
+
+        // Initialize unique tags
+        for (i, slot) in m.arena.iter_mut().enumerate() {
+            slot.tag = i as i32;
+        }
+
+        // Insert keys in a way that creates a deep but balanced tree
+        // Use a sequence that approximates a balanced tree (e.g., insert in sorted order with some variation)
+        let keys = vec![
+            100, 50, 150, 25, 75, 125, 175, 12, 37, 62, 87, 112, 137, 162, 187, 6, 18, 31, 43, 56,
+            68, 81, 93, 106, 118, 131, 143, 156, 168, 181, 193,
+        ];
+        for &k in &keys {
+            let v = k * 2;
+            let result = m.insert(k, v);
+            assert!(result.is_ok(), "Insert failed for key {k}");
+            let (old_val, tag) = result.unwrap();
+            assert_eq!(old_val, None, "Unexpected old value for key {k}");
+            reference.insert(k, (v, tag));
+        }
+
+        // Verify iterator produces keys in order
+        let mut expected_keys = keys.clone();
+        expected_keys.sort();
+        let iter_keys: Vec<i32> = m.view().iter().map(|(k, _)| k).collect();
+        assert_eq!(
+            iter_keys, expected_keys,
+            "Iterator produced incorrect key order"
+        );
+
+        // Verify key/value/tag consistency
+        for (&k, &(v, t)) in &reference {
+            let got = m.view().get(&k);
+            assert_eq!(got, Some((v, t)), "Tag mismatch for key {k}");
+        }
+
+        // Delete some keys to trigger two-child deletions and slot reuse
+        let delete_keys = vec![100, 50, 150];
+        for &k in &delete_keys {
+            let removed = m.remove(&k);
+            let expected_val = reference.remove(&k).map(|(v, _)| v);
+            assert_eq!(removed, expected_val, "Remove failed for key {k}");
+        }
+
+        // Re-insert into freed slots
+        let new_keys = vec![90, 110, 130];
+        for &k in &new_keys {
+            let v = k * 2;
+            let result = m.insert(k, v);
+            assert!(result.is_ok(), "Insert failed for key {k}");
+            let (old_val, tag) = result.unwrap();
+            assert_eq!(old_val, None, "Unexpected old value for key {k}");
+            reference.insert(k, (v, tag));
+        }
+
+        // Verify iterator and tags again
+        let mut expected_keys: Vec<i32> = reference.keys().copied().collect();
+        expected_keys.sort();
+        let iter_keys: Vec<i32> = m.view().iter().map(|(k, _)| k).collect();
+        assert_eq!(
+            iter_keys, expected_keys,
+            "Iterator produced incorrect key order after deletions/insertions"
+        );
+
+        for (&k, &(v, t)) in &reference {
+            let got = m.view().get(&k);
+            assert_eq!(got, Some((v, t)), "Tag mismatch for key {k}");
+        }
+
+        // Verify tree height is reasonable (should be ~log2(32) ≈ 5-6)
+        let max_height = m.view().height(m.header.root);
+        assert!(
+            max_height <= 10,
+            "Tree height {max_height} is unexpectedly large"
+        );
+
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+
+    proptest! {
+        #[test]
+        fn test_avl_map_prop(operations: Vec<(i32, i32)>) {
+            let mut header = AvlTreeMapHeader::default();
+            let mut buf = vec![Slot::<i32, i32>::default(); 1024];
+            let mut m = AvlTreeMap::new(&mut header, &mut buf);
+
+            for (k, v) in operations {
+                if m.view().len() >= m.view().capacity() {
+                    break;
+                }
+                prop_assert_eq!(m.insert(k, v), Ok((None, ())));
+                prop_assert_eq!(m.view().get(&k), Some((v, ())));
+
+                #[cfg(debug_assertions)]
+                m.view().assert_ok();
+            }
+        }
+
+        #[test]
+        fn test_avl_map_random_ops(ops in prop::collection::vec((0..3i32, -100i32..100i32), 1..100)) {
+            let mut header = AvlTreeMapHeader::default();
+            let mut buf = vec![Slot::<i32, i32>::default(); 1024];
+            let mut m = AvlTreeMap::new(&mut header, &mut buf);
+            let mut reference = std::collections::BTreeMap::new();
+
+            for (op, k) in ops {
+                match op {
+                    0 => {
+                        // Insert
+                        if m.view().len() < m.view().capacity() {
+                            let (old_m, _) = m.insert(k, k*2).unwrap();
+                            let old_ref = reference.insert(k, k*2);
+                            prop_assert_eq!(old_m, old_ref);
+                        }
+                    },
+                    1 => {
+                        // Remove
+                        let removed_m = m.remove(&k);
+                        let removed_ref = reference.remove(&k);
+                        prop_assert_eq!(removed_m, removed_ref);
+                    },
+                    2 => {
+                        // Get
+                        let val_m = m.view().get(&k);
+                        let val_ref = reference.get(&k).copied();
+                        prop_assert_eq!(val_m, val_ref.map(|v| (v, ())));
+                    },
+                    _ => unreachable!(),
+                }
+
+                // Verify tree properties
+                #[cfg(debug_assertions)]
+                m.view().assert_ok();
+
+                // Verify in-order iteration matches reference
+                prop_assert!(Iterator::eq(
+                    m.view().iter(),
+                    reference.iter().map(|(&k,&v)| (k,v))
+                ));
+            }
+        }
+
+        #[test]
+        fn test_avl_mapget_lte_matches_btreemap(query in -1000i32..=1000i32, kvs in prop::collection::btree_set(-1000i32..=1000i32, 0..200)) {
+            let mut header = AvlTreeMapHeader::default();
+            let mut buf = vec![Slot::<i32, i32>::default(); 2048];
+            let mut m = AvlTreeMap::new(&mut header, &mut buf);
+            let mut refmap = std::collections::BTreeMap::new();
+
+            for &k in &kvs {
+                let v = k * 2;
+                m.insert(k, v).unwrap();
+                refmap.insert(k, v);
+            }
+
+            let got = m.view().get_lte(&query);
+            let exp = refmap.range(..=query).next_back().map(|(&k, &v)| (k, v, ()));
+            prop_assert_eq!(got, exp);
+
+            #[cfg(debug_assertions)]
+            m.view().assert_ok();
+        }
+    }
+
+    #[test]
+    fn test_avl_map_stress_delete_reinsert_tags() {
+        use rand::Rng;
+
+        let mut header = AvlTreeMapHeader::default();
+        let mut buf = vec![Slot::<i32, i32, i32>::default(); 1024];
+        let mut m = AvlTreeMap::new(&mut header, &mut buf);
+        for (i, slot) in m.arena.iter_mut().enumerate() {
+            slot.tag = i as i32; // Initial tags: 0..1023
+        }
+        let mut key_tags = std::collections::HashMap::new(); // Track expected tag per key
+
+        let mut rng = rand::rng();
+
+        for i in 0..10000 {
+            let k: i32 = (rng.random::<i32>() % 100) as i32; // Small key range for duplicates
+            let v = k * 2;
+
+            match rng.random_range(0..4) {
+                0 => {
+                    // Insert/update
+                    let result = m.insert(k, v);
+                    if let Ok((old_val, tag)) = result {
+                        if old_val.is_none() {
+                            // New insert: record tag
+                            key_tags.insert(k, tag);
+                        } else {
+                            // Update: tag should match previous (no direct tag change here)
+                            let expected_tag = *key_tags.get(&k).unwrap();
+                            assert_eq!(tag, expected_tag, "Tag changed on update for key {k}");
+                        }
+                    }
+                }
+                1 => {
+                    // Delete
+                    let removed = m.remove(&k);
+                    if removed.is_some() {
+                        key_tags.remove(&k); // Tag no longer associated
+                    }
+                }
+                2 => {
+                    // Direct tag change (outside initial range)
+                    if let Some(slot) = m.get_slot_mut(&k) {
+                        let new_tag = 2000 + rng.random_range(0..1000) as i32; // e.g., 2000..2999
+                        let old_tag = slot.tag;
+                        slot.tag = new_tag;
+                        // Update tracking
+                        *key_tags.get_mut(&k).unwrap() = new_tag;
+                        // Verify the change took effect
+                        let got = m.view().get(&k);
+                        assert_eq!(
+                            got,
+                            Some((v, new_tag)),
+                            "Direct tag change didn't persist for key {k}"
+                        );
+                        eprintln!(
+                            "Direct tag change: key {k} old_tag {old_tag} -> new_tag {new_tag}"
+                        );
+                    }
+                }
+                3 => {
+                    // Get/validate existing tag
+                    if let Some((_, got_tag)) = m.view().get(&k) {
+                        let expected_tag = *key_tags.get(&k).unwrap();
+                        assert_eq!(
+                            got_tag, expected_tag,
+                            "Unexpected tag for key {k} during validation"
+                        );
+                    }
+                }
+                _ => unreachable!(),
+            }
+
+            // Periodic full validation (every ~100 ops or random)
+            if rng.random_bool(0.01) || (i % 100 == 0) {
+                for (&k, &expected_tag) in &key_tags {
+                    if let Some((_, got_tag)) = m.view().get(&k) {
+                        assert_eq!(
+                            got_tag, expected_tag,
+                            "Tag mismatch during periodic validation for key {k}"
+                        );
+                    }
+                }
+                #[cfg(debug_assertions)]
+                m.view().assert_ok();
+            }
+        }
+
+        // Final validation
+        for (&k, &expected_tag) in &key_tags {
+            let got = m.view().get(&k);
+            assert_eq!(
+                got.map(|(_, t)| t),
+                Some(expected_tag),
+                "Final tag mismatch for key {k}"
+            );
+        }
+        #[cfg(debug_assertions)]
+        m.view().assert_ok();
+    }
+    proptest! {
+        #[test]
+        fn test_avl_map_random_ops_with_tags(
+            ops in prop::collection::vec((0..5u8, -100i32..100i32, -100i32..100i32), 1..200)
+        ) {
+            let mut header = AvlTreeMapHeader::default();
+            let mut buf = vec![Slot::<i32, i32, i32>::default(); 1024];
+            let mut m = AvlTreeMap::new(&mut header, &mut buf);
+            // Initialize unique tags
+            for (i, slot) in m.arena.iter_mut().enumerate() {
+                slot.tag = i as i32;
+            }
+            let mut reference = BTreeMap::new();
+
+            for (op, k, v) in ops {
+                match op {
+                    0 | 1 => {
+                        // Insert or update
+                        if m.view().len() < m.view().capacity() {
+                            let result = m.insert(k, v);
+                            match result {
+                                Ok((old_val, tag)) => {
+                                    // Update reference
+                                    let old_ref = reference.insert(k, (v, tag));
+                                    // Verify old value matches
+                                    prop_assert_eq!(old_val, old_ref.map(|(v, _)| v));
+                                    // Verify tag: for new insert, tag comes from slot; for update, it’s the existing tag
+                                    let expected_tag = match old_ref {
+                                        None => tag, // New insert: tag from inserted slot
+                                        Some((_, t)) => t, // Update: tag from previous entry
+                                    };
+                                    prop_assert_eq!(tag, expected_tag, "Tag mismatch for key {}", k);
+                                }
+                                Err(Error::Full) => {
+                                    // Arena full, skip tag validation and reference update
+                                    prop_assert_eq!(m.view().len(), m.view().capacity(), "Expected full arena");
+                                }
+                            }
+                        }
+                    }
+                    2 => {
+                        // Remove
+                        let removed_m = m.remove(&k);
+                        let removed_ref = reference.remove(&k);
+                        prop_assert_eq!(removed_m, removed_ref.map(|(v, _)| v));
+                    }
+                    3 => {
+                        // Get
+                        let val_m = m.view().get(&k);
+                        let val_ref = reference.get(&k).map(|&(v, t)| (v, t));
+                        prop_assert_eq!(val_m, val_ref);
+                    }
+                    4 => {
+                        // Contains
+                        let contains_m = m.view().contains(&k);
+                        let contains_ref = reference.contains_key(&k);
+                        prop_assert_eq!(contains_m, contains_ref);
+                    }
+                    _ => unreachable!(),
+                }
+
+                // Verify tree properties
+                #[cfg(debug_assertions)]
+                m.view().assert_ok();
+
+                // Verify in-order iteration matches reference (key/value only)
+                prop_assert!(Iterator::eq(
+                    m.view().iter(),
+                    reference.iter().map(|(&k, &(v, _))| (k, v))
+                ));
+
+                // Verify tags for all keys in the tree
+                for (&k, &(v, t)) in &reference {
+                    let got = m.view().get(&k);
+                    prop_assert_eq!(got, Some((v, t)), "Tag mismatch for key {}", k);
+                }
+            }
+        }
+    }
+}

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -16,15 +16,16 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::storage::block::{bm25_max_free_space, BM25PageSpecialData};
-use crate::postgres::storage::buffer::{init_new_buffer, Buffer, BufferManager};
+use crate::postgres::storage::buffer::BufferManager;
+use crate::postgres::storage::fsm::v1::V1FSM;
+use crate::postgres::storage::fsm::v2::V2FSM;
 use crate::postgres::storage::metadata::MetaPage;
 use pgrx::iter::TableIterator;
-use pgrx::{name, pg_extern, pg_sys, AnyNumeric, PgRelation};
+use pgrx::{name, pg_extern, pg_sys, PgRelation};
 
 /// Denotes what the data on an FSM block looks like
 #[allow(non_camel_case_types)]
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(u32)]
 enum FSMBlockKind {
     /// This variant represents the original FSM format in pg_search versions 0.17.0 through 0.17.3
@@ -34,73 +35,23 @@ enum FSMBlockKind {
     #[allow(dead_code)]
     v0 = 0,
 
-    /// This represents the current FSM format and is the default for new FSM pages
-    #[default]
+    /// This represents an older FSM format
     v1_uncompressed = 1,
+
+    /// This represents the current FSM format, which is based on an AVL tree for organizing things by [`pg_sys::TransactionId`]
+    v2_avl_tree = 2,
 }
 
 /// A short header for the FSM block, stored at the beginning of each page, which allows us to quickly
 /// identify what kind of block we're about to work with
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 struct FSMBlockHeader {
     /// Denotes how the block data is stored on this page
     kind: FSMBlockKind,
 }
 
-/// The header information for the current FSM block format.  Its first field is purposely the [`FSMBlockHeader`]
-/// so that the block header can be read as that type.  `#[repr(C)]` ensures this is correct
-#[derive(Default, Debug, Copy, Clone)]
-#[repr(C)]
-struct V1Header {
-    header: FSMBlockHeader,
-
-    /// Denotes if this block is completely empty, meaning all its entries reference the
-    /// [`pg_sys::InvalidBlockNumber`].
-    ///
-    /// Empty blocks can be skipped without needing to read the entire entry data.  This is just a
-    /// hint towards `true`.  If it's `false` but all the entries are invalid, that's okay --
-    /// we only wasted some CPU cycles scanning the empty block.
-    empty: bool,
-}
-
-/// An individual entry on a [`FSMBlock`].  Represented as a pair of [`pg_sys::BlockNumber`] and
-/// [`pg_sys::TransactionId`].  The transaction id is the [`pg_sys::GetCurrentTransactionId()`] (or perhaps caller-provided)
-/// of the transaction that added the entry to the FSM.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub struct FSMEntry(pg_sys::BlockNumber, pg_sys::TransactionId);
-
-const MAX_ENTRIES_PER_PAGE: usize =
-    (bm25_max_free_space() - size_of::<V1Header>()) / size_of::<FSMEntry>();
-
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-struct FSMBlock {
-    header: V1Header,
-    entries: [FSMEntry; MAX_ENTRIES_PER_PAGE],
-}
-
-impl Default for FSMBlock {
-    fn default() -> Self {
-        Self {
-            header: Default::default(),
-            entries: [FSMEntry(pg_sys::InvalidBlockNumber, pg_sys::InvalidTransactionId);
-                MAX_ENTRIES_PER_PAGE],
-        }
-    }
-}
-
-impl FSMBlock {
-    #[inline]
-    fn any_invalid(&self) -> bool {
-        self.entries
-            .iter()
-            .any(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
-    }
-}
-
-/// The [`FreeSpaceManager`] is our version of Postgres' "free space map".  We need to track free space
+/// The [`V1FSM`] is our version of Postgres' "free space map".  We need to track free space
 /// as whole blocks and we'd prefer to not have to mark pages as deleted when giving them to the FSM.
 ///
 /// We also have a requirement that blocks be recycled in the future, after the transaction which
@@ -108,140 +59,37 @@ impl FSMBlock {
 /// those from hot-standby servers.  Reusing a block before all nodes in the cluster and/or all
 /// concurrent backends are aware that it's been deleted can cause race conditions and data corruption.
 ///
-/// The on-disk structure is simply a linked list of blocks where each block, a [`FSMBlock`],
+/// The on-disk structure is simply a linked list of blocks where each block, a [`v1::FSMBlock`],
 /// is a fixed-sized array of ([`pg_sys::BlockNumber`], [`pg_sys::TransactionId`]) pairs.
 ///
 /// Each block starts with a small [`FSMBlockHeader`] indicating the type of block (we've had a few
 /// styles so far).  This is denoted by the [`FSMBlockHeader::kind`] flag.
 ///
 /// Outside per-page exclusive locking when mutating a page, no special locking requirements exist
-/// to manage concurrency.  The intent is that the [`FreeSpaceManager`]'s linked list can grow
+/// to manage concurrency.  The intent is that the [`V1FSM`]'s linked list can grow
 /// unbounded, with the hope that it actually won't grow to be very large in practice.
 ///
 /// Any other kind of structure will likely need a more sophisticated approach to concurrency control.
 ///
-/// The user-facing API is meant to _kinda_ mimic a `Vec` in that the [`FreeSpaceManager`] can be
+/// The user-facing API is meant to _kinda_ mimic a `Vec` in that the [`V1FSM`] can be
 /// popped, drained, and extended.
-///
-/// There is a [`FSMBlockKind::v0`] variant which is used to represent the original FSM format, used
-/// prior to pg_search 0.17.4.  This variant is not meant to be used for making new pages, and if
-/// found on disk, we will immediately convert it to the new format, with the caveat that any data
-/// the `v0` block contains will be lost.  This will effectively orphan blocks that it referenced.
-///
-/// # V1
-///
-/// A `v1` block's content layout disk layout is:
-///
-/// ```text
-/// [kind (4 bytes)] [empty (1 byte)] [ [blockno (4 bytes)] [xid (4 bytes)] ][ ... ] (up to MAX_ENTRIES_PER_PAGE)
-/// ```
-///
-/// And blocks are linked together with the `next_blockno` field in the [`BM25PageSpecialData`].
-///
-#[derive(Debug)]
-pub struct FreeSpaceManager {
-    start_blockno: pg_sys::BlockNumber,
-}
+pub trait FreeSpaceManager {
+    /// Create a new [`V1FSM`] in the block storage of the specified `indexrel`.
+    unsafe fn create(indexrel: &PgSearchRelation) -> pg_sys::BlockNumber;
 
-impl FreeSpaceManager {
-    /// Create a new [`FreeSpaceManager`] in the block storage of the specified `indexrel`.
-    pub unsafe fn create(indexrel: &PgSearchRelation) -> pg_sys::BlockNumber {
-        let mut new_buffer = init_new_buffer(indexrel);
-        let mut page = new_buffer.page_mut();
-        *page.contents_mut::<FSMBlock>() = FSMBlock::default();
-        new_buffer.number()
-    }
-
-    /// Open an existing [`FreeSpaceManager`] which is rooted at the specified starting block number.
-    pub fn open(start_blockno: pg_sys::BlockNumber) -> Self {
-        Self { start_blockno }
-    }
+    /// Open an existing [`V1FSM`] which is rooted at the specified starting block number.
+    fn open(start_blockno: pg_sys::BlockNumber) -> Self;
 
     /// Retrieve a single recyclable [`pg_sys::BlockNumber`], which can be acquired and re-initialized.
     ///
     /// Returns `None` if no recyclable blocks are available.
     ///
-    /// Upon return, the block is removed from the [`FreeSpaceManager`]'s control.  It is the caller's
+    /// Upon return, the block is removed from the [`V1FSM`]'s control.  It is the caller's
     /// responsibility to ensure the block is properly used, or else it will be lost forever as
     /// dead space in the underlying relation.
-    pub fn pop(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
-        let xid_horizon =
-            unsafe { pg_sys::GetCurrentTransactionIdIfAny().max(pg_sys::FirstNormalTransactionId) };
-        let mut blockno = self.start_blockno;
-        loop {
-            if blockno == pg_sys::InvalidBlockNumber {
-                return None;
-            }
+    fn pop(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber>;
 
-            let buffer = bman.get_buffer(blockno);
-            let page = buffer.page();
-
-            blockno = page.special::<BM25PageSpecialData>().next_blockno;
-
-            if matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v0) {
-                // skip v0 blocks
-                continue;
-            }
-
-            let contents = page.contents_ref::<FSMBlock>();
-            if contents.header.empty {
-                continue;
-            }
-
-            let mut buffer = if blockno == pg_sys::InvalidBlockNumber {
-                // if we're at the end of the FSM, we'll wait for a buffer upgrade
-                // this is likely better than ending up not finding a block to recycle and requiring
-                // the caller to extend the relation
-                buffer.upgrade(bman)
-            } else {
-                // there is a next block so we'll conditionally upgrade the buffer.  If we don't get
-                // the upgrade then we'll move to the next block in FSM
-                let Some(buffer) = buffer.upgrade_conditional(bman) else {
-                    // and here's where that happens
-                    continue;
-                };
-                buffer
-            };
-            let mut page = buffer.page_mut();
-            let contents = page.contents_mut::<FSMBlock>();
-
-            if !contents.header.empty {
-                let mut found_blockno = None;
-                let mut all_invalid = true;
-
-                for FSMEntry(blockno, fsm_xid) in &mut contents.entries {
-                    if found_blockno.is_none()
-                        && *blockno != pg_sys::InvalidBlockNumber
-                        && passses_visibility_horizon(*fsm_xid, xid_horizon)
-                    {
-                        found_blockno = Some(*blockno);
-                        *blockno = pg_sys::InvalidBlockNumber;
-                    }
-
-                    all_invalid &= *blockno == pg_sys::InvalidBlockNumber;
-                }
-
-                if all_invalid {
-                    // the page is now all invalid so mark it as empty
-                    contents.header.empty = true;
-                } else if found_blockno.is_none() {
-                    // we didn't actually change the page and
-                    buffer.set_dirty(false);
-                    continue;
-                }
-
-                if found_blockno.is_some() {
-                    // return the block we found
-                    return found_blockno;
-                }
-            } else {
-                // page was empty by the time we got the exclusive lock -- we didn't change it
-                buffer.set_dirty(false);
-            }
-        }
-    }
-
-    /// Drain `n` recyclable blocks from this [`FreeSpaceManager`] instance, using the specified
+    /// Drain `n` recyclable blocks from this [`V1FSM`] instance, using the specified
     /// [`BufferManager`] for underlying disk access.
     ///
     /// As [`pg_sys::BlockNumber`]s are yielded from the returned iterator, they are removed from the
@@ -249,198 +97,1201 @@ impl FreeSpaceManager {
     ///
     /// It is the caller's responsibility to ensure each yielded block is properly used, or else it will
     /// be lost forever as dead space in the underlying relation.  Unyielded blocks are unaffected.
-    pub fn drain(
+    fn drain(
         &mut self,
         bman: &mut BufferManager,
         n: usize,
-    ) -> impl Iterator<Item = pg_sys::BlockNumber> {
-        let xid_horizon =
-            unsafe { pg_sys::GetCurrentTransactionIdIfAny().max(pg_sys::FirstNormalTransactionId) };
-        let mut blocks = Vec::with_capacity(n);
-        let mut blockno = self.start_blockno;
-        loop {
-            if blockno == pg_sys::InvalidBlockNumber {
-                return blocks.into_iter();
-            }
+    ) -> impl Iterator<Item = pg_sys::BlockNumber> + 'static;
 
-            let buffer = bman.get_buffer(blockno);
-            let page = buffer.page();
+    /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`V1FSM`].
+    ///
+    /// The added blocks will be recyclable in the future based on the current [`pg_sys::GetCurrentTransactionId`].
+    ///
+    /// The default implementation delegates to [`Self::extend_with_when_recyclable`] using the
+    /// current transaction id if any, or [`pg_sys::FirstNormalTransactionId`] otherwise.
+    fn extend(
+        &mut self,
+        bman: &mut BufferManager,
+        extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
+    ) -> bool {
+        let current_xid = unsafe {
+            pg_sys::GetCurrentFullTransactionIdIfAny()
+                .value
+                .max(pg_sys::FirstNormalTransactionId.into_inner() as u64)
+        };
+        self.extend_with_when_recyclable(
+            bman,
+            pg_sys::FullTransactionId { value: current_xid },
+            extend_with,
+        )
+    }
 
-            blockno = page.special::<BM25PageSpecialData>().next_blockno;
+    /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`V1FSM`].
+    ///
+    /// The added blocks will be recyclable in the future based on the provided `when_recyclable` transaction id.
+    fn extend_with_when_recyclable(
+        &mut self,
+        bman: &mut BufferManager,
+        when_recyclable: pg_sys::FullTransactionId,
+        extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
+    ) -> bool;
+}
 
-            if matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v0) {
-                // skip v0 blocks
-                continue;
-            }
+pub mod v1 {
+    use crate::postgres::rel::PgSearchRelation;
+    use crate::postgres::storage::block::{bm25_max_free_space, BM25PageSpecialData};
+    use crate::postgres::storage::buffer::{init_new_buffer, Buffer, BufferManager};
+    use crate::postgres::storage::fsm::{FSMBlockHeader, FSMBlockKind, FreeSpaceManager};
+    use pgrx::pg_sys;
 
-            let contents = page.contents_ref::<FSMBlock>();
-            if contents.header.empty {
-                continue;
-            }
+    /// The header information for the current FSM block format.  Its first field is purposely the [`FSMBlockHeader`]
+    /// so that the block header can be read as that type.  `#[repr(C)]` ensures this is correct
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    struct V1Header {
+        header: FSMBlockHeader,
 
-            let Some(mut buffer) = buffer.upgrade_conditional(bman) else {
-                continue;
-            };
-            let mut page = buffer.page_mut();
-            let contents = page.contents_mut::<FSMBlock>();
+        /// Denotes if this block is completely empty, meaning all its entries reference the
+        /// [`pg_sys::InvalidBlockNumber`].
+        ///
+        /// Empty blocks can be skipped without needing to read the entire entry data.  This is just a
+        /// hint towards `true`.  If it's `false` but all the entries are invalid, that's okay --
+        /// we only wasted some CPU cycles scanning the empty block.
+        empty: bool,
+    }
 
-            if !contents.header.empty {
-                let current_block_count = blocks.len();
-                let mut all_invalid = true;
-
-                for FSMEntry(blockno, fsm_xid) in &mut contents.entries {
-                    if blocks.len() < n
-                        && *blockno != pg_sys::InvalidBlockNumber
-                        && passses_visibility_horizon(*fsm_xid, xid_horizon)
-                    {
-                        blocks.push(*blockno);
-                        *blockno = pg_sys::InvalidBlockNumber;
-                    }
-
-                    all_invalid &= *blockno == pg_sys::InvalidBlockNumber;
-                }
-
-                if all_invalid {
-                    // the page is now all invalid so mark it as empty
-                    contents.header.empty = true;
-                } else if current_block_count == blocks.len() {
-                    // we didn't actually change the page
-                    buffer.set_dirty(false);
-                    continue;
-                }
-
-                if blocks.len() == n {
-                    // we have all the requested blocks so return them
-                    return blocks.into_iter();
-                }
-            } else {
-                // page was empty by the time we got the exclusive lock -- we didn't change it
-                buffer.set_dirty(false);
+    impl Default for V1Header {
+        fn default() -> Self {
+            Self {
+                header: FSMBlockHeader {
+                    kind: FSMBlockKind::v1_uncompressed,
+                },
+                empty: false,
             }
         }
     }
 
-    /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`FreeSpaceManager`].
-    ///
-    /// The added blocks will be recyclable in the future based on the current [`pg_sys::GetCurrentTransactionId`].
-    pub fn extend(
-        &self,
-        bman: &mut BufferManager,
-        extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
-    ) {
-        let current_xid =
-            unsafe { pg_sys::GetCurrentTransactionIdIfAny().max(pg_sys::FirstNormalTransactionId) };
-        self.extend_with_when_recyclable(bman, current_xid, extend_with);
+    /// An individual entry on a [`FSMBlock`].  Represented as a pair of [`pg_sys::BlockNumber`] and
+    /// [`pg_sys::TransactionId`].  The transaction id is the [`pg_sys::GetCurrentTransactionId()`] (or perhaps caller-provided)
+    /// of the transaction that added the entry to the FSM.
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    pub struct FSMEntry(pg_sys::BlockNumber, pg_sys::TransactionId);
+
+    const MAX_ENTRIES_PER_PAGE: usize =
+        (bm25_max_free_space() - size_of::<V1Header>()) / size_of::<FSMEntry>();
+
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    struct FSMBlock {
+        header: V1Header,
+        entries: [FSMEntry; MAX_ENTRIES_PER_PAGE],
     }
 
-    /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`FreeSpaceManager`].
+    impl Default for FSMBlock {
+        fn default() -> Self {
+            Self {
+                header: V1Header::default(),
+                entries: [FSMEntry(pg_sys::InvalidBlockNumber, pg_sys::InvalidTransactionId);
+                    MAX_ENTRIES_PER_PAGE],
+            }
+        }
+    }
+
+    impl FSMBlock {
+        #[inline]
+        fn any_invalid(&self) -> bool {
+            self.entries
+                .iter()
+                .any(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
+        }
+    }
+
+    /// # V1
     ///
-    /// The added blocks will be recyclable in the future based on the provided `when_recyclable` transaction id.
-    pub fn extend_with_when_recyclable(
-        &self,
-        bman: &mut BufferManager,
-        when_recyclable: pg_sys::TransactionId,
-        extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
-    ) {
-        let mut extend_with = extend_with.peekable();
-        let mut blockno = self.start_blockno;
-        loop {
-            let buffer = bman.get_buffer(blockno);
+    /// A `v1` block's content layout disk layout is:
+    ///
+    /// ```text
+    /// [kind (4 bytes)] [empty (1 byte)] [ [blockno (4 bytes)] [xid (4 bytes)] ][ ... ] (up to MAX_ENTRIES_PER_PAGE)
+    /// ```
+    ///
+    /// And blocks are linked together with the `next_blockno` field in the [`BM25PageSpecialData`].
+    ///
+    #[derive(Debug)]
+    pub struct V1FSM {
+        start_blockno: pg_sys::BlockNumber,
+    }
 
-            let need_v0_upgrade = |buffer: &Buffer| {
-                matches!(
-                    buffer.page().contents::<FSMBlockHeader>().kind,
-                    FSMBlockKind::v0
-                )
+    impl FreeSpaceManager for V1FSM {
+        /// Create a new [`V1FSM`] in the block storage of the specified `indexrel`.
+        unsafe fn create(indexrel: &PgSearchRelation) -> pg_sys::BlockNumber {
+            let mut new_buffer = init_new_buffer(indexrel);
+            let mut page = new_buffer.page_mut();
+            *page.contents_mut::<FSMBlock>() = FSMBlock::default();
+            new_buffer.number()
+        }
+
+        /// Open an existing [`V1FSM`] which is rooted at the specified starting block number.
+        fn open(start_blockno: pg_sys::BlockNumber) -> Self {
+            Self { start_blockno }
+        }
+
+        /// Retrieve a single recyclable [`pg_sys::BlockNumber`], which can be acquired and re-initialized.
+        ///
+        /// Returns `None` if no recyclable blocks are available.
+        ///
+        /// Upon return, the block is removed from the [`V1FSM`]'s control.  It is the caller's
+        /// responsibility to ensure the block is properly used, or else it will be lost forever as
+        /// dead space in the underlying relation.
+        fn pop(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
+            let xid_horizon = unsafe {
+                pg_sys::GetCurrentTransactionIdIfAny().max(pg_sys::FirstNormalTransactionId)
             };
-            let space_available = |buffer: &Buffer| {
-                need_v0_upgrade(buffer) || {
-                    let page = buffer.page();
-                    let block = page.contents_ref::<FSMBlock>();
-                    block.header.empty || block.any_invalid()
-                }
-            };
-
-            let mut buffer = if space_available(&buffer) {
-                let mut buffer = buffer.upgrade(bman);
-
-                if need_v0_upgrade(&buffer) {
-                    *buffer.page_mut().contents_mut::<FSMBlock>() = FSMBlock::default();
+            let mut blockno = self.start_blockno;
+            loop {
+                if blockno == pg_sys::InvalidBlockNumber {
+                    return None;
                 }
 
+                let buffer = bman.get_buffer(blockno);
+                let page = buffer.page();
+
+                blockno = page.special::<BM25PageSpecialData>().next_blockno;
+
+                if matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v0) {
+                    // skip v0 blocks
+                    continue;
+                }
+
+                let contents = page.contents_ref::<FSMBlock>();
+                if contents.header.empty {
+                    continue;
+                }
+
+                let mut buffer = if blockno == pg_sys::InvalidBlockNumber {
+                    // if we're at the end of the FSM, we'll wait for a buffer upgrade
+                    // this is likely better than ending up not finding a block to recycle and requiring
+                    // the caller to extend the relation
+                    buffer.upgrade(bman)
+                } else {
+                    // there is a next block so we'll conditionally upgrade the buffer.  If we don't get
+                    // the upgrade then we'll move to the next block in FSM
+                    let Some(buffer) = buffer.upgrade_conditional(bman) else {
+                        // and here's where that happens
+                        continue;
+                    };
+                    buffer
+                };
                 let mut page = buffer.page_mut();
                 let contents = page.contents_mut::<FSMBlock>();
-                let mut cnt = 0;
-                contents
-                    .entries
-                    .iter_mut()
-                    .filter(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
-                    .zip(&mut extend_with)
-                    .for_each(|(entry, blockno)| {
-                        *entry = FSMEntry(blockno, when_recyclable);
-                        cnt += 1;
-                    });
 
-                if cnt == 0 {
-                    // we didn't make any modifications so the page is not dirty -- no need to WAL log it
-                    buffer.set_dirty(false);
+                if !contents.header.empty {
+                    let mut found_blockno = None;
+                    let mut all_invalid = true;
+
+                    for FSMEntry(blockno, fsm_xid) in &mut contents.entries {
+                        if found_blockno.is_none()
+                            && *blockno != pg_sys::InvalidBlockNumber
+                            && passses_visibility_horizon(*fsm_xid, xid_horizon)
+                        {
+                            found_blockno = Some(*blockno);
+                            *blockno = pg_sys::InvalidBlockNumber;
+                        }
+
+                        all_invalid &= *blockno == pg_sys::InvalidBlockNumber;
+                    }
+
+                    if all_invalid {
+                        // the page is now all invalid so mark it as empty
+                        contents.header.empty = true;
+                    } else if found_blockno.is_none() {
+                        // we didn't actually change the page and
+                        buffer.set_dirty(false);
+                        continue;
+                    }
+
+                    if found_blockno.is_some() {
+                        // return the block we found
+                        return found_blockno;
+                    }
                 } else {
-                    // we added at least one block to this page so it's no longer empty
-                    contents.header.empty = false;
+                    // page was empty by the time we got the exclusive lock -- we didn't change it
+                    buffer.set_dirty(false);
+                }
+            }
+        }
+
+        /// Drain `n` recyclable blocks from this [`V1FSM`] instance, using the specified
+        /// [`BufferManager`] for underlying disk access.
+        ///
+        /// As [`pg_sys::BlockNumber`]s are yielded from the returned iterator, they are removed from the
+        /// FSM.  The returned iterator will never return more than `n`, but it could return fewer.
+        ///
+        /// It is the caller's responsibility to ensure each yielded block is properly used, or else it will
+        /// be lost forever as dead space in the underlying relation.  Unyielded blocks are unaffected.
+        fn drain(
+            &mut self,
+            bman: &mut BufferManager,
+            n: usize,
+        ) -> impl Iterator<Item = pg_sys::BlockNumber> + 'static {
+            let xid_horizon = unsafe {
+                pg_sys::GetCurrentTransactionIdIfAny().max(pg_sys::FirstNormalTransactionId)
+            };
+            let mut blocks = Vec::with_capacity(n);
+            let mut blockno = self.start_blockno;
+            loop {
+                if blockno == pg_sys::InvalidBlockNumber {
+                    return blocks.into_iter();
+                }
+
+                let buffer = bman.get_buffer(blockno);
+                let page = buffer.page();
+
+                blockno = page.special::<BM25PageSpecialData>().next_blockno;
+
+                if matches!(page.contents::<FSMBlockHeader>().kind, FSMBlockKind::v0) {
+                    // skip v0 blocks
+                    continue;
+                }
+
+                let contents = page.contents_ref::<FSMBlock>();
+                if contents.header.empty {
+                    continue;
+                }
+
+                let Some(mut buffer) = buffer.upgrade_conditional(bman) else {
+                    continue;
+                };
+                let mut page = buffer.page_mut();
+                let contents = page.contents_mut::<FSMBlock>();
+
+                if !contents.header.empty {
+                    let current_block_count = blocks.len();
+                    let mut all_invalid = true;
+
+                    for FSMEntry(blockno, fsm_xid) in &mut contents.entries {
+                        if blocks.len() < n
+                            && *blockno != pg_sys::InvalidBlockNumber
+                            && passses_visibility_horizon(*fsm_xid, xid_horizon)
+                        {
+                            blocks.push(*blockno);
+                            *blockno = pg_sys::InvalidBlockNumber;
+                        }
+
+                        all_invalid &= *blockno == pg_sys::InvalidBlockNumber;
+                    }
+
+                    if all_invalid {
+                        // the page is now all invalid so mark it as empty
+                        contents.header.empty = true;
+                    } else if current_block_count == blocks.len() {
+                        // we didn't actually change the page
+                        buffer.set_dirty(false);
+                        continue;
+                    }
+
+                    if blocks.len() == n {
+                        // we have all the requested blocks so return them
+                        return blocks.into_iter();
+                    }
+                } else {
+                    // page was empty by the time we got the exclusive lock -- we didn't change it
+                    buffer.set_dirty(false);
+                }
+            }
+        }
+
+        /// Add the specified `extend_with` iterator of [`pg_sys::BlockNumber`]s to this [`V1FSM`].
+        ///
+        /// The added blocks will be recyclable in the future based on the provided `when_recyclable` transaction id.
+        fn extend_with_when_recyclable(
+            &mut self,
+            bman: &mut BufferManager,
+            when_recyclable: pg_sys::FullTransactionId,
+            extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
+        ) -> bool {
+            let mut extend_with = extend_with.peekable();
+            let has_values = extend_with.peek().is_some();
+            let mut blockno = self.start_blockno;
+            loop {
+                let buffer = bman.get_buffer(blockno);
+
+                let need_v0_upgrade = |buffer: &Buffer| {
+                    matches!(
+                        buffer.page().contents::<FSMBlockHeader>().kind,
+                        FSMBlockKind::v0
+                    )
+                };
+                let space_available = |buffer: &Buffer| {
+                    need_v0_upgrade(buffer) || {
+                        let page = buffer.page();
+                        let block = page.contents_ref::<FSMBlock>();
+                        block.header.empty || block.any_invalid()
+                    }
+                };
+
+                let mut buffer = if space_available(&buffer) {
+                    let mut buffer = buffer.upgrade(bman);
+
+                    if need_v0_upgrade(&buffer) {
+                        *buffer.page_mut().contents_mut::<FSMBlock>() = FSMBlock::default();
+                    }
+
+                    let mut page = buffer.page_mut();
+                    let contents = page.contents_mut::<FSMBlock>();
+                    let mut cnt = 0;
+                    contents
+                        .entries
+                        .iter_mut()
+                        .filter(|FSMEntry(blockno, _)| *blockno == pg_sys::InvalidBlockNumber)
+                        .zip(&mut extend_with)
+                        .for_each(|(entry, blockno)| {
+                            *entry = FSMEntry(
+                                blockno,
+                                pg_sys::TransactionId::from(when_recyclable.value as u32),
+                            );
+                            cnt += 1;
+                        });
+
+                    if cnt == 0 {
+                        // we didn't make any modifications so the page is not dirty -- no need to WAL log it
+                        buffer.set_dirty(false);
+                    } else {
+                        // we added at least one block to this page so it's no longer empty
+                        contents.header.empty = false;
+                    }
+
+                    if extend_with.peek().is_none() {
+                        // no more blocks to add to the FSM
+                        return has_values;
+                    }
+
+                    blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
+                    if blockno != pg_sys::InvalidBlockNumber {
+                        // move to next block
+                        continue;
+                    }
+                    buffer
+                } else {
+                    blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
+                    if blockno != pg_sys::InvalidBlockNumber {
+                        // move to next block
+                        continue;
+                    }
+                    buffer.upgrade(bman)
+                };
+
+                // we still have blocks to apply but have no more space on this page
+                // so allocate a new page
+                let mut new_buffer = init_new_buffer(bman.buffer_access().rel());
+                let mut new_page = new_buffer.page_mut();
+
+                // initialize the new page with a default FSMBlock
+                *new_page.contents_mut::<FSMBlock>() = FSMBlock::default();
+
+                // move to this new page
+                let new_blockno = new_buffer.number();
+                buffer
+                    .page_mut()
+                    .special_mut::<BM25PageSpecialData>()
+                    .next_blockno = new_blockno;
+
+                // loop back around to try extending this new page
+                blockno = new_blockno;
+            }
+        }
+    }
+
+    impl V1FSM {
+        pub(super) fn used_blocks(&self, bman: &mut BufferManager) -> Vec<pg_sys::BlockNumber> {
+            let mut blocks = Vec::new();
+
+            let mut blockno = self.start_blockno;
+            while blockno != pg_sys::InvalidBlockNumber {
+                blocks.push(blockno);
+
+                let buffer = bman.get_buffer(blockno);
+                blockno = buffer.page().next_blockno();
+            }
+            blocks
+        }
+    }
+
+    /// The `xid_horizon` argument represents the oldest transaction id, across the Postgres cluster,
+    /// that can see blocks in the FSM.
+    ///
+    /// When being drained, the FSM compares each block's stored `fsm_xid`` with this value, ensuring the stored
+    /// value precedes or equals this `xid_horizon`, before it is considered recyclable.
+    #[inline(always)]
+    fn passses_visibility_horizon(
+        fsm_xid: pg_sys::TransactionId,
+        xid_horizon: pg_sys::TransactionId,
+    ) -> bool {
+        crate::postgres::utils::TransactionIdPrecedesOrEquals(fsm_xid, xid_horizon)
+    }
+}
+
+/// The [`v2`] FreeSpaceManager is a fixed-size AVL tree laid out as an array on the FSM's first block.
+///
+/// Each entry in the AVL tree is called a [`Slot`] and each slot has a key, value, and tag.  The key
+/// is a 64bit [`pg_sys::FullTransactionId`], the value is actually the Rust unit type ([`()`]), and
+/// the tag is a [`pg_sys::BlockNumber`].
+///
+/// Each slot gets its own statically assigned tag value when a relation's FSM is first initialized.
+/// This value is the block number that represents the start of the list of block numbers that are
+/// free for the xid key stored in that slot.  This value stays with the slot, even as the tree is
+/// mutated as generally speaking, with an array-backed AVL tree entries don't move slots, only their
+/// left/right pointers are updated during rebalancing.  Special consideration is made for deleting
+/// an entry, however, when the key/value is moved to a new slot -- in this case the tag values are
+/// swapped until the entry is finished moving.  Essentially, tags have an affinity for their key/value
+/// as long as the slot is occupied.
+///
+/// The FSM has two user-facing operations: extend and drain.
+///
+/// # Extend
+///
+/// The caller provides both a transaction id and an iterator of free blocks to associate with that
+/// transaction.  That transaction indicates the point in time in which those blocks are usable.  Any
+/// future transaction `>=` to that transaction will be able to use those blocks.
+///
+/// During an extension a share lock is acquired on the FSM's root page (the AVL tree) and the
+/// specified transaction id is searched.  If it's found, then an exclusive lock is taken on the block
+/// represented by that xid's `tag` -- the blocklist -- and the blocklist is extended from head-to-tail,
+/// filling in gaps along the way.  However, if a full page is encountered, then a shortcut is taken
+/// and a new blocklist is linked into the existing list at that point.
+///
+/// Concurrent extensions are allowed on the same xid, blocking one block in the block list at a time.
+/// However, in practice almost every call to [`FreeSpaceManager::extend_with_when_recyclable`] uses
+/// the current transaction id, and since each transaction has its own unique id, there'll be no blocking.
+///
+/// Sometimes a caller will use the result of [`pg_sys::ReadNextFullTransactionId()`] instead of the
+/// current transaction id.  This can cause concurrent extensions of the same transaction id.  This
+/// is fine and generally a rare situation.
+///
+/// If the provided transaction id is not found, then the shared lock on the FSM root is upgraded to
+/// an exclusive lock and the transaction id is inserted.  It is possible that by this time the
+/// transaction id now exists.  In either case, the `tag` value for the new (or now-existing) transaction
+/// id's slot is used as the blocklist, and it is extended.
+///
+/// The upgraded exclusive lock on the tree is *not* held during extension.  It only lives long enough
+/// to ensure proper insertion of the possibly new transaction id.
+///
+/// If, when extending a blocklist, another page is needed, it is acquired by extending the relation by
+/// a page, not by asking the FSM itself for a page.
+///
+/// ## What happens if the tree is full?
+///
+/// The AVL tree is backed by a fixed-size array of (at the time of writing) 338 slots.  If all the
+/// slots are occupied, we cannot insert a new key/value.  Instead, under an exclusive lock, we find
+/// the largest existing key (transaction id) an use that slot.
+///
+/// If that key is `>=` to the new transaction id we're trying to insert, then we simply use that
+/// slot's information.
+///
+/// If the transaction id we're trying to insert is larger, we **directly modify the existing key**
+/// to be the new transaction id.  The tree will maintain its balance as the new key is still greater
+/// than its predecessors.
+///
+/// Then extension happens as normal.
+///
+/// This has a side effect of moving either existing blocks or the set of new blocks to the future.
+/// For existing blocks this means they potentially won't be reused as soon as they could.
+///
+/// In practice, it'll be quite challenging to fill the tree -- perhaps even impossible.  It would
+/// require hundreds of concurrent merges to happen without any new segments being created.  This is
+/// not a scenario that can actually happen.  Merging is what returns blocks to the FSM and merging
+/// only happens against segments.
+///
+/// # Drain
+///
+/// Draining is the process of asking the FSM for free blocks.  The caller asks for `n` blocks and
+/// the FSM returns an iterator of blocks that can be reused by the current transaction.  "Current
+/// transaction" here literally means the result of `pg_sys::GetCurrentFullTransactionId()`, but
+/// _could_ be a different, father-in-the-past, transaction.
+///
+/// The drain process takes a shared lock on the root page and finds the entry that is less-than-or-equal-to
+/// the current transaction id.  A transaction can only reuse blocks related to the same or older
+/// transactions.
+///
+/// If no such key exists, [`FreeSpaceManager::drain`] returns an empty iterator.
+///
+/// Otherwise, the blocklist associated with that entry's slot is consumed, up to `n` blocks.  The
+/// locking through the blocklist here is conditional.  If an exclusive lock can't be acquired, the
+/// algorithm restarts, now looking for the next smallest transaction id.  This continues until `n`
+/// blocks have been found or the tree no longer has any keys that satisfy the condition.
+///
+/// This process of restarting with the next smallest transaction id also happens if the xid being
+/// evaluated doesn't contain enough blocks to satisfy `n`.
+///
+/// When draining, if an individual block in the blocklist (that isn't the first block) becomes empty,
+/// it is unlinked from the blocklist and returned to the FSM to be used in a future transaction.
+/// This helps to keep the FSM as small as possible throughout its life.
+///
+/// If, while draining, an entire blocklist is consumed for a transaction id, then that transaction
+/// id is removed from the tree.  This requires an exclusive lock on the tree itself and must happen
+/// outside holding any other locks.  It would be possible for two concurrent transactions to try
+/// and delete the same xid entry.  This is fine -- one will win and the other will happily think it won.
+pub mod v2 {
+    use crate::postgres::rel::PgSearchRelation;
+    use crate::postgres::storage::avl::{
+        AvlTreeMap, AvlTreeMapHeader, AvlTreeMapView, Error, Slot,
+    };
+    use crate::postgres::storage::block::{bm25_max_free_space, BM25PageSpecialData};
+    use crate::postgres::storage::buffer::{
+        init_new_buffer, BufferManager, BufferMut, Page, PageMut,
+    };
+    use crate::postgres::storage::fsm::{FSMBlockHeader, FSMBlockKind, FreeSpaceManager};
+    use pgrx::pg_sys;
+    use std::iter::Peekable;
+
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    struct V2Header {
+        header: FSMBlockHeader,
+    }
+
+    impl Default for V2Header {
+        fn default() -> Self {
+            Self {
+                header: FSMBlockHeader {
+                    kind: FSMBlockKind::v2_avl_tree,
+                },
+            }
+        }
+    }
+
+    /// We'd prefer to use [`pg_sys::FullTransactionId`] but it's not very ergonomic
+    type Key = u64;
+    type Value = ();
+    type Tag = pg_sys::BlockNumber;
+    type AvlSlot = Slot<Key, Value, Tag>;
+    type Avl<'a> = AvlTreeMapView<'a, Key, Value, Tag>;
+    type AvlMut<'a> = AvlTreeMap<'a, Key, Value, Tag>;
+
+    const MAX_SLOTS: usize = (bm25_max_free_space()
+        - (size_of::<V2Header>() + size_of::<AvlTreeMapHeader>()))
+        / size_of::<AvlSlot>();
+
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    struct FSMRootBlock {
+        header: V2Header,
+        avl_header: AvlTreeMapHeader,
+        avl_arena: [AvlSlot; MAX_SLOTS],
+    }
+
+    impl Default for FSMRootBlock {
+        fn default() -> Self {
+            Self {
+                header: V2Header::default(),
+                avl_header: Default::default(),
+                avl_arena: [AvlSlot::default(); MAX_SLOTS],
+            }
+        }
+    }
+
+    const MAX_ENTRIES: usize =
+        (bm25_max_free_space() - size_of::<u32>()) / size_of::<pg_sys::BlockNumber>();
+
+    #[derive(Debug, Copy, Clone)]
+    #[repr(C)]
+    pub(super) struct AvlLeaf {
+        pub(super) len: u32,
+        pub(super) entries: [pg_sys::BlockNumber; MAX_ENTRIES],
+    }
+
+    impl Default for AvlLeaf {
+        fn default() -> Self {
+            Self {
+                len: 0,
+                entries: [pg_sys::InvalidBlockNumber; MAX_ENTRIES],
+            }
+        }
+    }
+
+    impl AvlLeaf {
+        fn init_new_page(bman: &mut BufferManager) -> BufferMut {
+            let mut buffer = init_new_buffer(bman.buffer_access().rel());
+            let mut page = buffer.page_mut();
+            let contents = page.contents_mut::<AvlLeaf>();
+            *contents = AvlLeaf::default();
+            buffer
+        }
+    }
+
+    pub struct V2FSM {
+        start_blockno: pg_sys::BlockNumber,
+    }
+
+    impl FreeSpaceManager for V2FSM {
+        unsafe fn create(indexrel: &PgSearchRelation) -> pg_sys::BlockNumber {
+            let mut root = init_new_buffer(indexrel);
+            let mut page = root.page_mut();
+            let contents = page.contents_mut::<FSMRootBlock>();
+
+            // initialize the root page as an empty AVL tree
+            *contents = FSMRootBlock::default();
+
+            // each slot is initially allocated a new buffer and assigned to the slot's `tag, which
+            // will eventually be used to store the blocklist for whatever key ends up in that slot.
+            // the tag value remains unchanged throughout the lifetime of the tree, except in the
+            // case of removing an entry, and the tree needs to be rebalanced.  in this case the tag
+            // moves with the key/value entry through the tree and tags are swapped along the way
+            for slot in &mut contents.avl_arena {
+                slot.tag = init_new_buffer(indexrel).number();
+            }
+
+            // initialize an empty avl tree on the page
+            AvlMut::new(&mut contents.avl_header, &mut contents.avl_arena);
+
+            root.number()
+        }
+
+        fn open(start_blockno: pg_sys::BlockNumber) -> Self {
+            Self { start_blockno }
+        }
+
+        fn pop(&mut self, bman: &mut BufferManager) -> Option<pg_sys::BlockNumber> {
+            self.drain(bman, 1).next()
+        }
+
+        fn drain(
+            &mut self,
+            bman: &mut BufferManager,
+            many: usize,
+        ) -> impl Iterator<Item = pg_sys::BlockNumber> + 'static {
+            let current_xid = unsafe {
+                pg_sys::GetCurrentFullTransactionIdIfAny()
+                    .value
+                    .max(pg_sys::FirstNormalTransactionId.into_inner() as u64)
+            };
+
+            let mut xid = current_xid;
+            let mut blocks = Vec::with_capacity(many);
+
+            'outer: while blocks.len() < many {
+                let mut root = Some(bman.get_buffer(self.start_blockno));
+                let page = root.as_ref().unwrap().page();
+                let tree = self.avl_ref(&page);
+
+                let Some((found_xid, _unit, tag)) = tree.get_lte(&xid) else {
+                    break;
+                };
+
+                let mut head_blockno = tag as pg_sys::BlockNumber;
+                let mut blockno = head_blockno;
+                let mut cnt = 0;
+
+                while blocks.len() < many && blockno != pg_sys::InvalidBlockNumber {
+                    // we drop the "root" buffer after getting the head buffer.
+                    // this ensures that the `head_blockno` (the root entry's "tag" value)
+                    // is what it says it is
+                    //
+                    // the conditional lock here also ensures we're the only backend to start
+                    // draining the tree from this the head
+                    let mut buffer = match bman.get_buffer_conditional(blockno) {
+                        Some(buffer) => {
+                            root.take();
+                            buffer
+                        }
+                        None => {
+                            root.take();
+                            // move to the next candidate XID below this one.
+                            xid = found_xid - 1;
+                            if xid < pg_sys::FirstNormalTransactionId.into_inner() as u64 {
+                                break 'outer;
+                            }
+                            continue 'outer;
+                        }
+                    };
+
+                    let mut page = buffer.page_mut();
+                    let contents = page.contents_mut::<AvlLeaf>();
+                    let mut modified = false;
+
+                    let next_blockno = page.next_blockno();
+                    let should_unlink_head = if contents.len == 0 && head_blockno == blockno {
+                        // this is the first page in the list and it's empty
+                        //
+                        // we unlink initial empty pages when they *become* empty, not when the *are* empty
+                        //
+                        // this means a concurrent backend is in the process of recycling this page
+                        false
+                    } else {
+                        // get all that we can/need from this page
+                        while contents.len > 0 && blocks.len() < many {
+                            contents.len -= 1;
+                            blocks.push(contents.entries[contents.len as usize]);
+                            modified = true;
+                        }
+                        cnt += contents.len as usize;
+
+                        // should we unlink this block from the chain? -- only if it's the head and now empty
+                        blockno == head_blockno
+                            && contents.len == 0
+                            && next_blockno != pg_sys::InvalidBlockNumber
+                    };
+
+                    if !modified {
+                        // we didn't change anything
+                        buffer.set_dirty(false);
+                    }
+
+                    // drop the leaf buffer -- we're done with it and it's possible we'll need to
+                    // unlink it from the list and that requires an exclusive lock on the tree
+                    // and we can't have both at the same time
+                    drop(buffer);
+
+                    if should_unlink_head {
+                        let old_head = head_blockno;
+
+                        // get mutable tree without holding any other locks
+                        let mut root = bman.get_buffer_mut(self.start_blockno);
+                        let mut page = root.page_mut();
+                        let mut tree = self.avl_mut(&mut page);
+
+                        if let Some(slot) = tree.get_slot_mut(&found_xid) {
+                            if slot.tag == old_head {
+                                // change the head to the next block
+                                slot.tag = next_blockno;
+
+                                // and keep local state in sync
+                                head_blockno = next_blockno;
+                            }
+                            // else: someone already changed tag — that’s fine.
+                        }
+                        drop(root);
+
+                        // recycle the old head -- we’re not holding any other buffers here.
+                        self.extend_with_when_recyclable(
+                            bman,
+                            unsafe { pg_sys::ReadNextFullTransactionId() },
+                            std::iter::once(old_head),
+                        );
+
+                        // Continue with the new head
+                        blockno = next_blockno;
+                        continue;
+                    }
+
+                    // if this was the last block in the list *and* the entire list is empty,
+                    // remove the XID entry from the tree. We must hold no other locks while doing this
+                    if next_blockno == pg_sys::InvalidBlockNumber && cnt == 0 {
+                        let mut root = bman.get_buffer_mut(self.start_blockno);
+                        let mut page = root.page_mut();
+                        let mut tree = self.avl_mut(&mut page);
+
+                        // ok if another backend already removed it.
+                        let _ = tree.remove(&found_xid);
+                        drop(root);
+
+                        // move to the next candidate XID below this one.
+                        xid = found_xid - 1;
+                        if xid < pg_sys::FirstNormalTransactionId.into_inner() as u64 {
+                            break;
+                        }
+                        continue 'outer;
+                    }
+
+                    // advance to the next block in the chain.
+                    blockno = next_blockno;
+                }
+
+                if blocks.len() == many {
+                    break;
+                }
+
+                // exhausted this list
+                // move to the next candidate XID below this one.
+                xid = found_xid - 1;
+                if xid < pg_sys::FirstNormalTransactionId.into_inner() as u64 {
+                    break;
+                }
+            }
+
+            blocks.into_iter()
+        }
+
+        fn extend_with_when_recyclable(
+            &mut self,
+            bman: &mut BufferManager,
+            when_recyclable: pg_sys::FullTransactionId,
+            extend_with: impl Iterator<Item = pg_sys::BlockNumber>,
+        ) -> bool {
+            let tag = {
+                let root = bman.get_buffer(self.start_blockno);
+                let page = root.page();
+                let tree = self.avl_ref(&page);
+
+                match tree.get(&when_recyclable.value) {
+                    None => {
+                        let mut root = root.upgrade(bman);
+                        let mut page = root.page_mut();
+                        let mut tree = self.avl_mut(&mut page);
+
+                        match tree.insert(when_recyclable.value, ()) {
+                            Ok((_, tag)) => tag,
+                            Err(Error::Full) => self.handle_full_tree(root, when_recyclable),
+                        }
+                    }
+                    Some((_, tag)) => tag,
+                }
+            };
+
+            let mut extend_with = extend_with.peekable();
+            let has_values = extend_with.peek().is_some();
+            let start_block = bman.get_buffer_mut(tag as pg_sys::BlockNumber);
+            Self::extend_blocklist(bman, start_block, extend_with);
+            has_values
+        }
+    }
+
+    impl V2FSM {
+        fn handle_full_tree(
+            &mut self,
+            mut root: BufferMut,
+            when_recyclable: pg_sys::FullTransactionId,
+        ) -> Tag {
+            let mut page = root.page_mut();
+            let mut tree = self.avl_mut(&mut page);
+
+            // we find the slot containing the largest (maximum) xid and change it to the provided `when_recyclable`
+            // asserting that it is the same or greater than the maximum xid we found in the tree
+            let max_slot = tree
+                .get_max_slot()
+                .expect("a full tree must have a maximum entry");
+
+            if when_recyclable.value > max_slot.key {
+                // this is safe as the tree still maintains its balance.  we also have an exclusive lock
+                // on the tree at this stage which means no concurrent backends can be changing the tree
+                max_slot.key = when_recyclable.value;
+            }
+
+            max_slot.tag
+        }
+
+        fn extend_blocklist(
+            bman: &mut BufferManager,
+            start_block: BufferMut,
+            mut extend_with: Peekable<impl Iterator<Item = pg_sys::BlockNumber>>,
+        ) -> BufferMut {
+            let mut buffer = start_block;
+            loop {
+                let mut page = buffer.page_mut();
+                let contents = page.contents_mut::<AvlLeaf>();
+                let next_blockno = page.next_blockno();
+
+                if contents.len as usize == contents.entries.len()
+                    && next_blockno != pg_sys::InvalidBlockNumber
+                {
+                    // this block is full.  Chances are the next block is also full.
+                    // so we're going to populate a brand-new list with the rest of the iterator
+                    // and then link it in between this block and the next block.  This avoids
+                    // the possible overhead of scanning the rest of the blocklist just to discover
+                    // all the following blocks are full
+                    let new_block = AvlLeaf::init_new_page(bman);
+                    let new_blockno = new_block.number();
+
+                    let mut last_block = Self::extend_blocklist(bman, new_block, extend_with);
+
+                    // link the last block we just created to the next block
+                    let mut end_page = last_block.page_mut();
+                    end_page.special_mut::<BM25PageSpecialData>().next_blockno = next_blockno;
+
+                    // finally link this block to the new block
+                    page.special_mut::<BM25PageSpecialData>().next_blockno = new_blockno;
+
+                    return last_block;
+                }
+
+                while (contents.len as usize) < contents.entries.len() {
+                    match extend_with.peek() {
+                        None => break,
+                        Some(_) => {
+                            contents.entries[contents.len as usize] = extend_with.next().unwrap();
+                            contents.len += 1;
+                        }
+                    }
                 }
 
                 if extend_with.peek().is_none() {
-                    // no more blocks to add to the FSM
-                    return;
+                    break;
                 }
 
-                blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
-                if blockno != pg_sys::InvalidBlockNumber {
-                    // move to next block
-                    continue;
+                let mut next_blockno = page.next_blockno();
+                if next_blockno == pg_sys::InvalidBlockNumber {
+                    // link in a new block
+                    let new_buffer = AvlLeaf::init_new_page(bman);
+                    next_blockno = new_buffer.number();
+
+                    page.special_mut::<BM25PageSpecialData>().next_blockno = next_blockno;
+                    buffer = new_buffer;
+                } else {
+                    // move to next block already in the list
+                    buffer = bman.get_buffer_mut(next_blockno);
                 }
-                buffer
-            } else {
-                blockno = buffer.page().special::<BM25PageSpecialData>().next_blockno;
-                if blockno != pg_sys::InvalidBlockNumber {
-                    // move to next block
-                    continue;
-                }
-                buffer.upgrade(bman)
+            }
+
+            buffer
+        }
+
+        pub(super) fn avl_ref<'p>(&self, page: &'p Page<'p>) -> Avl<'p> {
+            let root_block = page.contents_ref::<FSMRootBlock>();
+            assert!(
+                matches!(root_block.header.header.kind, FSMBlockKind::v2_avl_tree),
+                "conversion of old FSM to v2 never happened"
+            );
+            unsafe {
+                AvlTreeMapView::with_header_and_arena(&root_block.avl_header, &root_block.avl_arena)
+            }
+        }
+
+        fn avl_mut<'p>(&mut self, page: &'p mut PageMut<'p>) -> AvlMut<'p> {
+            let root_block = page.contents_mut::<FSMRootBlock>();
+            assert!(
+                matches!(root_block.header.header.kind, FSMBlockKind::v2_avl_tree),
+                "conversion of old FSM to v2 never happened"
+            );
+            unsafe {
+                AvlTreeMap::with_header_and_arena(
+                    &mut root_block.avl_header,
+                    &mut root_block.avl_arena,
+                )
+            }
+        }
+    }
+
+    #[cfg(any(test, feature = "pg_test"))]
+    #[pgrx::pg_schema]
+    mod tests {
+        use pgrx::prelude::*;
+        use std::collections::HashSet;
+
+        use super::{MAX_SLOTS, V2FSM};
+        use crate::postgres::rel::PgSearchRelation;
+        use crate::postgres::storage::buffer::BufferManager;
+        use crate::postgres::storage::fsm::FreeSpaceManager;
+        use crate::postgres::storage::metadata::MetaPage;
+
+        #[pg_test]
+        unsafe fn test_fsmv2_basics() -> spi::Result<()> {
+            Spi::run("CREATE TABLE IF NOT EXISTS fsm_test (id serial8, data text)")?;
+            Spi::run("CREATE INDEX IF NOT EXISTS fsm_idx ON fsm_test USING bm25 (id, data) WITH (key_field = 'id')")?;
+
+            let index_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'fsm_idx'::regclass::oid")?
+                .unwrap_or(pg_sys::InvalidOid);
+
+            assert_ne!(index_oid, pg_sys::InvalidOid);
+
+            let indexrel = PgSearchRelation::with_lock(
+                index_oid,
+                pg_sys::RowExclusiveLock as pg_sys::LOCKMODE,
+            );
+
+            let mut bman = BufferManager::new(&indexrel);
+            let metapage = MetaPage::open(&indexrel);
+            let mut fsm = V2FSM::open(metapage.fsm());
+
+            fsm.extend_with_when_recyclable(
+                &mut bman,
+                pg_sys::FullTransactionId { value: 100 },
+                0..3,
+            );
+            let drained = fsm.drain(&mut bman, 3).collect::<Vec<_>>();
+            assert_eq!(drained, [2, 1, 0]);
+            assert!(
+                fsm.drain(&mut bman, 1).next().is_none(),
+                "fsm should be empty"
+            );
+
+            fsm.extend_with_when_recyclable(
+                &mut bman,
+                pg_sys::FullTransactionId { value: 100 },
+                0..3,
+            );
+            fsm.extend_with_when_recyclable(
+                &mut bman,
+                pg_sys::FullTransactionId { value: 101 },
+                3..6,
+            );
+
+            let drained = fsm.drain(&mut bman, 6).collect::<Vec<_>>();
+            assert_eq!(drained, [5, 4, 3, 2, 1, 0]);
+            assert!(
+                fsm.drain(&mut bman, 1).next().is_none(),
+                "fsm should be empty"
+            );
+
+            Ok(())
+        }
+
+        #[pg_test]
+        unsafe fn test_fsmv2_large_extend_drain() -> spi::Result<()> {
+            Spi::run("CREATE TABLE IF NOT EXISTS fsm_test (id serial8, data text)")?;
+            Spi::run("CREATE INDEX IF NOT EXISTS fsm_idx ON fsm_test USING bm25 (id, data) WITH (key_field = 'id')")?;
+
+            let index_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'fsm_idx'::regclass::oid")?
+                .unwrap_or(pg_sys::InvalidOid);
+
+            assert_ne!(index_oid, pg_sys::InvalidOid);
+
+            let indexrel = PgSearchRelation::with_lock(
+                index_oid,
+                pg_sys::RowExclusiveLock as pg_sys::LOCKMODE,
+            );
+
+            let mut bman = BufferManager::new(&indexrel);
+            let metapage = MetaPage::open(&indexrel);
+            let mut fsm = V2FSM::open(metapage.fsm());
+
+            fsm.extend_with_when_recyclable(
+                &mut bman,
+                pg_sys::FullTransactionId { value: 100 },
+                0..100_000,
+            );
+            let drained = fsm.drain(&mut bman, 100_000).collect::<HashSet<_>>();
+            assert_eq!(drained, (0..100_000).rev().collect::<HashSet<_>>());
+            assert!(
+                fsm.drain(&mut bman, 1).next().is_none(),
+                "fsm should be empty"
+            );
+
+            Ok(())
+        }
+
+        #[pg_test]
+        unsafe fn test_fsmv2_no_future_drain() -> spi::Result<()> {
+            Spi::run("CREATE TABLE IF NOT EXISTS fsm_test (id serial8, data text)")?;
+            Spi::run("CREATE INDEX IF NOT EXISTS fsm_idx ON fsm_test USING bm25 (id, data) WITH (key_field = 'id')")?;
+
+            let index_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'fsm_idx'::regclass::oid")?
+                .unwrap_or(pg_sys::InvalidOid);
+
+            assert_ne!(index_oid, pg_sys::InvalidOid);
+
+            let indexrel = PgSearchRelation::with_lock(
+                index_oid,
+                pg_sys::RowExclusiveLock as pg_sys::LOCKMODE,
+            );
+
+            let mut bman = BufferManager::new(&indexrel);
+            let metapage = MetaPage::open(&indexrel);
+            let mut fsm = V2FSM::open(metapage.fsm());
+
+            let current_xid = pg_sys::GetCurrentFullTransactionId();
+            let future_xid = pg_sys::FullTransactionId {
+                value: current_xid.value + 1,
+            };
+            fsm.extend_with_when_recyclable(&mut bman, future_xid, 0..3);
+            assert!(
+                fsm.drain(&mut bman, 1).next().is_none(),
+                "fsm should not find future transactions"
+            );
+
+            Ok(())
+        }
+
+        #[pg_test]
+        unsafe fn test_fsmv2_many_xids() -> spi::Result<()> {
+            Spi::run("CREATE TABLE IF NOT EXISTS fsm_test (id serial8, data text)")?;
+            Spi::run("CREATE INDEX IF NOT EXISTS fsm_idx ON fsm_test USING bm25 (id, data) WITH (key_field = 'id')")?;
+
+            let index_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'fsm_idx'::regclass::oid")?
+                .unwrap_or(pg_sys::InvalidOid);
+
+            assert_ne!(index_oid, pg_sys::InvalidOid);
+
+            let indexrel = PgSearchRelation::with_lock(
+                index_oid,
+                pg_sys::RowExclusiveLock as pg_sys::LOCKMODE,
+            );
+
+            let mut bman = BufferManager::new(&indexrel);
+            let metapage = MetaPage::open(&indexrel);
+            let mut fsm = V2FSM::open(metapage.fsm());
+
+            let current_xid = pg_sys::GetCurrentFullTransactionId();
+
+            for offset in -100i64..=100i64 {
+                let xid = pg_sys::FullTransactionId {
+                    value: current_xid.value.saturating_add_signed(offset),
+                };
+                fsm.extend_with_when_recyclable(&mut bman, xid, 0..3);
+                assert!(
+                    fsm.drain(&mut bman, 1).next().is_some(),
+                    "fsm should find something"
+                );
+            }
+
+            Ok(())
+        }
+
+        #[pg_test]
+        unsafe fn test_fsmv2_full() -> spi::Result<()> {
+            Spi::run("CREATE TABLE IF NOT EXISTS fsm_test (id serial8, data text)")?;
+            Spi::run("CREATE INDEX IF NOT EXISTS fsm_idx ON fsm_test USING bm25 (id, data) WITH (key_field = 'id')")?;
+
+            let index_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'fsm_idx'::regclass::oid")?
+                .unwrap_or(pg_sys::InvalidOid);
+
+            assert_ne!(index_oid, pg_sys::InvalidOid);
+
+            let indexrel = PgSearchRelation::with_lock(
+                index_oid,
+                pg_sys::RowExclusiveLock as pg_sys::LOCKMODE,
+            );
+
+            let mut bman = BufferManager::new(&indexrel);
+            let metapage = MetaPage::open(&indexrel);
+            let mut fsm = V2FSM::open(metapage.fsm());
+
+            assert!(
+                pg_sys::GetCurrentTransactionId().into_inner()
+                    > pg_sys::FirstNormalTransactionId.into_inner() + MAX_SLOTS as u32,
+                "test framework transaction id started too low to properly run this test"
+            );
+
+            let current_xid = pg_sys::FullTransactionId {
+                value: pg_sys::FirstNormalTransactionId.into_inner() as u64,
             };
 
-            // we still have blocks to apply but have no more space on this page
-            // so allocate a new page
-            let mut new_buffer = init_new_buffer(bman.buffer_access().rel());
-            let mut new_page = new_buffer.page_mut();
+            for offset in 0..=MAX_SLOTS as u64 {
+                let xid = pg_sys::FullTransactionId {
+                    value: current_xid.value + offset,
+                };
+                fsm.extend_with_when_recyclable(&mut bman, xid, 0..1);
+            }
 
-            // initialize the new page with a default FSMBlock
-            *new_page.contents_mut::<FSMBlock>() = FSMBlock::default();
+            let drained = fsm.drain(&mut bman, MAX_SLOTS + 1).collect::<Vec<_>>();
+            assert_eq!(
+                drained,
+                std::iter::repeat_n(0, MAX_SLOTS + 1).collect::<Vec<_>>()
+            );
 
-            // move to this new page
-            let new_blockno = new_buffer.number();
-            buffer
-                .page_mut()
-                .special_mut::<BM25PageSpecialData>()
-                .next_blockno = new_blockno;
+            let empty = fsm.drain(&mut bman, 1).next().is_none();
+            assert!(empty);
 
-            // loop back around to try extending this new page
-            blockno = new_blockno;
+            Ok(())
         }
     }
 }
 
-/// The `xid_horizon` argument represents the oldest transaction id, across the Postgres cluster,
-/// that can see blocks in the FSM.
-///
-/// When being drained, the FSM compares each block's stored `fsm_xid`` with this value, ensuring the stored
-/// value precedes or equals this `xid_horizon`, before it is considered recyclable.
-#[inline(always)]
-fn passses_visibility_horizon(
-    fsm_xid: pg_sys::TransactionId,
-    xid_horizon: pg_sys::TransactionId,
-) -> bool {
-    crate::postgres::utils::TransactionIdPrecedesOrEquals(fsm_xid, xid_horizon)
+pub fn convert_v1_to_v2(bman1: &mut BufferManager, mut v1: V1FSM, mut v2: V2FSM) {
+    let when_recyclable = pg_sys::FullTransactionId {
+        value: pg_sys::FirstNormalTransactionId.into_inner() as u64,
+    };
+
+    let mut bman2 = bman1.clone();
+    loop {
+        let extended =
+            v2.extend_with_when_recyclable(&mut bman2, when_recyclable, v1.drain(bman1, 1000));
+        if !extended {
+            break;
+        }
+    }
+
+    let v1_used_blocks = v1.used_blocks(bman1);
+    v2.extend_with_when_recyclable(&mut bman2, when_recyclable, v1_used_blocks.into_iter());
 }
 
 #[pg_extern]
@@ -449,45 +1300,83 @@ unsafe fn fsm_info(
 ) -> TableIterator<
     'static,
     (
-        name!(fsm_blockno, AnyNumeric),
-        name!(free_blockno, Option<AnyNumeric>),
+        name!(xid, pg_sys::TransactionId),
+        name!(fsm_blockno, i64),
+        name!(tag, i64),
+        name!(free_blockno, i64),
     ),
 > {
-    let index = PgSearchRelation::from_pg(index.as_ptr());
+    use crate::postgres::storage::fsm::v2::AvlLeaf;
+    use crate::postgres::storage::fsm::v2::V2FSM;
+
+    let index =
+        PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as pg_sys::LOCKMODE);
 
     let meta = MetaPage::open(&index);
     let bman = BufferManager::new(&index);
-    let mut mapping = Vec::<(pg_sys::BlockNumber, Vec<Option<FSMEntry>>)>::default();
 
-    let fsm_start = meta.fsm();
-    let mut blockno = fsm_start;
+    let root = bman.get_buffer(meta.fsm());
+    let page = root.page();
+    let avl = V2FSM::open(root.number()).avl_ref(&page);
 
-    while blockno != pg_sys::InvalidBlockNumber {
-        let buffer = bman.get_buffer(blockno);
-        let page = buffer.page();
-        let block = page.contents::<FSMBlock>();
-        if !block.header.empty {
-            let free_blocks = block
-                .entries
-                .into_iter()
-                .filter_map(|entry| {
-                    if entry.0 == pg_sys::InvalidBlockNumber {
-                        None
-                    } else {
-                        Some(Some(entry))
-                    }
-                })
-                .collect();
-            mapping.push((blockno, free_blocks));
-        } else {
-            mapping.push((blockno, vec![None]));
+    let mut results = Vec::new();
+
+    for slot in avl.arena {
+        if slot.is_used() {
+            let xid = slot.key;
+            let blockno = slot.tag as pg_sys::BlockNumber;
+
+            let mut current_blockno = blockno;
+            while current_blockno != pg_sys::InvalidBlockNumber {
+                let buffer = bman.get_buffer(current_blockno);
+                let page = buffer.page();
+                let leaf = page.contents_ref::<AvlLeaf>();
+
+                for i in 0..leaf.len {
+                    results.push((xid, current_blockno, slot.tag, leaf.entries[i as usize]));
+                }
+
+                current_blockno = page.next_blockno();
+            }
         }
-        blockno = page.special::<BM25PageSpecialData>().next_blockno;
     }
 
-    TableIterator::new(mapping.into_iter().flat_map(|(fsm_blockno, blocks)| {
-        blocks
+    TableIterator::new(
+        results
             .into_iter()
-            .map(move |blockno| (fsm_blockno.into(), blockno.map(|entry| entry.0.into())))
-    }))
+            .map(|(xid, fsm_blockno, tag, tracked_blockno)| {
+                (
+                    pg_sys::TransactionId::from(xid as u32),
+                    fsm_blockno as i64,
+                    tag as i64,
+                    tracked_blockno as i64,
+                )
+            }),
+    )
+}
+
+#[pg_extern]
+unsafe fn fsm_size(index: PgRelation) -> i64 {
+    use crate::postgres::storage::fsm::v2::V2FSM;
+    let index =
+        PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as pg_sys::LOCKMODE);
+
+    let meta = MetaPage::open(&index);
+    let bman = BufferManager::new(&index);
+
+    let root = bman.get_buffer(meta.fsm());
+    let page = root.page();
+    let avl = V2FSM::open(root.number()).avl_ref(&page);
+
+    let mut count = 1; // start with 1 b/c of the root page
+    for slot in avl.arena {
+        let mut blockno = slot.tag as pg_sys::BlockNumber;
+        while blockno != pg_sys::InvalidBlockNumber {
+            count += 1;
+            let buffer = bman.get_buffer(blockno);
+            let page = buffer.page();
+            blockno = page.next_blockno();
+        }
+    }
+    count as i64
 }

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -607,7 +607,7 @@ pub mod v1 {
 /// Draining is the process of asking the FSM for free blocks.  The caller asks for `n` blocks and
 /// the FSM returns an iterator of blocks that can be reused by the current transaction.  "Current
 /// transaction" here literally means the result of `pg_sys::GetCurrentFullTransactionId()`, but
-/// _could_ be a different, father-in-the-past, transaction.
+/// _could_ be a different, further-in-the-past, transaction.
 ///
 /// The drain process takes a shared lock on the root page and finds the entry that is less-than-or-equal-to
 /// the current transaction id.  A transaction can only reuse blocks related to the same or older

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -826,7 +826,7 @@ pub mod v2 {
                         }
                         cnt += contents.len as usize;
 
-                        // should we unlink this block from the chain? -- only if it's the head and now empty
+                        // should we unlink this block from the chain? -- only if it's the head and _we_ made it empty
                         blockno == head_blockno
                             && contents.len == 0
                             && next_blockno != pg_sys::InvalidBlockNumber

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -19,6 +19,7 @@ use super::block::{bm25_max_free_space, BM25PageSpecialData, LinkedList, LinkedL
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::blocklist;
 use crate::postgres::storage::buffer::{init_new_buffer, BufferManager, PageHeaderMethods};
+use crate::postgres::storage::fsm::FreeSpaceManager;
 use anyhow::Result;
 use pgrx::{check_for_interrupts, pg_sys};
 use std::cmp::min;
@@ -357,7 +358,7 @@ impl LinkedBytesList {
     /// Free Space Map behind this index.
     pub unsafe fn return_to_fsm(self) {
         let mut bman = self.bman().clone();
-        let fsm = bman.fsm();
+        let mut fsm = bman.fsm();
         fsm.extend(&mut bman, self.freeable_blocks());
     }
 

--- a/pg_search/src/postgres/storage/mod.rs
+++ b/pg_search/src/postgres/storage/mod.rs
@@ -90,6 +90,7 @@
 // | [next_blockno: BlockNumber, xmax: TransactionId]            |
 // +-------------------------------------------------------------+
 
+mod avl;
 pub mod block;
 mod blocklist;
 pub mod buffer;


### PR DESCRIPTION
## What

This implements a new `v2` FSM that's fronted by an AVL tree which allows for minimal locking during extension and draining.  It also provides efficient continuation during drain as xid blocklists are exhausted or found to be unavailable to the current transaction.  And it implements a (simple) transparent conversion of the current `v1` FSM to the new format.

Additionally, this fixes a problem with background merging where more than one background merger process could be spawned at once -- I've seen up to 8 concurrently.  It does this by introducing some a new page on disk to track the process and coordinate locking.

## Why

Our current FSM is very heavyweight in terms of lock contention.  This should get us to something that isn't.

## How

## Tests

A number of new tests for the array-backed AVL tree and the FSM itself.  All existing tests also pass and, at least, the `wide-table.toml` stressgres shows a slight performance improvement for the update jobs.