### PR TITLE
fix: tokenized phrase (###) operator now works with JSON fields

### DIFF
--- a/pg_search/tests/pg_regress/expected/tokenizer-json.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-json.out
@@ -78,9 +78,10 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE j->'
 (6 rows)
 
 SELECT * FROM index_json WHERE j->'key1' ### 'value1';
- id | j | jb 
-----+---+----
-(0 rows)
+ id |         j          |         jb         
+----+--------------------+--------------------
+  1 | {"key1": "value1"} | {"key2": "value2"}
+(1 row)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE j->'key1' === 'value1';
                                                  QUERY PLAN                                                 
@@ -162,9 +163,10 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE jb->
 (6 rows)
 
 SELECT * FROM index_json WHERE jb->'key2' ### 'value2';
- id | j | jb 
-----+---+----
-(0 rows)
+ id |         j          |         jb         
+----+--------------------+--------------------
+  1 | {"key1": "value1"} | {"key2": "value2"}
+(1 row)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE jb->'key2' === 'value2';
                                                  QUERY PLAN                                                  
@@ -340,9 +342,10 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE jb->
 (6 rows)
 
 SELECT * FROM index_json WHERE jb->'key2' ### 'value2';
- id | j | jb 
-----+---+----
-(0 rows)
+ id |         j          |         jb         
+----+--------------------+--------------------
+  1 | {"key1": "value1"} | {"key2": "value2"}
+(1 row)
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM index_json WHERE jb->'key2' === 'value2';
                                                  QUERY PLAN                                                  


### PR DESCRIPTION
## Summary

- Fixes the ### (tokenized phrase) operator not returning results when querying JSON/JSONB fields
- The root cause was that tokenized_phrase() was not properly handling JSON paths when creating search terms

## Changes

- Use field.root() for schema lookup instead of the full field path
- Pass field.path() to value_to_term() for proper JSON path encoding in terms

## Test plan

- Verified j->'key1' ### 'value1' now returns expected results

Fixes #3819