### PR TITLE
docs: Update CNPG docs URLs

### DIFF
--- a/docs/deploy/self-hosted/high-availability/configuration.mdx
+++ b/docs/deploy/self-hosted/high-availability/configuration.mdx
@@ -14,7 +14,7 @@ In a highly available configuration, ParadeDB deploys as a cluster of Postgres i
 
 If the primary server goes down, a standby server is promoted to become the new primary server. This process is called failover.
 
-For a thorough architecture overview, please consult the [CloudNativePG Architecture documentation](https://cloudnative-pg.io/documentation/current/architecture/).
+For a thorough architecture overview, please consult the [CloudNativePG Architecture documentation](https://cloudnative-pg.io/docs/1.28/architecture).
 
 ## Enable High Availability
 
@@ -47,9 +47,9 @@ By default, ParadeDB ships with asynchronuous replication, meaning transactions 
 the standby instances before committing.
 
 **Quorum-based synchronous replication** ensures that a transaction is successfully written to standbys before it completes.
-Please consult the [CloudNativePG Replication documentation](https://cloudnative-pg.io/documentation/current/replication/#synchronous-replication) for details.
+Please consult the [CloudNativePG Replication documentation](https://cloudnative-pg.io/docs/1.28/replication#synchronous-replication) for details.
 
 ## Backup and Disaster Recovery
 
 ParadeDB supports backups to cloud object stores (e.g. S3, GCS, etc.) and point-in-time-recovery
-via [Barman](https://pgbarman.org/). To configure the frequency and location of backups, please consult the [CloudNativePG Backup documentation](https://cloudnative-pg.io/documentation/current/backup/).
+via [Barman](https://pgbarman.org/). To configure the frequency and location of backups, please consult the [CloudNativePG Backup documentation](https://cloudnative-pg.io/docs/1.28/backup).

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -133,4 +133,4 @@ kubectl --namespace prometheus-community port-forward svc/prometheus-community-g
 `You can then access the Grafana dasbhoard at `localhost:3000` using the credentials`admin`as username
 and`prom-operator` as password. These default credentials are defined in the [`kube-stack-config.yaml`](https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/monitoring/kube-stack-config.yaml)
 file used as the `values.yaml`file in [Installing the Prometheus CRDs](#installing-the-prometheus-stack) and can be modified by providing
-your own`values.yaml` file. A more detailed guide on monitoring the cluster can be found in the [CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/monitoring/).
+your own`values.yaml` file. A more detailed guide on monitoring the cluster can be found in the [CloudNativePG documentation](https://cloudnative-pg.io/docs/1.28/monitoring).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
They updated their docs provider and the URLs changed: https://cloudnative-pg.io/docs/1.28/

This was surfaced by SEMRush as broken links, hurting our SEO.

## Why
^

## How
^

## Tests
Manually checked every URL.