### PR TITLE
fix: prevent false index matches for FuncExpr in expression matching (#3760)

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -418,12 +418,15 @@ pub unsafe fn field_name_from_node(
                 }
 
                 // a cast to `pdb.alias` can make it a `FuncExpr` that we need to unwrap
+                // Only unwrap pdb.alias casts; unwrapping other FuncExprs like abs() causes false index matches (#3760).
                 if let Some(func) = nodecast!(FuncExpr, T_FuncExpr, reduced_expression) {
-                    let args = PgList::<pg_sys::Node>::from_pg((*func).args);
-                    if args.len() == 1 {
-                        if let Some(arg) = args.get_ptr(0) {
-                            reduced_expression = arg.cast();
-                            continue;
+                    if type_is_alias((*func).funcresulttype) {
+                        let args = PgList::<pg_sys::Node>::from_pg((*func).args);
+                        if args.len() == 1 {
+                            if let Some(arg) = args.get_ptr(0) {
+                                reduced_expression = arg.cast();
+                                continue;
+                            }
                         }
                     }
                 }

--- a/pg_search/tests/pg_regress/expected/alias_non_text.out
+++ b/pg_search/tests/pg_regress/expected/alias_non_text.out
@@ -98,6 +98,51 @@ SELECT * FROM ints WHERE (i * 2) = 1 AND id @@@ pdb.all();
 (7 rows)
 
 DROP TABLE ints;
+-- Issue 3760: abs() indexed expression should not accept bare i - j predicate
+DROP TABLE IF EXISTS ints;
+CREATE TABLE ints (id SERIAL PRIMARY KEY, i integer, j integer);
+INSERT INTO ints (i, j) VALUES (1, 2), (2, 3), (3, 4);
+CREATE INDEX idx_ints ON ints USING bm25 (id, ((abs(i-j))::pdb.alias('another_name'))) with (key_field = 'id');
+-- This should NOT use the indexed abs() expression (uses heap_filter instead)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT * FROM ints WHERE i - j = 1 AND id @@@ pdb.all();
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on ints
+   Table: ints
+   Index: idx_ints
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}}]}},"field_filters":[{"heap_filter":"((i - j) = 1)"}]}}]}}
+(6 rows)
+
+SELECT * FROM ints WHERE i - j = 1 AND id @@@ pdb.all() ORDER BY id;
+ id | i | j 
+----+---+---
+(0 rows)
+
+-- This SHOULD use the indexed abs() expression (uses term query)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT * FROM ints WHERE abs(i - j) = 1 AND id @@@ pdb.all();
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on ints
+   Table: ints
+   Index: idx_ints
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"term":{"field":"another_name","value":1,"is_datetime":false}}]}}
+(6 rows)
+
+SELECT * FROM ints WHERE abs(i - j) = 1 AND id @@@ pdb.all() ORDER BY id;
+ id | i | j 
+----+---+---
+  1 | 1 | 2
+  2 | 2 | 3
+  3 | 3 | 4
+(3 rows)
+
+DROP TABLE ints;
 -- Verify that text/json types cannot be cast to pdb.alias
 DO $$
 DECLARE


### PR DESCRIPTION
## Summary

Fixes #3760

### The Problem

In `field_name_from_node`, when unwrapping the indexed expression to match against the WHERE clause, we unwrapped ANY `FuncExpr` with a single argument instead of checking if it's a `pdb.alias` cast function first.

**Example:**
- Index on: `(abs(i-j))::pdb.alias('another_name')`
- Query: `WHERE i - j = 1`

The old code would unwrap the indexed expression multiple times in the loop:
1. `(abs(i-j))::pdb.alias('another_name')` -> unwrap -> `abs(i-j)`
2. `abs(i-j)` -> unwrap -> `i-j` (incorrectly unwrapped `abs()` too!)

This caused `i - j = 1` to incorrectly match the index on `abs(i-j)`.

### The Fix

Added a guard to only unwrap `FuncExpr` nodes that return `pdb.alias` type:

```rust
if let Some(func) = nodecast!(FuncExpr, T_FuncExpr, reduced_expression) {
    if type_is_alias((*func).funcresulttype) {  // Only unwrap pdb.alias casts
        let args = PgList::<pg_sys::Node>::from_pg((*func).args);
        if args.len() == 1 {
            // unwrap...
        }
    }
}
```

Now:
1. `(abs(i-j))::pdb.alias('another_name')` -> returns `pdb.alias` -> unwrap -> `abs(i-j)`
2. `abs(i-j)` -> returns `integer` (not `pdb.alias`) -> STOP

## Test plan

Added regression test to `alias_non_text.sql`