### PR TITLE
chore: Fix typos and grammar across docs and source

### DIFF
--- a/docs/documentation/full-text/highlight.mdx
+++ b/docs/documentation/full-text/highlight.mdx
@@ -126,7 +126,7 @@ LIMIT 5;
 ## Byte Offsets
 
 `pdb.snippet_positions(<column>)` returns the byte offsets in the original text where the snippets would appear. It returns an array of
-tuples, where the the first element of the tuple is the byte index of the first byte of the highlighted region, and the second element is the byte index after the last byte of the region.
+tuples, where the first element of the tuple is the byte index of the first byte of the highlighted region, and the second element is the byte index after the last byte of the region.
 
 ```sql
 SELECT id, pdb.snippet(description), pdb.snippet_positions(description)

--- a/docs/legacy/full-text/highlighting.mdx
+++ b/docs/legacy/full-text/highlighting.mdx
@@ -63,7 +63,7 @@ If multiple fragments are found, `pdb.snippet` uses a two-tiered scoring system 
 ## Byte Offsets
 
 `pdb.snippet_positions(<column>)` returns the byte offsets in the original text where the snippets would appear. It returns an array of
-tuples, where the the first element of the tuple is the byte index of the first byte of the highlighted region, and the second element is the byte index after the last byte of the region.
+tuples, where the first element of the tuple is the byte index of the first byte of the highlighted region, and the second element is the byte index after the last byte of the region.
 
 ```sql
 SELECT id, pdb.snippet(description), pdb.snippet_positions(description)

--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -38,7 +38,7 @@ pub fn field(
             "the `stored` option is deprecated",
             function_name!(),
         )
-        .set_detail("the `stored` option is deprecated sine it is no longer needed by the index")
+        .set_detail("the `stored` option is deprecated since it is no longer needed by the index")
         .set_hint("remove it from the index configuration")
         .report(PgLogLevel::WARNING);
     }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -273,7 +273,7 @@ pub struct TopNAuxiliaryCollector {
     pub aggregation_collector: DistributedAggregationCollector,
     /// If MVCC filtering should be applied, then the visibility checker to use for that.
     ///
-    /// Note: If enabled, visibility checking is applied to to _both_ the TopN and to any
+    /// Note: If enabled, visibility checking is applied to _both_ the TopN and to any
     /// aggregation collector: this is because once you've bothered to filter for MVCC, you might
     /// as well feed the filtered result to TopN too.
     pub vischeck: Option<VisibilityChecker>,

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -340,7 +340,7 @@ pub unsafe extern "C-unwind" fn amgettuple(
                                 heap_compute_data_size((*scan).xs_hitupdesc, values, nulls);
                             let td = (*(*scan).xs_hitup).t_data;
 
-                            // TODO:  seems like this could crash with a varlena "key_field" of varrying sizes per row
+                            // TODO:  seems like this could crash with a varlena "key_field" of varying sizes per row
                             heap_fill_tuple(
                                 (*scan).xs_hitupdesc,
                                 values,

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -641,7 +641,7 @@ impl SearchField {
             FieldType::Bool(options) => options.is_fast(),
             FieldType::Date(options) => options.is_fast(),
             FieldType::Bytes(options) => options.is_fast(),
-            // TODO: Neither JSON nor range fields are not yet sortable by us
+            // TODO: JSON and range fields are not yet sortable by us
             FieldType::JsonObject(_) => false,
             _ => false,
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

Fixed 6 typos and grammar issues found across docs and source:

- `docs/documentation/full-text/highlight.mdx`: "the the" → "the" (duplicate word)
- `docs/legacy/full-text/highlighting.mdx`: "the the" → "the" (duplicate word)
- `pg_search/src/index/reader/index.rs`: "to to" → "to" (duplicate word)
- `pg_search/src/api/config.rs`: "sine" → "since" in user-facing deprecation warning
- `pg_search/src/postgres/scan.rs`: "varrying" → "varying"
- `pg_search/src/schema/mod.rs`: double negative ("Neither JSON nor range fields are not yet sortable") → "JSON and range fields are not yet sortable"

## Why

The `config.rs` one is user-facing. The rest are just cleanup.

## How

^

## Tests

No functional changes — text only.