### PR TITLE
feat: Always create a default `paradedb` database in Docker image

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -19,7 +19,7 @@ if [ "$POSTGRES_DB" != "paradedb" ]; then
   psql -d postgres -c "CREATE DATABASE paradedb;"
 fi
 
-# Load ParadeDB and third-party extensions into template1, $POSTGRES_DB, and paradedb
+# Load ParadeDB and third-party extensions into template1, paradedb, and $POSTGRES_DB
 # Creating extensions in template1 ensures that they are available in all new databases.
 for DB in template1 paradedb "$POSTGRES_DB"; do
   echo "Loading ParadeDB extensions into $DB"
@@ -35,7 +35,7 @@ for DB in template1 paradedb "$POSTGRES_DB"; do
 EOSQL
 done
 
-# Add the `paradedb` schema to template1, $POSTGRES_DB, and paradedb
+# Add the `paradedb` schema to template1, paradedb, and $POSTGRES_DB
 for DB in template1 paradedb "$POSTGRES_DB"; do
   echo "Adding 'paradedb' search_path to $DB"
   psql -d "$DB" -c "ALTER DATABASE \"$DB\" SET search_path TO public,paradedb;"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What

The Docker bootstrap script now always creates a `paradedb` database, in addition to whatever the user sets via `POSTGRES_DB`.

## Why

Users who download our Docker image should have a `paradedb` database available out of the box, regardless of their `POSTGRES_DB` configuration.

## How

Modified `docker/bootstrap.sh` to create a `paradedb` database if `POSTGRES_DB` is not already set to `paradedb`, and extended the extension installation and search path loops to include it.

## Tests

^