### PR TITLE
ci: Fix stressgres by pinning to PG18

### DIFF
--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -62,7 +62,7 @@ runs:
         stressgres headless \
           .github/stressgres/${{ inputs.test_file }} \
           --log-file stressgres-${{ steps.sanitize-inputs.outputs.jobname }}-${{ steps.resolve_ref.outputs.sha }}.log \
-          --pgversion pg18
+          --pgversion pg18 \
           --runtime ${{ inputs.duration }}
 
     - name: Generate CSV


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins Stressgres benchmark runs to Postgres 18 by adding `--pgversion pg18` in the composite action.
> 
> - **CI / GitHub Actions**:
>   - Update `/.github/actions/benchmark-stressgres/action.yml` to pass `--pgversion pg18` to `stressgres headless` for benchmark runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ab29624cfbff764c5723d83a9af974258b8345. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->