### PR TITLE
docs: Small inaccuracy on the "production readiness" section in our docs

### DIFF
--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -45,13 +45,12 @@ People usually compare ParadeDB to two other types of systems: OLTP databases li
 As a company, ParadeDB is over two years old. ParadeDB launched in the [Y Combinator (YC)](https://ycombinator.com) S23 batch and has been validated in
 production since December 2023.
 
-[ParadeDB Community](https://github.com/paradedb/paradedb), the open-source version of ParadeDB, has been deployed over 100,000 times in the past 12 months.
-ParadeDB Enterprise, the durable and production-hardened edition
-of ParadeDB, powers core search and analytics use cases at enterprises ranging from Fortune 500s to fast-growing startups. A few
+[ParadeDB Community](https://github.com/paradedb/paradedb), the open-source version of ParadeDB, has been deployed over 400,000 times in the past 12 months.
+ParadeDB Enterprise, the durable and production-hardened edition of ParadeDB, powers core search and analytics use cases at enterprises ranging from Fortune 500s to fast-growing startups. A few
 examples include:
 
-- **Alibaba**, the largest Asia-Pacific cloud provider, uses ParadeDB to power search inside their data warehouse. [Case study available](https://www.paradedb.com/blog/case-study-alibaba).
-- **Bilt Rewards**<sup>1</sup>, a rent payments technology company that processed over $36B in payments in 2024. [Case study available](https://www.paradedb.com/blog/case-study-bilt).
+- **Alibaba Cloud**, the largest Asia-Pacific cloud provider, uses ParadeDB to power search inside their data warehouse. [Case study available](https://www.paradedb.com/blog/case-study-alibaba).
+- **Bilt Rewards**, a rent payments technology company that processed over $36B in payments in 2024. [Case study available](https://www.paradedb.com/blog/case-study-bilt).
 - **Modern Treasury**<sup>1</sup>, a financial technology company that automates the full cycle of money movement.
 - **UnifyGTM**<sup>1</sup>, one of the fastest-growing startups in AI sales automation.
 - **TCDI**<sup>1</sup>, a giant in the legal software and litigation management space.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
BILT still had the "case study coming soon" even though it is there, and the deployment numbers were outdated.

## Why
^

## How
^

## Tests
^

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates deployment count to 400k and corrects customer names/case study links in the Production Readiness section.
> 
> - **Docs (`docs/welcome/introduction.mdx`)**:
>   - **Production Readiness**:
>     - Update deployment metric from `100,000` to `400,000` in the past 12 months.
>     - Clarify enterprise sentence formatting (single line).
>     - Rename `Alibaba` to `Alibaba Cloud` and confirm case study link.
>     - Update `Bilt Rewards` to remove footnote and link to the live case study.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebfd818490cee2da845f44bbcda9ee410b9b2f00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->