### PR TITLE
feat: Add flake.nix for NixOS builds of pg_search

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,8 +95,16 @@
               ]);
           };
 
-          # Replace with the correct hash after the first build attempt
-          cargoHash = lib.fakeHash;
+          # Use Cargo.lock directly — no vendored hash to maintain.
+          # Only the git dependency outputHashes need updating when their revs change.
+          # To get correct hashes, run: nix-prefetch-git <url> --rev <rev> | jq -r .hash
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "tantivy-0.26.0" = lib.fakeHash;
+              "tantivy-fst-0.5.0" = lib.fakeHash;
+            };
+          };
 
           inherit postgresql;
 


### PR DESCRIPTION
## Summary

A few users have requested support for NixOS, which a community contributor is attempting to merge here: https://github.com/NixOS/nixpkgs/pull/477892

While reading up on Nix, I discovered the concept of the `flake.nix` file. I figured it might be good for us to support this directly so it's easier for users to adopt us on NixOS via `nix build github:paradedb/paradedb`

## Details

- Uses `cargoLock.lockFile` instead of `cargoHash` so crate hashes are read directly from `Cargo.lock` — only the two git dependency hashes (`tantivy`, `tantivy-fst`) need manual maintenance, and only when their revs change. This might be a source of pain, though, as we change the `paradedb/tantivy` rev somewhat frequently.

- Took the best practices for Lindera cache from the PR linked above.

**First-time setup:** The two git dependencies `outputHashes` use `lib.fakeHash` placeholders. Run `nix build` once — it will fail and print the correct hashes to substitute. After that, these hashes only need to be updated when the tantivy/fst fork revision is bumped. To compute hashes directly:

```bash
nix-prefetch-git https://github.com/paradedb/tantivy.git --rev <rev> | jq -r .hash
nix-prefetch-git https://github.com/paradedb/fst.git --rev <rev> | jq -r .hash
```

### Usage

```bash
nix build                    # default (pg18)
nix build .#pg_search-pg15
nix build .#pg_search-pg16
nix build .#pg_search-pg17
nix build .#pg_search-pg18
```

## Test plan

- [ ] Run `nix flake check` to validate flake syntax
- [ ] Run `nix build`, get hash mismatch for git deps, update `outputHashes`
- [ ] Run `nix build` again — should produce the extension in `./result/`
- [ ] Verify against each PG version (pg15, pg16, pg17, pg18)