### PR TITLE
chore: Update baseline for Codecov on main

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -6,6 +6,9 @@
 name: Test pg_search
 
 on:
+  # We run nightly to update the code coverage baseline without excessive post-PR runs
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC (~2am ET)
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
@@ -36,7 +39,7 @@ jobs:
       - name: Define the PostgreSQL Version Matrix
         id: set-matrix
         run: |
-          if [[ ${{ github.event_name }} == "push" ]]; then
+          if [[ ${{ github.event_name }} == "push" || ${{ github.event_name }} == "schedule" ]]; then
             echo "Push event detected; using only PostgreSQL version 18."
             echo "matrix=[18]" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Without pushing from `main`, we won't update the baseline coverage. I figured we could do it nightly. It'll be slightly stale when doing PR comparisons, but that's plenty fine. Doing it post every PR merge on `main` seems very excessive.

## Why
^

## How
^

## Tests
^