### PR TITLE
docs: add Modern Treasury case study link

### DIFF
--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -63,11 +63,11 @@ examples include:
 
 - **Alibaba Cloud**, the largest Asia-Pacific cloud provider, uses ParadeDB to power search inside their data warehouse. [Case study available](https://www.paradedb.com/customers/case-study-alibaba).
 - **Bilt Rewards**, a rent payments technology company that processed over $36B in payments in 2024. [Case study available](https://www.paradedb.com/customers/case-study-bilt).
-- **Modern Treasury**<sup>1</sup>, a financial technology company that automates the full cycle of money movement.
-- **Span**<sup>1</sup>, one of the fastest-growing AI developer productivity platforms
+- **Modern Treasury**, a financial technology company that automates the full cycle of money movement. [Case study available](https://www.paradedb.com/customers/case-study-modern-treasury).
+- **Span**<sup>1</sup>, one of the fastest-growing AI developer productivity platforms.
 - **TCDI**<sup>1</sup>, a giant in the legal software and litigation management space.
 
-_1. Case study coming soon_
+_1. Case study coming soon._
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Links the Modern Treasury entry in `docs/welcome/introduction.mdx` to the published case study page
- Removes the `<sup>1</sup>` footnote marker from Modern Treasury since the case study is now live

## Test plan

- [x] Verify the case study link resolves: https://www.paradedb.com/customers/case-study-modern-treasury