### PR TITLE
chore: Port manual Stream implementations to the `async-stream` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,6 +5059,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "arrow-select",
+ "async-stream",
  "async-trait",
  "bincode",
  "bitpacking",

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -79,6 +79,7 @@ bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "=52.0.0", default-features = false }
 datafusion-proto = { version = "=52.0.0", default-features = false }
 futures = "0.3"
+async-stream = "0.3.6"
 
 [dev-dependencies]
 pgrx-tests.workspace = true

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -42,9 +42,7 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::filter_pushdown::{
     ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
 };
-use datafusion::physical_plan::metrics::{
-    Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
@@ -347,12 +345,13 @@ impl ExecutionPlan for PgSearchScanPlan {
 
         // Handle the case where no segments were claimed (EmptyStream).
         if states.is_empty() {
-            return Ok(Box::pin(EmptyStream::new(
-                self.properties.eq_properties.schema().clone(),
-            )));
+            let schema = self.properties.eq_properties.schema().clone();
+            return Ok(Box::pin(unsafe {
+                UnsafeSendStream::new(futures::stream::empty(), schema)
+            }));
         }
 
-        let UnsafeSendSync((mut scanner, ffhelper, visibility)) =
+        let UnsafeSendSync((mut scanner, ffhelper, mut visibility)) =
             states[partition].take().ok_or_else(|| {
                 DataFusionError::Internal(format!(
                     "Partition {} has already been executed",
@@ -370,18 +369,47 @@ impl ExecutionPlan for PgSearchScanPlan {
         let rows_pruned = has_dynamic_filters
             .then(|| MetricBuilder::new(&self.metrics).counter("rows_pruned", partition));
 
+        let schema = self.properties.eq_properties.schema().clone();
+        let dynamic_filters = self.dynamic_filters.clone();
+
+        let stream_gen = async_stream::try_stream! {
+            loop {
+                let pre_filters = build_filters(&dynamic_filters, &schema);
+                let pre_filters_wrapper = if pre_filters.is_empty() {
+                    None
+                } else {
+                    Some(crate::scan::pre_filter::PreFilters {
+                        filters: &pre_filters,
+                        schema: &schema,
+                    })
+                };
+
+                match scanner.next(
+                    &ffhelper,
+                    &mut visibility,
+                    pre_filters_wrapper.as_ref(),
+                ) {
+                    Some(batch) => {
+                        yield batch.to_record_batch(&schema);
+                    }
+                    None => {
+                        // Flush pre-materialization filter stats from Scanner.
+                        if let Some(ref counter) = rows_scanned {
+                            counter.add(scanner.pre_filter_rows_scanned);
+                        }
+                        if let Some(ref counter) = rows_pruned {
+                            counter.add(scanner.pre_filter_rows_pruned);
+                        }
+                        break;
+                    }
+                }
+            }
+        };
+
         // SAFETY: pg_search operates in a single-threaded Tokio executor within Postgres,
         // so it is safe to wrap !Send types for use within DataFusion.
         let stream = unsafe {
-            UnsafeSendStream::new(ScanStream {
-                scanner,
-                ffhelper,
-                visibility,
-                schema: self.properties.eq_properties.schema().clone(),
-                dynamic_filters: self.dynamic_filters.clone(),
-                rows_scanned,
-                rows_pruned,
-            })
+            UnsafeSendStream::new(stream_gen, self.properties.eq_properties.schema().clone())
         };
         Ok(Box::pin(stream))
     }
@@ -465,80 +493,26 @@ impl ExecutionPlan for PgSearchScanPlan {
     }
 }
 
-struct ScanStream {
-    scanner: Scanner,
-    ffhelper: Arc<FFHelper>,
-    visibility: Box<VisibilityChecker>,
-    schema: SchemaRef,
-    dynamic_filters: Vec<Arc<dyn PhysicalExpr>>,
-    /// Metrics counters for EXPLAIN ANALYZE (only set when dynamic filters are present).
-    rows_scanned: Option<Count>,
-    rows_pruned: Option<Count>,
-}
-
-impl ScanStream {
-    /// Evaluate the current dynamic filter expressions and convert them into
-    /// [`PreFilter`]s that the `Scanner` can apply before column materialization.
-    ///
-    /// This is called on every `poll_next` so that tightening thresholds (e.g.
-    /// from TopK) are picked up immediately.
-    ///
-    /// Only filter predicates that can be lowered to fast-field or term-ordinal
-    /// comparisons are retained. Anything else (unsupported types, non-comparison
-    /// operators) is silently dropped — the parent operator is still responsible
-    /// for enforcing the full predicate, so correctness is not affected.
-    fn build_filters(&self) -> Vec<PreFilter> {
-        let mut filters = Vec::new();
-        for df in &self.dynamic_filters {
-            if let Some(dynamic) = df.as_any().downcast_ref::<DynamicFilterPhysicalExpr>() {
-                if let Ok(current_expr) = dynamic.current() {
-                    collect_filters(&current_expr, &self.schema, &mut filters);
-                }
-            }
-        }
-        filters
-    }
-}
-
-impl Stream for ScanStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        let pre_filters = this.build_filters();
-        let pre_filters_wrapper = if pre_filters.is_empty() {
-            None
-        } else {
-            Some(crate::scan::pre_filter::PreFilters {
-                filters: &pre_filters,
-                schema: &this.schema,
-            })
-        };
-
-        match this.scanner.next(
-            &this.ffhelper,
-            &mut this.visibility,
-            pre_filters_wrapper.as_ref(),
-        ) {
-            Some(batch) => Poll::Ready(Some(Ok(batch.to_record_batch(&this.schema)))),
-            None => {
-                // Flush pre-materialization filter stats from Scanner.
-                if let Some(ref counter) = this.rows_scanned {
-                    counter.add(this.scanner.pre_filter_rows_scanned);
-                }
-                if let Some(ref counter) = this.rows_pruned {
-                    counter.add(this.scanner.pre_filter_rows_pruned);
-                }
-                Poll::Ready(None)
+/// Evaluate the current dynamic filter expressions and convert them into
+/// [`PreFilter`]s that the `Scanner` can apply before column materialization.
+///
+/// This is called on every `poll_next` (or loop iteration) so that tightening thresholds (e.g.
+/// from TopK) are picked up immediately.
+///
+/// Only filter predicates that can be lowered to fast-field or term-ordinal
+/// comparisons are retained. Anything else (unsupported types, non-comparison
+/// operators) is silently dropped — the parent operator is still responsible
+/// for enforcing the full predicate, so correctness is not affected.
+fn build_filters(dynamic_filters: &[Arc<dyn PhysicalExpr>], schema: &SchemaRef) -> Vec<PreFilter> {
+    let mut filters = Vec::new();
+    for df in dynamic_filters {
+        if let Some(dynamic) = df.as_any().downcast_ref::<DynamicFilterPhysicalExpr>() {
+            if let Ok(current_expr) = dynamic.current() {
+                collect_filters(&current_expr, schema, &mut filters);
             }
         }
     }
-}
-
-impl RecordBatchStream for ScanStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
+    filters
 }
 
 /// A wrapper that unsafely implements Send for a Stream.
@@ -546,11 +520,14 @@ impl RecordBatchStream for ScanStream {
 /// This is used to wrap `ScanStream` which is !Send because it contains Tantivy and Postgres
 /// state that is not Send. This is safe because pg_search operates in a single-threaded
 /// Tokio executor within Postgres, and these objects will never cross thread boundaries.
-pub(crate) struct UnsafeSendStream<T>(pub(crate) T);
+pub(crate) struct UnsafeSendStream<T> {
+    stream: T,
+    schema: SchemaRef,
+}
 
 impl<T> UnsafeSendStream<T> {
-    pub(crate) unsafe fn new(t: T) -> Self {
-        Self(t)
+    pub(crate) unsafe fn new(stream: T, schema: SchemaRef) -> Self {
+        Self { stream, schema }
     }
 }
 
@@ -560,36 +537,11 @@ impl<T: Stream> Stream for UnsafeSendStream<T> {
     type Item = T::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().0).poll_next(cx) }
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().stream).poll_next(cx) }
     }
 }
 
-impl<T: RecordBatchStream> RecordBatchStream for UnsafeSendStream<T> {
-    fn schema(&self) -> SchemaRef {
-        self.0.schema()
-    }
-}
-
-/// A stream that produces no batches.
-struct EmptyStream {
-    schema: SchemaRef,
-}
-
-impl EmptyStream {
-    fn new(schema: SchemaRef) -> Self {
-        Self { schema }
-    }
-}
-
-impl Stream for EmptyStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(None)
-    }
-}
-
-impl RecordBatchStream for EmptyStream {
+impl<T: Stream<Item = Result<RecordBatch>>> RecordBatchStream for UnsafeSendStream<T> {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -57,19 +57,16 @@ use arrow_schema::SchemaRef;
 use arrow_select::concat::concat_batches;
 use arrow_select::filter::filter_record_batch;
 use datafusion::common::{DataFusionError, Result};
-use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{
     Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use futures::Stream;
 use std::any::Any;
 use std::collections::BinaryHeap;
-use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll};
 use tantivy::termdict::TermOrdinal;
 use tantivy::SegmentOrdinal;
 
@@ -232,30 +229,69 @@ impl ExecutionPlan for SegmentedTopKExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let input_stream = self.input.execute(partition, context)?;
+        let mut input_stream = self.input.execute(partition, context)?;
         let rows_input = MetricBuilder::new(&self.metrics).counter("rows_input", partition);
         let rows_output = MetricBuilder::new(&self.metrics).counter("rows_output", partition);
         let segments_seen = MetricBuilder::new(&self.metrics).counter("segments_seen", partition);
 
+        let mut state = SegmentedTopKState {
+            sort_col_idx: self.sort_col_idx,
+            ff_index: self.ff_index,
+            ffhelper: Arc::clone(&self.ffhelper),
+            k: self.k,
+            descending: self.descending,
+            schema: self.properties.eq_properties.schema().clone(),
+            segment_heaps: HashMap::default(),
+            thresholds: Arc::clone(&self.thresholds),
+            batches: Vec::new(),
+            row_ordinals: Vec::new(),
+            rows_input,
+            rows_output,
+            segments_seen,
+        };
+
+        let stream_gen = async_stream::try_stream! {
+            use futures::StreamExt;
+            while let Some(batch_res) = input_stream.next().await {
+                let batch = batch_res?;
+                state.rows_input.add(batch.num_rows());
+                let batch_idx = state.batches.len();
+
+                match state.collect_batch(&batch, batch_idx)? {
+                    Some(pass_through) => {
+                        state.batches.push(batch);
+                        state.maybe_compact();
+                        state.rows_output.add(pass_through.num_rows());
+                        yield pass_through;
+                    }
+                    None => {
+                        state.batches.push(batch);
+                        state.maybe_compact();
+                    }
+                }
+            }
+
+            let survivors = state.build_survivors();
+            for (batch_idx, batch) in state.batches.iter().enumerate() {
+                let num_rows = batch.num_rows();
+
+                let mask: arrow_array::BooleanArray = (0..num_rows)
+                    .map(|row_idx| Some(survivors.contains(&(batch_idx, row_idx))))
+                    .collect();
+
+                let filtered = filter_record_batch(batch, &mask)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+                if filtered.num_rows() > 0 {
+                    state.rows_output.add(filtered.num_rows());
+                    yield filtered;
+                }
+            }
+        };
+
         // SAFETY: pg_search operates in a single-threaded Tokio executor within Postgres.
         let stream = unsafe {
-            UnsafeSendStream::new(SegmentedTopKStream {
-                input: input_stream,
-                sort_col_idx: self.sort_col_idx,
-                ff_index: self.ff_index,
-                ffhelper: Arc::clone(&self.ffhelper),
-                k: self.k,
-                descending: self.descending,
-                schema: self.properties.eq_properties.schema().clone(),
-                segment_heaps: HashMap::default(),
-                thresholds: Arc::clone(&self.thresholds),
-                batches: Vec::new(),
-                row_ordinals: Vec::new(),
-                state: StreamState::Collecting,
-                rows_input,
-                rows_output,
-                segments_seen,
-            })
+            UnsafeSendStream::new(stream_gen, self.properties.eq_properties.schema().clone())
         };
         Ok(Box::pin(stream))
     }
@@ -265,19 +301,7 @@ impl ExecutionPlan for SegmentedTopKExec {
     }
 }
 
-enum StreamState {
-    /// Collecting input batches while updating heaps and publishing thresholds.
-    Collecting,
-    /// Emitting filtered batches from the final survivor set.
-    Emitting {
-        survivors: crate::api::HashSet<(usize, usize)>,
-        next_batch: usize,
-    },
-    Done,
-}
-
-struct SegmentedTopKStream {
-    input: SendableRecordBatchStream,
+struct SegmentedTopKState {
     sort_col_idx: usize,
     ff_index: usize,
     ffhelper: Arc<FFHelper>,
@@ -297,7 +321,6 @@ struct SegmentedTopKStream {
     /// against the per-segment cutoff, correctly retaining all rows tied at the
     /// boundary (which a bounded heap alone would arbitrarily drop).
     row_ordinals: Vec<(usize, usize, SegmentOrdinal, u64)>,
-    state: StreamState,
     rows_input: Count,
     rows_output: Count,
     /// Counts segments that had rows participating in ordinal comparison (States 0+1).
@@ -305,7 +328,7 @@ struct SegmentedTopKStream {
     segments_seen: Count,
 }
 
-impl SegmentedTopKStream {
+impl SegmentedTopKState {
     /// Update the per-segment cutoff heap with a new ordinal. The heap tracks
     /// the K best transformed ordinals to determine the boundary. Row locations
     /// are tracked separately in `row_ordinals`.
@@ -622,79 +645,5 @@ impl SegmentedTopKStream {
         }
 
         survivors
-    }
-}
-
-impl Stream for SegmentedTopKStream {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            match &mut this.state {
-                StreamState::Collecting => {
-                    match Pin::new(&mut this.input).poll_next(cx) {
-                        Poll::Ready(Some(Ok(batch))) => {
-                            this.rows_input.add(batch.num_rows());
-                            let batch_idx = this.batches.len();
-                            match this.collect_batch(&batch, batch_idx) {
-                                Ok(pass_through) => {
-                                    this.batches.push(batch);
-                                    this.maybe_compact();
-                                    if let Some(pt) = pass_through {
-                                        this.rows_output.add(pt.num_rows());
-                                        return Poll::Ready(Some(Ok(pt)));
-                                    }
-                                }
-                                Err(e) => return Poll::Ready(Some(Err(e))),
-                            }
-                        }
-                        Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
-                        Poll::Ready(None) => {
-                            // Input exhausted — build survivor set and transition.
-                            let survivors = this.build_survivors();
-                            this.state = StreamState::Emitting {
-                                survivors,
-                                next_batch: 0,
-                            };
-                        }
-                        Poll::Pending => return Poll::Pending,
-                    }
-                }
-                StreamState::Emitting {
-                    survivors,
-                    next_batch,
-                } => {
-                    while *next_batch < this.batches.len() {
-                        let batch_idx = *next_batch;
-                        *next_batch += 1;
-                        let batch = &this.batches[batch_idx];
-                        let num_rows = batch.num_rows();
-
-                        let mask: BooleanArray = (0..num_rows)
-                            .map(|row_idx| Some(survivors.contains(&(batch_idx, row_idx))))
-                            .collect();
-
-                        let filtered = filter_record_batch(batch, &mask)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-
-                        if filtered.num_rows() > 0 {
-                            this.rows_output.add(filtered.num_rows());
-                            return Poll::Ready(Some(Ok(filtered)));
-                        }
-                    }
-                    this.state = StreamState::Done;
-                    return Poll::Ready(None);
-                }
-                StreamState::Done => return Poll::Ready(None),
-            }
-        }
-    }
-}
-
-impl RecordBatchStream for SegmentedTopKStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
     }
 }

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -1,7 +1,5 @@
 use std::any::Any;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use crate::index::fast_fields_helper::{
     ords_to_bytes_array, ords_to_string_array, FFHelper, FFType,
@@ -14,12 +12,13 @@ use arrow_array::{StructArray, UInt32Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::interleave::interleave;
 use datafusion::common::{DataFusionError, Result};
-use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet, RecordOutput,
+};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use futures::Stream;
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
 
@@ -185,59 +184,67 @@ impl ExecutionPlan for TantivyLookupExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let input_stream = self.input.execute(partition, context)?;
+        let mut input_stream = self.input.execute(partition, context)?;
         let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        let decoders = self.decoders.clone();
+        let ffhelper = Arc::clone(&self.ffhelper);
+        let schema = self.properties.eq_properties.schema().clone();
+
+        let stream_gen = async_stream::try_stream! {
+            use futures::StreamExt;
+            while let Some(batch_res) = input_stream.next().await {
+                let timer = baseline_metrics.elapsed_compute().timer();
+                let result = match batch_res {
+                    Ok(batch) => enrich_batch(batch, &decoders, &ffhelper, &schema),
+                    Err(e) => Err(e),
+                };
+                timer.done();
+
+                yield result.record_output(&baseline_metrics)?;
+            }
+            baseline_metrics.done();
+        };
+
         let stream = unsafe {
-            UnsafeSendStream::new(LookupStream {
-                input: input_stream,
-                decoders: self.decoders.clone(),
-                ffhelper: Arc::clone(&self.ffhelper),
-                schema: self.properties.eq_properties.schema().clone(),
-                baseline_metrics,
-            })
+            UnsafeSendStream::new(stream_gen, self.properties.eq_properties.schema().clone())
         };
         Ok(Box::pin(stream))
     }
 }
 
-struct LookupStream {
-    input: SendableRecordBatchStream,
-    decoders: Vec<DecoderInfo>,
-    ffhelper: Arc<FFHelper>,
-    schema: SchemaRef,
-    baseline_metrics: BaselineMetrics,
-}
+fn enrich_batch(
+    batch: RecordBatch,
+    decoders: &[DecoderInfo],
+    ffhelper: &FFHelper,
+    schema: &SchemaRef,
+) -> Result<RecordBatch> {
+    let num_rows = batch.num_rows();
+    // Clone the input arrays. We will overwrite the deferred ones by exact index.
+    let mut output_columns: Vec<ArrayRef> = batch.columns().to_vec();
 
-impl LookupStream {
-    fn enrich_batch(&self, batch: RecordBatch) -> Result<RecordBatch> {
-        let num_rows = batch.num_rows();
-        // Clone the input arrays. We will overwrite the deferred ones by exact index.
-        let mut output_columns: Vec<ArrayRef> = batch.columns().to_vec();
+    for decoder in decoders {
+        let union_array = output_columns[decoder.col_idx]
+            .as_any()
+            .downcast_ref::<arrow_array::UnionArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "expected UnionArray for deferred column at index {}",
+                    decoder.col_idx
+                ))
+            })?;
 
-        for decoder in &self.decoders {
-            let union_array = output_columns[decoder.col_idx]
-                .as_any()
-                .downcast_ref::<arrow_array::UnionArray>()
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "expected UnionArray for deferred column at index {}",
-                        decoder.col_idx
-                    ))
-                })?;
-
-            // Replace the raw UnionArray with the decoded String/Binary array
-            output_columns[decoder.col_idx] = materialize_deferred_column(
-                &self.ffhelper,
-                union_array,
-                decoder.ff_index,
-                decoder.is_bytes,
-                num_rows,
-            )?;
-        }
-
-        RecordBatch::try_new(self.schema.clone(), output_columns)
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+        // Replace the raw UnionArray with the decoded String/Binary array
+        output_columns[decoder.col_idx] = materialize_deferred_column(
+            ffhelper,
+            union_array,
+            decoder.ff_index,
+            decoder.is_bytes,
+            num_rows,
+        )?;
     }
+
+    RecordBatch::try_new(schema.clone(), output_columns)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
 /// Materializes deferred union values into their original text or bytes representation.
@@ -446,26 +453,4 @@ fn materialize_deferred_column(
         segment_arrays.iter().map(|a| a.as_ref()).collect();
     interleave(&segment_arrays_refs, &indices)
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-}
-
-impl Stream for LookupStream {
-    type Item = Result<RecordBatch>;
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let poll = Pin::new(&mut self.input).poll_next(cx);
-        let final_poll = match poll {
-            Poll::Ready(Some(Ok(batch))) => {
-                let timer = self.baseline_metrics.elapsed_compute().timer();
-                let result = self.enrich_batch(batch);
-                timer.done();
-                Poll::Ready(Some(result))
-            }
-            other => other,
-        };
-        self.baseline_metrics.record_poll(final_poll)
-    }
-}
-impl RecordBatchStream for LookupStream {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
 }


### PR DESCRIPTION
## What

Port all manual `Stream` implementations to the `async-stream` crate.

## Why

The `async-stream` crate provides a much more readable macro for creating streams (with a yield keyword similar to Python's async generators). The same code is produced under the hood.

## Tests

Existing tests.