### PR TITLE
feat: Report tuples_done in pg_stat_progress_create_index

### DIFF
--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -535,7 +535,7 @@ unsafe extern "C-unwind" fn build_callback(
             pg_sys::PROGRESS_CREATEIDX_TUPLES_DONE as i32,
             build_state.cnt as i64,
         );
-        #[cfg(not(any(feature = "pg15", feature = "pg16")))]
+        #[cfg(any(feature = "pg17", feature = "pg18"))]
         pg_sys::pgstat_progress_parallel_incr_param(
             pg_sys::PROGRESS_CREATEIDX_TUPLES_DONE as i32,
             1,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3826

## What

Report `tuples_done` and `tuples_total` in `pg_stat_progress_create_index` during BM25 index creation.

## Why

`tuples_done` was always empty because we never called the PostgreSQL progress reporting API — now users can monitor index build progress.

## How

- Call `pgstat_progress_parallel_incr_param` for `TUPLES_DONE` in `build_callback` (handles both parallel and serial builds)
- Call `pgstat_progress_update_param` for `TUPLES_TOTAL` before the scan using the existing `estimate_heap_reltuples`

## Tests

Built with `cargo pgrx run`, created a 1M row table, verified `tuples_done` increments and `tuples_total` is populated via `pg_stat_progress_create_index`.