### PR TITLE
fix: only show hot standby warning if `XLogInsertAllowed()`

### DIFF
--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -112,7 +112,7 @@ impl MetaPage {
     }
 
     pub fn open(indexrel: &PgSearchRelation) -> Self {
-        if unsafe { pgrx::pg_sys::HotStandbyActive() } {
+        if unsafe { pgrx::pg_sys::HotStandbyActive() } && unsafe { !pg_sys::XLogInsertAllowed() } {
             ErrorReport::new(
                 PgSqlErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED,
                 "Serving reads from a standby requires write-ahead log (WAL) integration, which is supported on ParadeDB Enterprise, not ParadeDB Community",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We had a community report that the hot standby warning was showing up on a primary that had a hot standby -- also check `XLogInsertAllowed` in hopes that this more accurately detects if we are actually a standby

## Why

## How

## Tests
