### PR TITLE
docs: Fix case study URLs

### DIFF
--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -61,8 +61,8 @@ production since December 2023.
 ParadeDB Enterprise, the durable and production-hardened edition of ParadeDB, powers core search and analytics use cases at enterprises ranging from Fortune 500s to fast-growing startups. A few
 examples include:
 
-- **Alibaba Cloud**, the largest Asia-Pacific cloud provider, uses ParadeDB to power search inside their data warehouse. [Case study available](https://www.paradedb.com/blog/case-study-alibaba).
-- **Bilt Rewards**, a rent payments technology company that processed over $36B in payments in 2024. [Case study available](https://www.paradedb.com/blog/case-study-bilt).
+- **Alibaba Cloud**, the largest Asia-Pacific cloud provider, uses ParadeDB to power search inside their data warehouse. [Case study available](https://www.paradedb.com/customers/case-study-alibaba).
+- **Bilt Rewards**, a rent payments technology company that processed over $36B in payments in 2024. [Case study available](https://www.paradedb.com/customers/case-study-bilt).
 - **Modern Treasury**<sup>1</sup>, a financial technology company that automates the full cycle of money movement.
 - **Span**<sup>1</sup>, one of the fastest-growing AI developer productivity platforms
 - **TCDI**<sup>1</sup>, a giant in the legal software and litigation management space.


### PR DESCRIPTION
## Summary
- SEMRush flagged 2 URLs with permanent redirects (308) pointing to `docs.paradedb.com/welcome/introduction`
- Updated case study links from `/blog/case-study-*` to `/customers/case-study-*` to match the current URL structure