### PR TITLE
ci: Allow triggering Antithesis test runs via PR label

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -140,6 +140,8 @@ jobs:
           labels: ${{ steps.extract-stressgres-metadata.outputs.labels }}
 
       # antithesis.duration is in minutes, 480 minutes = 8 hours
+      # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
+      # antithesis.source ensures Community and Enteprise have separate histories
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.10
         with:
@@ -154,3 +156,5 @@ jobs:
           email_recipients: ${{ github.event.inputs.emails || 'developers@paradedb.com' }}
           additional_parameters: |-
             antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '30') || '480' }}
+            antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
+            antithesis.source=paradedb


### PR DESCRIPTION
## Summary
- Adds the ability to trigger the `antithesis-trigger-test-run` workflow by adding an `antithesis` label to a PR, matching the pattern used by the benchmark workflows (`benchmark-queries`, `benchmark-stressgres`).
- The label is automatically removed after the job starts so it can be re-applied to trigger another run.
- For PR-triggered runs, checks out the PR head SHA to build the correct code.

## Test plan
- [x] Verify the workflow is triggered when the `antithesis` label is added to a PR
- [x] Verify the label is removed after the job starts
- [x] Verify existing schedule and workflow_dispatch triggers still work