### PR TITLE
feat: Additional Arrow type projection for DataFusion aggregate path

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -231,10 +231,30 @@ fn arrow_value_to_datum(
             let f_val = val as f64 / divisor;
             float64_to_datum(f_val, typoid)
         }
+        DataType::List(_) | DataType::LargeList(_) => list_to_datum(col, row_idx, typoid),
+        DataType::Binary => {
+            let val = col.as_any().downcast_ref::<BinaryArray>()?.value(row_idx);
+            // If 16 bytes, likely UUID
+            if val.len() == 16 {
+                let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
+                uuid.into_datum()
+            } else {
+                val.to_vec().into_datum()
+            }
+        }
+        DataType::FixedSizeBinary(16) => {
+            let val = col
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()?
+                .value(row_idx);
+            let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
+            uuid.into_datum()
+        }
         _ => {
             pgrx::warning!(
-                "Unsupported Arrow type {:?} for aggregate projection",
-                col.data_type()
+                "Unsupported Arrow type {:?} (Postgres OID {}) for aggregate projection",
+                col.data_type(),
+                typoid.to_u32()
             );
             None
         }
@@ -268,6 +288,120 @@ fn float64_to_datum(val: f64, typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
             numeric.into_datum()
         }
         _ => val.into_datum(), // Default to f64
+    }
+}
+
+/// Convert an Arrow List array element to a Postgres array datum.
+///
+/// Handles `ARRAY_AGG` results by converting the inner array elements to
+/// a Postgres array via `Vec<T>::into_datum()`.
+fn list_to_datum(col: &ArrayRef, row_idx: usize, _typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
+    use arrow_array::*;
+    use arrow_schema::DataType;
+
+    let list = col.as_any().downcast_ref::<ListArray>()?;
+    let inner = list.value(row_idx);
+    let inner_type = inner.data_type();
+
+    match inner_type {
+        DataType::Utf8 => {
+            let arr = inner.as_any().downcast_ref::<StringArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Utf8View => {
+            let arr = inner.as_any().downcast_ref::<StringViewArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::LargeUtf8 => {
+            let arr = inner.as_any().downcast_ref::<LargeStringArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Int64 => {
+            let arr = inner.as_any().downcast_ref::<Int64Array>()?;
+            let vals: Vec<Option<i64>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Int32 => {
+            let arr = inner.as_any().downcast_ref::<Int32Array>()?;
+            let vals: Vec<Option<i32>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Float64 => {
+            let arr = inner.as_any().downcast_ref::<Float64Array>()?;
+            let vals: Vec<Option<f64>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Boolean => {
+            let arr = inner.as_any().downcast_ref::<BooleanArray>()?;
+            let vals: Vec<Option<bool>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        _ => {
+            pgrx::warning!(
+                "Unsupported Arrow List element type {:?} for ARRAY_AGG projection",
+                inner_type
+            );
+            None
+        }
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -716,6 +716,36 @@ ORDER BY p.category;
  Toys        | f        | f
 (3 rows)
 
+-- Test 13.5: ARRAY_AGG on join
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {tech,computer,tech,gaming}
+ Sports      | {fitness,running}
+ Toys        | {tech,kids}
+(3 rows)
+
+-- Test 13.6: ARRAY_AGG parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {tech,computer,tech,gaming}
+ Sports      | {fitness,running}
+ Toys        | {tech,kids}
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
 -- Clean up the added column (drop+recreate index)
 DROP INDEX agg_join_products_idx;
 ALTER TABLE agg_join_products DROP COLUMN in_stock;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -491,6 +491,25 @@ WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
 
+-- Test 13.5: ARRAY_AGG on join
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.6: ARRAY_AGG parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+
 -- Clean up the added column (drop+recreate index)
 DROP INDEX agg_join_products_idx;
 ALTER TABLE agg_join_products DROP COLUMN in_stock;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4556

## What

Extend the Arrow-to-Postgres type projection in `datafusion_project.rs` to handle List, Binary, and UUID Arrow types. Improves the catch-all error message to include the Postgres OID.

## Why

ARRAY_AGG results return Arrow `List` arrays that need to be converted to Postgres arrays. UUID columns in GROUP BY produce Arrow `Binary(16)` or `FixedSizeBinary(16)`. Without these handlers, aggregate queries using these types would silently return NULLs instead of values.

## How

- **List/LargeList**: New `list_to_datum()` helper recursively projects inner array elements (Utf8, Int64, Int32, Float64, Boolean) to `Vec<Option<T>>::into_datum()` for Postgres array output
- **Binary(16)**: Detected as UUID, converted via `pgrx::Uuid::from_bytes()`
- **FixedSizeBinary(16)**: Same UUID conversion
- **Catch-all**: Warning now includes both Arrow type and Postgres OID for easier debugging

## Tests

- ARRAY_AGG test (Section 13.5) with GROUP BY producing text arrays
- ARRAY_AGG parity check (Section 13.6): DataFusion vs Postgres native