### PR TITLE
chore: Remove deprecated tokenizers: `en_stem`, `stem` and `lowercase`

### DIFF
--- a/pg_search/tests/pg_regress/expected/partial_index_score_fix.out
+++ b/pg_search/tests/pg_regress/expected/partial_index_score_fix.out
@@ -15,14 +15,14 @@ INSERT INTO partial_test (description, category, rating) VALUES
 ('Apple Watch', 'Electronics', 4),
 ('Adidas Sneakers', 'Footwear', 2);
 -- Create partial index with WHERE clause
-CREATE INDEX partial_test_idx ON partial_test 
+CREATE INDEX partial_test_idx ON partial_test
 USING bm25 (id, description)
 WITH (key_field = 'id')
 WHERE category = 'Electronics';
 -- Test Case 1: Query with only indexed field - should work correctly
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id, description, category, paradedb.score(id) as score
-FROM partial_test 
+FROM partial_test
 WHERE description @@@ 'Apple'
 ORDER BY score DESC;
                                                                          QUERY PLAN                                                                         
@@ -38,7 +38,7 @@ ORDER BY score DESC;
 (8 rows)
 
 SELECT id, description, category, paradedb.score(id) as score
-FROM partial_test 
+FROM partial_test
 WHERE description @@@ 'Apple'
 ORDER BY score DESC;
  id | description  |  category   |   score    
@@ -48,15 +48,15 @@ ORDER BY score DESC;
 (2 rows)
 
 -- Test Case 2: Query with indexed field + non-indexed predicate
--- This should use the partial index predicate (category = 'Electronics') 
+-- This should use the partial index predicate (category = 'Electronics')
 -- instead of All query for the non-indexed rating filter
 -- EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 -- SELECT id, description, category, rating, paradedb.score(id) as score
--- FROM partial_test 
+-- FROM partial_test
 -- WHERE description @@@ 'Apple' AND rating >= 4
 -- ORDER BY score DESC;
 SELECT id, description, category, rating, paradedb.score(id) as score
-FROM partial_test 
+FROM partial_test
 WHERE description @@@ 'Apple' AND rating >= 4
 ORDER BY score DESC;
  id | description  |  category   | rating | score 
@@ -69,7 +69,7 @@ ORDER BY score DESC;
 -- This should still use the partial index predicate for the base query
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id, description, category, rating, paradedb.score(id) as score
-FROM partial_test 
+FROM partial_test
 WHERE rating >= 4
 ORDER BY score DESC;
               QUERY PLAN               
@@ -81,7 +81,7 @@ ORDER BY score DESC;
 (4 rows)
 
 SELECT id, description, category, rating, paradedb.score(id) as score
-FROM partial_test 
+FROM partial_test
 WHERE rating >= 4
 ORDER BY score DESC;
  id |  description   |  category   | rating | score 
@@ -105,14 +105,14 @@ WITH (
     key_field = 'id',
     text_fields = '{
         "description": {
-            "tokenizer": {"type": "en_stem"}
+            "tokenizer": {"type": "default"}
         }
     }'
 ) WHERE category = 'Electronics';
 -- Test 1: Initial query should return only Electronics items with rating > 1
 -- This should return 5 results (all Electronics with rating > 1)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -129,7 +129,7 @@ ORDER BY rating LIMIT 20;
          Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"rating:>1","lenient":null,"conjunction_mode":null}}}}
 (9 rows)
 
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -150,7 +150,7 @@ INSERT INTO paradedb.test_partial_index (description, category, rating, in_stock
 -- Test 2: After insert, should return 6 results (5 original + 1 new Electronics with rating > 1)
 -- The key insight: Product 3 (Footwear) should NOT be returned since it's not in the partial index
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -169,7 +169,7 @@ ORDER BY rating LIMIT 20;
                Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"rating:>1","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -186,7 +186,7 @@ ORDER BY rating LIMIT 20;
 -- Test 3: Update Product 1 to Footwear - should reduce results to 5
 UPDATE paradedb.test_partial_index SET category = 'Footwear' WHERE description = 'Product 1';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -205,7 +205,7 @@ ORDER BY rating LIMIT 20;
                Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"rating:>1","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -218,10 +218,10 @@ ORDER BY rating LIMIT 20;
  Innovative wireless earbuds |      5 | Electronics
 (5 rows)
 
--- Test 4: Update Product 3 to Electronics - should increase results to 6  
+-- Test 4: Update Product 3 to Electronics - should increase results to 6
 UPDATE paradedb.test_partial_index SET category = 'Electronics' WHERE description = 'Product 3';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -240,7 +240,7 @@ ORDER BY rating LIMIT 20;
                Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"rating:>1","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
-SELECT description, rating, category 
+SELECT description, rating, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'rating:>1'
 ORDER BY rating LIMIT 20;
@@ -256,7 +256,7 @@ ORDER BY rating LIMIT 20;
 
 -- Test 5: Verify that non-Electronics items are not returned even if they match the query
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT description, category 
+SELECT description, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'category:Footwear AND rating:>1'
 ORDER BY rating LIMIT 20;
@@ -275,7 +275,7 @@ ORDER BY rating LIMIT 20;
                Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Footwear AND rating:>1","lenient":null,"conjunction_mode":null}}}}
 (11 rows)
 
-SELECT description, category 
+SELECT description, category
 FROM paradedb.test_partial_index
 WHERE test_partial_index @@@ 'category:Footwear AND rating:>1'
 ORDER BY rating LIMIT 20;
@@ -286,4 +286,4 @@ ORDER BY rating LIMIT 20;
 -- Cleanup
 DROP INDEX partial_idx;
 ERROR:  index "partial_idx" does not exist
-DROP TABLE paradedb.test_partial_index; 
+DROP TABLE paradedb.test_partial_index;

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -509,7 +509,7 @@ fn update_non_indexed_column(mut conn: PgConnection) -> Result<()> {
     r#"
     CREATE INDEX search_idx ON mock_items
     USING bm25 (id, description)
-    WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "en_stem", "lowercase": true, "remove_long": 255}}}')
+    WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "default", "lowercase": true, "remove_long": 255}}}')
     "#
       .execute(&mut conn);
 
@@ -653,7 +653,7 @@ fn bm25_partial_index_search(mut conn: PgConnection) {
         key_field = 'id',
         text_fields = '{
             "description": {
-                "tokenizer": {"type": "en_stem"}
+                "tokenizer": {"type": "default"}
             }
         }'
     ) WHERE category = 'Electronics';
@@ -764,7 +764,7 @@ fn bm25_partial_index_hybrid(mut conn: PgConnection) {
     WITH (
         key_field='id',
         text_fields='{
-            "description": {"tokenizer": {"type": "en_stem", "lowercase": true, "remove_long": 255}},
+            "description": {"tokenizer": {"type": "default", "lowercase": true, "remove_long": 255}},
             "category": {}
         }',
         numeric_fields='{"rating": {}}'
@@ -869,7 +869,7 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         key_field = 'id',
         text_fields = '{
             "description": {
-                "tokenizer": {"type": "en_stem"}
+                "tokenizer": {"type": "default"}
             }
         }'
     ) WHERE city = 'Electronics';
@@ -885,7 +885,7 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         key_field = 'id',
         text_fields = '{
             "description": {
-                "tokenizer": {"type": "en_stem"}
+                "tokenizer": {"type": "default"}
             }
         }'
     ) WHERE city = 'Electronics';
@@ -900,7 +900,7 @@ fn bm25_partial_index_invalid_statement(mut conn: PgConnection) {
         key_field = 'id',
         text_fields = '{
             "description": {
-                "tokenizer": {"type": "en_stem"}
+                "tokenizer": {"type": "default"}
             }
         }'
     ) WHERE category = 'Electronics';
@@ -921,7 +921,7 @@ fn bm25_partial_index_alter_and_drop(mut conn: PgConnection) {
     WITH (
         key_field='id',
         text_fields='{
-            "description": {"tokenizer": {"type": "en_stem", "lowercase": true, "remove_long": 255}}
+            "description": {"tokenizer": {"type": "default", "lowercase": true, "remove_long": 255}}
         }'
     ) WHERE category = 'Electronics';
     "#
@@ -949,7 +949,7 @@ fn bm25_partial_index_alter_and_drop(mut conn: PgConnection) {
     WITH (
         key_field='id',
         text_fields='{
-            "description": {"tokenizer": {"type": "en_stem", "lowercase": true, "remove_long": 255}}
+            "description": {"tokenizer": {"type": "default", "lowercase": true, "remove_long": 255}}
         }'
     );
     "#

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -43,10 +43,10 @@ fn defult_tokenizer(mut conn: PgConnection) {
 
 #[rstest]
 fn tokenizer_filters(mut conn: PgConnection) {
-    // Test en_stem tokenizer with default layers (lowercase => true, remove_long => 255).
+    // Test default tokenizer with default layers (lowercase => true, remove_long => 255).
     let rows: Vec<(String, i32)> = r#"
     SELECT * FROM paradedb.tokenize(
-      paradedb.tokenizer('en_stem'),
+      paradedb.tokenizer('default'),
       'Hello, hello, ladiesandgentlemen!'
     );
     "#
@@ -61,10 +61,10 @@ fn tokenizer_filters(mut conn: PgConnection) {
         ]
     );
 
-    // Test en_stem optimizer with explicit layers.
+    // Test default optimizer with explicit layers.
     let rows: Vec<(String, i32)> = r#"
     SELECT * FROM paradedb.tokenize(
-      paradedb.tokenizer('en_stem', lowercase => false, remove_long => 15),
+      paradedb.tokenizer('default', lowercase => false, remove_long => 15),
       'Hello, hello, ladiesandgentlemen!'
     );
     "#
@@ -94,9 +94,6 @@ fn list_tokenizers(mut conn: PgConnection) {
                 ("default".into(),),
                 ("keyword".into(),),
                 ("raw".into(),),
-                ("en_stem".into(),),
-                ("stem".into(),),
-                ("lowercase".into(),),
                 ("white_space".into(),),
                 ("regex_tokenizer".into(),),
                 ("chinese_compatible".into(),),
@@ -116,9 +113,6 @@ fn list_tokenizers(mut conn: PgConnection) {
                 ("default".into(),),
                 ("keyword".into(),),
                 ("raw".into(),),
-                ("en_stem".into(),),
-                ("stem".into(),),
-                ("lowercase".into(),),
                 ("white_space".into(),),
                 ("regex_tokenizer".into(),),
                 ("chinese_compatible".into(),),

--- a/tests/tests/index_config.rs
+++ b/tests/tests/index_config.rs
@@ -132,7 +132,7 @@ fn text_field_with_options(mut conn: PgConnection) {
 
     r#"CREATE INDEX index_config_index ON paradedb.index_config
         USING bm25 (id, description)
-        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "en_stem", "normalizer": "raw"}, "record": "freq", "fast": true}}');
+        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "default", "normalizer": "raw"}, "record": "freq", "fast": true}}');
 "#
         .execute(&mut conn);
 
@@ -155,7 +155,7 @@ fn multiple_text_fields(mut conn: PgConnection) {
         USING bm25 (id, description, category)
         WITH (
             key_field='id',
-            text_fields='{"description": {"tokenizer": {"type": "en_stem", "normalizer": "raw"}, "record": "freq", "fast": true}}'
+            text_fields='{"description": {"tokenizer": {"type": "default", "normalizer": "raw"}, "record": "freq", "fast": true}}'
         );
         "#
         .execute(&mut conn);
@@ -865,7 +865,7 @@ fn setup_view_for_order_by_limit_test(conn: &mut PgConnection) {
     DROP VIEW IF EXISTS products_view;
     DROP TABLE IF EXISTS products_2023_view;
     DROP TABLE IF EXISTS products_2024_view;
-    
+
     SET enable_indexscan TO off;
     SET enable_bitmapscan TO off;
     SET max_parallel_workers TO 0;
@@ -884,7 +884,7 @@ fn setup_view_for_order_by_limit_test(conn: &mut PgConnection) {
         amount DECIMAL,
         sale_date DATE
     );
-    
+
     -- Insert data to both tables
     INSERT INTO products_2023_view (product_name, amount, sale_date) VALUES
     ('Laptop', 1200.00, '2023-01-15'),
@@ -899,7 +899,7 @@ fn setup_view_for_order_by_limit_test(conn: &mut PgConnection) {
     ('Printer', 200.00, '2024-02-18'),
     ('Camera', 600.00, '2024-04-22'),
     ('Speaker', 120.00, '2024-06-30');
-    
+
     -- Create BM25 indexes for both tables
     CREATE INDEX idx_products_2023_view_bm25 ON products_2023_view
     USING bm25 (id, product_name, amount, sale_date)
@@ -918,7 +918,7 @@ fn setup_view_for_order_by_limit_test(conn: &mut PgConnection) {
         numeric_fields = '{"amount": {}}',
         datetime_fields = '{"sale_date": {"fast": true}}'
     );
-    
+
     -- Create view combining both tables
     CREATE VIEW products_view AS
     SELECT * FROM products_2023_view
@@ -935,7 +935,7 @@ fn partitioned_order_by_limit_pushdown(mut conn: PgConnection) {
     // Get the explain plan
     let explain_output = r#"
     EXPLAIN (ANALYZE, VERBOSE)
-    SELECT * FROM sales 
+    SELECT * FROM sales
     WHERE product_name @@@ 'laptop OR smartphone OR headphones'
     ORDER BY sale_date LIMIT 5;
     "#
@@ -965,7 +965,7 @@ fn partitioned_order_by_limit_pushdown(mut conn: PgConnection) {
 
     // Also test that we get the correct sorted results
     let results: Vec<(String, String)> = r#"
-    SELECT product_name, sale_date::text FROM sales 
+    SELECT product_name, sale_date::text FROM sales
     WHERE product_name @@@ 'laptop OR smartphone OR headphones'
     ORDER BY sale_date LIMIT 5;
     "#
@@ -993,7 +993,7 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
     let explain_output = r#"
     EXPLAIN (ANALYZE, VERBOSE)
     SELECT * FROM (
-        SELECT * FROM products_2023 
+        SELECT * FROM products_2023
         WHERE product_name @@@ 'laptop OR smartphone OR headphones'
         UNION ALL
         SELECT * FROM products_2024
@@ -1022,7 +1022,7 @@ fn non_partitioned_no_order_by_limit_pushdown(mut conn: PgConnection) {
     // Even without the optimization, verify the query returns correct results
     let results: Vec<(String, String)> = r#"
     SELECT product_name, sale_date::text FROM (
-        SELECT * FROM products_2023 
+        SELECT * FROM products_2023
         WHERE product_name @@@ 'laptop OR smartphone OR headphones'
         UNION ALL
         SELECT * FROM products_2024
@@ -1054,7 +1054,7 @@ fn view_no_order_by_limit_pushdown(mut conn: PgConnection) {
 
     // Verify the tables and indexes were created properly
     let table_check: Vec<(String,)> = r#"
-    SELECT tablename FROM pg_tables 
+    SELECT tablename FROM pg_tables
     WHERE tablename IN ('products_2023_view', 'products_2024_view')
     ORDER BY tablename;
     "#
@@ -1078,7 +1078,7 @@ fn view_no_order_by_limit_pushdown(mut conn: PgConnection) {
 
     // Verify direct table queries work
     let test_query: Vec<(String,)> = r#"
-    SELECT product_name FROM products_2023_view 
+    SELECT product_name FROM products_2023_view
     WHERE product_name @@@ 'laptop'
     LIMIT 1;
     "#

--- a/tests/tests/reindex.rs
+++ b/tests/tests/reindex.rs
@@ -243,7 +243,7 @@ async fn concurrent_index_creation(mut conn: PgConnection) -> Result<()> {
     WITH (
         key_field='id',
         text_fields='{
-            "description": {"tokenizer": {"type": "en_stem"}},
+            "description": {"tokenizer": {"type": "default"}},
             "category": {}
         }',
         numeric_fields='{"rating": {}}',

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -224,25 +224,8 @@ fn default_tokenizer_config(mut conn: PgConnection) {
         .execute(&mut conn);
 
     r#"CREATE INDEX tokenizer_config_idx ON paradedb.tokenizer_config
-        USING bm25 (id, description) WITH (key_field='id')"#
-        .execute(&mut conn);
-
-    let rows: Vec<()> = "
-    SELECT * FROM paradedb.tokenizer_config
-    WHERE tokenizer_config @@@ 'description:earbud' ORDER BY id"
-        .fetch(&mut conn);
-
-    assert!(rows.is_empty());
-}
-
-#[rstest]
-fn en_stem_tokenizer_config(mut conn: PgConnection) {
-    "CALL paradedb.create_bm25_test_table(table_name => 'tokenizer_config', schema_name => 'paradedb')"
-        .execute(&mut conn);
-
-    r#"CREATE INDEX tokenizer_config_idx ON paradedb.tokenizer_config
-        USING bm25 (id, description) 
-        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "en_stem"}}}')"#
+        USING bm25 (id, description)
+        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "default"}}}')"#
         .execute(&mut conn);
 
     let rows: Vec<(i32,)> = "
@@ -372,7 +355,7 @@ fn regex_tokenizer_config(mut conn: PgConnection) {
     r#"CREATE INDEX bm25_search_idx ON paradedb.bm25_search
         USING bm25 (id, description)
         WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "regex", "pattern": "\\b\\w{4,}\\b"}}}');
-    INSERT INTO paradedb.bm25_search (id, description) VALUES 
+    INSERT INTO paradedb.bm25_search (id, description) VALUES
         (11001, 'This is a simple test'),
         (11002, 'Rust is awesome'),
         (11003, 'Regex patterns are powerful'),
@@ -394,59 +377,6 @@ fn regex_tokenizer_config(mut conn: PgConnection) {
         "SELECT COUNT(*) FROM paradedb.bm25_search WHERE bm25_search @@@ 'description:longer'"
             .fetch_one(&mut conn);
     assert_eq!(count.0, 1);
-}
-
-#[rstest]
-fn language_stem_tokenizer_deprecated(mut conn: PgConnection) {
-    for (language, data, author_query, title_query, message_query) in LANGUAGES {
-        let language_str = language_to_str(language);
-        let setup_query = format!(
-            r#"
-            DROP TABLE IF EXISTS test_table;
-            CREATE TABLE IF NOT EXISTS test_table(
-                id SERIAL PRIMARY KEY,
-                author TEXT,
-                title TEXT,
-                message TEXT
-            );
-            INSERT INTO test_table (author, title, message)
-            VALUES {data};
-            CREATE INDEX stem_test ON test_table
-                USING bm25 (id, author, title, message)
-                WITH (key_field='id', text_fields='{{
-                    "author": {{"tokenizer": {{"type": "stem", "language": "{language_str}"}}}},
-                    "title": {{"tokenizer": {{"type": "stem", "language": "{language_str}"}}}},
-                    "message": {{"tokenizer": {{"type": "stem", "language": "{language_str}"}}}}
-                }}');"#
-        );
-
-        setup_query.execute(&mut conn);
-
-        let author_search_query = format!(
-            "SELECT id FROM test_table WHERE test_table @@@ 'author:{author_query}' ORDER BY id"
-        );
-        let title_search_query = format!(
-            "SELECT id FROM test_table WHERE test_table @@@ 'title:{title_query}' ORDER BY id"
-        );
-        let message_search_query = format!(
-            "SELECT id FROM test_table WHERE test_table @@@ 'message:{message_query}' ORDER BY id"
-        );
-
-        let row: (i32,) = author_search_query.fetch_one(&mut conn);
-        assert_eq!(row.0, 1);
-
-        let row: (i32,) = title_search_query.fetch_one(&mut conn);
-        assert_eq!(row.0, 2);
-
-        let row: (i32,) = message_search_query.fetch_one(&mut conn);
-        assert_eq!(row.0, 3);
-
-        r#"
-        DROP INDEX IF EXISTS stem_test;
-        DROP TABLE IF EXISTS test_table;
-        "#
-        .execute(&mut conn);
-    }
 }
 
 #[rstest]

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -294,30 +294,6 @@ fn whitespace_tokenizer_config(mut conn: PgConnection) {
 }
 
 #[rstest]
-fn lowercase_tokenizer_config(mut conn: PgConnection) {
-    r#"
-    CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');
-
-    CREATE INDEX bm25_search_idx ON paradedb.bm25_search
-        USING bm25 (id, description)
-        WITH (key_field='id', text_fields='{"description": {"tokenizer": {"type": "lowercase"}}}');
-    "#
-    .execute(&mut conn);
-
-    let count: (i64,) = "
-    SELECT COUNT(*) FROM paradedb.bm25_search
-    WHERE bm25_search @@@ 'description:shoes'"
-        .fetch_one(&mut conn);
-    assert_eq!(count.0, 0);
-
-    let count: (i64,) = r#"
-    SELECT COUNT(*) FROM paradedb.bm25_search
-    WHERE bm25_search @@@ 'description:"GENERIC SHOES"'"#
-        .fetch_one(&mut conn);
-    assert_eq!(count.0, 1);
-}
-
-#[rstest]
 fn raw_tokenizer_config(mut conn: PgConnection) {
     r#"
     CALL paradedb.create_bm25_test_table(table_name => 'bm25_search', schema_name => 'paradedb');

--- a/tests/tests/search_config.rs
+++ b/tests/tests/search_config.rs
@@ -233,7 +233,7 @@ fn default_tokenizer_config(mut conn: PgConnection) {
     WHERE tokenizer_config @@@ 'description:earbud' ORDER BY id"
         .fetch(&mut conn);
 
-    assert_eq!(rows[0], (12,));
+    assert!(rows.is_empty())
 }
 
 #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

For better maintainability:

1. Removes three extremely deprecated tokenizers: `en_stem`, `stem`, and `lowercase`
2. Wraps the filter builders in a macro, guaranteeing that all the filters are applied to all tokenizers

## Why

## How

## Tests
