### PR TITLE
chore: Audit pull request events for actions.

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -16,7 +16,7 @@ on:
       - "**/*.rs"
       - "**/*.toml"
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -17,7 +17,7 @@ on:
       - "**/*.rs"
       - "**/*.toml"
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -7,7 +7,7 @@ name: Check Typo
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -7,7 +7,7 @@ name: Lint Bash
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.sh"
       - ".github/workflows/lint-bash.yml"

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -7,7 +7,7 @@ name: Lint Docker
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -7,7 +7,7 @@ name: Lint Format
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -7,7 +7,7 @@ name: Lint Markdown
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.md"
       - "**/*.mdx"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,7 +7,7 @@ name: Lint PR Title
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -7,7 +7,7 @@ name: Lint Rust
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.rs"
       - "**/*.toml"

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -7,7 +7,7 @@ name: Lint YAML
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.yml"
       - "**/*.yaml"

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -7,7 +7,7 @@ name: SchemaBot Generate Diff
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -7,7 +7,7 @@ name: Test Docs
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -7,7 +7,7 @@ name: Test pg_search (Docker)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -7,7 +7,7 @@ name: Test pg_search (Nix)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -7,7 +7,7 @@ name: Test pg_search Upgrade
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     - cron: "0 7 * * *" # daily 07:00 UTC (~2am ET)
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -7,7 +7,7 @@ name: Test Stressgres (Docker)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - main
     paths:


### PR DESCRIPTION
* Do not re-run actions on `ready_to_review`
    * `ready_to_review` is the event sent when a PR moves from `Draft` to `Ready to Review`, which does not change the content of the PR.
* Do not do anything for `synchronize` for the benchmark jobs
    * They are inspecting `github.event.label.name`, which will be empty for everything but a `labeled` event.