### PR TITLE
chore: use upstream github-action-benchmark instead of paradedb fork

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -64,7 +64,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Benchmark Metrics
-      uses: paradedb/github-action-benchmark@paradedb-v1
+      uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search '${{ inputs.dataset }}' (${{ env.ROWS_LABEL }} rows)"
         ref: ${{ inputs.ref }}

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -109,7 +109,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish TPS Metrics
-      uses: paradedb/github-action-benchmark@paradedb-v1
+      uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
         ref: ${{ inputs.ref }}
@@ -137,7 +137,7 @@ runs:
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Other Metrics
-      uses: paradedb/github-action-benchmark@paradedb-v1
+      uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Summary
- Replaced `paradedb/github-action-benchmark@paradedb-v1` with `benchmark-action/github-action-benchmark@v1` in benchmark actions
- Affects `benchmark-queries` and `benchmark-stressgres` actions (3 references total)

## Test plan
- [x] Verify benchmark workflows run successfully with the upstream action