### PR TITLE
perf: Cache segment_id->segment_ordinal mapping during SearchIndexReader construction

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -316,6 +316,7 @@ pub struct SearchIndexReader {
     need_scores: bool,
     total_segment_count: usize,
     total_docs: u64,
+    segment_ordinal_by_id: HashMap<SegmentId, SegmentOrdinal>,
 
     // [`PinnedBuffer`] has a Drop impl, so we hold onto it but don't otherwise use it
     //
@@ -343,6 +344,7 @@ impl Clone for SearchIndexReader {
             need_scores: self.need_scores,
             total_segment_count: self.total_segment_count,
             total_docs: self.total_docs,
+            segment_ordinal_by_id: self.segment_ordinal_by_id.clone(),
             _cleanup_lock: self._cleanup_lock.clone(),
         }
     }
@@ -455,6 +457,12 @@ impl SearchIndexReader {
                 )
                 .unwrap_or_else(|e| panic!("{e}"))
         };
+        let segment_ord_by_id = searcher
+            .segment_readers()
+            .iter()
+            .enumerate()
+            .map(|(ord, reader)| (reader.segment_id(), ord as SegmentOrdinal))
+            .collect();
 
         Ok(Self {
             index_rel: index_relation.clone(),
@@ -466,6 +474,7 @@ impl SearchIndexReader {
             need_scores,
             total_segment_count,
             total_docs,
+            segment_ordinal_by_id: segment_ord_by_id,
             _cleanup_lock: cleanup_lock,
         })
     }
@@ -1391,25 +1400,22 @@ impl SearchIndexReader {
         (first_orderby_info, erased_features)
     }
 
+    fn segment_ordinal_by_id(&self, segment_id: &SegmentId) -> Option<SegmentOrdinal> {
+        self.segment_ordinal_by_id.get(segment_id).copied()
+    }
+
     /// NOTE: It is very important that this method consumes the input SegmentIds lazily, because
     /// some callers (the Top K exec method in particular) are producing them lazily by checking
     /// them out of shared mutable state as they go.
-    ///
-    /// TODO: See https://github.com/paradedb/paradedb/issues/2758 about removing the O(N) behavior
-    /// here.
     fn segment_readers_in_segments(
         &self,
         segment_ids: impl Iterator<Item = SegmentId>,
     ) -> impl Iterator<Item = (SegmentOrdinal, &SegmentReader)> {
         segment_ids.map(|segment_id| {
-            let (segment_ord, segment_reader) = self
-                .searcher
-                .segment_readers()
-                .iter()
-                .enumerate()
-                .find(|(_, reader)| reader.segment_id() == segment_id)
+            let ord = self
+                .segment_ordinal_by_id(&segment_id)
                 .unwrap_or_else(|| panic!("segment {segment_id} should exist"));
-            (segment_ord as SegmentOrdinal, segment_reader)
+            (ord, self.searcher.segment_reader(ord))
         })
     }
 


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #2758 

## What
Remove the O(n^2) behavior in `segment_readers_in_segments` by caching the `SegmentId`->`SegmentOrdinal` mapping during `SearchIndexReader` construction. This allows looking up a segment reader by segment id (via the segment ordinal) in O(1) time in the average case.

## Why
This should improve the performance of segment collection somewhat for cases with a large number of segments.

## How
See "what"

## Tests
- All existing tests pass