### PR TITLE
Add Synonym support 🪄

### DIFF
--- a/pg_search/src/api/builder_fns/pdb.rs
+++ b/pg_search/src/api/builder_fns/pdb.rs
@@ -52,6 +52,7 @@ mod pdb {
             distance: None,
             transposition_cost_one: None,
             prefix: None,
+            synonyms_table: None,
         }
     }
     #[builder_fn]
@@ -76,6 +77,7 @@ mod pdb {
             distance: None,
             transposition_cost_one: None,
             prefix: None,
+            synonyms_table: None,
         }
     }
 
@@ -134,6 +136,7 @@ mod pdb {
         transposition_cost_one: default!(Option<bool>, "NULL"),
         prefix: default!(Option<bool>, "NULL"),
         conjunction_mode: default!(Option<bool>, "NULL"),
+        synonyms_table: default!(Option<String>, "NULL"),
     ) -> pdb::Query {
         pdb::Query::Match {
             value,
@@ -142,6 +145,7 @@ mod pdb {
             transposition_cost_one,
             prefix,
             conjunction_mode,
+            synonyms_table,
         }
     }
 

--- a/pg_search/src/api/tokenizers/typmod/mod.rs
+++ b/pg_search/src/api/tokenizers/typmod/mod.rs
@@ -381,6 +381,11 @@ impl From<&ParsedTypmod> for SearchTokenizerFilters {
             ascii_folding: value.get("ascii_folding").and_then(|p| p.as_bool()),
             trim: value.get("trim").and_then(|p| p.as_bool()),
             normalizer: value.get("normalizer").and_then(|p| p.as_normalizer()),
+            // Store table name for query-time synonym expansion (not loaded at index time)
+            synonyms_table: value
+                .get("synonyms_table")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string()),
         }
     }
 }

--- a/pg_search/src/api/tokenizers/typmod/validation.rs
+++ b/pg_search/src/api/tokenizers/typmod/validation.rs
@@ -236,6 +236,7 @@ impl TypmodSchema {
                     ValueConstraint::StringChoiceMultiple(LANGUAGES.values().cloned().collect())
                 ),
                 rule!("stopwords", ValueConstraint::String),
+                rule!("synonyms_table", ValueConstraint::String),
                 rule!("alpha_num_only", ValueConstraint::Boolean),
                 rule!("ascii_folding", ValueConstraint::Boolean),
                 rule!("trim", ValueConstraint::Boolean),

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -23,6 +23,7 @@ pub mod pdb_query;
 pub(crate) mod proximity;
 mod range;
 mod score;
+pub mod synonym;
 
 use builder::{QueryBuilder, QueryOnlyBuilder, QueryTreeBuilder};
 use estimate_tree::QueryWithEstimates;
@@ -1465,6 +1466,7 @@ mod tests {
                 transposition_cost_one: None,
                 prefix: None,
                 conjunction_mode: None,
+                synonyms_table: None,
             },
         }
     }

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -20,6 +20,7 @@ use crate::query::pdb_query::pdb::{FuzzyData, ScoreAdjustStyle, SlopData};
 use crate::query::proximity::query::ProximityQuery;
 use crate::query::proximity::{ProximityClause, ProximityDistance};
 use crate::query::range::{Comparison, RangeField};
+use crate::query::synonym::{build_query as build_synonym_query, expand_tokens, SynonymMap};
 use crate::query::{
     check_range_bounds, coerce_bound_to_field_type, value_to_term, QueryError, SearchQueryInput,
 };
@@ -221,6 +222,7 @@ pub mod pdb {
             transposition_cost_one: Option<bool>,
             prefix: Option<bool>,
             conjunction_mode: Option<bool>,
+            synonyms_table: Option<String>,
         },
         MatchArray {
             tokens: Vec<String>,
@@ -519,6 +521,7 @@ impl pdb::Query {
                 transposition_cost_one,
                 prefix,
                 conjunction_mode,
+                synonyms_table,
             } => match_query(
                 &field,
                 schema,
@@ -529,6 +532,7 @@ impl pdb::Query {
                 transposition_cost_one,
                 prefix,
                 conjunction_mode,
+                synonyms_table,
             )?,
             pdb::Query::MatchArray {
                 tokens: value,
@@ -1407,12 +1411,37 @@ fn tokenized_phrase(
 
     let field_type = search_field.field_entry().field_type();
     let mut tokenizer = searcher.index().tokenizer_for_field(search_field.field())?;
-    let mut stream = tokenizer.token_stream(phrase);
     let path = field.path();
 
-    let mut tokens = Vec::new();
-    while let Some(token) = stream.next() {
-        let value = OwnedValue::Str(token.text.clone());
+    // Collect tokens (in a block to drop stream before reusing tokenizer)
+    let tokens: Vec<String> = {
+        let mut stream = tokenizer.token_stream(phrase);
+        let mut tokens = Vec::new();
+        while let Some(token) = stream.next() {
+            tokens.push(token.text.to_string());
+        }
+        tokens
+    };
+
+    // Check for synonyms_table in field config
+    let synonyms_table = search_field
+        .field_config()
+        .tokenizer()
+        .map(|t| t.filters())
+        .and_then(|f| f.synonyms_table.clone());
+
+    // If synonyms available, use synonym expansion
+    if let Some(table_name) = synonyms_table {
+        if let Ok(synonym_map) = SynonymMap::load_from_table(&table_name, &tokens, &mut tokenizer) {
+            let expanded = expand_tokens(&tokens, &synonym_map, &mut tokenizer);
+            return Ok(build_synonym_query(&expanded, search_field.field()));
+        }
+    }
+
+    // Standard phrase query (no synonyms)
+    let mut terms = Vec::new();
+    for token in tokens {
+        let value = OwnedValue::Str(token);
         let term = value_to_term(
             search_field.field(),
             &value,
@@ -1420,17 +1449,18 @@ fn tokenized_phrase(
             path.as_deref(),
             false,
         )?;
-        tokens.push(term);
+        terms.push(term);
     }
-    Ok(if tokens.is_empty() {
+
+    Ok(if terms.is_empty() {
         Box::new(EmptyQuery)
-    } else if tokens.len() == 1 {
+    } else if terms.len() == 1 {
         Box::new(TermQuery::new(
-            tokens.remove(0),
+            terms.remove(0),
             IndexRecordOption::WithFreqs.into(),
         ))
     } else {
-        let mut query = PhraseQuery::new(tokens);
+        let mut query = PhraseQuery::new(terms);
         query.set_slop(slop.unwrap_or(0));
         Box::new(query)
     })
@@ -1642,6 +1672,7 @@ fn match_query(
     transposition_cost_one: Option<bool>,
     prefix: Option<bool>,
     conjunction_mode: Option<bool>,
+    synonyms_table: Option<String>,
 ) -> anyhow::Result<Box<dyn TantivyQuery>> {
     let distance = distance.unwrap_or(0);
     let transposition_cost_one = transposition_cost_one.unwrap_or(true);
@@ -1658,11 +1689,37 @@ fn match_query(
             .expect("tantivy should support tokenizer {tokenizer:?}"),
         None => searcher.index().tokenizer_for_field(search_field.field())?,
     };
-    let mut stream = analyzer.token_stream(value);
-    let mut terms = Vec::new();
 
-    while stream.advance() {
-        let token = stream.token().text.clone();
+    // Collect tokens (in a block to drop stream before reusing analyzer)
+    let tokens = {
+        let mut stream = analyzer.token_stream(value);
+        let mut tokens = Vec::new();
+        while stream.advance() {
+            tokens.push(stream.token().text.clone());
+        }
+        tokens
+    };
+
+    // Get synonyms_table: use explicit param, or fall back to field's index config
+    let synonyms_table = synonyms_table.or_else(|| {
+        search_field
+            .field_config()
+            .tokenizer()
+            .map(|t| t.filters())
+            .and_then(|f| f.synonyms_table.clone())
+    });
+
+    // If synonyms_table is available, use query-time synonym expansion
+    if let Some(table_name) = synonyms_table {
+        let synonym_map = SynonymMap::load_from_table(&table_name, &tokens, &mut analyzer)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let expanded = expand_tokens(&tokens, &synonym_map, &mut analyzer);
+        return Ok(build_synonym_query(&expanded, search_field.field()));
+    }
+
+    // Standard match query behavior (no synonyms)
+    let mut terms = Vec::new();
+    for token in tokens {
         let term = value_to_term(
             search_field.field(),
             &OwnedValue::Str(token),

--- a/pg_search/src/query/synonym.rs
+++ b/pg_search/src/query/synonym.rs
@@ -1,0 +1,392 @@
+// Copyright (c) 2023-2025 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Query-time synonym expansion.
+//!
+//! This module provides Elasticsearch-style synonym expansion at query time.
+//! Synonyms are loaded from a PostgreSQL table and used to expand query terms
+//! into Boolean queries with term and phrase alternatives.
+//!
+//! ## Table Schema
+//!
+//! ```sql
+//! CREATE TABLE synonyms (
+//!     term TEXT PRIMARY KEY,      -- term to match (can be multi-word)
+//!     expansions TEXT[] NOT NULL  -- what to expand to (can include multi-word)
+//! );
+//!
+//! -- Equivalent synonyms: each term maps to all
+//! INSERT INTO synonyms VALUES ('ny', ARRAY['ny', 'new york', 'nyc']);
+//! INSERT INTO synonyms VALUES ('new york', ARRAY['ny', 'new york', 'nyc']);
+//! INSERT INTO synonyms VALUES ('nyc', ARRAY['ny', 'new york', 'nyc']);
+//! ```
+
+use pgrx::Spi;
+use std::collections::HashMap;
+use tantivy::query::{BooleanQuery, Occur, PhraseQuery, Query, TermQuery};
+use tantivy::schema::{Field, IndexRecordOption};
+use tantivy::tokenizer::TextAnalyzer;
+use tantivy::Term;
+
+/// Tokenize text using the provided analyzer.
+fn tokenize_text(text: &str, tokenizer: &mut TextAnalyzer) -> Vec<String> {
+    let mut stream = tokenizer.token_stream(text);
+    let mut tokens = Vec::new();
+    while stream.advance() {
+        tokens.push(stream.token().text.clone());
+    }
+    tokens
+}
+
+/// A trie node for efficient multi-word phrase prefix matching.
+#[derive(Clone, Default, Debug)]
+struct TrieNode {
+    children: HashMap<String, TrieNode>,
+    /// If Some, this node represents a complete term with expansions.
+    expansions: Option<Vec<String>>,
+}
+
+/// Synonym map supporting both single-word and multi-word terms.
+#[derive(Clone, Default, Debug)]
+pub struct SynonymMap {
+    /// Maps single-word terms to their expansions.
+    single_word: HashMap<String, Vec<String>>,
+    /// Trie for multi-word term matching.
+    multi_word_trie: TrieNode,
+    /// Whether there are any multi-word terms.
+    has_multi_word: bool,
+}
+
+impl SynonymMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a synonym rule using the provided tokenizer.
+    /// The tokenizer handles normalization (lowercasing, etc.) consistently.
+    pub fn insert(&mut self, term: &str, expansions: Vec<String>, tokenizer: &mut TextAnalyzer) {
+        let words = tokenize_text(term, tokenizer);
+        if words.len() == 1 {
+            self.single_word.insert(words[0].clone(), expansions);
+        } else if !words.is_empty() {
+            self.has_multi_word = true;
+            let mut node = &mut self.multi_word_trie;
+            for word in &words {
+                node = node
+                    .children
+                    .entry(word.clone())
+                    .or_insert_with(TrieNode::default);
+            }
+            node.expansions = Some(expansions);
+        }
+    }
+
+    /// Look up a single-word term.
+    pub fn get_single(&self, term: &str) -> Option<&Vec<String>> {
+        self.single_word.get(term)
+    }
+
+    /// Check if a sequence of tokens matches a multi-word term.
+    /// Returns (match_length, expansions) if found.
+    pub fn get_multi(&self, tokens: &[&str]) -> Option<(usize, &Vec<String>)> {
+        if !self.has_multi_word || tokens.is_empty() {
+            return None;
+        }
+
+        let mut node = &self.multi_word_trie;
+        let mut last_match: Option<(usize, &Vec<String>)> = None;
+
+        for (i, token) in tokens.iter().enumerate() {
+            match node.children.get(*token) {
+                Some(child) => {
+                    node = child;
+                    if let Some(ref expansions) = node.expansions {
+                        last_match = Some((i + 1, expansions));
+                    }
+                }
+                None => break,
+            }
+        }
+
+        last_match
+    }
+
+    /// Load synonyms from a PostgreSQL table, filtered by query tokens.
+    /// Table must have columns: term TEXT, expansions TEXT[]
+    /// Uses the provided tokenizer to consistently tokenize both synonym terms and expansions.
+    /// Only loads synonyms where the term starts with one of the query tokens (for efficiency).
+    pub fn load_from_table(
+        table_name: &str,
+        query_tokens: &[String],
+        tokenizer: &mut TextAnalyzer,
+    ) -> Result<Self, String> {
+        // Validate table name
+        if !table_name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+        {
+            return Err(format!(
+                "Invalid table name: '{}'. Only alphanumeric, underscore, and dot allowed.",
+                table_name
+            ));
+        }
+
+        if query_tokens.is_empty() {
+            return Ok(SynonymMap::new());
+        }
+
+        // Build a query that filters by tokens that could match
+        // We use LIKE 'token%' to match both single-word and multi-word terms
+        let like_conditions: Vec<String> = query_tokens
+            .iter()
+            .map(|t| format!("lower(term) LIKE '{}%'", t.to_lowercase().replace('\'', "''")))
+            .collect();
+        let where_clause = like_conditions.join(" OR ");
+        let query = format!(
+            "SELECT term, expansions FROM {} WHERE {}",
+            table_name, where_clause
+        );
+
+        let mut map = SynonymMap::new();
+
+        Spi::connect(|client| {
+            let result = client.select(&query, None, &[]);
+            match result {
+                Ok(table) => {
+                    for row in table {
+                        let term: Option<String> = row.get(1).ok().flatten();
+                        let expansions: Option<Vec<String>> = row.get(2).ok().flatten();
+
+                        if let (Some(term), Some(expansions)) = (term, expansions) {
+                            map.insert(&term, expansions, tokenizer);
+                        }
+                    }
+                }
+                Err(e) => {
+                    return Err(format!("Failed to load synonyms from '{}': {}", table_name, e));
+                }
+            }
+            Ok(())
+        })?;
+
+        Ok(map)
+    }
+}
+
+/// Represents an expanded query term.
+#[derive(Debug, Clone)]
+pub enum ExpandedTerm {
+    /// A single term (no expansion or single-word expansion).
+    Term(String),
+    /// Multiple alternatives (OR of terms and/or phrases).
+    Alternatives(Vec<Expansion>),
+}
+
+/// A single expansion - either a term or a phrase.
+#[derive(Debug, Clone)]
+pub enum Expansion {
+    Term(String),
+    Phrase(Vec<String>),
+}
+
+impl Expansion {
+    /// Convert to a Tantivy query.
+    pub fn to_query(&self, field: Field) -> Box<dyn Query> {
+        match self {
+            Expansion::Term(text) => term_query(field, text),
+            Expansion::Phrase(words) => {
+                let terms: Vec<Term> = words
+                    .iter()
+                    .map(|w| Term::from_field_text(field, w))
+                    .collect();
+                Box::new(PhraseQuery::new(terms))
+            }
+        }
+    }
+}
+
+/// Create a TermQuery for the given field and text.
+fn term_query(field: Field, text: &str) -> Box<dyn Query> {
+    let term = Term::from_field_text(field, text);
+    Box::new(TermQuery::new(term, IndexRecordOption::WithFreqsAndPositions))
+}
+
+/// Parse expansion strings into Expansion variants using the tokenizer.
+fn parse_expansions(expansions: &[String], tokenizer: &mut TextAnalyzer) -> Vec<Expansion> {
+    expansions
+        .iter()
+        .map(|exp| {
+            let words = tokenize_text(exp, tokenizer);
+            if words.len() == 1 {
+                Expansion::Term(words[0].clone())
+            } else {
+                Expansion::Phrase(words)
+            }
+        })
+        .collect()
+}
+
+/// Expand a sequence of tokens using the synonym map.
+/// Returns expanded terms, consuming multi-word matches greedily.
+/// Uses the provided tokenizer to parse expansion strings consistently.
+pub fn expand_tokens(tokens: &[String], synonym_map: &SynonymMap, tokenizer: &mut TextAnalyzer) -> Vec<ExpandedTerm> {
+    let mut result = Vec::new();
+    let mut i = 0;
+
+    while i < tokens.len() {
+        // First, try multi-word match (greedy)
+        let remaining: Vec<&str> = tokens[i..].iter().map(|s| s.as_str()).collect();
+        if let Some((match_len, expansions)) = synonym_map.get_multi(&remaining) {
+            result.push(ExpandedTerm::Alternatives(parse_expansions(expansions, tokenizer)));
+            i += match_len;
+            continue;
+        }
+
+        // Try single-word match
+        let token = &tokens[i];
+        if let Some(expansions) = synonym_map.get_single(token) {
+            result.push(ExpandedTerm::Alternatives(parse_expansions(expansions, tokenizer)));
+        } else {
+            // No synonym, keep original
+            result.push(ExpandedTerm::Term(token.clone()));
+        }
+
+        i += 1;
+    }
+
+    result
+}
+
+/// Convert an ExpandedTerm to a Tantivy query.
+fn expanded_term_to_query(exp: &ExpandedTerm, field: Field) -> Box<dyn Query> {
+    match exp {
+        ExpandedTerm::Term(text) => term_query(field, text),
+        ExpandedTerm::Alternatives(alts) if alts.len() == 1 => alts[0].to_query(field),
+        ExpandedTerm::Alternatives(alts) => {
+            let subqueries: Vec<(Occur, Box<dyn Query>)> = alts
+                .iter()
+                .map(|alt| (Occur::Should, alt.to_query(field)))
+                .collect();
+            Box::new(BooleanQuery::new(subqueries))
+        }
+    }
+}
+
+/// Build a Tantivy query from expanded terms.
+/// Uses AND semantics between terms, OR for alternatives.
+pub fn build_query(expanded: &[ExpandedTerm], field: Field) -> Box<dyn Query> {
+    match expanded.len() {
+        0 => Box::new(BooleanQuery::new(vec![])),
+        1 => expanded_term_to_query(&expanded[0], field),
+        _ => {
+            let subqueries: Vec<(Occur, Box<dyn Query>)> = expanded
+                .iter()
+                .map(|exp| (Occur::Must, expanded_term_to_query(exp, field)))
+                .collect();
+            Box::new(BooleanQuery::new(subqueries))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tantivy::tokenizer::{SimpleTokenizer, TokenizerManager};
+
+    fn simple_tokenizer() -> TextAnalyzer {
+        TextAnalyzer::builder(SimpleTokenizer::default())
+            .filter(tantivy::tokenizer::LowerCaser)
+            .build()
+    }
+
+    #[test]
+    fn test_single_word_synonyms() {
+        let mut map = SynonymMap::new();
+        let mut tokenizer = simple_tokenizer();
+        map.insert("cat", vec!["cat".to_string(), "feline".to_string(), "kitty".to_string()], &mut tokenizer);
+
+        let expansions = map.get_single("cat").unwrap();
+        assert_eq!(expansions.len(), 3);
+        assert!(expansions.contains(&"cat".to_string()));
+        assert!(expansions.contains(&"feline".to_string()));
+        assert!(expansions.contains(&"kitty".to_string()));
+    }
+
+    #[test]
+    fn test_multi_word_synonyms() {
+        let mut map = SynonymMap::new();
+        let mut tokenizer = simple_tokenizer();
+        map.insert("new york", vec!["new york".to_string(), "ny".to_string(), "nyc".to_string()], &mut tokenizer);
+
+        let tokens = vec!["new", "york", "city"];
+        let result = map.get_multi(&tokens);
+        assert!(result.is_some());
+        let (len, expansions) = result.unwrap();
+        assert_eq!(len, 2);
+        assert_eq!(expansions.len(), 3);
+    }
+
+    #[test]
+    fn test_expand_tokens_single() {
+        let mut map = SynonymMap::new();
+        let mut tokenizer = simple_tokenizer();
+        map.insert("cat", vec!["cat".to_string(), "feline".to_string()], &mut tokenizer);
+
+        let tokens = vec!["the".to_string(), "cat".to_string(), "runs".to_string()];
+        let expanded = expand_tokens(&tokens, &map, &mut tokenizer);
+
+        assert_eq!(expanded.len(), 3);
+        assert!(matches!(&expanded[0], ExpandedTerm::Term(t) if t == "the"));
+        assert!(matches!(&expanded[1], ExpandedTerm::Alternatives(alts) if alts.len() == 2));
+        assert!(matches!(&expanded[2], ExpandedTerm::Term(t) if t == "runs"));
+    }
+
+    #[test]
+    fn test_expand_tokens_multi_word() {
+        let mut map = SynonymMap::new();
+        let mut tokenizer = simple_tokenizer();
+        map.insert("new york", vec!["new york".to_string(), "ny".to_string()], &mut tokenizer);
+
+        let tokens = vec!["visit".to_string(), "new".to_string(), "york".to_string(), "today".to_string()];
+        let expanded = expand_tokens(&tokens, &map, &mut tokenizer);
+
+        assert_eq!(expanded.len(), 3); // "visit", "new york" (combined), "today"
+        assert!(matches!(&expanded[0], ExpandedTerm::Term(t) if t == "visit"));
+        assert!(matches!(&expanded[1], ExpandedTerm::Alternatives(_)));
+        assert!(matches!(&expanded[2], ExpandedTerm::Term(t) if t == "today"));
+    }
+
+    #[test]
+    fn test_greedy_multi_word_match() {
+        let mut map = SynonymMap::new();
+        let mut tokenizer = simple_tokenizer();
+        map.insert("new york", vec!["ny".to_string()], &mut tokenizer);
+        map.insert("new york city", vec!["nyc".to_string()], &mut tokenizer);
+
+        let tokens = vec!["new".to_string(), "york".to_string(), "city".to_string()];
+        let expanded = expand_tokens(&tokens, &map, &mut tokenizer);
+
+        // Should match "new york city" (longest), not "new york"
+        assert_eq!(expanded.len(), 1);
+        if let ExpandedTerm::Alternatives(alts) = &expanded[0] {
+            assert_eq!(alts.len(), 1);
+            assert!(matches!(&alts[0], Expansion::Term(t) if t == "nyc"));
+        } else {
+            panic!("Expected Alternatives");
+        }
+    }
+}

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -55,6 +55,8 @@ pub struct SearchTokenizerFilters {
     pub ascii_folding: Option<bool>,
     pub trim: Option<bool>,
     pub normalizer: Option<SearchNormalizer>,
+    /// Table name for query-time synonym expansion (e.g., "synonyms")
+    pub synonyms_table: Option<String>,
 }
 
 impl SearchTokenizerFilters {
@@ -75,6 +77,7 @@ impl SearchTokenizerFilters {
             alpha_num_only: None,
             trim: None,
             normalizer: Some(SearchNormalizer::Raw),
+            synonyms_table: None,
         }
     }
 
@@ -90,6 +93,7 @@ impl SearchTokenizerFilters {
             alpha_num_only: None,
             trim: None,
             normalizer: Some(SearchNormalizer::Raw),
+            synonyms_table: None,
         }
     }
 
@@ -187,7 +191,6 @@ impl SearchTokenizerFilters {
                 )
             })?);
         }
-
         Ok(filters)
     }
 
@@ -602,7 +605,7 @@ impl SearchTokenizer {
         Some(analyzer)
     }
 
-    fn filters(&self) -> &SearchTokenizerFilters {
+    pub fn filters(&self) -> &SearchTokenizerFilters {
         match self {
             SearchTokenizer::Simple(filters) => filters,
             SearchTokenizer::Keyword => SearchTokenizerFilters::keyword(),
@@ -775,6 +778,7 @@ mod tests {
                     trim: None,
                     normalizer: None,
                     alpha_num_only: None,
+                    synonyms_table: None,
                 }
             }
         );
@@ -800,6 +804,7 @@ mod tests {
                 trim: None,
                 normalizer: None,
                 alpha_num_only: None,
+                synonyms_table: None,
             },
         };
 


### PR DESCRIPTION
This is a POC at this stage it needs some work. 

After thinking about it for a few days I'm not sure if this is an elegant hack or just a great way of doing it. This has no Tantivy changes, it just maps synonyms into the existing query before we send it.

1. Create table as normal
2. Create a synonyms table (see below)
3. Create a BM25 index using `synonyms_table=synonyms`
4. Query as normal, and the words in synonyms get mapped, and expanded to phrase queries if multiword at query time.

Drawbacks / things to do:
1. How to manage synonyms table (auto-create? If so, how do you add existing ones?)
2. Format of synonyms table needs work. It should map onto the bi-directional way Elastic does it.
3. At the moment you can't do ```select 'new york':::pdb.simple('synonyms_table=synonyms')::text[]` because this uses a different code path. Not hard, but would have changed a lot more files.
4. Benchmark with large queries and large synonym tables.

```
pg_search=# \d docs
                             Table "public.docs"
 Column  |  Type   | Collation | Nullable |             Default              
---------+---------+-----------+----------+----------------------------------
 id      | integer |           | not null | nextval('docs_id_seq'::regclass)
 content | text    |           |          | 
Indexes:
    "docs_pkey" PRIMARY KEY, btree (id)

pg_search=# select * from docs;
 id |     content      
----+------------------
  1 | I love new york
  2 | nyc is great
  3 | visiting ny soon
  4 | hello world
(4 rows)

pg_search=# \d synonyms
               Table "public.synonyms"
   Column   |  Type  | Collation | Nullable | Default 
------------+--------+-----------+----------+---------
 term       | text   |           | not null | 
 expansions | text[] |           | not null | 
Indexes:
    "synonyms_pkey" PRIMARY KEY, btree (term)
    "synonyms_term_prefix_idx" btree (lower(term) text_pattern_ops)

pg_search=# select * from synonyms limit 2;
 term |     expansions      
------+---------------------
 ny       | {ny,"new york",nyc}
 new york | {ny,"new york",nyc}
(2 rows)


pg_search=# create index on docs using bm25(id, (content::pdb.whitespace('synonyms_table=synonyms'))) with (key_field=id);
CREATE INDEX
pg_search=#  SELECT * FROM docs WHERE content &&& 'new york';
 id |     content      
----+------------------
  1 | I love new york
  2 | nyc is great
  3 | visiting ny soon
(3 rows)

pg_search=# truncate synonyms ;
TRUNCATE TABLE
pg_search=#  SELECT * FROM docs WHERE content &&& 'new york';
 id |     content     
----+-----------------
  1 | I love new york
(1 row)
```
