### PR TITLE
feat: Add (split) debug symbols to release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ lto = "fat"
 panic = "unwind"
 opt-level = 3
 codegen-units = 1
+
+[profile.release-with-debug]
+inherits = "release"
 debug = true
 
 [workspace.dependencies]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,12 +79,12 @@ RUN ./runConfigureICU Linux --prefix=/usr/local && \
     make install && \
     ldconfig && ldconfig # Yes, running it twice
 
-# Build the extension
+# Build the extension in release mode, but with debug symbols (which will be split out later)
 WORKDIR /tmp/pg_search
-RUN cargo pgrx package --features icu --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
+RUN cargo pgrx package --features icu --profile=release-with-debug --pg-config "/usr/lib/postgresql/${PG_VERSION_MAJOR}/bin/pg_config"
 
 # Strip debug symbols from the extension and add a debug link
-RUN LIB_PATH="/tmp/target/release/pg_search-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/pg_search.so" && \
+RUN LIB_PATH="/tmp/target/release-with-debug/pg_search-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/pg_search.so" && \
     objcopy --only-keep-debug "${LIB_PATH}" "${LIB_PATH}.dbg" && \
     objcopy --strip-debug "${LIB_PATH}" && \
     objcopy --add-gnu-debuglink="${LIB_PATH}.dbg" "${LIB_PATH}"
@@ -170,8 +170,8 @@ COPY --from=builder-pg_ivm /tmp/pg_ivm/*.control /usr/share/postgresql/${PG_VERS
 COPY --from=builder-pg_ivm /tmp/pg_ivm/*.sql /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 
 # Copy the ParadeDB extension from its builder stage
-COPY --from=builder-pg_search /tmp/target/release/pg_search-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
-COPY --from=builder-pg_search /tmp/target/release/pg_search-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
+COPY --from=builder-pg_search /tmp/target/release-with-debug/pg_search-pg${PG_VERSION_MAJOR}/usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/* /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/
+COPY --from=builder-pg_search /tmp/target/release-with-debug/pg_search-pg${PG_VERSION_MAJOR}/usr/share/postgresql/${PG_VERSION_MAJOR}/extension/* /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/
 
 # Install Barman Cloud and its dependencies for Azure, Google, and AWS via `pip`, and clean up after the installation to
 # minimize the size of the image. These are required for enabling Postgres backups in our CloudNativePG deployments.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3471

## What

Adds split debug symbols to our production Docker image.

## Why

As described on #3471, we'd like to add debug symbols to our release build without impacting its performance in the common case.

## How

Add `debug = true` to the release profile, but strip those symbols while building our Docker image.

The image will still be larger, but the actual loaded `.so` file will remain the same size, and the debug file should only come into play when attaching a debugger.

## Tests

Inside the container, this looks like:
```console
-rwxr-xr-x 1 root root  69014120 Nov 22 00:15 pg_search.so
-rwxr-xr-x 1 root root 303531016 Nov 22 00:15 pg_search.so.dbg
```

And (when added to the container) `gdb` is able to read the symbols:
```console
> (gdb) file pg_search.so
Reading symbols from pg_search.so...
Reading symbols from /usr/lib/postgresql/17/lib/pg_search.so.dbg...
```