### PR TITLE
fix: Split memory limit among parallel aggregation workers

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -266,7 +266,7 @@ impl<'a> ParallelAggregationWorker<'a> {
         let base_collector = DistributedAggregationCollector::from_aggs(
             aggregations,
             AggregationLimitsGuard::new(
-                Some(self.config.memory_limit / nworkers as u64),
+                Some(self.config.memory_limit / std::cmp::max(nworkers as u64, 1)),
                 Some(self.config.bucket_limit),
             ),
         );


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
