### PR TITLE
feat: bump tantivy for sorted range query optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "bitpacking",
 ]
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7380,7 +7380,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=e441e6ee155f5aa2c61f2efb419e6938756cede2#e441e6ee155f5aa2c61f2efb419e6938756cede2"
+source = "git+https://github.com/paradedb/tantivy.git?rev=517ad3675aeb62170d51bfe279f51ccfad771527#517ad3675aeb62170d51bfe279f51ccfad771527"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "e441e6ee155f5aa2c61f2efb419e6938756cede2", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "517ad3675aeb62170d51bfe279f51ccfad771527", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.16.1"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "e441e6ee155f5aa2c61f2efb419e6938756cede2" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "517ad3675aeb62170d51bfe279f51ccfad771527" }


### PR DESCRIPTION
## Summary
- Updates tantivy rev to `85e38043` which adds O(log n) binary search for range queries on sorted indexes, replacing O(n) column scan
- Fixes https://github.com/paradedb/paradedb/issues/4169

## Test plan
- `cargo check` passes
- Tantivy-side tests in paradedb/tantivy#107

Ref: paradedb/tantivy#107