### PR TITLE
fix: Remap RTIs to fix duplicate table registration in JoinScan

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -214,8 +214,15 @@ impl JoinSourceCandidate {
     }
 
     /// Returns the alias to be used for this source in the DataFusion plan.
+    ///
+    /// Always incorporates the source index to guarantee uniqueness when the
+    /// same table appears multiple times (e.g. `contact_list` in both
+    /// `IN (SELECT ...)` and `NOT IN (SELECT ...)`).
     pub fn execution_alias(&self, index: usize) -> String {
-        self.alias().unwrap_or_else(|| format!("source_{}", index))
+        match &self.alias {
+            Some(alias) => format!("{}_{}", alias, index),
+            None => format!("source_{}", index),
+        }
     }
 
     /// Check if this source contains the given RTI.
@@ -274,13 +281,13 @@ pub struct JoinSource {
 impl JoinSource {
     /// Returns the alias to be used for this source in the DataFusion plan.
     ///
-    /// If the source has an explicit alias (from SQL), it is used.
-    /// Otherwise, a synthetic alias `source_{index}` is generated based on its position.
+    /// Always incorporates the source index to guarantee uniqueness when the
+    /// same table appears multiple times in a query.
     pub fn execution_alias(&self, index: usize) -> String {
-        self.scan_info
-            .alias
-            .clone()
-            .unwrap_or_else(|| format!("source_{}", index))
+        match &self.scan_info.alias {
+            Some(alias) => format!("{}_{}", alias, index),
+            None => format!("source_{}", index),
+        }
     }
 
     /// Check if this source contains the given RTI.
@@ -474,7 +481,14 @@ impl RelNode {
         match self {
             RelNode::Scan(_) => {}
             RelNode::Join(j) => {
-                if !matches!(j.join_type, JoinType::Inner | JoinType::Semi) {
+                if !matches!(
+                    j.join_type,
+                    JoinType::Inner
+                        | JoinType::Semi
+                        | JoinType::RightSemi
+                        | JoinType::UniqueOuter
+                        | JoinType::UniqueInner
+                ) {
                     acc.push(j.join_type);
                 }
                 j.left.collect_unsupported_join_types(acc);
@@ -489,6 +503,26 @@ impl RelNode {
             RelNode::Scan(s) => s.scan_info.heap_rti == rti,
             RelNode::Join(j) => j.left.contains_rti(rti) || j.right.contains_rti(rti),
             RelNode::Filter(f) => f.input.contains_rti(rti),
+        }
+    }
+
+    /// Remaps all RTIs in this subtree by applying the given offset.
+    /// Used to avoid RTI collisions when SubPlan inner queries have locally-scoped
+    /// RTIs that may collide with the outer query's RTIs.
+    pub fn remap_rtis(&mut self, offset: pg_sys::Index) {
+        match self {
+            RelNode::Scan(s) => {
+                s.scan_info.heap_rti += offset;
+            }
+            RelNode::Join(j) => {
+                j.left.remap_rtis(offset);
+                j.right.remap_rtis(offset);
+                for key in &mut j.equi_keys {
+                    key.outer_rti += offset;
+                    key.inner_rti += offset;
+                }
+            }
+            RelNode::Filter(f) => f.input.remap_rtis(offset),
         }
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -475,7 +475,7 @@ impl CustomScan for JoinScan {
             if !unsupported.is_empty() {
                 if is_interesting {
                     Self::add_detailed_planner_warning(
-                        "JoinScan not used: only INNER and SEMI JOIN are currently supported",
+                        "JoinScan not used: unsupported join type",
                         &aliases,
                         unsupported
                             .iter()

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -284,6 +284,12 @@ unsafe fn collect_join_sources_base_rel(
     let mut current_node = RelNode::Scan(Box::new(source));
     let mut all_keys = Vec::new();
 
+    // Use the outer query's simple_rel_array_size as a base offset for inner RTIs.
+    // Each extracted subquery gets a larger offset to avoid collisions between
+    // the outer query RTIs and between multiple subqueries.
+    let outer_rti_count = (*root).simple_rel_array_size as pg_sys::Index;
+    let mut rti_offset_base = outer_rti_count;
+
     // Wrap current_node in Join nodes for each extracted subquery
     for (subplan, is_anti, inner_root) in extracted_subqueries {
         // Find the final rel for the inner subquery
@@ -292,12 +298,23 @@ unsafe fn collect_join_sources_base_rel(
             continue; // Can't resolve inner relation, maybe log or skip
         }
 
-        let Some((inner_node, inner_keys)) = collect_join_sources(inner_root, inner_rel) else {
+        let Some((mut inner_node, inner_keys)) = collect_join_sources(inner_root, inner_rel) else {
             continue;
         };
 
-        // Recursively collect join sources for the inner subquery
-        all_keys.extend(inner_keys);
+        // Remap inner RTIs to avoid collisions with outer query RTIs.
+        // SubPlan inner queries have locally-scoped RTIs starting from 1,
+        // which can collide with the outer query's RTIs.
+        let inner_rti_count = (*inner_root).simple_rel_array_size as pg_sys::Index;
+        inner_node.remap_rtis(rti_offset_base);
+
+        // Also remap the inner keys
+        let mut remapped_inner_keys = inner_keys;
+        for key in &mut remapped_inner_keys {
+            key.outer_rti += rti_offset_base;
+            key.inner_rti += rti_offset_base;
+        }
+        all_keys.extend(remapped_inner_keys);
 
         let equi_keys = extract_equi_keys_from_subplan(subplan, &current_node, &inner_node);
 
@@ -315,6 +332,9 @@ unsafe fn collect_join_sources_base_rel(
 
         all_keys.extend(equi_keys);
         current_node = RelNode::Join(Box::new(join_node));
+
+        // Advance the offset for the next subquery
+        rti_offset_base += inner_rti_count;
     }
 
     Some((current_node, all_keys))

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -233,14 +233,19 @@ fn build_relnode_df<'a>(
     let f = async move {
         match node {
             RelNode::Scan(source) => {
-                let is_parallel = source.scan_info.heap_rti == partitioning_rti;
-                let mut df = build_source_df(ctx, source, join_clause, is_parallel).await?;
-
                 let plan_sources = join_clause.plan.sources();
+                // Use pointer identity to find the source index, not heap_rti.
+                // SubPlan extraction can produce sources with locally-scoped RTIs
+                // that collide with outer query RTIs (e.g., both get RTI=1).
+                let source_ptr = &**source as *const JoinSource;
                 let source_idx = plan_sources
                     .iter()
-                    .position(|s| s.scan_info.heap_rti == source.scan_info.heap_rti)
+                    .position(|s| std::ptr::eq(*s, source_ptr))
                     .unwrap();
+                let is_parallel = source.scan_info.heap_rti == partitioning_rti;
+                let mut df =
+                    build_source_df(ctx, source, source_idx, join_clause, is_parallel).await?;
+
                 let alias = source.execution_alias(source_idx);
                 df = df.alias(&alias)?;
                 Ok(df)
@@ -323,8 +328,9 @@ fn build_relnode_df<'a>(
                     crate::postgres::customscan::joinscan::build::JoinType::RightAnti => {
                         JoinType::RightAnti
                     }
-                    unsupported => {
-                        panic!("Join type {} is unsupported during execution", unsupported)
+                    crate::postgres::customscan::joinscan::build::JoinType::UniqueOuter
+                    | crate::postgres::customscan::joinscan::build::JoinType::UniqueInner => {
+                        JoinType::Inner
                     }
                 };
 
@@ -526,21 +532,27 @@ fn build_clause_df<'a>(
                 final_cols.push(expr.alias(col_alias));
             }
 
-            // ALWAYS carry forward all CTID columns from both sides
+            // ALWAYS carry forward all CTID columns from both sides.
+            // Deduplicate by ctid name because SubPlan extraction can produce
+            // sources with locally-scoped RTIs that collide with outer RTIs.
+            let mut seen_ctids = crate::api::HashSet::<String>::default();
             let mut base_relations = Vec::new();
             join_clause.collect_base_relations(&mut base_relations);
             for base in base_relations {
                 let rti = base.heap_rti;
                 let ctid_name = format!("ctid_{}", rti);
-                // Check if it already exists in df schema (it should)
-                if df.schema().field_with_unqualified_name(&ctid_name).is_ok() {
-                    // Carry it.
+                if df.schema().field_with_unqualified_name(&ctid_name).is_ok()
+                    && seen_ctids.insert(ctid_name.clone())
+                {
                     final_cols.push(col(&ctid_name));
                 }
             }
         } else {
+            let mut seen = crate::api::HashSet::<&str>::default();
             for field in df.schema().fields() {
-                final_cols.push(col(field.name()));
+                if seen.insert(field.name()) {
+                    final_cols.push(col(field.name()));
+                }
             }
         }
 
@@ -590,13 +602,16 @@ fn build_projection_expr(
 fn build_source_df<'a>(
     ctx: &'a SessionContext,
     source: &'a JoinSource,
+    source_idx: usize,
     join_clause: &'a JoinCSClause,
     is_parallel: bool,
 ) -> LocalBoxFuture<'a, Result<DataFrame>> {
     async move {
         let scan_info = source.scan_info.clone();
-        let source_alias = source.scan_info.alias.clone();
-        let alias = source_alias.as_deref().unwrap_or("base");
+        // Use the unique execution alias as the registration name to avoid
+        // collisions when the same table appears multiple times (e.g. contact_list
+        // in both IN and NOT IN subqueries).
+        let reg_name = source.execution_alias(source_idx);
         let fields: Vec<WhichFastField> = source
             .scan_info
             .fields
@@ -627,25 +642,34 @@ fn build_source_df<'a>(
         provider.try_enable_late_materialization(&required_early);
 
         let provider = Arc::new(provider);
-        ctx.register_table(alias, provider)?;
+        ctx.register_table(&reg_name, provider)?;
 
-        let mut df = ctx.table(alias).await?;
+        let mut df = ctx.table(&reg_name).await?;
 
-        // Select fields AND ensure CTID is aliased uniquely
+        // Select fields AND ensure CTID is aliased uniquely.
+        // Track seen expression names to skip duplicates — the same column name
+        // can appear more than once in the schema (e.g. system and user ctid).
         let mut exprs = Vec::new();
+        let mut seen_names = crate::api::HashSet::<String>::default();
         for df_field in df.schema().fields().iter() {
             let name = df_field.name();
             // NOTE: Matching on WhichFastField::Ctid specifically will fail if
             // the field list order doesn't match the DataFrame schema field order.
-            let expr = match fields.iter().find(|w| w.name() == *name) {
+            let (expr, expr_name) = match fields.iter().find(|w| w.name() == *name) {
                 Some(WhichFastField::Ctid) => {
-                    make_col(alias, name).alias(format!("ctid_{}", scan_info.heap_rti))
+                    let alias = format!("ctid_{}", scan_info.heap_rti);
+                    (make_col(&reg_name, name).alias(&alias), alias)
                 }
-                Some(WhichFastField::Score) => make_col(alias, name).alias(SCORE_COL_NAME),
-                _ => make_col(alias, name),
+                Some(WhichFastField::Score) => (
+                    make_col(&reg_name, name).alias(SCORE_COL_NAME),
+                    SCORE_COL_NAME.to_string(),
+                ),
+                _ => (make_col(&reg_name, name), name.to_string()),
             };
 
-            exprs.push(expr);
+            if seen_names.insert(expr_name) {
+                exprs.push(expr);
+            }
         }
         df = df.select(exprs)?;
 

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -58,24 +58,25 @@ WHERE id IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.00..11.00 rows=10 width=40)
    ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=10 width=40)
-         Relation Tree: table_a SEMI table_b
-         Join Cond: table_a.id = table_b.a_id
+         Relation Tree: table_b UNIQUEOUTER table_a
+         Join Cond: table_a_1.id = table_b_0.a_id
          Limit: 10
          Order By: table_a.id asc
          DataFusion Physical Plan: 
-           : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_1@0 as ctid_1]
-           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
-           :     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(a_id@0, id@1)]
-           :       CooperativeExec
-           :         PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1","is_datetime":false}}
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_3@0 as ctid_3, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(a_id@1, id@1)], projection=[ctid_3@0, ctid_1@2, id@3]
+           :       ProjectionExec: expr=[ctid@0 as ctid_3, a_id@1 as a_id]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1","is_datetime":false}}
            :       ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
-(15 rows)
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
 
 -- =====================================================================
 -- 2. Anti Join Only
@@ -125,7 +126,7 @@ AND id NOT IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER and SEMI JOIN are currently supported (types: ANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
+WARNING:  JoinScan not used: unsupported join type (type: ANTI) (tables: table_a_0, table_a_1, table_b_0, table_b_1, table_b_2)
  id  |    category     
 -----+-----------------
   10 | target_category
@@ -139,6 +140,51 @@ WARNING:  JoinScan not used: only INNER and SEMI JOIN are currently supported (t
   90 | target_category
  100 | target_category
 (10 rows)
+
+-- =====================================================================
+-- 4. Two Semi Joins on the same table (RTI collision repro)
+-- =====================================================================
+EXPLAIN (COSTS OFF)
+SELECT id, category
+FROM table_a
+WHERE id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_1'))
+AND id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_2'))
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: table_b UNIQUEOUTER (table_a SEMI table_b)
+         Join Cond: table_a_1.id = table_b_0.a_id, table_a_1.id = table_b_2.a_id
+         Limit: 10
+         Order By: table_a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_4@0 as ctid_4, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(a_id@1, id@1)], projection=[ctid_4@0, ctid_1@2, id@3]
+           :       ProjectionExec: expr=[ctid@0 as ctid_4, a_id@1 as a_id]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1","is_datetime":false}}
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, a_id@0)]
+           :         ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_2","is_datetime":false}}
+(19 rows)
+
+SELECT id, category
+FROM table_a
+WHERE id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_1'))
+AND id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_2'))
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
+ id | category 
+----+----------
+(0 rows)
 
 -- Cleanup
 DROP TABLE table_a CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti.sql
@@ -104,6 +104,26 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 
+-- =====================================================================
+-- 4. Two Semi Joins on the same table (RTI collision repro)
+-- =====================================================================
+EXPLAIN (COSTS OFF)
+SELECT id, category
+FROM table_a
+WHERE id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_1'))
+AND id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_2'))
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
+
+SELECT id, category
+FROM table_a
+WHERE id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_1'))
+AND id IN (SELECT a_id FROM table_b WHERE group_id IN ('group_2'))
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
+
 -- Cleanup
 DROP TABLE table_a CASCADE;
 DROP TABLE table_b CASCADE;


### PR DESCRIPTION
## Summary
- When the same table appears in multiple `IN`/`NOT IN` subqueries, inner queries have locally-scoped RTIs starting from 1 that collide with outer query RTIs, causing DataFusion table registration failures
- Always include source index in execution aliases to guarantee uniqueness
- Add `remap_rtis()` method to offset inner query RTIs by the outer query's array size
- Use pointer identity instead of RTI-based lookup for source index resolution
- Deduplicate CTID columns and schema fields to handle remapped RTI collisions
- Use unique registration names for DataFusion table providers

## Test plan
- [x] Added pg_regress test case 4: two `IN` subqueries on the same table (RTI collision repro)
- [x] `cargo pgrx regress pg18 join_semi_anti` passes
- [ ] CI passes