### PR TITLE
fix: Bound memory usage during merges.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5022,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "bitpacking",
 ]
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "nom",
 ]
@@ -5086,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.merge-memory#abe5badecd569d28fbb4fbdf47f6897357c0f67c"
+source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.merge-memory", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", ref = "f92d02054e7ef6df847efacae4e1296eb456fb6f", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -33,4 +33,4 @@ pgrx-tests = "=0.15.0"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.merge-memory" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", ref = "f92d02054e7ef6df847efacae4e1296eb456fb6f" }


### PR DESCRIPTION
## What

Bound memory usage during merges, rather than opening buffers as large as the posting list and positions files.

## Why

https://github.com/paradedb/tantivy/pull/32 optimized merge throughput by reading the entire postings/positions files into buffers at once. This memory was not accounted for by the `maintenance_work_mem` setting, and was unbounded.

## How

https://github.com/paradedb/tantivy/pull/71 moves to using a fixed size buffer per file: see the explanation there.

## Tests

Existing tests all pass, and stressgres is not impacted.

Using a modified stressgres config that foreground merges in a single thread, peak memory usage was below 128MB.