### PR TITLE
chore: Tighten and test min/max bounds for Arrow datetime tests

### DIFF
--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -22,15 +22,17 @@ pub static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
 
 /// The minimum nanoseconds from 1970-01-01 00:00:00 UTC that can be safely
 /// converted between Postgres types and Tantivy without underflowing i64 when floored to the
-/// second.
+/// day.
 #[allow(dead_code)]
-pub const MIN_SAFE_TANTIVY_NANOS: i64 = (i64::MIN / 1_000_000_000) * 1_000_000_000;
+pub const MIN_SAFE_TANTIVY_NANOS: i64 =
+    (i64::MIN / 1_000_000_000 / 86_400) * 86_400 * 1_000_000_000;
 
 /// The maximum nanoseconds from 1970-01-01 00:00:00 UTC that can be safely
 /// converted between Postgres types and Tantivy without overflowing i64 when floored to the
-/// second.
+/// day.
 #[allow(dead_code)]
-pub const MAX_SAFE_TANTIVY_NANOS: i64 = (i64::MAX / 1_000_000_000) * 1_000_000_000;
+pub const MAX_SAFE_TANTIVY_NANOS: i64 =
+    (i64::MAX / 1_000_000_000 / 86_400) * 86_400 * 1_000_000_000;
 
 #[inline]
 pub fn micros_to_tantivy_datetime(

--- a/pg_search/src/postgres/types_arrow.rs
+++ b/pg_search/src/postgres/types_arrow.rs
@@ -366,46 +366,84 @@ mod tests {
             }
         });
     }
+    fn do_test_arrow_int64_as_timestamp_to_datum(original_nanos: i64) {
+        let create_ts_array = |v: i64| {
+            let mut builder = Int64Builder::with_capacity(1);
+            builder.append_value(v);
+            Arc::new(builder.finish()) as Arc<dyn Array>
+        };
+
+        let pdt = ts_nanos_to_date_time(original_nanos).into_primitive();
+
+        // Test TIMESTAMPTZOID
+        let oid_timestamptz = PgOid::from(PgBuiltInOids::TIMESTAMPTZOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamptz, |_| {
+            TimestampWithTimeZone::with_timezone(
+                pdt.year(),
+                pdt.month().into(),
+                pdt.day(),
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+                "UTC",
+            )
+            .unwrap()
+        });
+
+        // Test TIMESTAMPOID
+        let oid_timestamp = PgOid::from(PgBuiltInOids::TIMESTAMPOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamp, |_| {
+            Timestamp::new(
+                pdt.year(),
+                pdt.month().into(),
+                pdt.day(),
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+            )
+            .unwrap()
+        });
+
+        // Test DATEOID
+        let oid_date = PgOid::from(PgBuiltInOids::DATEOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_date, |_| {
+            Date::new(pdt.year(), pdt.month().into(), pdt.day()).unwrap()
+        });
+
+        // Test TIMEOID
+        let oid_time = PgOid::from(PgBuiltInOids::TIMEOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_time, |_| {
+            Time::new(
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+            )
+            .unwrap()
+        });
+
+        // Test TIMETZOID
+        let oid_timetz = PgOid::from(PgBuiltInOids::TIMETZOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timetz, |_| {
+            TimeWithTimeZone::with_timezone(
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+                "UTC",
+            )
+            .unwrap()
+        });
+    }
+
+    #[pg_test]
+    fn test_arrow_int64_as_timestamp_to_datum_bounds() {
+        do_test_arrow_int64_as_timestamp_to_datum(MIN_SAFE_TANTIVY_NANOS);
+        do_test_arrow_int64_as_timestamp_to_datum(MAX_SAFE_TANTIVY_NANOS);
+    }
+
     #[pg_test]
     fn test_arrow_int64_as_timestamp_to_datum() {
-        proptest!(|(original_nanos in MIN_SAFE_TANTIVY_NANOS..MAX_SAFE_TANTIVY_NANOS)| {
-            let create_ts_array = |v: i64| {
-                let mut builder = Int64Builder::with_capacity(1);
-                builder.append_value(v);
-                Arc::new(builder.finish()) as Arc<dyn Array>
-            };
-
-            let pdt = ts_nanos_to_date_time(original_nanos).into_primitive();
-
-            // Test TIMESTAMPTZOID
-            let oid_timestamptz = PgOid::from(PgBuiltInOids::TIMESTAMPTZOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamptz, |_| {
-                TimestampWithTimeZone::with_timezone(pdt.year(), pdt.month().into(), pdt.day(), pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0, "UTC").unwrap()
-            });
-
-            // Test TIMESTAMPOID
-            let oid_timestamp = PgOid::from(PgBuiltInOids::TIMESTAMPOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamp, |_| {
-                Timestamp::new(pdt.year(), pdt.month().into(), pdt.day(), pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0).unwrap()
-            });
-
-            // Test DATEOID
-            let oid_date = PgOid::from(PgBuiltInOids::DATEOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_date, |_| {
-                Date::new(pdt.year(), pdt.month().into(), pdt.day()).unwrap()
-            });
-
-            // Test TIMEOID
-            let oid_time = PgOid::from(PgBuiltInOids::TIMEOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_time, |_| {
-                Time::new(pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0).unwrap()
-            });
-
-            // Test TIMETZOID
-            let oid_timetz = PgOid::from(PgBuiltInOids::TIMETZOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timetz, |_| {
-                TimeWithTimeZone::with_timezone(pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0, "UTC").unwrap()
-            });
+        proptest!(|(original_nanos in MIN_SAFE_TANTIVY_NANOS..=MAX_SAFE_TANTIVY_NANOS)| {
+            do_test_arrow_int64_as_timestamp_to_datum(original_nanos);
         });
     }
 
@@ -527,46 +565,84 @@ mod tests {
         });
     }
 
+    fn do_test_arrow_timestamp_to_datum(original_nanos: i64) {
+        let create_ts_array = |v: i64| {
+            let mut builder = TimestampNanosecondBuilder::with_capacity(1);
+            builder.append_value(v);
+            Arc::new(builder.finish()) as Arc<dyn Array>
+        };
+
+        let pdt = ts_nanos_to_date_time(original_nanos).into_primitive();
+
+        // Test TIMESTAMPTZOID
+        let oid_timestamptz = PgOid::from(PgBuiltInOids::TIMESTAMPTZOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamptz, |_| {
+            TimestampWithTimeZone::with_timezone(
+                pdt.year(),
+                pdt.month().into(),
+                pdt.day(),
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+                "UTC",
+            )
+            .unwrap()
+        });
+
+        // Test TIMESTAMPOID
+        let oid_timestamp = PgOid::from(PgBuiltInOids::TIMESTAMPOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamp, |_| {
+            Timestamp::new(
+                pdt.year(),
+                pdt.month().into(),
+                pdt.day(),
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+            )
+            .unwrap()
+        });
+
+        // Test DATEOID
+        let oid_date = PgOid::from(PgBuiltInOids::DATEOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_date, |_| {
+            Date::new(pdt.year(), pdt.month().into(), pdt.day()).unwrap()
+        });
+
+        // Test TIMEOID
+        let oid_time = PgOid::from(PgBuiltInOids::TIMEOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_time, |_| {
+            Time::new(
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+            )
+            .unwrap()
+        });
+
+        // Test TIMETZOID
+        let oid_timetz = PgOid::from(PgBuiltInOids::TIMETZOID.value());
+        test_conversion_roundtrip(original_nanos, create_ts_array, oid_timetz, |_| {
+            TimeWithTimeZone::with_timezone(
+                pdt.hour(),
+                pdt.minute(),
+                pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0,
+                "UTC",
+            )
+            .unwrap()
+        });
+    }
+
+    #[pg_test]
+    fn test_arrow_timestamp_to_datum_bounds() {
+        do_test_arrow_timestamp_to_datum(MIN_SAFE_TANTIVY_NANOS);
+        do_test_arrow_timestamp_to_datum(MAX_SAFE_TANTIVY_NANOS);
+    }
+
     #[pg_test]
     fn test_arrow_timestamp_to_datum() {
-        proptest!(|(original_nanos in MIN_SAFE_TANTIVY_NANOS..MAX_SAFE_TANTIVY_NANOS)| {
-            let create_ts_array = |v: i64| {
-                let mut builder = TimestampNanosecondBuilder::with_capacity(1);
-                builder.append_value(v);
-                Arc::new(builder.finish()) as Arc<dyn Array>
-            };
-
-            let pdt = ts_nanos_to_date_time(original_nanos).into_primitive();
-
-            // Test TIMESTAMPTZOID
-            let oid_timestamptz = PgOid::from(PgBuiltInOids::TIMESTAMPTZOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamptz, |_| {
-                TimestampWithTimeZone::with_timezone(pdt.year(), pdt.month().into(), pdt.day(), pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0, "UTC").unwrap()
-            });
-
-            // Test TIMESTAMPOID
-            let oid_timestamp = PgOid::from(PgBuiltInOids::TIMESTAMPOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timestamp, |_| {
-                Timestamp::new(pdt.year(), pdt.month().into(), pdt.day(), pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0).unwrap()
-            });
-
-            // Test DATEOID
-            let oid_date = PgOid::from(PgBuiltInOids::DATEOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_date, |_| {
-                Date::new(pdt.year(), pdt.month().into(), pdt.day()).unwrap()
-            });
-
-            // Test TIMEOID
-            let oid_time = PgOid::from(PgBuiltInOids::TIMEOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_time, |_| {
-                Time::new(pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0).unwrap()
-            });
-
-            // Test TIMETZOID
-            let oid_timetz = PgOid::from(PgBuiltInOids::TIMETZOID.value());
-            test_conversion_roundtrip(original_nanos, create_ts_array, oid_timetz, |_| {
-                TimeWithTimeZone::with_timezone(pdt.hour(), pdt.minute(), pdt.second() as f64 + pdt.microsecond() as f64 / 1_000_000.0, "UTC").unwrap()
-            });
+        proptest!(|(original_nanos in MIN_SAFE_TANTIVY_NANOS..=MAX_SAFE_TANTIVY_NANOS)| {
+            do_test_arrow_timestamp_to_datum(original_nanos);
         });
     }
 


### PR DESCRIPTION
## What

Further narrow the min/max bounds of our Arrow + Postgres + Tantivy datetime tests, and ensure that the bound is covered.

## Why

#4410 narrowed the bounds for these tests, but did not guarantee that the new values would be tested. Therefore, inevitably, the bounds were wrong!