### PR TITLE
fix: allow the RHS of `@@@` to support `pdb.query` at runtime

### DIFF
--- a/pg_search/tests/pg_regress/expected/issue_3300.out
+++ b/pg_search/tests/pg_regress/expected/issue_3300.out
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS issue3300;
+DROP TABLE IF EXISTS allowed_categories;
+CALL paradedb.create_bm25_test_table(
+        schema_name => 'public',
+        table_name => 'issue3300'
+     );
+CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.exact), metadata) WITH (key_field='id');
+CREATE TABLE allowed_categories
+(
+    category TEXT PRIMARY KEY
+);
+INSERT INTO allowed_categories (category)
+VALUES ('Electronics'),
+       ('Clothing');
+SELECT COUNT(*)
+FROM issue3300
+WHERE category @@@
+      paradedb.term_set(terms => ARRAY(SELECT paradedb.term('category', category) FROM allowed_categories LIMIT 5));
+ count 
+-------
+     5
+(1 row)
+
+SELECT COUNT(*)
+FROM issue3300
+WHERE category @@@ pdb.term_set(terms => ARRAY(SELECT category FROM allowed_categories LIMIT 5));
+ count 
+-------
+     5
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/issue_3300.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3300.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS issue3300;
+DROP TABLE IF EXISTS allowed_categories;
+CALL paradedb.create_bm25_test_table(
+        schema_name => 'public',
+        table_name => 'issue3300'
+     );
+
+CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.exact), metadata) WITH (key_field='id');
+
+CREATE TABLE allowed_categories
+(
+    category TEXT PRIMARY KEY
+);
+
+INSERT INTO allowed_categories (category)
+VALUES ('Electronics'),
+       ('Clothing');
+
+SELECT COUNT(*)
+FROM issue3300
+WHERE category @@@
+      paradedb.term_set(terms => ARRAY(SELECT paradedb.term('category', category) FROM allowed_categories LIMIT 5));
+
+SELECT COUNT(*)
+FROM issue3300
+WHERE category @@@ pdb.term_set(terms => ARRAY(SELECT category FROM allowed_categories LIMIT 5));


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3300

## What

This allows the rhs of `@@@` to support a `pdb.query` at runtime

## Why

## How

## Tests

Yes