### PR TITLE
fix: compiles and tests pass with `block_tracker` enabled (#3411)

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Compile & install pg_search extension
         working-directory: pg_search/
-        run: cargo pgrx install --sudo --features icu --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+        run: cargo pgrx install --sudo --features "icu,block_tracker" --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
       - name: Start Postgres via cargo-pgrx
         working-directory: pg_search/
@@ -200,7 +200,7 @@ jobs:
 
       - name: Compile & install pg_search extension
         working-directory: pg_search/
-        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features=pg${{ matrix.pg_version }},icu
+        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }},icu,block_tracker"
 
       - name: Start Postgres and create database
         working-directory: tests/

--- a/pg_search/src/index/directory/utils.rs
+++ b/pg_search/src/index/directory/utils.rs
@@ -160,7 +160,7 @@ pub unsafe fn save_new_metas(
 
             let existing_segment = incoming_segments.get(id).unwrap();
             let (mut meta_entry, blockno, _) = linked_list
-                .lookup_ex(|entry| entry.segment_id() == *id)
+                .lookup_ex(|entry| entry.segment_id() == *id, None)
                 .unwrap_or_else(|e| {
                     panic!("segment id `{id}` should be in the segment meta linked list:  {e}")
                 });
@@ -191,7 +191,7 @@ pub unsafe fn save_new_metas(
         .into_iter()
         .map(|id| {
             let (mut meta_entry, blockno, _) = linked_list
-                .lookup_ex(|entry| entry.segment_id() == *id)
+                .lookup_ex(|entry| entry.segment_id() == *id, None)
                 .unwrap_or_else(|e| {
                     panic!("segment id `{id}` should be in the segment meta linked list: {e}")
                 });

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -67,25 +67,41 @@ mod block_tracker {
     > = OnceLock::new();
 
     macro_rules! track {
-        ($style:ident, $pg_buffer:expr) => {
+        ($style:ident, $blockno:expr) => {
             use std::collections::hash_map::Entry;
-            let blockno = block_tracker::TrackedBlock::$style(
-                #[allow(unused_unsafe)]
-                unsafe {
-                    pg_sys::BufferGetBlockNumber($pg_buffer)
-                },
-            );
+
+            let blockno = block_tracker::TrackedBlock::$style($blockno);
+            assert!(!matches!(blockno, block_tracker::TrackedBlock::Drop(_)), "invalid block style: Drop not allowed");
+
             let map = block_tracker::BLOCK_TRACKER.get_or_init(|| Default::default());
             let mut lock = map.lock();
             match lock.entry(blockno) {
                 Entry::Occupied(existing) => {
-                    // having an existing block is okay if the existing block is Pinned and we're trying
-                    // to track another Pinned or Read version of the block.
-                    let existing_okay = matches!(existing.key(), block_tracker::TrackedBlock::Pinned(_))
-                            && (
-                                    matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
-                                    || matches!(blockno, block_tracker::TrackedBlock::Read(_))
-                            );
+                    // having an existing block is okay if the new block follows Postgres' rules for acquiring and releasing buffers
+                    let existing_okay = match existing.key() {
+                        block_tracker::TrackedBlock::Pinned(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                                || matches!(blockno, block_tracker::TrackedBlock::Read(_))
+                                || matches!(blockno, block_tracker::TrackedBlock::Write(_))
+                                || matches!(blockno, block_tracker::TrackedBlock::Conditional(_))
+                        }
+                        block_tracker::TrackedBlock::Read(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                        }
+                        block_tracker::TrackedBlock::Write(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                        }
+                        block_tracker::TrackedBlock::Conditional(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                        }
+                        block_tracker::TrackedBlock::ConditionalCleanup(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                        }
+                        block_tracker::TrackedBlock::Cleanup(_) => {
+                            matches!(blockno, block_tracker::TrackedBlock::Pinned(_))
+                        }
+                        block_tracker::TrackedBlock::Drop(_) => panic!("invalid existing block style"),
+                    };
 
                     if !existing_okay {
                         // any other combination is illegal within this process and we'll either WARN or panic
@@ -116,16 +132,10 @@ mod block_tracker {
     }
 
     macro_rules! forget {
-        ($pg_buffer:expr) => {
-            let blockno = {
-                #[allow(unused_unsafe)]
-                unsafe {
-                    pg_sys::BufferGetBlockNumber($pg_buffer)
-                }
-            };
+        ($blockno:expr) => {
             let map = block_tracker::BLOCK_TRACKER.get_or_init(|| Default::default());
             let mut lock = map.lock();
-            lock.remove(&block_tracker::TrackedBlock::Drop(blockno));
+            lock.remove(&block_tracker::TrackedBlock::Drop($blockno));
         };
     }
 
@@ -139,11 +149,11 @@ mod block_tracker {
 #[cfg(not(feature = "block_tracker"))]
 mod block_tracker {
     macro_rules! track {
-        ($style:ident, $pg_buffer:expr) => {};
+        ($style:ident, $blockno:expr) => {};
     }
 
     macro_rules! forget {
-        ($pg_buffer:expr) => {};
+        ($blockno:expr) => {};
     }
 
     pub(super) use forget;
@@ -158,7 +168,7 @@ pub struct Buffer {
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe {
-            block_tracker::forget!(self.pg_buffer);
+            block_tracker::forget!(pg_sys::BufferGetBlockNumber(self.pg_buffer));
             if self.pg_buffer != pg_sys::InvalidBuffer as pg_sys::Buffer
                 && pg_sys::InterruptHoldoffCount > 0    // if it's not we're likely unwinding the stack due to a panic and unlocking buffers isn't possible anymore
                 && crate::postgres::utils::IsTransactionState()
@@ -202,7 +212,7 @@ impl Buffer {
         let pg_buffer = bman
             .rbufacc
             .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE));
-        block_tracker::track!(Write, pg_buffer);
+        block_tracker::track!(Write, blockno);
         BufferMut {
             dirty: false,
             inner: Buffer::new(pg_buffer),
@@ -214,7 +224,7 @@ impl Buffer {
         drop(self);
 
         let pg_buffer = bman.rbufacc.get_buffer_conditional(blockno)?;
-        block_tracker::track!(Write, pg_buffer);
+        block_tracker::track!(Write, blockno);
         Some(BufferMut {
             dirty: false,
             inner: Buffer::new(pg_buffer),
@@ -313,7 +323,7 @@ pub struct PinnedBuffer {
 impl Drop for PinnedBuffer {
     fn drop(&mut self) {
         unsafe {
-            block_tracker::forget!(self.pg_buffer);
+            block_tracker::forget!(pg_sys::BufferGetBlockNumber(self.pg_buffer));
             if crate::postgres::utils::IsTransactionState() {
                 pg_sys::ReleaseBuffer(self.pg_buffer);
             }
@@ -631,6 +641,7 @@ impl BufferManager {
             .fsm()
             .pop(self)
             .map(|blockno| {
+                block_tracker::track!(Write, blockno);
                 self.rbufacc.get_buffer_extended(
                     blockno,
                     std::ptr::null_mut(),
@@ -638,9 +649,13 @@ impl BufferManager {
                     None,
                 )
             })
-            .unwrap_or_else(|| self.rbufacc.new_buffer());
+            .unwrap_or_else(|| {
+                #[allow(clippy::let_and_return)]
+                let pg_buffer = self.rbufacc.new_buffer();
+                block_tracker::track!(Write, unsafe { pg_sys::BufferGetBlockNumber(pg_buffer) });
+                pg_buffer
+            });
 
-        block_tracker::track!(Write, pg_buffer);
         BufferMut {
             dirty: false,
             inner: Buffer { pg_buffer },
@@ -660,13 +675,13 @@ impl BufferManager {
         let buffer_access = self.buffer_access().clone();
 
         let mut fsm_blocknos = self.fsm().drain(self, npages).map(move |blockno| {
+            block_tracker::track!(Write, blockno);
             let pg_buffer = buffer_access.get_buffer_extended(
                 blockno,
                 std::ptr::null_mut(),
                 pg_sys::ReadBufferMode::RBM_ZERO_AND_LOCK,
                 None,
             );
-            block_tracker::track!(Write, pg_buffer);
             BufferMut {
                 dirty: false,
                 inner: Buffer { pg_buffer },
@@ -692,7 +707,9 @@ impl BufferManager {
                 // by extending the relation with brand new buffers
                 new_buffers = Some(bman.buffer_access().new_buffers(remaining_from_fsm).map(
                     move |pg_buffer| {
-                        block_tracker::track!(Write, pg_buffer);
+                        block_tracker::track!(Write, unsafe {
+                            pg_sys::BufferGetBlockNumber(pg_buffer)
+                        });
                         BufferMut {
                             dirty: false,
                             inner: Buffer { pg_buffer },
@@ -708,7 +725,7 @@ impl BufferManager {
     }
 
     pub fn pinned_buffer(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {
-        block_tracker::track!(Pinned, pg_buffer);
+        block_tracker::track!(Pinned, blockno);
         PinnedBuffer::new(self.rbufacc.get_buffer(blockno, None))
     }
 
@@ -717,7 +734,7 @@ impl BufferManager {
             .rbufacc
             .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
 
-        block_tracker::track!(Read, pg_buffer);
+        block_tracker::track!(Read, blockno);
         Buffer::new(pg_buffer)
     }
 
@@ -734,7 +751,7 @@ impl BufferManager {
     }
 
     pub fn get_buffer_mut(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
-        block_tracker::track!(Write, pg_buffer);
+        block_tracker::track!(Write, blockno);
         BufferMut {
             dirty: false,
             inner: Buffer::new(
@@ -762,7 +779,7 @@ impl BufferManager {
         unsafe {
             let pg_buffer = self.rbufacc.get_buffer(blockno, None);
             if pg_sys::ConditionalLockBuffer(pg_buffer) {
-                block_tracker::track!(Conditional, pg_buffer);
+                block_tracker::track!(Conditional, blockno);
                 Some(BufferMut {
                     dirty: false,
                     inner: Buffer::new(pg_buffer),
@@ -777,7 +794,7 @@ impl BufferManager {
     pub fn get_buffer_for_cleanup(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
             let pg_buffer = self.rbufacc.get_buffer(blockno, None);
-            block_tracker::track!(Cleanup, pg_buffer);
+            block_tracker::track!(Cleanup, blockno);
             pg_sys::LockBufferForCleanup(pg_buffer);
             BufferMut {
                 dirty: false,
@@ -793,7 +810,7 @@ impl BufferManager {
         unsafe {
             let pg_buffer = self.rbufacc.get_buffer(blockno, None);
             if pg_sys::ConditionalLockBufferForCleanup(pg_buffer) {
-                block_tracker::track!(ConditionalCleanup, pg_buffer);
+                block_tracker::track!(ConditionalCleanup, blockno);
                 Some(BufferMut {
                     dirty: false,
                     inner: Buffer::new(pg_buffer),


### PR DESCRIPTION
- Closes #

- The extension now compiles with `block_tracker` turned on
- Instead of taking a buffer and getting the block number, `block_tracker` just takes a block number
- `block_tracker` caught a reentrant share lock in `LinkedItemsList`, which has been fixed
- Moved the `block_tracker` call in `fsm().drain()` to before the `RBM_ZERO_AND_LOCK`, since blocks drained from the FSM *must* not have any other locks
- Enables `block_tracker` in CI

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
