### PR TITLE
ci: Fix SchemaBot on push events

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Switch to Base git rev and Generate Schema Again
         run: |
-          # Add the PR target repo as 'upstream' (works for both same-repo & forks)
-          git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git" || true
+          # Add the PR target repo as 'upstream' (works for both same-repo & forks, and for pull_request & push events)
+          git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name || github.repository }}.git" || true
 
           # Fetch exactly the base commit object
           git fetch --no-tags --depth=1 upstream ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Fixes: https://github.com/paradedb/paradedb-enterprise/actions/runs/19050743091/job/54410154951

## Why
On enterprise, we run on push events.

## How
Fallback to the repository.

## Tests
Needs some manual testing to be sure, but should work