### PR TITLE
ci: Fix Stressgres CI

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -216,18 +216,9 @@ jobs:
       - name: Compile & install pg_search extension
         run: cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ env.pg_version }},icu --no-default-features
 
-      - name: Checkout Stressgres Repo
-        uses: actions/checkout@v6
-        with:
-          repository: paradedb/stressgres
-          path: stressgres
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
-
-      - name: Install the stressgres CLI tool
-        run: cd stressgres && CARGO_TARGET_DIR=../target/ cargo install --path .
-
-      - name: Remove stressgres repo
-        run: rm -rf stressgres
+      - name: Install the Stressgres CLI tool
+        working-directory: stressgres/
+        run: CARGO_TARGET_DIR=../target/ cargo install --path .
 
       # Runs default to 10 minutes, but can be configured to run for longer with the `duration` input.
       - name: Benchmark single-server.toml


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
When moving Stressgres over to the monorepo, I had forgotten that we were checking out the repo in the CI job.

## Why
It's now in this repo and this issue was causing the Stressgres CI to error: https://github.com/paradedb/paradedb/actions/runs/20665658479/job/59337279422

## How
Don't checkout

## Tests
CI