### PR TITLE
fix: use-after-free in FilterQuery for aggregate FILTER clauses

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -48,7 +48,14 @@ extern "C-unwind" {
 /// let context_guard = ExprContextGuard::new();
 /// // Use context_guard.as_ptr() to get the raw pointer
 /// // Context is automatically freed when context_guard goes out of scope
+#[derive(Debug)]
 pub struct ExprContextGuard(*mut pg_sys::ExprContext);
+
+// SAFETY: PostgreSQL doesn't execute within threads, despite Tantivy expecting it.
+// The ExprContextGuard is used in Tantivy queries that require Send+Sync, but in practice
+// these are never actually shared across threads in our PostgreSQL context.
+unsafe impl Send for ExprContextGuard {}
+unsafe impl Sync for ExprContextGuard {}
 
 impl ExprContextGuard {
     /// Creates a new standalone expression context


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #N/A

## What

Fixed a use-after-free bug in `FilterQuery` where the `ExprContext` was being freed while the tantivy query still held a pointer to it.

## Why

When `FilterQuery::new` was called at execution time, it created a local `ExprContextGuard` and passed its pointer to the `HeapFilterQuery`. However, the guard was dropped at the end of the function, leaving the query with a dangling pointer. This caused Bus errors (SIGBUS) during aggregate queries with `FILTER` clauses, particularly noticeable in PG18.

## How

- Added `expr_context_guard: Option<Arc<ExprContextGuard>>` field to `FilterQuery` to keep the context alive
- Used `Arc` so that clones of `FilterQuery` share ownership—the context is only freed when all instances are dropped
- Added `Debug`, `Send`, and `Sync` traits to `ExprContextGuard` for Tantivy compatibility

## Tests

- `groupby-agg-filter` regression test passes
