### PR TITLE
perf: Add a variant of `TermSet` which uses fast fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5022,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "bitpacking",
 ]
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "nom",
 ]
@@ -5086,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.term-set-fast-fields#72a22f6eaf80cee815ba4a3b8b21a0253be69621"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a8bacebd41eab1141416944172e4d6eb9e1d274d#a8bacebd41eab1141416944172e4d6eb9e1d274d"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.term-set-fast-fields", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "a8bacebd41eab1141416944172e4d6eb9e1d274d", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -33,4 +33,4 @@ pgrx-tests = "=0.15.0"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.term-set-fast-fields" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "a8bacebd41eab1141416944172e4d6eb9e1d274d" }


### PR DESCRIPTION
## What

Add a variant of `TermSet` for very large sets of terms which scans a fast fields column and intersects it with the `TermSet`.

## Why

ParadeDB users occasionally use `TermSet` as a "limited total size join" between two tables (essentially: an explicit hash join). But the implementation of `TermSet` which operates on posting lists requires creating one `Scorer` per term, and might potentially seek many times to read and merge posting lists.

This implementation is approximately 2x faster for a `paradedb.aggregate` call operating over an input `TermSet` query containing 10mm bigint terms.

## How

See https://github.com/paradedb/tantivy/pull/69.