### PR TITLE
ci: Restore `--runs 10` to benchmark queries

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -38,7 +38,7 @@ runs:
           echo "Unknown dataset!"
           exit 1
         fi
-        cargo run -- --url postgresql://localhost:288${{ env.pg_version }}/postgres --rows ${NUM_ROWS} --type pg_search --dataset ${{ inputs.dataset }} --output json
+        cargo run -- --url postgresql://localhost:288${{ env.pg_version }}/postgres --rows ${NUM_ROWS} --type pg_search --dataset ${{ inputs.dataset }} --runs 10 --output json
 
         # Format row count for display (e.g., 100000 -> 100K, 1000000 -> 1M)
         if [ ${NUM_ROWS} -ge 1000000000 ]; then


### PR DESCRIPTION
## Summary
- Restores the `--runs 10` flag to the benchmark queries action, which was accidentally removed in #4240
- Without this flag, benchmarks only execute once per query, making results less stable