### PR TITLE
ci: Pin antithesis-trigger-action to v0.10

### DIFF
--- a/.github/workflows/antithesis-launch-debugger.yml
+++ b/.github/workflows/antithesis-launch-debugger.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Antithesis Multiverse Debugger Session
-        uses: antithesishq/antithesis-trigger-action@main
+        uses: antithesishq/antithesis-trigger-action@v0.10
         with:
           notebook_name: debugging
           tenant: paradedb

--- a/.github/workflows/antithesis-trigger-bug-report.yml
+++ b/.github/workflows/antithesis-trigger-bug-report.yml
@@ -49,7 +49,7 @@ jobs:
           echo "vtime=${vtime_1:-$vtime_2}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger Antithesis Bug Report Generation
-        uses: antithesishq/antithesis-trigger-action@main
+        uses: antithesishq/antithesis-trigger-action@v0.10
         with:
           notebook_name: bug_report
           tenant: paradedb

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -128,7 +128,7 @@ jobs:
 
       # antithesis.duration is in minutes, 480 minutes = 8 hours
       - name: Trigger Antithesis Test
-        uses: antithesishq/antithesis-trigger-action@main
+        uses: antithesishq/antithesis-trigger-action@v0.10
         with:
           notebook_name: ${{ github.event.inputs.notebook || 'paradedb' }}
           tenant: paradedb


### PR DESCRIPTION
## Summary
- Pin `antithesishq/antithesis-trigger-action` from `@main` to `@v0.10` now that versioned releases are published
- Updated in all three Antithesis workflows: trigger test run, launch debugger, and trigger bug report

## Test plan
- [x] Verify Antithesis test run workflow triggers successfully
- [x] Verify Antithesis debugger launch workflow triggers successfully
- [x] Verify Antithesis bug report workflow triggers successfully