### PR TITLE
feat: allow disabling fieldnorms

### DIFF
--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -133,10 +133,7 @@ pub fn search_field_config_from_type(
 
     let parsed_typmod = typmod::load_typmod(typmod).unwrap_or_default();
 
-    let parsed_fieldnorms = parsed_typmod
-        .get("fieldnorms")
-        .and_then(|p| p.as_bool())
-        .unwrap_or(true);
+    let parsed_fieldnorms = parsed_typmod.get("fieldnorms").and_then(|p| p.as_bool());
     // columnar=true/false is our renaming of Tantivy's `fast` option
     // fast is default to true for any field that's not text or JSON
     // if it is text or JSON, it also default to true for literal and literal_normalized
@@ -147,15 +144,16 @@ pub fn search_field_config_from_type(
     {
         // literal and literal_normalized default to fast=true (columnar=true)
         let fast = columnar_explicit.unwrap_or(true);
-        (fast, parsed_fieldnorms, IndexRecordOption::Basic)
+
+        // literal and literal_normalized default to fieldnorms=false
+        let fieldnorms = parsed_fieldnorms.unwrap_or(false);
+        (fast, fieldnorms, IndexRecordOption::Basic)
     } else {
         // all others default to fast=false (columnar=false)
         let fast = columnar_explicit.unwrap_or(false);
-        (
-            fast,
-            parsed_fieldnorms,
-            IndexRecordOption::WithFreqsAndPositions,
-        )
+        // all others default to fieldnorms=true
+        let fieldnorms = parsed_fieldnorms.unwrap_or(true);
+        (fast, fieldnorms, IndexRecordOption::WithFreqsAndPositions)
     };
 
     if inner_typoid == pg_sys::JSONOID || inner_typoid == pg_sys::JSONBOID {

--- a/pg_search/tests/pg_regress/expected/issue_4028.out
+++ b/pg_search/tests/pg_regress/expected/issue_4028.out
@@ -15,7 +15,7 @@ SELECT * FROM paradedb.schema('test_bm25');
     name     | field_type | stored | indexed | fast | fieldnorms | expand_dots |               tokenizer                | record | normalizer 
 -------------+------------+--------+---------+------+------------+-------------+----------------------------------------+--------+------------
  ctid        | U64        | f      | t       | t    | f          |             |                                        |        | 
- description | Str        | f      | t       | t    | t          |             | literal_normalized[ascii_folding=true] | basic  | lowercase
+ description | Str        | f      | t       | t    | f          |             | literal_normalized[ascii_folding=true] | basic  | lowercase
  id          | I64        | f      | t       | t    | f          |             |                                        |        | 
 (3 rows)
 

--- a/pg_search/tests/pg_regress/expected/tokenize-text-arrays.out
+++ b/pg_search/tests/pg_regress/expected/tokenize-text-arrays.out
@@ -42,7 +42,7 @@ CREATE INDEX idxindex_text_array ON index_text_array USING bm25 (id, (arr::pdb.l
 SELECT * FROM paradedb.schema('idxindex_text_array') ORDER BY name;
  name | field_type | stored | indexed | fast | fieldnorms | expand_dots |        tokenizer         | record | normalizer 
 ------+------------+--------+---------+------+------------+-------------+--------------------------+--------+------------
- arr  | Str        | f      | t       | t    | t          |             | keyword[lowercase=false] | basic  | raw
+ arr  | Str        | f      | t       | t    | f          |             | keyword[lowercase=false] | basic  | raw
  ctid | U64        | f      | t       | t    | f          |             |                          |        | 
  id   | I64        | f      | t       | t    | f          |             |                          |        | 
 (3 rows)
@@ -76,7 +76,7 @@ CREATE INDEX idxindex_varchar_array ON index_varchar_array USING bm25 (id, (arr:
 SELECT * FROM paradedb.schema('idxindex_varchar_array') ORDER BY name;
  name | field_type | stored | indexed | fast | fieldnorms | expand_dots |        tokenizer         | record | normalizer 
 ------+------------+--------+---------+------+------------+-------------+--------------------------+--------+------------
- arr  | Str        | f      | t       | t    | t          |             | keyword[lowercase=false] | basic  | raw
+ arr  | Str        | f      | t       | t    | f          |             | keyword[lowercase=false] | basic  | raw
  ctid | U64        | f      | t       | t    | f          |             |                          |        | 
  id   | I64        | f      | t       | t    | f          |             |                          |        | 
 (3 rows)

--- a/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
@@ -27,8 +27,8 @@ SELECT * FROM paradedb.schema('idxtokenizer_fast') ORDER BY name;
  ctid     | U64        | f      | t       | t    | f          |             |                                                |        | 
  id       | I64        | f      | t       | t    | f          |             |                                                |        | 
  metadata | JsonObject | f      | t       | t    | f          | t           | literal_normalized[stopwords_language=English] | basic  | raw
- t        | Str        | f      | t       | t    | t          |             | keyword[lowercase=false]                       | basic  | raw
- t_long   | Str        | f      | t       | t    | t          |             | literal_normalized[stopwords_language=English] | basic  | raw
+ t        | Str        | f      | t       | t    | f          |             | keyword[lowercase=false]                       | basic  | raw
+ t_long   | Str        | f      | t       | t    | f          |             | literal_normalized[stopwords_language=English] | basic  | raw
 (5 rows)
 
 -- Top N over literal

--- a/pg_search/tests/pg_regress/expected/tokenizer-indexed-expressions-require-tokenizer.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-indexed-expressions-require-tokenizer.out
@@ -27,7 +27,7 @@ SELECT * FROM paradedb.schema('idxexpr') ORDER BY name;
 ------+------------+--------+---------+------+------------+-------------+--------------------------+--------+------------
  ctid | U64        | f      | t       | t    | f          |             |                          |        | 
  id   | I64        | f      | t       | t    | f          |             |                          |        | 
- t    | Str        | f      | t       | t    | t          |             | keyword[lowercase=false] | basic  | lowercase
+ t    | Str        | f      | t       | t    | f          |             | keyword[lowercase=false] | basic  | lowercase
 (3 rows)
 
 SELECT * FROM expr WHERE lower(t) &&& 'This is a TEST';

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-in-create-index.out
@@ -35,7 +35,7 @@ SELECT * FROM paradedb.schema('idxtok_in_ci') ORDER BY name;
  lindera_chinese    | Str        | f      | t       | f    | t          |             | chinese_lindera                            | position | 
  lindera_japanese   | Str        | f      | t       | f    | t          |             | japanese_lindera                           | position | 
  lindera_korean     | Str        | f      | t       | f    | t          |             | korean_lindera                             | position | 
- literal            | Str        | f      | t       | t    | t          |             | keyword[lowercase=false]                   | basic    | raw
+ literal            | Str        | f      | t       | t    | f          |             | keyword[lowercase=false]                   | basic    | raw
  ngram              | Str        | f      | t       | f    | t          |             | ngram_mingram:3_maxgram:5_prefixonly:false | position | 
  regex              | Str        | f      | t       | f    | t          |             | regex                                      | position | 
  simple             | Str        | f      | t       | f    | t          |             | default                                    | position | 


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #3998
## What
Add support for disabling fieldnorms via the v2 API
Users can now specify:
```sql 
content pdb.simple('fieldnorms=false')
```
When disabled, document length normalization is skipped, resulting in identical BM25 scores for documents with the same term frequency regardless of length.
## Why
This was requested by users who want BM25 scoring that does not penalize longer documents
## How
Extended the `TypmodSchema` to validate the `fieldnorms` option and read its value via `load_typmod` inside `search_field_config_from_type`. 
## Tests
Added test that verifies fieldnorms=false by asserting identical BM25 scores for documents with equal term frequency but different lengths, confirming document-length normalization is disabled.