### PR TITLE
ci: Better cherry-pick action

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,9 +1,9 @@
 name: Cherry Pick
 
 on:
-  # Trigger on pull request closed events targeting main branch, which enables cherry-picks for PRs coming from forks as well
-  pull_request_target:
-    branches: [main]
+  pull_request_target: # pull_request_target enables cherry-picks from forked repos
+    branches:
+      - main
     types: [closed]
 
 permissions:
@@ -13,7 +13,6 @@ permissions:
 jobs:
   backport:
     name: Backport (Cherry Pick)
-    # Only run when merged AND at least one label contains "cherry-pick/"
     if: >
       github.event.pull_request.merged == true &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
@@ -29,11 +28,11 @@ jobs:
         uses: korthout/backport-action@v4
         with:
           github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
-          # Make the action look for our labels instead of "backport <branch>"
-          label_pattern: "^cherry-pick/([^ ]+)$"
-          # Label the created PR(s)
+          git_committer_name: paradedb[bot]
+          git_committer_email: developers@paradedb.com
+          add_author_as_assignee: true
           add_labels: automated-cherry-pick
-          # Create a draft PR even when cherry-pick conflicts
+          label_pattern: "^cherry-pick/([^ ]+)$"
           experimental: |
             {
               "conflict_resolution": "draft_commit_conflicts"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3833 

## What
The action we've been using fails when there's a conflict, but instead we want it to raise a PR with conflicts. We were using an old and unsupported action. This one is much more recent and supports all the features we need, including that one.

## Why
^

## How
^

## Tests
I think this is hard to test until merging.