### PR TITLE
perf: Optimize `TermSet` for very large sets of terms. (#3412)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4979,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5034,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "bitpacking",
 ]
@@ -5042,7 +5042,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -5057,7 +5057,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5090,7 +5090,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "nom",
 ]
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5111,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5124,7 +5124,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=71c06fe78494533a7266953b59be8fba2b4c70e1#71c06fe78494533a7266953b59be8fba2b4c70e1"
+source = "git+https://github.com/paradedb/tantivy.git?rev=e9cc0da7a54856f36f0483844fb4b64c8089d8ee#e9cc0da7a54856f36f0483844fb4b64c8089d8ee"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lto = "thin"
 codegen-units = 32
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "71c06fe78494533a7266953b59be8fba2b4c70e1", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e9cc0da7a54856f36f0483844fb4b64c8089d8ee", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -33,4 +33,4 @@ pgrx-tests = "=0.15.0"
 tantivy-jieba = "0.11.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "71c06fe78494533a7266953b59be8fba2b4c70e1" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "e9cc0da7a54856f36f0483844fb4b64c8089d8ee" }

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -219,6 +219,10 @@ impl FieldName {
     }
 
     pub fn path(&self) -> Option<String> {
+        if !self.0.as_str().contains('.') {
+            return None;
+        }
+
         let json_path = split_json_path(self.0.as_str());
         if json_path.len() == 1 {
             None

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -871,28 +871,28 @@ impl SearchQueryInput {
                 }
             }
             SearchQueryInput::TermSet { terms: fields } => {
-                let mut terms = vec![];
-                for TermInput {
-                    field,
-                    value,
-                    is_datetime,
-                } in fields
-                {
-                    let search_field = schema
-                        .search_field(field.root())
-                        .ok_or(QueryError::NonIndexedField(field.clone()))?;
-                    let field_type = search_field.field_entry().field_type();
-                    let is_datetime = search_field.is_datetime() || is_datetime;
-                    terms.push(value_to_term(
-                        search_field.field(),
-                        &value,
-                        field_type,
-                        field.path().as_deref(),
-                        is_datetime,
-                    )?);
-                }
-
-                Ok(Box::new(TermSetQuery::new(terms)))
+                Ok(Box::new(TermSetQuery::new(fields.into_iter().map(
+                    |TermInput {
+                         field,
+                         value,
+                         is_datetime,
+                     }| {
+                        let search_field = schema
+                            .search_field(field.root())
+                            .ok_or_else(|| QueryError::NonIndexedField(field.clone()))
+                            .expect("could not find search field");
+                        let field_type = search_field.field_entry().field_type();
+                        let is_datetime = search_field.is_datetime() || is_datetime;
+                        value_to_term(
+                            search_field.field(),
+                            &value,
+                            field_type,
+                            field.path().as_deref(),
+                            is_datetime,
+                        )
+                        .expect("could not convert argument to search term")
+                    },
+                ))))
             }
             SearchQueryInput::WithIndex { query, .. } => query.into_tantivy_query(
                 schema,

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -683,19 +683,16 @@ fn term_set(
     let tantivy_field = search_field.field();
     let is_date_time = search_field.is_datetime();
 
-    let terms = terms
-        .into_iter()
-        .map(|term| {
-            value_to_term(
-                tantivy_field,
-                &term,
-                field_type,
-                field.path().as_deref(),
-                is_date_time,
-            )
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    Ok(Box::new(TermSetQuery::new(terms)))
+    Ok(Box::new(TermSetQuery::new(terms.into_iter().map(|term| {
+        value_to_term(
+            tantivy_field,
+            &term,
+            field_type,
+            field.path().as_deref(),
+            is_date_time,
+        )
+        .expect("could not convert argument to search term")
+    }))))
 }
 
 fn term(

--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -48,6 +48,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
+WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id |    name     
 ----+-------------
   1 | English Oak
@@ -72,6 +73,7 @@ FROM paradedb.aggregate(
   ),
   '{"count":{"value_count":{"field":"genus_id"}}}'
 );
+WARNING:  using `pdb.term_set` in aggregate position is deprecated
          aggregate         
 ---------------------------
  {"count": {"value": 3.0}}
@@ -90,6 +92,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
+WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id | name 
 ----+------
 (0 rows)


### PR DESCRIPTION
## What

Further optimizes `pdb.term_set` and `paradedb.term_set`, and deprecates using `pdb.term_set` in aggregate position.

## Why

#3351 optimized `term_set` queries for very large input term sets by switching to using fast fields when more than `1024` terms were used in the set. But there was more that could be done.

For a `paradedb.aggregate` query using a `pdb.term_set` constructed from an `array_agg` containing 10mm distinct inputs and 8 segments, this PR further optimizes the fast field execution path:

| version | runtime |
| ------- | -------- |
| pre-#3351 - 0 workers | 35.851 s |
| pre-#3351 - 8 workers | swapping - did not complete |
| #3351 - 0 workers | 12.573 s |
| #3351 - 8 workers | 13.708 s |
| #3412 - 0 workers | 5.532 s |
| #3412 - 8 workers | 8.538 s |

Before #3351, the posting-list based execution mode for term sets was not able to complete on my machine with multiple workers, because it required enough memory to trigger swapping.

Critical to note: in the case of a massive `pdb.term_set` like this, additional workers might be a pessimization. That's because the cost of propagating and creating the query is expensive enough that it can dwarf the actual aggregate time. For larger segment counts or larger aggregates, the results might be different.

Additionally, this change deprecates using `pdb.term_set` in aggregate position (as added in #3336): using `pdb.term_set` in function position with an `array_agg` is equivalent, and sometimes slightly faster.

## How

* Incorporates https://github.com/paradedb/tantivy/pull/75
* Removes some allocation from `pdb.term_set` and `paradedb.term_set` creation.
* Skips allocation `FieldName::path` arrays if they contain a single component.