### PR TITLE
chore: Expand join benchmarks

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -1,0 +1,31 @@
+-- Shape: Aggregate Sort (Computed Property)
+-- Join: Single Feature (Computed Aggregate)
+-- Description: The feature driving the ORDER BY does not exist until the join is performed. The user is sorting files by an aggregate of their related pages (e.g., "Most recently active" or "Most interactions"). This requires computing the aggregate (via GROUP BY or LATERAL) before the TopN can be resolved.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content @@@ 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO on; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content @@@ 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/disjunctive_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/disjunctive_search.sql
@@ -1,0 +1,39 @@
+-- Shape: Disjunctive Search (OR Logic)
+-- Join: Single Feature (Score)
+-- Description: A match can occur on *either* the main table *or* the joined table (Boolean OR), but the ranking is pinned to the score of the primary ID. This is difficult because standard joins are intersections (AND); handling an OR usually requires a union or a complex filter that disrupts standard index sorting.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT DISTINCT
+    f.id,
+    f.title,
+    paradedb.score(f.id) as score
+FROM files f
+LEFT JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents LIKE 'PARENT_GROUP_2%'   -- Scope to a subset
+    AND (
+        f.title @@@ 'Title'            -- Match Local
+        OR
+        d.title @@@ 'Title'            -- Match Foreign
+    )
+ORDER BY
+    score DESC                        -- Single Feature Sort (Primary Score)
+LIMIT 10;
+
+-- TODO: Currently fails with an "Unsupported query shape" error because our join cannot
+-- be executed due to the `DISTINCT`.
+SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
+    f.id,
+    f.title,
+    paradedb.score(f.id) as score
+FROM files f
+LEFT JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents LIKE 'PARENT_GROUP_2%'   -- Scope to a subset
+    AND (
+        f.title @@@ 'Title'            -- Match Local
+        OR
+        d.title @@@ 'Title'            -- Match Foreign
+    )
+ORDER BY
+    score DESC                        -- Single Feature Sort (Primary Score)
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
@@ -1,0 +1,31 @@
+-- Shape: Distinct Parent Sort (Join Explosion)
+-- Join: Single Feature (Local Field with Deduplication)
+-- Description: The user wants to find documents that match criteria in the pages table (a "Many" side join), ordered by a field on the documents table. Because joining to pages explodes the row count (1 Document -> N Pages), the query requires DISTINCT. This tests the engine's ability to maintain the sort order while deduplicating the join results.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT DISTINCT
+    d.id,
+    d.title,
+    d.parents
+FROM documents d
+JOIN files f ON d.id = f."documentId"
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    p."sizeInBytes" > 5000            -- Filter on the "Many" side
+    AND d.parents LIKE 'SFR%'       -- Local Filter
+ORDER BY
+    d.title ASC                     -- Single Feature Sort (Parent Field)
+LIMIT 50;
+
+SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
+    d.id,
+    d.title,
+    d.parents
+FROM documents d
+JOIN files f ON d.id = f."documentId"
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    p."sizeInBytes" > 5000            -- Filter on the "Many" side
+    AND d.parents LIKE 'SFR%'       -- Local Filter
+ORDER BY
+    d.title ASC                     -- Single Feature Sort (Parent Field)
+LIMIT 50;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -1,0 +1,31 @@
+-- Shape: Foreign Filter, Local Sort
+-- Join: Single Feature (Fast Field)
+-- Description: A standard join where the user filters by a property of the parent table (documents), but sorts by a deterministic "fast field" on the child table (files). The challenge is balancing the selectivity of the foreign filter against the sort order of the local table.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents LIKE 'PROJECT_ALPHA%' -- Foreign Filter
+    AND f.title @@@ 'collab12'    -- Local Filter
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents LIKE 'PROJECT_ALPHA%' -- Foreign Filter
+    AND f.title @@@ 'collab12'    -- Local Filter
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/line_items-distinct.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/line_items-distinct.sql
@@ -1,9 +1,0 @@
-SELECT DISTINCT pages.*
-FROM pages
-JOIN files
-  ON pages."fileId" = files.id
-WHERE pages.content @@@ 'Single Number Reach'
-  -- Matches ~0.00005 of the dataset.
-  AND files."sizeInBytes" < 5 AND files.id @@@ paradedb.all()
-ORDER by pages."createdAt" DESC
-LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -1,0 +1,29 @@
+-- Shape: Permissioned Search (Score Sort)
+-- Join: Single Feature (BM25 Score)
+-- Description: A Full Text Search (BM25) drives the ranking, but the result set must be restricted by a JOIN (e.g., checking permissions or document isolation). The score comes purely from the files table, but the validity of the row depends on the documents table.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT
+    f.id,
+    f.title,
+    paradedb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title @@@ 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents LIKE 'PARENT_GROUP_10%' -- Hard Constraint (Permission)
+ORDER BY
+    relevance DESC
+LIMIT 10;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
+    f.id,
+    f.title,
+    paradedb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title @@@ 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents LIKE 'PARENT_GROUP_10%' -- Hard Constraint (Permission)
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -1,0 +1,37 @@
+-- Shape: Semi-Join Filter (Term Set)
+-- Join: Single Feature (Fast Field)
+-- Description: The sort is simple (e.g., by Title), but the filter involves a "List" logic where the valid IDs are derived from a complex subquery or list. This was previously implemented using a term_set, effectively pushing a semi-join down to the search index.
+
+SET paradedb.enable_join_custom_scan TO off; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    -- The "Join" is a filter against a list of IDs (Semi-Join)
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents @@@ 'PROJECT_ALPHA'
+        AND title @@@ 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC                       -- Single Feature Sort (Local Fast Field)
+LIMIT 25;
+
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    -- The "Join" is a filter against a list of IDs (Semi-Join)
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents @@@ 'PROJECT_ALPHA'
+        AND title @@@ 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC                       -- Single Feature Sort (Local Fast Field)
+LIMIT 25;


### PR DESCRIPTION
## What

Add join queries to the benchmark suite which cover our "single feature" join use cases.

## Why

To begin tracking our performance for single feature joins. Aggregate score joins will follow.

## Tests

- `aggregate_sort.sql`
    - Not yet supported: does not have a limit, because it is being fed into an aggregate.
- `disjunctive_search.sql`
    - Not yet supported: uses DISTINCT, which Postgres implements by sorting on all output columns.
- `distinct_parent_sort.sql`
    - Not yet supported: uses three tables, and DISTINCT.
- `foreign_filter_local_sort.sql`
    - Supported.
- `permissioned_search.sql`
    - Supported.
- `semi_join_filter.sql`
    - Supported.