### PR TITLE
feat: support the `stopwords_language` typmod property

### DIFF
--- a/pg_search/src/api/tokenizers/typmod/mod.rs
+++ b/pg_search/src/api/tokenizers/typmod/mod.rs
@@ -322,9 +322,10 @@ impl From<&ParsedTypmod> for SearchTokenizerFilters {
                         other => panic!("unknown stemmer: {other}"),
                     }
                 }),
-            // TODO: handle stopwords
-            stopwords_language: None,
-            stopwords: None,
+            stopwords_language: value
+                .get("stopwords_language")
+                .and_then(|p| p.as_language().ok()),
+            stopwords: None, // TODO: handle stopwords list in a new way we haven't done up to this point
             ascii_folding: value.get("ascii_folding").and_then(|p| p.as_bool()),
             normalizer: value.get("normalizer").and_then(|p| p.as_normalizer()),
         }

--- a/pg_search/tests/pg_regress/expected/tokenizer-stopwords-language.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-stopwords-language.out
@@ -1,0 +1,66 @@
+DROP TABLE IF EXISTS stopwords_lang;
+CREATE TABLE stopwords_lang(
+    id serial8 not null primary key,
+    t text
+);
+CREATE INDEX idxstopwords_lang ON stopwords_lang USING bm25 (id, (t::pdb.simple('stopwords_language=english'))) WITH (key_field = 'id');
+INSERT INTO stopwords_lang (t) VALUES ('how many of these are in the stopwords list?');
+SELECT * FROM stopwords_lang WHERE t @@@ 'are in the';  -- runtime tantivy error
+ERROR:  could not parse query string 't:(are in the)'.
+           make sure to use column:term pairs, and to capitalize AND/OR.
+SELECT * FROM stopwords_lang WHERE t @@@ 'are in the stopwords list?'; -- finds the row
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+
+SELECT * FROM stopwords_lang WHERE t &&& 'are in the';
+ id | t 
+----+---
+(0 rows)
+
+SELECT * FROM stopwords_lang WHERE t ||| 'are in the';
+ id | t 
+----+---
+(0 rows)
+
+SELECT * FROM stopwords_lang WHERE t ### 'are in the';
+ id | t 
+----+---
+(0 rows)
+
+SELECT * FROM stopwords_lang WHERE t === 'are';
+ id | t 
+----+---
+(0 rows)
+
+SELECT * FROM stopwords_lang WHERE t @@@ 'stopwords list?';
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+
+SELECT * FROM stopwords_lang WHERE t &&& 'stopwords list?';
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+
+SELECT * FROM stopwords_lang WHERE t ||| 'stopwords list?';
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+
+SELECT * FROM stopwords_lang WHERE t ### 'stopwords list?';
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+
+SELECT * FROM stopwords_lang WHERE t === 'stopwords';
+ id |                      t                       
+----+----------------------------------------------
+  1 | how many of these are in the stopwords list?
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/tokenizer-stopwords-language.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-stopwords-language.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS stopwords_lang;
+CREATE TABLE stopwords_lang(
+    id serial8 not null primary key,
+    t text
+);
+
+CREATE INDEX idxstopwords_lang ON stopwords_lang USING bm25 (id, (t::pdb.simple('stopwords_language=english'))) WITH (key_field = 'id');
+
+INSERT INTO stopwords_lang (t) VALUES ('how many of these are in the stopwords list?');
+
+SELECT * FROM stopwords_lang WHERE t @@@ 'are in the';  -- runtime tantivy error
+SELECT * FROM stopwords_lang WHERE t @@@ 'are in the stopwords list?'; -- finds the row
+SELECT * FROM stopwords_lang WHERE t &&& 'are in the';
+SELECT * FROM stopwords_lang WHERE t ||| 'are in the';
+SELECT * FROM stopwords_lang WHERE t ### 'are in the';
+SELECT * FROM stopwords_lang WHERE t === 'are';
+
+SELECT * FROM stopwords_lang WHERE t @@@ 'stopwords list?';
+SELECT * FROM stopwords_lang WHERE t &&& 'stopwords list?';
+SELECT * FROM stopwords_lang WHERE t ||| 'stopwords list?';
+SELECT * FROM stopwords_lang WHERE t ### 'stopwords list?';
+SELECT * FROM stopwords_lang WHERE t === 'stopwords';


### PR DESCRIPTION
## What

This adds back in support for the language-specific built-in list of stopwords, using `stopwords_language=xxx`.

## Why

Stopwords are pretty useful!

## How

## Tests

A regression test has been added.