### PR TITLE
fix: Warning message when using `pdb.agg` without a custom scan should use `pdb.all` not `paradedb.all`

### DIFF
--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -113,7 +113,7 @@ mod pdb {
             pgrx::error!(
             "pdb.agg() must be handled by ParadeDB's custom scan. \
              This error usually means the query syntax is not supported. \
-             Try adding '@@@ paradedb.all()' to your WHERE clause to force custom scan usage, \
+             Try adding '@@@ pdb.all()' to your WHERE clause to force custom scan usage, \
              or file an issue at https://github.com/paradedb/paradedb/issues if this should be supported."
         )
         }

--- a/pg_search/src/postgres/customscan/pdbscan/mod.rs
+++ b/pg_search/src/postgres/customscan/pdbscan/mod.rs
@@ -350,7 +350,7 @@ unsafe fn query_has_window_agg_functions(root: *mut pg_sys::PlannerInfo) -> bool
                             "pdb.agg() can only be used as a window function in TopN queries \
                              (queries with ORDER BY and LIMIT). For GROUP BY aggregates, use standard \
                              SQL aggregates like COUNT(*), SUM(), etc. \
-                             Hint: Try using '@@@ paradedb.all()' with ORDER BY and LIMIT, \
+                             Hint: Try using '@@@ pdb.all()' with ORDER BY and LIMIT, \
                              or see https://github.com/paradedb/paradedb/issues for more information."
                         );
                     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
