### PR TITLE
fix: Background merging uses next xid for recycling

### DIFF
--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -314,7 +314,7 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         );
 
         let current_xid = pg_sys::GetCurrentFullTransactionId();
-        let next_xid = current_xid;
+        let next_xid = pg_sys::ReadNextFullTransactionId();
         let args = BackgroundMergeArgs::from_datum(arg, false).unwrap();
         let index = PgSearchRelation::try_open(
             args.index_oid(),


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This looked suspicious when I was auditing the code for potential corruption issues. The background merger is the only place where the current xid is used as a block's recycle horizon, everywhere else the next xid is used.

## Why

## How

## Tests
