### PR TITLE
fix: vint overflow during indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "bitpacking",
 ]
@@ -5113,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -5128,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5161,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "fnv",
  "nom",
@@ -5173,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=a7329cccff6c147376fbfdaa2c1db5380f569156#a7329cccff6c147376fbfdaa2c1db5380f569156"
+source = "git+https://github.com/paradedb/tantivy.git?rev=0e9b40e9e3f1743a15b303d4533be3d207ea3785#0e9b40e9e3f1743a15b303d4533be3d207ea3785"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "a7329cccff6c147376fbfdaa2c1db5380f569156", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "0e9b40e9e3f1743a15b303d4533be3d207ea3785", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -31,4 +31,4 @@ pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "a7329cccff6c147376fbfdaa2c1db5380f569156" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "0e9b40e9e3f1743a15b303d4533be3d207ea3785" }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Upgrades Tantivy hash, which contains the fix.

## Why

## How

## Tests
