### PR TITLE
fix: MAX/MIN aggregate pushdown for date/datetime types

### DIFF
--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -1204,3 +1204,15 @@ pub enum TantivyValueError {
     #[error("UTF8 conversion error: {0}")]
     Utf8ConversionError(#[from] std::str::Utf8Error),
 }
+
+/// Check if the given OID is a date/time type that requires special conversion
+pub fn is_datetime_type(typoid: pg_sys::Oid) -> bool {
+    matches!(
+        typoid,
+        pg_sys::DATEOID
+            | pg_sys::TIMESTAMPOID
+            | pg_sys::TIMESTAMPTZOID
+            | pg_sys::TIMEOID
+            | pg_sys::TIMETZOID
+    )
+}

--- a/pg_search/tests/pg_regress/expected/agg-max-pushdown.out
+++ b/pg_search/tests/pg_regress/expected/agg-max-pushdown.out
@@ -1,0 +1,269 @@
+-- Test for MAX/MIN aggregate pushdown with date/datetime types
+-- Issue: MAX agg pushdown always returns null values for dates
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Create test table with various date/time types
+CREATE TABLE date_agg_test (
+    id serial PRIMARY KEY,
+    d date,
+    ts timestamp,
+    tstz timestamptz,
+    t time,
+    ttz timetz
+);
+-- Insert test data with some NULL values
+INSERT INTO date_agg_test (d, ts, tstz, t, ttz) VALUES
+    ('2051-01-02'::date, '2051-01-02 10:30:00'::timestamp, '2051-01-02 10:30:00+00'::timestamptz, '10:30:00'::time, '10:30:00+00'::timetz),
+    ('2023-06-15'::date, '2023-06-15 14:45:30'::timestamp, '2023-06-15 14:45:30+00'::timestamptz, '14:45:30'::time, '14:45:30+00'::timetz),
+    ('1990-12-25'::date, '1990-12-25 08:00:00'::timestamp, '1990-12-25 08:00:00+00'::timestamptz, '08:00:00'::time, '08:00:00+00'::timetz),
+    (NULL, NULL, NULL, NULL, NULL);
+-- Create bm25 index
+CREATE INDEX ON date_agg_test USING bm25 (id, d, ts, tstz, t, ttz) WITH (key_field = 'id');
+-- Enable aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test MAX with date
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(d) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MAX'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(d)
+     Aggregate Definition: {"0":{"max":{"field":"d","missing":null}}}
+(6 rows)
+
+SELECT max(d) FROM date_agg_test WHERE id @@@ pdb.all();
+    max     
+------------
+ 01-02-2051
+(1 row)
+
+-- Test MIN with date
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MIN'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MIN(d)
+     Aggregate Definition: {"0":{"min":{"field":"d","missing":null}}}
+(6 rows)
+
+SELECT min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+    min     
+------------
+ 12-25-1990
+(1 row)
+
+-- Test MAX with timestamp
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MAX'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(ts)
+     Aggregate Definition: {"0":{"max":{"field":"ts","missing":null}}}
+(6 rows)
+
+SELECT max(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+           max            
+--------------------------
+ Mon Jan 02 10:30:00 2051
+(1 row)
+
+-- Test MIN with timestamp
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MIN'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MIN(ts)
+     Aggregate Definition: {"0":{"min":{"field":"ts","missing":null}}}
+(6 rows)
+
+SELECT min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+           min            
+--------------------------
+ Tue Dec 25 08:00:00 1990
+(1 row)
+
+-- Test MAX with timestamptz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MAX'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(tstz)
+     Aggregate Definition: {"0":{"max":{"field":"tstz","missing":null}}}
+(6 rows)
+
+SELECT max(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+             max              
+------------------------------
+ Mon Jan 02 02:30:00 2051 PST
+(1 row)
+
+-- Test MIN with timestamptz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MIN'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MIN(tstz)
+     Aggregate Definition: {"0":{"min":{"field":"tstz","missing":null}}}
+(6 rows)
+
+SELECT min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+             min              
+------------------------------
+ Tue Dec 25 00:00:00 1990 PST
+(1 row)
+
+-- Test MAX with time
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(t) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MAX'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(t)
+     Aggregate Definition: {"0":{"max":{"field":"t","missing":null}}}
+(6 rows)
+
+SELECT max(t) FROM date_agg_test WHERE id @@@ pdb.all();
+   max    
+----------
+ 14:45:30
+(1 row)
+
+-- Test MIN with time
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MIN'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MIN(t)
+     Aggregate Definition: {"0":{"min":{"field":"t","missing":null}}}
+(6 rows)
+
+SELECT min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+   min    
+----------
+ 08:00:00
+(1 row)
+
+-- Test MAX with timetz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MAX'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(ttz)
+     Aggregate Definition: {"0":{"max":{"field":"ttz","missing":null}}}
+(6 rows)
+
+SELECT max(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+     max     
+-------------
+ 14:45:30+00
+(1 row)
+
+-- Test MIN with timetz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.date_agg_test
+   Output: pdb.agg_fn('MIN'::text)
+   Index: date_agg_test_id_d_ts_tstz_t_ttz_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MIN(ttz)
+     Aggregate Definition: {"0":{"min":{"field":"ttz","missing":null}}}
+(6 rows)
+
+SELECT min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+     min     
+-------------
+ 08:00:00+00
+(1 row)
+
+-- Test without aggregate pushdown to verify correct expected values
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT max(d), min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+    max     |    min     
+------------+------------
+ 01-02-2051 | 12-25-1990
+(1 row)
+
+SELECT max(ts), min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+           max            |           min            
+--------------------------+--------------------------
+ Mon Jan 02 10:30:00 2051 | Tue Dec 25 08:00:00 1990
+(1 row)
+
+SELECT max(tstz), min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+             max              |             min              
+------------------------------+------------------------------
+ Mon Jan 02 02:30:00 2051 PST | Tue Dec 25 00:00:00 1990 PST
+(1 row)
+
+SELECT max(t), min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+   max    |   min    
+----------+----------
+ 14:45:30 | 08:00:00
+(1 row)
+
+SELECT max(ttz), min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+     max     |     min     
+-------------+-------------
+ 14:45:30+00 | 08:00:00+00
+(1 row)
+
+-- Test with all NULL datetime values
+CREATE TABLE all_null_dates (
+    id serial PRIMARY KEY,
+    d date
+);
+INSERT INTO all_null_dates (d) VALUES (NULL), (NULL);
+CREATE INDEX ON all_null_dates USING bm25 (id, d) WITH (key_field = 'id');
+SET paradedb.enable_aggregate_custom_scan TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.all_null_dates
+   Output: pdb.agg_fn('MAX'::text)
+   Index: all_null_dates_id_d_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: MAX(d)
+     Aggregate Definition: {"0":{"max":{"field":"d","missing":null}}}
+(6 rows)
+
+SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+ max 
+-----
+ 
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+ max 
+-----
+ 
+(1 row)
+
+DROP TABLE all_null_dates;
+-- Clean up
+DROP TABLE date_agg_test;

--- a/pg_search/tests/pg_regress/sql/agg-max-pushdown.sql
+++ b/pg_search/tests/pg_regress/sql/agg-max-pushdown.sql
@@ -1,0 +1,97 @@
+-- Test for MAX/MIN aggregate pushdown with date/datetime types
+-- Issue: MAX agg pushdown always returns null values for dates
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- Create test table with various date/time types
+CREATE TABLE date_agg_test (
+    id serial PRIMARY KEY,
+    d date,
+    ts timestamp,
+    tstz timestamptz,
+    t time,
+    ttz timetz
+);
+
+-- Insert test data with some NULL values
+INSERT INTO date_agg_test (d, ts, tstz, t, ttz) VALUES
+    ('2051-01-02'::date, '2051-01-02 10:30:00'::timestamp, '2051-01-02 10:30:00+00'::timestamptz, '10:30:00'::time, '10:30:00+00'::timetz),
+    ('2023-06-15'::date, '2023-06-15 14:45:30'::timestamp, '2023-06-15 14:45:30+00'::timestamptz, '14:45:30'::time, '14:45:30+00'::timetz),
+    ('1990-12-25'::date, '1990-12-25 08:00:00'::timestamp, '1990-12-25 08:00:00+00'::timestamptz, '08:00:00'::time, '08:00:00+00'::timetz),
+    (NULL, NULL, NULL, NULL, NULL);
+
+-- Create bm25 index
+CREATE INDEX ON date_agg_test USING bm25 (id, d, ts, tstz, t, ttz) WITH (key_field = 'id');
+
+-- Enable aggregate custom scan
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test MAX with date
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(d) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(d) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MIN with date
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MAX with timestamp
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MIN with timestamp
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MAX with timestamptz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MIN with timestamptz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MAX with time
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(t) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(t) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MIN with time
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MAX with timetz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test MIN with timetz
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test without aggregate pushdown to verify correct expected values
+SET paradedb.enable_aggregate_custom_scan TO off;
+
+SELECT max(d), min(d) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(ts), min(ts) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(tstz), min(tstz) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(t), min(t) FROM date_agg_test WHERE id @@@ pdb.all();
+SELECT max(ttz), min(ttz) FROM date_agg_test WHERE id @@@ pdb.all();
+
+-- Test with all NULL datetime values
+CREATE TABLE all_null_dates (
+    id serial PRIMARY KEY,
+    d date
+);
+INSERT INTO all_null_dates (d) VALUES (NULL), (NULL);
+CREATE INDEX ON all_null_dates USING bm25 (id, d) WITH (key_field = 'id');
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF) SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT max(d) FROM all_null_dates WHERE id @@@ pdb.all();
+
+DROP TABLE all_null_dates;
+
+-- Clean up
+DROP TABLE date_agg_test;
+


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #3574

## What

Fixed `MAX` and `MIN` aggregate pushdown returning null values for date, timestamp, timestamptz, time, and timetz columns.

## Why

When aggregate pushdown was enabled, queries like `SELECT max(d) FROM table WHERE id @@@ pdb.all()` on date columns returned null instead of the actual max value.

The root cause: Tantivy stores DateTime values as nanoseconds in fast fields and returns them as `f64` from MIN/MAX aggregates. The code was trying to convert this `f64` directly to PostgreSQL date types via `TantivyValue(OwnedValue::F64(value))`, but the conversion from `F64` to date types isn't supported—only `OwnedValue::Date` can be converted to dates.

## How

Added special handling in `aggregate_result_to_datum` for date/time types:
1. Detect when the expected PostgreSQL type is a date/time type using new `is_datetime_type()` helper
2. Convert the f64 value (nanoseconds) back to a `tantivy::DateTime` using `from_timestamp_nanos()`
3. Wrap it in `TantivyValue(OwnedValue::Date(...))` so the existing conversion to PostgreSQL types works

## Tests

Added `agg-max-pushdown` regression test.