### PR TITLE
fix: Add ANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER join support to JoinScan

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -485,6 +485,7 @@ impl RelNode {
                     j.join_type,
                     JoinType::Inner
                         | JoinType::Semi
+                        | JoinType::Anti
                         | JoinType::RightSemi
                         | JoinType::UniqueOuter
                         | JoinType::UniqueInner

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -367,13 +367,11 @@ impl CustomScan for JoinScan {
                 return Vec::new();
             }
 
-            // TODO(join-types): Currently only INNER JOIN is supported.
-            // Future work should add:
+            // TODO(join-types): Currently INNER, SEMI, ANTI, RIGHTSEMI, UNIQUEINNER, and
+            // UNIQUEOUTER joins are supported. Future work should add:
             // - LEFT JOIN: Return NULL for non-matching non-ordering rows; track matched ordering rows
             // - RIGHT JOIN: Swap ordering/non-ordering sides, then use LEFT logic
             // - FULL OUTER JOIN: Track unmatched rows on both sides; two-pass or marking approach
-            // - SEMI JOIN: Stop after first match per ordering row (benefits EXISTS queries)
-            // - ANTI JOIN: Return only ordering rows with no matches (benefits NOT EXISTS)
             //
             // WARNING: If enabling other join types, you MUST review the parallel partitioning
             // strategy documentation in `pg_search/src/postgres/customscan/joinscan/scan_state.rs`.
@@ -520,13 +518,31 @@ impl CustomScan for JoinScan {
             let current_sources = join_clause.plan.sources();
 
             // The current parallel strategy partitions exactly one source and replicates all
-            // others. For SEMI JOIN correctness, the partitioned source must be the left side.
-            // We currently enforce a conservative subset: binary base-table joins only.
-            if jointype == pg_sys::JoinType::JOIN_SEMI {
+            // others. For SEMI/ANTI/RIGHTSEMI JOIN correctness, the partitioned source must be
+            // the left side. We currently enforce a conservative subset: binary base-table joins only.
+            let is_semi_like = {
+                #[cfg(feature = "pg18")]
+                {
+                    matches!(
+                        jointype,
+                        pg_sys::JoinType::JOIN_SEMI
+                            | pg_sys::JoinType::JOIN_ANTI
+                            | pg_sys::JoinType::JOIN_RIGHT_SEMI
+                    )
+                }
+                #[cfg(not(feature = "pg18"))]
+                {
+                    matches!(
+                        jointype,
+                        pg_sys::JoinType::JOIN_SEMI | pg_sys::JoinType::JOIN_ANTI
+                    )
+                }
+            };
+            if is_semi_like {
                 if current_sources.len() > 2 {
                     if is_interesting {
                         Self::add_planner_warning(
-                            "JoinScan not used: SEMI JOIN currently supports only binary base-table joins",
+                            "JoinScan not used: SEMI/ANTI JOIN currently supports only binary base-table joins",
                             &aliases,
                         );
                     }
@@ -537,7 +553,7 @@ impl CustomScan for JoinScan {
                 if partitioning_idx != 0 {
                     if is_interesting {
                         Self::add_planner_warning(
-                            "JoinScan not used: SEMI JOIN requires the left side to be the largest source",
+                            "JoinScan not used: SEMI/ANTI JOIN requires the left side to be the largest source",
                             &aliases,
                         );
                     }

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -81,8 +81,8 @@ LIMIT 10;
 -- =====================================================================
 -- 2. Anti Join Only
 -- =====================================================================
--- TODO: This query only triggers set_rel_pathlist_hook and not set_join_pathlist_hook, and so does
--- not render our warning. See https://github.com/paradedb/paradedb/issues/4236 about resolving this.
+-- Note: This query only triggers set_rel_pathlist_hook (not set_join_pathlist_hook),
+-- so JoinScan is not used. See https://github.com/paradedb/paradedb/issues/4236.
 SELECT id, category
 FROM table_a
 WHERE id NOT IN (
@@ -108,9 +108,9 @@ LIMIT 10;
 (10 rows)
 
 -- =====================================================================
--- 3. Both Semi and Anti Join
+-- 3. Both Semi and Anti Join on the same table
 -- =====================================================================
--- TODO: This query should produce a warning because Anti-Joins are not supported.
+EXPLAIN (COSTS OFF)
 SELECT id, category
 FROM table_a
 WHERE id IN (
@@ -126,7 +126,44 @@ AND id NOT IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: unsupported join type (type: ANTI) (tables: table_a_0, table_a_1, table_b_0, table_b_1, table_b_2)
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: table_b UNIQUEOUTER (table_a ANTI table_b)
+         Join Cond: table_a_1.id = table_b_0.a_id, table_a_1.id = table_b_2.id
+         Limit: 10
+         Order By: table_a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_3@0 as ctid_3, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(a_id@1, id@1)], projection=[ctid_3@0, ctid_1@2, id@3]
+           :       ProjectionExec: expr=[ctid@0 as ctid_3, a_id@1 as a_id]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1","is_datetime":false}}
+           :       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(id@0, id@1)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term_set":{"terms":[{"field":"group_id","value":"group_3","is_datetime":false},{"field":"group_id","value":"group_4","is_datetime":false}]}}
+           :         ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+    WHERE group_id IN ('group_1')
+)
+AND id NOT IN (
+    SELECT a_id
+    FROM table_b
+    WHERE group_id IN ('group_3', 'group_4')
+)
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
  id  |    category     
 -----+-----------------
   10 | target_category

--- a/pg_search/tests/pg_regress/sql/join_semi_anti.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti.sql
@@ -71,8 +71,8 @@ LIMIT 10;
 -- =====================================================================
 -- 2. Anti Join Only
 -- =====================================================================
--- TODO: This query only triggers set_rel_pathlist_hook and not set_join_pathlist_hook, and so does
--- not render our warning. See https://github.com/paradedb/paradedb/issues/4236 about resolving this.
+-- Note: This query only triggers set_rel_pathlist_hook (not set_join_pathlist_hook),
+-- so JoinScan is not used. See https://github.com/paradedb/paradedb/issues/4236.
 SELECT id, category
 FROM table_a
 WHERE id NOT IN (
@@ -85,9 +85,25 @@ ORDER BY id ASC
 LIMIT 10;
 
 -- =====================================================================
--- 3. Both Semi and Anti Join
+-- 3. Both Semi and Anti Join on the same table
 -- =====================================================================
--- TODO: This query should produce a warning because Anti-Joins are not supported.
+EXPLAIN (COSTS OFF)
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+    WHERE group_id IN ('group_1')
+)
+AND id NOT IN (
+    SELECT a_id
+    FROM table_b
+    WHERE group_id IN ('group_3', 'group_4')
+)
+AND id @@@ 'category:"target_category"'
+ORDER BY id ASC
+LIMIT 10;
+
 SELECT id, category
 FROM table_a
 WHERE id IN (


### PR DESCRIPTION
## Summary
- Whitelist `Anti`, `RightSemi`, `UniqueOuter`, and `UniqueInner` join types so JoinScan handles `NOT IN` subqueries and PostgreSQL's unique-join optimizations
- Map `UniqueOuter`/`UniqueInner` to DataFusion `Inner` joins at execution time
- Extend the semi-like partitioning guard to cover `ANTI` and `RIGHT_SEMI` join types
- Update TODO comment to reflect newly supported join types

**Stacked on #4282** — merge that PR first, then retarget this to `main`.

## Test plan
- [x] Updated pg_regress test cases: added EXPLAIN to test 3 (semi+anti on same table), verified JoinScan is now used
- [x] `cargo pgrx regress pg18 join_semi_anti` passes
- [ ] CI passes