### PR TITLE
fix: Fix cherry-pick job permissions

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
       - name: Cherry Pick to ${{ matrix.branch }}
         uses: carloscastrojumo/github-cherry-pick-action@v1
         with:


### PR DESCRIPTION
## What

Try switching to using the bot's permissions to push.

## Why

#3408 caused all cherry-pick pushes to fail. Example: https://github.com/paradedb/paradedb/actions/runs/18819816257/job/53693573957#step:3:52