### PR TITLE
feat: Use Tantivy commit which uses flat arrays for BlockwiseLinear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7231,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7286,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "bitpacking",
 ]
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7354,7 +7354,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7367,7 +7367,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=6338e83a36f947d37aaa602cc57b253ec1c5d652#6338e83a36f947d37aaa602cc57b253ec1c5d652"
+source = "git+https://github.com/paradedb/tantivy.git?rev=d67a96b703acfd33a6fc4274c79b8a1b91cace59#d67a96b703acfd33a6fc4274c79b8a1b91cace59"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "6338e83a36f947d37aaa602cc57b253ec1c5d652", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d67a96b703acfd33a6fc4274c79b8a1b91cace59", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.17.0"
 tantivy-jieba = "0.17.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "6338e83a36f947d37aaa602cc57b253ec1c5d652" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d67a96b703acfd33a6fc4274c79b8a1b91cace59" }


### PR DESCRIPTION
From Tantivy PR:

> Refactor BlockwiseLinearReader to use flat arrays for better cache locality Replace the interleaved BlockWithData struct (Block + FileSlice + OnceLock per block, ~104B each) with separate compact arrays: Arc<[Line]>, Arc<[BitUnpacker]>, and Arc<[(FileSlice, OnceLock<OwnedBytes>)]>.
> 
> This improves CPU cache utilization in get_val() by keeping frequently accessed metadata (lines, bit_unpackers) together in memory rather than interleaved with FileSlice and OnceLock data.
> 