### PR TITLE
feat: Date/Timestamp Arrow projection for DataFusion aggregate path

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -194,6 +194,32 @@ fn arrow_value_to_datum(
             let val = col.as_any().downcast_ref::<BooleanArray>()?.value(row_idx);
             val.into_datum()
         }
+        DataType::Timestamp(_, _) => {
+            // Tantivy stores dates as TimestampNanosecond (i64 nanoseconds)
+            let val = col
+                .as_any()
+                .downcast_ref::<arrow_array::TimestampNanosecondArray>()?
+                .value(row_idx);
+            timestamp_nanos_to_datum(val, typoid)
+        }
+        DataType::Date32 => {
+            // Date32: days since epoch → convert to nanoseconds
+            let days = col
+                .as_any()
+                .downcast_ref::<arrow_array::Date32Array>()?
+                .value(row_idx);
+            let nanos = days as i64 * 86_400_000_000_000;
+            timestamp_nanos_to_datum(nanos, typoid)
+        }
+        DataType::Date64 => {
+            // Date64: milliseconds since epoch → convert to nanoseconds
+            let millis = col
+                .as_any()
+                .downcast_ref::<arrow_array::Date64Array>()?
+                .value(row_idx);
+            let nanos = millis * 1_000_000;
+            timestamp_nanos_to_datum(nanos, typoid)
+        }
         DataType::Decimal128(_, scale) => {
             let val = col
                 .as_any()
@@ -242,6 +268,49 @@ fn float64_to_datum(val: f64, typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
             numeric.into_datum()
         }
         _ => val.into_datum(), // Default to f64
+    }
+}
+
+/// Convert nanosecond timestamp to the appropriate Postgres date/time datum.
+fn timestamp_nanos_to_datum(nanos: i64, typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
+    use crate::postgres::types_arrow::ts_nanos_to_date_time;
+    use pgrx::datum;
+
+    let dt = ts_nanos_to_date_time(nanos);
+    let prim = dt.into_primitive();
+    let (h, m, s, micro) = prim.as_hms_micro();
+    let fractional_sec = s as f64 + (micro as f64 / 1_000_000.0);
+
+    match typoid {
+        pg_sys::TIMESTAMPTZOID => datum::TimestampWithTimeZone::with_timezone(
+            prim.year(),
+            prim.month().into(),
+            prim.day(),
+            h,
+            m,
+            fractional_sec,
+            "UTC",
+        )
+        .ok()?
+        .into_datum(),
+        pg_sys::TIMESTAMPOID => datum::Timestamp::new(
+            prim.year(),
+            prim.month().into(),
+            prim.day(),
+            h,
+            m,
+            fractional_sec,
+        )
+        .ok()?
+        .into_datum(),
+        pg_sys::DATEOID => datum::Date::new(prim.year(), prim.month().into(), prim.day())
+            .ok()?
+            .into_datum(),
+        _ => {
+            // Fallback: return as i64 microseconds
+            let micros = nanos / 1000;
+            micros.into_datum()
+        }
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -450,6 +450,66 @@ WHERE p.description @@@ 'laptop';
 -- Restore
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
+-- SECTION 10: Date/Timestamp aggregates on JOIN
+-- =====================================================================
+CREATE TABLE ts_orders (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    created_at TIMESTAMP
+);
+CREATE TABLE ts_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER,
+    item_name TEXT
+);
+INSERT INTO ts_orders (description, category, created_at) VALUES
+    ('Laptop order', 'Electronics', '2024-01-15 10:30:00'),
+    ('Phone order', 'Electronics', '2024-03-20 14:45:00'),
+    ('Shoes order', 'Sports', '2024-06-10 08:15:00');
+INSERT INTO ts_items (order_id, item_name) VALUES
+    (1, 'laptop'), (1, 'charger'),
+    (2, 'phone'),
+    (3, 'shoes'), (3, 'socks');
+CREATE INDEX ts_orders_idx ON ts_orders
+USING bm25 (id, description, category, created_at)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    datetime_fields='{"created_at": {"fast": true}}'
+);
+CREATE INDEX ts_items_idx ON ts_items
+USING bm25 (id, order_id, item_name)
+WITH (
+    key_field='id',
+    numeric_fields='{"order_id": {"fast": true}}',
+    text_fields='{"item_name": {"fast": true}}'
+);
+-- Test 10.1: MIN/MAX on timestamp column via join
+SELECT MIN(o.created_at), MAX(o.created_at)
+FROM ts_orders o
+JOIN ts_items i ON o.id = i.order_id
+WHERE o.description @@@ 'order';
+           min            |           max            
+--------------------------+--------------------------
+ Mon Jan 15 10:30:00 2024 | Mon Jun 10 08:15:00 2024
+(1 row)
+
+-- Test 10.2: GROUP BY with timestamp aggregate
+SELECT o.category, MIN(o.created_at), MAX(o.created_at)
+FROM ts_orders o
+JOIN ts_items i ON o.id = i.order_id
+WHERE o.description @@@ 'order'
+GROUP BY o.category;
+  category   |           min            |           max            
+-------------+--------------------------+--------------------------
+ Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
+ Sports      | Mon Jun 10 08:15:00 2024 | Mon Jun 10 08:15:00 2024
+(2 rows)
+
+DROP TABLE ts_items;
+DROP TABLE ts_orders;
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -302,6 +302,65 @@ WHERE p.description @@@ 'laptop';
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
+-- SECTION 10: Date/Timestamp aggregates on JOIN
+-- =====================================================================
+
+CREATE TABLE ts_orders (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    created_at TIMESTAMP
+);
+
+CREATE TABLE ts_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER,
+    item_name TEXT
+);
+
+INSERT INTO ts_orders (description, category, created_at) VALUES
+    ('Laptop order', 'Electronics', '2024-01-15 10:30:00'),
+    ('Phone order', 'Electronics', '2024-03-20 14:45:00'),
+    ('Shoes order', 'Sports', '2024-06-10 08:15:00');
+
+INSERT INTO ts_items (order_id, item_name) VALUES
+    (1, 'laptop'), (1, 'charger'),
+    (2, 'phone'),
+    (3, 'shoes'), (3, 'socks');
+
+CREATE INDEX ts_orders_idx ON ts_orders
+USING bm25 (id, description, category, created_at)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    datetime_fields='{"created_at": {"fast": true}}'
+);
+
+CREATE INDEX ts_items_idx ON ts_items
+USING bm25 (id, order_id, item_name)
+WITH (
+    key_field='id',
+    numeric_fields='{"order_id": {"fast": true}}',
+    text_fields='{"item_name": {"fast": true}}'
+);
+
+-- Test 10.1: MIN/MAX on timestamp column via join
+SELECT MIN(o.created_at), MAX(o.created_at)
+FROM ts_orders o
+JOIN ts_items i ON o.id = i.order_id
+WHERE o.description @@@ 'order';
+
+-- Test 10.2: GROUP BY with timestamp aggregate
+SELECT o.category, MIN(o.created_at), MAX(o.created_at)
+FROM ts_orders o
+JOIN ts_items i ON o.id = i.order_id
+WHERE o.description @@@ 'order'
+GROUP BY o.category;
+
+DROP TABLE ts_items;
+DROP TABLE ts_orders;
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4541

## What

Add Date/Timestamp type handling to the DataFusion aggregate Arrow-to-Postgres projection.

## Why

The DataFusion join aggregate path only supported numeric, string, boolean, and decimal types. Queries with MIN/MAX on timestamp columns or GROUP BY on date columns returned NULL.

## How

Add handlers in `arrow_value_to_datum` for:
- `DataType::Timestamp(_, _)` — TimestampNanosecond (Tantivy's native format)
- `DataType::Date32` — days since epoch
- `DataType::Date64` — milliseconds since epoch

All convert to nanoseconds then use `ts_nanos_to_date_time` → pgrx `Timestamp`/`TimestampWithTimeZone`/`Date` constructors, reusing the existing conversion pattern from `types_arrow.rs`.

## Tests

- `aggregate_join.sql` Section 10: MIN/MAX on timestamp column via join, GROUP BY with timestamp aggregates
- All existing tests pass (227 passed, 0 failed)