### PR TITLE
chore: move the `more_like_this` functions to the `pdb` schema

### DIFF
--- a/docs/documentation/advanced/specialized/more_like_this.mdx
+++ b/docs/documentation/advanced/specialized/more_like_this.mdx
@@ -18,7 +18,7 @@ All other parameters are compatible with both `document_id` and `document_fields
 -- document_id
 SELECT description, rating, category
 FROM mock_items
-WHERE id @@@ paradedb.more_like_this(
+WHERE id @@@ pdb.more_like_this(
   document_id => 3,
   min_term_frequency => 1
 );
@@ -26,7 +26,7 @@ WHERE id @@@ paradedb.more_like_this(
 -- document_fields
 SELECT description, rating, category
 FROM mock_items
-WHERE id @@@ paradedb.more_like_this(
+WHERE id @@@ pdb.more_like_this(
 document_fields => '{"description": "shoes"}',
 min_doc_frequency => 0,
 max_doc_frequency => 100,

--- a/pg_search/sql/pg_search--0.18.11--0.19.0.sql
+++ b/pg_search/sql/pg_search--0.18.11--0.19.0.sql
@@ -1700,3 +1700,10 @@ CREATE CAST (text[] AS pdb.const) WITH FUNCTION text_array_to_const(text[], inte
 CREATE CAST (pdb.query AS pdb.const) WITH FUNCTION query_to_const(pdb.query, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pdb.proximityclause AS pdb.const) WITH FUNCTION prox_to_const(pdb.proximityclause, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pdb.const AS pdb.const) WITH FUNCTION const_to_const(pdb.const, integer, boolean) AS IMPLICIT;
+
+--
+-- move the more_like_this functions over to the pdb schema
+--
+ALTER FUNCTION paradedb."more_like_this"() SET SCHEMA pdb;
+ALTER FUNCTION paradedb."more_like_this"(TEXT,INT, INT, INT, INT, INT, INT, real, TEXT[]) SET SCHEMA pdb;
+ALTER FUNCTION paradedb."more_like_this"(anyelement, INT, INT, INT, INT, INT, INT, real, TEXT[] ) SET SCHEMA pdb;

--- a/pg_search/src/api/builder_fns/mlt.rs
+++ b/pg_search/src/api/builder_fns/mlt.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/// Contains our various "more_like_this" functions which live in the `pdb` schema.
+#[pgrx::pg_schema]
+mod pdb {
+    use crate::api::HashMap;
+    use crate::postgres::types::TantivyValue;
+    use crate::query::SearchQueryInput;
+    use pgrx::{default, pg_extern, AnyElement, PgOid};
+
+    #[pg_extern(name = "more_like_this", immutable, parallel_safe)]
+    pub fn more_like_this_empty() -> SearchQueryInput {
+        panic!("more_like_this must be called with either document_id or document_fields");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[pg_extern(name = "more_like_this", immutable, parallel_safe)]
+    pub fn more_like_this_fields(
+        document_fields: String,
+        min_doc_frequency: default!(Option<i32>, "NULL"),
+        max_doc_frequency: default!(Option<i32>, "NULL"),
+        min_term_frequency: default!(Option<i32>, "NULL"),
+        max_query_terms: default!(Option<i32>, "NULL"),
+        min_word_length: default!(Option<i32>, "NULL"),
+        max_word_length: default!(Option<i32>, "NULL"),
+        boost_factor: default!(Option<f32>, "NULL"),
+        stop_words: default!(Option<Vec<String>>, "NULL"),
+    ) -> SearchQueryInput {
+        let document_fields: HashMap<String, tantivy::schema::OwnedValue> =
+            json5::from_str(&document_fields).expect("could not parse document_fields");
+
+        SearchQueryInput::MoreLikeThis {
+            min_doc_frequency: min_doc_frequency.map(|n| n as u64),
+            max_doc_frequency: max_doc_frequency.map(|n| n as u64),
+            min_term_frequency: min_term_frequency.map(|n| n as usize),
+            max_query_terms: max_query_terms.map(|n| n as usize),
+            min_word_length: min_word_length.map(|n| n as usize),
+            max_word_length: max_word_length.map(|n| n as usize),
+            boost_factor,
+            stop_words,
+            document_fields: Some(document_fields.into_iter().collect()),
+            document_id: None,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[pg_extern(name = "more_like_this", immutable, parallel_safe)]
+    pub fn more_like_this_id(
+        document_id: AnyElement,
+        min_doc_frequency: default!(Option<i32>, "NULL"),
+        max_doc_frequency: default!(Option<i32>, "NULL"),
+        min_term_frequency: default!(Option<i32>, "NULL"),
+        max_query_terms: default!(Option<i32>, "NULL"),
+        min_word_length: default!(Option<i32>, "NULL"),
+        max_word_length: default!(Option<i32>, "NULL"),
+        boost_factor: default!(Option<f32>, "NULL"),
+        stop_words: default!(Option<Vec<String>>, "NULL"),
+    ) -> SearchQueryInput {
+        SearchQueryInput::MoreLikeThis {
+            min_doc_frequency: min_doc_frequency.map(|n| n as u64),
+            max_doc_frequency: max_doc_frequency.map(|n| n as u64),
+            min_term_frequency: min_term_frequency.map(|n| n as usize),
+            max_query_terms: max_query_terms.map(|n| n as usize),
+            min_word_length: min_word_length.map(|n| n as usize),
+            max_word_length: max_word_length.map(|n| n as usize),
+            boost_factor,
+            stop_words,
+            document_fields: None,
+            document_id: unsafe {
+                Some(
+                    TantivyValue::try_from_datum(
+                        document_id.datum(),
+                        PgOid::from_untagged(document_id.oid()),
+                    )
+                    .unwrap_or_else(|err| {
+                        panic!("could not read more_like_this document_id: {err}")
+                    })
+                    .0,
+                )
+            },
+        }
+    }
+}

--- a/pg_search/src/api/builder_fns/mod.rs
+++ b/pg_search/src/api/builder_fns/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod mlt;
 mod paradedb;
 mod pdb;
 mod proximity;

--- a/tests/tests/bm25_search.rs
+++ b/tests/tests/bm25_search.rs
@@ -1522,7 +1522,7 @@ fn more_like_this_with_alias(mut conn: PgConnection) {
     // Test more_like_this with aliased field 'taste' (original 'flavour')
     let rows: Vec<(i32, String, String)> = r#"
     SELECT id, flavour, description FROM test_more_like_this_alias
-    WHERE id @@@ paradedb.more_like_this(
+    WHERE id @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"taste": "banana"}'

--- a/tests/tests/documentation.rs
+++ b/tests/tests/documentation.rs
@@ -1797,7 +1797,7 @@ fn specialized_queries(mut conn: PgConnection) {
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
     FROM mock_items
-    WHERE id @@@ paradedb.more_like_this(
+    WHERE id @@@ pdb.more_like_this(
       document_id => 3,
       min_term_frequency => 1
     );
@@ -1808,7 +1808,7 @@ fn specialized_queries(mut conn: PgConnection) {
     let rows: Vec<(String, i32, String)> = r#"
     SELECT description, rating, category
     FROM mock_items
-    WHERE id @@@ paradedb.more_like_this(
+    WHERE id @@@ pdb.more_like_this(
       document_fields => '{"description": "shoes"}',
       min_doc_frequency => 0,
       max_doc_frequency => 100,

--- a/tests/tests/mlt.rs
+++ b/tests/tests/mlt.rs
@@ -27,7 +27,7 @@ fn mlt_enables_scoring_issue1747(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
 
     let (id,) = "
-    SELECT id FROM paradedb.bm25_search WHERE id @@@ paradedb.more_like_this(
+    SELECT id FROM paradedb.bm25_search WHERE id @@@ pdb.more_like_this(
         document_id => 3,
         min_term_frequency => 1
     ) ORDER BY id LIMIT 1"
@@ -44,7 +44,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     SELECT * FROM paradedb.bm25_search
     WHERE id @@@ 
     paradedb.boolean(
-        must => paradedb.more_like_this(
+        must => pdb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
             document_fields => '{"description": "keyboard"}'
@@ -60,7 +60,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     SELECT * FROM paradedb.bm25_search
     WHERE id @@@ 
     paradedb.boolean(
-        must_not => paradedb.more_like_this(
+        must_not => pdb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
             document_fields => '{"description": "keyboard"}'
@@ -76,7 +76,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     SELECT * FROM paradedb.bm25_search
     WHERE id @@@ 
     paradedb.boolean(
-        should => paradedb.more_like_this(
+        should => pdb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
             document_fields => '{"description": "keyboard"}'
@@ -93,7 +93,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     WHERE id @@@ 
     paradedb.boost(
         factor => 1.5,
-        query => paradedb.more_like_this(
+        query => pdb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
             document_fields => '{"description": "keyboard"}'
@@ -110,7 +110,7 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     WHERE id @@@ 
     paradedb.const_score(
         score => 5,
-        query => paradedb.more_like_this(
+        query => pdb.more_like_this(
             min_doc_frequency => 2,
             min_term_frequency => 1,
             document_fields => '{"description": "keyboard"}'
@@ -127,12 +127,12 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
     WHERE id @@@ 
     paradedb.disjunction_max(
         disjuncts => ARRAY[
-            paradedb.more_like_this(
+            pdb.more_like_this(
                 min_doc_frequency => 2,
                 min_term_frequency => 1,
                 document_fields => '{"description": "keyboard"}'
             ), 
-            paradedb.more_like_this(
+            pdb.more_like_this(
                 min_doc_frequency => 2,
                 min_term_frequency => 1,
                 document_fields => '{"description": "shoes"}'
@@ -154,13 +154,13 @@ fn mlt_scoring_nested(mut conn: PgConnection) {
             disjuncts => ARRAY[
                 paradedb.boost(
                     factor => 3,
-                    query => paradedb.more_like_this(
+                    query => pdb.more_like_this(
                         min_doc_frequency => 2,
                         min_term_frequency => 1,
                         document_fields => '{"description": "keyboard"}'
                     ) 
                 ),
-                paradedb.more_like_this(
+                pdb.more_like_this(
                     min_doc_frequency => 2,
                     min_term_frequency => 1,
                     document_fields => '{"description": "shoes"}'

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -385,7 +385,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     match r#"
     SELECT id, flavour FROM test_more_like_this_table WHERE test_more_like_this_table @@@
-        paradedb.more_like_this();
+        pdb.more_like_this();
     "#
     .fetch_result::<()>(&mut conn)
     {
@@ -399,7 +399,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -410,7 +410,7 @@ fn more_like_this_raw(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_id => 2
@@ -444,7 +444,7 @@ fn more_like_this_empty(mut conn: PgConnection) {
 
     match r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this()
+    WHERE test_more_like_this_table @@@ pdb.more_like_this()
     ORDER BY id;
     "#
     .fetch_result::<()>(&mut conn)
@@ -482,7 +482,7 @@ fn more_like_this_text(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -515,7 +515,7 @@ fn more_like_this_boolean_key(mut conn: PgConnection) {
     let rows: Vec<(bool, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
        min_doc_frequency => 0,
        min_term_frequency => 0,
        document_fields => '{"flavour": "banana"}'
@@ -549,7 +549,7 @@ fn more_like_this_uuid_key(mut conn: PgConnection) {
 
     let rows: Vec<(uuid::Uuid, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -584,7 +584,7 @@ fn more_like_this_i64_key(mut conn: PgConnection) {
     let rows: Vec<(i64, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -618,7 +618,7 @@ fn more_like_this_i32_key(mut conn: PgConnection) {
 
     let rows: Vec<(i32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -652,7 +652,7 @@ fn more_like_this_literal_cast(mut conn: PgConnection) {
 
     let rows: Vec<(i32, i32)> = r#"
     SELECT id, year FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"year": 2012}'
@@ -686,7 +686,7 @@ fn more_like_this_i16_key(mut conn: PgConnection) {
 
     let rows: Vec<(i16, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -720,7 +720,7 @@ fn more_like_this_f32_key(mut conn: PgConnection) {
 
     let rows: Vec<(f32, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -754,7 +754,7 @@ fn more_like_this_f64_key(mut conn: PgConnection) {
     let rows: Vec<(f64, String)> = r#"
     SELECT id, flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -788,7 +788,7 @@ fn more_like_this_numeric_key(mut conn: PgConnection) {
 
     let rows: Vec<(f64, String)> = r#"
     SELECT CAST(id AS FLOAT8), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -821,7 +821,7 @@ fn more_like_this_date_key(mut conn: PgConnection) {
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@  paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@  pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -856,7 +856,7 @@ fn more_like_this_time_key(mut conn: PgConnection) {
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -891,7 +891,7 @@ fn more_like_this_timestamp_key(mut conn: PgConnection) {
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -926,7 +926,7 @@ fn more_like_this_timestamptz_key(mut conn: PgConnection) {
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
     WHERE test_more_like_this_table @@@
-    paradedb.more_like_this(
+    pdb.more_like_this(
         min_doc_frequency => 0,
         min_term_frequency => 0,
         document_fields => '{"flavour": "banana"}'
@@ -959,7 +959,7 @@ fn more_like_this_timetz_key(mut conn: PgConnection) {
 
     let rows: Vec<(String, String)> = r#"
     SELECT CAST(id AS TEXT), flavour FROM test_more_like_this_table
-    WHERE test_more_like_this_table @@@ paradedb.more_like_this(
+    WHERE test_more_like_this_table @@@ pdb.more_like_this(
             min_doc_frequency => 0,
             min_term_frequency => 0,
             document_fields => '{"flavour": "banana"}'


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #3301

## What

Move the various `more_like_this` functions over to the `pdb` schema.

## Why

@rebasedming told me to

## Tests

Tests updated