### PR TITLE
chore: Add support for configurable error ignores in `stressgres`.

### DIFF
--- a/stressgres/src/headless.rs
+++ b/stressgres/src/headless.rs
@@ -1,4 +1,4 @@
-use crate::runner::SuiteRunner;
+use crate::runner::{SuiteRunner, HARDCODED_IGNORE_ERRORS};
 use crate::MetricsLine;
 use postgres::Row;
 use rust_decimal::prelude::ToPrimitive;
@@ -150,11 +150,13 @@ pub fn run(
             let mut reported_errors = 0;
             for error in errors {
                 let errstr = error.to_string();
-                if errstr.contains("failed to merge: User requested cancel")
-                    || errstr.contains("Merge cancelled")
-                    || errstr.contains("canceling statement due to conflict with recovery")
+                if HARDCODED_IGNORE_ERRORS.iter().any(|p| errstr.contains(p))
+                    || suite_runner
+                        .suite()
+                        .ignore_errors()
+                        .iter()
+                        .any(|pattern| errstr.contains(pattern))
                 {
-                    // hack to detect this error message -- it's harmless and shouldn't cause an unsuccessful exit
                     eprintln!("IGNORING TERMINATION ERROR: {errstr}");
                     continue;
                 }

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -530,6 +530,10 @@ impl SuiteRunner {
         &self.pgver
     }
 
+    pub fn suite(&self) -> &Suite {
+        &self.suite
+    }
+
     pub fn monitor_runners(&self) -> impl Iterator<Item = Arc<JobRunner>> + '_ {
         self.monitors.iter().cloned()
     }
@@ -629,7 +633,7 @@ impl SuiteRunner {
             let job_errors = job.collect_errors().into_iter().filter(|e| {
                 e.source()
                     .and_then(|e| e.downcast_ref::<postgres::Error>())
-                    .map(is_ignorable_error)
+                    .map(|e| is_ignorable_error(e, self.suite.ignore_errors()))
                     .unwrap_or(false)
             });
 
@@ -648,6 +652,13 @@ impl SuiteRunner {
         Ok(all_errors)
     }
 }
+
+pub const HARDCODED_IGNORE_ERRORS: &[&str] = &[
+    "failed to merge: User requested cancel",
+    "Merge cancelled",
+    "canceling statement due to conflict with recovery",
+    "(SQLState: 57014)", // query_canceled
+];
 
 type Index = usize;
 
@@ -945,7 +956,7 @@ impl JobRunner {
                 let mut assert_error = None;
                 if rows.is_err() {
                     rows = rows.inspect_err(|e| {
-                        if !is_ignorable_error(e) {
+                        if !is_ignorable_error(e, self.suite.ignore_errors()) {
                             last_error = Some(Clone::clone(e));
                         }
                     });
@@ -1000,9 +1011,26 @@ impl JobRunner {
     }
 }
 
-fn is_ignorable_error(e: &postgres::Error) -> bool {
+fn is_ignorable_error(e: &postgres::Error, ignore_patterns: &[String]) -> bool {
     // user cancel request
-    e.as_db_error()
+    if e.as_db_error()
         .map(|dberror| dberror.code() == &SqlState::from_code("57014"))
         .unwrap_or_default()
+    {
+        return true;
+    }
+
+    let error_string = e.to_string();
+    for pattern in HARDCODED_IGNORE_ERRORS {
+        if error_string.contains(pattern) {
+            return true;
+        }
+    }
+    for pattern in ignore_patterns {
+        if error_string.contains(pattern) {
+            return true;
+        }
+    }
+
+    false
 }

--- a/stressgres/src/suite.rs
+++ b/stressgres/src/suite.rs
@@ -344,16 +344,24 @@ fn default_log_tps() -> bool {
 /// A full suite of jobs, plus optional name, setup, teardown, monitor.
 #[derive(Deserialize, Debug)]
 pub struct SuiteDefinition {
+    /// The file path to the suite definition.
     #[serde(skip_serializing)]
     pub path: Option<PathBuf>,
 
+    /// The display name of the suite.
     pub name: Option<String>,
 
+    /// The list of jobs to run as part of the suite.
     pub jobs: Vec<Job>,
 
+    /// The list of servers (Postgres instances) involved in the suite.
     #[serde(deserialize_with = "validate_server_list")]
     #[serde(rename = "server")]
     pub servers: Vec<Server>,
+
+    /// A list of error message substrings that should be ignored during execution and termination.
+    #[serde(default)]
+    pub ignore_errors: Vec<String>,
 }
 
 pub struct Suite {
@@ -427,6 +435,10 @@ impl Suite {
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "<no name>".to_string())
         })
+    }
+
+    pub fn ignore_errors(&self) -> &[String] {
+        &self.definition.ignore_errors
     }
 
     pub fn jobs(&self) -> impl Iterator<Item = &Job> {


### PR DESCRIPTION
## What

Add support for ignoring configurable error strings.

## Why

For use in enterprise.