### PR TITLE
chore: Revert "chore: Do not benchmark release branches on `push`."

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -10,8 +10,7 @@ on:
   push:
     branches:
       - main
-      # TODO: We do not run for release branch pushes, because we do not currently sort our graphs
-      # or PR comments by the git-graph. See https://github.com/paradedb/paradedb/issues/3769
+      - 0.*.x # Release branches
     paths:
       - "benchmarks/**"
       - "**/*.rs"
@@ -20,8 +19,6 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
-      # TODO: We support running benchmarks on release branch PRs, but they will always compare
-      # to `main`: see the TODO above.
       - 0.*.x # Release branches
   workflow_dispatch:
     inputs:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -11,8 +11,7 @@ on:
   push:
     branches:
       - main
-      # TODO: We do not run for release branch pushes, because we do not currently sort our graphs
-      # or PR comments by the git-graph. See https://github.com/paradedb/paradedb/issues/3769
+      - 0.*.x # Release branches
     paths:
       - "stressgres/suites/**"
       - "**/*.rs"
@@ -21,8 +20,6 @@ on:
     types: [labeled, synchronize]
     branches:
       - main
-      # TODO: We support running benchmarks on release branch PRs, but they will always compare
-      # to `main`: see the TODO above.
       - 0.*.x # Release branches
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Reverts paradedb/paradedb#3770