### PR TITLE
fix: Handle integer overflow in range bound canonicalization #2978

### DIFF
--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -611,9 +611,7 @@ fn check_range_bounds(
                 } else {
                     // Safe to increment within i64 range
                     match n.checked_add(1) {
-                        Some(next) if next <= i64_max => {
-                            Bound::Included(OwnedValue::U64(next))
-                        }
+                        Some(next) if next <= i64_max => Bound::Included(OwnedValue::U64(next)),
                         _ => {
                             // Would reach or exceed i64::MAX
                             Bound::Excluded(OwnedValue::U64(n))
@@ -708,9 +706,7 @@ fn check_range_bounds(
                 } else {
                     // Safe to increment within i64 range
                     match n.checked_add(1) {
-                        Some(next) if next <= i64_max => {
-                            Bound::Excluded(OwnedValue::U64(next))
-                        }
+                        Some(next) if next <= i64_max => Bound::Excluded(OwnedValue::U64(next)),
                         _ => {
                             // Shouldn't reach here since n < i64_max
                             Bound::Unbounded

--- a/tests/tests/pushdown.rs
+++ b/tests/tests/pushdown.rs
@@ -1055,8 +1055,10 @@ mod numeric_boundary_values {
         sql.execute(&mut conn);
 
         // Insert test data including boundary values
-        "INSERT INTO boundary_test (id, col_int8) VALUES (1, 9223372036854775807);".execute(&mut conn); // i64::MAX
-        "INSERT INTO boundary_test (id, col_int8) VALUES (2, -9223372036854775808);".execute(&mut conn); // i64::MIN
+        "INSERT INTO boundary_test (id, col_int8) VALUES (1, 9223372036854775807);"
+            .execute(&mut conn); // i64::MAX
+        "INSERT INTO boundary_test (id, col_int8) VALUES (2, -9223372036854775808);"
+            .execute(&mut conn); // i64::MIN
         "INSERT INTO boundary_test (id, col_int8) VALUES (3, 0);".execute(&mut conn);
         "INSERT INTO boundary_test (id, col_int8) VALUES (4, 42);".execute(&mut conn);
         "INSERT INTO boundary_test (id, col_int4) VALUES (5, 2147483647);".execute(&mut conn); // i32::MAX
@@ -1131,7 +1133,9 @@ mod numeric_boundary_values {
     /// Test that field > i64::MAX returns no results
     /// This tests that Excluded(i64::MAX) stays as Excluded when overflow occurs
     #[rstest]
-    fn test_i64_max_excluded_lower_bound(#[from(setup_boundary_test_table)] mut conn: PgConnection) {
+    fn test_i64_max_excluded_lower_bound(
+        #[from(setup_boundary_test_table)] mut conn: PgConnection,
+    ) {
         let sql = r#"
             EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
             SELECT count(*)
@@ -1160,7 +1164,9 @@ mod numeric_boundary_values {
     /// Test that field < i64::MIN returns no results
     /// This tests that Excluded(i64::MIN) for upper bound works correctly
     #[rstest]
-    fn test_i64_min_excluded_upper_bound(#[from(setup_boundary_test_table)] mut conn: PgConnection) {
+    fn test_i64_min_excluded_upper_bound(
+        #[from(setup_boundary_test_table)] mut conn: PgConnection,
+    ) {
         let sql = r#"
             EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
             SELECT count(*)


### PR DESCRIPTION
## Summary

Fixes #2978 - Resolves "attempt to add with overflow" panic when querying integer fields with boundary values (i64::MAX, u64::MAX). This also fixes a type mismatch issue where U64 values were incorrectly used for signed integer fields, resulting in 0 results returned.

## What Changed

### `pg_search/src/query/mod.rs`
- Enhanced `check_range_bounds()` with type-aware boundary handling for signed integer fields (INT2, INT4, INT8)
- Added special handling for U64 values on signed fields:
  - Converts `U64(i64::MAX)` to `I64(i64::MAX)` and keeps as Included (no canonicalization)
  - Returns Unbounded for U64 values exceeding i64::MAX
  - Safely canonicalizes U64 values within i64 range using `checked_add()`
- For I64 values: Uses `checked_add()` which returns None at i64::MAX, then returns Unbounded
- For U64 values on unsigned fields: Checks u64::MAX boundary
- All increment operations use `checked_add()` to prevent overflow panics

### `tests/tests/pushdown.rs`
- Added comprehensive boundary value integration tests (+269 lines)
- Tests cover all PostgreSQL integer types: int8, int4, int2
- Tests verify queries with i64::MAX, i64::MIN, i32::MAX, i32::MIN, i16::MAX, i16::MIN
- Tests use native integer columns (not JSONB) which exercise the actual `check_range_bounds()` code path

## Why These Changes

### Problem 1: Arithmetic Overflow
The canonicalization logic converts `Included(n)` to `Excluded(n+1)` by incrementing. For boundary values like i64::MAX and u64::MAX, this causes overflow panics: "attempt to add with overflow".

### Problem 2: Type Mismatch
Values from serde_json deserialization arrive as U64 for positive integers. When `U64(i64::MAX)` is incremented to `U64(9223372036854775808)`, it exceeds i64 range. This creates a U64 Tantivy term for an I64 field, causing type mismatch and returning 0 results instead of matching documents.

## How It Works

1. **Type Detection**: For U64 bounds, checks if the field is a signed integer type (INT2OID, INT4OID, INT8OID)

2. **U64 Boundary Handling on Signed Fields**:
   - `n > i64::MAX` → Returns Unbounded (out of signed range)
   - `n == i64::MAX` → Converts to `I64(i64::MAX)` and keeps as Included (avoids overflow and type mismatch)
   - `n < i64::MAX` → Safely canonicalizes using `checked_add()` within i64 range

3. **I64 Boundary Handling**:
   - Uses `checked_add()` for incrementing
   - When `checked_add()` returns None (at i64::MAX), returns Unbounded

4. **U64 on Unsigned Fields**:
   - Checks against u64::MAX
   - Uses `checked_add()` for safe canonicalization

## Test Coverage

Added 8 comprehensive integration tests:
- `test_i64_max_upper_bound` - Queries with `col_int8 <= i64::MAX`
- `test_i64_min_lower_bound` - Queries with `col_int8 >= i64::MIN`
- `test_i32_max_upper_bound` - Queries with `col_int4 <= i32::MAX`
- `test_i32_min_lower_bound` - Queries with `col_int4 >= i32::MIN`
- `test_i16_max_upper_bound` - Queries with `col_int2 <= i16::MAX`
- `test_i16_min_lower_bound` - Queries with `col_int2 >= i16::MIN`
- `test_range_with_i64_boundaries` - Range queries with both i64::MAX and i64::MIN
- `test_negative_boundary_values` - Queries with negative boundary values