### PR TITLE
fix: Fail nix workflow after auto-fixing cargoHash to prevent hiding CI failures

### DIFF
--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  cargoHash = "sha256-Z98shpXzCiAAYWAz0j0KlTI0DVMx028sQbfUg29FsbA=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
## Summary
- When the nix cargoHash check detects a stale hash, it pushes a fix commit and exits successfully. The push triggers a `synchronize` event that cancels in-progress CI runs (due to `cancel-in-progress: true`), while the nix check itself appears green — hiding any failures from other workflows.
- Now the workflow exits with failure after pushing the fix commit, so the PR cannot falsely appear green. The fresh CI run triggered on the updated HEAD will complete normally with all workflows running.

## Test plan
- [x] Open a PR that changes `Cargo.lock` with an outdated `cargoHash` in `nix/pg_search.nix`
- [x] Verify the nix workflow pushes the fix commit but reports failure
- [x] Verify the subsequent CI run on the new HEAD runs all workflows normally