### PR TITLE
fix: Don't default `target_segment_count` to 1 or 2 for machines with low CPU counts

### DIFF
--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -332,8 +332,7 @@ impl BM25IndexOptions {
         self.options_data()
             .target_segment_count()
             .map(|count| count as usize)
-            .unwrap_or_else(crate::available_parallelism)
-            .max(MIN_TARGET_SEGMENT_COUNT)
+            .unwrap_or(crate::available_parallelism().max(MIN_TARGET_SEGMENT_COUNT))
     }
 
     pub fn mutable_segment_rows(&self) -> Option<NonZeroUsize> {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

If `target_segment_count` is not explicitly set on a machine with a very low CPU count, we should still have at least 4 segments so index build/reads can be parallelized.

## Why

## How

## Tests
