### PR TITLE
fix: fetch full git graph for ancestry caching

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Derive Short Commit
         id: commit_info

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Derive Short Commit
         id: commit_info


### PR DESCRIPTION
# Ticket(s) Closed
The benchmark action needs to access git objects that are currently not visible. We only need this where we are using benchmark action. 
<img width="1232" height="218" alt="image" src="https://github.com/user-attachments/assets/3cf05ce9-82f4-4c62-8afc-62332a01bf61" />

- Closes #

## What

## Why

## How

## Tests
