### PR TITLE
feat: Add a `pdb.term_set` aggregate function.

### DIFF
--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -1,0 +1,120 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CREATE TABLE genus (
+  id BIGINT NOT NULL,
+  name TEXT NOT NULL
+);
+CREATE TABLE plants (
+  id BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY,
+  genus_id BIGINT NOT NULL,
+  name TEXT NOT NULL
+);
+INSERT INTO genus (id, name) VALUES
+(0, 'oak'),
+(1, 'maple'),
+(2, 'pine'),
+(3, 'apple');
+INSERT INTO plants (genus_id, name) VALUES
+(0, 'English Oak'),
+(0, 'Holly Oak'),
+(0, 'White Oak'),
+(1, 'Sugar Maple'),
+(1, 'Red Maple'),
+(1, 'Norway Maple'),
+(2, 'Scots Pine'),
+(2, 'Ponderosa Pine'),
+(3, 'Domestic Apple'),
+(3, 'Siberian Crabapple');
+CREATE INDEX plants_idx ON plants
+USING bm25 (id, genus_id, name)
+WITH (key_field = id);
+CREATE INDEX genus_idx ON genus
+USING bm25 (id, name)
+WITH (key_field = id);
+--
+-- Test 1: Basic CTE query
+-- Find all plants belonging to the 'oak' genus.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(id) as terms
+  FROM genus
+  WHERE genus.name @@@ 'oak'
+)
+SELECT plants.id, plants.name
+FROM plants, genus_terms
+WHERE plants.genus_id @@@ genus_terms.terms
+ORDER BY plants.id;
+ id |    name     
+----+-------------
+  1 | English Oak
+  2 | Holly Oak
+  3 | White Oak
+(3 rows)
+
+--
+-- Test 2: Basic paradedb.aggregate query
+-- Count all plants belonging to the 'oak' genus.
+--
+SELECT *
+FROM paradedb.aggregate(
+  'plants_idx',
+  paradedb.to_search_query_input(
+    'genus_id', 
+    (
+      SELECT pdb.term_set(id)
+      FROM genus
+      WHERE genus.name @@@ 'oak'
+    )
+  ),
+  '{"count":{"value_count":{"field":"genus_id"}}}'
+);
+         aggregate         
+---------------------------
+ {"count": {"value": 3.0}}
+(1 row)
+
+--
+-- Test 3: No matching genus
+-- Search for a genus that does not exist. Should return no plants.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(id) as terms
+  FROM genus
+  WHERE genus.name @@@ 'bamboo'
+)
+SELECT plants.id, plants.name
+FROM plants, genus_terms
+WHERE plants.genus_id @@@ genus_terms.terms
+ORDER BY plants.id;
+ id | name 
+----+------
+(0 rows)
+
+--
+-- Test 4: Incorrect data type
+-- Attempt to use term_set on a TEXT column. This should fail.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(name) as terms
+  FROM genus
+  WHERE genus.name @@@ 'oak'
+)
+SELECT 1;
+ERROR:  function pdb.term_set(text) does not exist at character 32
+DROP TABLE plants CASCADE;
+DROP TABLE genus CASCADE;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_mixed_fast_field_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/term_set_agg.sql
+++ b/pg_search/tests/pg_regress/sql/term_set_agg.sql
@@ -1,0 +1,103 @@
+\i common/common_setup.sql
+
+CREATE TABLE genus (
+  id BIGINT NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE plants (
+  id BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY,
+  genus_id BIGINT NOT NULL,
+  name TEXT NOT NULL
+);
+
+INSERT INTO genus (id, name) VALUES
+(0, 'oak'),
+(1, 'maple'),
+(2, 'pine'),
+(3, 'apple');
+
+INSERT INTO plants (genus_id, name) VALUES
+(0, 'English Oak'),
+(0, 'Holly Oak'),
+(0, 'White Oak'),
+(1, 'Sugar Maple'),
+(1, 'Red Maple'),
+(1, 'Norway Maple'),
+(2, 'Scots Pine'),
+(2, 'Ponderosa Pine'),
+(3, 'Domestic Apple'),
+(3, 'Siberian Crabapple');
+
+CREATE INDEX plants_idx ON plants
+USING bm25 (id, genus_id, name)
+WITH (key_field = id);
+
+CREATE INDEX genus_idx ON genus
+USING bm25 (id, name)
+WITH (key_field = id);
+
+--
+-- Test 1: Basic CTE query
+-- Find all plants belonging to the 'oak' genus.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(id) as terms
+  FROM genus
+  WHERE genus.name @@@ 'oak'
+)
+SELECT plants.id, plants.name
+FROM plants, genus_terms
+WHERE plants.genus_id @@@ genus_terms.terms
+ORDER BY plants.id;
+
+
+--
+-- Test 2: Basic paradedb.aggregate query
+-- Count all plants belonging to the 'oak' genus.
+--
+SELECT *
+FROM paradedb.aggregate(
+  'plants_idx',
+  paradedb.to_search_query_input(
+    'genus_id', 
+    (
+      SELECT pdb.term_set(id)
+      FROM genus
+      WHERE genus.name @@@ 'oak'
+    )
+  ),
+  '{"count":{"value_count":{"field":"genus_id"}}}'
+);
+
+
+--
+-- Test 3: No matching genus
+-- Search for a genus that does not exist. Should return no plants.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(id) as terms
+  FROM genus
+  WHERE genus.name @@@ 'bamboo'
+)
+SELECT plants.id, plants.name
+FROM plants, genus_terms
+WHERE plants.genus_id @@@ genus_terms.terms
+ORDER BY plants.id;
+
+
+--
+-- Test 4: Incorrect data type
+-- Attempt to use term_set on a TEXT column. This should fail.
+--
+WITH genus_terms AS (
+  SELECT pdb.term_set(name) as terms
+  FROM genus
+  WHERE genus.name @@@ 'oak'
+)
+SELECT 1;
+
+
+DROP TABLE plants CASCADE;
+DROP TABLE genus CASCADE;
+\i common/common_cleanup.sql


### PR DESCRIPTION
## What

Add the `pdb.term_set` aggregate function, which builds a term set.

## Why

For large input sets (1mm rows in this case) to a `paradedb.aggregate`, it is faster than two existing ways to accomplish the same thing:
```sql
-- `string_agg` followed by parse: about `2010 ms`
paradedb.parse(
  (
    SELECT concat('foreign_id:IN [', string_agg(id::TEXT, ' '), ']')
    FROM item_list
  )
)

-- `array_agg` followed by `paradedb.term_set`: about `1634 ms`
paradedb.term_set(
  'foreign_id',
  (
    SELECT array_agg(id)
    FROM item_list
  )
)

-- `term_set` as aggregate: about `1101 ms`
paradedb.to_search_query_input(
  'foreign_id',
  (
    SELECT pdb.term_set(ldf_id)
    FROM item_list
  )
)
```

## How

Add an aggregate implementation for the `pdb.term_set` function, which is equivalent to `pdb.term_set`.