### PR TITLE
feat: FULL OUTER JOIN support for aggregate-on-join queries

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -298,9 +298,9 @@ unsafe fn build_join_node(
 
     let join_type = JoinType::try_from(join.jointype).map_err(|e| e.to_string())?;
 
-    // Support INNER and LEFT/RIGHT JOINs
+    // Support INNER, LEFT/RIGHT, and FULL OUTER JOINs
     match join_type {
-        JoinType::Inner | JoinType::Left | JoinType::Right => {}
+        JoinType::Inner | JoinType::Left | JoinType::Right | JoinType::Full => {}
         _ => {
             return Err(format!(
                 "aggregate-on-join does not support {} JOIN",

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -501,6 +501,7 @@ fn build_relnode_df<'a>(
                     crate::postgres::customscan::joinscan::build::JoinType::Right => {
                         JoinType::Right
                     }
+                    crate::postgres::customscan::joinscan::build::JoinType::Full => JoinType::Full,
                     unsupported => {
                         return Err(DataFusionError::NotImplemented(format!(
                             "Aggregate-on-join does not support {} JOIN",

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -598,6 +598,76 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
+-- SECTION 13: FULL OUTER JOIN aggregates
+-- =====================================================================
+-- Test 13.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('COUNT'::text), pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Aggregates: COUNT(*)(*), COUNT(category), COUNT(tag_name)
+(5 rows)
+
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+ count | count | count 
+-------+-------+-------
+     8 |     8 |     8
+(1 row)
+
+-- Test 13.2: FULL OUTER JOIN with GROUP BY
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+-- Test 13.3: FULL OUTER JOIN parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -418,6 +418,47 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
+-- SECTION 13: FULL OUTER JOIN aggregates
+-- =====================================================================
+
+-- Test 13.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+-- Test 13.2: FULL OUTER JOIN with GROUP BY
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.3: FULL OUTER JOIN parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4554

## What

Add FULL OUTER JOIN support to the DataFusion aggregate-on-join execution path. Previously, FULL OUTER JOIN queries fell back to Postgres native plans.

## Why

INNER, LEFT, and RIGHT JOINs were already supported. FULL OUTER JOIN was the only remaining standard SQL join type that wasn't handled by the DataFusion backend, causing unnecessary fallback.

## How

- Add `JoinType::Full` to the allowed join types in `datafusion_build.rs` (parse tree walker)
- Add `JoinType::Full => JoinType::Full` mapping in `datafusion_exec.rs` (DataFusion plan builder)
- The `JoinType::Full` variant already existed in the enum — it was just blocked by the match guards

## Tests

New Section 13 in `aggregate_join.sql`:
- FULL OUTER JOIN with scalar COUNT (3 count variants)
- FULL OUTER JOIN with GROUP BY + SUM
- Parity check: DataFusion vs Postgres native results match