### PR TITLE
fix: Use local source for Nix package rather than fetching from GitHub

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           mkForPg =
             version:
             pkgs.callPackage ./nix/pg_search.nix {
+              inherit self;
               postgresql = pkgs."postgresql_${toString version}";
               inherit (pkgs) cargo-pgrx;
             };

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -1,13 +1,12 @@
 {
+  self,
   buildPgrxExtension,
   cargo-pgrx,
-  fetchFromGitHub,
   fetchurl,
   lib,
   nix-update-script,
   pkg-config,
   postgresql,
-  stdenv,
 }:
 
 let
@@ -59,13 +58,7 @@ in
 buildPgrxExtension (finalAttrs: {
   pname = "pg_search";
   version = rootCargoToml.workspace.package.version;
-
-  src = fetchFromGitHub {
-    owner = "paradedb";
-    repo = "paradedb";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-gvQOfyFU8SVtAJTGw0EuRatfDVZRqpv7WhIqYYZYbgc=";
-  };
+  src = self;
 
   # This hash needs to change any time the Rust dependencies are updated.
   # If maintainers forget to do so, Nix will throw an error message that begins


### PR DESCRIPTION
## What

Updates the Nix package build logic to use the local source tree to build rather than fetching the source from GitHub.

## Why

Fetching the Nix source from GitHub is necessary only in repos like Nixpkgs. It's redundant when the package source is already locally available.

## How

Update the `src` (source) for the derivation to use the local source rather than the `fetchFromGitHub` derivation.

## Tests

All Nix packages have built successfully.