### PR TITLE
docs: Another bunch of SEO fixes

### DIFF
--- a/docs/deploy/self-hosted/high-availability/configuration.mdx
+++ b/docs/deploy/self-hosted/high-availability/configuration.mdx
@@ -14,7 +14,7 @@ In a highly available configuration, ParadeDB deploys as a cluster of Postgres i
 
 If the primary server goes down, a standby server is promoted to become the new primary server. This process is called failover.
 
-For a thorough architecture overview, please consult the [CloudNativePG Architecture documentation](https://cloudnative-pg.io/legacy/1.18/architecture/).
+For a thorough architecture overview, please consult the [CloudNativePG Architecture documentation](https://cloudnative-pg.io/documentation/current/architecture/).
 
 ## Enable High Availability
 
@@ -47,9 +47,9 @@ By default, ParadeDB ships with asynchronuous replication, meaning transactions 
 the standby instances before committing.
 
 **Quorum-based synchronous replication** ensures that a transaction is successfully written to standbys before it completes.
-Please consult the [CloudNativePG Replication documentation](https://cloudnative-pg.io/legacy/1.18/replication/#synchronous-replication) for details.
+Please consult the [CloudNativePG Replication documentation](https://cloudnative-pg.io/documentation/current/replication/#synchronous-replication) for details.
 
 ## Backup and Disaster Recovery
 
 ParadeDB supports backups to cloud object stores (e.g. S3, GCS, etc.) and point-in-time-recovery
-via [Barman](https://pgbarman.org/). To configure the frequency and location of backups, please consult the [CloudNativePG Backup documentation](https://cloudnative-pg.io/legacy/1.18/backup_recovery/).
+via [Barman](https://pgbarman.org/). To configure the frequency and location of backups, please consult the [CloudNativePG Backup documentation](https://cloudnative-pg.io/documentation/current/backup/).

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -75,4 +75,4 @@ transaction are factored into the BM25 score.
 VACUUM mock_items;
 ```
 
-This can be automated with [autovacuum](/documentation/performance-tuning#autovacuum).
+This can be automated with [autovacuum](/documentation/performance-tuning/overview).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes documentation links: CNPG references now point to current pages and the autovacuum link is corrected.
> 
> - **Docs**:
>   - `docs/deploy/self-hosted/high-availability/configuration.mdx`
>     - Update CNPG links to current: architecture, synchronous replication, and backup pages.
>   - `docs/documentation/sorting/score.mdx`
>     - Update internal autovacuum link to `/documentation/performance-tuning/overview`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aa29870d4bd55ec3ae5a712282cf86aeb9b0c2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->