### PR TITLE
chore: Assign the cherry-pick author as a reviewer.

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -31,6 +31,7 @@ jobs:
           git_committer_name: paradedb[bot]
           git_committer_email: developers@paradedb.com
           add_author_as_assignee: true
+          add_author_as_reviewer: true
           add_labels: automated-cherry-pick
           pull_title: "${pull_title}"
           label_pattern: "^cherry-pick/([^ ]+)$"


### PR DESCRIPTION
## What

Assign the author of a cherry-picked PR as a reviewer of the cherry-pick PR.

## Why

Now that we're using round-robin assignment of reviewers, a random team member will be assigned if an explicit reviewer isn't added.