### PR TITLE
fix: early return in `TSVisibilityChecker` `Drop` if panicking

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -655,7 +655,7 @@ pub mod vischeck {
     impl Drop for TSVisibilityChecker {
         fn drop(&mut self) {
             unsafe {
-                if !pg_sys::IsTransactionState() {
+                if !pg_sys::IsTransactionState() || std::thread::panicking() {
                     // TODO: None of the below operations care about the transaction state: in
                     // particular, `ReleaseBuffer` is only dropping a pin, rather than releasing a
                     // lock. Consider removing this guard.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Ports over a double panic fix from enterprise

## Why

## How

## Tests
