### PR TITLE
chore: Swap benchmarking instances to `m5zn.metal`

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on:
       # To configure the runners: https://runs-on.com/configuration/job-labels/#how-it-works (runs in us-east-1)
       - runs-on=${{ github.run_id }}
-      - family=z1d.metal # 48 vCPUs, 384 GiBs Memory, 1.8 TiBs local NVMe
+      - family=m5zn.metal # 48 vCPUs, 192 GiBs Memory -- https://instances.vantage.sh/aws/ec2/m5zn.metal?currency=USD
       - image=ubuntu24-full-x64
       - extras=s3-cache # See https://runs-on.com/caching/magic-cache/
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-queries')

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on:
       # To configure the runners: https://runs-on.com/configuration/job-labels/#how-it-works (runs in us-east-1)
       - runs-on=${{ github.run_id }}
-      - family=z1d.metal # 48 vCPUs, 384 GiBs Memory, 1.8 TiBs local NVMe
+      - family=m5zn.metal # 48 vCPUs, 192 GiBs Memory -- https://instances.vantage.sh/aws/ec2/m5zn.metal?currency=USD
       - image=ubuntu24-full-x64
       - extras=s3-cache # See https://runs-on.com/caching/magic-cache/
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-stressgres')


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
The DataFusion community raised to my attention that this instance is also metal and is about 12% cheaper. Not a huge deal, but why not. It's not like we're using the extra 192 GBs of RAM of the `z1d.metal` 😅 

## Why
Less $$ for Bezos. He's got enough already.

## How
N/A

## Tests
Need to run a CI job to confirm the performance is comparable, or otherwise we'll need to backfill.