### PR TITLE
chore: rename `pdb.exact` to `pdb.literal`

### DIFF
--- a/docs/v2/full-text/topn.mdx
+++ b/docs/v2/full-text/topn.mdx
@@ -76,7 +76,7 @@ See [indexing expressions](/v2/indexing/indexing_expressions) for more informati
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (lower(description)::pdb.exact))
+USING bm25 (id, (lower(description)::pdb.literal))
 WITH (key_field='id');
 ```
 

--- a/docs/v2/tokenizers/available_tokenizers/exact.mdx
+++ b/docs/v2/tokenizers/available_tokenizers/exact.mdx
@@ -7,14 +7,14 @@ exact UUID matching is a common use case), and is useful for doing exact string 
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (description::pdb.exact))
+USING bm25 (id, (description::pdb.literal))
 WITH (key_field='id');
 ```
 
 To get a feel for this tokenizer, run the following command and replace the text with your own:
 
 ```sql
-SELECT 'Tokenize me!'::pdb.exact::text[];
+SELECT 'Tokenize me!'::pdb.literal::text[];
 ```
 
 ```ini Expected Response

--- a/docs/v2/tokenizers/multiple_per_field.mdx
+++ b/docs/v2/tokenizers/multiple_per_field.mdx
@@ -12,7 +12,7 @@ The alias name can be any string you like. For instance, the following statement
 CREATE INDEX search_idx ON mock_items
 USING bm25 (
   id,
-  (description::pdb.exact),
+  (description::pdb.literal),
   (description::pdb.simple('alias=description_simple'))
 ) WITH (key_field='id');
 ```
@@ -43,7 +43,7 @@ text field can reference the field directly:
 CREATE INDEX search_idx ON mock_items
 USING bm25 (
   id,
-  (description::pdb.exact),
+  (description::pdb.literal),
   (description::pdb.simple('alias=description_simple'))
 ) WITH (key_field='id');
 

--- a/pg_search/sql/pg_search--0.18.11--0.19.0.sql
+++ b/pg_search/sql/pg_search--0.18.11--0.19.0.sql
@@ -142,13 +142,13 @@ $$;
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:312
--- pg_search::api::tokenizers::definitions::exact_typmod_in
-CREATE  FUNCTION "exact_typmod_in"(
+-- pg_search::api::tokenizers::definitions::literal_typmod_in
+CREATE  FUNCTION "literal_typmod_in"(
     "typmod_parts" cstring[] /* pgrx::datum::array::Array<&core::ffi::c_str::CStr> */
 ) RETURNS INT /* i32 */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'exact_typmod_in_wrapper';
+AS 'MODULE_PATHNAME', 'literal_typmod_in_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -462,16 +462,16 @@ AS 'MODULE_PATHNAME', 'match_conjunction_array_wrapper';
 --   Type(pg_search::api::tokenizers::definitions::pdb::Exact)
 
 
-CREATE TYPE pdb.exact;
-CREATE OR REPLACE FUNCTION pdb.exact_in(cstring) RETURNS pdb.exact AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.exact_out(pdb.exact) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.exact_send(pdb.exact) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.exact_recv(internal) RETURNS pdb.exact AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
-CREATE TYPE pdb.exact (
-                          INPUT = pdb.exact_in,
-                          OUTPUT = pdb.exact_out,
-                          SEND = pdb.exact_send,
-                          RECEIVE = pdb.exact_recv,
+CREATE TYPE pdb.literal;
+CREATE OR REPLACE FUNCTION pdb.literal_in(cstring) RETURNS pdb.literal AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.literal_out(pdb.literal) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.literal_send(pdb.literal) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.literal_recv(internal) RETURNS pdb.literal AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
+CREATE TYPE pdb.literal (
+                          INPUT = pdb.literal_in,
+                          OUTPUT = pdb.literal_out,
+                          SEND = pdb.literal_send,
+                          RECEIVE = pdb.literal_recv,
                           COLLATABLE = true,
                           CATEGORY = 't', -- 't' is for tokenizer
                           PREFERRED = false,
@@ -482,11 +482,11 @@ CREATE TYPE pdb.exact (
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:329
 -- requires:
---   exact_typmod_in
---   exact_definition
+--   literal_typmod_in
+--   literal_definition
 
 
-ALTER TYPE pdb.exact SET (TYPMOD_IN = exact_typmod_in);
+ALTER TYPE pdb.literal SET (TYPMOD_IN = literal_typmod_in);
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -788,22 +788,22 @@ ALTER TYPE pdb.regex SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_ty
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:214
--- pg_search::api::tokenizers::definitions::pdb::tokenize_exact
-CREATE  FUNCTION pdb."tokenize_exact"(
-    "s" pdb.exact /* pg_search::api::tokenizers::definitions::pdb::Exact */
+-- pg_search::api::tokenizers::definitions::pdb::tokenize_literal
+CREATE  FUNCTION pdb."tokenize_literal"(
+    "s" pdb.literal /* pg_search::api::tokenizers::definitions::pdb::Exact */
 ) RETURNS TEXT[] /* alloc::vec::Vec<alloc::string::String> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'tokenize_exact_wrapper';
+AS 'MODULE_PATHNAME', 'tokenize_literal_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:214
 -- requires:
---   exact_definition
---   tokenize_exact
+--   literal_definition
+--   tokenize_literal
 
-CREATE CAST (pdb.exact AS TEXT[]) WITH FUNCTION pdb.tokenize_exact AS IMPLICIT;
+CREATE CAST (pdb.literal AS TEXT[]) WITH FUNCTION pdb.tokenize_literal AS IMPLICIT;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -952,15 +952,15 @@ CREATE CAST (jsonb AS pdb.lindera) WITH FUNCTION pdb.jsonb_to_lindera AS ASSIGNM
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:214
--- pg_search::api::tokenizers::definitions::pdb::json_to_exact
+-- pg_search::api::tokenizers::definitions::pdb::json_to_literal
 -- requires:
---   tokenize_exact
-CREATE  FUNCTION pdb."json_to_exact"(
+--   tokenize_literal
+CREATE  FUNCTION pdb."json_to_literal"(
     "json" json /* pg_search::api::tokenizers::GenericTypeWrapper<pgrx::datum::json::Json> */
-) RETURNS pdb.exact /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Exact> */
+) RETURNS pdb.literal /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Exact> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'json_to_exact_wrapper';
+AS 'MODULE_PATHNAME', 'json_to_literal_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1023,27 +1023,27 @@ CREATE CAST (jsonb AS pdb.simple) WITH FUNCTION pdb.jsonb_to_simple AS ASSIGNMEN
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:214
--- pg_search::api::tokenizers::definitions::pdb::jsonb_to_exact
+-- pg_search::api::tokenizers::definitions::pdb::jsonb_to_literal
 -- requires:
---   tokenize_exact
-CREATE  FUNCTION pdb."jsonb_to_exact"(
+--   tokenize_literal
+CREATE  FUNCTION pdb."jsonb_to_literal"(
     "jsonb" jsonb /* pg_search::api::tokenizers::GenericTypeWrapper<pgrx::datum::json::JsonB> */
-) RETURNS pdb.exact /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Exact> */
+) RETURNS pdb.literal /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Exact> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'jsonb_to_exact_wrapper';
+AS 'MODULE_PATHNAME', 'jsonb_to_literal_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
 -- pg_search/src/api/tokenizers/definitions.rs:214
 -- requires:
---   exact_definition
---   json_to_exact
---   jsonb_to_exact
+--   literal_definition
+--   json_to_literal
+--   jsonb_to_literal
 
 
-CREATE CAST (json AS pdb.exact) WITH FUNCTION pdb.json_to_exact AS ASSIGNMENT;
-CREATE CAST (jsonb AS pdb.exact) WITH FUNCTION pdb.jsonb_to_exact AS ASSIGNMENT;
+CREATE CAST (json AS pdb.literal) WITH FUNCTION pdb.json_to_literal AS ASSIGNMENT;
+CREATE CAST (jsonb AS pdb.literal) WITH FUNCTION pdb.jsonb_to_literal AS ASSIGNMENT;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -212,12 +212,12 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
-        Exact,
+        Literal,
         SearchTokenizer::Keyword,
-        tokenize_exact,
-        json_to_exact,
-        jsonb_to_exact,
-        "exact",
+        tokenize_literal,
+        json_to_literal,
+        jsonb_to_literal,
+        "literal",
         preferred = false,
         custom_typmod = true
     );
@@ -310,7 +310,7 @@ pub(crate) mod pdb {
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn exact_typmod_in<'a>(typmod_parts: Array<'a, &'a CStr>) -> i32 {
+fn literal_typmod_in<'a>(typmod_parts: Array<'a, &'a CStr>) -> i32 {
     let parsed_typmod = ParsedTypmod::try_from(&typmod_parts).unwrap();
     if parsed_typmod.len() == 1 && matches!(parsed_typmod[0].key(), Some("alias")) {
         drop(parsed_typmod);
@@ -319,7 +319,7 @@ fn exact_typmod_in<'a>(typmod_parts: Array<'a, &'a CStr>) -> i32 {
 
     ErrorReport::new(
         PgSqlErrorCode::ERRCODE_SYNTAX_ERROR,
-        "type modifier is not allowed for type \"exact\"",
+        "type modifier is not allowed for type \"literal\"",
         function_name!(),
     )
     .report(PgLogLevel::ERROR);
@@ -328,8 +328,8 @@ fn exact_typmod_in<'a>(typmod_parts: Array<'a, &'a CStr>) -> i32 {
 
 extension_sql!(
     r#"
-        ALTER TYPE pdb.exact SET (TYPMOD_IN = exact_typmod_in);
+        ALTER TYPE pdb.literal SET (TYPMOD_IN = literal_typmod_in);
     "#,
-    name = "exact_typmod",
-    requires = [exact_typmod_in, "exact_definition"]
+    name = "literal_typmod",
+    requires = [literal_typmod_in, "literal_definition"]
 );

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -74,7 +74,7 @@ pub fn search_field_config_from_type(
             filters: SearchTokenizerFilters::default(),
         },
         "whitespace" => SearchTokenizer::WhiteSpace(SearchTokenizerFilters::default()),
-        "exact" => SearchTokenizer::Keyword,
+        "literal" => SearchTokenizer::Keyword,
         "chinese_compatible" => {
             SearchTokenizer::ChineseCompatible(SearchTokenizerFilters::default())
         }
@@ -90,7 +90,7 @@ pub fn search_field_config_from_type(
 
     let normalizer = tokenizer.normalizer().unwrap_or_default();
 
-    let (fast, fieldnorms, record) = if type_name == "exact" {
+    let (fast, fieldnorms, record) = if type_name == "literal" {
         // non-tokenized fields get to be fast
         (true, false, IndexRecordOption::Basic)
     } else {

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -346,7 +346,7 @@ pub unsafe fn extract_field_attributes(
         let tantivy_type = SearchFieldType::try_from((pg_type, att_typmod, inner_typoid))
             .unwrap_or_else(|e| panic!("{e}"));
 
-        // non-plain-attribute expressions that aren't cast to a tokenizer type are forced to use our `pdb.exact` tokenizer
+        // non-plain-attribute expressions that aren't cast to a tokenizer type are forced to use our `pdb.literal` tokenizer
         let missing_tokenizer_cast = expression.is_some()
             && att_typmod == -1
             && matches!(tantivy_type, SearchFieldType::Text(..));

--- a/pg_search/tests/pg_regress/expected/issue_3300.out
+++ b/pg_search/tests/pg_regress/expected/issue_3300.out
@@ -4,7 +4,7 @@ CALL paradedb.create_bm25_test_table(
         schema_name => 'public',
         table_name => 'issue3300'
      );
-CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.exact), metadata) WITH (key_field='id');
+CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.literal), metadata) WITH (key_field='id');
 CREATE TABLE allowed_categories
 (
     category TEXT PRIMARY KEY

--- a/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
@@ -4,7 +4,7 @@ CREATE TABLE tokenizer_fast (
     t text
 );
 INSERT INTO tokenizer_fast (t) VALUES ('This is a TEST');
-CREATE INDEX idxtokenizer_fast ON tokenizer_fast USING bm25 (id, (t::pdb.exact)) WITH (key_field = 'id');
+CREATE INDEX idxtokenizer_fast ON tokenizer_fast USING bm25 (id, (t::pdb.literal)) WITH (key_field = 'id');
 SELECT * FROM paradedb.schema('idxtokenizer_fast') ORDER BY name;
  name | field_type | stored | indexed | fast | fieldnorms | expand_dots |        tokenizer         | record | normalizer 
 ------+------------+--------+---------+------+------------+-------------+--------------------------+--------+------------

--- a/pg_search/tests/pg_regress/expected/tokenizer-indexed-expressions-require-tokenizer.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-indexed-expressions-require-tokenizer.out
@@ -19,7 +19,7 @@ CREATE INDEX idxexpr
     ON expr
         USING bm25 (
                     id,
-                    (lower(t)::pdb.exact)
+                    (lower(t)::pdb.literal)
             )
     WITH (key_field = 'id');
 SELECT * FROM paradedb.schema('idxexpr') ORDER BY name;

--- a/pg_search/tests/pg_regress/expected/tokenizer-invalid-lhs.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-invalid-lhs.out
@@ -7,7 +7,7 @@ INSERT INTO invalid_lhs (t) VALUES ('This is a TEST');
 CREATE INDEX idxinvalid_lhs ON invalid_lhs USING bm25 (
    id,
    t,
-   (t::pdb.exact('alias=exact')),
+   (t::pdb.literal('alias=literal')),
    (t::pdb.simple('alias=simple')),
    (t::pdb.ngram(2, 3, 'alias=ngram_2_3')),
    (t::pdb.ngram(3, 5, 'alias=ngram_3_5'))
@@ -22,7 +22,7 @@ SELECT * FROM invalid_lhs WHERE t::text @@@ 'this is a test';
 --
 -- all of these are invalid
 --
-SELECT * FROM invalid_lhs where (t::pdb.exact) @@@ 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) @@@ 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `@@@(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) @@@ 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `@@@(field, TEXT)` operator: `This is a TEST`
@@ -30,7 +30,7 @@ SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english'
 ERROR:  query is incompatible with pg_search's `@@@(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) @@@ 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `@@@(field, TEXT)` operator: `This is a TEST`
-SELECT * FROM invalid_lhs where (t::pdb.exact) &&& 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) &&& 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) &&& 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `This is a TEST`
@@ -38,7 +38,7 @@ SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english'
 ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) &&& 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `This is a TEST`
-SELECT * FROM invalid_lhs where (t::pdb.exact) ||| 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) ||| 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) ||| 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `This is a TEST`
@@ -46,7 +46,7 @@ SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english'
 ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) ||| 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `This is a TEST`
-SELECT * FROM invalid_lhs where (t::pdb.exact) ### 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) ### 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) ### 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `This is a TEST`
@@ -54,7 +54,7 @@ SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english'
 ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) ### 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `This is a TEST`
-SELECT * FROM invalid_lhs where (t::pdb.exact) === 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) === 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `===(field, TEXT)` operator: `This is a TEST`
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) === 'This is a TEST';
 ERROR:  query is incompatible with pg_search's `===(field, TEXT)` operator: `This is a TEST`

--- a/pg_search/tests/pg_regress/expected/tokenizer-query-using-alias.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-query-using-alias.out
@@ -13,7 +13,7 @@ ERROR:  `pdb.alias` is not allowed in index definitions
 CREATE INDEX idxuse_alias ON use_alias USING bm25 (
     id,
     t,
-    (t::pdb.exact('alias=exact')),
+    (t::pdb.literal('alias=literal')),
     (t::pdb.simple('alias=simple')),
     (t::pdb.ngram(2, 3, 'alias=ngram_2_3')),
     (t::pdb.ngram(3, 5, 'alias=ngram_3_5'))
@@ -30,16 +30,16 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHER
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"t","query_string":"this is a test","lenient":null,"conjunction_mode":null}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(exact) @@@ 'this is a test';
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(literal) @@@ 'this is a test';
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Custom Scan (ParadeDB Scan) on use_alias
          Table: use_alias
          Index: idxuse_alias
          Exec Method: NormalScanExecState
          Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"exact","query_string":"this is a test","lenient":null,"conjunction_mode":null}}}}
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"literal","query_string":"this is a test","lenient":null,"conjunction_mode":null}}}}
 (7 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(simple) @@@ 'this is a test';

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
@@ -11,7 +11,7 @@ CREATE INDEX idxtok_in_ci ON tok_in_ci USING bm25
      id,
      t,
      (t::pdb.chinese_compatible('alias=chinese_compatible')),
-     (t::pdb.exact('alias=exact')),
+     (t::pdb.literal('alias=literal')),
      (t::pdb.jieba('alias=jieba')),
      (t::pdb.lindera(chinese, 'alias=lindera_chinese')),
      (t::pdb.lindera(japanese, 'alias=lindera_japanese')),
@@ -29,12 +29,12 @@ SELECT * FROM paradedb.schema('idxtok_in_ci') ORDER BY name;
 --------------------+------------+--------+---------+------+------------+-------------+--------------------------------------------+----------+------------
  chinese_compatible | Str        | f      | t       | f    | t          |             | chinese_compatible                         | position | 
  ctid               | U64        | f      | t       | t    | f          |             |                                            |          | 
- exact              | Str        | f      | t       | t    | f          |             | keyword[lowercase=false]                   | basic    | raw
  id                 | I64        | f      | t       | t    | f          |             |                                            |          | 
  jieba              | Str        | f      | t       | f    | t          |             | jieba                                      | position | 
  lindera_chinese    | Str        | f      | t       | f    | t          |             | chinese_lindera                            | position | 
  lindera_japanese   | Str        | f      | t       | f    | t          |             | japanese_lindera                           | position | 
  lindera_korean     | Str        | f      | t       | f    | t          |             | korean_lindera                             | position | 
+ literal            | Str        | f      | t       | t    | f          |             | keyword[lowercase=false]                   | basic    | raw
  ngram              | Str        | f      | t       | f    | t          |             | ngram_mingram:3_maxgram:5_prefixonly:false | position | 
  regex              | Str        | f      | t       | f    | t          |             | regex                                      | position | 
  simple             | Str        | f      | t       | f    | t          |             | default                                    | position | 
@@ -176,16 +176,16 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"jieba","query_string":"test","lenient":null,"conjunction_mode":null}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) @@@ 'test';
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) @@@ 'test';
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Custom Scan (ParadeDB Scan) on tok_in_ci
          Table: tok_in_ci
          Index: idxtok_in_ci
          Exec Method: NormalScanExecState
          Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"exact","query_string":"test","lenient":null,"conjunction_mode":null}}}}
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"literal","query_string":"test","lenient":null,"conjunction_mode":null}}}}
 (7 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) @@@ 'test';
@@ -332,16 +332,16 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"match":{"field":"jieba","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) &&& 'test';
-                                                                                           QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) &&& 'test';
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Custom Scan (ParadeDB Scan) on tok_in_ci
          Table: tok_in_ci
          Index: idxtok_in_ci
          Exec Method: NormalScanExecState
          Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"exact","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"literal","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
 (7 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) &&& 'test';
@@ -488,16 +488,16 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"match":{"field":"jieba","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) ||| 'test';
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) ||| 'test';
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Custom Scan (ParadeDB Scan) on tok_in_ci
          Table: tok_in_ci
          Index: idxtok_in_ci
          Exec Method: NormalScanExecState
          Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"exact","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"literal","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (7 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) ||| 'test';
@@ -644,16 +644,16 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"term":{"field":"jieba","value":"test","is_datetime":false}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) === 'test';
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) === 'test';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Aggregate
    ->  Custom Scan (ParadeDB Scan) on tok_in_ci
          Table: tok_in_ci
          Index: idxtok_in_ci
          Exec Method: NormalScanExecState
          Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"exact","value":"test","is_datetime":false}}}}
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"literal","value":"test","is_datetime":false}}}}
 (7 rows)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) === 'test';

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-table.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-table.out
@@ -9,7 +9,7 @@ CREATE TABLE all_types
     text_col               text,
     varchar_col            varchar,
     chinese_compatible_col pdb.chinese_compatible,
-    exact_col              pdb.exact,
+    exact_col              pdb.literal,
     jieba_col              pdb.jieba,
     lindera_chinese_col    pdb.lindera(chinese),
     lindera_japanese_col   pdb.lindera(japanese),

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -4,7 +4,7 @@ SELECT 'this is a test.'::pdb.chinese_compatible::text[];
  {this,is,a,test}
 (1 row)
 
-SELECT 'this is a test.'::pdb.exact::text[];
+SELECT 'this is a test.'::pdb.literal::text[];
         text         
 ---------------------
  {"this is a test."}

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -34,20 +34,20 @@ SELECT 'Running Shoes.  olé'::pdb.whitespace('lowercase=false', 'stemmer=englis
  {Run,Shoes.,ole}
 (1 row)
 
-SELECT 'Running Shoes.  olé'::pdb.exact::text[];
+SELECT 'Running Shoes.  olé'::pdb.literal::text[];
           text           
 -------------------------
  {"Running Shoes.  olé"}
 (1 row)
 
-SELECT 'Running Shoes.  olé'::pdb.exact('alias=foo')::text[];  -- only option supported for exact
+SELECT 'Running Shoes.  olé'::pdb.literal('alias=foo')::text[];  -- only option supported for exact
           text           
 -------------------------
  {"Running Shoes.  olé"}
 (1 row)
 
-SELECT 'Running Shoes.  olé'::pdb.exact('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
-ERROR:  type modifier is not allowed for type "exact" at character 31
+SELECT 'Running Shoes.  olé'::pdb.literal('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
+ERROR:  type modifier is not allowed for type "literal" at character 31
 SELECT 'Running Shoes.  olé'::pdb.chinese_compatible::text[];
         text         
 ---------------------

--- a/pg_search/tests/pg_regress/expected/topn-lower-text.out
+++ b/pg_search/tests/pg_regress/expected/topn-lower-text.out
@@ -9,7 +9,7 @@ CALL paradedb.create_bm25_test_table(
   table_name => 'mock_items'
 );
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (lower(description)::pdb.exact), rating)
+USING bm25 (id, (lower(description)::pdb.literal), rating)
 WITH (key_field='id');
 -- This gets a TopN scan
 EXPLAIN SELECT description, rating FROM mock_items

--- a/pg_search/tests/pg_regress/sql/issue_3300.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3300.sql
@@ -5,7 +5,7 @@ CALL paradedb.create_bm25_test_table(
         table_name => 'issue3300'
      );
 
-CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.exact), metadata) WITH (key_field='id');
+CREATE INDEX idxissue3000 ON issue3300 USING bm25 (id, description, rating, (category::pdb.literal), metadata) WITH (key_field='id');
 
 CREATE TABLE allowed_categories
 (

--- a/pg_search/tests/pg_regress/sql/tokenizer-fast-field.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-fast-field.sql
@@ -6,7 +6,7 @@ CREATE TABLE tokenizer_fast (
 
 INSERT INTO tokenizer_fast (t) VALUES ('This is a TEST');
 
-CREATE INDEX idxtokenizer_fast ON tokenizer_fast USING bm25 (id, (t::pdb.exact)) WITH (key_field = 'id');
+CREATE INDEX idxtokenizer_fast ON tokenizer_fast USING bm25 (id, (t::pdb.literal)) WITH (key_field = 'id');
 
 SELECT * FROM paradedb.schema('idxtokenizer_fast') ORDER BY name;
 SELECT * FROM tokenizer_fast WHERE t &&& 'This is a TEST';

--- a/pg_search/tests/pg_regress/sql/tokenizer-indexed-expressions-require-tokenizer.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-indexed-expressions-require-tokenizer.sql
@@ -20,7 +20,7 @@ CREATE INDEX idxexpr
     ON expr
         USING bm25 (
                     id,
-                    (lower(t)::pdb.exact)
+                    (lower(t)::pdb.literal)
             )
     WITH (key_field = 'id');
 

--- a/pg_search/tests/pg_regress/sql/tokenizer-invalid-lhs.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-invalid-lhs.sql
@@ -9,7 +9,7 @@ INSERT INTO invalid_lhs (t) VALUES ('This is a TEST');
 CREATE INDEX idxinvalid_lhs ON invalid_lhs USING bm25 (
    id,
    t,
-   (t::pdb.exact('alias=exact')),
+   (t::pdb.literal('alias=literal')),
    (t::pdb.simple('alias=simple')),
    (t::pdb.ngram(2, 3, 'alias=ngram_2_3')),
    (t::pdb.ngram(3, 5, 'alias=ngram_3_5'))
@@ -21,27 +21,27 @@ SELECT * FROM invalid_lhs WHERE t::text @@@ 'this is a test';
 --
 -- all of these are invalid
 --
-SELECT * FROM invalid_lhs where (t::pdb.exact) @@@ 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) @@@ 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) @@@ 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english')) @@@ 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) @@@ 'This is a TEST';
 
-SELECT * FROM invalid_lhs where (t::pdb.exact) &&& 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) &&& 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) &&& 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english')) &&& 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) &&& 'This is a TEST';
 
-SELECT * FROM invalid_lhs where (t::pdb.exact) ||| 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) ||| 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) ||| 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english')) ||| 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) ||| 'This is a TEST';
 
-SELECT * FROM invalid_lhs where (t::pdb.exact) ### 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) ### 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) ### 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english')) ### 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) ### 'This is a TEST';
 
-SELECT * FROM invalid_lhs where (t::pdb.exact) === 'This is a TEST';
+SELECT * FROM invalid_lhs where (t::pdb.literal) === 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=oopsie')) === 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.simple('alias=simple', 'stemmer=english')) === 'This is a TEST';
 SELECT * FROM invalid_lhs where (t::pdb.ngram(3, 6)) === 'This is a TEST';

--- a/pg_search/tests/pg_regress/sql/tokenizer-query-using-alias.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-query-using-alias.sql
@@ -15,14 +15,14 @@ CREATE INDEX idxuse_alias ON use_alias USING bm25 (
 CREATE INDEX idxuse_alias ON use_alias USING bm25 (
     id,
     t,
-    (t::pdb.exact('alias=exact')),
+    (t::pdb.literal('alias=literal')),
     (t::pdb.simple('alias=simple')),
     (t::pdb.ngram(2, 3, 'alias=ngram_2_3')),
     (t::pdb.ngram(3, 5, 'alias=ngram_3_5'))
 ) WITH (key_field = 'id');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t @@@ 'this is a test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(exact) @@@ 'this is a test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(literal) @@@ 'this is a test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(simple) @@@ 'this is a test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(ngram_2_3) @@@ 'this is a test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM use_alias WHERE t::pdb.alias(ngram_3_5) @@@ 'this is a test';

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-index.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-index.sql
@@ -13,7 +13,7 @@ CREATE INDEX idxtok_in_ci ON tok_in_ci USING bm25
      id,
      t,
      (t::pdb.chinese_compatible('alias=chinese_compatible')),
-     (t::pdb.exact('alias=exact')),
+     (t::pdb.literal('alias=literal')),
      (t::pdb.jieba('alias=jieba')),
      (t::pdb.lindera(chinese, 'alias=lindera_chinese')),
      (t::pdb.lindera(japanese, 'alias=lindera_japanese')),
@@ -40,7 +40,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(chinese, 'alias=lindera_chinese')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.jieba('alias=jieba')) @@@ 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) @@@ 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) @@@ 'test';
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE t &&& 'test';
@@ -54,7 +54,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(chinese, 'alias=lindera_chinese')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.jieba('alias=jieba')) &&& 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) &&& 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) &&& 'test';
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE t ||| 'test';
@@ -68,7 +68,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(chinese, 'alias=lindera_chinese')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.jieba('alias=jieba')) ||| 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) ||| 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) ||| 'test';
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE t === 'test';
@@ -82,6 +82,6 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(chinese, 'alias=lindera_chinese')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.jieba('alias=jieba')) === 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.exact('alias=exact')) === 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.literal('alias=literal')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.source_code('alias=source_code')) === 'test';
 

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-table.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-table.sql
@@ -10,7 +10,7 @@ CREATE TABLE all_types
     text_col               text,
     varchar_col            varchar,
     chinese_compatible_col pdb.chinese_compatible,
-    exact_col              pdb.exact,
+    exact_col              pdb.literal,
     jieba_col              pdb.jieba,
     lindera_chinese_col    pdb.lindera(chinese),
     lindera_japanese_col   pdb.lindera(japanese),

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
@@ -1,5 +1,5 @@
 SELECT 'this is a test.'::pdb.chinese_compatible::text[];
-SELECT 'this is a test.'::pdb.exact::text[];
+SELECT 'this is a test.'::pdb.literal::text[];
 SELECT 'this is a test.'::pdb.jieba::text[];
 SELECT 'this is a test.'::pdb.lindera(chinese)::text[];
 SELECT 'this is a test.'::pdb.lindera(japanese)::text[];

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
@@ -6,9 +6,9 @@ SELECT 'Running Shoes.  olé'::pdb.whitespace::text[];
 SELECT 'Running Shoes.  olé'::pdb.whitespace('lowercase=false')::text[];
 SELECT 'Running Shoes.  olé'::pdb.whitespace('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
 
-SELECT 'Running Shoes.  olé'::pdb.exact::text[];
-SELECT 'Running Shoes.  olé'::pdb.exact('alias=foo')::text[];  -- only option supported for exact
-SELECT 'Running Shoes.  olé'::pdb.exact('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
+SELECT 'Running Shoes.  olé'::pdb.literal::text[];
+SELECT 'Running Shoes.  olé'::pdb.literal('alias=foo')::text[];  -- only option supported for exact
+SELECT 'Running Shoes.  olé'::pdb.literal('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
 
 SELECT 'Running Shoes.  olé'::pdb.chinese_compatible::text[];
 SELECT 'Running Shoes.  olé'::pdb.chinese_compatible('lowercase=false')::text[];

--- a/pg_search/tests/pg_regress/sql/topn-lower-text.sql
+++ b/pg_search/tests/pg_regress/sql/topn-lower-text.sql
@@ -6,7 +6,7 @@ CALL paradedb.create_bm25_test_table(
 );
 
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (lower(description)::pdb.exact), rating)
+USING bm25 (id, (lower(description)::pdb.literal), rating)
 WITH (key_field='id');
 
 -- This gets a TopN scan


### PR DESCRIPTION
## What

Renames the new `pdb.exact` tokenizer to `pdb.literal`.

## Why

I think `literal` makes a lot more sense and is a generally more common way to describe a static value and this is our only opportunity to change it before we release.

## How

The power of search and replace

## Tests

A number of regression tests and their outputs needed to be adjusted