### PR TITLE
chore: Add a sort-merge-join variant of `semi_join_filter`.

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -8,7 +8,6 @@ SET paradedb.enable_columnar_sort TO off; SET paradedb.enable_join_custom_scan T
     f."createdAt"
 FROM files f
 WHERE
-    -- The "Join" is a filter against a list of IDs (Semi-Join)
     f."documentId" IN (
         SELECT id
         FROM documents
@@ -16,16 +15,16 @@ WHERE
         AND title @@@ 'Document Title 1'
     )
 ORDER BY
-    f.title ASC                       -- Single Feature Sort (Local Fast Field)
+    f.title ASC
 LIMIT 25;
 
+-- Sortedness disabled, with join scan.
 SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO off; SET paradedb.enable_join_custom_scan TO on; SELECT
     f.id,
     f.title,
     f."createdAt"
 FROM files f
 WHERE
-    -- The "Join" is a filter against a list of IDs (Semi-Join)
     f."documentId" IN (
         SELECT id
         FROM documents
@@ -33,7 +32,7 @@ WHERE
         AND title @@@ 'Document Title 1'
     )
 ORDER BY
-    f.title ASC                       -- Single Feature Sort (Local Fast Field)
+    f.title ASC
 LIMIT 25;
 
 -- Sortedness enabled, no join scan.
@@ -43,7 +42,6 @@ SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO
     f."createdAt"
 FROM files f
 WHERE
-    -- The "Join" is a filter against a list of IDs (Semi-Join)
     f."documentId" IN (
         SELECT id
         FROM documents
@@ -51,7 +49,7 @@ WHERE
         AND title @@@ 'Document Title 1'
     )
 ORDER BY
-    f.title ASC                       -- Single Feature Sort (Local Fast Field)
+    f.title ASC
 LIMIT 25;
 
 -- term_set workaround, no join
@@ -64,6 +62,23 @@ WHERE
     f."documentId" @@@ pdb.term_set((
         SELECT array_agg(id) FROM documents WHERE parents @@@ 'PROJECT_ALPHA' AND title @@@ 'Document Title 1'
     ))
+ORDER BY
+    f.title ASC
+LIMIT 25;
+
+-- Sortedness enabled, with join scan.
+SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents @@@ 'PROJECT_ALPHA'
+        AND title @@@ 'Document Title 1'
+    )
 ORDER BY
     f.title ASC
 LIMIT 25;


### PR DESCRIPTION
## What

Add a variant of `semi_join_filter` which uses SMJ.

## Why

We don't have one, but it is actually currently the default which is used by all of the other joins benchmark queries.