### PR TITLE
chore: Temporarily disable compound sorts in proptests.

### DIFF
--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -376,7 +376,9 @@ async fn generated_paging_small(database: Db) {
 
     proptest!(|(
         where_expr in arb_wheres(vec![table_name], &columns_named(vec!["name"])),
-        paging_exprs in arb_paging_exprs(table_name, vec!["name", "color", "age", "quantity"], vec!["id", "uuid"]),
+        // TODO: Compound top-n occasionally flakes, so we only use tiebreaker columns.
+        // See https://github.com/paradedb/paradedb/issues/3266.
+        paging_exprs in arb_paging_exprs(table_name, vec![], vec!["id", "uuid"]),
         gucs in any::<PgGucs>(),
     )| {
         compare(
@@ -459,7 +461,9 @@ async fn generated_subquery(database: Db) {
             COLUMNS,
         ),
         subquery_column in proptest::sample::select(&["name", "color", "age"]),
-        paging_exprs in arb_paging_exprs(inner_table_name, vec!["name", "color", "age"], vec!["id", "uuid"]),
+        // TODO: Compound top-n occasionally flakes, so we only use tiebreaker columns.
+        // See https://github.com/paradedb/paradedb/issues/3266.
+        paging_exprs in arb_paging_exprs(inner_table_name, vec![], vec!["id", "uuid"]),
         gucs in any::<PgGucs>(),
     )| {
         let pg = format!(


### PR DESCRIPTION
See https://github.com/paradedb/paradedb/issues/3266.