### PR TITLE
ci: parallelize Nix pg_search builds across PG versions

### DIFF
--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -29,6 +29,8 @@ jobs:
   nix-cargo-hash-check:
     name: Verify Nix Cargo Hash
     runs-on: ubuntu-latest
+    env:
+      PG_MAJOR_VERSION: "18"
 
     steps:
       - name: Checkout Git Repository
@@ -49,6 +51,7 @@ jobs:
             let
               flake = builtins.getFlake (toString ./.);
               system = builtins.currentSystem;
-            in flake.packages.${system}.pg_search-pg18.cargoDeps.drvPath
+              pkg = "pg_search-pg${builtins.getEnv "PG_MAJOR_VERSION"}";
+            in flake.packages.${system}.${pkg}.cargoDeps.drvPath
           ')
           nix build --no-link "$cargo_deps_drv"


### PR DESCRIPTION
## Summary
- simplify the workflow to a single CI test focused on Nix cargo hash drift
- run one job: evaluate and build `pg_search-pg18.cargoDeps` with Nix
- keep Determinate Nix + Magic Nix cache setup

## Why
The primary goal is to surface when Cargo dependency changes require updating the `cargoHash` in `nix/pg_search.nix`.

## Expected impact
- much faster CI than full extension builds
- still fails clearly on hash mismatch when Cargo manifests/lockfile change
