### PR TITLE
fix: Early return in fieldname extraction causes pushdown to not happen

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -473,11 +473,9 @@ pub unsafe fn field_name_from_node(
                     }
                     expr_no += 1;
                 } else if type_is_tokenizer(expr_type) {
-                    // Early return for non-tokenizable var types (preserves main branch behavior)
-                    if !type_can_be_tokenized((*var).vartype) {
-                        return None;
-                    }
-                    if var_matches_tokenizer_expr(var, expression.cast()) {
+                    if type_can_be_tokenized((*var).vartype)
+                        && var_matches_tokenizer_expr(var, expression.cast())
+                    {
                         return attname_from_var(heaprel, var);
                     }
                     expr_no += 1;

--- a/pg_search/tests/pg_regress/expected/issue_4070.out
+++ b/pg_search/tests/pg_regress/expected/issue_4070.out
@@ -1,0 +1,57 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+CREATE INDEX search_idx ON mock_items USING bm25 (id, (description::pdb.literal), rating) WITH (key_field = id);
+EXPLAIN SELECT * from mock_items where rating @@@ '4';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items  (cost=10.00..10.16 rows=16 width=641)
+   Table: mock_items
+   Index: search_idx
+   Segment Count: 1
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"rating","query_string":"4","lenient":null,"conjunction_mode":null}}}}
+(7 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE rating @@@ 'IN [1 2]';
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: search_idx
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"rating","query_string":"IN [1 2]","lenient":null,"conjunction_mode":null}}}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE id @@@ pdb.all() AND rating = 4;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: search_idx
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"term":{"field":"rating","value":4,"is_datetime":false}}]}}
+(6 rows)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE id @@@ pdb.all() AND rating IN (1, 2);
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Scan) on mock_items
+   Table: mock_items
+   Index: search_idx
+   Exec Method: NormalScanExecState
+   Scores: false
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"term_set":{"terms":[{"field":"rating","value":1,"is_datetime":false},{"field":"rating","value":2,"is_datetime":false}]}}]}}
+(6 rows)
+
+DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/expected/operators.out
+++ b/pg_search/tests/pg_regress/expected/operators.out
@@ -368,39 +368,39 @@ ERROR:  type `int4` is not compatible with the `&&&` operator
 SELECT * FROM mock_items WHERE sku &&& 'da2fea21-000e-411b-9e8c-2cb64e471293';
 ERROR:  type `uuid` is not compatible with the `&&&` operator
 SELECT * FROM mock_items WHERE in_stock &&& 'true';
-ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `true`
+ERROR:  type `bool` is not compatible with the `&&&` operator
 SELECT * FROM mock_items WHERE last_updated_date &&& '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `date` is not compatible with the `&&&` operator
 SELECT * FROM mock_items WHERE latest_available_time &&& '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `&&&(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `time` is not compatible with the `&&&` operator
 SELECT * FROM mock_items WHERE id ||| '42';
 ERROR:  type `int4` is not compatible with the `|||` operator
 SELECT * FROM mock_items WHERE sku ||| 'da2fea21-000e-411b-9e8c-2cb64e471293';
 ERROR:  type `uuid` is not compatible with the `|||` operator
 SELECT * FROM mock_items WHERE in_stock ||| 'true';
-ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `true`
+ERROR:  type `bool` is not compatible with the `|||` operator
 SELECT * FROM mock_items WHERE last_updated_date ||| '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `date` is not compatible with the `|||` operator
 SELECT * FROM mock_items WHERE latest_available_time ||| '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `|||(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `time` is not compatible with the `|||` operator
 SELECT * FROM mock_items WHERE id ### '42';
 ERROR:  type `int4` is not compatible with the `###` operator
 SELECT * FROM mock_items WHERE sku ### 'da2fea21-000e-411b-9e8c-2cb64e471293';
 ERROR:  type `uuid` is not compatible with the `###` operator
 SELECT * FROM mock_items WHERE in_stock ### 'true';
-ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `true`
+ERROR:  type `bool` is not compatible with the `###` operator
 SELECT * FROM mock_items WHERE last_updated_date ### '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `date` is not compatible with the `###` operator
 SELECT * FROM mock_items WHERE latest_available_time ### '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `###(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `time` is not compatible with the `###` operator
 SELECT * FROM mock_items WHERE id === '42';
 ERROR:  type `int4` is not compatible with the `===` operator
 SELECT * FROM mock_items WHERE sku === 'da2fea21-000e-411b-9e8c-2cb64e471293';
 ERROR:  type `uuid` is not compatible with the `===` operator
 SELECT * FROM mock_items WHERE in_stock === 'true';
-ERROR:  query is incompatible with pg_search's `===(field, TEXT)` operator: `true`
+ERROR:  type `bool` is not compatible with the `===` operator
 SELECT * FROM mock_items WHERE last_updated_date === '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `===(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `date` is not compatible with the `===` operator
 SELECT * FROM mock_items WHERE latest_available_time === '12-06-25'::date::text;
-ERROR:  query is incompatible with pg_search's `===(field, TEXT)` operator: `12-06-2025`
+ERROR:  type `time` is not compatible with the `===` operator
 DROP TABLE mock_items;

--- a/pg_search/tests/pg_regress/sql/issue_4070.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4070.sql
@@ -1,0 +1,14 @@
+\i common/common_setup.sql
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+CREATE INDEX search_idx ON mock_items USING bm25 (id, (description::pdb.literal), rating) WITH (key_field = id);
+EXPLAIN SELECT * from mock_items where rating @@@ '4';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE rating @@@ 'IN [1 2]';
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE id @@@ pdb.all() AND rating = 4;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM mock_items WHERE id @@@ pdb.all() AND rating IN (1, 2);
+
+DROP TABLE mock_items;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

An early return caused us to not push down fields instead of going to the next field in the index list

## Why

## How

## Tests
