### PR TITLE
ci: Allow benchmark workflows to run on PRs to any branch

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -17,9 +17,6 @@ on:
       - "**/*.toml"
   pull_request:
     types: [labeled, synchronize]
-    branches:
-      - main
-      - 0.*.x # Release branches
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -18,9 +18,6 @@ on:
       - "**/*.toml"
   pull_request:
     types: [labeled, synchronize]
-    branches:
-      - main
-      - 0.*.x # Release branches
   workflow_dispatch:
     inputs:
       commit:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

Removed the `branches` filter from the `pull_request` trigger in `benchmark-pg_search-stressgres.yml` and `benchmark-pg_search-benchmarks.yml`.

## Why

The `benchmark` / `benchmark-stressgres` / `benchmark-queries` labels only worked on PRs targeting `main` or `0.*.x`. PRs to `dev` (or any other branch) were silently ignored, so there was no way to benchmark before merging to `main`.

## How

^

## Tests

No functional changes — CI config only.