### PR TITLE
ci: Don't persist credentials in cherry-pick action

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false # To avoid using the default GITHUB_TOKEN in the cherry-pick action
       - name: Cherry Pick to ${{ matrix.branch }}
         uses: carloscastrojumo/github-cherry-pick-action@v1
         with:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This is coming from an LLM, but maybe it's right? What I can confirm is the bot token has Workflows Read-Write permission, so somehow the bot is not being used (?).

## Why
It fails: https://github.com/paradedb/paradedb/actions/runs/18771195774

## How
^

## Tests
Not sure how to test this until we merge, tbh.