### PR TITLE
fix: Skip `Drop` for `BorrowedBuffer` if not in transaction

### DIFF
--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -397,8 +397,10 @@ impl BorrowedBuffer {
 impl Drop for BorrowedBuffer {
     fn drop(&mut self) {
         unsafe {
-            // Only unlock, don't release
-            pg_sys::LockBuffer(self.pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
+            if crate::postgres::utils::IsTransactionState() {
+                // Only unlock, don't release
+                pg_sys::LockBuffer(self.pg_buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32);
+            }
         }
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Possibly related to some panics we're seeing in production -- the `Drop` impl should be skipped if we're not in a transaction state.

## Why

## How

## Tests
