### PR TITLE
chore: Improve test scripts

### DIFF
--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -10,32 +10,39 @@
 #  - 16.11
 #  - 17.7
 #  - 18.1 (default)
+#
+# After sourcing, the following are available:
+#  - BUILD_PARAMS: array of build flags (--release, --profile <value>)
+#  - EXTRA_ARGS: array of remaining arguments (everything else)
+#  - DATABASE_URL: connection string for the running database
+#  - PG_CONFIG: path to pg_config binary
 
 set -Eeuo pipefail
 
-# Parse arguments for the --release flag
+# Parse arguments: separate build flags from the rest
 BUILD_PARAMS=()
+EXTRA_ARGS=()
 
-# Loop through arguments
 i=1
 while [ $i -le $# ]; do
   arg="${!i}"
   if [ "$arg" = "--release" ]; then
-    BUILD_PARAMS=("${BUILD_PARAMS[@]}" "--release")
+    BUILD_PARAMS+=("--release")
   elif [ "$arg" = "--profile" ]; then
     i=$((i+1))
     if [ $i -le $# ]; then
       PROFILE_VALUE="${!i}"
-      # Check if the next argument is another flag
       if [[ "$PROFILE_VALUE" == --* ]]; then
         echo "Error: --profile requires a value"
         exit 1
       fi
-      BUILD_PARAMS=("${BUILD_PARAMS[@]}" "--profile" "${PROFILE_VALUE}")
+      BUILD_PARAMS+=("--profile" "${PROFILE_VALUE}")
     else
       echo "Error: --profile requires a value"
       exit 1
     fi
+  else
+    EXTRA_ARGS+=("$arg")
   fi
   i=$((i+1))
 done

--- a/scripts/pg_search_run.sh
+++ b/scripts/pg_search_run.sh
@@ -17,31 +17,11 @@ set -Eeuo pipefail
 # Get script directory
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
-# Extract --release flag if present
-COMMON_ARGS=()
-OTHER_ARGS=()
-i=1
-while [ $i -le $# ]; do
-  arg="${!i}"
-  if [ "$arg" = "--release" ]; then
-    COMMON_ARGS+=("$arg")
-  elif [ "$arg" = "--profile" ]; then
-    COMMON_ARGS+=("$arg")
-    i=$((i+1))
-    if [ $i -le $# ]; then
-      COMMON_ARGS+=("${!i}")
-    fi
-  else
-    OTHER_ARGS+=("$arg")
-  fi
-  i=$((i+1))
-done
-
-# Source the common setup script with appropriate arguments
+# Source the common setup script — it parses args into BUILD_PARAMS and EXTRA_ARGS
 # shellcheck source=./scripts/pg_search_common.sh
-source "${SCRIPT_DIR}/pg_search_common.sh" "${COMMON_ARGS[@]+"${COMMON_ARGS[@]}"}"
+source "${SCRIPT_DIR}/pg_search_common.sh" "$@"
 
 cd "${CURRENT_DIR}"
 
-# Connect to the database with psql and pass any additional arguments
-psql "${DATABASE_URL}" "${OTHER_ARGS[@]+"${OTHER_ARGS[@]}"}"
+# Connect to the database with psql and pass any non-build arguments
+psql "${DATABASE_URL}" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"

--- a/scripts/pg_search_test.sh
+++ b/scripts/pg_search_test.sh
@@ -15,26 +15,9 @@ set -Eeuo pipefail
 # Get script directory
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
-# Extract --release flag if present
-COMMON_ARGS=()
-i=1
-while [ $i -le $# ]; do
-  arg="${!i}"
-  if [ "$arg" = "--release" ]; then
-    COMMON_ARGS+=("$arg")
-  elif [ "$arg" = "--profile" ]; then
-    COMMON_ARGS+=("$arg")
-    i=$((i+1))
-    if [ $i -le $# ]; then
-      COMMON_ARGS+=("${!i}")
-    fi
-  fi
-  i=$((i+1))
-done
-
-# Source the common setup script with appropriate arguments
+# Source the common setup script — it parses args into BUILD_PARAMS and EXTRA_ARGS
 # shellcheck source=./scripts/pg_search_common.sh
-source "${SCRIPT_DIR}/pg_search_common.sh" "${COMMON_ARGS[@]+"${COMMON_ARGS[@]}"}"
+source "${SCRIPT_DIR}/pg_search_common.sh" "$@"
 
-# Run the test suite with backtrace enabled and pass along all arguments
-RUST_BACKTRACE=1 cargo test --package tests --package tokenizers "$@"
+# Run the test suite with backtrace enabled and pass any non-build arguments
+RUST_BACKTRACE=1 cargo test --package tests --package tokenizers "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This was caught by Claude Code when I was cleaning up some other work. @mdashti need you to review since I know you use them. I figured I'd raise since it cleans things up.

>   3. Deduplicated arg parsing — pg_search_common.sh now parses args into BUILD_PARAMS and EXTRA_ARGS arrays. pg_search_run.sh and pg_search_test.sh just pass "$@" through and use EXTRA_ARGS for their downstream commands (psql / cargo
  test), eliminating the duplicated parsing loops
> 4. Fixed pg_search_test.sh double-passing — now uses EXTRA_ARGS instead of raw $@ for cargo test, so --release/--profile only go to the build step

## Why
^

## How
^

## Tests
^