### PR TITLE
docs: Fix broken Postgres link

### DIFF
--- a/docs/documentation/performance-tuning/reads.mdx
+++ b/docs/documentation/performance-tuning/reads.mdx
@@ -68,7 +68,7 @@ can be set globally in `postgresql.conf` or for a specific table.
 ALTER TABLE mock_items SET (autovacuum_vacuum_threshold = 500);
 ```
 
-There are several [autovacuum settings](https://www.postgresql.org/docs/current/runtime-config-autovacuum.html), but the important ones to
+There are several [autovacuum settings](https://www.postgresql.org/docs/current/routine-vacuuming.html#AUTOVACUUM), but the important ones to
 note are:
 
 1. `autovacuum_vacuum_scale_factor` triggers an autovacuum if a certain percentage of rows in a table have been updated.


### PR DESCRIPTION
P18 has broken this link, so falling back to a description of vaccum which exists in all versions.

old link: https://www.postgresql.org/docs/17/runtime-config-autovacuum.html
new link: https://www.postgresql.org/docs/18/runtime-config-vacuum.html

fix link (used in docs now, exists in all): https://www.postgresql.org/docs/current/routine-vacuuming.html#AUTOVACUUM
