### PR TITLE
chore: Incorporate Tantivy with index sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "bitpacking",
 ]
@@ -6329,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -6389,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a0c6da462c72b55abf36e0452852a2448c66c22f#a0c6da462c72b55abf36e0452852a2448c66c22f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "03f09a2b5be7828918b04a50523e966cfc132835", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "a0c6da462c72b55abf36e0452852a2448c66c22f", features = [
   "quickwit",        # for sstable support
   "stopwords",
   "lz4-compression",
@@ -38,4 +38,4 @@ pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "03f09a2b5be7828918b04a50523e966cfc132835" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "a0c6da462c72b55abf36e0452852a2448c66c22f" }

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -811,7 +811,6 @@ mod tests {
         let SegmentMetaEntryContent::Immutable(entry) = entry.content else {
             todo!("test_list_meta_entries");
         };
-        assert!(entry.store.is_some());
         assert!(entry.field_norms.is_some());
         assert!(entry.fast_fields.is_some());
         assert!(entry.postings.is_some());

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -47,7 +47,7 @@ impl PendingSegment {
 
     fn with_id(index: &Index, memory_budget: NonZeroUsize, segment_id: SegmentId) -> Result<Self> {
         let segment = index.new_segment_with_id(segment_id);
-        let writer = SegmentWriter::for_segment(memory_budget.into(), segment.clone())?;
+        let writer = SegmentWriter::for_segment(memory_budget.into(), segment.clone(), true)?;
         Ok(Self {
             segment,
             writer,

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -16,7 +16,9 @@ pub struct SegmentComponentWriter {
 
 impl SegmentComponentWriter {
     pub unsafe fn new(indexrel: &PgSearchRelation, path: &Path) -> Self {
-        if path.component_type() == Some(SegmentComponent::Store) {
+        if path.component_type() == Some(SegmentComponent::Store)
+            || path.component_type() == Some(SegmentComponent::TempStore)
+        {
             Self {
                 inner: None,
                 path: path.to_path_buf(),

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -327,11 +327,6 @@ impl SegmentMetaEntryImmutable {
             )
             .chain(self.terms.iter().map(|fe| (fe, SegmentComponent::Terms)))
             .chain(
-                self.temp_store
-                    .iter()
-                    .map(|fe| (fe, SegmentComponent::TempStore)),
-            )
-            .chain(
                 self.delete
                     .as_ref()
                     .map(|d| (&d.file_entry, SegmentComponent::Delete)),


### PR DESCRIPTION
## What

This is a clone of #2691 which does not actually begin using a `ctid` sort, and just incorporates https://github.com/paradedb/tantivy/pull/92 .

## Why

To enable work on https://github.com/paradedb/paradedb/issues/3053.