### PR TITLE
docs: Fix leftover mentions of PG14 and missing mentions of PG18

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -7,7 +7,7 @@
 
 `pg_search` is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using `pgrx`. Please refer to the [ParadeDB documentation](https://docs.paradedb.com/documentation/getting-started/quickstart) to get started.
 
-`pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at v14.
+`pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at PostgreSQL 15.
 
 Benchmarks can be found in the [`/benchmarks` directory](../benchmarks/README.md).
 
@@ -47,29 +47,20 @@ This enables the extension to spawn a background worker process that performs wr
 
 We provide prebuilt binaries for Debian-based Linux for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
-#### RHEL/Rocky and Other Linux Distributions Using Pigsty
+#### RHEL/Rocky
 
-- `pg_search` can also be installed for various Linux distributions (using `apt` and `infra`) with the [Pigsty extension repository](https://pigsty.io/ext/repo/).
-- To install `pig` for `yum` / `dnf` compatible systems [follow these instructions](https://pigsty.io/ext/repo/yum/). Then:
+We provide prebuilt binaries for Red Hat-based Linux for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
+
+You can also install `pg_search` via [Pigsty](https://pigsty.io/ext/repo/). To install `pig` for `yum` / `dnf` compatible systems [follow these instructions](https://pigsty.io/ext/repo/yum/). Then:
 
 ```bash
 dnf install pig
 pig install pg_search
 ```
 
-You should then be able to run `CREATE EXTENSION pg_search;` as superuser in PostgreSQL.
-
 #### macOS
 
-We don't suggest running production workloads on macOS. As a result, we don't provide prebuilt binaries for macOS. If you are running Postgres on macOS and want to install `pg_search`, please follow the [development](#development) instructions, but do `cargo pgrx install --release` instead of `cargo pgrx run`. This will build the extension from source and install it in your Postgres instance.
-
-You can then create the extension in your database by running:
-
-```sql
-CREATE EXTENSION pg_search;
-```
-
-Note: If you are using a managed Postgres service like Amazon RDS, you will not be able to install `pg_search` until the Postgres service explicitly supports it.
+We provide prebuilt binaries for macOS for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
 
 #### Windows
 
@@ -92,12 +83,12 @@ Then, install the PostgreSQL version of your choice using your system package ma
 
 ```bash
 # macOS
-brew install postgresql@17
+brew install postgresql@18
 
 # Ubuntu
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-sudo apt-get update && sudo apt-get install -y postgresql-17 postgresql-server-dev-17
+sudo apt-get update && sudo apt-get install -y postgresql-18 postgresql-server-dev-18
 
 # Arch Linux
 sudo pacman -S extra/postgresql
@@ -152,16 +143,16 @@ git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
 # macOS arm64
-PG_CONFIG=/opt/homebrew/opt/postgresql@17/bin/pg_config make
-sudo PG_CONFIG=/opt/homebrew/opt/postgresql@17/bin/pg_config make install # may need sudo
+PG_CONFIG=/opt/homebrew/opt/postgresql@18/bin/pg_config make
+sudo PG_CONFIG=/opt/homebrew/opt/postgresql@18/bin/pg_config make install # may need sudo
 
 # macOS amd64
-PG_CONFIG=/usr/local/opt/postgresql@17/bin/pg_config make
-sudo PG_CONFIG=/usr/local/opt/postgresql@17/bin/pg_config make install # may need sudo
+PG_CONFIG=/usr/local/opt/postgresql@18/bin/pg_config make
+sudo PG_CONFIG=/usr/local/opt/postgresql@18/bin/pg_config make install # may need sudo
 
 # Ubuntu
-PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config make
-sudo PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config make install # may need sudo
+PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config make
+sudo PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config make install # may need sudo
 
 # Arch Linux
 PG_CONFIG=/usr/bin/pg_config make
@@ -213,7 +204,7 @@ DATABASE_URL=postgres://USER_NAME@localhost:PORT/pg_search
 
 USER_NAME should be replaced with your system user name. (eg: output of `whoami`)
 
-PORT should be replaced with 28800 + your postgres version. (eg: 28817 for Postgres 17)
+PORT should be replaced with 28800 + your postgres version. (eg: 28818 for Postgres 18)
 
 ## License
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,10 +10,10 @@ If you are using pgrx’s bundled PostgreSQL, follow these steps from the root o
 #! /bin/sh
 
 set -x
-export DATABASE_URL=postgresql://localhost:28817/pg_search
+export DATABASE_URL=postgresql://localhost:28818/pg_search
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
-cargo pgrx install --package pg_search --pg-config ~/.pgrx/17.0/pgrx-install/bin/pg_config
+cargo pgrx install --package pg_search --pg-config ~/.pgrx/18.1/pgrx-install/bin/pg_config
 cargo pgrx start --package pg_search
 
 cargo test --package tests
@@ -27,10 +27,10 @@ If you are using a self-hosted PostgreSQL installation, install the `pg_search` 
 #! /bin/sh
 
 set -x
-export DATABASE_URL=postgresql://localhost:28817/pg_search
+export DATABASE_URL=postgresql://localhost:28818/pg_search
 export RUST_BACKTRACE=1
 cargo pgrx stop --package pg_search
-cargo pgrx install --package pg_search --pg-config /opt/homebrew/opt/postgresql@17/bin/pg_config
+cargo pgrx install --package pg_search --pg-config /opt/homebrew/opt/postgresql@18/bin/pg_config
 cargo pgrx start --package pg_search
 
 cargo test --package tests


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
These were missing from when we defaulted to PG18 and when we removed support for PG14. I've also updated the docs macOS binary section of the `pg_search` README which was incorrect.

## Why
Accurate docs.

## How
^

## Tests
^

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to reflect current Postgres versions and streamlined setup.
> 
> - Clarifies support baseline to PG15+ and updates examples/ports to Postgres 18 (e.g., `postgresql-18`, `pg_config` paths, `28818`)
> - Adds macOS prebuilt binaries; replaces prior guidance that omitted macOS binaries
> - Refreshes RHEL/Rocky section and Pigsty instructions; keeps Debian/Ubuntu notes for PG15+
> - Updates `pgvector` build instructions to use Postgres 18 `pg_config`
> - Syncs `tests/README.md` with Postgres 18 for `DATABASE_URL`, `cargo pgrx install`, and paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc5fbc5ec0154f4cf10f137f9119ecf27808b6c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->