### PR TITLE
chore: Do not benchmark release branches on `push`.

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches:
       - main
-      - 0.*.x # Release branches
+      # TODO: We do not run for release branch pushes, because we do not currently sort our graphs
+      # or PR comments by the git-graph. See https://github.com/paradedb/paradedb/issues/3769
     paths:
       - "benchmarks/**"
       - "**/*.rs"
@@ -19,6 +20,8 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
+      # TODO: We support running benchmarks on release branch PRs, but they will always compare
+      # to `main`: see the TODO above.
       - 0.*.x # Release branches
   workflow_dispatch:
     inputs:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -11,7 +11,8 @@ on:
   push:
     branches:
       - main
-      - 0.*.x # Release branches
+      # TODO: We do not run for release branch pushes, because we do not currently sort our graphs
+      # or PR comments by the git-graph. See https://github.com/paradedb/paradedb/issues/3769
     paths:
       - ".github/stressgres/**"
       - "**/*.rs"
@@ -20,6 +21,8 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
+      # TODO: We support running benchmarks on release branch PRs, but they will always compare
+      # to `main`: see the TODO above.
       - 0.*.x # Release branches
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What

Do not record benchmark data on release branches.

## Why

See https://github.com/paradedb/paradedb/issues/3769