### PR TITLE
fix: remove unintended lockfile churn from cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,7 +5804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",


### PR DESCRIPTION
## Summary
- The tantivy bump in e44fd633 was done with `cargo update` instead of `cargo check`, which caused `prost-derive` to unnecessarily switch from `itertools 0.14.0` to `0.13.0`
- Reverted `Cargo.lock` to pre-bump state and regenerated with `cargo check` to include only the intended tantivy rev changes

## Test plan
- `cargo check` passes
- Pre-commit hooks pass (fmt, clippy, machete, taplo)