### PR TITLE
chore: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         args: ["--branch", "main", "--branch", "dev"]
@@ -36,26 +36,25 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.11.0-1
+    rev: v3.12.0-2
     hooks:
       - id: shfmt
         args: ["-i", "2", "-ci"]
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/kaechele/pre-commit-mirror-prettier
-    rev: v3.2.5
+    rev: v3.8.1
     hooks:
       - id: prettier
-        additional_dependencies: ["prettier@3.2.5"]
 
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
@@ -67,14 +66,14 @@ repos:
       - id: cargo-check
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: v3.3.7
+    rev: v4.0.4
     hooks:
       - id: pylint
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Updates all pre-commit hooks to their latest versions. Also removes the pinned `additional_dependencies` for prettier — the mirror repo rev already bundles the correct version, so the pin was redundant and was causing version drift between pre-commit and CI (CI installs latest, pre-commit was stuck on 3.2.5).

## Why
^

## How
^

## Tests
Pre-commit hooks pass locally.