### PR TITLE
feat: Add auto-tuning for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -250,11 +250,17 @@ COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 # ensure that the `postgres` user has the correct permissions on the data directory, we let
 # the upstream `entrypoint.sh` script run as the entrypoint and don't specify a custom user.
 
+
+# Copy the auto-tuning scripts. 'tune-postgresql.sh' contains the logic to calculate
+# configuration values based on container resources. 'entrypoint-wrapper.sh' wraps
+# the upstream entrypoint to ensure tuning runs at the correct time (boot vs restart).
 COPY ./docker/tune-postgresql.sh /usr/local/bin/tune-postgresql.sh
 COPY ./docker/entrypoint-wrapper.sh /usr/local/bin/entrypoint-wrapper.sh
 
 RUN chmod +x /usr/local/bin/tune-postgresql.sh /usr/local/bin/entrypoint-wrapper.sh
 
+# Override the default entrypoint to use our wrapper. This wrapper will trigger
+# the auto-tuning script and then exec the upstream docker-entrypoint.sh.
 ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
 
 CMD ["postgres"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -260,5 +260,3 @@ RUN chmod +x /usr/local/bin/tune-postgresql.sh /usr/local/bin/entrypoint-wrapper
 # Override the default entrypoint to use our wrapper. This wrapper will trigger
 # the auto-tuning script and then exec the upstream docker-entrypoint.sh.
 ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
-
-CMD ["postgres"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -249,3 +249,12 @@ COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 # on the PostgreSQL data directory. To maintain compatibility with the upstream image and
 # ensure that the `postgres` user has the correct permissions on the data directory, we let
 # the upstream `entrypoint.sh` script run as the entrypoint and don't specify a custom user.
+
+COPY ./docker/tune-postgresql.sh /usr/local/bin/tune-postgresql.sh
+COPY ./docker/entrypoint-wrapper.sh /usr/local/bin/entrypoint-wrapper.sh
+
+RUN chmod +x /usr/local/bin/tune-postgresql.sh /usr/local/bin/entrypoint-wrapper.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
+
+CMD ["postgres"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,7 +255,6 @@ COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 # the upstream entrypoint to ensure tuning runs at the correct time (boot vs restart).
 COPY ./docker/tune-postgresql.sh /usr/local/bin/tune-postgresql.sh
 COPY ./docker/entrypoint-wrapper.sh /usr/local/bin/entrypoint-wrapper.sh
-
 RUN chmod +x /usr/local/bin/tune-postgresql.sh /usr/local/bin/entrypoint-wrapper.sh
 
 # Override the default entrypoint to use our wrapper. This wrapper will trigger

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -250,7 +250,6 @@ COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 # ensure that the `postgres` user has the correct permissions on the data directory, we let
 # the upstream `entrypoint.sh` script run as the entrypoint and don't specify a custom user.
 
-
 # Copy the auto-tuning scripts. 'tune-postgresql.sh' contains the logic to calculate
 # configuration values based on container resources. 'entrypoint-wrapper.sh' wraps
 # the upstream entrypoint to ensure tuning runs at the correct time (boot vs restart).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -260,3 +260,4 @@ RUN chmod +x /usr/local/bin/tune-postgresql.sh /usr/local/bin/entrypoint-wrapper
 # Override the default entrypoint to use our wrapper. This wrapper will trigger
 # the auto-tuning script and then exec the upstream docker-entrypoint.sh.
 ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
+CMD ["postgres"]

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -41,4 +41,7 @@ for DB in template1 paradedb "$POSTGRES_DB"; do
   psql -d "$DB" -c "ALTER DATABASE \"$DB\" SET search_path TO public,paradedb;"
 done
 
+echo "ParadeDB auto-tune: Running initial configuration..."
+/usr/local/bin/tune-postgresql.sh
+
 echo "ParadeDB bootstrap completed!"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -41,7 +41,7 @@ for DB in template1 paradedb "$POSTGRES_DB"; do
   psql -d "$DB" -c "ALTER DATABASE \"$DB\" SET search_path TO public,paradedb;"
 done
 
-echo "ParadeDB auto-tune: Running initial configuration..."
+echo "Tuning postgresql.conf based on available container resources..."
 /usr/local/bin/tune-postgresql.sh
 
 echo "ParadeDB bootstrap completed!"

--- a/docker/entrypoint-wrapper.sh
+++ b/docker/entrypoint-wrapper.sh
@@ -4,9 +4,9 @@ set -e
 export PGDATA=${PGDATA:-/var/lib/postgresql/data}
 
 if [ -s "$PGDATA/PG_VERSION" ]; then
-    /usr/local/bin/tune-postgresql.sh
+	/usr/local/bin/tune-postgresql.sh
 else
-    echo "ParadeDB auto-tune: Detected fresh install. Deferring tuning to bootstrap."
+	echo "ParadeDB auto-tune: Detected fresh install.Deferring tuning to bootstrap."
 fi
 
 exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker/entrypoint-wrapper.sh
+++ b/docker/entrypoint-wrapper.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-set -e
+set -Eeuo pipefail
 
 export PGDATA=${PGDATA:-/var/lib/postgresql/data}
 # We only tune from `entrypoint-wrapper.sh` on pre-existing deployments, as it is otherwise handled by `bootstrap.sh` as part of the initial deploy.
 if [ -s "$PGDATA/PG_VERSION" ]; then
-	/usr/local/bin/tune-postgresql.sh
-else
-	echo "ParadeDB auto-tune: Detected fresh install.Deferring tuning to bootstrap."
+  /usr/local/bin/tune-postgresql.sh
 fi
 
 exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker/entrypoint-wrapper.sh
+++ b/docker/entrypoint-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+export PGDATA=${PGDATA:-/var/lib/postgresql/data}
+
+if [ -s "$PGDATA/PG_VERSION" ]; then
+    /usr/local/bin/tune-postgresql.sh
+else
+    echo "ParadeDB auto-tune: Detected fresh install. Deferring tuning to bootstrap."
+fi
+
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker/entrypoint-wrapper.sh
+++ b/docker/entrypoint-wrapper.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+
 set -Eeuo pipefail
 
 export PGDATA=${PGDATA:-/var/lib/postgresql/data}
+
 # We only tune from `entrypoint-wrapper.sh` on pre-existing deployments, as it is otherwise handled by `bootstrap.sh` as part of the initial deploy.
 if [ -s "$PGDATA/PG_VERSION" ]; then
   /usr/local/bin/tune-postgresql.sh

--- a/docker/entrypoint-wrapper.sh
+++ b/docker/entrypoint-wrapper.sh
@@ -2,7 +2,7 @@
 set -e
 
 export PGDATA=${PGDATA:-/var/lib/postgresql/data}
-
+# We only tune from `entrypoint-wrapper.sh` on pre-existing deployments, as it is otherwise handled by `bootstrap.sh` as part of the initial deploy.
 if [ -s "$PGDATA/PG_VERSION" ]; then
 	/usr/local/bin/tune-postgresql.sh
 else

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -Eeuo pipefail
 
 PGDATA=${PGDATA:-/var/lib/postgresql/data}

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+
+PGDATA=${PGDATA:-/var/lib/postgresql/data}
+CONF_FILE="$PGDATA/postgresql.auto.conf"
+
+log() {
+    echo "ParadeDB auto-tune: $1"
+}
+
+if [ "$PG_TUNE_ENABLED" = "false" ]; then
+    log "Disabled via PG_TUNE_ENABLED"
+    exit 0
+fi
+
+if [ ! -d "$PGDATA" ]; then
+    log "PGDATA ($PGDATA) does not exist. Skipping tuning."
+    exit 0
+fi
+
+
+if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
+    TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
+elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+else
+    TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
+fi
+
+TOTAL_RAM_MB=$((TOTAL_RAM_BYTES / 1024 / 1024))
+
+if [ "$TOTAL_RAM_MB" -lt 512 ]; then
+    log "System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
+    exit 0
+fi
+
+CPU_COUNT=$(nproc)
+
+SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
+ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")
+MWM_MB=$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")
+WM_MB=$(awk "BEGIN {print int(($TOTAL_RAM_MB - $SB_MB) / (100 * 3))}")
+WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
+
+PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
+
+log "Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
+
+tune_param() {
+    local param=$1
+    local value=$2
+    local env_override=$3
+
+    local final_val=${env_override:-$value}
+
+    if [ ! -f "$CONF_FILE" ]; then
+        touch "$CONF_FILE"
+        chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
+    fi
+
+    if grep -q "^$param =" "$CONF_FILE"; then
+        sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
+    else
+        echo "$param = '$final_val'" >> "$CONF_FILE"
+    fi
+}
+
+tune_param "shared_buffers" "${SB_MB}MB" "$PG_TUNE_SHARED_BUFFERS"
+tune_param "effective_cache_size" "${ECS_MB}MB" "$PG_TUNE_EFFECTIVE_CACHE_SIZE"
+tune_param "maintenance_work_mem" "${MWM_MB}MB" "$PG_TUNE_MAINTENANCE_WORK_MEM"
+tune_param "work_mem" "${WM_MB}MB" "$PG_TUNE_WORK_MEM"
+tune_param "wal_buffers" "${WAL_MB}MB" "$PG_TUNE_WAL_BUFFERS"
+tune_param "max_worker_processes" "$CPU_COUNT" "$PG_TUNE_MAX_WORKER_PROCESSES"
+tune_param "max_parallel_workers" "$CPU_COUNT" "$PG_TUNE_MAX_PARALLEL_WORKERS"
+tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "$PG_TUNE_MAX_PARALLEL_GATHER"
+tune_param "random_page_cost" "1.1" "$PG_TUNE_RANDOM_PAGE_COST"
+tune_param "effective_io_concurrency" "200" "$PG_TUNE_IO_CONCURRENCY"
+
+log "Configuration written to $CONF_FILE"

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -44,12 +44,21 @@ fi
 
 TOTAL_RAM_MB=$((TOTAL_RAM_BYTES / 1024 / 1024))
 
+# Safety floor: Do not auto-tune on very small instances (< 512MB)
+# to prevent misconfiguration issues.
+
 if [ "$TOTAL_RAM_MB" -lt 512 ]; then
   echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
   exit 0
 fi
 
 CPU_COUNT=$(nproc)
+
+# shared_buffers: 25% of RAM
+# effective_cache_size: 75% of RAM
+# maintenance_work_mem: min(2GB, RAM/16)
+# work_mem: (RAM - shared_buffers) / (max_connections * 3) -> assuming default 100 connections
+# wal_buffers: min(64MB, shared_buffers / 32)
 
 SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
 ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -1,36 +1,51 @@
 #!/bin/bash
-set -e
+set -Eeuo pipefail
 
 PGDATA=${PGDATA:-/var/lib/postgresql/data}
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
-log() {
-	echo "ParadeDB auto-tune: $1"
+tune_param() {
+  local param=$1
+  local value=$2
+  local env_override=$3
+
+  local final_val=${env_override:-$value}
+
+  if [ ! -f "$CONF_FILE" ]; then
+    touch "$CONF_FILE"
+    chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
+  fi
+
+  if grep -q "^$param =" "$CONF_FILE"; then
+    sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
+  else
+    echo "$param = '$final_val'" >> "$CONF_FILE"
+  fi
 }
 
-if [ "$PG_TUNE_ENABLED" = "false" ]; then
-	log "Disabled via PG_TUNE_ENABLED"
-	exit 0
+if [ "${PG_TUNE_ENABLED:-true}" = "false" ]; then
+  echo "ParadeDB auto-tune: Disabled via PG_TUNE_ENABLED"
+  exit 0
 fi
 
 if [ ! -d "$PGDATA" ]; then
-	log "PGDATA ($PGDATA) does not exist. Skipping tuning."
-	exit 0
+  echo "ParadeDB auto-tune: PGDATA ($PGDATA) does not exist. Skipping tuning."
+  exit 0
 fi
 
 if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
-	TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
+  TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
 elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-	TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+  TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 else
-	TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
+  TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
 fi
 
 TOTAL_RAM_MB=$((TOTAL_RAM_BYTES / 1024 / 1024))
 
 if [ "$TOTAL_RAM_MB" -lt 512 ]; then
-	log "System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
-	exit 0
+  echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
+  exit 0
 fi
 
 CPU_COUNT=$(nproc)
@@ -43,36 +58,17 @@ WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
 PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
 
-log "Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
+echo "ParadeDB auto-tune: Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
 
-tune_param() {
-	local param=$1
-	local value=$2
-	local env_override=$3
+tune_param "shared_buffers" "${SB_MB}MB" "${PG_TUNE_SHARED_BUFFERS:-}"
+tune_param "effective_cache_size" "${ECS_MB}MB" "${PG_TUNE_EFFECTIVE_CACHE_SIZE:-}"
+tune_param "maintenance_work_mem" "${MWM_MB}MB" "${PG_TUNE_MAINTENANCE_WORK_MEM:-}"
+tune_param "work_mem" "${WM_MB}MB" "${PG_TUNE_WORK_MEM:-}"
+tune_param "wal_buffers" "${WAL_MB}MB" "${PG_TUNE_WAL_BUFFERS:-}"
+tune_param "max_worker_processes" "$CPU_COUNT" "${PG_TUNE_MAX_WORKER_PROCESSES:-}"
+tune_param "max_parallel_workers" "$CPU_COUNT" "${PG_TUNE_MAX_PARALLEL_WORKERS:-}"
+tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_GATHER:-}"
+tune_param "random_page_cost" "1.1" "${PG_TUNE_RANDOM_PAGE_COST:-}"
+tune_param "effective_io_concurrency" "200" "${PG_TUNE_IO_CONCURRENCY:-}"
 
-	local final_val=${env_override:-$value}
-
-	if [ ! -f "$CONF_FILE" ]; then
-		touch "$CONF_FILE"
-		chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
-	fi
-
-	if grep -q "^$param =" "$CONF_FILE"; then
-		sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
-	else
-		echo "$param = '$final_val'" >>"$CONF_FILE"
-	fi
-}
-
-tune_param "shared_buffers" "${SB_MB}MB" "$PG_TUNE_SHARED_BUFFERS"
-tune_param "effective_cache_size" "${ECS_MB}MB" "$PG_TUNE_EFFECTIVE_CACHE_SIZE"
-tune_param "maintenance_work_mem" "${MWM_MB}MB" "$PG_TUNE_MAINTENANCE_WORK_MEM"
-tune_param "work_mem" "${WM_MB}MB" "$PG_TUNE_WORK_MEM"
-tune_param "wal_buffers" "${WAL_MB}MB" "$PG_TUNE_WAL_BUFFERS"
-tune_param "max_worker_processes" "$CPU_COUNT" "$PG_TUNE_MAX_WORKER_PROCESSES"
-tune_param "max_parallel_workers" "$CPU_COUNT" "$PG_TUNE_MAX_PARALLEL_WORKERS"
-tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "$PG_TUNE_MAX_PARALLEL_GATHER"
-tune_param "random_page_cost" "1.1" "$PG_TUNE_RANDOM_PAGE_COST"
-tune_param "effective_io_concurrency" "200" "$PG_TUNE_IO_CONCURRENCY"
-
-log "Configuration written to $CONF_FILE"
+echo "ParadeDB auto-tune: Configuration written to $CONF_FILE"

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -5,33 +5,32 @@ PGDATA=${PGDATA:-/var/lib/postgresql/data}
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
 log() {
-    echo "ParadeDB auto-tune: $1"
+	echo "ParadeDB auto-tune: $1"
 }
 
 if [ "$PG_TUNE_ENABLED" = "false" ]; then
-    log "Disabled via PG_TUNE_ENABLED"
-    exit 0
+	log "Disabled via PG_TUNE_ENABLED"
+	exit 0
 fi
 
 if [ ! -d "$PGDATA" ]; then
-    log "PGDATA ($PGDATA) does not exist. Skipping tuning."
-    exit 0
+	log "PGDATA ($PGDATA) does not exist. Skipping tuning."
+	exit 0
 fi
 
-
 if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
-    TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
+	TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
 elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+	TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 else
-    TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
+	TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
 fi
 
 TOTAL_RAM_MB=$((TOTAL_RAM_BYTES / 1024 / 1024))
 
 if [ "$TOTAL_RAM_MB" -lt 512 ]; then
-    log "System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
-    exit 0
+	log "System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
+	exit 0
 fi
 
 CPU_COUNT=$(nproc)
@@ -47,22 +46,22 @@ PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
 log "Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
 
 tune_param() {
-    local param=$1
-    local value=$2
-    local env_override=$3
+	local param=$1
+	local value=$2
+	local env_override=$3
 
-    local final_val=${env_override:-$value}
+	local final_val=${env_override:-$value}
 
-    if [ ! -f "$CONF_FILE" ]; then
-        touch "$CONF_FILE"
-        chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
-    fi
+	if [ ! -f "$CONF_FILE" ]; then
+		touch "$CONF_FILE"
+		chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
+	fi
 
-    if grep -q "^$param =" "$CONF_FILE"; then
-        sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
-    else
-        echo "$param = '$final_val'" >> "$CONF_FILE"
-    fi
+	if grep -q "^$param =" "$CONF_FILE"; then
+		sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
+	else
+		echo "$param = '$final_val'" >>"$CONF_FILE"
+	fi
 }
 
 tune_param "shared_buffers" "${SB_MB}MB" "$PG_TUNE_SHARED_BUFFERS"

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -29,6 +29,12 @@ if [ "${PG_TUNE_ENABLED:-true}" = "false" ]; then
   exit 0
 fi
 
+# Skip auto-tuning in Kubernetes environments to avoid conflicts with resource limits
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
+  echo "ParadeDB auto-tune: Kubernetes environment detected. Disabling auto-tuning."
+  exit 0
+fi
+
 if [ ! -d "$PGDATA" ]; then
   echo "ParadeDB auto-tune: PGDATA ($PGDATA) does not exist. Skipping tuning."
   exit 0

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-
 set -Eeuo pipefail
 
 PGDATA=${PGDATA:-/var/lib/postgresql/data}
 
 # NOTE: This script writes directly to postgresql.auto.conf, which is the same file
-# used by PostgreSQL's 'ALTER SYSTEM' command. Manual 'ALTER SYSTEM' changes to 
-# tuned parameters will be preserved on container restart unless overridden by PG_TUNE_* 
-# environment variables. To permanently pin a specific value, users must use PG_TUNE_* 
+# used by PostgreSQL's 'ALTER SYSTEM' command. Manual 'ALTER SYSTEM' changes to
+# tuned parameters will be preserved on container restart unless overridden by PG_TUNE_*
+# environment variables. To permanently pin a specific value, users must use PG_TUNE_*
 # environment variables.
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
@@ -34,7 +33,7 @@ tune_param() {
   elif ! grep -qE "^\s*$param\s*=" "$CONF_FILE" 2>/dev/null; then
     echo "$param = '$value'" >> "$CONF_FILE"
     echo "ParadeDB auto-tune: $param = $value (auto-tuned)"
-  
+
   # 3. Parameter already exists and no env override - skip tuning
   else
     echo "ParadeDB auto-tune: $param is already set in $CONF_FILE, skipping auto-tune"
@@ -58,13 +57,12 @@ if [ ! -d "$PGDATA" ]; then
 fi
 
 # To handle large numbers that appear in scientific notation (8.3e+09), which Bash math cannot process but awk can.
-
 if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
   TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $(cat /sys/fs/cgroup/memory.max) / 1024 / 1024}")
 elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
   CGROUP_V1_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
   # cgroup v1 reports ~2^63 when no limit is set -- fall through to /proc/meminfo
-  if [ "$CGROUP_V1_LIMIT" -lt 68719476736 ]; then  # < 64TB = real limit
+  if [ "$CGROUP_V1_LIMIT" -lt 68719476736 ]; then # < 64TB = real limit
     TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $CGROUP_V1_LIMIT / 1024 / 1024}")
   else
     TOTAL_RAM_MB=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", $2 / 1024}')
@@ -76,7 +74,6 @@ fi
 
 # Safety floor: Do not auto-tune on very small instances (< 512MB)
 # to prevent misconfiguration issues.
-
 if [ -z "$TOTAL_RAM_MB" ] || [ "$TOTAL_RAM_MB" -lt 512 ]; then
   echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
   exit 0
@@ -84,19 +81,11 @@ fi
 
 CPU_COUNT=$(nproc)
 
-# shared_buffers: 25% of RAM
-# effective_cache_size: 75% of RAM
-# maintenance_work_mem: min(2GB, RAM/16)
-# work_mem: (RAM - shared_buffers) / (max_connections * 3) -> assuming default 100 connections
-# wal_buffers: min(64MB, shared_buffers / 32)
-
 SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
 ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")
 MWM_MB=$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")
-
 MAX_CONN=${PG_TUNE_MAX_CONNECTIONS:-100}
 WM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SB_MB) / ($MAX_CONN * 3)); print (w < 4 ? 4 : w)}")
-
 WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
 PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -82,9 +82,14 @@ else
   TOTAL_RAM_MB=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", $2 / 1024}')
 fi
 
-# Safety floor: Do not auto-tune on very small instances (< 512MB)
-if [ -z "$TOTAL_RAM_MB" ] || [ "$TOTAL_RAM_MB" -lt 512 ]; then
-  echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
+# Split safety checks for clearer logging
+if [ -z "$TOTAL_RAM_MB" ]; then
+  echo "ParadeDB auto-tune: WARNING: Could not detect system RAM. Skipping."
+  exit 0
+fi
+
+if [ "$TOTAL_RAM_MB" -lt 512 ]; then
+  echo "ParadeDB auto-tune: System RAM (${TOTAL_RAM_MB}MB) below 512MB minimum. Skipping."
   exit 0
 fi
 
@@ -107,15 +112,16 @@ if [ "$CPU_COUNT" -lt 1 ]; then
   CPU_COUNT=1
 fi
 
-SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
+# shared_buffers: 25% of RAM, capped at 16GB (16384MB) to prevent diminishing returns
+SB_MB=$(awk "BEGIN {s=int($TOTAL_RAM_MB * 0.25); print (s > 16384 ? 16384 : s)}")
 ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")
 MWM_MB=$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")
 MAX_CONN=${PG_TUNE_MAX_CONNECTIONS:-100}
 WM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SB_MB) / ($MAX_CONN * 3)); print (w < 4 ? 4 : w)}")
 WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
-# Global worker pools: 5x CPU count based on production observations, +8 for background tasks
-PARALLEL_WORKERS=$(awk "BEGIN {print int($CPU_COUNT * 5)}")
+# Global worker pools: 5x CPU count, capped at 128 to prevent excessive shared memory usage. +8 for background tasks.
+PARALLEL_WORKERS=$(awk "BEGIN {w=int($CPU_COUNT * 5); print (w > 128 ? 128 : w)}")
 WORKER_PROCESSES=$(awk "BEGIN {print int($PARALLEL_WORKERS + 8)}")
 
 # Per-query workers (half of CPUs, min 1)
@@ -139,7 +145,12 @@ tune_param "max_worker_processes" "$WORKER_PROCESSES" "${PG_TUNE_MAX_WORKER_PROC
 tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_WORKERS_PER_GATHER:-}"
 tune_param "max_parallel_maintenance_workers" "$PMW" "${PG_TUNE_MAX_PARALLEL_MAINTENANCE_WORKERS:-}"
 
+# SSD assumptions: random_page_cost=1.1 and effective_io_concurrency=200 are optimized for solid-state drives.
 tune_param "random_page_cost" "1.1" "${PG_TUNE_RANDOM_PAGE_COST:-}"
 tune_param "effective_io_concurrency" "200" "${PG_TUNE_EFFECTIVE_IO_CONCURRENCY:-}"
 
 echo "ParadeDB auto-tune: Configuration written to $CONF_FILE"
+
+# CRITICAL: GNU sed -i creates a temp file and renames it, changing the owner to root.
+# We must chown the file back to postgres at the very end so ALTER SYSTEM continues to work.
+chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE at exit"

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -Eeuo pipefail
 
 PGDATA=${PGDATA:-/var/lib/postgresql/data}
@@ -20,22 +21,20 @@ tune_param() {
     chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE"
   fi
 
-  # 1. If user provided a Docker env var override, always force overwrite
   if [ -n "$env_override" ]; then
+    # 1. If user provided a Docker env var override, always force overwrite
     if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
       sed -i "s|^\s*$param\s*=.*|$param = '$env_override'|" "$CONF_FILE"
     else
       echo "$param = '$env_override'" >> "$CONF_FILE"
     fi
     echo "ParadeDB auto-tune: $param = $env_override (via env var)"
-
-  # 2. Otherwise, only tune if parameter is NOT already in file (respect ALTER SYSTEM)
   elif ! grep -qE "^\s*$param\s*=" "$CONF_FILE" 2>/dev/null; then
+    # 2. Otherwise, only tune if parameter is NOT already in file (respect ALTER SYSTEM)
     echo "$param = '$value'" >> "$CONF_FILE"
     echo "ParadeDB auto-tune: $param = $value (auto-tuned)"
-
-  # 3. Parameter already exists and no env override - skip tuning
   else
+    # 3. Parameter already exists and no env override - skip tuning
     echo "ParadeDB auto-tune: $param is already set in $CONF_FILE, skipping auto-tune"
   fi
 }

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -30,7 +30,7 @@ tune_param() {
     fi
     echo "ParadeDB auto-tune: $param = $env_override (via env var)"
 
-  # 2. Force Recalculate: If PG_TUNE_FORCE is true, overwrite existing settings with new math
+    # 2. Force Recalculate: If PG_TUNE_FORCE is true, overwrite existing settings with new math
   elif [ "${PG_TUNE_FORCE:-false}" = "true" ]; then
     if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
       sed -i "s|^\s*$param\s*=.*|$param = '$value'|" "$CONF_FILE"
@@ -39,12 +39,12 @@ tune_param() {
     fi
     echo "ParadeDB auto-tune: $param = $value (forced recalculation)"
 
-  # 3. Standard Behavior: Only tune if parameter is MISSING (Respects ALTER SYSTEM)
+    # 3. Standard Behavior: Only tune if parameter is MISSING (Respects ALTER SYSTEM)
   elif ! grep -qE "^\s*$param\s*=" "$CONF_FILE" 2>/dev/null; then
     echo "$param = '$value'" >> "$CONF_FILE"
     echo "ParadeDB auto-tune: $param = $value (auto-tuned)"
-  
-  # 4. Parameter exists and not forcing: Skip
+
+    # 4. Parameter exists and not forcing: Skip
   else
     echo "ParadeDB auto-tune: $param is already set, skipping (use PG_TUNE_FORCE=true to overwrite)"
   fi

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -21,21 +21,32 @@ tune_param() {
     chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE"
   fi
 
+  # 1. Highest Priority: Docker Environment Variable Override (Always Overwrites)
   if [ -n "$env_override" ]; then
-    # 1. If user provided a Docker env var override, always force overwrite
     if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
       sed -i "s|^\s*$param\s*=.*|$param = '$env_override'|" "$CONF_FILE"
     else
       echo "$param = '$env_override'" >> "$CONF_FILE"
     fi
     echo "ParadeDB auto-tune: $param = $env_override (via env var)"
+
+  # 2. Force Recalculate: If PG_TUNE_FORCE is true, overwrite existing settings with new math
+  elif [ "${PG_TUNE_FORCE:-false}" = "true" ]; then
+    if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
+      sed -i "s|^\s*$param\s*=.*|$param = '$value'|" "$CONF_FILE"
+    else
+      echo "$param = '$value'" >> "$CONF_FILE"
+    fi
+    echo "ParadeDB auto-tune: $param = $value (forced recalculation)"
+
+  # 3. Standard Behavior: Only tune if parameter is MISSING (Respects ALTER SYSTEM)
   elif ! grep -qE "^\s*$param\s*=" "$CONF_FILE" 2>/dev/null; then
-    # 2. Otherwise, only tune if parameter is NOT already in file (respect ALTER SYSTEM)
     echo "$param = '$value'" >> "$CONF_FILE"
     echo "ParadeDB auto-tune: $param = $value (auto-tuned)"
+  
+  # 4. Parameter exists and not forcing: Skip
   else
-    # 3. Parameter already exists and no env override - skip tuning
-    echo "ParadeDB auto-tune: $param is already set in $CONF_FILE, skipping auto-tune"
+    echo "ParadeDB auto-tune: $param is already set, skipping (use PG_TUNE_FORCE=true to overwrite)"
   fi
 }
 
@@ -72,13 +83,29 @@ else
 fi
 
 # Safety floor: Do not auto-tune on very small instances (< 512MB)
-# to prevent misconfiguration issues.
 if [ -z "$TOTAL_RAM_MB" ] || [ "$TOTAL_RAM_MB" -lt 512 ]; then
   echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
   exit 0
 fi
 
-CPU_COUNT=$(nproc)
+if [ -f /sys/fs/cgroup/cpu.max ] && [ "$(awk '{print $1}' /sys/fs/cgroup/cpu.max)" != "max" ]; then
+  # cgroup v2
+  CPU_QUOTA=$(awk '{print $1}' /sys/fs/cgroup/cpu.max)
+  CPU_PERIOD=$(awk '{print $2}' /sys/fs/cgroup/cpu.max)
+  CPU_COUNT=$(awk "BEGIN {printf \"%.0f\", $CPU_QUOTA / $CPU_PERIOD}")
+elif [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ "$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)" != "-1" ]; then
+  # cgroup v1
+  CPU_QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+  CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+  CPU_COUNT=$(awk "BEGIN {printf \"%.0f\", $CPU_QUOTA / $CPU_PERIOD}")
+else
+  CPU_COUNT=$(nproc)
+fi
+
+# Ensure CPU_COUNT is at least 1
+if [ "$CPU_COUNT" -lt 1 ]; then
+  CPU_COUNT=1
+fi
 
 SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
 ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")
@@ -87,7 +114,13 @@ MAX_CONN=${PG_TUNE_MAX_CONNECTIONS:-100}
 WM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SB_MB) / ($MAX_CONN * 3)); print (w < 4 ? 4 : w)}")
 WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
+# Global worker pools: 5x CPU count based on production observations, +8 for background tasks
+PARALLEL_WORKERS=$(awk "BEGIN {print int($CPU_COUNT * 5)}")
+WORKER_PROCESSES=$(awk "BEGIN {print int($PARALLEL_WORKERS + 8)}")
+
+# Per-query workers (half of CPUs, min 1)
 PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
+# Maintenance workers (half of CPUs, min 2, max 8)
 PMW=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p > 8 ? 8 : (p < 2 ? 2 : p))}")
 
 echo "ParadeDB auto-tune: Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
@@ -98,7 +131,11 @@ tune_param "maintenance_work_mem" "${MWM_MB}MB" "${PG_TUNE_MAINTENANCE_WORK_MEM:
 tune_param "work_mem" "${WM_MB}MB" "${PG_TUNE_WORK_MEM:-}"
 tune_param "wal_buffers" "${WAL_MB}MB" "${PG_TUNE_WAL_BUFFERS:-}"
 
-# We only auto-tune the per-query and maintenance workers.
+# Global worker pools
+tune_param "max_parallel_workers" "$PARALLEL_WORKERS" "${PG_TUNE_MAX_PARALLEL_WORKERS:-}"
+tune_param "max_worker_processes" "$WORKER_PROCESSES" "${PG_TUNE_MAX_WORKER_PROCESSES:-}"
+
+# Per-query and maintenance workers
 tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_WORKERS_PER_GATHER:-}"
 tune_param "max_parallel_maintenance_workers" "$PMW" "${PG_TUNE_MAX_PARALLEL_MAINTENANCE_WORKERS:-}"
 

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -3,6 +3,11 @@
 set -Eeuo pipefail
 
 PGDATA=${PGDATA:-/var/lib/postgresql/data}
+
+# NOTE: This script writes directly to postgresql.auto.conf, which is the same file
+# used by PostgreSQL's 'ALTER SYSTEM' command. Therefore, any manual 'ALTER SYSTEM'
+# changes to the tuned parameters will be overwritten on the next container restart.
+# To permanently pin a specific value, users must use the PG_TUNE_* environment variables.
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
 tune_param() {
@@ -14,11 +19,11 @@ tune_param() {
 
   if [ ! -f "$CONF_FILE" ]; then
     touch "$CONF_FILE"
-    chown postgres:postgres "$CONF_FILE" 2>/dev/null || true
+    chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE"
   fi
 
-  if grep -q "^$param =" "$CONF_FILE"; then
-    sed -i "s|^$param =.*|$param = '$final_val'|" "$CONF_FILE"
+  if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
+    sed -i "s|^\s*$param\s*=.*|$param = '$final_val'|" "$CONF_FILE"
   else
     echo "$param = '$final_val'" >> "$CONF_FILE"
   fi
@@ -30,7 +35,7 @@ if [ "${PG_TUNE_ENABLED:-true}" = "false" ]; then
 fi
 
 # Skip auto-tuning in Kubernetes environments to avoid conflicts with resource limits
-if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] && [ "${PG_TUNE_ENABLED:-}" != "true" ]; then
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] && [ -n "${KUBERNETES_SERVICE_PORT:-}" ] && [ "${PG_TUNE_ENABLED:-}" != "true" ]; then
   echo "ParadeDB auto-tune: Kubernetes environment detected. Disabling auto-tuning."
   exit 0
 fi
@@ -45,8 +50,15 @@ fi
 if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
   TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $(cat /sys/fs/cgroup/memory.max) / 1024 / 1024}")
 elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-  TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1024 / 1024}")
+  CGROUP_V1_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+  # cgroup v1 reports ~2^63 when no limit is set -- fall through to /proc/meminfo
+  if [ "$CGROUP_V1_LIMIT" -lt 68719476736 ]; then  # < 64TB = real limit
+    TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $CGROUP_V1_LIMIT / 1024 / 1024}")
+  else
+    TOTAL_RAM_MB=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", $2 / 1024}')
+  fi
 else
+  # Fallback to host /proc/meminfo if cgroups are not available
   TOTAL_RAM_MB=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", $2 / 1024}')
 fi
 
@@ -69,7 +81,10 @@ CPU_COUNT=$(nproc)
 SB_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.25)}")
 ECS_MB=$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")
 MWM_MB=$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")
-WM_MB=$(awk "BEGIN {print int(($TOTAL_RAM_MB - $SB_MB) / (100 * 3))}")
+
+MAX_CONN=${PG_TUNE_MAX_CONNECTIONS:-100}
+WM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SB_MB) / ($MAX_CONN * 3)); print (w < 4 ? 4 : w)}")
+
 WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
 PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
@@ -83,8 +98,8 @@ tune_param "work_mem" "${WM_MB}MB" "${PG_TUNE_WORK_MEM:-}"
 tune_param "wal_buffers" "${WAL_MB}MB" "${PG_TUNE_WAL_BUFFERS:-}"
 tune_param "max_worker_processes" "$CPU_COUNT" "${PG_TUNE_MAX_WORKER_PROCESSES:-}"
 tune_param "max_parallel_workers" "$CPU_COUNT" "${PG_TUNE_MAX_PARALLEL_WORKERS:-}"
-tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_GATHER:-}"
+tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_WORKERS_PER_GATHER:-}"
 tune_param "random_page_cost" "1.1" "${PG_TUNE_RANDOM_PAGE_COST:-}"
-tune_param "effective_io_concurrency" "200" "${PG_TUNE_IO_CONCURRENCY:-}"
+tune_param "effective_io_concurrency" "200" "${PG_TUNE_EFFECTIVE_IO_CONCURRENCY:-}"
 
 echo "ParadeDB auto-tune: Configuration written to $CONF_FILE"

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -5,9 +5,10 @@ set -Eeuo pipefail
 PGDATA=${PGDATA:-/var/lib/postgresql/data}
 
 # NOTE: This script writes directly to postgresql.auto.conf, which is the same file
-# used by PostgreSQL's 'ALTER SYSTEM' command. Therefore, any manual 'ALTER SYSTEM'
-# changes to the tuned parameters will be overwritten on the next container restart.
-# To permanently pin a specific value, users must use the PG_TUNE_* environment variables.
+# used by PostgreSQL's 'ALTER SYSTEM' command. Manual 'ALTER SYSTEM' changes to 
+# tuned parameters will be preserved on container restart unless overridden by PG_TUNE_* 
+# environment variables. To permanently pin a specific value, users must use PG_TUNE_* 
+# environment variables.
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
 tune_param() {
@@ -15,17 +16,28 @@ tune_param() {
   local value=$2
   local env_override=$3
 
-  local final_val=${env_override:-$value}
-
   if [ ! -f "$CONF_FILE" ]; then
     touch "$CONF_FILE"
     chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE"
   fi
 
-  if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
-    sed -i "s|^\s*$param\s*=.*|$param = '$final_val'|" "$CONF_FILE"
+  # 1. If user provided a Docker env var override, always force overwrite
+  if [ -n "$env_override" ]; then
+    if grep -qE "^\s*$param\s*=" "$CONF_FILE"; then
+      sed -i "s|^\s*$param\s*=.*|$param = '$env_override'|" "$CONF_FILE"
+    else
+      echo "$param = '$env_override'" >> "$CONF_FILE"
+    fi
+    echo "ParadeDB auto-tune: $param = $env_override (via env var)"
+
+  # 2. Otherwise, only tune if parameter is NOT already in file (respect ALTER SYSTEM)
+  elif ! grep -qE "^\s*$param\s*=" "$CONF_FILE" 2>/dev/null; then
+    echo "$param = '$value'" >> "$CONF_FILE"
+    echo "ParadeDB auto-tune: $param = $value (auto-tuned)"
+  
+  # 3. Parameter already exists and no env override - skip tuning
   else
-    echo "$param = '$final_val'" >> "$CONF_FILE"
+    echo "ParadeDB auto-tune: $param is already set in $CONF_FILE, skipping auto-tune"
   fi
 }
 
@@ -88,6 +100,7 @@ WM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SB_MB) / ($MAX_CONN * 3)); print (w 
 WAL_MB=$(awk "BEGIN {w=int($SB_MB / 32); print (w > 64 ? 64 : w)}")
 
 PARALLEL_GATHER=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")
+PMW=$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p > 8 ? 8 : (p < 2 ? 2 : p))}")
 
 echo "ParadeDB auto-tune: Applying settings for $TOTAL_RAM_MB MB RAM and $CPU_COUNT CPUs"
 
@@ -96,9 +109,11 @@ tune_param "effective_cache_size" "${ECS_MB}MB" "${PG_TUNE_EFFECTIVE_CACHE_SIZE:
 tune_param "maintenance_work_mem" "${MWM_MB}MB" "${PG_TUNE_MAINTENANCE_WORK_MEM:-}"
 tune_param "work_mem" "${WM_MB}MB" "${PG_TUNE_WORK_MEM:-}"
 tune_param "wal_buffers" "${WAL_MB}MB" "${PG_TUNE_WAL_BUFFERS:-}"
-tune_param "max_worker_processes" "$CPU_COUNT" "${PG_TUNE_MAX_WORKER_PROCESSES:-}"
-tune_param "max_parallel_workers" "$CPU_COUNT" "${PG_TUNE_MAX_PARALLEL_WORKERS:-}"
+
+# We only auto-tune the per-query and maintenance workers.
 tune_param "max_parallel_workers_per_gather" "$PARALLEL_GATHER" "${PG_TUNE_MAX_PARALLEL_WORKERS_PER_GATHER:-}"
+tune_param "max_parallel_maintenance_workers" "$PMW" "${PG_TUNE_MAX_PARALLEL_MAINTENANCE_WORKERS:-}"
+
 tune_param "random_page_cost" "1.1" "${PG_TUNE_RANDOM_PAGE_COST:-}"
 tune_param "effective_io_concurrency" "200" "${PG_TUNE_EFFECTIVE_IO_CONCURRENCY:-}"
 

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -30,7 +30,7 @@ if [ "${PG_TUNE_ENABLED:-true}" = "false" ]; then
 fi
 
 # Skip auto-tuning in Kubernetes environments to avoid conflicts with resource limits
-if [ -n "${KUBERNETES_SERVICE_HOST:-}" ]; then
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] && [ "${PG_TUNE_ENABLED:-}" != "true" ]; then
   echo "ParadeDB auto-tune: Kubernetes environment detected. Disabling auto-tuning."
   exit 0
 fi
@@ -40,20 +40,20 @@ if [ ! -d "$PGDATA" ]; then
   exit 0
 fi
 
-if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
-  TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory.max)
-elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-  TOTAL_RAM_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
-else
-  TOTAL_RAM_BYTES=$(grep MemTotal /proc/meminfo | awk '{print $2 * 1024}')
-fi
+# To handle large numbers that appear in scientific notation (8.3e+09), which Bash math cannot process but awk can.
 
-TOTAL_RAM_MB=$((TOTAL_RAM_BYTES / 1024 / 1024))
+if [ -f /sys/fs/cgroup/memory.max ] && [ "$(cat /sys/fs/cgroup/memory.max)" != "max" ]; then
+  TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $(cat /sys/fs/cgroup/memory.max) / 1024 / 1024}")
+elif [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+  TOTAL_RAM_MB=$(awk "BEGIN {printf \"%.0f\", $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1024 / 1024}")
+else
+  TOTAL_RAM_MB=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", $2 / 1024}')
+fi
 
 # Safety floor: Do not auto-tune on very small instances (< 512MB)
 # to prevent misconfiguration issues.
 
-if [ "$TOTAL_RAM_MB" -lt 512 ]; then
+if [ -z "$TOTAL_RAM_MB" ] || [ "$TOTAL_RAM_MB" -lt 512 ]; then
   echo "ParadeDB auto-tune: System RAM ($TOTAL_RAM_MB MB) is too low. Skipping."
   exit 0
 fi

--- a/docker/tune-postgresql.sh
+++ b/docker/tune-postgresql.sh
@@ -11,6 +11,9 @@ PGDATA=${PGDATA:-/var/lib/postgresql/data}
 # environment variables.
 CONF_FILE="$PGDATA/postgresql.auto.conf"
 
+# Ensure the file is always owned by postgres on exit, even if the script fails midway.
+trap 'chown postgres:postgres "$CONF_FILE" 2>/dev/null || true' EXIT
+
 tune_param() {
   local param=$1
   local value=$2
@@ -18,7 +21,6 @@ tune_param() {
 
   if [ ! -f "$CONF_FILE" ]; then
     touch "$CONF_FILE"
-    chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE"
   fi
 
   # 1. Highest Priority: Docker Environment Variable Override (Always Overwrites)
@@ -150,7 +152,3 @@ tune_param "random_page_cost" "1.1" "${PG_TUNE_RANDOM_PAGE_COST:-}"
 tune_param "effective_io_concurrency" "200" "${PG_TUNE_EFFECTIVE_IO_CONCURRENCY:-}"
 
 echo "ParadeDB auto-tune: Configuration written to $CONF_FILE"
-
-# CRITICAL: GNU sed -i creates a temp file and renames it, changing the owner to root.
-# We must chown the file back to postgres at the very end so ALTER SYSTEM continues to work.
-chown postgres:postgres "$CONF_FILE" 2>/dev/null || echo "ParadeDB auto-tune: Warning: could not chown $CONF_FILE at exit"

--- a/docs/deploy/docker.mdx
+++ b/docs/deploy/docker.mdx
@@ -1,0 +1,34 @@
+---
+title: Docker
+description: How to deploy ParadeDB with Docker
+canonical: https://docs.paradedb.com/deploy/docker
+---
+
+ParadeDB provides Docker images for easy deployment to any container platform. These images package PostgreSQL and `pg_search` together.
+
+## Docker Auto-Tuning
+
+ParadeDB automatically detects container resource limits (CPU/RAM) and optimizes PostgreSQL configuration on startup.
+
+### Configuration Environment Variables
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `PG_TUNE_ENABLED` | `true` | Set to `false` to disable auto-tuning. **Note:** In Kubernetes, this defaults to `false` to avoid conflicts with operators. Set to `true` to force enable in K8s. |
+| `PG_TUNE_FORCE` | `false` | By default, the script will not overwrite manual `ALTER SYSTEM` changes. Set to `true` to allow the script to overwrite existing settings (required for auto-scaling on restart). |
+| `PG_TUNE_MAX_CONNECTIONS` | `100` | Used to calculate `work_mem` accurately if you plan to change the connection limit. |
+
+Users can also pin specific parameters by setting `PG_TUNE_<PARAMETER_NAME>` (e.g., `PG_TUNE_SHARED_BUFFERS=1GB`).
+
+### How Auto-Tuning Works
+
+The auto-tuning script (`tune-postgresql.sh`) runs when the container starts and:
+
+1. Detects cgroup memory limits (v1 and v2) and CPU quotas
+2. Calculates optimal PostgreSQL settings based on available resources
+3. Writes to `postgresql.auto.conf` (same file used by `ALTER SYSTEM`)
+4. Respects existing manual settings unless `PG_TUNE_FORCE=true`
+
+### Kubernetes Note
+
+When running in Kubernetes, auto-tuning is disabled by default to avoid conflicts with CloudNativePG operators. To enable it, set `PG_TUNE_ENABLED=true`.

--- a/docs/deploy/docker.mdx
+++ b/docs/deploy/docker.mdx
@@ -12,13 +12,16 @@ ParadeDB automatically detects container resource limits (CPU/RAM) and optimizes
 
 ### Configuration Environment Variables
 
-| Variable | Default | Description |
-| :--- | :--- | :--- |
-| `PG_TUNE_ENABLED` | `true` | Set to `false` to disable auto-tuning. **Note:** In Kubernetes, this defaults to `false` to avoid conflicts with operators. Set to `true` to force enable in K8s. |
-| `PG_TUNE_FORCE` | `false` | By default, the script will not overwrite manual `ALTER SYSTEM` changes. Set to `true` to allow the script to overwrite existing settings (required for auto-scaling on restart). |
-| `PG_TUNE_MAX_CONNECTIONS` | `100` | Used to calculate `work_mem` accurately if you plan to change the connection limit. |
+**`PG_TUNE_ENABLED`** (default: `true`)
+Set to `false` to disable auto-tuning. In Kubernetes, this defaults to `false` to avoid conflicts with operators. Set to `true` to force enable in K8s.
 
-Users can also pin specific parameters by setting `PG_TUNE_<PARAMETER_NAME>` (e.g., `PG_TUNE_SHARED_BUFFERS=1GB`).
+**`PG_TUNE_FORCE`** (default: `false`)
+By default, the script will not overwrite manual `ALTER SYSTEM` changes. Set to `true` to allow the script to overwrite existing settings (required for auto-scaling on restart).
+
+**`PG_TUNE_MAX_CONNECTIONS`** (default: `100`)
+Used to calculate `work_mem` accurately if you plan to change the connection limit.
+
+You can also pin specific parameters by setting `PG_TUNE_<PARAMETER_NAME>` — for example, `PG_TUNE_SHARED_BUFFERS=1GB`.
 
 ### How Auto-Tuning Works
 

--- a/docs/documentation/performance-tuning/overview.mdx
+++ b/docs/documentation/performance-tuning/overview.mdx
@@ -23,6 +23,8 @@ SET maintenance_work_mem = '8GB'
 If ParadeDB is deployed with [CloudNativePG](/deploy/self-hosted/kubernetes), these settings should be set in your
 `.tfvars` file.
 
+If ParadeDB is deployed with [Docker](/deploy/docker), PostgreSQL settings are automatically tuned based on detected container resource limits. See the [Docker Auto-Tuning](/deploy/docker#docker-auto-tuning) section for configuration options.
+
 ```hcl .tfvars
 postgresql = {
     parameters = {

--- a/scripts/update-nix-cargo-hash.sh
+++ b/scripts/update-nix-cargo-hash.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Updates the cargoHash in nix/pg_search.nix by building the cargoDeps
 # derivation with a fake hash and extracting the correct one from the error.


### PR DESCRIPTION
# Ticket(s) Closed


- Closes #3857

## What


### Docker Auto-Tuning

ParadeDB automatically detects the memory and CPU limits of your Docker container and configures PostgreSQL settings (like `shared_buffers` and `max_worker_processes`) for optimal performance.

## How to Use
Simply run the container with resource limits. ParadeDB will calculate the best settings automatically.

```bash
docker run -d \
  --name paradedb \
  --memory="4g" \
  --cpus="2.0" \
  -e POSTGRES_USER=user \
  -e POSTGRES_PASSWORD=password \
  paradedb/paradedb:latest
```

### Configuration Flags
You can control the tuning behavior using environment variables:

| Variable | Default | Description |
| :--- | :--- | :--- |
| `PG_TUNE_ENABLED` | `true` | Set to `false` to completely disable auto-tuning. |
| `PG_TUNE_SHARED_BUFFERS` | (Auto) | Override the calculated shared buffers size (e.g., `1GB`). Use this if you want a specific amount of memory cache, ignoring the auto-calculation.|
| `PG_TUNE_WORK_MEM` | (Auto) | Override the calculated work memory size. Use this if your queries are very complex and need more memory per operation than the default. |
| `PG_TUNE_MAX_WORKER_PROCESSES` | (Auto) | Override the number of background workers. |

*Note: You can override any specific parameter (e.g., `PG_TUNE_WAL_BUFFERS`) while keeping the rest automatic.*

### How it Works

1.  **Initial Setup (First Run):**
    When you start a fresh container, ParadeDB detects the container's RAM and CPU limits immediately after the database is initialized. It writes optimized settings to the configuration file before the database accepts connections.

2.  **Restart & Auto-Scaling:**
    If you change the container's resources (e.g., `docker update --memory="8g" paradedb`) and restart the container, the tuning script detects the change. It recalculates the settings and updates the configuration automatically on boot.
## Why
This change ensures that ParadeDB automatically scales with the Docker container's limits, reducing friction for users who would otherwise have to manually tune `postgresql.conf`.

## Tests
I verified this manually by building a test image and running the following scenarios:

**1. Fresh Install (1GB RAM limit)**
*   Ran container with `--memory="1g"`.
*   Verified logs: `ParadeDB auto-tune: Detected fresh install. Deferring tuning to bootstrap.` followed by `ParadeDB auto-tune: Applying settings for 1024 MB RAM`.
*   Verified config: `SHOW shared_buffers;` returned `256MB`.

**2. Container Restart with Scaling (2GB RAM limit)**
*   Updated container resources: `docker update --memory="2g"`.
*   Restarted container.
*   Verified logs: `ParadeDB auto-tune: Applying settings for 2048 MB RAM`.
*   Verified config: `SHOW shared_buffers;` returned `512MB`.