### PR TITLE
docs: reorder nav and fix Render Blueprint capitalization

### DIFF
--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -13,7 +13,7 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/render
 </Note>
 
 [Render](https://render.com) is a cloud platform that makes it easy to deploy and manage applications. The
-[ParadeDB Render template](https://github.com/paradedb/render-blueprint) provides a one-click deployment
+[ParadeDB Render Blueprint](https://github.com/paradedb/render-blueprint) provides a one-click deployment
 that runs ParadeDB Community as a private service with persistent SSD storage.
 
 ## One-Click Deploy

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -301,20 +301,20 @@
                     ]
                   },
                   {
+                    "group": "Cloud Platforms",
+                    "pages": [
+                      "deploy/cloud-platforms/railway",
+                      "deploy/cloud-platforms/render",
+                      "deploy/cloud-platforms/digitalocean"
+                    ]
+                  },
+                  {
                     "group": "Logical Replication",
                     "pages": [
                       "deploy/logical-replication/getting-started",
                       "deploy/logical-replication/operational-guide",
                       "deploy/logical-replication/configuration",
                       "deploy/logical-replication/multi-database"
-                    ]
-                  },
-                  {
-                    "group": "Cloud Platforms",
-                    "pages": [
-                      "deploy/cloud-platforms/railway",
-                      "deploy/cloud-platforms/render",
-                      "deploy/cloud-platforms/digitalocean"
                     ]
                   },
                   "deploy/byoc",


### PR DESCRIPTION
## Summary
- Move Logical Replication below Cloud Platforms in the Deploy sidebar navigation
- Capitalize "Blueprint" in the Render deployment page ("Render template" → "Render Blueprint")

## Test plan
- [ ] Verify the docs site sidebar shows Cloud Platforms above Logical Replication under Deploy
- [ ] Verify the Render page displays "ParadeDB Render Blueprint"