### PR TITLE
fix: Allow the joinscan to run for a semi/anti join, even when partitioning is not optimal.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -620,6 +620,19 @@ impl RelNode {
         unsupported
     }
 
+    /// Returns true if the query tree contains a SEMI or ANTI join at any level.
+    pub fn has_semi_or_anti(&self) -> bool {
+        match self {
+            RelNode::Scan(_) => false,
+            RelNode::Join(j) => {
+                matches!(j.join_type, JoinType::Semi | JoinType::Anti)
+                    || j.left.has_semi_or_anti()
+                    || j.right.has_semi_or_anti()
+            }
+            RelNode::Filter(f) => f.input.has_semi_or_anti(),
+        }
+    }
+
     fn collect_unsupported_join_types(&self, acc: &mut Vec<JoinType>) {
         match self {
             RelNode::Scan(_) => {}
@@ -810,6 +823,8 @@ pub struct JoinCSClause {
     pub output_projection: Option<Vec<ChildProjection>>,
     /// Whether the join has DISTINCT specified.
     pub has_distinct: bool,
+    /// Optional index of the source that MUST be partitioned, overriding cost-based selection.
+    pub forced_partitioning_idx: Option<usize>,
 }
 
 impl JoinCSClause {
@@ -822,6 +837,7 @@ impl JoinCSClause {
             order_by: Vec::new(),
             output_projection: None,
             has_distinct: false,
+            forced_partitioning_idx: None,
         };
         for (i, source) in clause.plan.sources_mut().into_iter().enumerate() {
             source.plan_position = i;
@@ -903,20 +919,26 @@ impl JoinCSClause {
         self
     }
 
+    pub fn with_forced_partitioning(mut self, idx: usize) -> Self {
+        self.forced_partitioning_idx = Some(idx);
+        self
+    }
+
     /// Returns the source that should be partitioned for parallel execution.
-    /// This is the source with the largest row estimate.
     pub fn partitioning_source(&self) -> JoinSource {
         let sources = self.plan.sources();
         sources
-            .into_iter()
-            .max_by(|a, b| a.scan_info.estimate.cmp(&b.scan_info.estimate))
+            .get(self.partitioning_source_index())
             .cloned()
             .expect("JoinScan requires at least one source")
+            .clone()
     }
 
     /// Returns the index of the source that should be partitioned for parallel execution.
-    /// This is the source with the largest row estimate.
     pub fn partitioning_source_index(&self) -> usize {
+        if let Some(idx) = self.forced_partitioning_idx {
+            return idx;
+        }
         let sources = self.plan.sources();
         sources
             .iter()

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -520,21 +520,26 @@ impl CustomScan for JoinScan {
                 }
             }
 
-            let current_sources = join_clause.plan.sources();
-
             // The current parallel strategy partitions exactly one source and replicates all
-            // others. For SEMI JOIN correctness, the partitioned source must be the left side.
-            // We currently enforce a conservative subset: binary base-table joins only.
-            if jointype == pg_sys::JoinType::JOIN_SEMI {
-                let partitioning_idx = join_clause.partitioning_source_index();
-                if partitioning_idx != 0 {
-                    Self::add_planner_warning(
-                            "JoinScan not used: SEMI JOIN requires the left side to be the largest source",
-                            &aliases,
-                        );
-                    return Vec::new();
+            // others. For SEMI JOIN and ANTI JOIN correctness, the partitioned source MUST be
+            // the left side to avoid duplicate emissions from replicated workers.
+            // TODO: Because we force the left side to be partitioned, we will fully replicate
+            // (broadcast) the right side even if it is significantly larger. This reduces
+            // performance but ensures correctness. We can remove this limitation once we transition
+            // away from a broadcast strategy to true plan partitioning:
+            // https://github.com/paradedb/paradedb/issues/4152
+            if join_clause.plan.has_semi_or_anti() {
+                if join_clause.partitioning_source_index() != 0 {
+                    pgrx::warning!(
+                        "For SEMI/ANTI join correctness, JoinScan needs to use a suboptimal \
+                        parallel partitioning strategy for this query. See \
+                        https://github.com/paradedb/paradedb/issues/4152"
+                    );
                 }
+                join_clause = join_clause.with_forced_partitioning(0);
             }
+
+            let current_sources = join_clause.plan.sources();
 
             // Extract join-level predicates (search predicates and heap conditions)
             // This builds an expression tree that can reference:

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -340,6 +340,58 @@ LIMIT 10;
  100 | target_category
 (10 rows)
 
+-- =====================================================================
+-- 6. Semi Join with selective outer filter
+-- =====================================================================
+-- The outer filter is so selective that this query requires our ability to force the left side
+-- to be partitioned (even when that might be less efficient).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+)
+AND id @@@ 'id:1'
+ORDER BY id ASC
+LIMIT 10;
+WARNING:  For SEMI/ANTI join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: table_a.id, table_a.category
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: table_a.id, table_a.category
+         Relation Tree: table_a SEMI table_b
+         Join Cond: table_a.id = table_b.a_id
+         Limit: 10
+         Order By: table_a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, a_id@0)]
+           :       ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"id:1","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query="all"
+(17 rows)
+
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+)
+AND id @@@ 'id:1'
+ORDER BY id ASC
+LIMIT 10;
+WARNING:  For SEMI/ANTI join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    category    
+----+----------------
+  1 | other_category
+(1 row)
+
 -- Cleanup
 DROP TABLE table_a CASCADE;
 DROP TABLE table_b CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti.sql
@@ -193,6 +193,32 @@ AND id @@@ 'category:"target_category"'
 ORDER BY category ASC, id ASC
 LIMIT 10;
 
+-- =====================================================================
+-- 6. Semi Join with selective outer filter
+-- =====================================================================
+-- The outer filter is so selective that this query requires our ability to force the left side
+-- to be partitioned (even when that might be less efficient).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+)
+AND id @@@ 'id:1'
+ORDER BY id ASC
+LIMIT 10;
+
+SELECT id, category
+FROM table_a
+WHERE id IN (
+    SELECT a_id
+    FROM table_b
+)
+AND id @@@ 'id:1'
+ORDER BY id ASC
+LIMIT 10;
+
 -- Cleanup
 DROP TABLE table_a CASCADE;
 DROP TABLE table_b CASCADE;

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -878,12 +878,18 @@ async fn generated_joinscan_semi_like(database: Db) {
         |_| {},
     );
 
-    // Keep the semi-join left side ("users") decisively larger than right-side candidates.
-    // JoinScan's SEMI implementation requires the left side to be the largest source.
-    let tables_and_sizes = [("users", 500), ("products", 120), ("orders", 40)];
+    // Use varied table sizes to test both when the left side is the largest source
+    // and when the right side is the largest source (which now forces the partition
+    // to the left side anyway for SEMI/ANTI correctness).
+    let tables_and_sizes = [
+        ("users", 500),
+        ("products", 120),
+        ("orders", 40),
+        ("logs", 1000),
+    ];
     let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
 
-    let all_tables = vec!["users", "products", "orders"];
+    let all_tables = vec!["users", "products", "orders", "logs"];
     let join_key_columns = vec!["id", "age", "uuid"];
     let search_terms = vec![
         "alice", "bob", "cloe", "sally", "brandy", "brisket", "anchovy",
@@ -895,9 +901,6 @@ async fn generated_joinscan_semi_like(database: Db) {
         is_anti_join in proptest::bool::ANY,
         limit in 1..=50usize,
     )| {
-        // For now, JoinScan SEMI requires the left side to be the largest source.
-        // TODO: Remove this once JoinScan SEMI supports non-base-table joins.
-        prop_assume!(semi_join.outer_table() == "users");
         let outer = semi_join.outer_table();
         let inner = semi_join.inner_table();
         let join_col = semi_join.join_column();


### PR DESCRIPTION
## What

Force the "preserved" side of a semi/anti join to be partitioned, even if is smaller than the non-preserved side(s).

## Why

Currently, when the joinscan would not be able to use optimal partitioning for a semi/anti join, it refuses to run, with:
> JoinScan not used: SEMI JOIN requires the left side to be the largest source

This is reasonable, but the problem is that this is based on estimates that change based on the data distribution and WHERE clause selectivity, rather than based on the shape of the query itself. That means that if you've written a query that uses `pdb.score` and tested it on a particular set of data, it might begin failing (with an "Unsupported query shape" error) on a different set of data. 

## How

Add and use `with_forced_partitioning`.