### PR TITLE
fix: remove dependency for cherry pick

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -29,7 +29,7 @@ jobs:
 
   cherry-pick:
     name: Cherry Pick
-    needs: [validate-cherry-pick-labels, get-branches]
+    needs: [get-branches]
     if: needs.get-branches.outputs.branches != '[]'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
# Ticket(s) Closed
Validation happens before PR is merged so this action is running post merge. They cannot have dependency. 
- Closes #

## What

## Why

## How

## Tests
