### PR TITLE
feat: Properly create `pdb` schema and associated permissions

### DIFF
--- a/pg_search/src/api/operator/boost.rs
+++ b/pg_search/src/api/operator/boost.rs
@@ -130,7 +130,6 @@ mod typedef {
 
     extension_sql!(
         r#"
-            CREATE SCHEMA IF NOT EXISTS pdb;
             CREATE TYPE pdb.boost;
         "#,
         name = "BoostType_shell",

--- a/pg_search/src/api/operator/const_score.rs
+++ b/pg_search/src/api/operator/const_score.rs
@@ -130,7 +130,6 @@ mod typedef {
 
     extension_sql!(
         r#"
-            CREATE SCHEMA IF NOT EXISTS pdb;
             CREATE TYPE pdb.const;
         "#,
         name = "ConstType_shell",

--- a/pg_search/src/api/operator/fuzzy.rs
+++ b/pg_search/src/api/operator/fuzzy.rs
@@ -119,7 +119,6 @@ mod typedef {
 
     extension_sql!(
         r#"
-            CREATE SCHEMA IF NOT EXISTS pdb;
             CREATE TYPE pdb.fuzzy;
         "#,
         name = "FuzzyType_shell",

--- a/pg_search/src/api/operator/slop.rs
+++ b/pg_search/src/api/operator/slop.rs
@@ -119,7 +119,6 @@ mod typedef {
 
     extension_sql!(
         r#"
-            CREATE SCHEMA IF NOT EXISTS pdb;
             CREATE TYPE pdb.slop;
         "#,
         name = "SlopType_shell",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts schema DDL and permissions handling.
> 
> - In `lib.rs`, replaces blanket grants with a DO block that conditionally grants on existing `paradedb`/`pdb` schemas; for `pdb` adds USAGE/CREATE on schema, ALL PRIVILEGES on existing tables/sequences/functions, USAGE on types, and ALTER DEFAULT PRIVILEGES for future objects
> - Removes `CREATE SCHEMA IF NOT EXISTS pdb;` from type shell DDL in `boost.rs`, `const_score.rs`, `fuzzy.rs`, and `slop.rs`, leaving only `CREATE TYPE pdb.*` declarations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68572f377077e6af14ea4b1f4ae2f1c1254fed7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->