### PR TITLE
docs: Docs SEO fixes from SEMRush

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For more information, including enterprise features and support, please [contact
 
 ### Extensions
 
-You can find prebuilt binaries for the ParadeDB Postgres extensions on Debian 12, 13, Ubuntu 22.04 and 24.04, Red Hat Enterprise Linux 9 and 10, and macOS 14 (Sonoma) and 15 (Sequoia) for Postgres 15+ in the [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
+You can find prebuilt binaries for the ParadeDB Postgres extensions on Debian 12, 13, Ubuntu 22.04 and 24.04, Red Hat Enterprise Linux 9 and 10, and macOS 14 (Sonoma) and 15 (Sequoia) for Postgres 15+ in the [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 ParadeDB supports all versions supported by the PostgreSQL Global Development Group, which includes PostgreSQL 15+, and you can compile the extensions for other versions of Postgres by following the instructions in the respective extension's README.
 

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -33,7 +33,7 @@ If you are using a different version of Postgres or a different operating system
 
 #### pg_search
 
-The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
+The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
   You can replace `0.21.6` with the `pg_search` version you wish to install and


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

Updated the GitHub Releases link in `README.md` and `docs/deploy/self-hosted/extension.mdx` from `/releases/latest` to `/releases`.

## Why

`/releases/latest` only points to the single most recent release. `/releases` shows all releases, which is more useful for users who need to find a specific version.

## How

^

## Tests

No functional changes — docs only.