### PR TITLE
chore: Skip readline in `pgrx`-managed CI

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -116,7 +116,7 @@ jobs:
       # ---------- pgrx-managed Postgres setup ----------
       - name: Initialize cargo-pgrx environment (pgrx download)
         if: matrix.pg_impl == 'pgrx'
-        run: cargo pgrx init "--pg${{ matrix.pg_version }}=download"
+        run: cargo pgrx init "--pg${{ matrix.pg_version }}=download" --configure-flag="--without-readline"
 
       # Needed for hybrid search unit/integration tests
       - name: Install pgvector (system)


### PR DESCRIPTION
## What

Skip readline in the `pgrx`-managed Postgres install.

## Why

Some of the ubuntu runners that we have do not have readline (headers) installed.