### PR TITLE
ci: Adjust PR retrieval for SchemaBot

### DIFF
--- a/.github/workflows/schemabot-post-comment.yml
+++ b/.github/workflows/schemabot-post-comment.yml
@@ -12,9 +12,6 @@
 name: SchemaBot Post Comment
 
 on:
-  push:
-    branches:
-      - phil/schemabot-comment-pissed
   workflow_run:
     workflows: ["SchemaBot Generate Diff"]
     types: [completed]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Apparently, my code worked for PRs internal to our org, but not for forks. See: https://github.com/paradedb/paradedb/actions/runs/19080545878/job/54507667794

Unfortunately, this stuff is hard to test because it needs to be in `main` in order to trigger... 

## Why
Actually be able to post PR comments from forks.

## How
LLM in this case.

## Tests
Not sure how to test without merging...