### PR TITLE
fix: stressgres version in `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6183,7 +6183,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.20.5"
+version = "0.20.7"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Ticket(s) Closed

- N/A

## What

Updates the `stressgres` package version from `0.20.5` to `0.20.7` in `Cargo.lock`.

## Why

The lockfile was out of sync with the actual stressgres version.

## How

Updated the version string in `Cargo.lock`.

## Tests

N/A - lockfile update only.
