### PR TITLE
ci: Move more workflows to Ubicloud

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint-rust:
     name: Lint Rust Files
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
 
     steps:
       - name: Checkout Git Repository


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
I noticed our CI was a bit high, and these are heavy runs which should be on Ubicloud.

## Why
^

## How
^

## Tests
^