### PR TITLE
fix: `paradedb.snippet` projects correctly when called multiple times over the same field

### DIFF
--- a/pg_search/tests/pg_regress/expected/issue_3256.out
+++ b/pg_search/tests/pg_regress/expected/issue_3256.out
@@ -1,0 +1,24 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX on mock_items USING bm25 (id, description, rating, category, metadata) WITH (key_field='id');
+SELECT
+    paradedb.snippet(description, start_tag => '<b>', end_tag => '</b>', max_num_chars => 10),
+    paradedb.snippet(description, start_tag => '<i>', end_tag => '</i>'),
+    paradedb.snippet_positions(description)
+FROM mock_items WHERE description @@@ 'shoes';
+   snippet    |          snippet           | snippet_positions 
+--------------+----------------------------+-------------------
+ <b>shoes</b> | Sleek running <i>shoes</i> | {"{14,19}"}
+ <b>shoes</b> | White jogging <i>shoes</i> | {"{14,19}"}
+ <b>shoes</b> | Generic <i>shoes</i>       | {"{8,13}"}
+(3 rows)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/issue_3256.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3256.sql
@@ -1,0 +1,15 @@
+\i common/common_setup.sql
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX on mock_items USING bm25 (id, description, rating, category, metadata) WITH (key_field='id');
+SELECT
+    paradedb.snippet(description, start_tag => '<b>', end_tag => '</b>', max_num_chars => 10),
+    paradedb.snippet(description, start_tag => '<i>', end_tag => '</i>'),
+    paradedb.snippet_positions(description)
+FROM mock_items WHERE description @@@ 'shoes';
+
+DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3256 

## What

See GH issue

## Why

## How

When mapping a const node to our list of snippet generators, we were matching only on the field name and function OID, which is not unique enough -- it doesn't account for the function arguments.

## Tests

Added regression test