### PR TITLE
chore: Fail on error in schema upgrade job.

### DIFF
--- a/.github/workflows/check-pg_search-schema-upgrade.yml
+++ b/.github/workflows/check-pg_search-schema-upgrade.yml
@@ -30,6 +30,9 @@ jobs:
   check-pg_search-schema-upgrade:
     name: SchemaBot
     runs-on: ubicloud-standard-8
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     strategy:
       matrix:
         pg_version: [14] # pg_search's minimum supported Postgres version


### PR DESCRIPTION
## What

Adjust the schema upgrade CI job to fail on errors.

## Why

The schema upgrade CI job will not currently fail to run if the diffing fails, which can mean silently missing diffs. For example: https://github.com/paradedb/paradedb/actions/runs/18512323803/job/52755747323