### PR TITLE
chore: Use approved image for Stressgres

### DIFF
--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,7 +11,7 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.90.0-slim-trixie
+FROM rust:1.90-slim
 
 # Install build and runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This was being flagged by DockerHub, randomly caught it.

## Why
^

## How
^

## Tests
^