### PR TITLE
revert "chore: Bump version to `0.22.4` for development. (#4472)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7081,7 +7081,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7463,7 +7463,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -7631,7 +7631,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.4"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "emoji",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.4"
+version = "0.22.3"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-eigvneca61cWW0hV0NTAJPa+MApZgA/YjPDsTq05754=";
+  cargoHash = "sha256-TbFKEU5Hv6+4D7h1tvd03dlsGYq3YYGWte7SH0KovpA=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
This reverts commit 9aae0ac996fc2f0321eed00c052ba0ef67d32f5d.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
