### PR TITLE
docs: fix outdated Django code blocks in full-text docs

### DIFF
--- a/docs/documentation/full-text/fuzzy.mdx
+++ b/docs/documentation/full-text/fuzzy.mdx
@@ -43,21 +43,21 @@ LIMIT 5;
 ```
 
 ```python Django
-from paradedb.search import Fuzzy, ParadeDB
+from paradedb.search import Match, ParadeDB, Term
 
-# Fuzzy match disjunction (operator=None defaults to OR/|||)
+# Fuzzy match disjunction
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('runing shose', distance=2))
+    description=ParadeDB(Match('runing', 'shose', operator='OR', distance=2))
 ).values('id', 'description')[:5]
 
 # Fuzzy match conjunction
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('runing shose', distance=2, operator='AND'))
+    description=ParadeDB(Match('runing', 'shose', operator='AND', distance=2))
 ).values('id', 'description')[:5]
 
 # Fuzzy term
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('shose', distance=2, operator='TERM'))
+    description=ParadeDB(Term('shose', distance=2))
 ).values('id', 'description')[:5]
 ```
 
@@ -94,10 +94,10 @@ LIMIT 5;
 ```
 
 ```python Django
-from paradedb.search import Fuzzy, ParadeDB
+from paradedb.search import ParadeDB, Term
 
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('rann', distance=1, prefix=True, operator='TERM'))
+    description=ParadeDB(Term('rann', distance=1, prefix=True))
 ).values('id', 'description')[:5]
 ```
 
@@ -119,10 +119,10 @@ LIMIT 5;
 ```
 
 ```python Django
-from paradedb.search import Fuzzy, ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('slee rann', distance=1, prefix=True, operator='AND'))
+    description=ParadeDB(Match('slee', 'rann', operator='AND', distance=1, prefix=True))
 ).values('id', 'description')[:5]
 ```
 
@@ -142,10 +142,10 @@ LIMIT 5;
 ```
 
 ```python Django
-from paradedb.search import Fuzzy, ParadeDB
+from paradedb.search import ParadeDB, Term
 
 MockItem.objects.filter(
-    description=ParadeDB(Fuzzy('shose', distance=1, transposition_cost_one=True, operator='TERM'))
+    description=ParadeDB(Term('shose', distance=1, transposition_cost_one=True))
 ).values('id', 'description')[:5]
 ```
 

--- a/docs/documentation/full-text/highlight.mdx
+++ b/docs/documentation/full-text/highlight.mdx
@@ -30,10 +30,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippet
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('shoes')
+    description=ParadeDB(Match('shoes', operator='OR'))
 ).annotate(
     snippet=Snippet('description')
 ).values('id', 'snippet')[:5]
@@ -64,10 +64,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippet
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('shoes')
+    description=ParadeDB(Match('shoes', operator='OR'))
 ).annotate(
     snippet=Snippet('description', start_sel='<i>', stop_sel='</i>')
 ).values('id', 'snippet')[:5]
@@ -89,10 +89,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippets
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('artistic vase')
+    description=ParadeDB(Match('artistic vase', operator='OR'))
 ).annotate(
     snippets=Snippets('description', max_num_chars=15)
 ).values('id', 'snippets')[:5]
@@ -146,10 +146,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippets
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running')
+    description=ParadeDB(Match('running', operator='OR'))
 ).annotate(
     snippets=Snippets('description', max_num_chars=15, limit=1)
 ).values('id', 'snippets')[:5]
@@ -169,10 +169,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippets
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running')
+    description=ParadeDB(Match('running', operator='OR'))
 ).annotate(
     snippets=Snippets('description', max_num_chars=15, limit=1, offset=1)
 ).values('id', 'snippets')[:5]
@@ -196,10 +196,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippets
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('artistic vase')
+    description=ParadeDB(Match('artistic vase', operator='OR'))
 ).annotate(
     snippets=Snippets('description', max_num_chars=15, sort_by='position')
 ).values('id', 'snippets')[:5]
@@ -222,10 +222,10 @@ LIMIT 5;
 
 ```python Django
 from paradedb.functions import Snippet, SnippetPositions
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('shoes')
+    description=ParadeDB(Match('shoes', operator='OR'))
 ).annotate(
     snippet=Snippet('description'),
     snippet_positions=SnippetPositions('description')

--- a/docs/documentation/full-text/match.mdx
+++ b/docs/documentation/full-text/match.mdx
@@ -21,10 +21,10 @@ WHERE description ||| 'running shoes';
 ```
 
 ```python Django
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running shoes', operator='OR')
+    description=ParadeDB(Match('running shoes', operator='OR'))
 ).values('description', 'rating', 'category')
 ```
 
@@ -80,10 +80,10 @@ WHERE description &&& 'running shoes';
 ```
 
 ```python Django
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running shoes')
+    description=ParadeDB(Match('running shoes', operator='AND'))
 ).values('description', 'rating', 'category')
 ```
 
@@ -149,10 +149,10 @@ WHERE description ||| 'running shoes'::pdb.whitespace;
 ```
 
 ```python Django
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running shoes', operator='OR', tokenizer='whitespace')
+    description=ParadeDB(Match('running shoes', operator='OR', tokenizer='whitespace'))
 ).values('description', 'rating', 'category')
 ```
 
@@ -171,10 +171,10 @@ WHERE description &&& ARRAY['running', 'shoes'];
 ```
 
 ```python Django
-from paradedb.search import ParadeDB
+from paradedb.search import Match, ParadeDB
 
 MockItem.objects.filter(
-    description=ParadeDB('running', 'shoes')
+    description=ParadeDB(Match('running', 'shoes', operator='AND'))
 ).values('description', 'rating', 'category')
 ```
 


### PR DESCRIPTION
## Summary

- Replace removed plain-string `ParadeDB('text', operator=...)` API with the correct `ParadeDB(Match(..., operator=...))` syntax in `match.mdx` and `highlight.mdx`
- Remove non-existent `Fuzzy` class from `fuzzy.mdx` and replace with `Match` (for multi-word fuzzy) and `Term` (for single-word fuzzy), using the correct `distance`, `prefix`, and `transposition_cost_one` parameters

## Test plan

- [ ] Verify Django code blocks in `match.mdx` use `Match` with explicit `operator`
- [ ] Verify Django code blocks in `highlight.mdx` use `Match` with `operator='OR'`
- [ ] Verify Django code blocks in `fuzzy.mdx` use `Match`/`Term` instead of removed `Fuzzy` class

🤖 Generated with [Claude Code](https://claude.com/claude-code)