### PR TITLE
chore: Upgrade to pgrx 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
  "bitflags 2.10.0",
@@ -5109,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcfb88f7fa9ba42b4ea9d1f85a1d968bbb407cc30308b35f73bdfe6c966f64b"
+checksum = "dd42eed31a68e3e6d7cec284cdaacd8ffa9b2b3ebb3f1df9ec2fd3558834c6e7"
 dependencies = [
  "bitflags 2.10.0",
  "bitvec",
@@ -5130,15 +5130,15 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
+checksum = "d30fa3688ab1cb6429ca46725eb32d5d9f186806c0f0aa6419f86e418b8a81ab"
 dependencies = [
  "bindgen",
  "cc",
  "clang-sys",
  "eyre",
- "pgrx-pg-config 0.16.1",
+ "pgrx-pg-config 0.17.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5149,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab542dd4041773874f90cd8e3448195749548dc3fb1daf501e7e11ebfb1dd22"
+checksum = "1ca7cc537daa4cc004f12ad1d31756b506358aa900251a82c3280e719da88fa4"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -5179,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff9b29df94c3f9fcb0cde220f92eea6975ed05962784a98fb557754ad663501"
+checksum = "1cd8670ad408093a83615fc68071929d7677b40021a475649a626319c464f0a3"
 dependencies = [
  "cargo_toml 0.22.3",
  "codepage",
@@ -5199,9 +5199,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934f2536953ccb6722bef2cfdfb1f8d6d3cd4a4f2c508d56ec85b649c5680c2b"
+checksum = "d9f81faae87d533b573156261b17521c0c7f66f5ca5dab2b9e6ddbf5a63dbd14"
 dependencies = [
  "cee-scape",
  "libc",
@@ -5213,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
+checksum = "4800fa91a481a83d3c1aaffd1324fcd2e587df0ed342c71d6a66d0899027e505"
 dependencies = [
  "convert_case 0.8.0",
  "eyre",
@@ -5229,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d5d5f614a32310af2cc1b9587c69e041d97e8ab812d8d31fdcd3d33d27325c"
+checksum = "3d8026b55f3782cc227b32dcd1de61163b50175c98705d888f03e7095d371c41"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -5240,7 +5240,7 @@ dependencies = [
  "paste",
  "pgrx",
  "pgrx-macros",
- "pgrx-pg-config 0.16.1",
+ "pgrx-pg-config 0.17.0",
  "postgres",
  "proptest",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
   "stemmer",
   "stopwords",
 ], default-features = false }
-pgrx = "=0.16.1"
-pgrx-tests = "=0.16.1"
+pgrx = "=0.17.0"
+pgrx-tests = "=0.17.0"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ ENV PATH="/usr/local/bin:/root/.cargo/bin:$PATH" \
 COPY Cargo.toml /tmp/
 WORKDIR /tmp/
 
-# Extract version from Cargo.toml (handles 'pgrx = "=0.16.1"')
+# Extract version from Cargo.toml (handles 'pgrx = "=0.17.0"')
 # This replaces `cargo tree` to avoid needing the full source tree
 RUN PGRX_VERSION=$(grep 'pgrx =' Cargo.toml | head -n 1 | cut -d '"' -f 2 | tr -d '=') && \
     echo "PGRX_VERSION=$PGRX_VERSION" && \

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -104,7 +104,7 @@ Then, install and initialize `pgrx`:
 
 ```bash
 # Note: Replace --pg18 with your version of Postgres, if different (i.e. --pg17, etc.)
-cargo install --locked cargo-pgrx --version 0.16.1
+cargo install --locked cargo-pgrx --version 0.17.0
 
 # macOS arm64
 cargo pgrx init --pg18=/opt/homebrew/opt/postgresql@18/bin/pg_config


### PR DESCRIPTION
## Summary
- bump workspace pgrx and pgrx-tests pins from 0.16.1 to 0.17.0
- regenerate lockfile to pull the pgrx 0.17.0 family (pgrx, pgrx-pg-sys, pgrx-tests, etc.)
- update local developer/docs references to cargo-pgrx 0.17.0

## Testing
- cargo check -p pg_search
- cargo check --workspace