### PR TITLE
fix: upgrade script and relocate `agg_funcoid`

### DIFF
--- a/pg_search/sql/pg_search--0.20.1--0.20.2.sql
+++ b/pg_search/sql/pg_search--0.20.1--0.20.2.sql
@@ -30,18 +30,6 @@ CREATE AGGREGATE pdb.agg (
 	STYPE = internal, /* pgrx::datum::internal::Internal */
 	FINALFUNC = pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize" /* pg_search::api::aggregate::pdb::AggPlaceholderWithMVCC::final */
 );
-/* pg_search::api::aggregate::pdb */
-/* </end connected objects> */
-/* <begin connected objects> */
--- pg_search/src/api/aggregate.rs:150
--- pg_search::api::aggregate::pdb::agg_fn
-CREATE  FUNCTION pdb."agg_fn"(
-	"_agg_name" TEXT, /* &str */
-	"_solve_mvcc" bool /* bool */
-) RETURNS jsonb /* pgrx::datum::json::JsonB */
-STRICT VOLATILE PARALLEL SAFE
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'agg_fn_placeholder_with_mvcc_wrapper';
 
 /* </end connected objects> */
 /* <begin connected objects> */

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -206,6 +206,12 @@ pub fn agg_fn_oid() -> pgrx::pg_sys::Oid {
     lookup_pdb_function("agg_fn", &[pgrx::pg_sys::TEXTOID])
 }
 
+/// Get the OID of the pdb.agg() aggregate function
+/// Returns InvalidOid if the function doesn't exist yet (e.g., during extension creation)
+pub fn agg_funcoid() -> pgrx::pg_sys::Oid {
+    lookup_pdb_function("agg", &[pgrx::pg_sys::JSONBOID])
+}
+
 /// Get the OID of the pdb.agg(jsonb, bool) aggregate function with solve_mvcc parameter
 /// Returns InvalidOid if the function doesn't exist yet (e.g., during extension creation)
 pub fn agg_with_solve_mvcc_funcoid() -> pgrx::pg_sys::Oid {

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -31,9 +31,9 @@ use pgrx::{
     direct_function_call, pg_cast, pg_sys, InOutFuncs, IntoDatum, PostgresType, StringInfo,
 };
 
-use crate::postgres::utils::lookup_pdb_function;
 pub use aggregate::{
-    agg_fn_oid, agg_with_solve_mvcc_funcoid, extract_solve_mvcc_from_const, MvccVisibility,
+    agg_fn_oid, agg_funcoid, agg_with_solve_mvcc_funcoid, extract_solve_mvcc_from_const,
+    MvccVisibility,
 };
 pub use rustc_hash::FxHashMap as HashMap;
 pub use rustc_hash::FxHashSet as HashSet;
@@ -320,10 +320,4 @@ impl OrderByInfo {
     pub fn is_score(&self) -> bool {
         matches!(self.feature, OrderByFeature::Score)
     }
-}
-
-/// Get the OID of the pdb.agg() aggregate function
-/// Returns InvalidOid if the function doesn't exist yet (e.g., during extension creation)
-pub fn agg_funcoid() -> pg_sys::Oid {
-    lookup_pdb_function("agg", &[pg_sys::JSONBOID])
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

- Removed erroneous `agg_fn` function definition from the `0.20.1 -> 0.20.2` upgrade script
- Moved `agg_funcoid()` from `api/mod.rs` to `api/aggregate.rs` alongside related functions

## Why

The upgrade script incorrectly included a duplicate `agg_fn` function creation that shouldn't be part of the migration. Additionally, `agg_funcoid` belongs with the other aggregate-related OID lookup functions in `aggregate.rs` for better code organization.

## How

- Deleted the spurious SQL block from `pg_search--0.20.1--0.20.2.sql`
- Relocated `agg_funcoid()` to `aggregate.rs` and re-exported it from `mod.rs`

## Tests

Existing tests should cover this change.
