### PR TITLE
docs: Update Postgres version (18) in installation notes

### DIFF
--- a/docs/documentation/getting-started/install.mdx
+++ b/docs/documentation/getting-started/install.mdx
@@ -9,7 +9,7 @@ your primary Postgres is in a virtual private cloud (VPC), we recommend deployin
 instance within your VPC to avoid exposing public IP addresses and needing to provision traffic routing
 rules.
 
-**Note**: ParadeDB supports Postgres 14+, and the `latest` tag ships with Postgres 17. To specify a different Postgres version, please refer to the available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
+**Note**: ParadeDB supports Postgres 14+, and the `latest` tag ships with Postgres 18. To specify a different Postgres version, please refer to the available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
 docker run \


### PR DESCRIPTION
Minor docs update
Postgres 18 is now the default as of v0.21.0
chore: Default to PG18 #3672

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
