### PR TITLE
fix: Mutable segment corruption when reading beyond number of entries

### DIFF
--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -298,7 +298,7 @@ fn index_info(
     for index in index_kind.partitions() {
         // open the specified index
         let mut segment_components = MetaPage::open(&index).segment_metas();
-        let all_entries = unsafe { segment_components.list() };
+        let all_entries = unsafe { segment_components.list(None) };
 
         for entry in all_entries {
             if !show_invisible && unsafe { !entry.visible() } {

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -375,7 +375,7 @@ impl Directory for MVCCDirectory {
         unsafe {
             Ok(MetaPage::open(&self.indexrel)
                 .segment_metas()
-                .list()
+                .list(None)
                 .iter()
                 .flat_map(|entry| entry.get_component_paths())
                 .collect())
@@ -733,7 +733,7 @@ mod tests {
                 .unwrap();
         let indexrel = PgSearchRelation::open(relation_oid);
         let linked_list = MetaPage::open(&indexrel).segment_metas();
-        let mut listed_files = unsafe { linked_list.list() };
+        let mut listed_files = unsafe { linked_list.list(None) };
         assert_eq!(listed_files.len(), 1);
         let entry = listed_files.pop().unwrap();
         let SegmentMetaEntryContent::Immutable(entry) = entry.content else {

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -460,7 +460,11 @@ impl SegmentMetaEntry {
             return Err("Cannot snapshot a non-mutable segment");
         };
 
-        let entries = unsafe { content.open(indexrel).list() };
+        let entries = unsafe {
+            content
+                .open(indexrel)
+                .list(Some(self.max_doc() as usize + self.num_deleted_docs()))
+        };
 
         // The mutable segment is composed of Adds and Removes in some order: in order to align with
         // the snapshot of the SegmentMeta entry as it existed when we opened it, we should only

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -285,7 +285,7 @@ impl MergeList {
     }
 
     pub unsafe fn list(&self) -> Vec<MergeEntry> {
-        self.entries.list()
+        self.entries.list(None)
     }
 
     pub unsafe fn garbage_collect(&mut self, when_recyclable: pg_sys::FullTransactionId) {
@@ -331,7 +331,7 @@ impl MergeList {
     pub unsafe fn list_segment_ids(&self) -> impl Iterator<Item = SegmentId> + use<'_> {
         Box::new(
             self.entries
-                .list()
+                .list(None)
                 .into_iter()
                 .flat_map(move |merge_entry| {
                     merge_entry


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Under physical replication, we've observed a rare issue where entries of the mutable segment fail to deserialize.

This always seems to happen when we are reading beyond the actual length of the mutable segment list. For instance, the mutable segment list only contains 400 entries, but we try and deserialize entry 401.

I don't yet have a perfect theory for why this is happening, but stopping the reading of the merge segment list when we've reached the number of entries seems to be working as a stopgap.

## Why

## How

## Tests
