### PR TITLE
fix: Pin `ubicloud-standard` to `*-ubuntu-2204`.

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -27,7 +27,8 @@ concurrency:
 jobs:
   schemabot-generate-diff:
     name: Generate Schema Diff
-    runs-on: ubicloud-standard-8
+    # TODO: See https://github.com/paradedb/paradedb/issues/3613
+    runs-on: ubicloud-standard-8-ubuntu-2204
     defaults:
       run:
         shell: bash -eo pipefail {0}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -25,7 +25,8 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image
-    runs-on: ubicloud-standard-8
+    # TODO: See https://github.com/paradedb/paradedb/issues/3613
+    runs-on: ubicloud-standard-8-ubuntu-2204
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -31,7 +31,8 @@ concurrency:
 jobs:
   test-pg_search-upgrade:
     name: Test upgrading pg_search via ALTER EXTENSION
-    runs-on: ubicloud-standard-8
+    # TODO: See https://github.com/paradedb/paradedb/issues/3613
+    runs-on: ubicloud-standard-8-ubuntu-2204
     strategy:
       matrix:
         pg_version: [17]

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -55,18 +55,21 @@ jobs:
         # Base: system Postgres on regular runner for all versions
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         pg_impl: [system]
-        runner: [ubicloud-standard-8]
+        # TODO: See https://github.com/paradedb/paradedb/issues/3613
+        runner: [ubicloud-standard-8-ubuntu-2204]
         arch: [amd64]
         include:
           # Add pgrx-managed Postgres for PG 17 (regular runner)
           - pg_version: 17
             pg_impl: pgrx
-            runner: ubicloud-standard-8
+            # TODO: See https://github.com/paradedb/paradedb/issues/3613
+            runner: ubicloud-standard-8-ubuntu-2204
             arch: amd64
           # Add ARM run for PG 17 (system Postgres)
           - pg_version: 17
             pg_impl: system
-            runner: ubicloud-standard-8-arm
+            # TODO: See https://github.com/paradedb/paradedb/issues/3613
+            runner: ubicloud-standard-8-arm-ubuntu-2204
             arch: arm64
 
     steps:


### PR DESCRIPTION
## What

Pin `ubicloud-standard` to `*-ubuntu-2204`.

## Why

`icu` versions shift on (some patch versions of...?) `24.04`: https://github.com/paradedb/paradedb-enterprise/actions/runs/19619721242/job/56177796848