### PR TITLE
ci: Properly account for beta releases in SQL script verification

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           current_tag_version="${{ github.event.inputs.version }}"
           latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
-          echo "Current latest release is $latest_tag_version_version"
+          echo "Current latest release is $latest_tag_version"
           echo "Current version to be released is $current_tag_version"
 
           echo ""


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I added the ability to check, before a release, that the SQL script exists. But did not account for beta releases having `-rc.X` in their name. This modifies the verification to strip the `-rc.X` tag and check that the SQL script exists.

## Why
So it works for beta releases too.

## How
^

## Tests
^