### PR TITLE
chore: Add a tag to our `paradedb/github-action-benchmark` ref

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -50,7 +50,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Benchmark Metrics
-      uses: paradedb/github-action-benchmark
+      uses: paradedb/github-action-benchmark@paradedb-v0
       with:
         name: "pg_search '${{ inputs.dataset }}' Query Performance"
         ref: ${{ inputs.ref }}

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -109,7 +109,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish TPS Metrics
-      uses: paradedb/github-action-benchmark
+      uses: paradedb/github-action-benchmark@paradedb-v0
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
         ref: ${{ inputs.ref }}
@@ -137,7 +137,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Other Metrics
-      uses: paradedb/github-action-benchmark
+      uses: paradedb/github-action-benchmark@paradedb-v0
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
## What

Add a tag to our `paradedb/github-action-benchmark` ref

## Why

To fix https://github.com/paradedb/paradedb-enterprise/actions/runs/20732440053/job/59523035476