### PR TITLE
docs: New highlighting limit/offset capabilities

### DIFF
--- a/docs/documentation/full-text/highlighting.mdx
+++ b/docs/documentation/full-text/highlighting.mdx
@@ -9,7 +9,7 @@ number of snippets that need to be generated.
 </Note>
 
 <Note>
-Highlighting is not supported for `paradedb.fuzzy_term` and `paradedb.match`.
+Highlighting is not supported for queries that use fuzziness, like `paradedb.fuzzy_term`.
 </Note>
 
 Highlighting refers to the practice of visually emphasizing the portions of a document that match a user's
@@ -28,16 +28,6 @@ WHERE description @@@ 'shoes'
 LIMIT 5;
 ```
 
-<ParamField body="start_tag" default="<b>">
-  The leading indicator around the highlighted region.
-</ParamField>
-<ParamField body="end_tag" default="</b>">
-  The trailing indicator around the highlighted region.
-</ParamField>
-<ParamField body="max_num_chars" default={150}>
-  Max number of characters for a highlighted fragment.
-</ParamField>
-
 By default, `<b></b>` encloses the snippet. This can be configured with `start_tag` and `end_tag`:
 
 ```sql
@@ -46,6 +36,23 @@ FROM mock_items
 WHERE description @@@ 'shoes'
 LIMIT 5;
 ```
+
+## Fragment Size
+
+For every highlighted term, a fragment of size `max_num_chars` is created containing the term and its surrounding text. A fragment can contain
+multiple highlighted terms if they are within `max_num_chars` distance of one another. By default, `max_num_chars` is set to `150`.
+
+```sql
+SELECT id, paradedb.snippet(description, max_num_chars => 100)
+FROM mock_items
+WHERE description @@@ 'shoes'
+LIMIT 5;
+```
+
+If multiple fragments are found, `paradedb.snippet` uses a two-tiered scoring system to determine which fragment to display:
+
+1. Each highlighted term receives a score based on its inverse document frequency. This means that fragments containing rarer terms will score higher.
+2. If there is a tie, the fragment that appears earlier in the source text will be displayed.
 
 ## Byte Offsets
 
@@ -69,3 +76,29 @@ LIMIT 5;
 (3 rows)
 ```
 </Accordion>
+
+## Snippet Limit and Offset
+
+Both `paradedb.snippet` and `paradedb.snippet_positions` accept `limit` and `offset` arguments. A `limit` restricts the number of
+highlighted terms, while an `offset` ignores the first `offset` highlighted terms. This can be useful for paginating
+through documents that contain large numbers of highlighted terms.
+
+```sql
+SELECT id, paradedb.snippet(description, "limit" => 1, "offset" => 1)
+FROM mock_items
+WHERE description @@@ 'shoes' AND description @@@ 'sleek' AND description @@@ 'running';
+```
+
+```sql Expected Response
+ id |          snippet
+----+----------------------------
+  3 | Sleek <b>running</b> shoes
+(1 row)
+```
+
+<Note>
+The `limit` and `offset` arguments must be wrapped in double quotes because they are reserved keywords in Postgres.
+</Note>
+
+In the output above, notice that `sleek` is not highlighted because an offset of `1` skips the first highlighted term.
+Similarly, `shoes` is not highlighted because of the limit `1`.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Documents the new `limit` and `offset` capabilities for the snippet functions.

## Why

## How

## Tests
