### PR TITLE
fix: call previous ExecutorRun hook in fake aminsertcleanup

### DIFF
--- a/pg_search/src/postgres/fake_aminsertcleanup.rs
+++ b/pg_search/src/postgres/fake_aminsertcleanup.rs
@@ -113,7 +113,11 @@ pub unsafe fn register() {
         execute_once: bool,
     ) {
         EXECUTOR_RUN_STACK.push(None);
-        pg_sys::standard_ExecutorRun(query_desc, direction, count, execute_once);
+        if let Some(prev_hook) = PREV_EXECUTOR_RUN_HOOK {
+            prev_hook(query_desc, direction, count, execute_once);
+        } else {
+            pg_sys::standard_ExecutorRun(query_desc, direction, count, execute_once);
+        }
     }
 
     #[pg_guard]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes 

## What
We fix oversight in `executor_run_hook` where the previous hook was not being called.

## Why
It can prevent breaking the PostgreSQL executor hook chain, which could lead to missing functionality from other extensions or modules that also hook into `ExecutorRun`. This ensures proper interoperability with other PostgreSQL extensions and maintains the expected execution flow.

## How

## Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> executor_run_hook now calls the previous hook when present, falling back to standard_ExecutorRun.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eacc34f822e870703c170adfdade399a9ff9b12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->