### PR TITLE
fix: Double panic during `CREATE INDEX`

### DIFF
--- a/pg_search/src/index/writer/segment_component.rs
+++ b/pg_search/src/index/writer/segment_component.rs
@@ -138,6 +138,8 @@ impl<W: Write> Write for PanicSafeBufWriter<W> {
     }
 }
 
+/// We are intentionally not using impl_safe_drop! here because
+/// we want to skip the `Drop` of the writer entirely on panic
 impl<W: Write> Drop for PanicSafeBufWriter<W> {
     fn drop(&mut self) {
         if std::thread::panicking() {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

In low memory conditions, it is possible for all buffers in the buffer cache to be pinned. This causes Postgres to error, which gets translated into a Rust panic, which can double panic if Tantivy panics when unwinding the stack.

## Why

## How

## Tests
