### PR TITLE
fix: Support deprecated raw tokenizer in `0.19.x`

### DIFF
--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -18,6 +18,7 @@
 use crate::postgres::rel::PgSearchRelation;
 use anyhow::Result;
 use tantivy::Index;
+use tokenizers::manager::SearchTokenizerFilters;
 use tokenizers::{create_normalizer_manager, create_tokenizer_manager, SearchTokenizer};
 
 pub fn setup_tokenizers(index_relation: &PgSearchRelation, index: &mut Index) -> Result<()> {
@@ -41,6 +42,10 @@ pub fn setup_tokenizers(index_relation: &PgSearchRelation, index: &mut Index) ->
     // so this is necessary to maintain backwards compatibility with existing indexes
     #[allow(deprecated)]
     tokenizers.push(SearchTokenizer::KeywordDeprecated);
+    #[allow(deprecated)]
+    tokenizers.push(SearchTokenizer::Raw(
+        SearchTokenizerFilters::keyword_deprecated().clone(),
+    ));
 
     index.set_tokenizers(create_tokenizer_manager(tokenizers));
     index.set_fast_field_tokenizers(create_normalizer_manager());


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The same thing we did in #3379 also needs to be done for the raw tokenizer, which is the default for UUID fields.

## Why

## How

## Tests
