### PR TITLE
feat: Add Debian 13 and EL10 build support

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -78,6 +78,47 @@ jobs:
             image: debian:12-slim
             pg_version: 17
             arch: arm64
+          # Debian 13 (Trixie)
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-8
+            image: debian:13-slim
+            pg_version: 14
+            arch: amd64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-4-arm
+            image: debian:13-slim
+            pg_version: 14
+            arch: arm64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-8
+            image: debian:13-slim
+            pg_version: 15
+            arch: amd64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-4-arm
+            image: debian:13-slim
+            pg_version: 15
+            arch: arm64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-8
+            image: debian:13-slim
+            pg_version: 16
+            arch: amd64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-4-arm
+            image: debian:13-slim
+            pg_version: 16
+            arch: arm64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-8
+            image: debian:13-slim
+            pg_version: 17
+            arch: amd64
+          - name: Debian 13 (Trixie)
+            runner: ubicloud-standard-4-arm
+            image: debian:13-slim
+            pg_version: 17
+            arch: arm64
           # Debian 11 (Bullseye)
           # We build for Debian 11 for compatibility with one of our integration partners
           - name: Debian 11 (Bullseye)

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -6,7 +6,8 @@
 # out by the `if` condition of the job.
 #
 # Note: Prebuilt binaries for RHEL do not support the ICU tokenizer due to the lack of the
-# required ICU library versions on RHEL 8/9.
+# required ICU library versions on RHEL 8/9. EL 10 support uses Rocky Linux 10 as the build
+# environment, which may have updated ICU support (to be tested).
 
 name: Publish pg_search (Red Hat)
 
@@ -81,6 +82,47 @@ jobs:
             image: redhat/ubi8:latest
             pg_version: 17
             arch: aarch64
+          # Enterprise Linux 10
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-8
+            image: rockylinux/rockylinux:10
+            pg_version: 14
+            arch: x86_64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-4-arm
+            image: rockylinux/rockylinux:10
+            pg_version: 14
+            arch: aarch64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-8
+            image: rockylinux/rockylinux:10
+            pg_version: 15
+            arch: x86_64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-4-arm
+            image: rockylinux/rockylinux:10
+            pg_version: 15
+            arch: aarch64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-8
+            image: rockylinux/rockylinux:10
+            pg_version: 16
+            arch: x86_64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-4-arm
+            image: rockylinux/rockylinux:10
+            pg_version: 16
+            arch: aarch64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-8
+            image: rockylinux/rockylinux:10
+            pg_version: 17
+            arch: x86_64
+          - name: Enterprise Linux 10
+            runner: ubicloud-standard-4-arm
+            image: rockylinux/rockylinux:10
+            pg_version: 17
+            arch: aarch64
           # Red Hat Enterprise Linux 9
           - name: Red Hat Enterprise Linux 9
             runner: ubicloud-standard-8
@@ -127,7 +169,16 @@ jobs:
       - name: Install Dependencies
         run: |
           # Extract RHEL version from the image name
-          RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
+          # Handles formats: redhat/ubi8:latest, redhat/ubi9:latest, rockylinux:10
+          if [[ "${{ matrix.image }}" == *"ubi"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
+          elif [[ "${{ matrix.image }}" == *"rockylinux"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          elif [[ "${{ matrix.image }}" == *"almalinux"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          else
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          fi
 
           # Install dependencies
           dnf install -y sudo wget git ca-certificates gcc llvm-toolset pkgconf-pkg-config openssl-devel jq rpm-build clang clang-devel
@@ -209,7 +260,17 @@ jobs:
       - name: Install & Configure Supported PostgreSQL Version on RHEL
         run: |
           # Extract RHEL version from the image name
-          RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
+          # Handles formats: redhat/ubi8:latest, redhat/ubi9:latest, rockylinux:10
+          if [[ "${{ matrix.image }}" == *"ubi"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F'ubi|:' '{print $2}')
+          elif [[ "${{ matrix.image }}" == *"rockylinux"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          elif [[ "${{ matrix.image }}" == *"almalinux"* ]]; then
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          else
+            RHEL_VERSION=$(echo "${{ matrix.image }}" | awk -F':' '{print $2}')
+          fi
+          echo "Detected RHEL Version: $RHEL_VERSION for image: ${{ matrix.image }}"
 
           # Install the repository RPM:
           sudo dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION}-${{ matrix.arch }}/pgdg-redhat-repo-latest.noarch.rpm

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more information, including enterprise features and support, please [contact
 
 ### Extensions
 
-You can find prebuilt binaries for the ParadeDB Postgres extensions on Debian 11, 12, Ubuntu 22.04 and 24.04, Red Hat Enterprise Linux 8 and 9, and macOS 14 (Sonoma) and 15 (Sequoia) for Postgres 14+ in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
+You can find prebuilt binaries for the ParadeDB Postgres extensions on Debian 11, 12, 13, Ubuntu 22.04 and 24.04, Red Hat Enterprise Linux 8, 9, and 10, and macOS 14 (Sonoma) and 15 (Sequoia) for Postgres 14+ in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
 
 ParadeDB supports all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 14+, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
 


### PR DESCRIPTION
Add comprehensive CI/CD support for new Linux distributions:

https://github.com/paradedb/paradedb/issues/3539

Debian 13 Support:
- Add 8 new matrix entries for Debian 13 in publish-pg_search-debian.yml
- Support PostgreSQL versions 14, 15, 16, 17 on amd64 and arm64
- Use debian:13-slim container image with standard PGDG repositories

Enterprise Linux 10 Support:
- Add 8 new matrix entries for EL 10 in publish-pg_search-rhel.yml
- Support PostgreSQL versions 14, 15, 16, 17 on x86_64 and aarch64
- Use rockylinux/rockylinux:10 as RHEL 10 compatible build environment
- Update version extraction logic to handle multiple container image formats
- Fix duplicated version extraction logic that would cause build failures

Documentation:
- Update README.md to reflect Debian 13 and RHEL 10 support
- Update workflow comments about ICU tokenizer support on EL 10

Technical improvements:
- Unified RHEL version extraction logic for UBI, Rocky Linux, and AlmaLinux images
- Added debug output for version detection
- Corrected Rocky Linux container image format from rockylinux:10 to rockylinux/rockylinux:10

This adds 16 new CI jobs total (8 for Debian 13, 8 for EL 10) to the build matrix.

Not sure if it works on ubicloud el10 / d13, but I'm sure the same building process works on EL 10 & Debian 13

https://pgext.cloud/e/pg_search


