### PR TITLE
fix: Allow aggregate scan planning warnings to be disabled.

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -32,6 +32,9 @@ static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// Allows the user to toggle the use of our "ParadeDB Aggregate Scan".
 static ENABLE_AGGREGATE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Validate aggregate scan eligibility
+static CHECK_AGGREGATE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
+
 /// Allows the user to toggle the use of our "ParadeDB Join Scan".
 static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
@@ -144,6 +147,17 @@ pub fn init() {
         c"Enable ParadeDB's custom aggregate scan",
         c"Enable ParadeDB's custom aggregate scan, which replaces row-based aggregates with column-based aggregates where beneficial",
         &ENABLE_AGGREGATE_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.check_aggregate_scan",
+        c"Validate Aggregate scan eligibility",
+        c"When enabled, logs a warning if a query expected to use the aggregate scan cannot. \
+          This helps detect performance issues during development where queries expected \
+          to use the aggregate scan fall back to slower execution methods.",
+        &CHECK_AGGREGATE_SCAN,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -332,9 +346,9 @@ pub fn init() {
     GucRegistry::define_bool_guc(
         c"paradedb.check_topk_scan",
         c"Validate Top K scan eligibility for LIMIT queries",
-        c"When enabled, logs a warning if a query with LIMIT cannot use Top K scan. \
+        c"When enabled, logs a warning if a query with LIMIT cannot use the Top K scan. \
           This helps detect performance issues during development where queries expected \
-          to use Top K optimization fall back to slower execution methods.",
+          to use the Top K optimization fall back to slower execution methods.",
         &CHECK_TOPK_SCAN,
         GucContext::Userset,
         GucFlags::default(),
@@ -395,6 +409,10 @@ pub fn enable_custom_scan() -> bool {
 
 pub fn enable_aggregate_custom_scan() -> bool {
     ENABLE_AGGREGATE_CUSTOM_SCAN.get()
+}
+
+pub fn check_aggregate_scan() -> bool {
+    CHECK_AGGREGATE_SCAN.get()
 }
 
 pub fn enable_join_custom_scan() -> bool {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -90,6 +90,9 @@ impl CustomScan for AggregateScan {
     }
 
     fn create_custom_path(builder: CustomPathBuilder<Self>) -> Vec<pg_sys::CustomPath> {
+        // When `has_paradedb_agg`, the aggregate scan must run, because the placeholder
+        // aggregate functions have no valid implementation: the only way they can be satisfied is
+        // via this scan.
         let has_paradedb_agg = unsafe {
             let parse = builder.args().root().parse;
             !parse.is_null()
@@ -161,11 +164,20 @@ impl CustomScan for AggregateScan {
             }
             Err(CustomScanBuildError::Incompatible(e)) => {
                 // If it failed to build, we only log a warning if it was considered "interesting"
-                if has_paradedb_agg || gucs::enable_aggregate_custom_scan() {
-                    Self::add_planner_warning(
-                        format!("Aggregate Scan not used: {}", e),
-                        _table.name().to_string(),
-                    );
+                if has_paradedb_agg
+                    || (gucs::enable_aggregate_custom_scan() && gucs::check_aggregate_scan())
+                {
+                    let warning_msg = if has_paradedb_agg {
+                        format!("Aggregate Scan not used: {}", e)
+                    } else {
+                        format!(
+                            "Aggregate Scan not used: {}. \
+                             To disable this warning: SET paradedb.check_aggregate_scan = false",
+                            e,
+                        )
+                    };
+
+                    Self::add_planner_warning(warning_msg, _table.name().to_string());
                 }
                 Vec::new()
             }

--- a/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
+++ b/pg_search/tests/pg_regress/expected/aggregate-groupby-conflict.out
@@ -209,7 +209,7 @@ FROM groupby_conflict_test
 WHERE category @@@ 'electronics'
 GROUP BY title
 ORDER BY title;
-WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field (table: groupby_conflict_test)
+WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: groupby_conflict_test)
                                                                              QUERY PLAN                                                                              
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -236,7 +236,7 @@ WHERE category @@@ 'electronics'
 GROUP BY title
 ORDER BY title
 LIMIT 5;
-WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field (table: groupby_conflict_test)
+WARNING:  Aggregate Scan not used: grouping column title exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: groupby_conflict_test)
    title    |       avg_rating       | count 
 ------------+------------------------+-------
  Product A1 | 1.00000000000000000000 |     1

--- a/pg_search/tests/pg_regress/expected/aggregate.out
+++ b/pg_search/tests/pg_regress/expected/aggregate.out
@@ -432,7 +432,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -453,7 +453,7 @@ WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
  count |        sum         
 -------+--------------------
      2 | 2799.9700000000003
@@ -465,7 +465,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG(LENGTH(description))
 FROM products
 WHERE category @@@ 'Electronics';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: products)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -482,7 +482,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG(LENGTH(description))
 FROM products
 WHERE category @@@ 'Electronics';
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: products)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
          avg         
 ---------------------
  24.5000000000000000

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -502,7 +502,7 @@ FROM empty_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 HAVING COUNT(*) > 0;
-WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206) (table: empty_test)
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
  category | cnt 
 ----------+-----
 (0 rows)
@@ -517,7 +517,7 @@ SELECT
 FROM empty_test
 WHERE id @@@ paradedb.all()
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: empty_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
  category | total_count | distinct_values | high_values | doubled_avg 
 ----------+-------------+-----------------+-------------+-------------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
+++ b/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
@@ -491,7 +491,7 @@ SELECT
     STDDEV(price) FILTER (WHERE category @@@ 'electronics') AS price_stddev,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2158 (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2158. To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
  total |   price_stddev   | apple_count 
 -------+------------------+-------------
     20 | 901.871070925012 |           3
@@ -1031,7 +1031,7 @@ SELECT
     COUNT(DISTINCT category) AS unique_categories,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
  unique_categories | apple_count 
 -------------------+-------------
                  4 |           3

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -480,7 +480,7 @@ SELECT category, COUNT(DISTINCT rating), SUM(price)
 FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -503,7 +503,7 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678) (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     2 | 2529.96

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
@@ -58,7 +58,7 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating, id
 ORDER BY rating, id
 LIMIT 5 OFFSET 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column (table: products)
+WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/issue_3050.out
+++ b/pg_search/tests/pg_regress/expected/issue_3050.out
@@ -17,7 +17,7 @@ WHERE id @@@ paradedb.all()
 GROUP BY id, rating
 ORDER BY id, rating
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column (table: mock_items)
+WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Limit
@@ -41,7 +41,7 @@ WHERE id @@@ paradedb.all()
 GROUP BY id, rating
 ORDER BY id, rating
 LIMIT 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column (table: mock_items)
+WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
  id | rating | count 
 ----+--------+-------
   1 |      4 |     1

--- a/pg_search/tests/pg_regress/expected/issue_3196.out
+++ b/pg_search/tests/pg_regress/expected/issue_3196.out
@@ -47,7 +47,7 @@ SELECT COUNT(rating) FROM mock_items WHERE id @@@ paradedb.all();
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(metadata->>'color') FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate
@@ -61,7 +61,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 (8 rows)
 
 SELECT COUNT(metadata->>'color') FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: mock_items)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
  count 
 -------
     41
@@ -86,7 +86,7 @@ SELECT COUNT(COALESCE(rating, 0)) FROM mock_items WHERE id @@@ paradedb.all();
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(COALESCE(metadata->>'color', 'red')) FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable (table: mock_items)
+WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Aggregate
@@ -100,7 +100,7 @@ WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a 
 (8 rows)
 
 SELECT COUNT(COALESCE(metadata->>'color', 'red')) FROM mock_items WHERE id @@@ paradedb.all();
-WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable (table: mock_items)
+WARNING:  Aggregate Scan not used: first argument of COALESCE must resolve to a variable. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
  count 
 -------
     43

--- a/pg_search/tests/pg_regress/expected/issue_3827.out
+++ b/pg_search/tests/pg_regress/expected/issue_3827.out
@@ -77,7 +77,7 @@ FROM issue_3827_t
 GROUP BY txt
 HAVING (txt @@@ pdb.parse('foo')) OR SUM(n) < 0
 ORDER BY txt;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
  txt 
 -----
  foo
@@ -91,7 +91,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY not_indexed
 ORDER BY not_indexed;
-WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  GroupAggregate
@@ -114,7 +114,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY not_indexed
 ORDER BY not_indexed;
-WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column not_indexed is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
  not_indexed | count 
 -------------+-------
           10 |     1
@@ -129,7 +129,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY txt, n
 ORDER BY txt, n;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  GroupAggregate
@@ -152,7 +152,7 @@ FROM issue_3827_t
 WHERE id @@@ pdb.all()
 GROUP BY txt, n
 ORDER BY txt, n;
-WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field (table: issue_3827_t)
+WARNING:  Aggregate Scan not used: grouping column txt exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_3827_t)
  txt | n | count 
 -----+---+-------
  foo | 1 |     1

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -505,8 +505,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless' AND s.name = 'TechCorp'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                                   QUERY PLAN                                                                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                  QUERY PLAN                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -517,17 +517,16 @@ ORDER BY p.name
          Order By: p.name asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
-           :   SortExec: TopK(fetch=10), expr=[name@2 ASC NULLS LAST], preserve_partitioning=[false]
-           :     TantivyLookupExec: decode=[name]
-           :       SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
-           :           ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
-           :             CooperativeExec
-           :               PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
-           :           ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, name@2 as name]
-           :             CooperativeExec
-           :               PgSearchScan: segments=1, dynamic_filters=3, segmented_thresholds=true, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+           :   TantivyLookupExec: decode=[name]
+           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
+           :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
+           :         ProjectionExec: expr=[ctid@0 as ctid_1, supplier_id@1 as supplier_id, name@2 as name]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=2, segmented_thresholds=true, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
 
 -- =============================================================================
 -- TEST 10: Fallback — DISTINCT with non-fast-field column

--- a/pg_search/tests/pg_regress/expected/json_agg.out
+++ b/pg_search/tests/pg_regress/expected/json_agg.out
@@ -128,7 +128,7 @@ FROM json_test
 WHERE id @@@ paradedb.exists('metadata_json.value')
 GROUP BY metadata_json->>'value'
 ORDER BY value;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test)
  value  | count | min_count | max_count 
 --------+-------+-----------+-----------
  apple  |     3 |         2 |         5

--- a/pg_search/tests/pg_regress/expected/json_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_aggregate.out
@@ -120,7 +120,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((metadata->>'price')::numeric) as total_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -138,7 +138,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((metadata->>'price')::numeric) as total_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  total_price 
 -------------
         3862
@@ -149,7 +149,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((metadata->>'price')::numeric) as electronics_total
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -166,7 +166,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((metadata->>'price')::numeric) as electronics_total
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  electronics_total 
 -------------------
               3097
@@ -177,7 +177,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT SUM((data->>'stock')::integer) as total_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('data.stock');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  Aggregate
@@ -194,7 +194,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT SUM((data->>'stock')::integer) as total_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('data.stock');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  total_stock 
 -------------
          125
@@ -208,7 +208,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((metadata->>'price')::numeric) as avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -226,7 +226,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((metadata->>'price')::numeric) as avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
       avg_price       
 ----------------------
  482.7500000000000000
@@ -237,7 +237,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((metadata->>'price')::numeric) as apple_avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.brand', 'Apple');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -254,7 +254,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((metadata->>'price')::numeric) as apple_avg_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.brand', 'Apple');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  apple_avg_price 
 -----------------
                 
@@ -265,7 +265,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT AVG((data->>'stock')::integer) as avg_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'clothing');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -282,7 +282,7 @@ WARNING:  Aggregate Scan not used: argument to aggregate function is neither a d
 SELECT AVG((data->>'stock')::integer) as avg_stock
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'clothing');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
       avg_stock      
 ---------------------
  25.0000000000000000
@@ -298,7 +298,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
  Aggregate
@@ -318,7 +318,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  min_price | max_price 
 -----------+-----------
         79 |      1299
@@ -331,7 +331,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_electronics_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -350,7 +350,7 @@ SELECT
     MAX((metadata->>'price')::numeric) as max_electronics_price
 FROM json_agg_test 
 WHERE id @@@ paradedb.term('metadata.category', 'electronics');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  min_electronics_price | max_electronics_price 
 -----------------------+-----------------------
                    799 |                  1299
@@ -363,7 +363,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.brand');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Aggregate
@@ -382,7 +382,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.brand');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  first_brand | last_brand 
 -------------+------------
  Adidas      | Samsung
@@ -403,7 +403,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
                                                                                                                                     QUERY PLAN                                                                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -428,7 +428,7 @@ SELECT
     MAX(metadata->>'brand') as last_brand
 FROM json_agg_test 
 WHERE id @@@ paradedb.exists('metadata.price');
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_agg_test)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_agg_test)
  item_count | total_value |      avg_price       | min_price | max_price | first_brand | last_brand 
 ------------+-------------+----------------------+-----------+-----------+-------------+------------
           8 |        3862 | 482.7500000000000000 |        79 |      1299 | Adidas      | Samsung

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -182,7 +182,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  GroupAggregate
@@ -207,7 +207,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
  category | total_price 
 ----------+-------------
           |        3285
@@ -222,7 +222,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -248,7 +248,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
   brand  |       avg_price       | item_count 
 ---------+-----------------------+------------
  Apple   | 1149.0000000000000000 |          2
@@ -266,7 +266,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -293,7 +293,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'category'
 ORDER BY category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
  category | min_price | max_price | item_count 
 ----------+-----------+-----------+------------
           |        89 |      1299 |          5
@@ -311,7 +311,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
                                                                                                                  QUERY PLAN                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -340,7 +340,7 @@ FROM json_test_aggregates
 WHERE id @@@ paradedb.exists('metadata.price')
 GROUP BY metadata->>'brand'
 ORDER BY brand;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_aggregates)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_aggregates)
   brand  | item_count | total_value |       avg_price       | min_price | max_price 
 ---------+------------+-------------+-----------------------+-----------+-----------
  Apple   |          2 |        2298 | 1149.0000000000000000 |       999 |      1299
@@ -806,7 +806,7 @@ WHERE id @@@ paradedb.exists('document.source.system')
   AND id @@@ paradedb.exists('document.metrics.category')
 GROUP BY document->'source'->>'system', document->'metrics'->>'category'
 ORDER BY source_system, metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
                                                                                               QUERY PLAN                                                                                              
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -834,7 +834,7 @@ WHERE id @@@ paradedb.exists('document.source.system')
   AND id @@@ paradedb.exists('document.metrics.category')
 GROUP BY document->'source'->>'system', document->'metrics'->>'category'
 ORDER BY source_system, metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
  source_system | metric_category | count |      avg_score      
 ---------------+-----------------+-------+---------------------
  billing       | A               |     1 | 95.0000000000000000
@@ -855,7 +855,7 @@ FROM json_test_complex
 WHERE id @@@ paradedb.exists('document.metrics.score')
 GROUP BY document->'metrics'->>'category'
 ORDER BY metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
                                                                                                                                                                        QUERY PLAN                                                                                                                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -884,7 +884,7 @@ FROM json_test_complex
 WHERE id @@@ paradedb.exists('document.metrics.score')
 GROUP BY document->'metrics'->>'category'
 ORDER BY metric_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_complex)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_complex)
  metric_category | total_records | total_score |      avg_score      | min_score | max_score 
 -----------------+---------------+-------------+---------------------+-----------+-----------
  A               |             2 |         180 | 90.0000000000000000 |        85 |        95
@@ -1156,7 +1156,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('order_details.category')
 GROUP BY user_profile->>'department', order_details->>'category'
 ORDER BY department, product_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
                                                                                              QUERY PLAN                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1185,7 +1185,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
   AND id @@@ paradedb.exists('order_details.category')
 GROUP BY user_profile->>'department', order_details->>'category'
 ORDER BY department, product_category;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
  department  | product_category | order_count | total_quantity 
 -------------+------------------+-------------+----------------
  Engineering | electronics      |           3 |              9
@@ -1211,7 +1211,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
 GROUP BY user_profile->>'department', user_profile->>'location', 
          order_details->>'product', order_details->>'category'
 ORDER BY department, location, product;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
                                                                                                                                          QUERY PLAN                                                                                                                                         
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1244,7 +1244,7 @@ WHERE id @@@ paradedb.exists('user_profile.department')
 GROUP BY user_profile->>'department', user_profile->>'location', 
          order_details->>'product', order_details->>'category'
 ORDER BY department, location, product;
-WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression (table: json_test_multi_subfields)
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: json_test_multi_subfields)
  department  | location | product |  category   | order_count |       avg_price       | total_quantity 
 -------------+----------+---------+-------------+-------------+-----------------------+----------------
  Engineering | NYC      | mouse   | electronics |           1 |   25.0000000000000000 |              5


### PR DESCRIPTION
## What

Allow aggregate scan planning warnings to be disabled.

## Why

The aggregate scan planning warnings are helpful for users who:
1. are designing queries to get ideal performance
2. are using `pdb.agg` (in which case the aggregate scan _must_ be used)

...but they are not necessarily helpful for users who have turned on the scan globally in order to get wins whenever possible, without necessarily focusing on the performance of individual queries.

## How

Added the `paradedb.check_aggregate_scan`, which is obeyed unless `pdb.agg` is used (in which case the scan is the only possible way to satisfy a query).