### PR TITLE
feat(topn): Support ORDER BY indexed expressions in TopN scan path (#4390)

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -309,7 +309,10 @@ pub enum OrderByFeature {
     Score {
         rti: u32,
     },
-    Field(FieldName),
+    Field {
+        name: FieldName,
+        rti: u32,
+    },
     /// A reference to a PostgreSQL variable (column) by its Range Table Index (RTI) and Attribute Number.
     ///
     /// This variant is primarily used by `JoinScan` to unambiguously identify columns across multiple

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -761,7 +761,10 @@ impl SearchIndexReader {
         let (first_orderby_info, erased_features) = self.prepare_features(orderby_info);
         match first_orderby_info {
             OrderByInfo {
-                feature: OrderByFeature::Field(sort_field),
+                feature:
+                    OrderByFeature::Field {
+                        name: sort_field, ..
+                    },
                 direction,
             } => {
                 let field = self
@@ -1352,7 +1355,10 @@ impl SearchIndexReader {
         for orderby_info in remainder.iter() {
             match orderby_info {
                 OrderByInfo {
-                    feature: OrderByFeature::Field(sort_field),
+                    feature:
+                        OrderByFeature::Field {
+                            name: sort_field, ..
+                        },
                     direction,
                 } => {
                     // NOTE: The list of supported field types for `SortByErasedType` must be synced with

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -334,7 +334,7 @@ impl AggregateCSClause {
                 SortDirection::AscNullsLast | SortDirection::DescNullsFirst => false,
             })
             .filter_map(|info| match &info.feature {
-                OrderByFeature::Field(name) => Some(name.to_string()),
+                OrderByFeature::Field { name, .. } => Some(name.to_string()),
                 OrderByFeature::Score { .. } | OrderByFeature::Var { .. } => None,
             })
             .collect()
@@ -459,7 +459,10 @@ impl CollectNested<GroupedKey> for AggregateCSClause {
 
         Ok(grouping_columns.into_iter().map(move |column| {
             let orderby = orderby_info.iter().find(|info| {
-                if let OrderByFeature::Field(field_name) = &info.feature {
+                if let OrderByFeature::Field {
+                    name: field_name, ..
+                } = &info.feature
+                {
                     field_name == &FieldName::from(column.field_name.clone())
                 } else {
                     false

--- a/pg_search/src/postgres/customscan/aggregatescan/orderby.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/orderby.rs
@@ -109,13 +109,17 @@ impl CustomScanClause<AggregateScan> for OrderByClause {
                 &schema,
                 |f| f.is_fast(),
                 |_| false,
+                Some(&index_expressions),
             )
         };
 
         let orderby_info = OrderByStyle::extract_orderby_info(pathkeys.pathkeys())
             .into_iter()
             .filter(|info| {
-                if let OrderByFeature::Field(field_name) = &info.feature {
+                if let OrderByFeature::Field {
+                    name: field_name, ..
+                } = &info.feature
+                {
                     sort_fields.contains(field_name.as_ref())
                 } else {
                     false

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -628,7 +628,9 @@ impl CustomScan for BaseScan {
             let schema = bm25_index
                 .schema()
                 .expect("custom_scan: should have a schema");
-            let topk_pathkey_info = pullup_topk_pathkeys(rti, &schema, root);
+            let index_expressions = bm25_index.index_expressions();
+            let topk_pathkey_info =
+                pullup_topk_pathkeys(rti, &schema, root, Some(&index_expressions));
 
             #[cfg(feature = "pg15")]
             let baserels = (*builder.args().root).all_baserels;
@@ -1246,7 +1248,10 @@ impl CustomScan for BaseScan {
                     .iter()
                     .map(|oi| match oi {
                         OrderByInfo {
-                            feature: OrderByFeature::Field(fieldname),
+                            feature:
+                                OrderByFeature::Field {
+                                    name: fieldname, ..
+                                },
                             direction,
                             ..
                         } => {
@@ -2204,6 +2209,7 @@ unsafe fn pullup_topk_pathkeys(
     rti: pg_sys::Index,
     schema: &SearchIndexSchema,
     root: *mut pg_sys::PlannerInfo,
+    index_expressions: Option<&PgList<pg_sys::Expr>>,
 ) -> PathKeyInfo {
     match extract_pathkey_styles_with_sortability_check(
         root,
@@ -2211,6 +2217,7 @@ unsafe fn pullup_topk_pathkeys(
         schema,
         |search_field| search_field.is_raw_sortable(),
         |search_field| search_field.is_lower_sortable(),
+        index_expressions,
     ) {
         PathKeyInfo::UsableAll(styles) if styles.len() <= MAX_TOPK_FEATURES => {
             // Top K is the base scan's only executor which supports sorting, and supports up to

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -29,14 +29,18 @@ pub enum OrderByStyle {
         pathkey: *mut pg_sys::PathKey,
         rti: u32,
     },
-    Field(*mut pg_sys::PathKey, FieldName),
+    Field {
+        pathkey: *mut pg_sys::PathKey,
+        name: FieldName,
+        rti: u32,
+    },
 }
 
 impl OrderByStyle {
     pub fn pathkey(&self) -> *mut pg_sys::PathKey {
         match self {
             OrderByStyle::Score { pathkey, .. } => *pathkey,
-            OrderByStyle::Field(pathkey, _) => *pathkey,
+            OrderByStyle::Field { pathkey, .. } => *pathkey,
         }
     }
 
@@ -82,7 +86,10 @@ impl OrderByStyle {
 impl From<&OrderByStyle> for OrderByInfo {
     fn from(value: &OrderByStyle) -> Self {
         let feature = match value {
-            OrderByStyle::Field(_, name) => OrderByFeature::Field(name.to_owned()),
+            OrderByStyle::Field { name, rti, .. } => OrderByFeature::Field {
+                name: name.to_owned(),
+                rti: *rti,
+            },
             OrderByStyle::Score { rti, .. } => OrderByFeature::Score { rti: *rti },
         };
         OrderByInfo {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1016,7 +1016,9 @@ impl CustomScan for JoinScan {
                     .order_by
                     .iter()
                     .map(|oi| match &oi.feature {
-                        OrderByFeature::Field(f) => format!("{} {}", f, oi.direction.as_ref()),
+                        OrderByFeature::Field { name: f, .. } => {
+                            format!("{} {}", f, oi.direction.as_ref())
+                        }
                         OrderByFeature::Var { rti, attno, name } => {
                             if let Some(info) = base_relations.iter().find(|i| i.heap_rti == *rti) {
                                 let col_name = get_attname_safe(

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -33,7 +33,7 @@ use crate::index::fast_fields_helper::WhichFastField;
 use crate::nodecast;
 use crate::postgres::customscan::basescan::projections::score::is_score_func;
 use crate::postgres::customscan::opexpr::lookup_operator;
-use crate::postgres::customscan::pullup::resolve_fast_field;
+use crate::postgres::customscan::pullup::{field_type_for_pullup, resolve_fast_field};
 use crate::postgres::customscan::qual_inspect::{extract_quals, PlannerContext, QualExtractState};
 use crate::postgres::customscan::range_table::{bms_iter, get_plain_relation_relid};
 use crate::postgres::customscan::score_funcoids;
@@ -790,7 +790,10 @@ pub(super) unsafe fn collect_required_fields(
                     ensure_column(source, *rti, *attno);
                 }
             }
-            OrderByFeature::Field(name_wrapper) => {
+            OrderByFeature::Field {
+                name: name_wrapper,
+                rti,
+            } => {
                 let name = name_wrapper.as_ref();
                 if let Some((alias, col_name)) = name.split_once('.') {
                     let raw_col_name = col_name.trim_matches('"');
@@ -798,6 +801,27 @@ pub(super) unsafe fn collect_required_fields(
                         if source.scan_info.alias.as_deref() == Some(alias) {
                             if let Some(attno) = get_attno_by_name(source, raw_col_name) {
                                 ensure_field(source, attno);
+                            }
+                            break;
+                        }
+                    }
+                } else {
+                    // Unqualified field name (e.g. from indexed expression) — use RTI
+                    // to find the correct source and ensure the column is projected.
+                    for source in &mut plan_sources {
+                        if source.contains_rti(*rti) {
+                            // Try as a regular column first, then fall back to
+                            // expression-indexed field.  The column `name` may
+                            // exist in the table but only be indexed via an
+                            // expression (e.g. upper(name)), in which case
+                            // ensure_field (via resolve_fast_field) won't find it.
+                            let added = get_attno_by_name(source, name)
+                                .and_then(|attno| try_ensure_field(source, attno))
+                                .is_some();
+                            if !added {
+                                if let Err(e) = ensure_expression_field(source, name) {
+                                    pgrx::warning!("JoinScan: failed to project expression field '{name}': {e}");
+                                }
                             }
                             break;
                         }
@@ -827,24 +851,66 @@ unsafe fn ensure_ctid(source: &mut JoinSource) {
 
 /// Appends a specific attribute number to the list of output fields for a `JoinSource` if not already present.
 unsafe fn ensure_field(side: &mut JoinSource, attno: pg_sys::AttrNumber) {
+    if try_ensure_field(side, attno).is_none() {
+        pgrx::warning!(
+            "JoinScan: could not resolve fast field for attno {} on relation {}",
+            attno,
+            side.scan_info.heaprelid
+        );
+    }
+}
+
+/// Like `ensure_field`, but returns `Some(())` on success or `None` on failure
+/// (instead of printing a warning).
+unsafe fn try_ensure_field(side: &mut JoinSource, attno: pg_sys::AttrNumber) -> Option<()> {
     if side.scan_info.fields.iter().any(|f| f.attno == attno) {
-        return;
+        return Some(());
     }
 
     let heaprel = PgSearchRelation::open(side.scan_info.heaprelid);
     let indexrel = PgSearchRelation::open(side.scan_info.indexrelid);
     let tupdesc = heaprel.tuple_desc();
 
-    if let Some(field) = resolve_fast_field(attno as i32, &tupdesc, &indexrel) {
-        side.scan_info.add_field(attno, field);
-        return;
-    }
+    let field = resolve_fast_field(attno as i32, &tupdesc, &indexrel)?;
+    side.scan_info.add_field(attno, field);
+    Some(())
+}
 
-    pgrx::warning!(
-        "ensure_field: failed for attno {} in relation {:?}",
-        attno,
-        side.scan_info.alias.clone()
+/// Ensures an expression-indexed fast field is projected from a `JoinSource`.
+///
+/// Unlike `ensure_field` (which resolves plain columns via attno), this function
+/// looks up a search field by name in the BM25 index schema and adds the
+/// corresponding `WhichFastField` directly.  Used for ORDER BY on indexed
+/// expressions like `upper(name)`, where the Tantivy field has no matching
+/// PostgreSQL column attno.
+unsafe fn ensure_expression_field(source: &mut JoinSource, field_name: &str) -> Result<(), String> {
+    let index_rel = PgSearchRelation::open(source.scan_info.indexrelid);
+    let schema = SearchIndexSchema::open(&index_rel).map_err(|e| {
+        format!(
+            "Failed to open schema for index {}: {e}",
+            source.scan_info.indexrelid
+        )
+    })?;
+    let search_field = schema
+        .search_field(field_name)
+        .ok_or_else(|| format!("Field '{field_name}' is not part of the schema"))?;
+    if !search_field.is_fast() {
+        return Err(format!("Field '{field_name}' is not a fast field"));
+    }
+    let categorized = schema.categorized_fields();
+    let (_, data) = categorized
+        .iter()
+        .find(|(sf, _)| sf == &search_field)
+        .ok_or_else(|| format!("Field '{field_name}' not found in categorized fields"))?;
+    let field_type = field_type_for_pullup(search_field.field_type(), data.is_array)
+        .ok_or_else(|| format!("Field '{field_name}' has unsupported type for pullup"))?;
+
+    let synthetic_attno = -(source.scan_info.fields.len() as pg_sys::AttrNumber + 1);
+    source.scan_info.add_field(
+        synthetic_attno,
+        WhichFastField::Named(field_name.to_string(), field_type),
     );
+    Ok(())
 }
 
 /// Helper function to retrieve an attribute number given a column name from a `JoinSource`'s underlying heap relation.
@@ -893,7 +959,9 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
                 }
             }
 
-            if let Some(var) = nodecast!(Var, T_Var, expr) {
+            let check_expr = strip_wrappers(expr.cast());
+
+            if let Some(var) = nodecast!(Var, T_Var, check_expr) {
                 let varno = (*var).varno as pg_sys::Index;
                 let varattno = (*var).varattno;
 
@@ -907,6 +975,30 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
                         ) {
                             return false;
                         }
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return false;
+                }
+            } else {
+                // Non-Var expression — check if it matches an indexed expression
+                // so we can emit it directly from the index.
+                let mut found = false;
+                for source in sources {
+                    let index_rel = PgSearchRelation::open(source.scan_info.indexrelid);
+                    let Ok(schema) = SearchIndexSchema::open(&index_rel) else {
+                        continue;
+                    };
+                    if find_matching_fast_field(
+                        expr as *mut pg_sys::Node,
+                        &index_rel.index_expressions(),
+                        schema,
+                        source.scan_info.heap_rti,
+                    )
+                    .is_some()
+                    {
                         found = true;
                         break;
                     }
@@ -1238,6 +1330,34 @@ pub(super) unsafe fn extract_orderby(
                         direction,
                     });
                     pathkey_resolved = true;
+                }
+            } else {
+                // Non-Var expression — check if it matches an indexed expression
+                // so we can push the sort into the index.
+                for source in sources {
+                    if !output_rtis.contains(&source.scan_info.heap_rti) {
+                        continue;
+                    }
+                    let index_rel = PgSearchRelation::open(source.scan_info.indexrelid);
+                    let Ok(schema) = SearchIndexSchema::open(&index_rel) else {
+                        continue;
+                    };
+                    if let Some(search_field) = find_matching_fast_field(
+                        check_expr as *mut pg_sys::Node,
+                        &index_rel.index_expressions(),
+                        schema,
+                        source.scan_info.heap_rti,
+                    ) {
+                        result.push(OrderByInfo {
+                            feature: OrderByFeature::Field {
+                                name: search_field.name().into(),
+                                rti: source.scan_info.heap_rti,
+                            },
+                            direction,
+                        });
+                        pathkey_resolved = true;
+                        break;
+                    }
                 }
             }
             if pathkey_resolved {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -610,7 +610,21 @@ fn build_clause_df<'a>(
                                 .unwrap_or_else(|| col("unknown_score"))
                         }
                     }
-                    OrderByFeature::Field(name) => col(name.as_ref()),
+                    OrderByFeature::Field { name, rti } => join_clause
+                        .plan
+                        .sources()
+                        .iter()
+                        .enumerate()
+                        .find(|(_, s)| s.contains_rti(*rti))
+                        .map(|(idx, source)| {
+                            let alias = RelationAlias::new(source.scan_info.alias.as_deref())
+                                .execution(idx);
+                            make_col(&alias, name.as_ref())
+                        })
+                        .unwrap_or_else(|| {
+                            pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
+                            col(name.as_ref())
+                        }),
                     OrderByFeature::Var { rti, attno, .. } => {
                         if !distinct_col_map.is_empty() {
                             resolve_distinct_col(false, *rti, *attno, "")
@@ -771,8 +785,10 @@ fn build_source_df<'a>(
         if join_clause.has_distinct {
             for info in &join_clause.order_by {
                 match &info.feature {
-                    OrderByFeature::Field(name) => {
-                        required_early.insert(name.as_ref().to_string());
+                    OrderByFeature::Field { name, rti } => {
+                        if source.contains_rti(*rti) {
+                            required_early.insert(name.as_ref().to_string());
+                        }
                     }
                     OrderByFeature::Var { rti, attno, .. } => {
                         // Only insert columns belonging to THIS source

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -27,6 +27,7 @@
 use crate::api::FieldName;
 use crate::index::reader::index::MAX_TOPK_FEATURES;
 use crate::nodecast;
+use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
 use crate::postgres::customscan::builders::custom_path::OrderByStyle;
 use crate::postgres::customscan::score_funcoids;
 use crate::postgres::options::{SortByDirection, SortByField};
@@ -45,6 +46,8 @@ pub enum SortExpressionType {
     Lower,
     /// Sorting by a raw field: `ORDER BY col`
     Raw,
+    /// Sorting by an expression that matched an indexed expression in `pg_index.indexprs`.
+    IndexedExpression,
 }
 
 /// Reason why pathkeys cannot be used for Top K execution
@@ -128,10 +131,58 @@ unsafe fn extract_lower_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var>
     None
 }
 
+/// Extract any `Var` node from an arbitrary expression tree.
+///
+/// This is needed for `IndexedExpression` handling, where we need a `Var` to check
+/// relation membership via `is_varno_valid_for_relation`. Returns the first `Var` found
+/// by recursively walking the expression tree.
+unsafe fn extract_any_var_from_expr(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var> {
+    if node.is_null() {
+        return None;
+    }
+    match (*node).type_ {
+        pg_sys::NodeTag::T_Var => Some(node as *mut pg_sys::Var),
+        pg_sys::NodeTag::T_FuncExpr => {
+            let args = PgList::<pg_sys::Node>::from_pg((*(node as *mut pg_sys::FuncExpr)).args);
+            let result = args
+                .iter_ptr()
+                .find_map(|arg| extract_any_var_from_expr(arg));
+            result
+        }
+        pg_sys::NodeTag::T_OpExpr => {
+            let args = PgList::<pg_sys::Node>::from_pg((*(node as *mut pg_sys::OpExpr)).args);
+            let result = args
+                .iter_ptr()
+                .find_map(|arg| extract_any_var_from_expr(arg));
+            result
+        }
+        pg_sys::NodeTag::T_RelabelType => {
+            extract_any_var_from_expr((*(node as *mut pg_sys::RelabelType)).arg.cast())
+        }
+        pg_sys::NodeTag::T_CoerceViaIO => {
+            extract_any_var_from_expr((*(node as *mut pg_sys::CoerceViaIO)).arg.cast())
+        }
+        pg_sys::NodeTag::T_CoerceToDomain => {
+            extract_any_var_from_expr((*(node as *mut pg_sys::CoerceToDomain)).arg.cast())
+        }
+        _ => None,
+    }
+}
+
+pub struct IndexExpressionInfo<'a> {
+    pub index_expressions: &'a PgList<pg_sys::Expr>,
+    pub schema: &'a SearchIndexSchema,
+    pub heap_rti: pg_sys::Index,
+}
+
 /// Analyzes an ORDER BY expression to determine its type and extract the underlying variable.
 ///
 /// This function unifies the logic for identifying sort keys across the planner hook (validation)
 /// and the custom scan planner (execution).
+///
+/// When `index_expressions`, `schema`, and `heap_rti` are provided, the function will also
+/// attempt to match the expression against indexed expressions via `find_matching_fast_field`
+/// as a fallback when the hardcoded patterns (Score, lower, Raw) don't match.
 ///
 /// Returns:
 /// - `Some((type, var, field_name))` if the expression is a supported sort key.
@@ -139,6 +190,7 @@ unsafe fn extract_lower_var(node: *mut pg_sys::Node) -> Option<*mut pg_sys::Var>
 pub unsafe fn analyze_sort_expression(
     node: *mut pg_sys::Node,
     context: VarContext,
+    index_info: Option<&IndexExpressionInfo>,
 ) -> Option<(SortExpressionType, *mut pg_sys::Var, Option<FieldName>)> {
     if let Some(var) = extract_score_var(node) {
         return Some((SortExpressionType::Score, var, None));
@@ -152,6 +204,22 @@ pub unsafe fn analyze_sort_expression(
 
     if let Some((var, field_name)) = find_one_var_and_fieldname(context, node) {
         return Some((SortExpressionType::Raw, var, Some(field_name)));
+    }
+
+    // This handles arbitrary expressions like upper(col), trim(col), col1 + col2, etc.
+    // that were used when building the BM25 index.
+    if let Some(info) = index_info {
+        if let Some(fast_field) = find_matching_fast_field(
+            node,
+            info.index_expressions,
+            info.schema.clone(),
+            info.heap_rti,
+        ) {
+            let field_name = FieldName::from(fast_field.name());
+            if let Some(var) = extract_any_var_from_expr(node) {
+                return Some((SortExpressionType::IndexedExpression, var, Some(field_name)));
+            }
+        }
     }
 
     None
@@ -224,6 +292,7 @@ pub unsafe fn extract_pathkey_styles_with_sortability_check<F1, F2>(
     schema: &SearchIndexSchema,
     regular_sortability_check: F1,
     lower_sortability_check: F2,
+    index_expressions: Option<&PgList<pg_sys::Expr>>,
 ) -> PathKeyInfo
 where
     F1: Fn(&SearchField) -> bool,
@@ -246,7 +315,8 @@ where
             let expr = (*member).em_expr;
 
             // Handle PlaceHolderVar: unwrap to check if it contains a sortable expression.
-            // We support any valid sort expression (Score, Lower, Raw) that might be wrapped.
+            // We support any valid sort expression (Score, Lower, Raw, IndexedExpression)
+            // that might be wrapped.
             let mut expr_to_analyze = expr;
             if let Some(phv) = nodecast!(PlaceHolderVar, T_PlaceHolderVar, expr) {
                 if let Some(funcexpr) = extract_funcexpr_from_placeholder(phv) {
@@ -254,9 +324,17 @@ where
                 }
             }
 
-            if let Some((sort_type, var, field_name_opt)) =
-                analyze_sort_expression(expr_to_analyze.cast(), VarContext::from_planner(root))
-            {
+            let index_info = index_expressions.map(|idx_exprs| IndexExpressionInfo {
+                index_expressions: idx_exprs,
+                schema,
+                heap_rti: rti,
+            });
+
+            if let Some((sort_type, var, field_name_opt)) = analyze_sort_expression(
+                expr_to_analyze.cast(),
+                VarContext::from_planner(root),
+                index_info.as_ref(),
+            ) {
                 // Verify the var belongs to the correct relation (either the relation itself or its parent)
                 if !is_varno_valid_for_relation(root, (*var).varno as pg_sys::Index, rti) {
                     continue;
@@ -272,7 +350,11 @@ where
                         if let Some(field_name) = field_name_opt {
                             if let Some(search_field) = schema.search_field(field_name.root()) {
                                 if lower_sortability_check(&search_field) {
-                                    pathkey_styles.push(OrderByStyle::Field(pathkey, field_name));
+                                    pathkey_styles.push(OrderByStyle::Field {
+                                        pathkey,
+                                        name: field_name,
+                                        rti,
+                                    });
                                     found_valid_member = true;
                                     break;
                                 }
@@ -283,7 +365,26 @@ where
                         if let Some(field_name) = field_name_opt {
                             if let Some(search_field) = schema.search_field(field_name.root()) {
                                 if regular_sortability_check(&search_field) {
-                                    pathkey_styles.push(OrderByStyle::Field(pathkey, field_name));
+                                    pathkey_styles.push(OrderByStyle::Field {
+                                        pathkey,
+                                        name: field_name,
+                                        rti,
+                                    });
+                                    found_valid_member = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    SortExpressionType::IndexedExpression => {
+                        if let Some(field_name) = field_name_opt {
+                            if let Some(search_field) = schema.search_field(field_name.root()) {
+                                if search_field.is_fast() {
+                                    pathkey_styles.push(OrderByStyle::Field {
+                                        pathkey,
+                                        name: field_name,
+                                        rti,
+                                    });
                                     found_valid_member = true;
                                     break;
                                 }
@@ -332,8 +433,13 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
     let target_list = PgList::<pg_sys::TargetEntry>::from_pg((*parse).targetList);
 
     // We need to identify the single relation that this Top K query targets
-    // Tuple: (varno, relid, schema)
-    let mut target_relation_info: Option<(pg_sys::Index, pg_sys::Oid, SearchIndexSchema)> = None;
+    // Tuple: (varno, relid, schema, index_expressions)
+    let mut target_relation_info: Option<(
+        pg_sys::Index,
+        pg_sys::Oid,
+        SearchIndexSchema,
+        PgList<pg_sys::Expr>,
+    )> = None;
 
     for sort_clause in sort_list.iter_ptr() {
         let tle_ref = (*sort_clause).tleSortGroupRef;
@@ -343,9 +449,20 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
 
         let expr = (*te).expr as *mut pg_sys::Node;
 
+        // Pass index expressions if we have them (after first sort clause identifies the relation)
+        let index_info = target_relation_info
+            .as_ref()
+            .map(|(_, _, schema, idx_exprs)| IndexExpressionInfo {
+                index_expressions: idx_exprs,
+                schema,
+                // TODO: heap_rti should use the actual varno from target_relation_info
+                // rather than hardcoded 1. Only matters for the #3455 window function path.
+                heap_rti: 1 as pg_sys::Index,
+            });
+
         // Use analyze_sort_expression to identify the sort key type and underlying variable
         let Some((sort_type, var, field_name_opt)) =
-            analyze_sort_expression(expr, VarContext::from_query(parse))
+            analyze_sort_expression(expr, VarContext::from_query(parse), index_info.as_ref())
         else {
             return false;
         };
@@ -356,7 +473,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
             return false;
         }
 
-        if let Some((expected_varno, _, _)) = &target_relation_info {
+        if let Some((expected_varno, _, _, _)) = &target_relation_info {
             if varno != *expected_varno {
                 // Sorting by different relations
                 return false;
@@ -379,11 +496,13 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 Err(_) => return false,
             };
 
-            target_relation_info = Some((varno, relid, schema));
+            let index_expressions = bm25_index.index_expressions();
+
+            target_relation_info = Some((varno, relid, schema, index_expressions));
         }
 
         // Validate sortability
-        let (_, _, schema) = target_relation_info.as_ref().unwrap();
+        let (_, _, schema, _) = target_relation_info.as_ref().unwrap();
 
         match sort_type {
             SortExpressionType::Score => {
@@ -409,6 +528,17 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                     return false;
                 };
                 if !search_field.is_raw_sortable() {
+                    return false;
+                }
+            }
+            SortExpressionType::IndexedExpression => {
+                let Some(field_name) = field_name_opt else {
+                    return false;
+                };
+                let Some(search_field) = schema.search_field(field_name.root()) else {
+                    return false;
+                };
+                if !search_field.is_fast() {
                     return false;
                 }
             }
@@ -505,7 +635,11 @@ unsafe fn check_var_matches_sort_by(
         return None;
     }
 
-    Some(OrderByStyle::Field(pathkey, sort_field_name.into()))
+    Some(OrderByStyle::Field {
+        pathkey,
+        name: sort_field_name.into(),
+        rti,
+    })
 }
 
 pub unsafe fn pathkey_matches_sort_by(

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -1,0 +1,436 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- Test TopN scan with indexed expressions (issue #3303)
+-- Verifies that ORDER BY <expr> LIMIT N uses TopN scan when <expr> was
+-- used to build the BM25 index, not just for the hardcoded patterns
+-- (pdb.score(), lower(), plain col).
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+-- Test 1: FuncExpr - upper() indexed expression gets TopN scan
+-- We search on category (separate column) and sort by upper(description).
+CREATE INDEX upper_idx ON mock_items
+    USING bm25 (id, category, (upper(description)::pdb.literal), rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: upper_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: description desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"electronics","is_datetime":false}}}}
+(9 rows)
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+         description         | rating 
+-----------------------------+--------
+ Plastic Keyboard            |      4
+ Innovative wireless earbuds |      5
+ Fast charging power bank    |      4
+ Ergonomic metal keyboard    |      4
+ Bluetooth-enabled speaker   |      3
+(5 rows)
+
+DROP INDEX upper_idx;
+-- Test 2: FuncExpr - trim() to verify it's not just upper() that works
+CREATE INDEX trim_idx ON mock_items
+    USING bm25 (id, category, (trim(description)::pdb.literal), rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY trim(description) DESC
+    LIMIT 5;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: trim_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: description desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"electronics","is_datetime":false}}}}
+(9 rows)
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY trim(description) DESC
+    LIMIT 5;
+         description         | rating 
+-----------------------------+--------
+ Plastic Keyboard            |      4
+ Innovative wireless earbuds |      5
+ Fast charging power bank    |      4
+ Ergonomic metal keyboard    |      4
+ Bluetooth-enabled speaker   |      3
+(5 rows)
+
+DROP INDEX trim_idx;
+-- Test 3: Negative test - expression NOT in index should NOT use TopN
+CREATE INDEX plain_idx ON mock_items
+    USING bm25 (id, description, rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items)
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (upper(description)) DESC
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items
+               Table: mock_items
+               Index: plain_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"term":{"field":"description","value":"sleek running shoes","is_datetime":false}}}}
+(9 rows)
+
+DROP INDEX plain_idx;
+-- Test 4: lower() still works as before (regression test)
+CREATE INDEX lower_idx ON mock_items
+    USING bm25 (id, (lower(description)::pdb.literal), rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) DESC
+    LIMIT 5;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: lower_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: description desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"description","value":"sleek running shoes","is_datetime":false}}}}
+(9 rows)
+
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) DESC
+    LIMIT 5;
+     description     | rating 
+---------------------+--------
+ Sleek running shoes |      5
+(1 row)
+
+DROP INDEX lower_idx;
+-- Test 5: Mixed expression types - lower() + rating
+CREATE INDEX mixed_idx ON mock_items
+    USING bm25 (id, (lower(description)::pdb.literal), rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) ASC, rating DESC
+    LIMIT 5;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: mixed_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: description asc, rating desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"description","value":"sleek running shoes","is_datetime":false}}}}
+(9 rows)
+
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) ASC, rating DESC
+    LIMIT 5;
+     description     | rating 
+---------------------+--------
+ Sleek running shoes |      5
+(1 row)
+
+DROP INDEX mixed_idx;
+-- Test 6: Mixed - indexed expression + plain column
+CREATE INDEX mixed_expr_idx ON mock_items
+    USING bm25 (id, category, (upper(description)::pdb.literal), rating)
+    WITH (key_field='id');
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) ASC, rating DESC
+    LIMIT 5;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items
+         Table: mock_items
+         Index: mixed_expr_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: description asc, rating desc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"term":{"field":"category","value":"electronics","is_datetime":false}}}}
+(9 rows)
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) ASC, rating DESC
+    LIMIT 5;
+         description         | rating 
+-----------------------------+--------
+ Bluetooth-enabled speaker   |      3
+ Ergonomic metal keyboard    |      4
+ Fast charging power bank    |      4
+ Innovative wireless earbuds |      5
+ Plastic Keyboard            |      4
+(5 rows)
+
+DROP INDEX mixed_expr_idx;
+DROP TABLE mock_items;
+-- =============================================================================
+-- Tests 7-9: JoinScan with indexed expressions
+-- Exercises order_by_columns_are_fast_fields() and extract_orderby() changes.
+-- =============================================================================
+CREATE TABLE expr_products (
+                               id INTEGER PRIMARY KEY,
+                               name TEXT NOT NULL,
+                               description TEXT,
+                               category TEXT NOT NULL
+);
+CREATE TABLE expr_suppliers (
+                                id INTEGER PRIMARY KEY,
+                                product_id INTEGER NOT NULL,
+                                name TEXT NOT NULL,
+                                contact_info TEXT
+);
+INSERT INTO expr_products (id, name, description, category) VALUES
+                                                                (1, 'Wireless Mouse', 'Ergonomic wireless mouse with Bluetooth', 'electronics'),
+                                                                (2, 'USB Cable', 'High-speed USB-C cable for data transfer', 'accessories'),
+                                                                (3, 'Keyboard', 'Mechanical keyboard with RGB wireless', 'electronics'),
+                                                                (4, 'Monitor Stand', 'Adjustable monitor stand ergonomic', 'furniture'),
+                                                                (5, 'Webcam', 'HD webcam for video conferencing', 'electronics'),
+                                                                (6, 'Headphones', 'Wireless noise-canceling headphones', 'electronics'),
+                                                                (7, 'Mouse Pad', 'Large gaming mouse pad wireless charging', 'accessories'),
+                                                                (8, 'Cable Organizer', 'Desktop cable organizer for setup', 'furniture'),
+                                                                (9, 'Wireless Charger', 'Fast wireless charging pad', 'electronics'),
+                                                                (10, 'USB Hub', 'Multi-port USB hub for connectivity', 'accessories');
+INSERT INTO expr_suppliers (id, product_id, name, contact_info) VALUES
+                                                                    (1, 1, 'TechCorp', 'wireless technology'),
+                                                                    (2, 2, 'CableCo', 'cable manufacturing'),
+                                                                    (3, 3, 'TechCorp', 'wireless technology'),
+                                                                    (4, 4, 'FurniPro', 'furniture solutions'),
+                                                                    (5, 5, 'TechCorp', 'wireless technology'),
+                                                                    (6, 6, 'TechCorp', 'wireless technology'),
+                                                                    (7, 7, 'CableCo', 'cable manufacturing'),
+                                                                    (8, 8, 'FurniPro', 'furniture solutions'),
+                                                                    (9, 9, 'TechCorp', 'wireless technology'),
+                                                                    (10, 10, 'CableCo', 'cable manufacturing');
+-- BM25 indexes with fast fields and an indexed expression: upper(name)
+CREATE INDEX expr_products_bm25 ON expr_products
+    USING bm25 (id, description, category, (upper(name)::pdb.literal))
+    WITH (
+    key_field = 'id',
+    text_fields = '{"category": {"fast": true}}'
+    );
+CREATE INDEX expr_suppliers_bm25 ON expr_suppliers
+    USING bm25 (id, product_id, name, contact_info)
+    WITH (
+    key_field = 'id',
+    text_fields = '{"name": {"fast": true}}',
+    numeric_fields = '{"product_id": {"fast": true}}'
+    );
+SET paradedb.enable_join_custom_scan = on;
+-- Test 7: JoinScan with ORDER BY indexed expression
+-- upper(name) is an indexed expression on expr_products — JoinScan should
+-- push the sort via extract_orderby()'s new indexed-expression branch.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.name) ASC
+    LIMIT 5;
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.name, s.name, (upper(p.name))
+   ->  Result
+         Output: p.name, s.name, upper(p.name)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.name, s.name
+               Relation Tree: s INNER p
+               Join Cond: p.id = s.product_id
+               Limit: 5
+               Order By: name asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+                 :   TantivyLookupExec: decode=[name]
+                 :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, name@1 as name]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, name@2, ctid_0@3]
+                 :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id, name@2 as name]
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :           ProjectionExec: expr=[ctid@0 as ctid_0, product_id@1 as product_id]
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(22 rows)
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.name) ASC
+    LIMIT 5;
+       name       | supplier_name 
+------------------+---------------
+ Headphones       | TechCorp
+ Keyboard         | TechCorp
+ Mouse Pad        | CableCo
+ Wireless Charger | TechCorp
+ Wireless Mouse   | TechCorp
+(5 rows)
+
+-- Test 8: JoinScan with ORDER BY plain fast-field column (regression)
+-- Ensures the existing Var path in order_by_columns_are_fast_fields()
+-- is not broken by the new else branch.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY s.name ASC
+    LIMIT 5;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.name, s.name
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.name, s.name
+         Relation Tree: s INNER p
+         Join Cond: p.id = s.product_id
+         Limit: 5
+         Order By: s.name asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, name@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyLookupExec: decode=[name]
+           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5
+           :       ProjectionExec: expr=[ctid_0@1 as ctid_0, name@2 as name, ctid_1@0 as ctid_1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, ctid_0@2, name@4]
+           :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           ProjectionExec: expr=[ctid@0 as ctid_0, product_id@1 as product_id, name@2 as name]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(20 rows)
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY s.name ASC
+    LIMIT 5;
+       name       | supplier_name 
+------------------+---------------
+ Mouse Pad        | CableCo
+ Wireless Mouse   | TechCorp
+ Keyboard         | TechCorp
+ Headphones       | TechCorp
+ Wireless Charger | TechCorp
+(5 rows)
+
+-- Test 9: JoinScan negative — upper(category) is NOT an indexed expression.
+-- order_by_columns_are_fast_fields() rejects it because find_matching_fast_field
+-- finds no match, so JoinScan falls back to native PG execution.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.category) ASC
+    LIMIT 5;
+WARNING:  JoinScan not used: all ORDER BY columns must be fast fields in the BM25 index (tables: p, s)
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.name, s.name, (upper(p.category))
+   ->  Sort
+         Output: p.name, s.name, (upper(p.category))
+         Sort Key: (upper(p.category))
+         ->  Hash Join
+               Output: p.name, s.name, upper(p.category)
+               Inner Unique: true
+               Hash Cond: (s.product_id = p.id)
+               ->  Seq Scan on public.expr_suppliers s
+                     Output: s.id, s.product_id, s.name, s.contact_info
+               ->  Hash
+                     Output: p.name, p.category, p.id
+                     ->  Custom Scan (ParadeDB Base Scan) on public.expr_products p
+                           Output: p.name, p.category, p.id
+                           Table: expr_products
+                           Index: expr_products_bm25
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.category) ASC
+    LIMIT 5;
+WARNING:  JoinScan not used: all ORDER BY columns must be fast fields in the BM25 index (tables: p, s)
+       name       | supplier_name 
+------------------+---------------
+ Mouse Pad        | CableCo
+ Wireless Mouse   | TechCorp
+ Keyboard         | TechCorp
+ Headphones       | TechCorp
+ Wireless Charger | TechCorp
+(5 rows)
+
+RESET paradedb.enable_join_custom_scan;
+DROP INDEX expr_products_bm25;
+DROP INDEX expr_suppliers_bm25;
+DROP TABLE expr_suppliers;
+DROP TABLE expr_products;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_columnar_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/topk-indexed-expressions.sql
+++ b/pg_search/tests/pg_regress/sql/topk-indexed-expressions.sql
@@ -1,0 +1,244 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+
+-- Test TopN scan with indexed expressions (issue #3303)
+-- Verifies that ORDER BY <expr> LIMIT N uses TopN scan when <expr> was
+-- used to build the BM25 index, not just for the hardcoded patterns
+-- (pdb.score(), lower(), plain col).
+
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items'
+);
+
+-- Test 1: FuncExpr - upper() indexed expression gets TopN scan
+-- We search on category (separate column) and sort by upper(description).
+CREATE INDEX upper_idx ON mock_items
+    USING bm25 (id, category, (upper(description)::pdb.literal), rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+
+DROP INDEX upper_idx;
+
+-- Test 2: FuncExpr - trim() to verify it's not just upper() that works
+CREATE INDEX trim_idx ON mock_items
+    USING bm25 (id, category, (trim(description)::pdb.literal), rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY trim(description) DESC
+    LIMIT 5;
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY trim(description) DESC
+    LIMIT 5;
+
+DROP INDEX trim_idx;
+
+-- Test 3: Negative test - expression NOT in index should NOT use TopN
+CREATE INDEX plain_idx ON mock_items
+    USING bm25 (id, description, rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY upper(description) DESC
+    LIMIT 5;
+
+DROP INDEX plain_idx;
+
+-- Test 4: lower() still works as before (regression test)
+CREATE INDEX lower_idx ON mock_items
+    USING bm25 (id, (lower(description)::pdb.literal), rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) DESC
+    LIMIT 5;
+
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) DESC
+    LIMIT 5;
+
+DROP INDEX lower_idx;
+
+-- Test 5: Mixed expression types - lower() + rating
+CREATE INDEX mixed_idx ON mock_items
+    USING bm25 (id, (lower(description)::pdb.literal), rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) ASC, rating DESC
+    LIMIT 5;
+
+SELECT description, rating FROM mock_items
+WHERE description === 'sleek running shoes'
+ORDER BY lower(description) ASC, rating DESC
+    LIMIT 5;
+
+DROP INDEX mixed_idx;
+
+-- Test 6: Mixed - indexed expression + plain column
+CREATE INDEX mixed_expr_idx ON mock_items
+    USING bm25 (id, category, (upper(description)::pdb.literal), rating)
+    WITH (key_field='id');
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) ASC, rating DESC
+    LIMIT 5;
+
+SELECT description, rating FROM mock_items
+WHERE category === 'electronics'
+ORDER BY upper(description) ASC, rating DESC
+    LIMIT 5;
+
+DROP INDEX mixed_expr_idx;
+
+DROP TABLE mock_items;
+
+-- =============================================================================
+-- Tests 7-9: JoinScan with indexed expressions
+-- Exercises order_by_columns_are_fast_fields() and extract_orderby() changes.
+-- =============================================================================
+
+CREATE TABLE expr_products (
+                               id INTEGER PRIMARY KEY,
+                               name TEXT NOT NULL,
+                               description TEXT,
+                               category TEXT NOT NULL
+);
+
+CREATE TABLE expr_suppliers (
+                                id INTEGER PRIMARY KEY,
+                                product_id INTEGER NOT NULL,
+                                name TEXT NOT NULL,
+                                contact_info TEXT
+);
+
+INSERT INTO expr_products (id, name, description, category) VALUES
+                                                                (1, 'Wireless Mouse', 'Ergonomic wireless mouse with Bluetooth', 'electronics'),
+                                                                (2, 'USB Cable', 'High-speed USB-C cable for data transfer', 'accessories'),
+                                                                (3, 'Keyboard', 'Mechanical keyboard with RGB wireless', 'electronics'),
+                                                                (4, 'Monitor Stand', 'Adjustable monitor stand ergonomic', 'furniture'),
+                                                                (5, 'Webcam', 'HD webcam for video conferencing', 'electronics'),
+                                                                (6, 'Headphones', 'Wireless noise-canceling headphones', 'electronics'),
+                                                                (7, 'Mouse Pad', 'Large gaming mouse pad wireless charging', 'accessories'),
+                                                                (8, 'Cable Organizer', 'Desktop cable organizer for setup', 'furniture'),
+                                                                (9, 'Wireless Charger', 'Fast wireless charging pad', 'electronics'),
+                                                                (10, 'USB Hub', 'Multi-port USB hub for connectivity', 'accessories');
+
+INSERT INTO expr_suppliers (id, product_id, name, contact_info) VALUES
+                                                                    (1, 1, 'TechCorp', 'wireless technology'),
+                                                                    (2, 2, 'CableCo', 'cable manufacturing'),
+                                                                    (3, 3, 'TechCorp', 'wireless technology'),
+                                                                    (4, 4, 'FurniPro', 'furniture solutions'),
+                                                                    (5, 5, 'TechCorp', 'wireless technology'),
+                                                                    (6, 6, 'TechCorp', 'wireless technology'),
+                                                                    (7, 7, 'CableCo', 'cable manufacturing'),
+                                                                    (8, 8, 'FurniPro', 'furniture solutions'),
+                                                                    (9, 9, 'TechCorp', 'wireless technology'),
+                                                                    (10, 10, 'CableCo', 'cable manufacturing');
+
+-- BM25 indexes with fast fields and an indexed expression: upper(name)
+CREATE INDEX expr_products_bm25 ON expr_products
+    USING bm25 (id, description, category, (upper(name)::pdb.literal))
+    WITH (
+    key_field = 'id',
+    text_fields = '{"category": {"fast": true}}'
+    );
+
+CREATE INDEX expr_suppliers_bm25 ON expr_suppliers
+    USING bm25 (id, product_id, name, contact_info)
+    WITH (
+    key_field = 'id',
+    text_fields = '{"name": {"fast": true}}',
+    numeric_fields = '{"product_id": {"fast": true}}'
+    );
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- Test 7: JoinScan with ORDER BY indexed expression
+-- upper(name) is an indexed expression on expr_products — JoinScan should
+-- push the sort via extract_orderby()'s new indexed-expression branch.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.name) ASC
+    LIMIT 5;
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.name) ASC
+    LIMIT 5;
+
+-- Test 8: JoinScan with ORDER BY plain fast-field column (regression)
+-- Ensures the existing Var path in order_by_columns_are_fast_fields()
+-- is not broken by the new else branch.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY s.name ASC
+    LIMIT 5;
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY s.name ASC
+    LIMIT 5;
+
+-- Test 9: JoinScan negative — upper(category) is NOT an indexed expression.
+-- order_by_columns_are_fast_fields() rejects it because find_matching_fast_field
+-- finds no match, so JoinScan falls back to native PG execution.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.category) ASC
+    LIMIT 5;
+
+SELECT p.name, s.name AS supplier_name
+FROM expr_products p
+         JOIN expr_suppliers s ON p.id = s.product_id
+WHERE p.description @@@ 'wireless'
+ORDER BY upper(p.category) ASC
+    LIMIT 5;
+
+RESET paradedb.enable_join_custom_scan;
+
+DROP INDEX expr_products_bm25;
+DROP INDEX expr_suppliers_bm25;
+DROP TABLE expr_suppliers;
+DROP TABLE expr_products;
+\i common/common_cleanup.sql

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -114,6 +114,12 @@ const COLUMNS: &[Column] = &[
         })
         .bm25_numeric_field(r#""rating": { "fast": true }"#)
         .random_generator_sql("(floor(random() * 5) + 1)::int"),
+    Column::new("category", "TEXT", "'electronics'")
+        .whereable(false)
+        .bm25_v2_expression(r#"(upper(category)::pdb.literal)"#)
+        .random_generator_sql(
+            "(ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int]"
+        ),
     Column::new("literal_normalized", "TEXT", "'Hello World'")
         .whereable({
             // literal_normalized lowercases text, so BM25 @@@ would match case-insensitively
@@ -642,9 +648,15 @@ async fn generated_joinscan(database: Db) {
         heap_condition in arb_cross_rel_expr(all_tables[0], all_tables[1], numeric_columns.to_vec()),
         // Optional DISTINCT keyword
         include_distinct in proptest::bool::ANY,
+        // Indexed expression ORDER BY (e.g. ORDER BY upper(category))
+        include_expr_ordering in proptest::bool::ANY,
         // Result limit
         limit in 1..=50usize,
     )| {
+        // DISTINCT + expression ORDER BY requires projecting the expression in SELECT,
+        // which JoinScan doesn't support yet. Skip this combination.
+        prop_assume!(!(include_distinct && include_expr_ordering));
+
         // Build join with selected number of tables
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
 
@@ -715,9 +727,17 @@ async fn generated_joinscan(database: Db) {
         // Build deterministic ORDER BY with tie-breaker columns
         // When joins produce multiple matching rows, we need to include columns from both sides
         // to ensure deterministic results when LIMIT is applied
-        let mut order_parts = vec![format!("{}.id", used_tables[0])];
-        for table in &used_tables[1..] {
-            order_parts.push(format!("{}.id", table));
+        let mut order_parts = Vec::new();
+        if include_expr_ordering {
+            order_parts.push(format!("upper({}.category)", used_tables[0]));
+        }
+        order_parts.push(format!("{}.id", used_tables[0]));
+        // Only add inner table tiebreakers when NOT using expression ordering,
+        // because SegmentedTopKExec may not project all sort keys from inner tables.
+        if !include_expr_ordering {
+            for table in &used_tables[1..] {
+                order_parts.push(format!("{}.id", table));
+            }
         }
         let order_by = order_parts.join(", ");
 


### PR DESCRIPTION
Closes #3303

## Why

`ORDER BY <expr> LIMIT N` queries could only use the TopN scan path for three hardcoded expression patterns: `pdb.score()`, `lower(col)`, and plain column references. Any other expression — `upper(col)`, `trim(col)`, etc. — was rejected even if it had been explicitly indexed in the BM25 index. The expression-to-index matching capability already existed in `find_matching_fast_field()` (used by the aggregate scan path) but was not wired into the TopN planning logic.

## How

- Add `SortExpressionType::IndexedExpression` variant to represent ORDER BY expressions matched against `pg_index.indexprs` via `find_matching_fast_field`
- Extend `analyze_sort_expression()` with a fourth fallback arm: Score → Lower → Raw → IndexedExpression → None. Three new optional parameters (`index_expressions`, `schema`, `heap_rti`) allow callers with index metadata to enable the fallback; callers without it pass `None` and get existing behavior
- Add `extract_any_var_from_expr()` helper to recursively walk arbitrary expression trees (`FuncExpr`, `OpExpr`, `RelabelType`, `CoerceViaIO`, `CoerceToDomain`) and extract a `Var` for RTI validation
- Plumb index expressions through `pullup_topk_pathkeys()` and `extract_pathkey_styles_with_sortability_check()` in BaseScan, and through the aggregate scan's existing call site
- Extend `validate_topk_compatibility()` in the planner hook to store and pass index expressions for sort clauses after the first
- In JoinScan, add `strip_wrappers()` before the Var check in `order_by_columns_are_fast_fields()`, and add an `else` branch that validates non-Var expressions via `find_matching_fast_field` — rejecting unindexed expressions early
- Defensive `is_fast()` checks added in both `validate_topk_compatibility()` and
`extract_pathkey_styles_with_sortability_check()` for `IndexedExpression`, despite `find_matching_fast_field` already validating fast-field status

### Known limitations

- **JoinScan indexed expression ORDER BY:** `order_by_columns_are_fast_fields()` accepts indexed expressions, but `extract_orderby()` does not yet resolve them into `OrderByInfo` — JoinScan falls back gracefully with a warning instead of pushing the sort. Full support requires extending `extract_orderby()` and ensuring the DataFusion plan builder projects the resolved field (tracked separately)
- **`validate_topk_compatibility()` first-clause gap:** The first sort clause gets `None` for index metadata (relation not yet identified), so `IndexedExpression` can't match. Only affects the #3455 window function workaround path — the main TopN path is unaffected

## Tests

Added `topk-indexed-expressions.sql` with 9 tests:

- **Tests 1–2:** Positive — `upper()` and `trim()` indexed expressions use TopKScanExecState
- **Test 3:** Negative — unindexed expression falls back to NormalScanExecState with warning
- **Tests 4–5:** Regression — `lower()` and `lower()` + rating mixed still work via existing special case
- **Test 6:** Mixed — indexed expression + plain column in multi-column TopN
- **Test 7:** JoinScan — indexed expression ORDER BY falls back gracefully (known limitation)
- **Test 8:** JoinScan regression — plain fast-field ORDER BY still uses JoinScan with SegmentedTopKExec
- **Test 9:** JoinScan negative — unindexed expression rejected with warning

---------