### PR TITLE
chore: Jan 12th Tantivy rebase. (#3924)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "bitpacking"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1d3e2bfd8d06048a179f7b17afc3188effa10385e7b00dc65af6aae732ea92"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
 ]
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -6401,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "bitpacking",
 ]
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6457,7 +6457,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -6482,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=03f09a2b5be7828918b04a50523e966cfc132835#03f09a2b5be7828918b04a50523e966cfc132835"
+source = "git+https://github.com/paradedb/tantivy.git?rev=876f5a55478176130dfc7b3e9d16e714702ea818#876f5a55478176130dfc7b3e9d16e714702ea818"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,16 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "03f09a2b5be7828918b04a50523e966cfc132835", features = [
-  "quickwit",                  # for sstable support
-  "stopwords",
-  "lz4-compression",
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "876f5a55478176130dfc7b3e9d16e714702ea818", features = [
   "columnar-zstd-compression",
+  "lz4-compression",
+  "quickwit",                  # for sstable support
+  "stemmer",
+  "stopwords",
 ], default-features = false }
 pgrx = "=0.16.1"
 pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "03f09a2b5be7828918b04a50523e966cfc132835" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "876f5a55478176130dfc7b3e9d16e714702ea818" }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = { version = "1.0.100", features = ["backtrace"] }
 arrow-array = "55.2.0"
 arrow-buffer = "55.2.0"
 arrow-schema = "55.2.0"
-bitpacking = "0.9.2"
+bitpacking = "0.9.3"
 chrono = "0.4.42"
 time = "0.3.44"
 derive_more = { version = "2.1.0", features = ["full"] }

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -783,7 +783,6 @@ mod tests {
         let SegmentMetaEntryContent::Immutable(entry) = entry.content else {
             todo!("test_list_meta_entries");
         };
-        assert!(entry.store.is_some());
         assert!(entry.field_norms.is_some());
         assert!(entry.fast_fields.is_some());
         assert!(entry.postings.is_some());

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -47,7 +47,7 @@ impl PendingSegment {
 
     fn with_id(index: &Index, memory_budget: NonZeroUsize, segment_id: SegmentId) -> Result<Self> {
         let segment = index.new_segment_with_id(segment_id);
-        let writer = SegmentWriter::for_segment(memory_budget.into(), segment.clone())?;
+        let writer = SegmentWriter::for_segment(memory_budget.into(), segment.clone(), true)?;
         Ok(Self {
             segment,
             writer,

--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -16,7 +16,9 @@ pub struct SegmentComponentWriter {
 
 impl SegmentComponentWriter {
     pub unsafe fn new(indexrel: &PgSearchRelation, path: &Path) -> Self {
-        if path.component_type() == Some(SegmentComponent::Store) {
+        if path.component_type() == Some(SegmentComponent::Store)
+            || path.component_type() == Some(SegmentComponent::TempStore)
+        {
             Self {
                 inner: None,
                 path: path.to_path_buf(),

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -214,7 +214,7 @@ impl SegmentDeleter {
                 deleted_ctids: Vec::default(),
             }))
         } else {
-            let delete_queue = DeleteQueue::new();
+            let delete_queue = DeleteQueue::default();
             let delete_cursor = delete_queue.cursor();
             let opstamp = segment_meta.delete_opstamp().unwrap_or_default();
 

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -327,11 +327,6 @@ impl SegmentMetaEntryImmutable {
             )
             .chain(self.terms.iter().map(|fe| (fe, SegmentComponent::Terms)))
             .chain(
-                self.temp_store
-                    .iter()
-                    .map(|fe| (fe, SegmentComponent::TempStore)),
-            )
-            .chain(
                 self.delete
                     .as_ref()
                     .map(|d| (&d.file_entry, SegmentComponent::Delete)),

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_05_union_window_functions.out
@@ -309,28 +309,32 @@ SELECT title, author, rating, price
 FROM union_test_b
 WHERE title @@@ 'Book B' AND rating > 3
 ORDER BY rating DESC, title;
-                                                                                                                                         QUERY PLAN                                                                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: union_test_a.rating DESC, union_test_a.title
-   ->  HashAggregate
-         Group Key: union_test_a.title, union_test_a.author, union_test_a.rating, union_test_a.price
-         ->  Append
-               ->  Custom Scan (ParadeDB Scan) on union_test_a
-                     Table: union_test_a
-                     Index: union_test_a_idx
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, price, rating, title
-                     Scores: false
-                     Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}}]}}
-               ->  Custom Scan (ParadeDB Scan) on union_test_b
-                     Table: union_test_b
-                     Index: union_test_b_idx
-                     Exec Method: MixedFastFieldExecState
-                     Fast Fields: author, price, rating, title
-                     Scores: false
-                     Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}}]}}
-(19 rows)
+   ->  Unique
+         ->  Merge Append
+               Sort Key: union_test_a.title, union_test_a.author, union_test_a.rating, union_test_a.price
+               ->  Sort
+                     Sort Key: union_test_a.title, union_test_a.author, union_test_a.rating, union_test_a.price
+                     ->  Custom Scan (ParadeDB Scan) on union_test_a
+                           Table: union_test_a
+                           Index: union_test_a_idx
+                           Exec Method: MixedFastFieldExecState
+                           Fast Fields: author, price, rating, title
+                           Scores: false
+                           Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}}]}}
+               ->  Sort
+                     Sort Key: union_test_b.title, union_test_b.author, union_test_b.rating, union_test_b.price
+                     ->  Custom Scan (ParadeDB Scan) on union_test_b
+                           Table: union_test_b
+                           Index: union_test_b_idx
+                           Exec Method: MixedFastFieldExecState
+                           Fast Fields: author, price, rating, title
+                           Scores: false
+                           Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book B","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"rating","lower_bound":{"excluded":3.0},"upper_bound":null,"is_datetime":false}}]}}
+(23 rows)
 
 SELECT title, author, rating, price
 FROM union_test_a
@@ -615,8 +619,8 @@ SELECT title, author, rating, source,
        RANK() OVER (PARTITION BY author ORDER BY rating DESC) as author_rank
 FROM combined_books
 ORDER BY title, author, author_rank;
-                                                                                                                                                  QUERY PLAN                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                        QUERY PLAN                                                                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: combined_books.title, combined_books.author, (rank() OVER w1)
    ->  WindowAgg
@@ -624,22 +628,29 @@ ORDER BY title, author, author_rank;
          ->  Sort
                Sort Key: combined_books.author, combined_books.rating DESC
                ->  Subquery Scan on combined_books
-                     ->  HashAggregate
-                           Group Key: union_test_a.title, union_test_a.author, union_test_a.rating, ('A'::text)
-                           ->  Append
-                                 ->  Custom Scan (ParadeDB Scan) on union_test_a
-                                       Table: union_test_a
-                                       Index: union_test_a_idx
-                                       Exec Method: NormalScanExecState
-                                       Scores: false
-                                       Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":3.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-                                 ->  Custom Scan (ParadeDB Scan) on union_test_b
-                                       Table: union_test_b
-                                       Index: union_test_b_idx
-                                       Exec Method: NormalScanExecState
-                                       Scores: false
-                                       Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":2.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(22 rows)
+                     ->  Unique
+                           ->  Sort
+                                 Sort Key: union_test_a.title, union_test_a.author, union_test_a.rating, ('A'::text)
+                                 ->  Append
+                                       ->  Sort
+                                             Sort Key: union_test_a.title, union_test_a.author, union_test_a.rating
+                                             ->  Custom Scan (ParadeDB Scan) on union_test_a
+                                                   Table: union_test_a
+                                                   Index: union_test_a_idx
+                                                   Exec Method: MixedFastFieldExecState
+                                                   Fast Fields: author, rating, title
+                                                   Scores: false
+                                                   Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":3.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
+                                       ->  Sort
+                                             Sort Key: union_test_b.title, union_test_b.author, union_test_b.rating
+                                             ->  Custom Scan (ParadeDB Scan) on union_test_b
+                                                   Table: union_test_b
+                                                   Index: union_test_b_idx
+                                                   Exec Method: MixedFastFieldExecState
+                                                   Fast Fields: author, rating, title
+                                                   Scores: false
+                                                   Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":2.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
+(29 rows)
 
 WITH combined_books AS (
     SELECT title, author, rating, 'A' as source
@@ -905,32 +916,36 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 (SELECT author FROM union_test_a WHERE rating > 4.5 and title @@@ 'Book A')
 INTERSECT
 (SELECT author FROM union_test_b WHERE rating > 4.0 and title @@@ 'Book A');
-                                                                                                                                   QUERY PLAN                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- HashSetOp Intersect
-   ->  Custom Scan (ParadeDB Scan) on union_test_a
-         Table: union_test_a
-         Index: union_test_a_idx
-         Exec Method: MixedFastFieldExecState
-         Fast Fields: author
-         Scores: false
-         Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-   ->  Custom Scan (ParadeDB Scan) on union_test_b
-         Table: union_test_b
-         Index: union_test_b_idx
-         Exec Method: MixedFastFieldExecState
-         Fast Fields: author
-         Scores: false
-         Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
-(15 rows)
+                                                                                                                                      QUERY PLAN                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SetOp Intersect
+   ->  Sort
+         Sort Key: union_test_a.author
+         ->  Custom Scan (ParadeDB Scan) on union_test_a
+               Table: union_test_a
+               Index: union_test_a_idx
+               Exec Method: MixedFastFieldExecState
+               Fast Fields: author
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.5},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
+   ->  Sort
+         Sort Key: union_test_b.author
+         ->  Custom Scan (ParadeDB Scan) on union_test_b
+               Table: union_test_b
+               Index: union_test_b_idx
+               Exec Method: MixedFastFieldExecState
+               Fast Fields: author
+               Scores: false
+               Tantivy Query: {"boolean":{"must":[{"range":{"field":"rating","lower_bound":{"excluded":4.0},"upper_bound":null,"is_datetime":false}},{"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Book A","lenient":null,"conjunction_mode":null}}}}]}}
+(19 rows)
 
 (SELECT author FROM union_test_a WHERE rating > 4.5 and title @@@ 'Book A')
 INTERSECT
 (SELECT author FROM union_test_b WHERE rating > 4.0 and title @@@ 'Book A');
   author   
 -----------
- Author 5
  Author 10
+ Author 5
 (2 rows)
 
 -- Verify actual results of UNION (not just execution method)

--- a/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/mixedff_advanced_06_score_function.out
@@ -447,8 +447,8 @@ ORDER BY title, author, pdb.score(id) DESC;
  Post 28                    | Author 4      | 2.7986248
  Post 49                    | Author 5      |  2.796766
  Post 63                    | Author 4      | 2.7958398
- Post 84                    | Author 5      | 2.7945328
- Post 98                    | Author 4      | 2.7936544
+ Post 84                    | Author 5      | 2.7945325
+ Post 98                    | Author 4      | 2.7936542
  Special Technology Post    | Author Expert | 2.8048325
  Technology Trends Analysis | Author Expert | 2.8048325
 (8 rows)

--- a/pg_search/tests/pg_regress/expected/recursive_estimates.out
+++ b/pg_search/tests/pg_regress/expected/recursive_estimates.out
@@ -328,16 +328,16 @@ WHERE id @@@ paradedb.range(
     field => 'rating',
     range => int4range(4, 5)
 );
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Scan) on recursive_test.estimate_items  (cost=10.00..10.41 rows=41 width=641)
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on recursive_test.estimate_items  (cost=10.00..10.04 rows=4 width=641)
    Output: id, description, rating, category, in_stock, metadata, created_at, last_updated_date, latest_available_time, weight_range
    Table: estimate_items
    Index: idx_recursive_estimates
    Segment Count: 1
    Exec Method: NormalScanExecState
    Scores: false
-   Tantivy Query: {"with_index":{"query":{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":{"excluded":5},"is_datetime":false},"estimated_docs":41}},"estimated_docs":41}
+   Tantivy Query: {"with_index":{"query":{"range":{"field":"rating","lower_bound":{"included":4},"upper_bound":{"excluded":5},"is_datetime":false},"estimated_docs":4}},"estimated_docs":4}
 (8 rows)
 
 -- Test 5.4: Regex query (CRITICAL: Tests pattern matching estimates)
@@ -1207,32 +1207,32 @@ WHERE rating @@@ paradedb.range(
     field => 'rating',
     range => int4range(4, 5)
 );
-                                                                                                          QUERY PLAN                                                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [                                                                                                                                                                                                                           +
-   {                                                                                                                                                                                                                         +
-     "Plan": {                                                                                                                                                                                                               +
-       "Node Type": "Custom Scan",                                                                                                                                                                                           +
-       "Custom Plan Provider": "ParadeDB Scan",                                                                                                                                                                              +
-       "Parallel Aware": false,                                                                                                                                                                                              +
-       "Async Capable": false,                                                                                                                                                                                               +
-       "Relation Name": "estimate_items",                                                                                                                                                                                    +
-       "Schema": "recursive_test",                                                                                                                                                                                           +
-       "Alias": "estimate_items",                                                                                                                                                                                            +
-       "Startup Cost": 10.00,                                                                                                                                                                                                +
-       "Total Cost": 10.41,                                                                                                                                                                                                  +
-       "Plan Rows": 41,                                                                                                                                                                                                      +
-       "Plan Width": 641,                                                                                                                                                                                                    +
-       "Disabled": false,                                                                                                                                                                                                    +
-       "Output": ["id", "description", "rating", "category", "in_stock", "metadata", "created_at", "last_updated_date", "latest_available_time", "weight_range"],                                                            +
-       "Table": "estimate_items",                                                                                                                                                                                            +
-       "Index": "idx_recursive_estimates",                                                                                                                                                                                   +
-       "Segment Count": 1,                                                                                                                                                                                                   +
-       "Exec Method": "NormalScanExecState",                                                                                                                                                                                 +
-       "Scores": false,                                                                                                                                                                                                      +
-       "Tantivy Query": "{\"with_index\":{\"query\":{\"range\":{\"field\":\"rating\",\"lower_bound\":{\"included\":4},\"upper_bound\":{\"excluded\":5},\"is_datetime\":false},\"estimated_docs\":41}},\"estimated_docs\":41}"+
-     }                                                                                                                                                                                                                       +
-   }                                                                                                                                                                                                                         +
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [                                                                                                                                                                                                                         +
+   {                                                                                                                                                                                                                       +
+     "Plan": {                                                                                                                                                                                                             +
+       "Node Type": "Custom Scan",                                                                                                                                                                                         +
+       "Custom Plan Provider": "ParadeDB Scan",                                                                                                                                                                            +
+       "Parallel Aware": false,                                                                                                                                                                                            +
+       "Async Capable": false,                                                                                                                                                                                             +
+       "Relation Name": "estimate_items",                                                                                                                                                                                  +
+       "Schema": "recursive_test",                                                                                                                                                                                         +
+       "Alias": "estimate_items",                                                                                                                                                                                          +
+       "Startup Cost": 10.00,                                                                                                                                                                                              +
+       "Total Cost": 10.04,                                                                                                                                                                                                +
+       "Plan Rows": 4,                                                                                                                                                                                                     +
+       "Plan Width": 641,                                                                                                                                                                                                  +
+       "Disabled": false,                                                                                                                                                                                                  +
+       "Output": ["id", "description", "rating", "category", "in_stock", "metadata", "created_at", "last_updated_date", "latest_available_time", "weight_range"],                                                          +
+       "Table": "estimate_items",                                                                                                                                                                                          +
+       "Index": "idx_recursive_estimates",                                                                                                                                                                                 +
+       "Segment Count": 1,                                                                                                                                                                                                 +
+       "Exec Method": "NormalScanExecState",                                                                                                                                                                               +
+       "Scores": false,                                                                                                                                                                                                    +
+       "Tantivy Query": "{\"with_index\":{\"query\":{\"range\":{\"field\":\"rating\",\"lower_bound\":{\"included\":4},\"upper_bound\":{\"excluded\":5},\"is_datetime\":false},\"estimated_docs\":4}},\"estimated_docs\":4}"+
+     }                                                                                                                                                                                                                     +
+   }                                                                                                                                                                                                                       +
  ]
 (1 row)
 


### PR DESCRIPTION
## What

Incorporate a [Jan 12th Tantivy rebase](https://github.com/paradedb/tantivy/pull/93) (from
[794ff1ffc9a7169ff7e41fba89a23d13afb358f4](https://github.com/quickwit-oss/tantivy/commits/794ff1ffc9a7169ff7e41fba89a23d13afb358f4) to [c92e831dde738163054729a2276ed74dfa1a8eee](https://github.com/quickwit-oss/tantivy/commits/c92e831dde738163054729a2276ed74dfa1a8eee))

## Why

To stay up to date, and pull in performance improvements.

## Tests

Some benchmarks show 20-40% improvements.