### PR TITLE
chore: Audit `Drop` impls reachable from aggregates.

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -634,7 +634,9 @@ pub mod vischeck {
         fn drop(&mut self) {
             unsafe {
                 if !pg_sys::IsTransactionState() {
-                    // we are not in a transaction, so we can't do things like release buffers and close relations
+                    // TODO: None of the below operations care about the transaction state: in
+                    // particular, `ReleaseBuffer` is only dropping a pin, rather than releasing a
+                    // lock. Consider removing this guard.
                     return;
                 }
 


### PR DESCRIPTION
## What

Audit `Drop` impls reachable from aggregates.

## Why

We suspect that one of the `Drop` implementations which is used in aggregates is not safe for use during an aborted transaction. `ExprContextGuard` is the most likely candidate.