### PR TITLE
chore: Add a check that the lockfile is stable in CI.

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -36,6 +36,9 @@ jobs:
           components: rustfmt, clippy
           cache: false
 
+      - name: Check Cargo.lock
+        run: cargo metadata --format-version 1 --locked > /dev/null
+
       # Required by Stressgres
       - name: Install fontconfig
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev


### PR DESCRIPTION
## What

Fail CI if the lockfile is not stable.

## Why

To avoid uncommitted lockfile changes.

## Tests

A failing check looks like:
```console
$ cargo metadata --format-version 1 --locked > /dev/null
error: the lock file Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```