### PR TITLE
ci: Adding Antithesis Bug report action

### DIFF
--- a/.github/workflows/run-bug-report-antithesis.yml
+++ b/.github/workflows/run-bug-report-antithesis.yml
@@ -1,4 +1,4 @@
-name: Run a bug report
+name: Run a bug report (Antithesis)
 
 on: 
   workflow_dispatch:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This allows provides the ability to launch a bug report from Antithesis for issues found on the platform

## Why
Makes it easier than running a curl command

## How

## Tests
Not tested yet