### PR TITLE
chore: Use smaller merge buffers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "bitpacking",
 ]
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5029,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "nom",
 ]
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5050,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.smaller-merge-buffers#a34bb2ee89a2d5d3ba33e20969c089472593346f"
+source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.smaller-merge-buffers", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "71c06fe78494533a7266953b59be8fba2b4c70e1", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -33,4 +33,4 @@ pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.smaller-merge-buffers" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "71c06fe78494533a7266953b59be8fba2b4c70e1" }


### PR DESCRIPTION
## What

Reduce the per-segment buffer sizes from 4MB to 512KB.

## Why

For merges with very large segment counts, we need to be using more conservative buffer sizes.

## Tests

Running the `CREATE INDEX` for our benchmarks locally (`cargo run -p benchmarks -- --url=postgres://localhost:28817 --dataset=logs --rows=100000000 --runs=0`), I see no appreciable difference:
| Rev | Duration (min) | Index Size (MB) | Segment Count |
|------------|----------------|-----------------|---------------|
| `bd7b92399-full-file-buffers` | 3.58 | 6495 | 8 |
| `6a7429f15-4MB-buffers` | 3.77 | 6322 | 8 |
| `#3399-512KB-buffers` | 3.77 | 6509 | 8 |