### PR TITLE
chore: Fix `Cargo.toml` syntax.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "bitpacking",
 ]
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4985,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "nom",
 ]
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5052,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git#f92d02054e7ef6df847efacae4e1296eb456fb6f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=f92d02054e7ef6df847efacae4e1296eb456fb6f#f92d02054e7ef6df847efacae4e1296eb456fb6f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", ref = "f92d02054e7ef6df847efacae4e1296eb456fb6f", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "f92d02054e7ef6df847efacae4e1296eb456fb6f", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -33,4 +33,4 @@ pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", ref = "f92d02054e7ef6df847efacae4e1296eb456fb6f" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "f92d02054e7ef6df847efacae4e1296eb456fb6f" }


### PR DESCRIPTION
## What

`main` is currently rendering a warning:
```console
warning: Cargo.toml: unused manifest key: workspace.dependencies.tantivy.ref
warning: Cargo.toml: unused manifest key: patch.crates-io.tantivy-tokenizer-api.ref
```

## Why

`ref` is not a valid key: `rev` is. Because of the lockfile, this is harmless (note that we were still using the specified sha), but it could cause trouble if someone changed our Tantivy fork's `main` branch, and then also ran a `cargo update`.

## Tests

The warning is gone, and the lockfile looks correct. Unfortunately, there does not currently appear to be a way to turn "unused manifest key" warnings into errors.