### PR TITLE
chore: Upgrade Rust base image to 1.93-slim

### DIFF
--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,7 +11,7 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.90-slim
+FROM rust:1.93-slim
 
 # Install build and runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Updated base image from Rust 1.90 to 1.93.

# Ticket(s) Closed

- Closes #N/A

## What
DockerHub was yelling about unsupported image.

## Why
^

## How
^

## Tests
^