### PR TITLE
feat: Aggregate-on-join benchmark queries (M1 baseline)

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -5,13 +5,15 @@
 -- DataFusion backend's basic scan → join → aggregate pipeline.
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*)
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content @@@ 'Section';
 
 -- DataFusion aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content @@@ 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -5,13 +5,15 @@
 -- in a single pass over the joined data.
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content @@@ 'Section';
 
 -- DataFusion aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content @@@ 'Section';


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4491

## What

Add benchmark query files for aggregate-on-join performance measurement to the `docs` dataset.

## Why

We need baseline numbers to measure M2 improvements (TopK pushdown, parallelization) against, and to verify the planner branching logic doesn't regress single-table aggregate planning performance. The existing `aggregate_sort.sql` covers GROUP BY + ORDER BY + LIMIT on joins — these two new files cover the remaining shapes.

## How

Two new query files in `benchmarks/datasets/docs/queries/pg_search/`:

- **`aggregate_join_count.sql`** — scalar `COUNT(*)` on JOIN with `@@@` predicate. Each query runs twice: once with Postgres default plan (GUC off) and once with DataFusion aggregate scan (GUC on), enabling direct A/B comparison.
- **`aggregate_join_multi.sql`** — multiple aggregates (`COUNT`, `MIN`, `MAX`) on the same JOIN, testing multi-aggregate computation in a single pass.

Together with the existing `aggregate_sort.sql` (GROUP BY + ORDER BY + LIMIT), these three files provide comprehensive aggregate-on-join benchmark coverage.

To run: `cargo run -p benchmarks -- --url $DATABASE_URL --dataset docs --benchmark sql`

## Tests

- Verified queries execute correctly against a live database
- `aggregate_join` regression test passes
- All pre-commit hooks pass