### PR TITLE
feat: DataFusion aggregate plan builder for join aggregates

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -1,0 +1,357 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+// These functions are not yet called — they will be used by the execution
+// integration in #4488. Suppress dead_code until then.
+#![allow(dead_code)]
+
+//! DataFusion plan builder for aggregate-on-join queries.
+//!
+//! Builds a DataFusion logical plan from a [`RelNode`] join tree and a
+//! [`JoinAggregateTargetList`], producing: scan(s) → join → aggregate.
+//!
+//! Key difference from JoinScan's plan builder: no CTID columns, no late
+//! materialization, no SegmentedTopK — aggregates run entirely on fast fields
+//! and the result is aggregate rows, not individual tuples.
+
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, JoinType, Result};
+use datafusion::execution::context::{QueryPlanner, SessionState};
+use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::logical_expr::{lit, Expr};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+use datafusion::prelude::{DataFrame, SessionConfig, SessionContext};
+use futures::future::{FutureExt, LocalBoxFuture};
+
+use async_trait::async_trait;
+use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
+
+use crate::index::fast_fields_helper::WhichFastField;
+use crate::postgres::customscan::aggregatescan::join_targetlist::{
+    AggKind, JoinAggregateTargetList,
+};
+use crate::postgres::customscan::joinscan::build::{JoinSource, RelNode, RelationAlias};
+use crate::postgres::customscan::joinscan::planner::SortMergeJoinEnforcer;
+use crate::postgres::customscan::joinscan::translator::make_col;
+use crate::scan::PgSearchTableProvider;
+
+// Re-export DataFusion aggregate helpers
+use datafusion::functions_aggregate::expr_fn::{avg, count, max, min, sum};
+
+/// Custom query planner that uses our LateMaterializePlanner extension.
+/// Same as JoinScan's PgSearchQueryPlanner.
+#[derive(Debug)]
+struct AggQueryPlanner;
+
+#[async_trait]
+impl QueryPlanner for AggQueryPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &datafusion::logical_expr::LogicalPlan,
+        session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let physical_planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
+            crate::scan::late_materialization::LateMaterializePlanner {},
+        )]);
+        physical_planner
+            .create_physical_plan(logical_plan, session_state)
+            .await
+    }
+}
+
+/// Create a DataFusion [`SessionContext`] for aggregate workloads.
+///
+/// Similar to JoinScan's `create_session_context()` but without
+/// `SegmentedTopKRule` (row-level TopK doesn't apply to aggregates).
+pub fn create_aggregate_session_context() -> SessionContext {
+    let config = SessionConfig::new().with_target_partitions(1);
+
+    let mut builder = SessionStateBuilder::new().with_config(config);
+
+    // SortMergeJoinEnforcer: converts HashJoinExec → SortMergeJoinExec when inputs are sorted
+    if crate::gucs::is_columnar_sort_enabled() {
+        builder = builder.with_physical_optimizer_rule(Arc::new(SortMergeJoinEnforcer::new()));
+        builder =
+            builder.with_physical_optimizer_rule(Arc::new(FilterPushdown::new_post_optimization()));
+    }
+
+    // LateMaterializationRule: defer string column reads during join phase
+    builder = builder.with_optimizer_rule(Arc::new(
+        crate::scan::late_materialization::LateMaterializationRule,
+    ));
+
+    // Our custom query planner
+    builder = builder.with_query_planner(Arc::new(AggQueryPlanner {}));
+
+    // Skip SegmentedTopKRule — not applicable to aggregates (M2 will add TopKAggregateRule)
+
+    // FilterPushdown: push filters to PgSearchTableProvider
+    builder =
+        builder.with_physical_optimizer_rule(Arc::new(FilterPushdown::new_post_optimization()));
+
+    SessionContext::new_with_state(builder.build())
+}
+
+/// Build the complete DataFusion logical plan for an aggregate-on-join query:
+/// scan(s) → join → aggregate.
+pub async fn build_join_aggregate_plan(
+    plan: &RelNode,
+    targetlist: &JoinAggregateTargetList,
+    ctx: &SessionContext,
+) -> Result<datafusion::logical_expr::LogicalPlan> {
+    // Step 1: Build the join DataFrame from the RelNode tree
+    let df = build_relnode_df(ctx, plan).await?;
+
+    // Step 2: Build GROUP BY expressions
+    let group_exprs: Vec<Expr> = targetlist
+        .group_columns
+        .iter()
+        .map(|gc| {
+            let source = plan.source_for_rti_in_subtree(gc.rti);
+            let (alias, _col_name) = resolve_source_column(source, gc.rti, &gc.field_name, plan);
+            make_col(&alias, &gc.field_name)
+        })
+        .collect();
+
+    // Step 3: Build aggregate expressions
+    let agg_exprs: Vec<Expr> = targetlist
+        .aggregates
+        .iter()
+        .enumerate()
+        .map(|(i, agg)| {
+            let agg_expr = match agg.agg_kind {
+                AggKind::CountStar => count(lit(1)),
+                AggKind::Count => {
+                    let col_expr = agg_field_col(agg, plan);
+                    count(col_expr)
+                }
+                AggKind::Sum => {
+                    let col_expr = agg_field_col(agg, plan);
+                    sum(col_expr)
+                }
+                AggKind::Avg => {
+                    let col_expr = agg_field_col(agg, plan);
+                    avg(col_expr)
+                }
+                AggKind::Min => {
+                    let col_expr = agg_field_col(agg, plan);
+                    min(col_expr)
+                }
+                AggKind::Max => {
+                    let col_expr = agg_field_col(agg, plan);
+                    max(col_expr)
+                }
+            };
+            // Alias for stable reference
+            agg_expr.alias(format!("agg_{}", i))
+        })
+        .collect();
+
+    // Step 4: Apply aggregate
+    let df = df.aggregate(group_exprs, agg_exprs)?;
+
+    df.into_optimized_plan()
+}
+
+/// Build a DataFusion physical plan from a logical plan.
+pub async fn build_aggregate_physical_plan(
+    ctx: &SessionContext,
+    logical_plan: datafusion::logical_expr::LogicalPlan,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let state = ctx.state();
+    let plan = state
+        .query_planner()
+        .create_physical_plan(&logical_plan, &state)
+        .await?;
+
+    if plan.output_partitioning().partition_count() > 1 {
+        Ok(Arc::new(CoalescePartitionsExec::new(plan)) as Arc<dyn ExecutionPlan>)
+    } else {
+        Ok(plan)
+    }
+}
+
+/// Recursively lower a [`RelNode`] tree into a DataFusion [`DataFrame`].
+///
+/// Unlike JoinScan's `build_relnode_df`, this version:
+/// - Does NOT include CTID columns (no heap fetch needed for aggregates)
+/// - Does NOT handle LIMIT, ORDER BY, DISTINCT, or output projection
+///   (those are handled by the aggregate layer above)
+/// - Is single-threaded (no partitioning logic)
+fn build_relnode_df<'a>(
+    ctx: &'a SessionContext,
+    node: &'a RelNode,
+) -> LocalBoxFuture<'a, Result<DataFrame>> {
+    async move {
+        match node {
+            RelNode::Scan(source) => {
+                let plan_position = source.plan_position;
+                let df = build_source_df(ctx, source, plan_position).await?;
+                let alias =
+                    RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
+                Ok(df.alias(&alias)?)
+            }
+            RelNode::Join(join) => {
+                let left_df = build_relnode_df(ctx, &join.left).await?;
+                let right_df = build_relnode_df(ctx, &join.right).await?;
+
+                // Build equi-join expressions
+                let mut on: Vec<Expr> = Vec::new();
+                for jk in &join.equi_keys {
+                    let ((left_source, left_attno), (right_source, right_attno)) =
+                        jk.resolve_against(&join.left, &join.right).ok_or_else(|| {
+                            DataFusionError::Internal(format!(
+                                "Failed to resolve join key: outer_rti={}, inner_rti={}",
+                                jk.outer_rti, jk.inner_rti
+                            ))
+                        })?;
+
+                    let left_alias = RelationAlias::new(left_source.scan_info.alias.as_deref())
+                        .execution(left_source.plan_position);
+                    let right_alias = RelationAlias::new(right_source.scan_info.alias.as_deref())
+                        .execution(right_source.plan_position);
+
+                    let left_col = left_source
+                        .column_name(left_attno)
+                        .ok_or_else(|| DataFusionError::Internal("Missing left column".into()))?;
+                    let right_col = right_source
+                        .column_name(right_attno)
+                        .ok_or_else(|| DataFusionError::Internal("Missing right column".into()))?;
+
+                    on.push(
+                        make_col(&left_alias, &left_col).eq(make_col(&right_alias, &right_col)),
+                    );
+                }
+
+                let df_join_type = match join.join_type {
+                    crate::postgres::customscan::joinscan::build::JoinType::Inner => {
+                        JoinType::Inner
+                    }
+                    unsupported => {
+                        return Err(DataFusionError::NotImplemented(format!(
+                            "Aggregate-on-join only supports INNER JOIN, got {}",
+                            unsupported
+                        )));
+                    }
+                };
+
+                if on.is_empty() {
+                    left_df.join(right_df, df_join_type, &[], &[], None)
+                } else {
+                    left_df.join_on(right_df, df_join_type, on)
+                }
+            }
+            RelNode::Filter(filter) => {
+                // For now, filters in the RelNode tree are not expected for aggregate queries.
+                // The search predicates are pushed into PgSearchTableProvider at scan level.
+                let df = build_relnode_df(ctx, &filter.input).await?;
+                // TODO: translate filter.predicate to DataFusion Expr if needed
+                Ok(df)
+            }
+        }
+    }
+    .boxed_local()
+}
+
+/// Build a DataFusion [`DataFrame`] for a single scan source.
+///
+/// Unlike JoinScan's `build_source_df`, this version:
+/// - Does NOT include CTID or Score columns
+/// - Is always single-threaded (no partitioning)
+/// - Does NOT set up late materialization
+async fn build_source_df(
+    ctx: &SessionContext,
+    source: &JoinSource,
+    plan_position: usize,
+) -> Result<DataFrame> {
+    let scan_info = source.scan_info.clone();
+    let alias = RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
+
+    // Collect only Named fast fields — skip Ctid, Score, Junk
+    let fields: Vec<WhichFastField> = source
+        .scan_info
+        .fields
+        .iter()
+        .filter_map(|f| match &f.field {
+            WhichFastField::Named(..) | WhichFastField::Deferred(..) => Some(f.field.clone()),
+            WhichFastField::Ctid
+            | WhichFastField::Score
+            | WhichFastField::Junk(_)
+            | WhichFastField::TableOid => None,
+        })
+        .collect();
+
+    let provider = PgSearchTableProvider::new(scan_info, fields.clone(), None, false);
+    let provider = Arc::new(provider);
+    ctx.register_table(alias.as_str(), provider)?;
+
+    let mut df = ctx.table(alias.as_str()).await?;
+
+    // Select only the named fields
+    let exprs: Vec<Expr> = fields
+        .iter()
+        .map(|f| make_col(alias.as_str(), &f.name()))
+        .collect();
+
+    if !exprs.is_empty() {
+        df = df.select(exprs)?;
+    }
+
+    Ok(df)
+}
+
+/// Resolve a source column to its DataFusion alias and column name.
+fn resolve_source_column(
+    source: Option<&JoinSource>,
+    rti: pgrx::pg_sys::Index,
+    field_name: &str,
+    plan: &RelNode,
+) -> (String, String) {
+    if let Some(src) = source {
+        let alias = RelationAlias::new(src.scan_info.alias.as_deref()).execution(src.plan_position);
+        (alias, field_name.to_string())
+    } else {
+        // Fallback: find the source by walking sources list
+        for src in plan.sources() {
+            if src.contains_rti(rti) {
+                let alias =
+                    RelationAlias::new(src.scan_info.alias.as_deref()).execution(src.plan_position);
+                return (alias, field_name.to_string());
+            }
+        }
+        // Should not happen — the planner validated all RTIs
+        (format!("unknown_rti_{}", rti), field_name.to_string())
+    }
+}
+
+/// Build a DataFusion column expression for an aggregate's field reference.
+fn agg_field_col(
+    agg: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateEntry,
+    plan: &RelNode,
+) -> Expr {
+    let (rti, _attno, ref field_name) = agg
+        .field_ref
+        .as_ref()
+        .expect("non-COUNT(*) aggregate must have a field reference");
+
+    let source = plan.source_for_rti_in_subtree(*rti);
+    let (alias, _) = resolve_source_column(source, *rti, field_name, plan);
+    make_col(&alias, field_name)
+}

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -18,6 +18,7 @@
 pub mod aggregate_type;
 pub mod build;
 pub mod datafusion_build;
+pub mod datafusion_exec;
 pub mod exec;
 pub mod filterquery;
 pub mod groupby;

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -460,7 +460,7 @@ impl JoinSource {
     }
 
     /// Resolve an attribute number to its DataFusion column name.
-    pub(super) fn column_name(&self, attno: pg_sys::AttrNumber) -> Option<String> {
+    pub fn column_name(&self, attno: pg_sys::AttrNumber) -> Option<String> {
         self.scan_info
             .fields
             .iter()

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -141,7 +141,7 @@
 pub mod build;
 mod explain;
 pub mod memory;
-mod planner;
+pub mod planner;
 mod planning;
 pub mod predicate;
 mod privdat;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4486

## What

Add `aggregatescan/datafusion_exec.rs` — the DataFusion plan building infrastructure that translates a `RelNode` join tree + `JoinAggregateTargetList` into a DataFusion logical plan: scan(s) → join → aggregate.

## Why

This is the core engine that will power aggregate-on-join execution. It takes the planner's serialized join tree and aggregate spec (#4485) and produces a DataFusion plan that runs entirely on fast fields without heap access.

## How

- `create_aggregate_session_context()`: sets up a DataFusion `SessionContext` with the right optimizer rules for aggregates — `SortMergeJoinEnforcer`, `LateMaterializationRule`, `FilterPushdown`, but *not* `SegmentedTopKRule` (row-level TopK doesn't apply to aggregates)
- `build_join_aggregate_plan()`: builds the full logical plan by recursively lowering the `RelNode` tree into a join DataFrame, then appending a DataFusion `Aggregate` node. Maps `AggKind` to `count(lit(1))` / `sum(col(...))` / `avg(col(...))` / etc.
- `build_aggregate_physical_plan()`: converts logical to physical plan via the session context
- `build_relnode_df()`: recursive `RelNode` → `DataFrame` lowering, simplified from JoinScan's version (no CTID columns, no partitioning, no late materialization)
- `build_source_df()`: creates `PgSearchTableProvider` per source, selecting only Named fast fields

Also promotes `JoinSource::column_name()` to `pub` and `joinscan::planner` to `pub mod` for `SortMergeJoinEnforcer` access.

Builds on #4485 (planner integration), #4484 (target list), #4483 (join tree), #4482 (shared infra).

## Tests

- `cargo check` — zero errors, zero warnings
- All 11 aggregate regression tests pass
- All pre-commit hooks pass (fmt, clippy, cargo check)
- Functions are `#![allow(dead_code)]` until wired into execution in #4488