### PR TITLE
chore: stabilize JoinScan EXPLAIN output across machines + disable DataFusion parallelization

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -160,7 +160,10 @@ use self::planning::{
 use self::predicate::extract_join_level_conditions;
 use self::privdat::PrivateData;
 
-use self::scan_state::{build_joinscan_logical_plan, build_joinscan_physical_plan, JoinScanState};
+use self::scan_state::{
+    build_joinscan_logical_plan, build_joinscan_physical_plan, create_session_context,
+    JoinScanState,
+};
 use crate::api::OrderByFeature;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
@@ -175,7 +178,6 @@ use crate::scan::PgSearchExtensionCodec;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::displayable;
-use datafusion::prelude::SessionContext;
 use datafusion_proto::bytes::{
     logical_plan_from_bytes_with_extension_codec, logical_plan_to_bytes_with_extension_codec,
 };
@@ -702,7 +704,7 @@ impl CustomScan for JoinScan {
         }
 
         if let Some(ref logical_plan) = state.custom_state().logical_plan {
-            let ctx = SessionContext::new();
+            let ctx = create_session_context();
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("Failed to create tokio runtime");
@@ -780,7 +782,7 @@ impl CustomScan for JoinScan {
                     .expect("Logical plan is required");
 
                 // Deserialize the logical plan
-                let ctx = SessionContext::new();
+                let ctx = create_session_context();
                 let logical_plan = logical_plan_from_bytes_with_extension_codec(
                     plan_bytes,
                     &ctx.task_ctx(),

--- a/pg_search/tests/pg_regress/expected/join_custom_scan.out
+++ b/pg_search/tests/pg_regress/expected/join_custom_scan.out
@@ -114,18 +114,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -169,18 +166,15 @@ LIMIT 5;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-                 :     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -220,18 +214,15 @@ LIMIT 5;
                Order By: p.supplier_id asc, s.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, NULL as col_2, NULL as col_3, id@1 as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                 :   SortPreservingMergeExec: [supplier_id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], fetch=5
-                 :     SortExec: TopK(fetch=5), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=5), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -352,18 +343,15 @@ LIMIT 5;
                      Order By: pdb.score() desc, p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                       :   SortPreservingMergeExec: [score@1 DESC, id@3 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[score@1 DESC, id@3 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(30 rows)
+                       :   SortExec: TopK(fetch=5), expr=[score@1 DESC, id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(27 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id)
 FROM products p
@@ -413,18 +401,15 @@ LIMIT 5;
                      Order By: p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                       :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id) AS score
 FROM products p
@@ -476,18 +461,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, score@0 as col_4, ctid_2@1 as ctid_2, ctid_1@2 as ctid_1]
-                 :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@2, supplier_id@1)], projection=[score@0, ctid_2@1, ctid_1@3, id@5]
-                 :         RepartitionExec: partitioning=Hash([id@2], 8), input_partitions=1
-                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(28 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@1)], projection=[score@0, ctid_2@1, ctid_1@3, id@5]
+                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(25 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(s.id) AS supplier_score
 FROM products p
@@ -541,18 +523,15 @@ LIMIT 10;
                      Order By: p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, score@2 as col_3, NULL as col_4, score@0 as col_5, ctid_2@1 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortPreservingMergeExec: [id@4 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, score@3, ctid_1@4, id@6]
-                       :         RepartitionExec: partitioning=Hash([id@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(30 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, score@3, ctid_1@4, id@6]
+                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(27 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name,
        paradedb.score(p.id) AS product_score,
@@ -599,18 +578,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(28 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(25 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -666,18 +642,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(29 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(26 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -751,18 +724,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -836,22 +806,19 @@ WARNING:  JoinScan not used: join key columns must be fast fields (tables: c, p,
                      Order By: p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
+                       :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
                ->  Hash
                      Output: c.name, c.id
                      ->  Seq Scan on public.categories c
                            Output: c.name, c.id
-(35 rows)
+(32 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, c.name AS category_name
 FROM products p
@@ -941,18 +908,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1022,18 +986,15 @@ LIMIT 3;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=3
-                 :     SortExec: TopK(fetch=3), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=3), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1131,18 +1092,15 @@ LIMIT 10;
                Order By: o.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(customer_code@1, customer_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([customer_code@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, customer_code@1 as customer_code]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([customer_code@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, customer_code@1 as customer_code, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(customer_code@1, customer_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, customer_code@1 as customer_code]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_code@1 as customer_code, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT o.id, o.description, c.name AS customer_name
 FROM orders o
@@ -1203,8 +1161,8 @@ JOIN warehouses w ON i.region_id = w.region_id AND i.warehouse_code = w.warehous
 WHERE i.product_name @@@ 'wireless'
 ORDER BY i.id
 LIMIT 10;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id, i.product_name, w.name
    ->  Sort
@@ -1221,18 +1179,15 @@ LIMIT 10;
                Order By: i.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(region_id@1, region_id@1), (warehouse_code@2, warehouse_code@2)], projection=[ctid_2@0, ctid_1@3, id@6]
-                 :         RepartitionExec: partitioning=Hash([region_id@1, warehouse_code@2], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, region_id@1 as region_id, warehouse_code@2 as warehouse_code]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([region_id@1, warehouse_code@2], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, region_id@1 as region_id, warehouse_code@2 as warehouse_code, id@3 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(region_id@1, region_id@1), (warehouse_code@2, warehouse_code@2)], projection=[ctid_2@0, ctid_1@3, id@6]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, region_id@1 as region_id, warehouse_code@2 as warehouse_code]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, region_id@1 as region_id, warehouse_code@2 as warehouse_code, id@3 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT i.id, i.product_name, w.name AS warehouse_name
 FROM inventory i
@@ -1304,18 +1259,15 @@ LIMIT 10;
                Order By: i.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(type_id@1, type_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([type_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, type_id@1 as type_id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([type_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, type_id@1 as type_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(type_id@1, type_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, type_id@1 as type_id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, type_id@1 as type_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT i.id, i.name, t.type_name
 FROM items i
@@ -1403,18 +1355,15 @@ LIMIT 10;
                Order By: lo.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT lo.id, lo.description, ls.name AS supplier_name
 FROM large_orders lo
@@ -1460,18 +1409,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1513,18 +1459,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1577,20 +1520,16 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_1@1) OR row_in_set(ctid_2@0) AND row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=8
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             FilterExec: row_in_set(ctid@0) OR row_in_set(ctid@0) OR row_in_set(ctid@0)
-                 :               RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1
-                 :                 CooperativeExec
-                 :                   PgSearchScan
-(30 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_1@1) OR row_in_set(ctid_2@0) AND row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         FilterExec: row_in_set(ctid@0) OR row_in_set(ctid@0) OR row_in_set(ctid@0)
+                 :           CooperativeExec
+                 :             PgSearchScan
+(26 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1632,18 +1571,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1685,18 +1621,15 @@ LIMIT 10;
                Order By: p.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([supplier_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1772,18 +1705,15 @@ LIMIT 10;
                      Order By: d.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(author_code@1, author_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :         RepartitionExec: partitioning=Hash([author_code@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, author_code@1 as author_code]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([author_code@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, author_code@1 as author_code, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(author_code@1, author_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, author_code@1 as author_code]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, author_code@1 as author_code, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 SELECT d.title, a.name
 FROM docs d
@@ -1856,18 +1786,15 @@ LIMIT 10;
                      Order By: i.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([category_id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 -- Should return only rows with non-NULL category_id that match the search
 -- The 2 items with NULL category_id are excluded by the JOIN
@@ -2009,18 +1936,15 @@ LIMIT 10;
                      Order By: od.order_id asc, oi.order_id asc, od.line_num asc, oi.line_num asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, order_id@4 as col_2, line_num@5 as col_3, NULL as col_4, NULL as col_5, ctid_2@0 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortPreservingMergeExec: [order_id@4 ASC NULLS LAST, order_id@1 ASC NULLS LAST, line_num@5 ASC NULLS LAST, line_num@2 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[order_id@1 ASC NULLS LAST, line_num@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(order_id@1, order_id@1), (line_num@2, line_num@2)]
-                       :         RepartitionExec: partitioning=Hash([order_id@1, line_num@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, order_id@1 as order_id, line_num@2 as line_num]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([order_id@1, line_num@2], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, order_id@1 as order_id, line_num@2 as line_num]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=10), expr=[order_id@1 ASC NULLS LAST, line_num@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(order_id@1, order_id@1), (line_num@2, line_num@2)]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, order_id@1 as order_id, line_num@2 as line_num]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, order_id@1 as order_id, line_num@2 as line_num]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 SELECT od.product_name, oi.quantity, oi.notes
 FROM order_details od
@@ -2154,18 +2078,15 @@ LIMIT 10;
                      Order By: o.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([customer_id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, customer_id@1 as customer_id, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_id@1 as customer_id, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 SELECT o.description, c.name
 FROM uuid_orders o
@@ -2501,18 +2422,15 @@ LIMIT 5;
                Order By: qgen_users.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-                 :     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2556,18 +2474,15 @@ LIMIT 5;
                Order By: qgen_users.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-                 :     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2610,18 +2525,15 @@ LIMIT 5;
                Order By: qgen_users.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=5
-                 :     SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(age@1, age@1)], filter=row_in_set(ctid_2@0) OR row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([age@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], filter=row_in_set(ctid_2@0) OR row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2691,18 +2603,15 @@ LIMIT 10;
                Order By: tp.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                 :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, ref_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([ref_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, ref_id@1 as ref_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, ref_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, ref_id@1 as ref_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT tp.id, tp.description, tr.name
 FROM tiny_products tp
@@ -2771,18 +2680,15 @@ LIMIT 20;
                Order By: hp.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=20
-                 :     SortExec: TopK(fetch=20), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                 :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-                 :         RepartitionExec: partitioning=Hash([category_id@1], 8), input_partitions=1
-                 :           ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
-                 :             CooperativeExec
-                 :               PgSearchScan
-(27 rows)
+                 :   SortExec: TopK(fetch=20), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT hp.id, hp.description, hc.name AS category_name
 FROM hint_test_products hp
@@ -2982,18 +2888,15 @@ LIMIT 5;
                      Order By: m.ID asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, ID@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortPreservingMergeExec: [ID@2 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[ID@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, JoinKey@1)], projection=[ctid_2@0, ctid_1@2, ID@4]
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([JoinKey@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, JoinKey@1 as JoinKey, ID@2 as ID]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(29 rows)
+                       :   SortExec: TopK(fetch=5), expr=[ID@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, JoinKey@1)], projection=[ctid_2@0, ctid_1@2, ID@4]
+                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, JoinKey@1 as JoinKey, ID@2 as ID]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(26 rows)
 
 SELECT m."Content", s.name
 FROM "MixedCaseTable" m
@@ -3090,25 +2993,20 @@ LIMIT 10;
                      Order By: p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1]
-                       :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, ctid_1@1 as ctid_1, id@2 as id]
-                       :         HashJoinExec: mode=Partitioned, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
-                       :           RepartitionExec: partitioning=Hash([category_id@2], 8), input_partitions=8
-                       :             HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
-                       :               RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :                 ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :                   CooperativeExec
-                       :                     PgSearchScan
-                       :               RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-                       :                 ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
-                       :                   CooperativeExec
-                       :                     PgSearchScan
-                       :           RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :             ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-                       :               CooperativeExec
-                       :                 PgSearchScan
-(37 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, ctid_1@1 as ctid_1, id@2 as id]
+                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
+                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
+                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :             CooperativeExec
+                       :               PgSearchScan
+                       :           ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
+                       :             CooperativeExec
+                       :               PgSearchScan
+                       :         ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+(32 rows)
 
 SELECT p.name AS product, s.name AS supplier, c.name AS category
 FROM products p
@@ -3154,24 +3052,19 @@ LIMIT 10;
                      Order By: p.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1, ctid_4@3 as ctid_4]
-                       :   SortPreservingMergeExec: [id@2 ASC NULLS LAST], fetch=10
-                       :     SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
-                       :         RepartitionExec: partitioning=Hash([category_id@2], 8), input_partitions=8
-                       :           HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
-                       :             RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :               ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :                 CooperativeExec
-                       :                   PgSearchScan
-                       :             RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-                       :               ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
-                       :                 CooperativeExec
-                       :                   PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-(36 rows)
+                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
+                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
+                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+                       :         ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(31 rows)
 
 SELECT p.name AS product, s.name AS supplier, c.name AS category
 FROM products p
@@ -3213,25 +3106,20 @@ LIMIT 5;
          Order By: pdb.score() desc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, score@2 as col_2, ctid_2@0 as ctid_2, ctid_4@1 as ctid_4, ctid_1@3 as ctid_1]
-           :   SortPreservingMergeExec: [score@2 DESC], fetch=5
-           :     SortExec: TopK(fetch=5), expr=[score@2 DESC], preserve_partitioning=[true]
-           :       ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, score@1 as score, ctid_1@2 as ctid_1]
-           :         HashJoinExec: mode=Partitioned, join_type=Inner, on=[(category_id@3, id@1)], projection=[ctid_2@0, score@1, ctid_1@2, ctid_4@4]
-           :           RepartitionExec: partitioning=Hash([category_id@3], 8), input_partitions=8
-           :             HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, supplier_id@3)], projection=[ctid_2@0, score@2, ctid_1@3, category_id@4]
-           :               RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-           :                 ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-           :                   CooperativeExec
-           :                     PgSearchScan
-           :               RepartitionExec: partitioning=Hash([supplier_id@3], 8), input_partitions=1
-           :                 ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, category_id@2 as category_id, supplier_id@3 as supplier_id]
-           :                   CooperativeExec
-           :                     PgSearchScan
-           :           RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-           :             ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-           :               CooperativeExec
-           :                 PgSearchScan
-(32 rows)
+           :   SortExec: TopK(fetch=5), expr=[score@2 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, score@1 as score, ctid_1@2 as ctid_1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@3, id@1)], projection=[ctid_2@0, score@1, ctid_1@2, ctid_4@4]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@3)], projection=[ctid_2@0, score@2, ctid_1@3, category_id@4]
+           :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :             CooperativeExec
+           :               PgSearchScan
+           :           ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, category_id@2 as category_id, supplier_id@3 as supplier_id]
+           :             CooperativeExec
+           :               PgSearchScan
+           :         ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+           :           CooperativeExec
+           :             PgSearchScan
+(27 rows)
 
 SELECT p.name, paradedb.score(p.id)
 FROM products p
@@ -3271,24 +3159,19 @@ LIMIT 5;
          Order By: pdb.score() desc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, score@0 as col_2, ctid_2@1 as ctid_2, ctid_1@2 as ctid_1, ctid_4@3 as ctid_4]
-           :   SortPreservingMergeExec: [score@0 DESC], fetch=5
-           :     SortExec: TopK(fetch=5), expr=[score@0 DESC], preserve_partitioning=[true]
-           :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(category_id@3, id@1)], projection=[score@0, ctid_2@1, ctid_1@2, ctid_4@4]
-           :         RepartitionExec: partitioning=Hash([category_id@3], 8), input_partitions=8
-           :           HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, ctid_1@3, category_id@4]
-           :             RepartitionExec: partitioning=Hash([id@2], 8), input_partitions=1
-           :               ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
-           :                 CooperativeExec
-           :                   PgSearchScan
-           :             RepartitionExec: partitioning=Hash([supplier_id@2], 8), input_partitions=1
-           :               ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id]
-           :                 CooperativeExec
-           :                   PgSearchScan
-           :         RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-           :           ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-           :             CooperativeExec
-           :               PgSearchScan
-(31 rows)
+           :   SortExec: TopK(fetch=5), expr=[score@0 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@3, id@1)], projection=[score@0, ctid_2@1, ctid_1@2, ctid_4@4]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, ctid_1@3, category_id@4]
+           :         ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
+           :           CooperativeExec
+           :             PgSearchScan
+           :         ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id]
+           :           CooperativeExec
+           :             PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(26 rows)
 
 SELECT s.name, paradedb.score(s.id)
 FROM products p
@@ -3359,31 +3242,24 @@ LIMIT 5;
                      Order By: l1.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, NULL as col_5, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
-                       :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       ProjectionExec: expr=[ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@3 as ctid_1, id@4 as id, ctid_2@2 as ctid_2]
-                       :         HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
-                       :           RepartitionExec: partitioning=Hash([id@3], 8), input_partitions=8
-                       :             HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
-                       :               RepartitionExec: partitioning=Hash([id@2], 8), input_partitions=8
-                       :                 HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
-                       :                   RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :                     ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :                       CooperativeExec
-                       :                         PgSearchScan
-                       :                   RepartitionExec: partitioning=Hash([l4_id@1], 8), input_partitions=1
-                       :                     ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :                       CooperativeExec
-                       :                         PgSearchScan
-                       :               RepartitionExec: partitioning=Hash([l3_id@2], 8), input_partitions=1
-                       :                 ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :                   CooperativeExec
-                       :                     PgSearchScan
-                       :           RepartitionExec: partitioning=Hash([l2_id@1], 8), input_partitions=1
-                       :             ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     ProjectionExec: expr=[ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@3 as ctid_1, id@4 as id, ctid_2@2 as ctid_2]
+                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
+                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
+                       :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
+                       :             ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
                        :               CooperativeExec
                        :                 PgSearchScan
-(44 rows)
+                       :             ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
+                       :               CooperativeExec
+                       :                 PgSearchScan
+                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                       :             CooperativeExec
+                       :               PgSearchScan
+                       :         ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+(37 rows)
 
 SELECT l1.name, l2.name, l3.name, l4.name
 FROM level1 l1
@@ -3434,30 +3310,23 @@ LIMIT 5;
                      Order By: l1.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortPreservingMergeExec: [id@4 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
-                       :         RepartitionExec: partitioning=Hash([id@3], 8), input_partitions=8
-                       :           HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
-                       :             RepartitionExec: partitioning=Hash([id@2], 8), input_partitions=8
-                       :               HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
-                       :                 RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :                   ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :                     CooperativeExec
-                       :                       PgSearchScan
-                       :                 RepartitionExec: partitioning=Hash([l4_id@1], 8), input_partitions=1
-                       :                   ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :                     CooperativeExec
-                       :                       PgSearchScan
-                       :             RepartitionExec: partitioning=Hash([l3_id@2], 8), input_partitions=1
-                       :               ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :                 CooperativeExec
-                       :                   PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([l2_id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
+                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
+                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
+                       :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
                        :             CooperativeExec
                        :               PgSearchScan
-(44 rows)
+                       :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
+                       :             CooperativeExec
+                       :               PgSearchScan
+                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(37 rows)
 
 SELECT l1.name, l4.name
 FROM level1 l1
@@ -3505,30 +3374,23 @@ LIMIT 5;
                      Order By: l1.id asc
                      DataFusion Physical Plan: 
                        : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_4@0 as ctid_4, ctid_6@1 as ctid_6, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortPreservingMergeExec: [id@4 ASC NULLS LAST], fetch=5
-                       :     SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[true]
-                       :       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_4@0, ctid_6@1, ctid_2@2, ctid_1@4, id@6]
-                       :         RepartitionExec: partitioning=Hash([id@3], 8), input_partitions=8
-                       :           HashJoinExec: mode=Partitioned, join_type=Inner, on=[(id@1, l3_id@2)], projection=[ctid_4@0, ctid_6@2, ctid_2@3, id@4]
-                       :             RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=8
-                       :               HashJoinExec: mode=Partitioned, join_type=Inner, on=[(l4_id@1, id@1)], projection=[ctid_4@0, id@2, ctid_6@3]
-                       :                 RepartitionExec: partitioning=Hash([l4_id@1], 8), input_partitions=1
-                       :                   ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :                     CooperativeExec
-                       :                       PgSearchScan
-                       :                 RepartitionExec: partitioning=Hash([id@1], 8), input_partitions=1
-                       :                   ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :                     CooperativeExec
-                       :                       PgSearchScan
-                       :             RepartitionExec: partitioning=Hash([l3_id@2], 8), input_partitions=1
-                       :               ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :                 CooperativeExec
-                       :                   PgSearchScan
-                       :         RepartitionExec: partitioning=Hash([l2_id@1], 8), input_partitions=1
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_4@0, ctid_6@1, ctid_2@2, ctid_1@4, id@6]
+                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l3_id@2)], projection=[ctid_4@0, ctid_6@2, ctid_2@3, id@4]
+                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l4_id@1, id@1)], projection=[ctid_4@0, id@2, ctid_6@3]
+                       :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
                        :             CooperativeExec
                        :               PgSearchScan
-(44 rows)
+                       :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
+                       :             CooperativeExec
+                       :               PgSearchScan
+                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                       :           CooperativeExec
+                       :             PgSearchScan
+                       :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                       :         CooperativeExec
+                       :           PgSearchScan
+(37 rows)
 
 SELECT l1.name, l4.name
 FROM level1 l1


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #2968 (partial)

## What

Disable DataFusion parallelization for JoinScan to ensure deterministic EXPLAIN output.

## Why

The physical plan output from `EXPLAIN` on JoinScan queries included partition counts (e.g., `input_partitions=8`, `Hash([...], 8)`) that varied based on the machine's CPU count. This made regression tests flaky and output hard to compare across environments. Also, DataFusion parallelization shouldn't be enabled.

## How

- Added `create_session_context()` helper that configures DataFusion with `target_partitions=1`
- Replaced all `SessionContext::new()` calls in JoinScan with this helper
- This forces single-partition execution, removing machine-dependent partition counts from EXPLAIN output

## Tests

Updated expected output in `join_custom_scan.out` to reflect the new stable physical plan format (e.g., `HashJoinExec: mode=CollectLeft` instead of partitioned mode with repartitioning).
