### PR TITLE
fix: Re-work Nix logic around package brokenness

### DIFF
--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -43,19 +43,15 @@ jobs:
 
       # https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-flake-check
       - name: Run Flake Checks
-        run: NIXPKGS_ALLOW_BROKEN=1 nix flake check --impure
+        run: nix flake check
 
       # If this step fails due to an incorrect hash in flake.nix, the error will
       # provide the correct hash
       - name: Build pg_search for Nix
-        env:
-          # This is necessary due to longstanding issues surrounding running Postgres
-          # in Nix's tightly controlled sandbox
-          NIXPKGS_ALLOW_BROKEN: 1
         run: |
           system=$(nix eval --raw --impure --expr builtins.currentSystem)
           nix flake show --json 2>/dev/null \
             | jq -r --arg s "$system" '.packages[$s] | keys[] | ".#\(.)"' \
-            | xargs -L1 nix build --impure
+            | xargs -L1 nix build
 
           echo "All pg_search packages built successfully."

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,11 @@
             # Provides a system-specific, configured Nixpkgs
             pkgs = import inputs.nixpkgs {
               inherit system;
+              # This "allow broken" setting is necessary because *all* PostgreSQL plugins
+              # based on Nixpkgs are technically broken from Nix's standpoint because tests
+              # require a running instance of PostgreSQL in the Nix sandbox, which is
+              # generally infeasible. But the resulting extensions do work just fine in Postgres.
+              config.allowBroken = true;
               overlays = [ self.overlays.default ];
             };
           }
@@ -45,13 +50,9 @@
     {
       # Package outputs
       # To build pg_search for the most recent supported version of Postgres:
-      # NIXPKGS_ALLOW_BROKEN=1 nix build --impure
-      # The "allow broken" setting is necessary because *all* PostgreSQL plugins based on Nixpkgs
-      # are technically broken from Nix's standpoing because tests require a running instance of
-      # PostgreSQL in the Nix sandbox, which is generally infeasible. But the resulting extensions
-      # do work just fine in Postgres.
+      # nix build
       # You can also build the extension for specific versions of Postgres. Example:
-      # NIXPKGS_ALLOW_BROKEN=1 nix build --impure .#pg_search-pg17
+      # nix build --impure .#pg_search-pg17
       packages = forEachSupportedSystem (
         { pkgs, system }:
         let
@@ -131,7 +132,7 @@
       formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
 
       # Flake checks
-      # To run all checks: NIXPKGS_ALLOW_BROKEN=1 nix flake check --impure
+      # To run all checks: nix flake check
       checks = forEachSupportedSystem (
         { pkgs, system }:
         {


### PR DESCRIPTION
@philippemnoel Just a quick follow-up to #4210 that randomly occurred to me today. Should make the Nix experience a bit nicer.

## What

Provides a more ergonomic way to handle the Nix package being technically "broken" (according to Nix).

## Why

Needing to specify `NIXPKGS_ALLOW_BROKEN=1` and `--impure` for basic commands is cumbersome.

## How

Setting the `allowBroken = true` parameter when importing Nixpkgs accomplishes the same thing.

## Tests

I've built all packages locally without needing `NIXPKGS_ALLOW_BROKEN=1` and `--impure`.
