### PR TITLE
fix: SchemaBot to handle psql meta-commands in migration files

### DIFF
--- a/.github/scripts/check_migration_diff.py
+++ b/.github/scripts/check_migration_diff.py
@@ -16,6 +16,8 @@ def extract_statements(content):
     content = re.sub(r"--[^\n]*", "", content)
     # Remove block comments (/* ... */)
     content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    # Remove psql meta-commands (\echo, \quit, etc.) - they don't end with semicolons
+    content = re.sub(r"\\[a-zA-Z]+[^\n]*", "", content)
     # Normalize whitespace
     content = re.sub(r"\s+", " ", content).strip()
 


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #N/A

## What

Strip psql meta-commands (`\echo`, `\quit`, etc.) from migration files before comparing SQL statements.

## Why

Migration files typically start with `\echo Use "ALTER EXTENSION..." \quit`. These commands don't end with semicolons, so after whitespace normalization they get concatenated with the next SQL statement, causing false mismatches like:

```
\echo Use "ALTER EXTENSION..." \quit DROP FUNCTION IF EXISTS...
```

This doesn't match the regex `^(CREATE|ALTER|DROP)` because it starts with `\echo`.

## How

Added a regex to strip psql meta-commands before normalizing whitespace:

```python
content = re.sub(r"\\[a-zA-Z]+[^\n]*", "", content)
```

## Tests

Verified the SchemaBot check now correctly validates migration files containing `\echo ... \quit` headers.
