### PR TITLE
ci: Fix marking Docker images as latest

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -103,7 +103,8 @@ jobs:
           npm install semver
 
           echo ""
-          echo "Comparing versions to determine if the current version is the latest..."
+          echo "Comparing versions to determine if we need to mark this release as latest..."
+          echo "We should mark as latest if the current version of the tag triggering this workflow is equal to the latest tag found in GitHub Releases."
           if npx semver -r ">=$latest_tag_version" "$current_tag_version"; then
             echo "is_latest=true"
             echo "is_latest=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We had changed the way we check for latest to be via the GitHub Releases tags, and since we are just past releasing the current tag, we need to account for the version being equal.

## Why
We were no longer properly marking releases as latest.

## How
Greater than or equal.

## Tests
Locally, yes