### PR TITLE
ci: Check for existence of SQL script

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -140,9 +140,6 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Fail
-        run: exit 1
-
       # The tag_name will have "-rc.X" suffix and be marked as a prerelease for beta releases,
       # and no suffix and marked as a full release for prod releases
       - name: Create GitHub Release


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We kept forgetting SQL upgrade scripts and burning our users... This prevents issuing a release without the upgrade script that upgrades to that version.

## Why
So users don't face issues of "no upgrade path to version X".

## How
Check for the existence of a SQL upgrade script with the upcoming release version in its filename.

## Tests
Missing script: https://github.com/paradedb/paradedb/actions/runs/19057075473/job/54429579453
Found script: https://github.com/paradedb/paradedb/actions/runs/19057104178/job/54429660239