### PR TITLE
fix: flaky `join_custom_scan` regression tests

### DIFF
--- a/pg_search/tests/pg_regress/expected/join_custom_scan.out
+++ b/pg_search/tests/pg_regress/expected/join_custom_scan.out
@@ -42,7 +42,7 @@ INSERT INTO products (id, name, description, supplier_id, price) VALUES
 (204, 'Monitor Stand', 'Adjustable monitor stand for ergonomic setup', 153, 49.99),
 (205, 'Webcam', 'HD webcam for video conferencing', 154, 59.99),
 (206, 'Headphones', 'Wireless noise-canceling headphones with premium sound', 151, 199.99),
-(207, 'Mouse Pad', 'Large gaming mouse pad with wireless charging', 152, 29.99),
+(207, 'Mouse Pad', 'Large gaming mouse pad with wireless charging', 152, 39.69),
 (208, 'Cable Organizer', 'Desktop cable organizer for clean setup', 153, 14.99);
 -- Create BM25 indexes on both tables
 -- Note: JoinScan requires all join key columns and ORDER BY columns to be fast fields
@@ -332,7 +332,7 @@ SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id)
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-ORDER BY paradedb.score(p.id) DESC
+ORDER BY paradedb.score(p.id) DESC, p.id
 LIMIT 5;
  id  |      name      | supplier_name |   score    
 -----+----------------+---------------+------------
@@ -891,8 +891,8 @@ ORDER BY p.price DESC
 LIMIT 3;
  id  |      name      | supplier_name 
 -----+----------------+---------------
- 201 | Wireless Mouse | TechCorp
  207 | Mouse Pad      | GlobalSupply
+ 201 | Wireless Mouse | TechCorp
 (2 rows)
 
 -- =============================================================================
@@ -1728,7 +1728,7 @@ INSERT INTO uuid_orders (customer_id, description, amount) VALUES
 ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Wireless keyboard order', 99.99),
 ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'USB hub purchase', 29.99),
 ('b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', 'Monitor stand order', 49.99),
-('c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', 'Wireless mouse order', 39.99);
+('c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', 'Wireless mouse order', 39.69);
 -- Note: uuid_orders.customer_id must be a fast field for the join key
 -- UUID columns use key_field which is implicitly fast, or explicit text_fields config
 CREATE INDEX uuid_orders_bm25_idx ON uuid_orders USING bm25 (id, description, customer_id)
@@ -2411,7 +2411,7 @@ LIMIT 10;
  id  |    name    | price  |   supplier   | min_order_value 
 -----+------------+--------+--------------+-----------------
  206 | Headphones | 199.99 | TechCorp     |           50.00
- 207 | Mouse Pad  |  29.99 | GlobalSupply |           15.00
+ 207 | Mouse Pad  |  39.69 | GlobalSupply |           15.00
 (2 rows)
 
 -- Test case: Search predicate OR multi-table predicate (unified expression tree)

--- a/pg_search/tests/pg_regress/sql/join_custom_scan.sql
+++ b/pg_search/tests/pg_regress/sql/join_custom_scan.sql
@@ -50,7 +50,7 @@ INSERT INTO products (id, name, description, supplier_id, price) VALUES
 (204, 'Monitor Stand', 'Adjustable monitor stand for ergonomic setup', 153, 49.99),
 (205, 'Webcam', 'HD webcam for video conferencing', 154, 59.99),
 (206, 'Headphones', 'Wireless noise-canceling headphones with premium sound', 151, 199.99),
-(207, 'Mouse Pad', 'Large gaming mouse pad with wireless charging', 152, 29.99),
+(207, 'Mouse Pad', 'Large gaming mouse pad with wireless charging', 152, 39.69),
 (208, 'Cable Organizer', 'Desktop cable organizer for clean setup', 153, 14.99);
 
 -- Create BM25 indexes on both tables
@@ -199,7 +199,7 @@ SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id)
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-ORDER BY paradedb.score(p.id) DESC
+ORDER BY paradedb.score(p.id) DESC, p.id
 LIMIT 5;
 
 -- =============================================================================
@@ -1155,7 +1155,7 @@ INSERT INTO uuid_orders (customer_id, description, amount) VALUES
 ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'Wireless keyboard order', 99.99),
 ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'USB hub purchase', 29.99),
 ('b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22', 'Monitor stand order', 49.99),
-('c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', 'Wireless mouse order', 39.99);
+('c0eebc99-9c0b-4ef8-bb6d-6bb9bd380a33', 'Wireless mouse order', 39.69);
 
 -- Note: uuid_orders.customer_id must be a fast field for the join key
 -- UUID columns use key_field which is implicitly fast, or explicit text_fields config


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #

## What

Adds explicit `ORDER BY` clauses to queries in the `join_custom_scan` regression tests that use `LIMIT` without deterministic ordering.

## Why

Queries using `LIMIT` without `ORDER BY` return results in non-deterministic order, causing intermittent test failures when the actual output doesn't match the expected output due to row ordering differences.

## How

Added `ORDER BY` clauses to 5 affected queries.

## Tests

Updated both the SQL test file and expected output file to reflect the new ordering.
