### PR TITLE
fix: Disable global mutable segment override by default

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -24,6 +24,8 @@ use std::ffi::CStr;
 use std::num::NonZeroUsize;
 use tantivy::aggregation::DEFAULT_BUCKET_LIMIT;
 
+use crate::postgres::options::MAX_MUTABLE_SEGMENT_ROWS;
+
 /// Allows the user to toggle the use of our "ParadeDB Scan".
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
@@ -87,7 +89,7 @@ static PER_TUPLE_COST: GucSetting<f64> = GucSetting::<f64>::new(100_000_000.0);
 
 static GLOBAL_TARGET_SEGMENT_COUNT: GucSetting<i32> = GucSetting::<i32>::new(0);
 static GLOBAL_ENABLE_BACKGROUND_MERGING: GucSetting<bool> = GucSetting::<bool>::new(true);
-static GLOBAL_MUTABLE_SEGMENT_ROWS: GucSetting<i32> = GucSetting::<i32>::new(1000);
+static GLOBAL_MUTABLE_SEGMENT_ROWS: GucSetting<i32> = GucSetting::<i32>::new(-1);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
@@ -252,7 +254,7 @@ pub fn init() {
         c"Setting this to a non-negative value ignores the `mutable_segment_rows` property on all indexes in favor of this value",
         &GLOBAL_MUTABLE_SEGMENT_ROWS,
         -1,
-        10000,
+        MAX_MUTABLE_SEGMENT_ROWS as i32,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -68,6 +68,9 @@ pub(crate) const DEFAULT_BACKGROUND_LAYER_SIZES: &[u64] = &[
     1000000 * 1024 * 1024, // 1TB
 ];
 
+pub(crate) const DEFAULT_MUTABLE_SEGMENT_ROWS: usize = 1000;
+pub(crate) const MAX_MUTABLE_SEGMENT_ROWS: usize = 10000;
+
 #[pg_guard]
 extern "C-unwind" fn validate_text_fields(value: *const std::os::raw::c_char) {
     let json_str = cstr_to_rust_str(value);
@@ -815,9 +818,9 @@ pub unsafe fn init() {
         RELOPT_KIND_PDB,
         "mutable_segment_rows".as_pg_cstr(),
         "The size of mutable segments.".as_pg_cstr(),
+        DEFAULT_MUTABLE_SEGMENT_ROWS as i32,
         0,
-        0,
-        i32::MAX,
+        MAX_MUTABLE_SEGMENT_ROWS as i32,
         pg_sys::AccessExclusiveLock as pg_sys::LOCKMODE,
     );
     pg_sys::add_string_reloption(


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Instead of using the global `paradedb.global_mutable_segment_rows` to default mutable segments to `1000`, we should default the per-index configuration to `1000` and have the global override disabled by default.

## Why

The global setting overrides the per-index settings, so having it enabled by default can be confusing.

## How

## Tests
