### PR TITLE
docs: Add Snowball explanation to stemmers docs

### DIFF
--- a/docs/documentation/token-filters/stemming.mdx
+++ b/docs/documentation/token-filters/stemming.mdx
@@ -5,7 +5,8 @@ canonical: https://docs.paradedb.com/documentation/token-filters/stemming
 ---
 
 Stemming is the process of reducing words to their root form. In English, for example, the root form of "running" and "runs" is "run".
-Stemming can be configured for any tokenizer besides the [literal](/documentation/tokenizers/available-tokenizers/literal) tokenizer.
+Stemming can be configured for any tokenizer besides the [literal](/documentation/tokenizers/available-tokenizers/literal) tokenizer. Stemmers
+in ParadeDB are based on stemming algorithms obtained from the official [Snowball website](https://snowballstem.org/).
 
 To set a stemmer, append `stemmer=<language>` to the tokenizer's arguments.
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
A community user was wondering where they came from. We use Snowball (like Elastic and Lucene) and should be upfront about it. I followed the structure here: https://crates.io/crates/tantivy-stemmers/0.2.0 for the wording.

## Why
Clearer docs!

## How
^

## Tests
^