### PR TITLE
fix: update Cargo hash for Nix package and fix CI issues

### DIFF
--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -47,11 +47,4 @@ jobs:
       # compiling pg_search for every Postgres variant.
       - name: Verify Nix Cargo Hash
         run: |
-          cargo_deps_drv=$(nix eval --raw --impure --expr '
-            let
-              flake = builtins.getFlake (toString ./.);
-              system = builtins.currentSystem;
-              pkg = "pg_search-pg${builtins.getEnv "PG_MAJOR_VERSION"}";
-            in flake.packages.${system}.${pkg}.cargoDeps.drvPath
-          ')
-          nix build --no-link "$cargo_deps_drv"
+          nix build --no-link ".#pg_search-pg${{ env.PG_MAJOR_VERSION }}.cargoDeps"

--- a/flake.lock
+++ b/flake.lock
@@ -22,12 +22,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
-        "revCount": 948083,
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "revCount": 960399,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.948083%2Brev-0182a361324364ae3f436a63005877674cf45efb/019c71f3-061e-7c0e-b75b-ea375738503a/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.960399%2Brev-9dcb002ca1690658be4a04645215baea8b95f31d/019cd400-6f38-7074-b8c8-f84603ddd88b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,6 @@
             pkgs.callPackage ./nix/pg_search.nix {
               inherit self;
               postgresql = pkgs."postgresql_${toString version}";
-              inherit (pkgs) cargo-pgrx;
             };
         in
         (builtins.listToAttrs (
@@ -148,9 +147,6 @@
 
       # A Nixpkgs overlay that adds a Fenix-based Rust toolchain
       overlays.default = final: prev: {
-        # standardizes the cargo-pgrx version
-        cargo-pgrx = final.cargo-pgrx_0_16_1;
-
         rustToolchain =
           with inputs.fenix.packages.${prev.stdenv.hostPlatform.system};
           combine (

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '/nix/store/7kdyfnwwfni20qzfr849fz3g4a1ssc50-pg_search-0.21.13-vendor-staging.drv'
-  cargoHash = "sha256-NRrDmswQ+oiVNeIbhfhDA7k4wOxotTLsOuT7WMewX6Y=";
+  cargoHash = "sha256-66EAVHhY2heb0PzCsTQOlIPfFgyT2HH/nkDIm+sWOgc=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4332

## What

* An updated `cargoHash` value for the Nix derivation
* A simplified `nix build` command for CI that works as expected, whereas the previous script seemed to not invoke the `nix build` command for some reason
* Updated the `cargo-pgrx` package to 0.17.0

## Why

CI for the Nix build is currently not failing but should be. This PR fixes both the Nix build and the false positive in CI. The previous script used in the workflow seems to have been malformed in some way; it worked fine locally for me but the CI logs suggest that the `nix build` command somehow wasn't being invoked.

## How

Some updates to the Nix machinery.

## Tests

I ran this expected-to-fail workflow in my fork with a fake `cargoHash`, which indeed failed as predicted and printed the correct hash: https://github.com/lucperkins/paradedb/actions/runs/22953900686/job/66625335433
