### PR TITLE
chore: replace Slack invite link with paradedb.com/slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/paradedb/paradedb/discussions
     about: Please ask and answer general questions here.
   - name: ParadeDB Community Slack
-    url: https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw
+    url: https://paradedb.com/slack
     about: Our Slack community is the best place to get quick help and feedback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! We're excited that you're interested in contributing to ParadeDB and wa
 
 ## Technical Info
 
-Before submitting a pull request, please review this document, which outlines what conventions to follow when submitting changes. If you have any questions not covered in this document, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw) or via [email](mailto:support@paradedb.com).
+Before submitting a pull request, please review this document, which outlines what conventions to follow when submitting changes. If you have any questions not covered in this document, please reach out to us in the [ParadeDB Community Slack](https://paradedb.com/slack) or via [email](mailto:support@paradedb.com).
 
 ### Selecting GitHub Issues
 
@@ -24,7 +24,7 @@ from a maintainer to pick an issue.
 
 2. To claim an unassigned issue, comment `/take` on the issue. This will automatically assign the issue to you.
 
-If you find yourself unable to make progress, don't hesitate to seek help in the issue comments or the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw). If you no longer wish to
+If you find yourself unable to make progress, don't hesitate to seek help in the issue comments or the [ParadeDB Community Slack](https://paradedb.com/slack). If you no longer wish to
 work on the issue(s) you self-assigned, please use the `unassign me` link at the top of the issue(s) page to release it.
 
 ### Development Workflow
@@ -85,7 +85,7 @@ In order for us, ParadeDB, Inc., to accept patches and other contributions from 
 
 ParadeDB uses a tool called CLA Assistant to help us track contributors' CLA status. CLA Assistant will post a comment to your pull request indicating whether you have signed the CLA. If you have not signed the CLA, you must do so before we can accept your contribution. Signing the CLA is a one-time process, is valid for all future contributions to ParadeDB, and can be done in under a minute by signing in with your GitHub account.
 
-If you have any questions about the CLA, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw) or via email at [legal@paradedb.com](mailto:legal@paradedb.com).
+If you have any questions about the CLA, please reach out to us in the [ParadeDB Community Slack](https://paradedb.com/slack) or via email at [legal@paradedb.com](mailto:legal@paradedb.com).
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
   <a href="https://docs.paradedb.com">Docs</a> &bull;
-  <a href="https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw">Community</a> &bull;
+  <a href="https://paradedb.com/slack">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
   <a href="https://docs.paradedb.com/changelog/">Changelog</a>
 </h3>
@@ -22,7 +22,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/paradedb/paradedb)](https://hub.docker.com/r/paradedb/paradedb)
 [![License](https://img.shields.io/github/license/paradedb/paradedb?color=blue)](https://github.com/paradedb/paradedb?tab=AGPL-3.0-1-ov-file#readme)
 [![Codecov](https://codecov.io/gh/paradedb/paradedb/branch/main/graph/badge.svg)](https://codecov.io/gh/paradedb/paradedb)
-[![Slack URL](https://img.shields.io/badge/Join%20Slack-purple?logo=slack&link=https%3A%2F%2Fjoin.slack.com%2Ft%2Fparadedbcommunity%2Fshared_invite%2Fzt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw)](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw)
+[![Slack URL](https://img.shields.io/badge/Join%20Slack-purple?logo=slack&link=https%3A%2F%2Fparadedb.com%2Fslack)](https://paradedb.com/slack)
 [![X URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Ftwitter.com%2Fparadedb&label=Follow%20%40paradedb)](https://x.com/paradedb)
 
 [ParadeDB](https://paradedb.com) is a modern Elasticsearch alternative built on Postgres. Built for real-time, update-heavy workloads.
@@ -98,7 +98,7 @@ If you're missing a feature or have found a bug, please open a
 
 To get community support, you can:
 
-- Post a question in the [ParadeDB Slack Community](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw)
+- Post a question in the [ParadeDB Slack Community](https://paradedb.com/slack)
 - Ask for help on our [GitHub Discussions](https://github.com/paradedb/paradedb/discussions)
 
 If you need commercial support, please [contact the ParadeDB team](mailto:sales@paradedb.com).
@@ -107,7 +107,7 @@ If you need commercial support, please [contact the ParadeDB team](mailto:sales@
 
 We welcome community contributions, big or small, and are here to guide you along
 the way. To get started contributing, check our [first timer issues](https://github.com/paradedb/paradedb/labels/good%20first%20issue)
-or message us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw). Once you contribute, ping us in Slack and we'll send you some ParadeDB swag!
+or message us in the [ParadeDB Community Slack](https://paradedb.com/slack). Once you contribute, ping us in Slack and we'll send you some ParadeDB swag!
 
 For more information on how to contribute, please see our
 [Contributing Guide](/CONTRIBUTING.md).

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -204,4 +204,4 @@ When using ParadeDB with Citus:
 - **Search queries** execute in parallel across shards and results are merged by the coordinator
 - **Distribution column** should be chosen based on your query patterns to minimize cross-shard operations
 
-For more guidance on optimizing distributed search workloads, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw) or via [email](mailto:support@paradedb.com).
+For more guidance on optimizing distributed search workloads, please reach out to us in the [ParadeDB Community Slack](https://paradedb.com/slack) or via [email](mailto:support@paradedb.com).

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -40,7 +40,7 @@ ParadeDB has been tested with and supports the following popular extensions:
 <Note>
   If you encounter any issues with extension compatibility, please [open an
   issue](https://github.com/paradedb/paradedb/issues) or reach out to our
-  [community](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw).
+  [community](https://paradedb.com/slack).
 </Note>
 
 ## Installing Third Party Extensions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -450,7 +450,7 @@
     "links": [
       {
         "label": "Community",
-        "href": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw"
+        "href": "https://paradedb.com/slack"
       },
       {
         "label": "Blog",
@@ -499,7 +499,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/paradedb/paradedb",
-      "slack": "https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw",
+      "slack": "https://paradedb.com/slack",
       "twitter": "https://twitter.com/paradedb"
     }
   },

--- a/docs/welcome/support.mdx
+++ b/docs/welcome/support.mdx
@@ -5,7 +5,7 @@ canonical: https://docs.paradedb.com/welcome/support
 ---
 
 For questions regarding enterprise support or commercial licensing, please [contact sales](mailto:sales@paradedb.com).
-For community support and general questions, please join the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw).
+For community support and general questions, please join the [ParadeDB Community Slack](https://paradedb.com/slack).
 
 ## Ask a Question
 


### PR DESCRIPTION
## Summary
- Replace long Slack invite URL (`join.slack.com/...`) with `https://paradedb.com/slack` redirect across all files
- Updated: README.md, CONTRIBUTING.md, docs (support, citus, third-party-extensions, docs.json), and issue template config

## Test plan
- [x] Verify `https://paradedb.com/slack` redirects to the Slack invite page