### PR TITLE
ci: Remove unnecessary token requirement for Schemabot

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch the entire history
 
       - name: Extract pgrx Version
         id: pgrx


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We had a super convoluted way to checkout the repo with the Schemabot workflow, which is no longer necessary thanks to @mdashti's great work. I am removing it, so that the workflow can also run on external contributor's PRs.

## Why
^

## How
^

## Tests
See here: https://github.com/paradedb/paradedb/actions/runs/20677436245/job/59366973582?pr=3848