### PR TITLE
ci: Publish redhat w `icu` feature

### DIFF
--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -243,7 +243,7 @@ jobs:
           PARADEDB_VERSION: ${{ steps.version.outputs.tag_version }}
         run: |
           PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
-          cargo pgrx package --pg-config $PG_CONFIG_PATH
+          cargo pgrx package --features icu --pg-config $PG_CONFIG_PATH
 
       - name: Create .rpm Package
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This is now fine since we use the Rust ICU crate. Without it, the upgrade is broken for redhat.

## Why

## How

## Tests
