### PR TITLE
chore: Split benchmark labels by dataset

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -41,7 +41,13 @@ jobs:
       - family=z1d.metal # 48 vCPUs, 384 GiBs Memory, 1.8 TiBs local NVMe
       - image=ubuntu24-full-x64
       - extras=s3-cache # See https://runs-on.com/caching/magic-cache/
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-queries') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-queries-logs') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-queries-docs')
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
+      )
     env:
       pg_version: 18
 
@@ -50,7 +56,9 @@ jobs:
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
         uses: actions-ecosystem/action-remove-labels@v1
-        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs' || github.event.label.name == 'benchmark-queries-docs')
+        if: >-
+          github.event_name == 'pull_request' &&
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
         with:
           labels: |
             benchmark
@@ -90,7 +98,8 @@ jobs:
           echo "Deriving short commit: $short_commit"
 
       - name: Fetch the Latest Composite Actions
-        if: github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-queries' && github.event.label.name != 'benchmark-queries-logs' && github.event.label.name != 'benchmark-queries-docs'
+        if: >-
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
         uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
@@ -100,16 +109,19 @@ jobs:
           ref: main
 
       - name: Copy latest actions into place
-        if: github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-queries' && github.event.label.name != 'benchmark-queries-logs' && github.event.label.name != 'benchmark-queries-docs'
+        if: >-
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
-        if: github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-queries' && github.event.label.name != 'benchmark-queries-logs' && github.event.label.name != 'benchmark-queries-docs'
+        if: >-
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
         run: rm -rf actions-temp
 
       # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
       - name: Fetch latest benchmark code, suites
-        if: github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-queries' && github.event.label.name != 'benchmark-queries-logs' && github.event.label.name != 'benchmark-queries-docs'
+        if: >-
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-docs"]'), github.event.label.name)
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -231,7 +243,9 @@ jobs:
 
       # Benchmark "logs" dataset at multiple scales (10K, 100K, 1M, 10M, 100M)
       - name: Benchmark "logs" Dataset (10K rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: logs
@@ -243,7 +257,9 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark "logs" Dataset (100K rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: logs
@@ -255,7 +271,9 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark "logs" Dataset (1M rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: logs
@@ -267,7 +285,9 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark "logs" Dataset (10M rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: logs
@@ -279,7 +299,9 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark "logs" Dataset (100M rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-logs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: logs
@@ -291,7 +313,9 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark "docs" Dataset (25M rows)
-        if: github.event_name != 'pull_request' || github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-queries' || github.event.label.name == 'benchmark-queries-docs'
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-docs"]'), github.event.label.name)
         uses: ./.github/actions/benchmark-queries
         with:
           dataset: docs


### PR DESCRIPTION
## What

Further subdivide our benchmark labels to allow running benchmarks for only one of the query datasets.

Add `benchmark-queries-logs` or `benchmark-queries-docs` to run only those datasets.

## Why

To get answers more quickly with less money spent on compute.