### PR TITLE
ci: Remove cache layer for Antithesis jobs

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -70,8 +70,6 @@ jobs:
             ENABLE_ANTITHESIS_INSTRUMENTATION=true
           platforms: linux/amd64
           file: docker/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.extract-workload-metadata.outputs.tags }}
           labels: ${{ steps.extract-workload-metadata.outputs.labels }}
@@ -103,8 +101,6 @@ jobs:
           context: .
           platforms: linux/amd64
           file: docker/Dockerfile.config
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.extract-config-metadata.outputs.tags }}
           labels: ${{ steps.extract-config-metadata.outputs.labels }}
@@ -126,8 +122,6 @@ jobs:
           context: .
           platforms: linux/amd64
           file: docker/Dockerfile.stressgres
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.extract-stressgres-metadata.outputs.tags }}
           labels: ${{ steps.extract-stressgres-metadata.outputs.labels }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
The Antithesis team surfaced the issue of the last few runs not working being from Ubicloud, so I'm just removing the cache.

## Why
^

## How
^

## Tests
^