### PR TITLE
chore: Fix benchmark data destination.

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -74,7 +74,7 @@ runs:
         gh-repository: github.com/${{ github.repository }}
         gh-pages-branch: gh-pages
         auto-push: ${{ github.event_name != 'pull_request' }}
-        benchmark-data-dir-path: benchmarks/${{ inputs.dataset }}-${{ env.ROWS_LABEL }}
+        benchmark-data-dir-path: benchmarks
         alert-threshold: "115%"
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"


### PR DESCRIPTION
## What

Send all query benchmark data to the same directory.

## Why

In #4080, we accidentally introduced subdirectories of our `benchmarks` dataset, which resulted in separate datasets and pages to render them, rather than a single dataset and page.

<img width="145" height="413" alt="Screenshot 2026-02-08 at 5 04 35 PM" src="https://github.com/user-attachments/assets/5afbcaf0-d823-4507-b0ab-36494b839661" />

Each subdirectory has its own `data.js` and `index.html`, but we want it to be merged into the parent directory's data.