### PR TITLE
perf: tune scanner batch size for late materialization

### DIFF
--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -35,6 +35,11 @@ use tantivy::{DocAddress, DocId, Score, SegmentOrdinal};
 /// be held in memory at a time.
 const MAX_BATCH_SIZE: usize = 128_000;
 
+/// The maximum number of rows to batch when all string/byte columns are
+/// deferred during late materialization. Aligned with DataFusion's default
+/// batch size, since we are not fetching string dictionaries during the scan phase.
+const DEFERRED_BATCH_SIZE: usize = 8_192;
+
 /// Compact `ids` and `scores` in-place based on a boolean mask.
 fn compact_with_mask(
     ids: &mut Vec<DocId>,
@@ -154,9 +159,29 @@ impl Scanner {
         which_fast_fields: Vec<WhichFastField>,
         table_oid: u32,
     ) -> Self {
+        let all_strings_deferred = !which_fast_fields.iter().any(|wff| {
+            matches!(
+                wff,
+                WhichFastField::Named(_, field_type) if matches!(
+                    field_type.arrow_data_type(),
+                    arrow_schema::DataType::Utf8View
+                        | arrow_schema::DataType::BinaryView
+                        | arrow_schema::DataType::LargeUtf8
+                        | arrow_schema::DataType::LargeBinary
+                )
+            )
+        });
+
+        let default_batch_size = if all_strings_deferred {
+            DEFERRED_BATCH_SIZE
+        } else {
+            MAX_BATCH_SIZE
+        };
+
         let batch_size = batch_size_hint
-            .unwrap_or(MAX_BATCH_SIZE)
-            .min(MAX_BATCH_SIZE);
+            .unwrap_or(default_batch_size)
+            .min(default_batch_size);
+
         Self {
             search_results,
             batch_size,

--- a/pg_search/tests/pg_regress/expected/join_sort_merge.out
+++ b/pg_search/tests/pg_regress/expected/join_sort_merge.out
@@ -381,7 +381,7 @@ LIMIT 10;
            :           SegmentedTopKExec: expr=[val@4 ASC NULLS LAST], k=10, metrics=[rows_input=18.19 K, rows_output=20, segments_seen=2]
            :             SortMergeJoinExec: join_type=Inner, on=[(t1_id@1, id@1)], metrics=[output_rows=18.19 K, output_bytes=999.0 KB, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, input_batches=6, input_rows=38.19 K, peak_mem_used=1.20 M]
            :               SortPreservingMergeExec: [t1_id@1 ASC], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=3]
-           :                 ProjectionExec: expr=[ctid@0 as ctid_0, t1_id@1 as t1_id], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=2]
+           :                 ProjectionExec: expr=[ctid@0 as ctid_0, t1_id@1 as t1_id], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :                   CooperativeExec
            :                     PgSearchScan: segments=2, query="all"
            :               SortPreservingMergeExec: [id@1 ASC], metrics=[output_rows=18.19 K, output_bytes=1012.7 KB, output_batches=3]


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #4319

## What
Reduce the scanner batch size when all string/byte columns are fully deferred during late materialization, instead of using the default MAX_BATCH_SIZE (128k).

## Why
When all string/byte columns are deferred, the scan phase only touches lightweight numeric/primitive fast fields. Using a large batch size designed for expensive string dictionary lookups is unnecessary overhead. A smaller batch size (aligned with DataFusion's default of 8192) reduces memory pressure and allows Top K to tighten its threshold more frequently between batches.

## How
In `Scanner::new`, compute whether all `Named` string/byte columns have been converted to `Deferred` by checking the `WhichFastField` types. If fully deferred, use `DEFERRED_BATCH_SIZE` (8_192) instead of `MAX_BATCH_SIZE` for the default batch size path. Explicitly passed `batch_size_hint` values are left untouched.

## Tests
Existing late materialization and join integration tests cover correctness.