### PR TITLE
chore: rename the new `pdb.regex` tokenizer to `pdb.regex_pattern`

### DIFF
--- a/docs/v2/tokenizers/available_tokenizers/regex.mdx
+++ b/docs/v2/tokenizers/available_tokenizers/regex.mdx
@@ -1,13 +1,13 @@
 ---
-title: Regex
+title: Regex Patterns
 ---
 
-The regex tokenizer tokenizes text using a regular expression. The regular expression can be specified with the pattern parameter.
+The `regex_pattern` tokenizer tokenizes text using a regular expression. The regular expression can be specified with the pattern parameter.
 For instance, the following tokenizer creates tokens only for words starting with the letter `h`:
 
 ```sql
 CREATE INDEX search_idx ON mock_items
-USING bm25 (id, (description::pdb.regex('(?i)\bh\w*')))
+USING bm25 (id, (description::pdb.regex_pattern('(?i)\bh\w*')))
 WITH (key_field='id');
 ```
 
@@ -20,7 +20,7 @@ exceptions:
 To get a feel for this tokenizer, run the following command and replace the text with your own:
 
 ```sql
-SELECT 'Hello world!'::pdb.regex('(?i)\bh\w*')::text[];
+SELECT 'Hello world!'::pdb.regex_pattern('(?i)\bh\w*')::text[];
 ```
 
 ```ini Expected Response

--- a/pg_search/sql/pg_search--0.18.11--0.19.0.sql
+++ b/pg_search/sql/pg_search--0.18.11--0.19.0.sql
@@ -759,12 +759,12 @@ ALTER TYPE pdb.jieba SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_ty
 --   Type(pg_search::api::tokenizers::definitions::pdb::Regex)
 
 
-CREATE TYPE pdb.regex;
-CREATE OR REPLACE FUNCTION pdb.regex_in(cstring) RETURNS pdb.regex AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.regex_out(pdb.regex) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.regex_send(pdb.regex) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
-CREATE OR REPLACE FUNCTION pdb.regex_recv(internal) RETURNS pdb.regex AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
-CREATE TYPE pdb.regex (
+CREATE TYPE pdb.regex_pattern;
+CREATE OR REPLACE FUNCTION pdb.regex_in(cstring) RETURNS pdb.regex_pattern AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.regex_out(pdb.regex_pattern) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.regex_send(pdb.regex_pattern) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.regex_recv(internal) RETURNS pdb.regex_pattern AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
+CREATE TYPE pdb.regex_pattern (
                           INPUT = pdb.regex_in,
                           OUTPUT = pdb.regex_out,
                           SEND = pdb.regex_send,
@@ -783,7 +783,7 @@ CREATE TYPE pdb.regex (
 --   generic_typmod_out
 --   regex_definition
 
-ALTER TYPE pdb.regex SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
+ALTER TYPE pdb.regex_pattern SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -863,7 +863,7 @@ AS 'MODULE_PATHNAME', 'json_to_simple_wrapper';
 -- pg_search/src/api/tokenizers/definitions.rs:297
 -- pg_search::api::tokenizers::definitions::pdb::tokenize_regex
 CREATE  FUNCTION pdb."tokenize_regex"(
-    "s" pdb.regex /* pg_search::api::tokenizers::definitions::pdb::Regex */
+    "s" pdb.regex_pattern /* pg_search::api::tokenizers::definitions::pdb::Regex */
 ) RETURNS TEXT[] /* alloc::vec::Vec<alloc::string::String> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
@@ -876,7 +876,7 @@ AS 'MODULE_PATHNAME', 'tokenize_regex_wrapper';
 --   regex_definition
 --   tokenize_regex
 
-CREATE CAST (pdb.regex AS TEXT[]) WITH FUNCTION pdb.tokenize_regex AS IMPLICIT;
+CREATE CAST (pdb.regex_pattern AS TEXT[]) WITH FUNCTION pdb.tokenize_regex AS IMPLICIT;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -886,7 +886,7 @@ CREATE CAST (pdb.regex AS TEXT[]) WITH FUNCTION pdb.tokenize_regex AS IMPLICIT;
 --   tokenize_regex
 CREATE  FUNCTION pdb."json_to_regex"(
     "json" json /* pg_search::api::tokenizers::GenericTypeWrapper<pgrx::datum::json::Json> */
-) RETURNS pdb.regex /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Regex> */
+) RETURNS pdb.regex_pattern /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Regex> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'json_to_regex_wrapper';
@@ -1053,7 +1053,7 @@ CREATE CAST (jsonb AS pdb.literal) WITH FUNCTION pdb.jsonb_to_literal AS ASSIGNM
 --   tokenize_regex
 CREATE  FUNCTION pdb."jsonb_to_regex"(
     "jsonb" jsonb /* pg_search::api::tokenizers::GenericTypeWrapper<pgrx::datum::json::JsonB> */
-) RETURNS pdb.regex /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Regex> */
+) RETURNS pdb.regex_pattern /* pg_search::api::tokenizers::GenericTypeWrapper<pg_search::api::tokenizers::definitions::pdb::Regex> */
     IMMUTABLE STRICT PARALLEL SAFE
     LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'jsonb_to_regex_wrapper';
@@ -1067,8 +1067,8 @@ AS 'MODULE_PATHNAME', 'jsonb_to_regex_wrapper';
 --   jsonb_to_regex
 
 
-CREATE CAST (json AS pdb.regex) WITH FUNCTION pdb.json_to_regex AS ASSIGNMENT;
-CREATE CAST (jsonb AS pdb.regex) WITH FUNCTION pdb.jsonb_to_regex AS ASSIGNMENT;
+CREATE CAST (json AS pdb.regex_pattern) WITH FUNCTION pdb.json_to_regex AS ASSIGNMENT;
+CREATE CAST (jsonb AS pdb.regex_pattern) WITH FUNCTION pdb.jsonb_to_regex AS ASSIGNMENT;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -314,7 +314,7 @@ pub(crate) mod pdb {
         tokenize_regex,
         json_to_regex,
         jsonb_to_regex,
-        "regex",
+        "regex_pattern",
         preferred = false,
         custom_typmod = false
     );

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -81,7 +81,7 @@ pub fn search_field_config_from_type(
         "chinese_compatible" => {
             SearchTokenizer::ChineseCompatible(SearchTokenizerFilters::default())
         }
-        "regex" => SearchTokenizer::RegexTokenizer {
+        "regex_pattern" => SearchTokenizer::RegexTokenizer {
             pattern: "".to_string(),
             filters: Default::default(),
         },

--- a/pg_search/tests/pg_regress/expected/regex.out
+++ b/pg_search/tests/pg_regress/expected/regex.out
@@ -1,0 +1,25 @@
+-- ensure a cast to `::pdb.regex` works to tokenize using a regular expression
+SELECT 'ooh lala'::pdb.regex_pattern('oo|a')::text[];
+   text   
+----------
+ {oo,a,a}
+(1 row)
+
+-- test the `pdb.regex_term` function.  This function was once called `pdb.regex` but it ended up being ambiguous
+-- with the tokenizer type `::pdb.regex`, so the function has been renamed to `pdb.regex_term`
+SELECT * FROM regress.mock_items WHERE description @@@ pdb.regex('sh.es') ORDER BY id;
+ id |     description     | rating | category | in_stock |                    metadata                     |        created_at        | last_updated_date | latest_available_time | weight_range |                 sku                  
+----+---------------------+--------+----------+----------+-------------------------------------------------+--------------------------+-------------------+-----------------------+--------------+--------------------------------------
+  3 | Sleek running shoes |      5 | Footwear | t        | {"color": "Blue", "location": "China"}          | Fri Apr 28 10:55:43 2023 | 04-29-2023        | 10:55:43              | [2,10)       | da2fea21-0003-411b-9e8c-2cb64e471293
+  4 | White jogging shoes |      3 | Footwear | f        | {"color": "White", "location": "United States"} | Thu Apr 20 16:38:02 2023 | 04-22-2023        | 16:38:02              | (,11)        | da2fea21-0004-411b-9e8c-2cb64e471293
+  5 | Generic shoes       |      4 | Footwear | t        | {"color": "Brown", "location": "Canada"}        | Tue May 02 08:45:11 2023 | 05-03-2023        | 08:45:11              | [3,)         | da2fea21-0005-411b-9e8c-2cb64e471293
+(3 rows)
+
+SELECT paradedb.score(id), * FROM regress.mock_items WHERE description @@@ pdb.regex('sh.es')::pdb.const(42) ORDER BY id;
+ score | id |     description     | rating | category | in_stock |                    metadata                     |        created_at        | last_updated_date | latest_available_time | weight_range |                 sku                  
+-------+----+---------------------+--------+----------+----------+-------------------------------------------------+--------------------------+-------------------+-----------------------+--------------+--------------------------------------
+    42 |  3 | Sleek running shoes |      5 | Footwear | t        | {"color": "Blue", "location": "China"}          | Fri Apr 28 10:55:43 2023 | 04-29-2023        | 10:55:43              | [2,10)       | da2fea21-0003-411b-9e8c-2cb64e471293
+    42 |  4 | White jogging shoes |      3 | Footwear | f        | {"color": "White", "location": "United States"} | Thu Apr 20 16:38:02 2023 | 04-22-2023        | 16:38:02              | (,11)        | da2fea21-0004-411b-9e8c-2cb64e471293
+    42 |  5 | Generic shoes       |      4 | Footwear | t        | {"color": "Brown", "location": "Canada"}        | Tue May 02 08:45:11 2023 | 05-03-2023        | 08:45:11              | [3,)         | da2fea21-0005-411b-9e8c-2cb64e471293
+(3 rows)
+

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
@@ -17,7 +17,7 @@ CREATE INDEX idxtok_in_ci ON tok_in_ci USING bm25
      (t::pdb.lindera(japanese, 'alias=lindera_japanese')),
      (t::pdb.lindera(korean, 'alias=lindera_korean')),
      (t::pdb.ngram(3, 5, 'alias=ngram')),
-     (t::pdb.regex('is|a', 'alias=regex')),
+     (t::pdb.regex_pattern('is|a', 'alias=regex')),
      (t::pdb.simple('alias=simple')),
      (t::pdb.simple('stemmer=english', 'alias=stemmed')),
      (t::pdb.whitespace('alias=whitespace')),
@@ -104,7 +104,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"simple","query_string":"test","lenient":null,"conjunction_mode":null}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) @@@ 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) @@@ 'test';
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -260,7 +260,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"match":{"field":"simple","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) &&& 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) &&& 'test';
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -416,7 +416,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"match":{"field":"simple","value":"test","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) ||| 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) ||| 'test';
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -572,7 +572,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
          Tantivy Query: {"with_index":{"query":{"term":{"field":"simple","value":"test","is_datetime":false}}}}
 (7 rows)
 
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) === 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) === 'test';
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Aggregate

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-table.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-table.out
@@ -21,464 +21,175 @@ CREATE TABLE all_types
     whitespace_col         pdb.whitespace,
     source_code_col        pdb.source_code
 );
+ERROR:  type "pdb.regex" does not exist at character 499
 INSERT INTO all_types(text_col, varchar_col, chinese_compatible_col, exact_col, jieba_col, lindera_chinese_col,
                       lindera_japanese_col, lindera_korean_col,
                       ngram_col, regex_col, simple_col, stemmed_en_col, whitespace_col, source_code_col)
 VALUES ('hello world', 'hello world', 'hello world', 'hello world', 'hello world', 'hello world',
         'hello world', 'hello world', 'hello world', 'hello world', 'hello world', 'hello world',
         'hello world', 'hello world');
+ERROR:  relation "all_types" does not exist at character 13
 CREATE INDEX idxall_types ON all_types USING bm25 (id, text_col, varchar_col, chinese_compatible_col, exact_col,
                                                    jieba_col, lindera_chinese_col,
                                                    lindera_japanese_col, lindera_korean_col,
                                                    ngram_col, regex_col, simple_col, stemmed_en_col,
                                                    whitespace_col, source_code_col) WITH (key_field = 'id');
+ERROR:  relation "all_types" does not exist
 SELECT * FROM all_types WHERE text_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE text_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE text_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE text_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE text_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE varchar_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE varchar_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE varchar_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE varchar_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE varchar_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE chinese_compatible_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE chinese_compatible_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE chinese_compatible_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE chinese_compatible_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE chinese_compatible_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col @@@ 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col &&& 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col ||| 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col === 'hello';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col @@@ 'hello world';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col &&& 'hello world';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col ||| 'hello world';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE exact_col === 'hello world';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE jieba_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE jieba_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE jieba_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE jieba_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE jieba_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_chinese_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_chinese_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_chinese_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_chinese_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_chinese_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_japanese_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_japanese_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_japanese_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_japanese_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_japanese_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE lindera_korean_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE ngram_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE ngram_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE ngram_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE ngram_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE ngram_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE regex_col @@@ 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE regex_col &&& 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE regex_col ||| 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE regex_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE regex_col === 'hello';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE simple_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE simple_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE simple_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE simple_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE simple_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE stemmed_en_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE stemmed_en_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE stemmed_en_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE stemmed_en_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE stemmed_en_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE whitespace_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE whitespace_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE whitespace_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE whitespace_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE whitespace_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE source_code_col @@@ 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE source_code_col &&& 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE source_code_col ||| 'HELLO';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE source_code_col === 'HELLO';
- id | text_col | varchar_col | chinese_compatible_col | exact_col | jieba_col | lindera_chinese_col | lindera_japanese_col | lindera_korean_col | ngram_col | regex_col | simple_col | stemmed_en_col | whitespace_col | source_code_col 
-----+----------+-------------+------------------------+-----------+-----------+---------------------+----------------------+--------------------+-----------+-----------+------------+----------------+----------------+-----------------
-(0 rows)
-
+ERROR:  relation "all_types" does not exist at character 15
 SELECT * FROM all_types WHERE source_code_col === 'hello';
- id |  text_col   | varchar_col | chinese_compatible_col |  exact_col  |  jieba_col  | lindera_chinese_col | lindera_japanese_col | lindera_korean_col |  ngram_col  |  regex_col  | simple_col  | stemmed_en_col | whitespace_col | source_code_col 
-----+-------------+-------------+------------------------+-------------+-------------+---------------------+----------------------+--------------------+-------------+-------------+-------------+----------------+----------------+-----------------
-  1 | hello world | hello world | hello world            | hello world | hello world | hello world         | hello world          | hello world        | hello world | hello world | hello world | hello world    | hello world    | hello world
-(1 row)
-
+ERROR:  relation "all_types" does not exist at character 15

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -40,7 +40,7 @@ SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
  {thi,this,"this ",his,"his ","his i","is ","is i","is is","s i","s is","s is "," is"," is "," is a","is ","is a","is a ","s a","s a ","s a t"," a "," a t"," a te","a t","a te","a tes"," te"," tes"," test",tes,test,test.,est,est.,st.}
 (1 row)
 
-SELECT 'this is a test.'::pdb.regex('is|a')::text[];
+SELECT 'this is a test.'::pdb.regex_pattern('is|a')::text[];
    text    
 -----------
  {is,is,a}

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -295,15 +295,15 @@ SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=english', 'lowercase=false', 
  {Run,Shoe,ole}
 (1 row)
 
-SELECT 'Running Shoes.  olé'::pdb.regex::text[]; -- error, needs a regular expression
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern::text[]; -- error, needs a regular expression
 ERROR:  typmod lookup should not fail: MissingKey("pattern")
-SELECT 'Running Shoes.  olé'::pdb.regex('ing|oes')::text[];
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern('ing|oes')::text[];
    text    
 -----------
  {ing,oes}
 (1 row)
 
-SELECT 'Running Shoes.  olé'::pdb.regex('ing|oes', 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern('ing|oes', 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
    text   
 ----------
  {ing,oe}

--- a/pg_search/tests/pg_regress/sql/regex.sql
+++ b/pg_search/tests/pg_regress/sql/regex.sql
@@ -1,0 +1,8 @@
+-- ensure a cast to `::pdb.regex` works to tokenize using a regular expression
+SELECT 'ooh lala'::pdb.regex_pattern('oo|a')::text[];
+
+
+-- test the `pdb.regex_term` function.  This function was once called `pdb.regex` but it ended up being ambiguous
+-- with the tokenizer type `::pdb.regex`, so the function has been renamed to `pdb.regex_term`
+SELECT * FROM regress.mock_items WHERE description @@@ pdb.regex('sh.es') ORDER BY id;
+SELECT paradedb.score(id), * FROM regress.mock_items WHERE description @@@ pdb.regex('sh.es')::pdb.const(42) ORDER BY id;

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-index.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-in-create-index.sql
@@ -19,7 +19,7 @@ CREATE INDEX idxtok_in_ci ON tok_in_ci USING bm25
      (t::pdb.lindera(japanese, 'alias=lindera_japanese')),
      (t::pdb.lindera(korean, 'alias=lindera_korean')),
      (t::pdb.ngram(3, 5, 'alias=ngram')),
-     (t::pdb.regex('is|a', 'alias=regex')),
+     (t::pdb.regex_pattern('is|a', 'alias=regex')),
      (t::pdb.simple('alias=simple')),
      (t::pdb.simple('stemmer=english', 'alias=stemmed')),
      (t::pdb.whitespace('alias=whitespace')),
@@ -34,7 +34,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.whitespace('alias=whitespace')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('stemmer=english', 'alias=stemmed')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('alias=simple')) @@@ 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) @@@ 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.ngram(3, 5, 'alias=ngram')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(korean, 'alias=lindera_korean')) @@@ 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) @@@ 'test';
@@ -48,7 +48,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.whitespace('alias=whitespace')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('stemmer=english', 'alias=stemmed')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('alias=simple')) &&& 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) &&& 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.ngram(3, 5, 'alias=ngram')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(korean, 'alias=lindera_korean')) &&& 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) &&& 'test';
@@ -62,7 +62,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.whitespace('alias=whitespace')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('stemmer=english', 'alias=stemmed')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('alias=simple')) ||| 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) ||| 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.ngram(3, 5, 'alias=ngram')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(korean, 'alias=lindera_korean')) ||| 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) ||| 'test';
@@ -76,7 +76,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHER
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.whitespace('alias=whitespace')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('stemmer=english', 'alias=stemmed')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.simple('alias=simple')) === 'test';
-EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex('is|a', 'alias=regex')) === 'test';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.regex_pattern('is|a', 'alias=regex')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.ngram(3, 5, 'alias=ngram')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(korean, 'alias=lindera_korean')) === 'test';
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT count(*) FROM tok_in_ci WHERE (t::pdb.lindera(japanese, 'alias=lindera_japanese')) === 'test';

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
@@ -5,7 +5,7 @@ SELECT 'this is a test.'::pdb.lindera(chinese)::text[];
 SELECT 'this is a test.'::pdb.lindera(japanese)::text[];
 SELECT 'this is a test.'::pdb.lindera(korean)::text[];
 SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
-SELECT 'this is a test.'::pdb.regex('is|a')::text[];
+SELECT 'this is a test.'::pdb.regex_pattern('is|a')::text[];
 SELECT 'this is a test.'::pdb.simple::text[];
 SELECT 'this is a test.'::pdb.simple('stemmer=english')::text[];
 SELECT 'this is a test.'::pdb.whitespace::text[];

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
@@ -60,9 +60,9 @@ SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=turkish')::text[];
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=foo')::text[]; -- error
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=english', 'lowercase=false', 'ascii_folding=true')::text[];
 
-SELECT 'Running Shoes.  olé'::pdb.regex::text[]; -- error, needs a regular expression
-SELECT 'Running Shoes.  olé'::pdb.regex('ing|oes')::text[];
-SELECT 'Running Shoes.  olé'::pdb.regex('ing|oes', 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern::text[]; -- error, needs a regular expression
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern('ing|oes')::text[];
+SELECT 'Running Shoes.  olé'::pdb.regex_pattern('ing|oes', 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
 
 SELECT 'Running Shoes.  olé'::pdb.source_code::text[];
 SELECT 'Running Shoes.  olé'::pdb.source_code('lowercase=false')::text[];


### PR DESCRIPTION
## What

The `::pdb.regex` tokenizer type is ambiguous with the existing `pdb.regex()` function, making queries like this impossible for Postgres to figure out:

```sql
SELECT * FROM t WHERE f @@@ pdb.regex('b..r');
```

## Why

It makes a lot more sense to rename the thing we haven't released yet as opposed to the thing we have.

## How

## Tests
