### PR TITLE
ci: Properly do comparison for setting `is_latest` in Docker publish workflow

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -134,8 +134,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest && !contains(github.ref, '-')}}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest && !contains(github.ref, '-') }}
+            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest == 'true' && !contains(steps.version.outputs.tag, '-') }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest == 'true' && !contains(steps.version.outputs.tag, '-') }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Our Docker images get tagged as `latest` even if `is_latest=false`, because an non-empty string is truthy. This fixes that.

Also fixed a small issue that tripped me where instead of checking for - in tag we do it ref, which incorrectly triggers when doing manual deploys for testing.

## Why
^

## How
^

## Tests
^