### PR TITLE
perf: Serialize solved expressions for parallel workers, rather than the entire query

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -110,9 +110,14 @@ impl SolvePostgresExpressions for AggregateType {
         }
     }
 
-    fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext) {
+    fn solve_postgres_expressions(
+        &mut self,
+        expr_context: *mut pg_sys::ExprContext,
+    ) -> Vec<SearchQueryInput> {
         if let Some(filter) = self.filter_expr_mut() {
-            filter.solve_postgres_expressions(expr_context);
+            filter.solve_postgres_expressions(expr_context)
+        } else {
+            Vec::new()
         }
     }
 }

--- a/pg_search/src/postgres/customscan/basescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/basescan/privdat.rs
@@ -31,6 +31,12 @@ pub struct PrivateData {
     heaprelid: Option<pg_sys::Oid>,
     indexrelid: Option<pg_sys::Oid>,
     range_table_index: Option<pg_sys::Index>,
+    /// The search query as extracted during planning.
+    ///
+    /// NOTE: For parallel execution, this query must be updated with resolved
+    /// expressions from `ParallelScanState` using `apply_solved_expressions()`.
+    /// This ensures that `PostgresExpression` nodes (which may contain `InitPlan`
+    /// parameters) are correctly re-hydrated in parallel workers.
     query: Option<SearchQueryInput>,
     limit: Option<usize>,
     // ORDER-BY info that will be used iff the appropriate ExecMethodType is chosen.

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -238,7 +238,7 @@ impl ParallelQueryCapable for JoinScan {
 
         let args = ParallelScanArgs {
             segment_readers: reader.segment_readers(),
-            query: vec![], // We don't need to pass query bytes for JoinScan (handled by plan)
+            solved_expressions: vec![], // We don't need to pass solved expressions for JoinScan (handled by plan)
             with_aggregates: false,
         };
 
@@ -269,9 +269,13 @@ impl ParallelQueryCapable for JoinScan {
         assert!(!pscan_state.is_null(), "coordinate is null");
 
         state.custom_state_mut().parallel_state = Some(pscan_state);
-        // We don't need to deserialize query from parallel state for JoinScan
+        // We don't need to deserialize solved expressions from parallel state for JoinScan
         // because the full plan (including query) is serialized in PrivateData
         // and available to the worker via the plan.
+        //
+        // NOTE: In order to support InitPlan nodes (scalar subqueries), we will
+        // likely need to send the solved expressions (which have been resolved by
+        // the leader) through ParallelScanState, just as BaseScan does.
     }
 }
 

--- a/pg_search/src/postgres/customscan/solve_expr.rs
+++ b/pg_search/src/postgres/customscan/solve_expr.rs
@@ -34,11 +34,15 @@ impl SearchQueryInput {
         cnt
     }
 
-    pub fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext) {
+    pub fn solve_postgres_expressions(
+        &mut self,
+        expr_context: *mut pg_sys::ExprContext,
+    ) -> Vec<SearchQueryInput> {
         assert!(
             !expr_context.is_null(),
             "expr_context was never initialized"
         );
+        let mut solved_expressions = Vec::new();
         unsafe {
             pg_sys::MemoryContextReset((*expr_context).ecxt_per_tuple_memory);
 
@@ -47,6 +51,7 @@ impl SearchQueryInput {
                 self.visit(&mut |sqi| {
                     if let SearchQueryInput::PostgresExpression { expr } = sqi {
                         if let Some(resolved_sqi) = expr.solve(expr_context, sqi_typoid) {
+                            solved_expressions.push(resolved_sqi.clone());
                             *sqi = resolved_sqi;
                         } else {
                             // PostgresExpression evaluated to NULL (e.g., subquery returned no results)
@@ -55,12 +60,29 @@ impl SearchQueryInput {
                                 "PostgresExpression evaluated to NULL for expression: {}",
                                 pgrx::node_to_string(expr.node()).unwrap_or("unknown")
                             );
+                            solved_expressions.push(SearchQueryInput::Empty);
                             *sqi = SearchQueryInput::Empty;
                         }
                     }
                 });
             })
         }
+        solved_expressions
+    }
+
+    pub fn apply_solved_expressions(
+        &mut self,
+        solved: &mut std::collections::VecDeque<SearchQueryInput>,
+    ) {
+        self.visit(&mut |sqi| {
+            if let SearchQueryInput::PostgresExpression { .. } = sqi {
+                if let Some(resolved) = solved.pop_front() {
+                    *sqi = resolved;
+                } else {
+                    panic!("Not enough solved expressions provided!");
+                }
+            }
+        });
     }
 }
 
@@ -93,7 +115,10 @@ pub trait SolvePostgresExpressions {
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState);
     fn has_heap_filters(&mut self) -> bool;
     fn has_postgres_expressions(&mut self) -> bool;
-    fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext);
+    fn solve_postgres_expressions(
+        &mut self,
+        expr_context: *mut pg_sys::ExprContext,
+    ) -> Vec<SearchQueryInput>;
 
     unsafe fn init_expr_context(
         &mut self,
@@ -124,11 +149,13 @@ pub trait SolvePostgresExpressions {
         &mut self,
         planstate: *mut pg_sys::PlanState,
         expr_context: *mut pg_sys::ExprContext,
-    ) {
+    ) -> Vec<SearchQueryInput> {
         self.init_search_query_input();
         if self.has_postgres_expressions() {
             self.init_postgres_expressions(planstate);
-            self.solve_postgres_expressions(expr_context);
+            self.solve_postgres_expressions(expr_context)
+        } else {
+            Vec::new()
         }
     }
 }

--- a/pg_search/tests/pg_regress/expected/subquery_in_where_scale.out
+++ b/pg_search/tests/pg_regress/expected/subquery_in_where_scale.out
@@ -1,5 +1,6 @@
 -- Test scalar subquery pattern at larger scale
 -- This tests the paging-string-max benchmark pattern with more realistic data volume
+CREATE EXTENSION IF NOT EXISTS pg_search;
 -- Cleanup
 DROP TABLE IF EXISTS test_pages_scale CASCADE;
 DROP TABLE IF EXISTS test_metadata_scale CASCADE;

--- a/pg_search/tests/pg_regress/sql/subquery_in_where_scale.sql
+++ b/pg_search/tests/pg_regress/sql/subquery_in_where_scale.sql
@@ -1,6 +1,8 @@
 -- Test scalar subquery pattern at larger scale
 -- This tests the paging-string-max benchmark pattern with more realistic data volume
 
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
 -- Cleanup
 DROP TABLE IF EXISTS test_pages_scale CASCADE;
 DROP TABLE IF EXISTS test_metadata_scale CASCADE;


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #3490

## What

Serialize solved expressions in the `ParallelScanState`, rather than the entire `SearchQueryInput` (which is already passed via the `PrivateData`).

## Why

This reduces the amount of data that we serialize to send to parallel workers, and helps to clarify what portion the workers actually need to receive via the parallel state.

As explained in the comments: `InitPlan` nodes can only be computed safely on the leader, so it does so via `solve_postgres_expressions`. But after solving the expressions, they are the only portion which needs to be transferred to the parallel workers.