### PR TITLE
docs: Add referral and UTM params to Railway deploy button

### DIFF
--- a/docs/deploy/cloud-platforms/railway.mdx
+++ b/docs/deploy/cloud-platforms/railway.mdx
@@ -20,7 +20,7 @@ that runs ParadeDB Community with persistent storage and a TCP proxy.
 
 The fastest way to get started is to click the button below, which will deploy ParadeDB to your Railway account.
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/paradedb)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/paradedb?referralCode=l5qxN4&utm_medium=integration&utm_source=button&utm_campaign=paradedb)
 
 ## Configuration
 


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What

Update the Railway deploy button link to include a referral code and UTM tracking parameters.

## Why

To track deployments originating from the ParadeDB docs and attribute them via Railway's referral program.

## How

Updated the deploy button URL in `docs/deploy/cloud-platforms/railway.mdx` from:
```
https://railway.com/deploy/paradedb
```
to:
```
https://railway.com/deploy/paradedb?referralCode=l5qxN4&utm_medium=integration&utm_source=button&utm_campaign=paradedb
```

## Tests

- Verified the markdown renders correctly
- No code changes, docs-only update