### PR TITLE
chore: Prune unused code in customscan module

### DIFF
--- a/pg_search/sql/pg_search--0.21.6--0.21.7.sql
+++ b/pg_search/sql/pg_search--0.21.6--0.21.7.sql
@@ -1,1 +1,5 @@
-\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.21.7'" to load this file. \quit
+
+DROP FUNCTION IF EXISTS score(_relation_reference anyelement);
+CREATE OR REPLACE FUNCTION score(relation_reference anyelement) RETURNS pg_catalog.float4 AS 'MODULE_PATHNAME', 'paradedb_score_from_relation_wrapper' COST 1 LANGUAGE c PARALLEL SAFE STABLE STRICT;
+DROP FUNCTION IF EXISTS pdb.score(_relation_reference anyelement);
+CREATE OR REPLACE FUNCTION pdb.score(relation_reference anyelement) RETURNS pg_catalog.float4 AS 'MODULE_PATHNAME', 'score_from_relation_wrapper' COST 1 LANGUAGE c PARALLEL SAFE STABLE STRICT;

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -479,7 +479,6 @@ impl AggregationResults {
         sentinel_sub.collect_group_keys(Vec::new(), &mut rows);
 
         // for each row of group keys, collect aggregates
-        let num_filters = filter_entries.len();
         for row in &mut rows {
             let mut aggregates = Vec::new();
 

--- a/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
@@ -67,7 +67,7 @@ impl CustomScanClause<AggregateScan> for GroupByClause {
 
     fn from_pg(
         args: &Self::Args,
-        heap_rti: pg_sys::Index,
+        _heap_rti: pg_sys::Index,
         index: &PgSearchRelation,
     ) -> Option<Self> {
         let mut grouping_columns = Vec::new();

--- a/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
@@ -21,7 +21,7 @@ use crate::postgres::customscan::aggregatescan::{AggregateScan, CustomScanClause
 use crate::postgres::customscan::builders::custom_path::CustomPathBuilder;
 use crate::postgres::customscan::CustomScan;
 use crate::postgres::rel::PgSearchRelation;
-use pgrx::{pg_sys, FromDatum, PgList};
+use pgrx::{pg_sys, FromDatum};
 
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LimitOffsetClause {
@@ -64,8 +64,8 @@ impl CustomScanClause<AggregateScan> for LimitOffsetClause {
 
     fn from_pg(
         args: &Self::Args,
-        heap_rti: pg_sys::Index,
-        index: &PgSearchRelation,
+        _heap_rti: pg_sys::Index,
+        _index: &PgSearchRelation,
     ) -> Option<Self> {
         let parse = args.root().parse;
         let (limit, offset) = unsafe {
@@ -84,7 +84,6 @@ impl CustomScanClause<AggregateScan> for LimitOffsetClause {
         };
 
         unsafe {
-            let sort_clause = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause);
             if !(*parse).groupClause.is_null()
                 && limit.unwrap_or(0) + offset.unwrap_or(0) > gucs::max_term_agg_buckets() as u32
             {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -92,7 +92,7 @@ impl CustomScan for AggregateScan {
         let Some(heap_rte) = heap_rte else {
             return Vec::new();
         };
-        let Some((table, index)) = rel_get_bm25_index(unsafe { (*heap_rte).relid }) else {
+        let Some((_table, index)) = rel_get_bm25_index(unsafe { (*heap_rte).relid }) else {
             return Vec::new();
         };
         let Some((builder, aggregate_clause)) = AggregateCSClause::build(builder, heap_rti, &index)
@@ -157,7 +157,7 @@ impl CustomScan for AggregateScan {
 
     fn explain_custom_scan(
         state: &CustomScanStateWrapper<Self>,
-        ancestors: *mut pg_sys::List,
+        _ancestors: *mut pg_sys::List,
         explainer: &mut Explainer,
     ) {
         explainer.add_text("Index", state.custom_state().indexrel().name());
@@ -179,7 +179,7 @@ impl CustomScan for AggregateScan {
     fn begin_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
         estate: *mut pg_sys::EState,
-        eflags: i32,
+        _eflags: i32,
     ) {
         unsafe {
             let rte = pg_sys::exec_rt_fetch(state.custom_state().execution_rti, estate);
@@ -473,7 +473,7 @@ impl CustomScan for AggregateScan {
         }
     }
 
-    fn shutdown_custom_scan(state: &mut CustomScanStateWrapper<Self>) {}
+    fn shutdown_custom_scan(_state: &mut CustomScanStateWrapper<Self>) {}
 
     fn end_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
         // Clean up the reusable scan slot

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -75,7 +75,7 @@ impl AggregateScanState {
 }
 
 impl CustomScanState for AggregateScanState {
-    fn init_exec_method(&mut self, cstate: *mut pg_sys::CustomScanState) {
+    fn init_exec_method(&mut self, _cstate: *mut pg_sys::CustomScanState) {
         // TODO: Unused currently. See the comment on `trait CustomScanState` regarding making this
         // more useful.
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/targetlist.rs
@@ -183,11 +183,10 @@ impl CustomScanClause<AggregateScan> for TargetList {
 
         for expr in target_list.iter_ptr() {
             unsafe {
-                let node_tag = (*expr).type_;
                 let var_context = VarContext::from_planner(args.root() as *const _ as *mut _);
 
                 // Try to extract field name from the expression (handles both Var and JSON operators)
-                if let Some((var, field_name)) =
+                if let Some((_, field_name)) =
                     find_one_var_and_fieldname(var_context, expr as *mut pg_sys::Node)
                 {
                     // This could be a Var or a JSON projection (OpExpr) - check if it's a grouping column

--- a/pg_search/src/postgres/customscan/basescan/exec_methods.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods.rs
@@ -58,7 +58,7 @@ pub trait ExecMethod {
         self.reset(state)
     }
 
-    fn uses_visibility_map(&self, state: &BaseScanState) -> bool {
+    fn uses_visibility_map(&self, _state: &BaseScanState) -> bool {
         true
     }
 

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_n.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_n.rs
@@ -143,13 +143,13 @@ impl TopNScanExecState {
             (None, _) => {
                 // Not parallel: will search all segments.
                 let all_segments = search_reader.segment_ids();
-                Box::new(all_segments.into_iter().inspect(|segment_id| {
+                Box::new(all_segments.into_iter().inspect(|_segment_id| {
                     check_for_interrupts!();
                 }))
             }
             (Some(_), Some(claimed_segments)) => {
                 // Parallel, but we have already claimed our segments. Emit them again.
-                Box::new(claimed_segments.into_iter().inspect(|segment_id| {
+                Box::new(claimed_segments.into_iter().inspect(|_segment_id| {
                     check_for_interrupts!();
                 }))
             }
@@ -288,7 +288,7 @@ impl TopNScanExecState {
 
 impl ExecMethod for TopNScanExecState {
     /// Initialize the exec method with data from the scan state
-    fn init(&mut self, state: &mut BaseScanState, cstate: *mut pg_sys::CustomScanState) {
+    fn init(&mut self, state: &mut BaseScanState, _cstate: *mut pg_sys::CustomScanState) {
         // Call the default init behavior first
         self.reset(state);
 

--- a/pg_search/src/postgres/customscan/basescan/parallel.rs
+++ b/pg_search/src/postgres/customscan/basescan/parallel.rs
@@ -41,7 +41,7 @@ pub enum RowEstimate {
 impl ParallelQueryCapable for BaseScan {
     fn estimate_dsm_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
-        pcxt: *mut ParallelContext,
+        _pcxt: *mut ParallelContext,
     ) -> Size {
         if state.custom_state().search_reader.is_none() {
             BaseScan::init_search_reader(state);
@@ -57,7 +57,7 @@ impl ParallelQueryCapable for BaseScan {
 
     fn initialize_dsm_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
-        pcxt: *mut ParallelContext,
+        _pcxt: *mut ParallelContext,
         coordinate: *mut c_void,
     ) {
         let args = state.custom_state().parallel_scan_args();
@@ -71,8 +71,8 @@ impl ParallelQueryCapable for BaseScan {
     }
 
     fn reinitialize_dsm_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        pcxt: *mut ParallelContext,
+        _state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut ParallelContext,
         coordinate: *mut c_void,
     ) {
         let pscan_state = coordinate.cast::<ParallelScanState>();
@@ -81,7 +81,7 @@ impl ParallelQueryCapable for BaseScan {
 
     fn initialize_worker_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
-        toc: *mut shm_toc,
+        _toc: *mut shm_toc,
         coordinate: *mut c_void,
     ) {
         let pscan_state = coordinate.cast::<ParallelScanState>();

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -25,8 +25,9 @@ use std::ptr::addr_of_mut;
 mod pdb {
     use pgrx::{extension_sql, pg_extern, AnyElement};
 
+    #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
-    fn score_from_relation(_relation_reference: AnyElement) -> f32 {
+    fn score_from_relation(relation_reference: AnyElement) -> f32 {
         panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
     }
 
@@ -42,8 +43,9 @@ mod pdb {
 // In `0.19.0`, we renamed the schema from `paradedb` to `pdb`.
 // This is a backwards compatibility shim to ensure that old queries continue to work.
 #[warn(deprecated)]
+#[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
-fn paradedb_score_from_relation(_relation_reference: AnyElement) -> Option<f32> {
+fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
     panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
 }
 

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -259,6 +259,7 @@ pub mod pdb {
         }
     }
 
+    #[allow(unused_variables)]
     #[pg_extern(name = "snippet", stable, parallel_safe)]
     fn snippet_from_relation(
         field: AnyElement,
@@ -271,6 +272,7 @@ pub mod pdb {
         panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
     }
 
+    #[allow(unused_variables)]
     #[pg_extern(name = "snippets", stable, parallel_safe)]
     fn snippets_from_relation(
         field: AnyElement,
@@ -284,6 +286,7 @@ pub mod pdb {
         panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
     }
 
+    #[allow(unused_variables)]
     #[pg_extern(
         name = "snippet_positions",
         stable,
@@ -300,9 +303,9 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
 "#
     )]
     fn snippet_positions_from_relation(
-        _field: AnyElement,
-        _limit: default!(Option<i32>, "NULL"),
-        _offset: default!(Option<i32>, "NULL"),
+        field: AnyElement,
+        limit: default!(Option<i32>, "NULL"),
+        offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
         panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
     }
@@ -311,6 +314,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
 // In `0.19.0`, we renamed `paradedb.snippet*` functions to `pdb.snippet*`.
 // This is a backwards compatibility shim to ensure that old queries continue to work.
 #[warn(deprecated)]
+#[allow(unused_variables)]
 #[pg_extern(name = "snippet", stable, parallel_safe)]
 fn paradedb_snippet_from_relation(
     field: AnyElement,
@@ -324,6 +328,7 @@ fn paradedb_snippet_from_relation(
 }
 
 #[warn(deprecated)]
+#[allow(unused_variables)]
 #[pg_extern(name = "snippets", stable, parallel_safe)]
 fn paradedb_snippets_from_relation(
     field: AnyElement,
@@ -338,6 +343,7 @@ fn paradedb_snippets_from_relation(
 }
 
 #[warn(deprecated)]
+#[allow(unused_variables)]
 #[pg_extern(
     name = "snippet_positions",
     stable,
@@ -354,9 +360,9 @@ AS 'MODULE_PATHNAME', 'paradedb_snippet_positions_from_relation_wrapper';
 "#
 )]
 fn paradedb_snippet_positions_from_relation(
-    _field: AnyElement,
-    _limit: default!(Option<i32>, "NULL"),
-    _offset: default!(Option<i32>, "NULL"),
+    field: AnyElement,
+    limit: default!(Option<i32>, "NULL"),
+    offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
     panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
 }

--- a/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
@@ -514,11 +514,7 @@ unsafe fn validate_and_build_target_list(
     let window_clause = window_clauses.get_ptr(window_clause_idx).unwrap();
 
     let has_partition_by = window_has_partition_by(parse, (*window_clause).partitionClause);
-    let has_frame_clause = window_has_custom_frame_clause(
-        (*window_clause).frameOptions,
-        (*window_clause).startOffset,
-        (*window_clause).endOffset,
-    );
+    let has_frame_clause = window_has_custom_frame_clause((*window_clause).frameOptions);
     let has_order_by = window_has_order_by(parse, (*window_clause).orderClause);
 
     // Reject if PARTITION BY, frame clause, or ORDER BY is present
@@ -533,8 +529,6 @@ unsafe fn validate_and_build_target_list(
 /// (not the default RANGE UNBOUNDED PRECEDING AND CURRENT ROW)
 unsafe fn window_has_custom_frame_clause(
     frame_options: i32, // frameOptions is a bitmask containing frame type and bounds
-    start_offset: *mut pg_sys::Node,
-    end_offset: *mut pg_sys::Node,
 ) -> bool {
     const FRAMEOPTION_NONDEFAULT: i32 = 0x00001;
     // Check if there's a non-default frame clause

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -650,7 +650,7 @@ unsafe fn query_has_window_func_nodes(parse: *mut pg_sys::Query) -> bool {
     // Check subqueries in RTEs
     if !(*parse).rtable.is_null() {
         let rtable = PgList::<pg_sys::RangeTblEntry>::from_pg((*parse).rtable);
-        for (idx, rte) in rtable.iter_ptr().enumerate() {
+        for rte in rtable.iter_ptr() {
             if (*rte).rtekind == pg_sys::RTEKind::RTE_SUBQUERY
                 && !(*rte).subquery.is_null()
                 && query_has_window_func_nodes((*rte).subquery)
@@ -960,7 +960,7 @@ unsafe fn replace_windowfuncs_recursively(parse: *mut pg_sys::Query) {
     // Recursively process subqueries in RTEs
     if !(*parse).rtable.is_null() {
         let rtable = PgList::<pg_sys::RangeTblEntry>::from_pg((*parse).rtable);
-        for (idx, rte) in rtable.iter_ptr().enumerate() {
+        for rte in rtable.iter_ptr() {
             if (*rte).rtekind == pg_sys::RTEKind::RTE_SUBQUERY && !(*rte).subquery.is_null() {
                 // For subqueries, check if they should have window functions replaced
                 // Each subquery is independent and may have its own TopN context

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -17,7 +17,6 @@
 
 //! https://www.postgresql.org/docs/current/custom-scan.html
 
-#![allow(unused_variables)]
 #![allow(clippy::tabs_in_doc_comments)]
 
 use parking_lot::Mutex;

--- a/pg_search/src/postgres/customscan/path.rs
+++ b/pg_search/src/postgres/customscan/path.rs
@@ -44,9 +44,9 @@ pub extern "C-unwind" fn plan_custom_path<CS: CustomScan>(
 /// adjust_appendrel_attrs or adjust_appendrel_attrs_multilevel as required.
 #[pg_guard]
 pub extern "C-unwind" fn reparameterize_custom_path_by_child<CS: CustomScan>(
-    root: *mut pg_sys::PlannerInfo,
-    custom_private: *mut pg_sys::List,
-    child_rel: *mut pg_sys::RelOptInfo,
+    _root: *mut pg_sys::PlannerInfo,
+    _custom_private: *mut pg_sys::List,
+    _child_rel: *mut pg_sys::RelOptInfo,
 ) -> *mut pg_sys::List {
     todo!("reparameterize_custom_path_by_child")
 }

--- a/pg_search/src/postgres/customscan/projections.rs
+++ b/pg_search/src/postgres/customscan/projections.rs
@@ -466,7 +466,7 @@ pub unsafe fn inject_placeholders(
     snippets_funcoids: [pg_sys::Oid; 2],
     snippet_positions_funcoids: [pg_sys::Oid; 2],
     attname_lookup: &HashMap<(Varno, pg_sys::AttrNumber), FieldName>,
-    snippet_generators: &HashMap<SnippetType, Option<(tantivy::schema::Field, SnippetGenerator)>>,
+    snippet_generators: &HashMap<SnippetType, Option<SnippetGenerator>>,
 ) -> (
     *mut pg_sys::List,
     *mut pg_sys::Const,
@@ -484,7 +484,6 @@ pub unsafe fn inject_placeholders(
         #[inline(always)]
         unsafe fn inner(node: *mut pg_sys::Node, data: &mut Data) -> Option<*mut pg_sys::Node> {
             let funcexpr = nodecast!(FuncExpr, T_FuncExpr, node)?;
-            let args = PgList::<pg_sys::Node>::from_pg((*funcexpr).args);
 
             if data.score_funcoids.contains(&(*funcexpr).funcid) {
                 return Some(data.const_score_node.cast());
@@ -575,8 +574,7 @@ pub unsafe fn inject_placeholders(
         snippet_positions_funcoids: [pg_sys::Oid; 2],
         attname_lookup: &'a HashMap<(Varno, pg_sys::AttrNumber), FieldName>,
 
-        snippet_generators:
-            &'a HashMap<SnippetType, Option<(tantivy::schema::Field, SnippetGenerator)>>,
+        snippet_generators: &'a HashMap<SnippetType, Option<SnippetGenerator>>,
         const_snippet_nodes: HashMap<SnippetType, Vec<*mut pg_sys::Const>>,
     }
 

--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -124,7 +124,6 @@ macro_rules! pushdown {
                 let context = PlannerContext::from_planner($root);
                 Qual::Expr {
                     node: funcexpr.cast(),
-                    expr_state: std::ptr::null_mut(),
                     expr_desc: deparse_expr(Some(&context), $indexrel, funcexpr.cast()),
                 }
             }

--- a/pg_search/tests/pg_regress/expected/recursive_estimates.out
+++ b/pg_search/tests/pg_regress/expected/recursive_estimates.out
@@ -870,7 +870,7 @@ EXPLAIN (ANALYZE, VERBOSE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT * FROM rec
    Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"running shoes","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true},"estimated_docs":1}},"estimated_docs":1}
    Buffers: shared hit=21
  Planning:
-   Buffers: shared hit=36
+   Buffers: shared hit=27
 (13 rows)
 
 -- Test 7.3: Verify EXPLAIN without VERBOSE does NOT show estimates


### PR DESCRIPTION
## What

Remove a module-level `#![allow(unused_variables)]`, and clean up the dead code that was exposed.

## Why

Less dead code.