### PR TITLE
docs: small v2 tokenization fixes

### DIFF
--- a/docs/v2/indexing/create_index.mdx
+++ b/docs/v2/indexing/create_index.mdx
@@ -57,11 +57,11 @@ There are many [available tokenizers](/v2/tokenizers/available_tokenizers) to ch
 
 ## Token Filters
 
-After tokens are created, [token filters](/v2/token_filters) can be configured to apply further processing like lowercasing, stemming, or unaccenting.
+After tokens are created, [token filters](/v2/token_filters/overview) can be configured to apply further processing like lowercasing, stemming, or unaccenting.
 For example, the following code block adds English stemming to `description`:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (description::pdb.ngram(2,3,'stemmer=english')), category)
+USING bm25 (id, (description::pdb.simple('stemmer=english')), category)
 WITH (key_field='id');
 ```

--- a/docs/v2/tokenizers/available_tokenizers/exact.mdx
+++ b/docs/v2/tokenizers/available_tokenizers/exact.mdx
@@ -26,5 +26,5 @@ SELECT 'Tokenize me!'::pdb.exact::text[];
 
 <Note>
   Because the exact tokenizer preserves the source text exactly, [token
-  filters](/v2/token_filters) cannot be configured for this tokenizer.
+  filters](/v2/token_filters/overview) cannot be configured for this tokenizer.
 </Note>

--- a/docs/v2/tokenizers/available_tokenizers/whitespace.mdx
+++ b/docs/v2/tokenizers/available_tokenizers/whitespace.mdx
@@ -2,7 +2,7 @@
 title: Whitespace
 ---
 
-The whitespace tokenizer is exactly like the [simple](/v2/tokenizers/available_tokenizers/whitespace) tokenizer, but splits only on whitespace and preserves
+The whitespace tokenizer is exactly like the [simple](/v2/tokenizers/available_tokenizers/simple) tokenizer, but splits only on whitespace and preserves
 punctuation. It also lowercases by default.
 
 ```sql


### PR DESCRIPTION
- some token_filters -> token_filters/overview link fixes
- one link went to whitespace instead of simple
- we had ngram with a stemmer as an example, which does not work (silently)

