### PR TITLE
ci: Fix GitHub Release publish workflow

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
-      # We confirm that if the release type is beta, the version in Cargo.toml matches with `-rc.X`, and that the
+      # We confirm that if the release type is beta, the version in Cargo.toml matches with "-rc.X", and that the
       # version provided matches the version in Cargo.toml. If the user forgot to increment the version, they will
       # need to do it in a PR, which will trigger the workflow test_pg_search-upgrade.yml, ensuring that the upgrade is tested.
       - name: Validate Cargo.toml Version Matches Release Type
@@ -63,15 +63,15 @@ jobs:
           echo "Release check passed!"
 
           if [[ "${{ github.event.inputs.beta }}" == "true" ]]; then
-            echo "Validating that the version in Cargo.toml contains `-rc.X`..."
+            echo "Validating that the version in Cargo.toml contains "-rc.X"..."
             if [[ "${{ github.event.inputs.version }}" != *"-rc."* ]]; then
-              echo "Version (${{ github.event.inputs.version }}) does not contain `-rc.X` but is marked as a beta release."
+              echo "Version (${{ github.event.inputs.version }}) does not contain "-rc.X" but is marked as a beta release."
               exit 1
             fi
           else
-            echo "Validating that the version in Cargo.toml does not contain `-rc.X`..."
+            echo "Validating that the version in Cargo.toml does not contain "-rc.X"..."
             if [[ "${{ github.event.inputs.version }}" == *"-rc."* ]]; then
-              echo "Version (${{ github.event.inputs.version }}) contains `-rc.X` but is not marked as a beta release."
+              echo "Version (${{ github.event.inputs.version }}) contains "-rc.X" but is not marked as a beta release."
               exit 1
             fi
           fi
@@ -98,8 +98,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
         run: |
           current_tag_version="${{ github.event.inputs.version }}"
-          latest_tag=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
-          echo "Current latest release is $latest_tag_version"
+          latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
+          echo "Current latest release is $latest_tag_version_version"
           echo "Current version to be released is $current_tag_version"
 
           echo ""
@@ -108,7 +108,7 @@ jobs:
 
           echo ""
           echo "Comparing versions to determine if the current version is the latest..."
-          if npx semver -r ">$latest_tag" "$current"; then
+          if npx semver -r ">$latest_tag_version" "$current_tag_version"; then
             echo "is_latest=true"
             echo "is_latest=true" >> $GITHUB_OUTPUT
           else
@@ -116,7 +116,7 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
-      # The tag_name will have `-rc.X` suffix and be marked as a prerelease for beta releases,
+      # The tag_name will have "-rc.X" suffix and be marked as a prerelease for beta releases,
       # and no suffix and marked as a full release for prod releases
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Fixes the `is_latest` not working in v0.19.0. See here for logs: https://github.com/paradedb/paradedb/actions/runs/18508022419/job/52741706161

It seems this change was reverted somewhere (??) - https://github.com/paradedb/paradedb/commit/5cc744eec672fec8e49409eb5a31fe14573b89b8

## Why
Broken

## How
Fix var names

## Tests
N/A