### PR TITLE
fix: upgrade script to handle existing aggregate functions

### DIFF
--- a/pg_search/sql/pg_search--0.20.1--0.20.2.sql
+++ b/pg_search/sql/pg_search--0.20.1--0.20.2.sql
@@ -3,7 +3,7 @@
 /* <begin connected objects> */
 -- pg_search/src/api/aggregate.rs:94
 -- pg_search::api::aggregate::pdb::agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state
-CREATE  FUNCTION pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state"(
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state"(
 	"this" internal, /* pgrx::datum::internal::Internal */
 	"arg_one" jsonb /* pgrx::datum::json::JsonB */
 ) RETURNS internal /* pgrx::datum::internal::Internal */
@@ -13,7 +13,7 @@ AS 'MODULE_PATHNAME', 'agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_state
 /* <begin connected objects> */
 -- pg_search/src/api/aggregate.rs:94
 -- pg_search::api::aggregate::pdb::agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize
-CREATE  FUNCTION pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize"(
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_with_mvcc_agg_placeholder_with_mvcc_finalize"(
 	"this" internal /* pgrx::datum::internal::Internal */
 ) RETURNS jsonb /* pgrx::datum::json::JsonB */
 LANGUAGE c /* Rust */


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3743

## What

Changed `CREATE FUNCTION` to `CREATE OR REPLACE FUNCTION` for the aggregate helper functions in the 0.20.1 → 0.20.2 upgrade script.

## Why

The upgrade script was failing when the aggregate functions already existed, causing upgrade errors for users.

## How

Use `CREATE OR REPLACE FUNCTION` instead of `CREATE FUNCTION` for `agg_placeholder_with_mvcc_state` and `agg_placeholder_with_mvcc_finalize` so they gracefully replace existing definitions rather than erroring.

## Tests

Manual upgrade testing from 0.20.1 to 0.20.2.
