### PR TITLE
test: Negative tests for aggregate-on-join graceful fallback

### DIFF
--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -1,0 +1,173 @@
+-- =====================================================================
+-- Negative tests: verify graceful fallback to Postgres native plans
+-- for unsupported aggregate-on-join query patterns.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- Test Data Setup (3 tables for multi-table join tests)
+-- =====================================================================
+CREATE TABLE fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+CREATE TABLE fb_tags (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    tag_name TEXT
+);
+CREATE TABLE fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99);
+INSERT INTO fb_tags (product_id, tag_name) VALUES
+    (1, 'tech'), (2, 'fitness'), (3, 'outdoor');
+INSERT INTO fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4);
+CREATE INDEX fb_products_idx ON fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+CREATE INDEX fb_tags_idx ON fb_tags
+USING bm25 (id, product_id, tag_name)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}}',
+    text_fields='{"tag_name": {"fast": true}}'
+);
+CREATE INDEX fb_reviews_idx ON fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Test 1: 3-table join → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+JOIN fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop';
+WARNING:  Aggregate Scan (DataFusion) not used: only 2-table joins are currently supported (table: join)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Nested Loop
+         Join Filter: (p.id = t.product_id)
+         ->  Hash Join
+               Hash Cond: (r.product_id = p.id)
+               ->  Seq Scan on fb_reviews r
+               ->  Hash
+                     ->  Custom Scan (ParadeDB Base Scan) on fb_products p
+                           Table: fb_products
+                           Index: fb_products_idx
+                           Exec Method: ColumnarExecState
+                           Fast Fields: id
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+         ->  Seq Scan on fb_tags t
+(15 rows)
+
+SELECT COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+JOIN fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop';
+WARNING:  Aggregate Scan (DataFusion) not used: only 2-table joins are currently supported (table: join)
+ count 
+-------
+     2
+(1 row)
+
+-- =====================================================================
+-- Test 2: CROSS JOIN → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT COUNT(*)
+FROM fb_products p
+CROSS JOIN fb_tags t
+WHERE p.description @@@ 'laptop';
+WARNING:  Aggregate Scan (DataFusion) not used: CROSS JOINs are not supported (no equi-join keys) (table: join)
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Nested Loop
+         ->  Custom Scan (ParadeDB Base Scan) on fb_products p
+               Table: fb_products
+               Index: fb_products_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+         ->  Seq Scan on fb_tags t
+(9 rows)
+
+SELECT COUNT(*)
+FROM fb_products p
+CROSS JOIN fb_tags t
+WHERE p.description @@@ 'laptop';
+WARNING:  Aggregate Scan (DataFusion) not used: CROSS JOINs are not supported (no equi-join keys) (table: join)
+ count 
+-------
+     3
+(1 row)
+
+-- =====================================================================
+-- Test 3: HAVING clause → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT p.category, COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+HAVING COUNT(*) > 1;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: p.category
+   Filter: (count(*) > 1)
+   ->  Sort
+         Sort Key: p.category
+         ->  Hash Join
+               Hash Cond: (t.product_id = p.id)
+               ->  Seq Scan on fb_tags t
+               ->  Hash
+                     ->  Custom Scan (ParadeDB Base Scan) on fb_products p
+                           Table: fb_products
+                           Index: fb_products_idx
+                           Exec Method: ColumnarExecState
+                           Fast Fields: category, id
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
+(16 rows)
+
+SELECT p.category, COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+HAVING COUNT(*) > 1;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
+ category | count 
+----------+-------
+(0 rows)
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+DROP TABLE fb_reviews;
+DROP TABLE fb_tags;
+DROP TABLE fb_products;

--- a/pg_search/tests/pg_regress/sql/aggregate_join_fallback.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join_fallback.sql
@@ -1,0 +1,118 @@
+-- =====================================================================
+-- Negative tests: verify graceful fallback to Postgres native plans
+-- for unsupported aggregate-on-join query patterns.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- Test Data Setup (3 tables for multi-table join tests)
+-- =====================================================================
+CREATE TABLE fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+
+CREATE TABLE fb_tags (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    tag_name TEXT
+);
+
+CREATE TABLE fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99);
+
+INSERT INTO fb_tags (product_id, tag_name) VALUES
+    (1, 'tech'), (2, 'fitness'), (3, 'outdoor');
+
+INSERT INTO fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4);
+
+CREATE INDEX fb_products_idx ON fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+
+CREATE INDEX fb_tags_idx ON fb_tags
+USING bm25 (id, product_id, tag_name)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}}',
+    text_fields='{"tag_name": {"fast": true}}'
+);
+
+CREATE INDEX fb_reviews_idx ON fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- Test 1: 3-table join → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+JOIN fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop';
+
+SELECT COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+JOIN fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop';
+
+-- =====================================================================
+-- Test 2: CROSS JOIN → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT COUNT(*)
+FROM fb_products p
+CROSS JOIN fb_tags t
+WHERE p.description @@@ 'laptop';
+
+SELECT COUNT(*)
+FROM fb_products p
+CROSS JOIN fb_tags t
+WHERE p.description @@@ 'laptop';
+
+-- =====================================================================
+-- Test 3: HAVING clause → should fall back to Postgres native
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT p.category, COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+HAVING COUNT(*) > 1;
+
+SELECT p.category, COUNT(*)
+FROM fb_products p
+JOIN fb_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+HAVING COUNT(*) > 1;
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+DROP TABLE fb_reviews;
+DROP TABLE fb_tags;
+DROP TABLE fb_products;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4542

## What

Add regression tests that verify the DataFusion aggregate path gracefully falls back to Postgres native plans for unsupported query patterns.

## Why

Our regression tests only covered the happy path. The qgen fuzzer found multiple failure classes that hand-written tests missed. These negative tests codify the expected fallback behavior and document the supported query surface.

## How

New test file `aggregate_join_fallback.sql` with:
- 3-table join → verify Postgres native plan (not DataFusion)
- CROSS JOIN → verify fallback
- HAVING clause → verify fallback with warning message

Each test uses EXPLAIN to verify the plan doesn't contain "ParadeDB Aggregate Scan" with "Backend: DataFusion", then runs the query to verify correct results via Postgres native.

## Tests

- `aggregate_join_fallback.sql`: 3 fallback scenarios, all produce correct results
- All existing tests pass (228 passed, 0 failed)