### PR TITLE
chore: Add skeleton of join scan

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -32,6 +32,9 @@ static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// Allows the user to toggle the use of our "ParadeDB Aggregate Scan".
 static ENABLE_AGGREGATE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Allows the user to toggle the use of our "ParadeDB Join Scan".
+static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
@@ -116,6 +119,15 @@ pub fn init() {
         c"Enable ParadeDB's custom aggregate scan",
         c"Enable ParadeDB's custom aggregate scan, which replaces row-based aggregates with column-based aggregates where beneficial",
         &ENABLE_AGGREGATE_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_join_custom_scan",
+        c"Enable ParadeDB's experimental join custom scan",
+        c"Enable ParadeDB's experimental join custom scan. Default is false.",
+        &ENABLE_JOIN_CUSTOM_SCAN,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -302,6 +314,10 @@ pub fn enable_custom_scan() -> bool {
 
 pub fn enable_aggregate_custom_scan() -> bool {
     ENABLE_AGGREGATE_CUSTOM_SCAN.get()
+}
+
+pub fn enable_join_custom_scan() -> bool {
+    ENABLE_JOIN_CUSTOM_SCAN.get()
 }
 
 pub fn enable_custom_scan_without_operator() -> bool {

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -103,6 +103,7 @@ pub unsafe extern "C-unwind" fn _PG_init() {
     #[allow(deprecated)]
     customscan::register_rel_pathlist(customscan::basescan::BaseScan);
     customscan::register_upper_path(customscan::aggregatescan::AggregateScan);
+    customscan::register_join_pathlist(customscan::joinscan::JoinScan);
 
     // Register global planner hook for window function support
     customscan::register_window_aggregate_hook();

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JoinCSClause {}

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+pub mod build;
+pub mod privdat;
+pub mod scan_state;
+
+use self::privdat::PrivateData;
+use self::scan_state::JoinScanState;
+use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
+use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
+use crate::postgres::customscan::builders::custom_state::{
+    CustomScanStateBuilder, CustomScanStateWrapper,
+};
+use crate::postgres::customscan::explainer::Explainer;
+use crate::postgres::customscan::{CustomScan, ExecMethod, JoinPathlistHookArgs, PlainExecCapable};
+use pgrx::pg_sys;
+use std::ffi::CStr;
+
+#[derive(Default)]
+pub struct JoinScan;
+
+impl CustomScan for JoinScan {
+    const NAME: &'static CStr = c"ParadeDB Join Scan";
+    type Args = JoinPathlistHookArgs;
+    type State = JoinScanState;
+    type PrivateData = PrivateData;
+
+    fn create_custom_path(_builder: CustomPathBuilder<Self>) -> Option<pg_sys::CustomPath> {
+        // Planning should never trigger for now
+        None
+    }
+
+    fn plan_custom_path(builder: CustomScanBuilder<Self>) -> pg_sys::CustomScan {
+        builder.build()
+    }
+
+    fn create_custom_scan_state(
+        builder: CustomScanStateBuilder<Self, Self::PrivateData>,
+    ) -> *mut CustomScanStateWrapper<Self> {
+        builder.build()
+    }
+
+    fn explain_custom_scan(
+        _state: &CustomScanStateWrapper<Self>,
+        _ancestors: *mut pg_sys::List,
+        _explainer: &mut Explainer,
+    ) {
+    }
+
+    fn begin_custom_scan(
+        _state: &mut CustomScanStateWrapper<Self>,
+        _estate: *mut pg_sys::EState,
+        _eflags: i32,
+    ) {
+    }
+
+    fn rescan_custom_scan(_state: &mut CustomScanStateWrapper<Self>) {}
+
+    fn exec_custom_scan(_state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
+        todo!("JoinScan execution not implemented")
+    }
+
+    fn shutdown_custom_scan(_state: &mut CustomScanStateWrapper<Self>) {}
+
+    fn end_custom_scan(_state: &mut CustomScanStateWrapper<Self>) {}
+}
+
+impl ExecMethod for JoinScan {
+    fn exec_methods() -> *const pg_sys::CustomExecMethods {
+        <JoinScan as PlainExecCapable>::exec_methods()
+    }
+}
+
+impl PlainExecCapable for JoinScan {}

--- a/pg_search/src/postgres/customscan/joinscan/privdat.rs
+++ b/pg_search/src/postgres/customscan/joinscan/privdat.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::api::AsCStr;
+use crate::postgres::customscan::joinscan::build::JoinCSClause;
+use pgrx::pg_sys;
+use pgrx::pg_sys::AsPgCStr;
+use pgrx::PgList;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PrivateData {
+    pub join_clause: JoinCSClause,
+}
+
+impl From<*mut pg_sys::List> for PrivateData {
+    fn from(list: *mut pg_sys::List) -> Self {
+        unsafe {
+            let list = PgList::<pg_sys::Node>::from_pg(list);
+            let node = list.get_ptr(0).unwrap();
+            let content = node
+                .as_c_str()
+                .unwrap()
+                .to_str()
+                .expect("string node should be valid utf8");
+            serde_json::from_str(content).unwrap()
+        }
+    }
+}
+
+impl From<PrivateData> for *mut pg_sys::List {
+    fn from(value: PrivateData) -> Self {
+        let content = serde_json::to_string(&value).unwrap();
+        unsafe {
+            let mut ser = PgList::new();
+            ser.push(pg_sys::makeString(content.as_pg_cstr()).cast::<pg_sys::Node>());
+            ser.into_pg()
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::postgres::customscan::joinscan::build::JoinCSClause;
+use crate::postgres::customscan::CustomScanState;
+use pgrx::pg_sys;
+
+#[derive(Default)]
+pub struct JoinScanState {
+    #[allow(dead_code)]
+    pub join_clause: JoinCSClause,
+}
+
+impl CustomScanState for JoinScanState {
+    fn init_exec_method(&mut self, _cstate: *mut pg_sys::CustomScanState) {}
+}

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -34,6 +34,7 @@ mod exec;
 pub mod explain;
 mod explainer;
 mod hook;
+pub mod joinscan;
 mod opexpr;
 mod path;
 pub mod projections;
@@ -57,7 +58,10 @@ use crate::postgres::customscan::builders::custom_state::{
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::path::{plan_custom_path, reparameterize_custom_path_by_child};
 use crate::postgres::customscan::scan::create_custom_scan_state;
-pub use hook::{register_rel_pathlist, register_upper_path, register_window_aggregate_hook};
+pub use hook::{
+    register_join_pathlist, register_rel_pathlist, register_upper_path,
+    register_window_aggregate_hook,
+};
 
 // TODO: This trait should be expanded to include a `reset` method, which would become the
 // default/only implementation of `rescan_custom_scan`.
@@ -253,6 +257,55 @@ impl RelPathlistHookArgs {
 
     pub fn rte(&self) -> &pg_sys::RangeTblEntry {
         unsafe { self.rte.as_ref().expect("Args::rte should not be null") }
+    }
+}
+
+#[derive(Debug)]
+pub struct JoinPathlistHookArgs {
+    pub root: *mut pg_sys::PlannerInfo,
+    #[allow(dead_code)]
+    pub joinrel: *mut pg_sys::RelOptInfo,
+    #[allow(dead_code)]
+    pub outerrel: *mut pg_sys::RelOptInfo,
+    #[allow(dead_code)]
+    pub innerrel: *mut pg_sys::RelOptInfo,
+    #[allow(dead_code)]
+    pub jointype: pg_sys::JoinType::Type,
+    #[allow(dead_code)]
+    pub extra: *mut pg_sys::JoinPathExtraData,
+}
+
+impl JoinPathlistHookArgs {
+    #[allow(dead_code)]
+    pub fn root(&self) -> &pg_sys::PlannerInfo {
+        unsafe { self.root.as_ref().expect("Args::root should not be null") }
+    }
+
+    #[allow(dead_code)]
+    pub fn joinrel(&self) -> &pg_sys::RelOptInfo {
+        unsafe {
+            self.joinrel
+                .as_ref()
+                .expect("Args::joinrel should not be null")
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn outerrel(&self) -> &pg_sys::RelOptInfo {
+        unsafe {
+            self.outerrel
+                .as_ref()
+                .expect("Args::outerrel should not be null")
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn innerrel(&self) -> &pg_sys::RelOptInfo {
+        unsafe {
+            self.innerrel
+                .as_ref()
+                .expect("Args::innerrel should not be null")
+        }
     }
 }
 


### PR DESCRIPTION
## What

Add an initial skeleton of a join custom scan. It is disabled by default by a GUC, and has no body.

## Why

To enable parallel work on the planning and execution portions.