### PR TITLE
perf: Always claim `ORDER BY` path keys in the join scan

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -838,11 +838,7 @@ impl CustomScan for BaseScan {
                         ..
                     }
                 ) {
-                    if let Some(pathkeys) = topn_pathkey_info.pathkeys() {
-                        for pathkey in pathkeys {
-                            path_builder = path_builder.add_path_key(pathkey);
-                        }
-                    }
+                    path_builder = path_builder.set_pathkeys((*builder.args().root).query_pathkeys);
                 } else if is_sorted {
                     // For sorted mixed fast field execution, add the sort pathkey
                     if let Some(ref pathkey_style) = sort_by_pathkey {

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -272,6 +272,11 @@ impl<CS: CustomScan> CustomPathBuilder<CS> {
         self
     }
 
+    pub fn set_pathkeys(mut self, pathkeys: *mut pg_sys::List) -> Self {
+        self.custom_path_node.path.pathkeys = pathkeys;
+        self
+    }
+
     pub fn set_force_path(mut self, force: bool) -> Self {
         if force {
             self.flags.insert(Flags::Force);

--- a/pg_search/tests/pg_regress/expected/join_custom_scan.out
+++ b/pg_search/tests/pg_regress/expected/join_custom_scan.out
@@ -96,33 +96,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -148,33 +145,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'keyboard'
 ORDER BY p.id
 LIMIT 5;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
-               Limit: 5
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}
+         Limit: 5
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -322,36 +316,32 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY paradedb.score(p.id) DESC, p.id
 LIMIT 5;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, (paradedb.score(p.id))
-   ->  Incremental Sort
+   ->  Result
          Output: p.id, p.name, s.name, (paradedb.score(p.id))
-         Sort Key: (paradedb.score(p.id)) DESC, p.id
-         Presorted Key: (paradedb.score(p.id))
-         ->  Result
-               Output: p.id, p.name, s.name, (paradedb.score(p.id))
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.id, p.name, (paradedb.score(p.id)), s.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: products (p)
-                     Join Cond: p.supplier_id = s.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: pdb.score() desc, p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[score@1 DESC, id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(27 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.id, p.name, (paradedb.score(p.id)), s.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: products (p)
+               Join Cond: p.supplier_id = s.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: pdb.score() desc, p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=5), expr=[score@1 DESC, id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id)
 FROM products p
@@ -381,35 +371,32 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, (paradedb.score(p.id))
-   ->  Sort
+   ->  Result
          Output: p.id, p.name, s.name, (paradedb.score(p.id))
-         Sort Key: p.id
-         ->  Result
-               Output: p.id, p.name, s.name, (paradedb.score(p.id))
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.id, p.name, (paradedb.score(p.id)), s.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: products (p)
-                     Join Cond: p.supplier_id = s.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.id, p.name, (paradedb.score(p.id)), s.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: products (p)
+               Join Cond: p.supplier_id = s.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, score@1 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, score@2, ctid_1@3, id@5]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(p.id) AS score
 FROM products p
@@ -442,34 +429,31 @@ WHERE p.description @@@ 'wireless'
   AND s.contact_info @@@ 'technology'
 ORDER BY p.id
 LIMIT 10;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, (paradedb.score(s.id))
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name, (paradedb.score(s.id))
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name, (paradedb.score(s.id))
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, score@0 as col_4, ctid_2@1 as ctid_2, ctid_1@2 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@1)], projection=[score@0, ctid_2@1, ctid_1@3, id@5]
-                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(25 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, score@0 as col_4, ctid_2@1 as ctid_2, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@1)], projection=[score@0, ctid_2@1, ctid_1@3, id@5]
+           :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(22 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(s.id) AS supplier_score
 FROM products p
@@ -502,36 +486,33 @@ WHERE p.description @@@ 'wireless'
   AND s.contact_info @@@ 'technology'
 ORDER BY p.id
 LIMIT 10;
-                                                                                   QUERY PLAN                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, (paradedb.score(p.id)), (paradedb.score(s.id))
-   ->  Sort
+   ->  Result
          Output: p.id, p.name, s.name, (paradedb.score(p.id)), (paradedb.score(s.id))
-         Sort Key: p.id
-         ->  Result
-               Output: p.id, p.name, s.name, (paradedb.score(p.id)), (paradedb.score(s.id))
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.id, p.name, (paradedb.score(p.id)), s.name, (paradedb.score(s.id))
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: products (p)
-                     Join Cond: p.supplier_id = s.id
-                     Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, score@2 as col_3, NULL as col_4, score@0 as col_5, ctid_2@1 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, score@3, ctid_1@4, id@6]
-                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(27 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.id, p.name, (paradedb.score(p.id)), s.name, (paradedb.score(s.id))
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: products (p)
+               Join Cond: p.supplier_id = s.id
+               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, score@2 as col_3, NULL as col_4, score@0 as col_5, ctid_2@1 as ctid_2, ctid_1@3 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, supplier_id@2)], projection=[score@0, ctid_2@1, score@3, ctid_1@4, id@6]
+                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_2, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[pdb.score()@0 as score, ctid@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(24 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name,
        paradedb.score(p.id) AS product_score,
@@ -559,34 +540,31 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless' AND s.contact_info @@@ 'technology'
 ORDER BY p.id
 LIMIT 10;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(25 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(22 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -622,35 +600,32 @@ WHERE p.description @@@ 'wireless'
   AND (p.name @@@ 'headphones' OR s.name @@@ 'TechCorp')
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                QUERY PLAN                                                                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                             QUERY PLAN                                                                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"headphones","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"TechCorp","lenient":null,"conjunction_mode":null}}}})
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(26 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"headphones","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"TechCorp","lenient":null,"conjunction_mode":null}}}})
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(23 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -706,33 +681,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless' OR s.contact_info @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                      QUERY PLAN                                                                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                   QUERY PLAN                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}})
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}})
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -890,33 +862,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless' OR s.contact_info @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                      QUERY PLAN                                                                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                   QUERY PLAN                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}})
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}})
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -968,33 +937,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'mouse'
 ORDER BY p.id
 LIMIT 3;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}
-               Limit: 3
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=3), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}
+         Limit: 3
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=3), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1016,35 +982,32 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'mouse'
 ORDER BY p.price DESC
 LIMIT 3;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, p.price
-   ->  Sort
+   ->  Result
          Output: p.id, p.name, s.name, p.price
-         Sort Key: p.price DESC
-         ->  Result
-               Output: p.id, p.name, s.name, p.price
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.id, p.name, p.price, s.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: products (p)
-                     Join Cond: p.supplier_id = s.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 3
-                     Order By: p.price desc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, NULL as col_2, price@2 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=3), expr=[price@2 DESC], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, price@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, price@2 as price]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.id, p.name, p.price, s.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: products (p)
+               Join Cond: p.supplier_id = s.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}
+               Limit: 3
+               Order By: p.price desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, NULL as col_2, price@2 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=3), expr=[price@2 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, price@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, price@2 as price]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1097,33 +1060,30 @@ JOIN customers c ON o.customer_code = c.customer_code
 WHERE o.description @@@ 'wireless'
 ORDER BY o.id
 LIMIT 10;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: o.id, o.description, c.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: o.id, o.description, c.name
-         Sort Key: o.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: o.id, o.description, c.name
-               Join Type: Inner
-               Relation 0: customers (c)
-               Relation 1: orders (o)
-               Join Cond: o.customer_code = c.customer_code
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: o.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(customer_code@1, customer_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, customer_code@1 as customer_code]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_code@1 as customer_code, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: customers (c)
+         Relation 1: orders (o)
+         Join Cond: o.customer_code = c.customer_code
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: o.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(customer_code@1, customer_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, customer_code@1 as customer_code]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_code@1 as customer_code, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT o.id, o.description, c.name AS customer_name
 FROM orders o
@@ -1184,33 +1144,30 @@ JOIN warehouses w ON i.region_id = w.region_id AND i.warehouse_code = w.warehous
 WHERE i.product_name @@@ 'wireless'
 ORDER BY i.id
 LIMIT 10;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id, i.product_name, w.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: i.id, i.product_name, w.name
-         Sort Key: i.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: i.id, i.product_name, w.name
-               Join Type: Inner
-               Relation 0: warehouses (w)
-               Relation 1: inventory (i)
-               Join Cond: i.region_id = w.region_id, i.warehouse_code = w.warehouse_code
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"product_name","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: i.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(region_id@1, region_id@1), (warehouse_code@2, warehouse_code@2)], projection=[ctid_2@0, ctid_1@3, id@6]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, region_id@1 as region_id, warehouse_code@2 as warehouse_code]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, region_id@1 as region_id, warehouse_code@2 as warehouse_code, id@3 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: warehouses (w)
+         Relation 1: inventory (i)
+         Join Cond: i.region_id = w.region_id, i.warehouse_code = w.warehouse_code
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"product_name","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(region_id@1, region_id@1), (warehouse_code@2, warehouse_code@2)], projection=[ctid_2@0, ctid_1@3, id@6]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, region_id@1 as region_id, warehouse_code@2 as warehouse_code]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, region_id@1 as region_id, warehouse_code@2 as warehouse_code, id@3 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT i.id, i.product_name, w.name AS warehouse_name
 FROM inventory i
@@ -1264,33 +1221,30 @@ JOIN item_types t ON i.type_id = t.type_id
 WHERE i.details @@@ 'wireless'
 ORDER BY i.id
 LIMIT 10;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id, i.name, t.type_name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: i.id, i.name, t.type_name
-         Sort Key: i.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: i.id, i.name, t.type_name
-               Join Type: Inner
-               Relation 0: item_types (t)
-               Relation 1: items (i)
-               Join Cond: i.type_id = t.type_id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"details","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: i.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(type_id@1, type_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, type_id@1 as type_id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, type_id@1 as type_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: item_types (t)
+         Relation 1: items (i)
+         Join Cond: i.type_id = t.type_id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"details","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(type_id@1, type_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, type_id@1 as type_id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, type_id@1 as type_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT i.id, i.name, t.type_name
 FROM items i
@@ -1360,33 +1314,30 @@ JOIN large_suppliers ls ON lo.supplier_id = ls.id
 WHERE lo.description @@@ 'wireless'
 ORDER BY lo.id
 LIMIT 10;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: lo.id, lo.description, ls.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: lo.id, lo.description, ls.name
-         Sort Key: lo.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: lo.id, lo.description, ls.name
-               Join Type: Inner
-               Relation 0: large_suppliers (ls)
-               Relation 1: large_orders (lo)
-               Join Cond: lo.supplier_id = ls.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: lo.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: large_suppliers (ls)
+         Relation 1: large_orders (lo)
+         Join Cond: lo.supplier_id = ls.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: lo.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT lo.id, lo.description, ls.name AS supplier_name
 FROM large_orders lo
@@ -1414,33 +1365,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE (p.description @@@ 'wireless' AND NOT p.description @@@ 'mouse') OR s.contact_info @@@ 'shipping'
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Join Predicate: (p:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}]}}]}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}})
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: (p:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}]}}]}} OR s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}})
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1464,33 +1412,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE NOT (p.description @@@ 'cable' OR p.description @@@ 'stand')
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"stand","lenient":null,"conjunction_mode":null}}}}]}}]}}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"boolean":{"must":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"stand","lenient":null,"conjunction_mode":null}}}}]}}]}}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1524,35 +1469,32 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'keyboard' OR (p.description @@@ 'headphones' OR (s.contact_info @@@ 'shipping' AND NOT p.description @@@ 'wireless'))
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}]}}]}}
-               Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}} OR p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}} OR (s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}} AND p:{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}]}}))
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_1@1) OR row_in_set(ctid_2@0) AND row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         FilterExec: row_in_set(ctid@0) OR row_in_set(ctid@0) OR row_in_set(ctid@0)
-                 :           CooperativeExec
-                 :             PgSearchScan
-(26 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}]}}]}}
+         Join Predicate: (p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}} OR p:{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}} OR (s:{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}} AND p:{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}]}}))
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_1@1) OR row_in_set(ctid_2@0) AND row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         FilterExec: row_in_set(ctid@0) OR row_in_set(ctid@0) OR row_in_set(ctid@0)
+           :           CooperativeExec
+           :             PgSearchScan
+(23 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1576,33 +1518,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE (p.description @@@ 'wireless' AND p.description @@@ 'mouse') OR (s.contact_info @@@ 'shipping' AND s.country @@@ 'UK')
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Join Predicate: (p:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}]}} OR s:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"UK","lenient":null,"conjunction_mode":null}}}}]}})
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: (p:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"mouse","lenient":null,"conjunction_mode":null}}}}]}} OR s:{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"shipping","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"UK","lenient":null,"conjunction_mode":null}}}}]}})
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=row_in_set(ctid_1@1) OR row_in_set(ctid_2@0), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1626,33 +1565,30 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE NOT (NOT (NOT p.description @@@ 'cable'))
 ORDER BY p.id
 LIMIT 10;
-                                                                                                  QUERY PLAN                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, s.name
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}}}]}}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}}}]}}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -1708,35 +1644,32 @@ JOIN authors a ON d.author_code = a.author_code
 WHERE d.content @@@ 'search'
 ORDER BY d.id
 LIMIT 10;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: d.title, a.name, d.id
-   ->  Sort
+   ->  Result
          Output: d.title, a.name, d.id
-         Sort Key: d.id
-         ->  Result
-               Output: d.title, a.name, d.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: d.title, d.id, a.name
-                     Join Type: Inner
-                     Relation 0: authors (a)
-                     Relation 1: docs (d)
-                     Join Cond: d.author_code = a.author_code
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: d.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(author_code@1, author_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, author_code@1 as author_code]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, author_code@1 as author_code, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: d.title, d.id, a.name
+               Join Type: Inner
+               Relation 0: authors (a)
+               Relation 1: docs (d)
+               Join Cond: d.author_code = a.author_code
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"search","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: d.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(author_code@1, author_code@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, author_code@1 as author_code]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, author_code@1 as author_code, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT d.title, a.name
 FROM docs d
@@ -1789,35 +1722,32 @@ JOIN categories_with_nulls c ON i.category_id = c.id
 WHERE i.content @@@ 'item OR laptop OR novel'
 ORDER BY i.id
 LIMIT 10;
-                                                                                       QUERY PLAN                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.name, c.name, i.id
-   ->  Sort
+   ->  Result
          Output: i.name, c.name, i.id
-         Sort Key: i.id
-         ->  Result
-               Output: i.name, c.name, i.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: i.name, i.id, c.name
-                     Join Type: Inner
-                     Relation 0: categories_with_nulls (c)
-                     Relation 1: items_with_nulls (i)
-                     Join Cond: i.category_id = c.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"item OR laptop OR novel","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: i.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: i.name, i.id, c.name
+               Join Type: Inner
+               Relation 0: categories_with_nulls (c)
+               Relation 1: items_with_nulls (i)
+               Join Cond: i.category_id = c.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"item OR laptop OR novel","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: i.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 -- Should return only rows with non-NULL category_id that match the search
 -- The 2 items with NULL category_id are excluded by the JOIN
@@ -2081,35 +2011,32 @@ JOIN uuid_customers c ON o.customer_id = c.id
 WHERE o.description @@@ 'wireless'
 ORDER BY o.id
 LIMIT 10;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: o.description, c.name, o.id
-   ->  Sort
+   ->  Result
          Output: o.description, c.name, o.id
-         Sort Key: o.id
-         ->  Result
-               Output: o.description, c.name, o.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: o.description, o.id, c.name
-                     Join Type: Inner
-                     Relation 0: uuid_customers (c)
-                     Relation 1: uuid_orders (o)
-                     Join Cond: o.customer_id = c.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: o.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_id@1 as customer_id, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: o.description, o.id, c.name
+               Join Type: Inner
+               Relation 0: uuid_customers (c)
+               Relation 1: uuid_orders (o)
+               Join Cond: o.customer_id = c.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: o.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, customer_id@1 as customer_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT o.description, c.name
 FROM uuid_orders o
@@ -2163,35 +2090,32 @@ JOIN numeric_accounts a ON t.account_num = a.account_num
 WHERE t.description @@@ 'wire'
 ORDER BY t.id
 LIMIT 10;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t.description, a.holder_name, t.amount, t.id
-   ->  Sort
+   ->  Result
          Output: t.description, a.holder_name, t.amount, t.id
-         Sort Key: t.id
-         ->  Result
-               Output: t.description, a.holder_name, t.amount, t.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: t.description, t.amount, t.id, a.holder_name
-                     Join Type: Inner
-                     Relation 0: numeric_accounts (a)
-                     Relation 1: numeric_transactions (t)
-                     Join Cond: t.account_num = a.account_num
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wire","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: t.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, NULL as col_2, id@2 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(account_num@1, account_num@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, account_num@1 as account_num]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, account_num@1 as account_num, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: t.description, t.amount, t.id, a.holder_name
+               Join Type: Inner
+               Relation 0: numeric_accounts (a)
+               Relation 1: numeric_transactions (t)
+               Join Cond: t.account_num = a.account_num
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wire","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: t.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, NULL as col_2, id@2 as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(account_num@1, account_num@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, account_num@1 as account_num]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, account_num@1 as account_num, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 -- =============================================================================
 -- TEST 28: Large result set (functional, not performance)
@@ -2432,33 +2356,30 @@ JOIN qgen_products ON qgen_users.age = qgen_products.age
 WHERE qgen_users.name @@@ 'bob' 
 ORDER BY qgen_users.id 
 LIMIT 5;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: qgen_users.id, qgen_users.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: qgen_users.id, qgen_users.name
-         Sort Key: qgen_users.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: qgen_users.id, qgen_users.name
-               Join Type: Inner
-               Relation 0: qgen_products
-               Relation 1: qgen_users
-               Join Cond: qgen_users.age = qgen_products.age
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-               Limit: 5
-               Order By: qgen_users.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: qgen_products
+         Relation 1: qgen_users
+         Join Cond: qgen_users.age = qgen_products.age
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+         Limit: 5
+         Order By: qgen_users.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2484,33 +2405,30 @@ JOIN qgen_products ON qgen_users.age = qgen_products.age
 WHERE NOT (qgen_users.name @@@ 'bob') 
 ORDER BY qgen_users.id 
 LIMIT 5;
-                                                                                             QUERY PLAN                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: qgen_users.id, qgen_users.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: qgen_users.id, qgen_users.name
-         Sort Key: qgen_users.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: qgen_users.id, qgen_users.name
-               Join Type: Inner
-               Relation 0: qgen_products
-               Relation 1: qgen_users
-               Join Cond: qgen_users.age = qgen_products.age
-               Tantivy Query 1: {"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
-               Limit: 5
-               Order By: qgen_users.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: qgen_products
+         Relation 1: qgen_users
+         Join Cond: qgen_users.age = qgen_products.age
+         Tantivy Query 1: {"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
+         Limit: 5
+         Order By: qgen_users.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2535,33 +2453,30 @@ JOIN qgen_products ON qgen_users.age = qgen_products.age
 WHERE (qgen_products.name @@@ 'alice') OR (qgen_users.name @@@ 'bob')
 ORDER BY qgen_users.id 
 LIMIT 5;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                  QUERY PLAN                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: qgen_users.id, qgen_users.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: qgen_users.id, qgen_users.name
-         Sort Key: qgen_users.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: qgen_users.id, qgen_users.name
-               Join Type: Inner
-               Relation 0: qgen_products
-               Relation 1: qgen_users
-               Join Cond: qgen_users.age = qgen_products.age
-               Join Predicate: (qgen_products:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"alice","lenient":null,"conjunction_mode":null}}}} OR qgen_users:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}})
-               Limit: 5
-               Order By: qgen_users.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], filter=row_in_set(ctid_2@0) OR row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: qgen_products
+         Relation 1: qgen_users
+         Join Cond: qgen_users.age = qgen_products.age
+         Join Predicate: (qgen_products:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"alice","lenient":null,"conjunction_mode":null}}}} OR qgen_users:{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}})
+         Limit: 5
+         Order By: qgen_users.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], filter=row_in_set(ctid_2@0) OR row_in_set(ctid_1@1), projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, age@1 as age]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, age@1 as age, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT qgen_users.id, qgen_users.name 
 FROM qgen_users 
@@ -2613,33 +2528,30 @@ JOIN tiny_refs tr ON tp.ref_id = tr.id
 WHERE tp.description @@@ 'wireless'
 ORDER BY tp.id
 LIMIT 10;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: tp.id, tp.description, tr.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: tp.id, tp.description, tr.name
-         Sort Key: tp.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: tp.id, tp.description, tr.name
-               Join Type: Inner
-               Relation 0: tiny_refs (tr)
-               Relation 1: tiny_products (tp)
-               Join Cond: tp.ref_id = tr.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 10
-               Order By: tp.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, ref_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, ref_id@1 as ref_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: tiny_refs (tr)
+         Relation 1: tiny_products (tp)
+         Join Cond: tp.ref_id = tr.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 10
+         Order By: tp.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, ref_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, ref_id@1 as ref_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT tp.id, tp.description, tr.name
 FROM tiny_products tp
@@ -2690,33 +2602,30 @@ JOIN hint_test_categories hc ON hp.category_id = hc.id
 WHERE hp.description @@@ 'wireless'
 ORDER BY hp.id
 LIMIT 20;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hp.id, hp.description, hc.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: hp.id, hp.description, hc.name
-         Sort Key: hp.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: hp.id, hp.description, hc.name
-               Join Type: Inner
-               Relation 0: hint_test_categories (hc)
-               Relation 1: hint_test_products (hp)
-               Join Cond: hp.category_id = hc.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Limit: 20
-               Order By: hp.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                 :   SortExec: TopK(fetch=20), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(24 rows)
+         Join Type: Inner
+         Relation 0: hint_test_categories (hc)
+         Relation 1: hint_test_products (hp)
+         Join Cond: hp.category_id = hc.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Limit: 20
+         Order By: hp.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=20), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, category_id@1)], projection=[ctid_2@0, ctid_1@2, id@4]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, id@2 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(21 rows)
 
 SELECT hp.id, hp.description, hc.name AS category_name
 FROM hint_test_products hp
@@ -2793,34 +2702,31 @@ WHERE p.description @@@ 'wireless'
   AND p.price >= s.min_order_value
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, p.price, s.name, s.min_order_value
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, p.price, s.name, s.min_order_value
-         Sort Key: p.id
-         ->  Custom Scan (ParadeDB Join Scan)
-               Output: p.id, p.name, p.price, s.name, s.min_order_value
-               Join Type: Inner
-               Relation 0: suppliers (s)
-               Relation 1: products (p)
-               Join Cond: p.supplier_id = s.id
-               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-               Join Predicate: heap:{OPEXPR :opno 1757 :opfuncid 1721 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 5 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 5 :location -1} {VAR :varno 2 :varattno 5 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 5 :location -1}) :location -1}
-               Limit: 10
-               Order By: p.id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, price@3 as col_3, NULL as col_4, min_order_value@1 as col_5, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
-                 :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=min_order_value@0 <= price@1, projection=[ctid_2@0, min_order_value@2, ctid_1@3, price@5, id@6]
-                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, min_order_value@2 as min_order_value]
-                 :         CooperativeExec
-                 :           PgSearchScan
-                 :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, price@2 as price, id@3 as id]
-                 :         CooperativeExec
-                 :           PgSearchScan
-(25 rows)
+         Join Type: Inner
+         Relation 0: suppliers (s)
+         Relation 1: products (p)
+         Join Cond: p.supplier_id = s.id
+         Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+         Join Predicate: heap:{OPEXPR :opno 1757 :opfuncid 1721 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 5 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 5 :location -1} {VAR :varno 2 :varattno 5 :vartype 1700 :vartypmod 655366 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 5 :location -1}) :location -1}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@4 as col_1, NULL as col_2, price@3 as col_3, NULL as col_4, min_order_value@1 as col_5, ctid_2@0 as ctid_2, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], filter=min_order_value@0 <= price@1, projection=[ctid_2@0, min_order_value@2, ctid_1@3, price@5, id@6]
+           :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, min_order_value@2 as min_order_value]
+           :         CooperativeExec
+           :           PgSearchScan
+           :       ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, price@2 as price, id@3 as id]
+           :         CooperativeExec
+           :           PgSearchScan
+(22 rows)
 
 -- Test case: Search predicate OR multi-table predicate (unified expression tree)
 -- Products where EITHER description matches 'cable' OR price >= supplier's min_order_value
@@ -2929,35 +2835,32 @@ JOIN suppliers s ON m."JoinKey" = s.id
 WHERE m."Content" @@@ 'wireless'
 ORDER BY m."ID"
 LIMIT 5;
-                                                                               QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: m."Content", s.name, m."ID"
-   ->  Sort
+   ->  Result
          Output: m."Content", s.name, m."ID"
-         Sort Key: m."ID"
-         ->  Result
-               Output: m."Content", s.name, m."ID"
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: m."Content", m."ID", s.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: MixedCaseTable (m)
-                     Join Cond: m.JoinKey = s.id
-                     Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"Content","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: m.ID asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, ID@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[ID@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, JoinKey@1)], projection=[ctid_2@0, ctid_1@2, ID@4]
-                       :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, JoinKey@1 as JoinKey, ID@2 as ID]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(26 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: m."Content", m."ID", s.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: MixedCaseTable (m)
+               Join Cond: m.JoinKey = s.id
+               Tantivy Query 1: {"with_index":{"query":{"parse_with_field":{"field":"Content","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: m.ID asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, ID@2 as col_2, NULL as col_3, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1]
+                 :   SortExec: TopK(fetch=5), expr=[ID@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, JoinKey@1)], projection=[ctid_2@0, ctid_1@2, ID@4]
+                 :       ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, JoinKey@1 as JoinKey, ID@2 as ID]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(23 rows)
 
 SELECT m."Content", s.name
 FROM "MixedCaseTable" m
@@ -3033,41 +2936,38 @@ JOIN categories c ON p.category_id = c.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name, c.name, p.id
-   ->  Sort
+   ->  Result
          Output: p.name, s.name, c.name, p.id
-         Sort Key: p.id
-         ->  Result
-               Output: p.name, s.name, c.name, p.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.name, p.id, s.name, c.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: categories (c)
-                     Relation 2: products (p)
-                     Join Cond: p.category_id = c.id, p.supplier_id = s.id
-                     Tantivy Query 2: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1]
-                       :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, ctid_1@1 as ctid_1, id@2 as id]
-                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
-                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :           ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-(32 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.name, p.id, s.name, c.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: categories (c)
+               Relation 2: products (p)
+               Join Cond: p.category_id = c.id, p.supplier_id = s.id
+               Tantivy Query 2: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     ProjectionExec: expr=[ctid_2@0 as ctid_2, ctid_4@3 as ctid_4, ctid_1@1 as ctid_1, id@2 as id]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
+                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :           ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :         ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+(29 rows)
 
 SELECT p.name AS product, s.name AS supplier, c.name AS category
 FROM products p
@@ -3092,40 +2992,37 @@ JOIN categories c ON p.category_id = c.id
 WHERE s.contact_info @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-                                                                                  QUERY PLAN                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name, c.name, p.id
-   ->  Sort
+   ->  Result
          Output: p.name, s.name, c.name, p.id
-         Sort Key: p.id
-         ->  Result
-               Output: p.name, s.name, c.name, p.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: p.name, p.id, s.name, c.name
-                     Join Type: Inner
-                     Relation 0: suppliers (s)
-                     Relation 1: products (p)
-                     Relation 2: categories (c)
-                     Join Cond: p.category_id = c.id, p.supplier_id = s.id
-                     Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 10
-                     Order By: p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1, ctid_4@3 as ctid_4]
-                       :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
-                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
-                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-                       :         ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(31 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.name, p.id, s.name, c.name
+               Join Type: Inner
+               Relation 0: suppliers (s)
+               Relation 1: products (p)
+               Relation 2: categories (c)
+               Join Cond: p.category_id = c.id, p.supplier_id = s.id
+               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+               Limit: 10
+               Order By: p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, NULL as col_4, ctid_2@0 as ctid_2, ctid_1@1 as ctid_1, ctid_4@3 as ctid_4]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category_id@2, id@1)], projection=[ctid_2@0, ctid_1@1, id@3, ctid_4@4]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], projection=[ctid_2@0, ctid_1@2, category_id@3, id@5]
+                 :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+                 :         ProjectionExec: expr=[ctid@0 as ctid_1, category_id@1 as category_id, supplier_id@2 as supplier_id, id@3 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_4, id@1 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(28 rows)
 
 SELECT p.name AS product, s.name AS supplier, c.name AS category
 FROM products p
@@ -3281,46 +3178,43 @@ JOIN level4 l4 ON l3.l4_id = l4.id
 WHERE l4.description @@@ 'deepest'
 ORDER BY l1.id
 LIMIT 5;
-                                                                                                QUERY PLAN                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: l1.name, l2.name, l3.name, l4.name, l1.id
-   ->  Sort
+   ->  Result
          Output: l1.name, l2.name, l3.name, l4.name, l1.id
-         Sort Key: l1.id
-         ->  Result
-               Output: l1.name, l2.name, l3.name, l4.name, l1.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: l1.name, l1.id, l2.name, l3.name, l4.name
-                     Join Type: Inner
-                     Relation 0: level4 (l4)
-                     Relation 1: level3 (l3)
-                     Relation 2: level1 (l1)
-                     Relation 3: level2 (l2)
-                     Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
-                     Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"deepest","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: l1.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, NULL as col_5, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
-                       :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     ProjectionExec: expr=[ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@3 as ctid_1, id@4 as id, ctid_2@2 as ctid_2]
-                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
-                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
-                       :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
-                       :             ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :               CooperativeExec
-                       :                 PgSearchScan
-                       :             ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :               CooperativeExec
-                       :                 PgSearchScan
-                       :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-(37 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: l1.name, l1.id, l2.name, l3.name, l4.name
+               Join Type: Inner
+               Relation 0: level4 (l4)
+               Relation 1: level3 (l3)
+               Relation 2: level1 (l1)
+               Relation 3: level2 (l2)
+               Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
+               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"deepest","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: l1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, NULL as col_4, NULL as col_5, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+                 :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     ProjectionExec: expr=[ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_1@3 as ctid_1, id@4 as id, ctid_2@2 as ctid_2]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
+                 :             ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
+                 :               CooperativeExec
+                 :                 PgSearchScan
+                 :             ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
+                 :               CooperativeExec
+                 :                 PgSearchScan
+                 :           ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :         ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+(34 rows)
 
 SELECT l1.name, l2.name, l3.name, l4.name
 FROM level1 l1
@@ -3348,46 +3242,43 @@ JOIN level4 l4 ON l3.l4_id = l4.id
 WHERE l1.name @@@ 'L1-A' AND l4.description @@@ 'deepest'
 ORDER BY l1.id
 LIMIT 5;
-                                                                                 QUERY PLAN                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: l1.name, l4.name, l1.id
-   ->  Sort
+   ->  Result
          Output: l1.name, l4.name, l1.id
-         Sort Key: l1.id
-         ->  Result
-               Output: l1.name, l4.name, l1.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: l1.name, l1.id, l4.name
-                     Join Type: Inner
-                     Relation 0: level4 (l4)
-                     Relation 1: level3 (l3)
-                     Relation 2: level2 (l2)
-                     Relation 3: level1 (l1)
-                     Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
-                     Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"deepest","lenient":null,"conjunction_mode":null}}}}
-                     Tantivy Query 3: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L1-A","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: l1.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
-                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
-                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
-                       :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(37 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: l1.name, l1.id, l4.name
+               Join Type: Inner
+               Relation 0: level4 (l4)
+               Relation 1: level3 (l3)
+               Relation 2: level2 (l2)
+               Relation 3: level1 (l1)
+               Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
+               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"deepest","lenient":null,"conjunction_mode":null}}}}
+               Tantivy Query 3: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L1-A","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: l1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_6@0 as ctid_6, ctid_4@1 as ctid_4, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
+                 :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_6@0, ctid_4@1, ctid_2@2, ctid_1@4, id@6]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@2)], projection=[ctid_6@0, ctid_4@1, ctid_2@3, id@4]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@1)], projection=[ctid_6@0, ctid_4@2, id@4]
+                 :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(34 rows)
 
 SELECT l1.name, l4.name
 FROM level1 l1
@@ -3412,46 +3303,43 @@ JOIN level4 l4 ON l3.l4_id = l4.id
 WHERE l2.name @@@ 'L2-B' AND l3.name @@@ 'L3-B'
 ORDER BY l1.id
 LIMIT 5;
-                                                                                 QUERY PLAN                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: l1.name, l4.name, l1.id
-   ->  Sort
+   ->  Result
          Output: l1.name, l4.name, l1.id
-         Sort Key: l1.id
-         ->  Result
-               Output: l1.name, l4.name, l1.id
-               ->  Custom Scan (ParadeDB Join Scan)
-                     Output: l1.name, l1.id, l4.name
-                     Join Type: Inner
-                     Relation 0: level3 (l3)
-                     Relation 1: level4 (l4)
-                     Relation 2: level2 (l2)
-                     Relation 3: level1 (l1)
-                     Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
-                     Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L3-B","lenient":null,"conjunction_mode":null}}}}
-                     Tantivy Query 2: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L2-B","lenient":null,"conjunction_mode":null}}}}
-                     Limit: 5
-                     Order By: l1.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_4@0 as ctid_4, ctid_6@1 as ctid_6, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_4@0, ctid_6@1, ctid_2@2, ctid_1@4, id@6]
-                       :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l3_id@2)], projection=[ctid_4@0, ctid_6@2, ctid_2@3, id@4]
-                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l4_id@1, id@1)], projection=[ctid_4@0, id@2, ctid_6@3]
-                       :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
-                       :             CooperativeExec
-                       :               PgSearchScan
-                       :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
-                       :           CooperativeExec
-                       :             PgSearchScan
-                       :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
-                       :         CooperativeExec
-                       :           PgSearchScan
-(37 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: l1.name, l1.id, l4.name
+               Join Type: Inner
+               Relation 0: level3 (l3)
+               Relation 1: level4 (l4)
+               Relation 2: level2 (l2)
+               Relation 3: level1 (l1)
+               Join Cond: l3.l4_id = l4.id, l1.l2_id = l2.id, l2.l3_id = l3.id
+               Tantivy Query 0: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L3-B","lenient":null,"conjunction_mode":null}}}}
+               Tantivy Query 2: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L2-B","lenient":null,"conjunction_mode":null}}}}
+               Limit: 5
+               Order By: l1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_4@0 as ctid_4, ctid_6@1 as ctid_6, ctid_2@2 as ctid_2, ctid_1@3 as ctid_1]
+                 :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_4@0, ctid_6@1, ctid_2@2, ctid_1@4, id@6]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l3_id@2)], projection=[ctid_4@0, ctid_6@2, ctid_2@3, id@4]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l4_id@1, id@1)], projection=[ctid_4@0, id@2, ctid_6@3]
+                 :           ProjectionExec: expr=[ctid@0 as ctid_4, l4_id@1 as l4_id, id@2 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :           ProjectionExec: expr=[ctid@0 as ctid_6, id@1 as id]
+                 :             CooperativeExec
+                 :               PgSearchScan
+                 :         ProjectionExec: expr=[ctid@0 as ctid_2, id@1 as id, l3_id@2 as l3_id]
+                 :           CooperativeExec
+                 :             PgSearchScan
+                 :       ProjectionExec: expr=[ctid@0 as ctid_1, l2_id@1 as l2_id, id@2 as id]
+                 :         CooperativeExec
+                 :           PgSearchScan
+(34 rows)
 
 SELECT l1.name, l4.name
 FROM level1 l1


### PR DESCRIPTION
## What

Always claim all `ORDER BY` path keys in the join scan, since it is required to take over all sorting in order to be able to apply the `LIMIT`.

## Why

To simplify plans by removing unnecessary sorts.