### PR TITLE
chore: Cherry pick is_latest fix to 0.19.x

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -132,8 +132,8 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}-pg${{ matrix.pg_version }}
             type=raw,value=${{ steps.version.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ steps.version.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
-            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest && !contains(github.ref, '-')}}
-            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest && !contains(github.ref, '-') }}
+            type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ steps.release_latest.outputs.is_latest == 'true' && !contains(steps.version.outputs.tag, '-') }}
+            type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && steps.release_latest.outputs.is_latest == 'true' && !contains(steps.version.outputs.tag, '-') }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Cherry-picks https://github.com/paradedb/paradedb/pull/3406/files which failed, see #3408.

## Why
^

## How
^

## Tests
^