### PR TITLE
ci: Add notebook input to Antithesis test

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@main
         with:
-          notebook_name: ${{ github.event.inputs.duration || 'paradedb' }}
+          notebook_name: ${{ github.event.inputs.notebook || 'paradedb' }}
           tenant: paradedb
           username: ${{ vars.ANTITHESIS_USERNAME }}
           password: ${{ secrets.ANTITHESIS_PASSWORD }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Make it configurable when doing manual runs, so we can try new notebooks without code changes, and default to the notebook Antithesis made for us.

## Why
^

## How
^

## Tests
^