### PR TITLE
fix: keep heap relation alive for the lifetime of HeapFetchState

### DIFF
--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -245,6 +245,9 @@ impl VisibilityChecker {
 pub struct HeapFetchState {
     pub scan: *mut pg_sys::IndexFetchTableData,
     slot: *mut pg_sys::BufferHeapTupleTableSlot,
+    // Hold a reference to the heap relation to keep it open for the lifetime of the scan.
+    // The scan stores an internal pointer to the relation, so it must not be closed early.
+    _heaprel: PgSearchRelation,
 }
 
 impl HeapFetchState {
@@ -256,6 +259,7 @@ impl HeapFetchState {
             Self {
                 scan,
                 slot: slot.cast(),
+                _heaprel: heaprel.clone(),
             }
         }
     }


### PR DESCRIPTION
## What
- Potentially fixes a segfault when indexing a memory segment
- Crash dump showed memory corruption in the `table_index_fetch_tuple` call
- It looks like `heap_fetch_state` is using a heap relation which was closed by the time `table_index_fetch_tuple` is called

## Why

## How