### PR TITLE
feat: STRING_AGG, ARRAY_AGG, BOOL_AND/OR support for aggregate-on-join

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -51,8 +51,10 @@ use crate::scan::PgSearchTableProvider;
 // Re-export DataFusion aggregate helpers
 use datafusion::functions_aggregate::count::count_udaf;
 use datafusion::functions_aggregate::expr_fn::{
-    avg, count, max, min, stddev, stddev_pop, sum, var_pop, var_sample,
+    array_agg, avg, bool_and, bool_or, count, max, min, stddev, stddev_pop, sum, var_pop,
+    var_sample,
 };
+use datafusion::functions_aggregate::string_agg::string_agg_udaf;
 
 /// Custom query planner that uses our LateMaterializePlanner extension.
 /// Same as JoinScan's PgSearchQueryPlanner.
@@ -201,6 +203,31 @@ pub async fn build_join_aggregate_plan(
                 AggKind::VarPop => {
                     let col_expr = agg_field_col(agg, plan);
                     var_pop(col_expr)
+                }
+                AggKind::BoolAnd => {
+                    let col_expr = agg_field_col(agg, plan);
+                    bool_and(col_expr)
+                }
+                AggKind::BoolOr => {
+                    let col_expr = agg_field_col(agg, plan);
+                    bool_or(col_expr)
+                }
+                AggKind::ArrayAgg => {
+                    let col_expr = agg_field_col(agg, plan);
+                    array_agg(col_expr)
+                }
+                AggKind::StringAgg(ref separator) => {
+                    let col_expr = agg_field_col(agg, plan);
+                    Expr::AggregateFunction(
+                        datafusion::logical_expr::expr::AggregateFunction::new_udf(
+                            string_agg_udaf(),
+                            vec![col_expr, lit(separator.clone())],
+                            false,  // distinct
+                            None,   // filter
+                            vec![], // order_by
+                            None,   // null_treatment
+                        ),
+                    )
                 }
             };
             // Alias for stable reference

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -55,6 +55,11 @@ pub enum AggKind {
     StddevPop,
     VarSamp,
     VarPop,
+    BoolAnd,
+    BoolOr,
+    ArrayAgg,
+    /// STRING_AGG(col, separator) — stores the separator string.
+    StringAgg(String),
 }
 
 impl std::fmt::Display for AggKind {
@@ -71,6 +76,10 @@ impl std::fmt::Display for AggKind {
             AggKind::StddevPop => write!(f, "STDDEV_POP"),
             AggKind::VarSamp => write!(f, "VAR_SAMP"),
             AggKind::VarPop => write!(f, "VAR_POP"),
+            AggKind::BoolAnd => write!(f, "BOOL_AND"),
+            AggKind::BoolOr => write!(f, "BOOL_OR"),
+            AggKind::ArrayAgg => write!(f, "ARRAY_AGG"),
+            AggKind::StringAgg(_) => write!(f, "STRING_AGG"),
         }
     }
 }
@@ -154,6 +163,11 @@ fn classify_aggregate_by_name(aggfnoid: u32) -> Option<AggKind> {
         "stddev_pop" => Some(AggKind::StddevPop),
         "variance" | "var_samp" => Some(AggKind::VarSamp),
         "var_pop" => Some(AggKind::VarPop),
+        "bool_and" | "every" => Some(AggKind::BoolAnd),
+        "bool_or" => Some(AggKind::BoolOr),
+        "array_agg" => Some(AggKind::ArrayAgg),
+        // STRING_AGG separator is extracted later in extract_aggregate_targetlist
+        "string_agg" => Some(AggKind::StringAgg(",".into())),
         _ => None,
     }
 }
@@ -232,8 +246,14 @@ pub unsafe fn extract_aggregate_targetlist(
                 );
             }
 
-            let agg_kind = classify_aggregate_oid(aggfnoid, (*aggref).aggstar, has_distinct)
+            let mut agg_kind = classify_aggregate_oid(aggfnoid, (*aggref).aggstar, has_distinct)
                 .ok_or_else(|| format!("unsupported aggregate function OID: {}", aggfnoid))?;
+
+            // For STRING_AGG, extract the separator from the second argument
+            if matches!(agg_kind, AggKind::StringAgg(_)) {
+                let separator = extract_string_agg_separator(aggref).unwrap_or_else(|| ",".into());
+                agg_kind = AggKind::StringAgg(separator);
+            }
 
             let field_ref = extract_aggref_field_ref(aggref, sources)?;
             // Use the actual Postgres result type from the Aggref node,
@@ -259,6 +279,34 @@ pub unsafe fn extract_aggregate_targetlist(
         group_columns,
         aggregates,
     })
+}
+
+/// Extract the separator string from a STRING_AGG's second argument.
+///
+/// STRING_AGG(col, separator) stores the separator as the second TargetEntry.
+/// Returns `None` if the separator cannot be extracted (non-const, missing).
+unsafe fn extract_string_agg_separator(aggref: *mut pg_sys::Aggref) -> Option<String> {
+    let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
+    if args.len() < 2 {
+        return None;
+    }
+    let second_arg = args.get_ptr(1)?;
+    let expr = (*second_arg).expr as *mut pg_sys::Node;
+    if expr.is_null() || (*expr).type_ != pg_sys::NodeTag::T_Const {
+        return None;
+    }
+    let konst = expr as *mut pg_sys::Const;
+    if (*konst).constisnull {
+        return None;
+    }
+    let datum = (*konst).constvalue;
+    let text_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
+    let cstr = pg_sys::text_to_cstring(text_ptr);
+    if cstr.is_null() {
+        return None;
+    }
+    let s = std::ffi::CStr::from_ptr(cstr).to_str().ok()?.to_owned();
+    Some(s)
 }
 
 /// Extract the field reference from an `Aggref`'s arguments.

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -598,7 +598,136 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
--- SECTION 13: FULL OUTER JOIN aggregates
+-- SECTION 13: Additional aggregate functions (BOOL_AND/OR, ARRAY_AGG, STRING_AGG)
+-- =====================================================================
+-- Add a boolean column for BOOL_AND/OR tests
+ALTER TABLE agg_join_products ADD COLUMN in_stock BOOLEAN DEFAULT true;
+UPDATE agg_join_products SET in_stock = false WHERE category = 'Toys';
+-- We need fast field access for in_stock; recreate BM25 index
+DROP INDEX agg_join_products_idx;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating, in_stock)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}',
+    boolean_fields='{"in_stock": {"fast": true}}'
+);
+-- Test 13.1: BOOL_AND on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (bool_and(p.in_stock))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: BOOL_AND(in_stock)
+(6 rows)
+
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and 
+-------------+----------
+ Electronics | t
+ Sports      | t
+ Toys        | f
+(3 rows)
+
+-- Test 13.2: BOOL_OR on join
+SELECT p.category, BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_or 
+-------------+---------
+ Electronics | t
+ Sports      | t
+ Toys        | f
+(3 rows)
+
+-- Test 13.3: STRING_AGG on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (string_agg(t.tag_name, ', '::text))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: STRING_AGG(tag_name)
+(6 rows)
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          string_agg          
+-------------+------------------------------
+ Electronics | tech, computer, tech, gaming
+ Sports      | fitness, running
+ Toys        | tech, kids
+(3 rows)
+
+-- Test 13.4: BOOL_AND/OR parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and | bool_or 
+-------------+----------+---------
+ Electronics | t        | t
+ Sports      | t        | t
+ Toys        | f        | f
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and | bool_or 
+-------------+----------+---------
+ Electronics | t        | t
+ Sports      | t        | t
+ Toys        | f        | f
+(3 rows)
+
+-- Clean up the added column (drop+recreate index)
+DROP INDEX agg_join_products_idx;
+ALTER TABLE agg_join_products DROP COLUMN in_stock;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- SECTION 14: FULL OUTER JOIN aggregates
 -- =====================================================================
 -- Test 13.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -418,7 +418,92 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
--- SECTION 13: FULL OUTER JOIN aggregates
+-- SECTION 13: Additional aggregate functions (BOOL_AND/OR, ARRAY_AGG, STRING_AGG)
+-- =====================================================================
+
+-- Add a boolean column for BOOL_AND/OR tests
+ALTER TABLE agg_join_products ADD COLUMN in_stock BOOLEAN DEFAULT true;
+UPDATE agg_join_products SET in_stock = false WHERE category = 'Toys';
+
+-- We need fast field access for in_stock; recreate BM25 index
+DROP INDEX agg_join_products_idx;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating, in_stock)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}',
+    boolean_fields='{"in_stock": {"fast": true}}'
+);
+
+-- Test 13.1: BOOL_AND on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category;
+
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.2: BOOL_OR on join
+SELECT p.category, BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.3: STRING_AGG on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.4: BOOL_AND/OR parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Clean up the added column (drop+recreate index)
+DROP INDEX agg_join_products_idx;
+ALTER TABLE agg_join_products DROP COLUMN in_stock;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- SECTION 14: FULL OUTER JOIN aggregates
 -- =====================================================================
 
 -- Test 13.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4555

## What

Add four new aggregate functions to the DataFusion aggregate-on-join path: BOOL_AND, BOOL_OR, ARRAY_AGG, and STRING_AGG. Total supported functions: 15 (was 11).

## Why

These are standard SQL aggregates that users need on join queries. Previously, queries using these functions fell back to Postgres native plans. STRING_AGG is particularly useful for concatenating values from joined tables (e.g., collecting tag names per product).

## How

- Add `AggKind` variants: `BoolAnd`, `BoolOr`, `ArrayAgg`, `StringAgg(String)`
- Classify via `classify_aggregate_by_name` (name-based fallback for OIDs not in pg_sys constants)
- Map to DataFusion: `bool_and()`, `bool_or()`, `array_agg()` from expr_fn; `string_agg_udaf()` for STRING_AGG with separator argument
- Extract STRING_AGG separator from Aggref's second `Const` argument via `extract_string_agg_separator()`

## Tests

New Section 13 in `aggregate_join.sql`:
- BOOL_AND with GROUP BY (Electronics=true, Toys=false)
- BOOL_OR with GROUP BY
- STRING_AGG with separator (concatenates tag names with `, `)
- Parity check: BOOL_AND/OR results match Postgres native