### PR TITLE
fix: migrate sort_by type tests to v2 syntax and add EXPLAIN coverage

### DIFF
--- a/pg_search/tests/pg_regress/expected/sorted_index_scan.out
+++ b/pg_search/tests/pg_regress/expected/sorted_index_scan.out
@@ -439,6 +439,20 @@ ORDER BY priority DESC NULLS LAST;
 -- 4.1: INTEGER type (using main table)
 \echo 'Test 4.1: INTEGER field sorting (using main table priority column)'
 Test 4.1: INTEGER field sorting (using main table priority column)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, priority FROM sorted_scan_test WHERE content @@@ 'searchable' ORDER BY priority DESC NULLS LAST;
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on sorted_scan_test
+   Table: sorted_scan_test
+   Index: sorted_scan_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: id, priority
+   Order By: priority DESC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"searchable","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
 SELECT id, priority FROM sorted_scan_test WHERE content @@@ 'searchable' ORDER BY priority DESC NULLS LAST;
  id | priority 
 ----+----------
@@ -487,6 +501,20 @@ INSERT INTO dtype_float_test (content, rating) VALUES
 CREATE INDEX dtype_float_test_idx ON dtype_float_test
 USING bm25 (id, content, rating)
 WITH (key_field = 'id', sort_by = 'rating DESC NULLS LAST');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, rating FROM dtype_float_test WHERE content @@@ 'movie' ORDER BY rating DESC NULLS LAST;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on dtype_float_test
+   Table: dtype_float_test
+   Index: dtype_float_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: id, rating
+   Order By: rating DESC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"movie","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
 SELECT id, rating FROM dtype_float_test WHERE content @@@ 'movie' ORDER BY rating DESC NULLS LAST;
  id | rating 
 ----+--------
@@ -516,6 +544,20 @@ INSERT INTO dtype_ts_test (content, created_at) VALUES
 CREATE INDEX dtype_ts_test_idx ON dtype_ts_test
 USING bm25 (id, content, created_at)
 WITH (key_field = 'id', sort_by = 'created_at DESC NULLS LAST');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, created_at FROM dtype_ts_test WHERE content @@@ 'event' ORDER BY created_at DESC NULLS LAST;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on dtype_ts_test
+   Table: dtype_ts_test
+   Index: dtype_ts_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: created_at, id
+   Order By: created_at DESC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"event","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
 SELECT id, created_at FROM dtype_ts_test WHERE content @@@ 'event' ORDER BY created_at DESC NULLS LAST;
  id |        created_at        
 ----+--------------------------
@@ -545,6 +587,20 @@ INSERT INTO dtype_date_test (content, event_date) VALUES
 CREATE INDEX dtype_date_test_idx ON dtype_date_test
 USING bm25 (id, content, event_date)
 WITH (key_field = 'id', sort_by = 'event_date ASC NULLS FIRST');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, event_date FROM dtype_date_test WHERE content @@@ 'appointment' ORDER BY event_date ASC NULLS FIRST;
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on dtype_date_test
+   Table: dtype_date_test
+   Index: dtype_date_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: event_date, id
+   Order By: event_date ASC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"appointment","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
 SELECT id, event_date FROM dtype_date_test WHERE content @@@ 'appointment' ORDER BY event_date ASC NULLS FIRST;
  id | event_date 
 ----+------------
@@ -573,13 +629,25 @@ INSERT INTO dtype_uuid_test (content, uuid_col) VALUES
     ('uuid', '00000000-0000-0000-0000-000000000003'),
     ('uuid', '00000000-0000-0000-0000-000000000100');
 CREATE INDEX dtype_uuid_test_idx ON dtype_uuid_test
-USING bm25 (id, content, uuid_col)
-WITH (
-    key_field = 'id',
-    text_fields = '{"content": {}, "uuid_col": {"fast": true, "tokenizer": {"type": "keyword"}}}',
-    sort_by = 'uuid_col ASC NULLS FIRST'
-);
-SELECT id, uuid_col::text FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
+USING bm25 (id, content, (uuid_col::pdb.literal))
+WITH (key_field = 'id', sort_by = 'uuid_col ASC NULLS FIRST');
+-- Select the native UUID column (no ::text cast) so ORDER BY resolves to the
+-- base Var and matches the index pathkey on uuid_col.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, uuid_col FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on dtype_uuid_test
+   Table: dtype_uuid_test
+   Index: dtype_uuid_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: id, uuid_col
+   Order By: uuid_col ASC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"uuid","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
+SELECT id, uuid_col FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
  id |               uuid_col               
 ----+--------------------------------------
   4 | 
@@ -611,22 +679,30 @@ INSERT INTO dtype_numeric_test (content, amount) VALUES
     ('num', 50);
 CREATE INDEX dtype_numeric_test_idx ON dtype_numeric_test
 USING bm25 (id, content, amount)
-WITH (
-    key_field = 'id',
-    text_fields = '{"content": {}}',
-    numeric_fields = '{"amount": {"fast": true}}',
-    sort_by = 'amount ASC NULLS FIRST'
-);
--- Order by the source NUMERIC column to avoid sorting text output lexicographically.
-SELECT id, amount::text FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY dtype_numeric_test.amount ASC NULLS FIRST;
+WITH (key_field = 'id', sort_by = 'amount ASC NULLS FIRST');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, amount FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY amount ASC NULLS FIRST;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Base Scan) on dtype_numeric_test
+   Table: dtype_numeric_test
+   Index: dtype_numeric_test_idx
+   Exec Method: ColumnarExecState
+   Fast Fields: amount, id
+   Order By: amount ASC
+   Scores: false
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"num","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
+SELECT id, amount FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY amount ASC NULLS FIRST;
  id |             amount             
 ----+--------------------------------
-  1 | 
-  5 | 1
-  3 | 5
-  4 | 10
-  8 | 50
-  7 | 500
+  1 |                               
+  5 |                              1
+  3 |                              5
+  4 |                             10
+  8 |                             50
+  7 |                            500
   2 | 100000000000000000000000000000
   6 | 100000000000000000000000000001
 (8 rows)

--- a/pg_search/tests/pg_regress/sql/sorted_index_scan.sql
+++ b/pg_search/tests/pg_regress/sql/sorted_index_scan.sql
@@ -198,6 +198,8 @@ ORDER BY priority DESC NULLS LAST;
 
 -- 4.1: INTEGER type (using main table)
 \echo 'Test 4.1: INTEGER field sorting (using main table priority column)'
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, priority FROM sorted_scan_test WHERE content @@@ 'searchable' ORDER BY priority DESC NULLS LAST;
 SELECT id, priority FROM sorted_scan_test WHERE content @@@ 'searchable' ORDER BY priority DESC NULLS LAST;
 
 -- 4.2: FLOAT type
@@ -216,6 +218,8 @@ CREATE INDEX dtype_float_test_idx ON dtype_float_test
 USING bm25 (id, content, rating)
 WITH (key_field = 'id', sort_by = 'rating DESC NULLS LAST');
 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, rating FROM dtype_float_test WHERE content @@@ 'movie' ORDER BY rating DESC NULLS LAST;
 SELECT id, rating FROM dtype_float_test WHERE content @@@ 'movie' ORDER BY rating DESC NULLS LAST;
 DROP TABLE dtype_float_test CASCADE;
 
@@ -239,6 +243,8 @@ CREATE INDEX dtype_ts_test_idx ON dtype_ts_test
 USING bm25 (id, content, created_at)
 WITH (key_field = 'id', sort_by = 'created_at DESC NULLS LAST');
 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, created_at FROM dtype_ts_test WHERE content @@@ 'event' ORDER BY created_at DESC NULLS LAST;
 SELECT id, created_at FROM dtype_ts_test WHERE content @@@ 'event' ORDER BY created_at DESC NULLS LAST;
 DROP TABLE dtype_ts_test CASCADE;
 
@@ -262,6 +268,8 @@ CREATE INDEX dtype_date_test_idx ON dtype_date_test
 USING bm25 (id, content, event_date)
 WITH (key_field = 'id', sort_by = 'event_date ASC NULLS FIRST');
 
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, event_date FROM dtype_date_test WHERE content @@@ 'appointment' ORDER BY event_date ASC NULLS FIRST;
 SELECT id, event_date FROM dtype_date_test WHERE content @@@ 'appointment' ORDER BY event_date ASC NULLS FIRST;
 DROP TABLE dtype_date_test CASCADE;
 
@@ -283,14 +291,14 @@ INSERT INTO dtype_uuid_test (content, uuid_col) VALUES
     ('uuid', '00000000-0000-0000-0000-000000000100');
 
 CREATE INDEX dtype_uuid_test_idx ON dtype_uuid_test
-USING bm25 (id, content, uuid_col)
-WITH (
-    key_field = 'id',
-    text_fields = '{"content": {}, "uuid_col": {"fast": true, "tokenizer": {"type": "keyword"}}}',
-    sort_by = 'uuid_col ASC NULLS FIRST'
-);
+USING bm25 (id, content, (uuid_col::pdb.literal))
+WITH (key_field = 'id', sort_by = 'uuid_col ASC NULLS FIRST');
 
-SELECT id, uuid_col::text FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
+-- Select the native UUID column (no ::text cast) so ORDER BY resolves to the
+-- base Var and matches the index pathkey on uuid_col.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, uuid_col FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
+SELECT id, uuid_col FROM dtype_uuid_test WHERE content @@@ 'uuid' ORDER BY uuid_col ASC NULLS FIRST;
 DROP TABLE dtype_uuid_test CASCADE;
 
 -- 4.6: NUMERIC type (NumericBytes)
@@ -314,15 +322,11 @@ INSERT INTO dtype_numeric_test (content, amount) VALUES
 
 CREATE INDEX dtype_numeric_test_idx ON dtype_numeric_test
 USING bm25 (id, content, amount)
-WITH (
-    key_field = 'id',
-    text_fields = '{"content": {}}',
-    numeric_fields = '{"amount": {"fast": true}}',
-    sort_by = 'amount ASC NULLS FIRST'
-);
+WITH (key_field = 'id', sort_by = 'amount ASC NULLS FIRST');
 
--- Order by the source NUMERIC column to avoid sorting text output lexicographically.
-SELECT id, amount::text FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY dtype_numeric_test.amount ASC NULLS FIRST;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, amount FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY amount ASC NULLS FIRST;
+SELECT id, amount FROM dtype_numeric_test WHERE content @@@ 'num' ORDER BY amount ASC NULLS FIRST;
 DROP TABLE dtype_numeric_test CASCADE;
 
 -- =============================================================================

--- a/tests/tests/index_sorting.rs
+++ b/tests/tests/index_sorting.rs
@@ -475,12 +475,8 @@ fn index_sort_by_type_multi_segment(mut conn: PgConnection, #[case] variant: &st
                 r#"
                     CREATE TABLE test_sort (id SERIAL PRIMARY KEY, content TEXT, sort_col TEXT);
                     CREATE INDEX test_sort_idx ON test_sort
-                    USING bm25 (id, content, sort_col)
-                    WITH (
-                        key_field = 'id',
-                        text_fields = '{"content": {}, "sort_col": {"fast": true, "tokenizer": {"type": "raw"}}}',
-                        sort_by = 'sort_col ASC NULLS FIRST'
-                    );
+                    USING bm25 (id, content, (sort_col::pdb.literal))
+                    WITH (key_field = 'id', sort_by = 'sort_col ASC NULLS FIRST');
                 "#,
                 vec![
                     "INSERT INTO test_sort (content, sort_col) VALUES ('fruit', 'mango'), ('fruit', 'apple')",
@@ -501,12 +497,8 @@ fn index_sort_by_type_multi_segment(mut conn: PgConnection, #[case] variant: &st
                 r#"
                     CREATE TABLE test_sort (id SERIAL PRIMARY KEY, content TEXT, sort_col TEXT);
                     CREATE INDEX test_sort_idx ON test_sort
-                    USING bm25 (id, content, sort_col)
-                    WITH (
-                        key_field = 'id',
-                        text_fields = '{"content": {}, "sort_col": {"fast": true, "tokenizer": {"type": "raw"}}}',
-                        sort_by = 'sort_col DESC NULLS LAST'
-                    );
+                    USING bm25 (id, content, (sort_col::pdb.literal))
+                    WITH (key_field = 'id', sort_by = 'sort_col DESC NULLS LAST');
                 "#,
                 vec![
                     "INSERT INTO test_sort (content, sort_col) VALUES ('fruit', 'mango'), ('fruit', 'apple')",
@@ -527,19 +519,15 @@ fn index_sort_by_type_multi_segment(mut conn: PgConnection, #[case] variant: &st
                 r#"
                     CREATE TABLE test_sort (id SERIAL PRIMARY KEY, content TEXT, sort_col UUID);
                     CREATE INDEX test_sort_idx ON test_sort
-                    USING bm25 (id, content, sort_col)
-                    WITH (
-                        key_field = 'id',
-                        text_fields = '{"content": {}, "sort_col": {"fast": true, "tokenizer": {"type": "keyword"}}}',
-                        sort_by = 'sort_col ASC NULLS FIRST'
-                    );
+                    USING bm25 (id, content, (sort_col::pdb.literal))
+                    WITH (key_field = 'id', sort_by = 'sort_col ASC NULLS FIRST');
                 "#,
                 vec![
                     "INSERT INTO test_sort (content, sort_col) VALUES ('uuid', '00000000-0000-0000-0000-000000000002'), ('uuid', '00000000-0000-0000-0000-000000000010')",
                     "INSERT INTO test_sort (content, sort_col) VALUES ('uuid', '00000000-0000-0000-0000-000000000001'), ('uuid', NULL)",
                     "INSERT INTO test_sort (content, sort_col) VALUES ('uuid', '00000000-0000-0000-0000-000000000003'), ('uuid', '00000000-0000-0000-0000-000000000100')",
                 ],
-                "SELECT sort_col::text FROM test_sort WHERE content @@@ 'uuid' ORDER BY sort_col ASC NULLS FIRST",
+                "SELECT sort_col::text AS sort_col_text FROM test_sort WHERE content @@@ 'uuid' ORDER BY sort_col ASC NULLS FIRST",
                 vec![
                     None,
                     Some("00000000-0000-0000-0000-000000000001".into()),
@@ -554,21 +542,14 @@ fn index_sort_by_type_multi_segment(mut conn: PgConnection, #[case] variant: &st
                     CREATE TABLE test_sort (id SERIAL PRIMARY KEY, content TEXT, sort_col NUMERIC(30,0));
                     CREATE INDEX test_sort_idx ON test_sort
                     USING bm25 (id, content, sort_col)
-                    WITH (
-                        key_field = 'id',
-                        text_fields = '{"content": {}}',
-                        numeric_fields = '{"sort_col": {"fast": true}}',
-                        sort_by = 'sort_col ASC NULLS FIRST'
-                    );
+                    WITH (key_field = 'id', sort_by = 'sort_col ASC NULLS FIRST');
                 "#,
                 vec![
                     "INSERT INTO test_sort (content, sort_col) VALUES ('num', NULL), ('num', 100000000000000000000000000000), ('num', 5)",
                     "INSERT INTO test_sort (content, sort_col) VALUES ('num', 10), ('num', 1), ('num', 100000000000000000000000000001)",
                     "INSERT INTO test_sort (content, sort_col) VALUES ('num', 500), ('num', 50)",
                 ],
-                // Table-qualify sort_col so Postgres doesn't resolve to the output column
-                // (sort_col::text) and sort lexicographically instead of numerically.
-                "SELECT sort_col::text FROM test_sort WHERE content @@@ 'num' ORDER BY test_sort.sort_col ASC NULLS FIRST",
+                "SELECT sort_col::text AS sort_col_text FROM test_sort WHERE content @@@ 'num' ORDER BY sort_col ASC NULLS FIRST",
                 vec![
                     None,
                     Some("1".into()),


### PR DESCRIPTION
## Summary

Follow-up to #4140 applying @rebasedming's review feedback: migrate the new `sort_by` type tests to **v2 `CREATE INDEX` syntax** and add **`EXPLAIN`** coverage.

## Changes

- **`sorted_index_scan.sql` Section 4:** add `EXPLAIN` for 4.1–4.6. Every type now shows `ColumnarExecState` on the sorted-index path.
- **Test 4.5 (UUID):** v1 `text_fields` JSON → `(uuid_col::pdb.literal)`. Drop `::text` cast so `ORDER BY` matches the index pathkey.
- **Test 4.6 (NUMERIC(30,0)):** drop `text_fields`/`numeric_fields` JSON (numeric is columnar by default). Drop `::text` + table qualifier. Verifies the NumericBytes sorted path end-to-end.
- **`index_sorting.rs` `index_sort_by_type_multi_segment`:** all 4 cases → v2 with `(sort_col::pdb.literal)`. `uuid_asc` / `numeric_bytes_asc` use `sort_col::text AS sort_col_text` so `ORDER BY sort_col` resolves to the base Var.

## Verification

- `cargo pgrx regress pg17 sorted_index_scan` → PASS
- `cargo test --package tests --test index_sorting index_sort_by_type_multi_segment` → 4 passed