### PR TITLE
chore(benchmarks): stabilize CPU frequency to reduce benchmark noise

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -191,6 +191,13 @@ jobs:
       - name: Running for ${{ steps.pr_label.outputs.result }}"
         run: echo ${{ steps.pr_label.outputs.result }}
 
+      - name: Stabilize CPU Frequency
+        run: |
+          # Lock CPU governor to performance mode (fixed frequency)
+          echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+          # Disable turbo boost — turbo is thermally opportunistic and inherently noisy
+          echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -172,6 +172,13 @@ jobs:
       - name: Running for ${{ steps.pr_label.outputs.result }}"
         run: echo ${{ steps.pr_label.outputs.result }}
 
+      - name: Stabilize CPU Frequency
+        run: |
+          # Lock CPU governor to performance mode (fixed frequency)
+          echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+          # Disable turbo boost — turbo is thermally opportunistic and inherently noisy
+          echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
## Summary
- Disables Intel turbo boost and locks the CPU governor to `performance` mode before running benchmarks
- Applied to both the **queries** (`benchmark-pg_search-benchmarks.yml`) and **stressgres** (`benchmark-pg_search-stressgres.yml`) workflows
- Turbo boost is thermally opportunistic — it boosts clock speed when thermal headroom allows, making it a major source of run-to-run variance even on z1d.metal instances

## Test plan
- [ ] Verify the workflow steps run successfully on the z1d.metal runners (the `cpufreq` and `intel_pstate` sysfs interfaces should be available)
- [ ] Compare coefficient of variation of benchmark results before/after this change