### PR TITLE
feat: Upgrade rust_icu

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN curl -L -o icu4c-76_1-src.tgz https://github.com/unicode-org/icu/releases/do
 
 # Compile and install the ICU library
 WORKDIR /tmp/icu/source/
-RUN ./runConfigureICU Linux --prefix=/usr/local --enable-static && \
+RUN ./runConfigureICU Linux --prefix=/usr/local && \
     make "-j$(nproc)" && \
     make install && \
     ldconfig && ldconfig # Yes, running it twice

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -32,7 +32,6 @@ optional = true
 [dependencies.rust_icu_sys]
 version = "5.2.0"
 optional = true
-features = ["static"]
 
 [dependencies.rust_icu_ustring]
 version = "5.2.0"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3613 

## What
~We've had many reports over the months of incompatible `icu4c` versions. We used to depend on a runtime version of libicu. This PR upgrades us to latest rust_icu and enables the `static` flag so that this issue is no longer present for our users.~

Static compilation doesn't work since it conflicts with Postgres' icu compilation. I had tested upgrading the version, so I figured I'd at least PR that.

## Why
^

## How
^

## Tests
`cargo test -p tokenizers` still works and all tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade rust_icu dependencies and lockfile, adding rust_icu_release.
> 
> - **Dependencies**:
>   - Update `tokenizers/Cargo.toml` to bump `rust_icu_*` crates (`rust_icu_ubrk`, `rust_icu_sys`, `rust_icu_ustring`, `rust_icu_uloc`, `rust_icu_common`) from `5.0.0` to `5.2.0`.
>   - Refresh `Cargo.lock` to `5.4.0` series for `rust_icu_*` crates and add `rust_icu_release`; update related checksums and transitive deps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79a8c9df7ef63cbfab62379c380d8924a9e65720. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->