### PR TITLE
docs: Add 0.21.15 changelog

### DIFF
--- a/docs/changelog/0.21.15.mdx
+++ b/docs/changelog/0.21.15.mdx
@@ -1,0 +1,11 @@
+---
+title: 0.21.15
+noindex: true
+---
+
+## Bug Fixes 🐛
+
+- Fixed `ReadBuffer` errors from stale ctids after `VACUUM` truncation
+- Fixed RLS policies that get planned as `SubPlan`s
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.21.15).

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -50,7 +50,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases/latest).
 
 <Note>
-  You can replace `0.21.14` with the `pg_search` version you wish to install and
+  You can replace `0.21.15` with the `pg_search` version you wish to install and
   `17` with the version of Postgres you are using.
 </Note>
 
@@ -58,49 +58,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/postgresql-17-pg-search_0.21.14-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/postgresql-17-pg-search_0.21.15-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/postgresql-17-pg-search_0.21.14-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/postgresql-17-pg-search_0.21.15-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/postgresql-17-pg-search_0.21.14-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/postgresql-17-pg-search_0.21.15-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/postgresql-17-pg-search_0.21.14-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/postgresql-17-pg-search_0.21.15-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/pg_search_17-0.21.14-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/pg_search_17-0.21.15-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/pg_search_17-0.21.14-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/pg_search_17-0.21.15-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/pg_search@17--0.21.14.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/pg_search@17--0.21.15.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.14/pg_search@17--0.21.14.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.21.15/pg_search@17--0.21.15.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.21.14`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.21.15`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.21.14
+docker pull paradedb/paradedb:0.21.15
 ```
 
-The latest version of the Docker image should be `0.21.14`.
+The latest version of the Docker image should be `0.21.15`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.21.14';
+ALTER EXTENSION pg_search UPDATE TO '0.21.15';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.21.14",
+        "version": "v0.21.15",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -322,6 +322,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.21.15",
                   "changelog/0.21.14",
                   "changelog/0.21.13",
                   "changelog/0.21.12",


### PR DESCRIPTION
## Summary
- Add changelog entry for 0.21.15 with two bug fixes:
  - Fixed `ReadBuffer` errors from stale ctids after `VACUUM` truncation
  - Fixed RLS policies that get planned as `SubPlan`s
- Update version references in docs (upgrading, extension install, docs.json)

## Test plan
- [ ] Verify changelog renders correctly on docs site