### PR TITLE
feat: Add Postgres-version-specific Nix development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ node_modules/
 
 # Nix artifacts
 result*
+.pg/
 
 # Cursor
 .cursor/

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       # A helper for providing system-specific attributes
       forEachSupportedSystem =
         f:
-        inputs.nixpkgs.lib.genAttrs supportedSystems (
+        lib.genAttrs supportedSystems (
           system:
           f {
             inherit system;
@@ -46,6 +46,14 @@
             };
           }
         );
+
+      # The PostgreSQL versions supported for pg_search (see ./pg_search/Cargo.toml)
+      supportedPgVersions = [
+        15
+        16
+        17
+        18
+      ];
     in
     {
       # Package outputs
@@ -56,14 +64,6 @@
       packages = forEachSupportedSystem (
         { pkgs, system }:
         let
-          # The PostgreSQL versions supported for pg_search (see ./pg_search/Cargo.toml)
-          supportedPgVersions = [
-            15
-            16
-            17
-            18
-          ];
-
           # A helper function for building Postgres-version-specific
           # variants of pg_search
           mkForPg =
@@ -104,7 +104,7 @@
               self.formatter.${system}
 
               # Adds PostgreSQL related tools to the environment (pg_ctl, psql, etc)
-              postgresql
+              postgresql_18
 
               # Makefile tools
               postgresql.pg_config
@@ -119,6 +119,31 @@
             shellHook = "";
           };
         }
+        # These development environments enable you to spin up a
+        # local Postgres 15 through 18 with the version-appropriate
+        # pg_search extension installed.
+
+        # Activate the environment from this repo: nix develop .#pg{version}
+        # Example: nix develop .#pg18
+        # Start Postgres: start-pg
+        # Connect to Postgres: psql
+
+        # To activate this environment outside of this repo:
+        # nix develop github:paradedb/paradedb#pg{version}
+        # Example:
+        # nix develop github:paradedb/paradedb#pg18
+
+        // (builtins.listToAttrs (
+          map (v: {
+            name = "pg${toString v}";
+            value = import ./nix/env.nix {
+              inherit pkgs;
+              postgresql = pkgs."postgresql_${toString v}";
+              pgVersion = v;
+              pg_search = self.packages.${system}."pg_search-pg${toString v}";
+            };
+          }) supportedPgVersions
+        ))
       );
 
       # Nix formatter

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  pgVersion,
+  postgresql,
+  pg_search,
+}:
+
+pkgs.mkShellNoCC {
+  packages = [
+    (postgresql.withPackages (_: [
+      pg_search
+    ]))
+  ];
+
+  shellHook = ''
+    export PGDATA="$PWD/.pg/v${toString pgVersion}"
+    export PGHOST="$PGDATA"
+    export PGDATABASE="postgres"
+
+    start-pg() {
+      if [ ! -d "$PGDATA" ]; then
+        initdb --no-locale --encoding=UTF8 > /dev/null 2>&1
+      fi
+
+      pg_ctl start -l "$PGDATA/log" -o "-k $PGHOST -h '''"
+      psql --command "CREATE EXTENSION IF NOT EXISTS pg_search;"
+    }
+
+    seed-pg() {
+      psql --command "${builtins.readFile ./sql/setup.sql}"
+    }
+
+    stop-pg() {
+      pg_ctl stop
+    }
+
+    echo "Development environment for pg_search on PostgreSQL ${toString pgVersion} 🚀"
+    echo "Created PostgreSQL database \"$PGDATABASE\" and data directory at $PGDATA ✅"
+    echo "Available commands:"
+    echo "    start-pg    Start up PostgreSQL with the pg_search extension already created"
+    echo "    seed-pg     Seed Postgres with the setup data from the pg_search quickstart tutorial"
+    echo "    stop-pg     Stop the running Postgres instance"
+  '';
+}

--- a/nix/sql/setup.sql
+++ b/nix/sql/setup.sql
@@ -1,0 +1,8 @@
+CALL paradedb.create_bm25_test_table(
+    schema_name => 'public',
+    table_name => 'mock_items'
+);
+
+CREATE INDEX IF NOT EXISTS search_idx ON mock_items
+USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+WITH (key_field='id');


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What

Adds Nix development environments in which you can easily spin up specific versions of Postgres with `pg_search` available (versions 15 through 18). An example set of commands:

```shell
nix develop ".#pg18" # enter the dev environment for Postgres 18
start-pg # Start Postgres with pg_search already loaded
seed-pg # Create the example table and index in the quickstart
psql -c "SELECT * FROM mock_items;" # now do whatever you want
```

Or you can run a dev environment outside the repo:

```shell
nix develop github:paradedb/paradedb#pg18 # or another version
```

## Why

Provides a new way for Nix users (and potentially people who don't use Nix yet!) to experiment with `pg_search`.

## How

Added some additional Nix expressions that should be relatively intuitive.

## Tests

I've tried out all of the version-specific dev environments locally and all have worked as expected.
