### PR TITLE
fix(custom-scan): skip hook when extension is not installed (#4106)

### DIFF
--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -768,6 +768,14 @@ pub fn lookup_pdb_function(func_name: &str, arg_types: &[pg_sys::Oid]) -> pg_sys
     }
 }
 
+/// Returns true if the pg_search extension is installed in the current database.
+///
+/// This is used to guard shared_preload_libraries hooks from touching schemas/types/functions
+/// that only exist after `CREATE EXTENSION pg_search`.
+pub fn pg_search_extension_installed() -> bool {
+    unsafe { pg_sys::get_extension_oid(c"pg_search".as_ptr(), true) != pg_sys::InvalidOid }
+}
+
 /// RAII wrapper for `pg_sys::List` that automatically frees the list on drop.
 ///
 /// This is useful when you need to create a temporary PostgreSQL list for use with

--- a/pg_search/tests/pg_regress/expected/issue_4103.out
+++ b/pg_search/tests/pg_regress/expected/issue_4103.out
@@ -1,0 +1,23 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_mixed_fast_field_exec = true;
+-- Issue 4103: custom scan hook should ignore databases without pg_search installed
+SELECT current_database() AS orig_db \gset
+CREATE DATABASE issue_4103_noext TEMPLATE template0;
+\set QUIET 1
+\c issue_4103_noext
+\set QUIET 0
+SELECT count(*) OVER () AS total_count FROM (VALUES ('a')) AS t(x);
+ total_count 
+-------------
+           1
+(1 row)
+
+\set QUIET 1
+\c :orig_db
+\set QUIET 0
+DROP DATABASE issue_4103_noext;
+DROP DATABASE

--- a/pg_search/tests/pg_regress/sql/issue_4103.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4103.sql
@@ -1,0 +1,18 @@
+\i common/common_setup.sql
+
+-- Issue 4103: custom scan hook should ignore databases without pg_search installed
+SELECT current_database() AS orig_db \gset
+
+CREATE DATABASE issue_4103_noext TEMPLATE template0;
+
+\set QUIET 1
+\c issue_4103_noext
+\set QUIET 0
+
+SELECT count(*) OVER () AS total_count FROM (VALUES ('a')) AS t(x);
+
+\set QUIET 1
+\c :orig_db
+\set QUIET 0
+
+DROP DATABASE issue_4103_noext;


### PR DESCRIPTION
- Closes #4103

- Skip planner and custom scan hooks when `pg_search` is not installed in the current database.
- Add a regression test for running a window function in a database without the extension.

When `pg_search` is preloaded but not installed, hook code tries to access paradedb objects and crashes with `"schema paradedb does not exist"`.

- Check if the `pg_search` extension exists before running hook logic.
- Add `issue_4103` regression test that creates a database without the extension and runs a window function.

- `cargo pgrx regress pg17 issue_4103`
- Manual: created a DB without extension and ran `SELECT count(*) OVER ()`

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
