### PR TITLE
feat: STDDEV and VARIANCE support for aggregate-on-join queries

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -50,7 +50,9 @@ use crate::scan::PgSearchTableProvider;
 
 // Re-export DataFusion aggregate helpers
 use datafusion::functions_aggregate::count::count_udaf;
-use datafusion::functions_aggregate::expr_fn::{avg, count, max, min, sum};
+use datafusion::functions_aggregate::expr_fn::{
+    avg, count, max, min, stddev, stddev_pop, sum, var_pop, var_sample,
+};
 
 /// Custom query planner that uses our LateMaterializePlanner extension.
 /// Same as JoinScan's PgSearchQueryPlanner.
@@ -174,6 +176,22 @@ pub async fn build_join_aggregate_plan(
                 AggKind::Max => {
                     let col_expr = agg_field_col(agg, plan);
                     max(col_expr)
+                }
+                AggKind::StddevSamp => {
+                    let col_expr = agg_field_col(agg, plan);
+                    stddev(col_expr)
+                }
+                AggKind::StddevPop => {
+                    let col_expr = agg_field_col(agg, plan);
+                    stddev_pop(col_expr)
+                }
+                AggKind::VarSamp => {
+                    let col_expr = agg_field_col(agg, plan);
+                    var_sample(col_expr)
+                }
+                AggKind::VarPop => {
+                    let col_expr = agg_field_col(agg, plan);
+                    var_pop(col_expr)
                 }
             };
             // Alias for stable reference

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -51,6 +51,10 @@ pub enum AggKind {
     Avg,
     Min,
     Max,
+    StddevSamp,
+    StddevPop,
+    VarSamp,
+    VarPop,
 }
 
 impl std::fmt::Display for AggKind {
@@ -63,6 +67,10 @@ impl std::fmt::Display for AggKind {
             AggKind::Avg => write!(f, "AVG"),
             AggKind::Min => write!(f, "MIN"),
             AggKind::Max => write!(f, "MAX"),
+            AggKind::StddevSamp => write!(f, "STDDEV_SAMP"),
+            AggKind::StddevPop => write!(f, "STDDEV_POP"),
+            AggKind::VarSamp => write!(f, "VAR_SAMP"),
+            AggKind::VarPop => write!(f, "VAR_POP"),
         }
     }
 }
@@ -126,6 +134,26 @@ fn classify_aggregate_oid(aggfnoid: u32, aggstar: bool, has_distinct: bool) -> O
         F_MIN_INT8 | F_MIN_INT4 | F_MIN_INT2 | F_MIN_FLOAT4 | F_MIN_FLOAT8 | F_MIN_DATE
         | F_MIN_TIME | F_MIN_TIMETZ | F_MIN_MONEY | F_MIN_TIMESTAMP | F_MIN_TIMESTAMPTZ
         | F_MIN_NUMERIC => Some(AggKind::Min),
+        _ => classify_aggregate_by_name(aggfnoid),
+    }
+}
+
+/// Fallback classification by looking up the function name from the catalog.
+/// Handles aggregate functions whose OIDs aren't exposed as constants in pg_sys
+/// (e.g., STDDEV, VARIANCE and their variants).
+fn classify_aggregate_by_name(aggfnoid: u32) -> Option<AggKind> {
+    let name = unsafe {
+        let name_ptr = pg_sys::get_func_name(pg_sys::Oid::from(aggfnoid));
+        if name_ptr.is_null() {
+            return None;
+        }
+        std::ffi::CStr::from_ptr(name_ptr).to_str().ok()?.to_owned()
+    };
+    match name.as_str() {
+        "stddev" | "stddev_samp" => Some(AggKind::StddevSamp),
+        "stddev_pop" => Some(AggKind::StddevPop),
+        "variance" | "var_samp" => Some(AggKind::VarSamp),
+        "var_pop" => Some(AggKind::VarPop),
         _ => None,
     }
 }

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -450,7 +450,54 @@ WHERE p.description @@@ 'laptop';
 -- Restore
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
--- SECTION 10: Date/Timestamp aggregates on JOIN
+-- SECTION 10: STDDEV/VARIANCE aggregates on JOIN
+-- =====================================================================
+-- Test 10.1: STDDEV and VARIANCE on join
+SELECT STDDEV(p.price), VARIANCE(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+       stddev       |      variance      
+--------------------+--------------------
+ 495.71737339507706 | 245735.71428571426
+(1 row)
+
+-- Test 10.2: STDDEV_POP and VAR_POP on join with GROUP BY
+SELECT p.category, STDDEV_POP(p.rating), VAR_POP(p.rating)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+  category   | stddev_pop | var_pop 
+-------------+------------+---------
+ Electronics |          0 |       0
+ Sports      |          0 |       0
+ Toys        |          0 |       0
+(3 rows)
+
+-- Test 10.3: STDDEV parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT STDDEV(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+      stddev       
+-------------------
+ 495.7173733950771
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT STDDEV(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+       stddev       
+--------------------
+ 495.71737339507706
+(1 row)
+
+-- =====================================================================
+-- SECTION 11: Date/Timestamp aggregates on JOIN
 -- =====================================================================
 CREATE TABLE ts_orders (
     id SERIAL PRIMARY KEY,

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -302,7 +302,37 @@ WHERE p.description @@@ 'laptop';
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
--- SECTION 10: Date/Timestamp aggregates on JOIN
+-- SECTION 10: STDDEV/VARIANCE aggregates on JOIN
+-- =====================================================================
+
+-- Test 10.1: STDDEV and VARIANCE on join
+SELECT STDDEV(p.price), VARIANCE(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+-- Test 10.2: STDDEV_POP and VAR_POP on join with GROUP BY
+SELECT p.category, STDDEV_POP(p.rating), VAR_POP(p.rating)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+
+-- Test 10.3: STDDEV parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT STDDEV(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT STDDEV(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+-- =====================================================================
+-- SECTION 11: Date/Timestamp aggregates on JOIN
 -- =====================================================================
 
 CREATE TABLE ts_orders (


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4544

## What

Add STDDEV, STDDEV_POP, VARIANCE (VAR_SAMP), and VAR_POP aggregate support for DataFusion aggregate-on-join queries.

## Why

These are standard SQL statistical aggregates that were previously rejected with "unsupported aggregate function OID".

## How

- Add `AggKind::StddevSamp`, `StddevPop`, `VarSamp`, `VarPop` variants
- Add `classify_aggregate_by_name` fallback: for OIDs not in the known constant list, look up the function name via `pg_sys::get_func_name` and match on `stddev`/`stddev_samp`/`stddev_pop`/`variance`/`var_samp`/`var_pop`
- Map to DataFusion's `stddev()`, `stddev_pop()`, `var_sample()`, `var_pop()`

## Tests

- `aggregate_join.sql` Section 10: STDDEV/VARIANCE on join, STDDEV_POP/VAR_POP with GROUP BY, parity check
- All existing tests pass (227 passed, 0 failed)