### PR TITLE
fix: Adjust path for stressgres suite in Antithesis

### DIFF
--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -14,7 +14,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000
 
 echo ""
 echo "Stressgres completed!"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Failed with this error: https://paradedb.antithesis.com/report/RDW8aykxk9kFseDQsxdl5zKL/tsCrttq9RIh35meILTjA6uim8E4sHuar7lrA1JJaqlw.html?auth=v2.public.eyJuYmYiOiIyMDI2LTAxLTAyVDIxOjQyOjMzLjk1MTc2NDY3MloiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoidHNDcnR0cTlSSWgzNW1lSUxUakE2dWltOEU0c0h1YXI3bHJBMUpKYXFsdy5odG1sIiwicmVwb3J0X2lkIjoiUkRXOGF5a3hrOWtGc2VEUXN4ZGw1ektMIn19fWuZl-GXYNcoS3OLx_pMNm__TYsjXrxTCUaXbHzoGanlT1La2JNz9sHy6M3f4tN0nv43N-IW2cIPKRChwOzQrAw

Fixing the path should ensure it can find the suite now that we moved Stressgres into the monorepo.

## Why
^

## How
^

## Tests
^