### PR TITLE
fix: Add GRANT permissions for index_layer-info

### DIFF
--- a/pg_search/sql/pg_search--0.18.15--0.19.0.sql
+++ b/pg_search/sql/pg_search--0.18.15--0.19.0.sql
@@ -1860,3 +1860,5 @@ from (select relname,
       where low < high
       group by relname, low, high
       order by relname, low desc) x;
+
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;

--- a/pg_search/sql/pg_search--0.19.1--0.19.2.sql
+++ b/pg_search/sql/pg_search--0.19.1--0.19.2.sql
@@ -38,3 +38,6 @@ from (select relname,
       where low < high
       group by relname, low, high
       order by relname, low desc) x;
+
+GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;

--- a/pg_search/sql/pg_search--0.19.2--0.19.3.sql
+++ b/pg_search/sql/pg_search--0.19.2--0.19.3.sql
@@ -14,6 +14,3 @@ CREATE  FUNCTION pdb."snippets"(
 STABLE PARALLEL SAFE 
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'snippets_from_relation_wrapper';
-
--- Grant permissions on index_layer_info view to allow users to query index statistics
-GRANT SELECT ON pdb.index_layer_info TO PUBLIC;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #
Fixes 
```Error collecting user query","query":"paradedb_index_layer","logging_pod":"paradedb-1","targetDatabase":"paradedb","error":"ERROR: permission denied for view index_layer_info (SQLSTATE ...```

## What

## Why

## How

## Tests
