### PR TITLE
ci: Remove unnecessary secret usage

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Fetch the entire history (required to checkout tags)
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
External contributors can't use secrets, so this workflow would fail: https://github.com/paradedb/paradedb/actions/runs/18993328645/job/54249572082?pr=3472

That's not necessary, and we want to improve the experience for external contributors, so remove it.

## Why
^

## How
^

## Tests
^