### PR TITLE
chore: Add tests for TOPK multi-term fixes

### DIFF
--- a/benchmarks/datasets/logs/queries/pg_search/top_n-score-multi-term-asc.sql
+++ b/benchmarks/datasets/logs/queries/pg_search/top_n-score-multi-term-asc.sql
@@ -1,0 +1,1 @@
+SELECT *, pdb.score(id) FROM benchmark_logs WHERE message ||| 'discovered analyzed monitored captured processed' ORDER BY pdb.score(id) LIMIT 10;

--- a/benchmarks/datasets/logs/queries/pg_search/top_n-score-multi-term-desc.sql
+++ b/benchmarks/datasets/logs/queries/pg_search/top_n-score-multi-term-desc.sql
@@ -1,0 +1,1 @@
+SELECT *, pdb.score(id) FROM benchmark_logs WHERE message ||| 'discovered analyzed monitored captured processed' ORDER BY pdb.score(id) DESC LIMIT 10;


### PR DESCRIPTION
Just adding two tests as prework which (hopefully) will show multi-term TOPK getting faster once PR #4195 drops