### PR TITLE
feat: Enable SegmentedTopK for ORDER BY on columns from multiple tables

### DIFF
--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -104,6 +104,41 @@ use std::sync::Arc;
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
 
+/// Controls whether SegmentedTopKExec operates in full mode (with threshold
+/// pushdown) or degraded mode (heaps only, no pushdown).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentedTopKMode {
+    /// Single-index sort: full optimization with threshold pushdown.
+    SingleIndex,
+    /// Multi-index sort: heaps and late materialization only, no threshold pushdown.
+    MultiIndex,
+}
+
+/// A composite key identifying the specific segment combination from which
+/// a row's deferred columns originate. Each entry is (indexrelid, segment_ordinal).
+/// Ordinals are only comparable within rows sharing the same CompositeSegmentKey.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CompositeSegmentKey {
+    /// Sorted list of (indexrelid, segment_ordinal) pairs.
+    /// Sorting ensures consistent hashing regardless of column order.
+    segments: Vec<(u32, u32)>,
+}
+
+impl CompositeSegmentKey {
+    pub fn new(mut segments: Vec<(u32, u32)>) -> Self {
+        segments.sort_by_key(|(oid, _)| *oid);
+        Self { segments }
+    }
+
+    /// Create a single-index key (backward compatible).
+    #[allow(dead_code)]
+    pub fn single(indexrelid: u32, segment_ord: u32) -> Self {
+        Self {
+            segments: vec![(indexrelid, segment_ord)],
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct DeferredSortColumn {
     pub sort_col_idx: usize,
@@ -116,8 +151,13 @@ pub struct SegmentedTopKExec {
     sort_exprs: LexOrdering,
     /// The deferred string/bytes columns that are part of the Top K order.
     deferred_columns: Vec<DeferredSortColumn>,
-    /// FFHelper for Tantivy fast field access (shared with TantivyLookupExec).
-    ffhelper: Arc<FFHelper>,
+    /// FFHelpers for Tantivy fast field access, keyed by indexrelid.
+    /// For single-index sorts, this contains one entry.
+    /// For multi-index sorts, one entry per index involved in the sort.
+    ff_helpers: HashMap<u32, Arc<FFHelper>>,
+    /// Execution mode: SingleIndex (full with threshold pushdown) or
+    /// MultiIndex (heaps only, no threshold pushdown).
+    mode: SegmentedTopKMode,
     /// Maximum rows to keep per segment.
     k: usize,
     /// Dynamic filter pushed down through DataFusion's standard filter pushdown
@@ -151,7 +191,8 @@ impl SegmentedTopKExec {
         input: Arc<dyn ExecutionPlan>,
         sort_exprs: LexOrdering,
         deferred_columns: Vec<DeferredSortColumn>,
-        ffhelper: Arc<FFHelper>,
+        ff_helpers: HashMap<u32, Arc<FFHelper>>,
+        mode: SegmentedTopKMode,
         k: usize,
     ) -> Self {
         use datafusion::physical_expr::expressions::lit;
@@ -176,7 +217,8 @@ impl SegmentedTopKExec {
             input,
             sort_exprs,
             deferred_columns,
-            ffhelper,
+            ff_helpers,
+            mode,
             k,
             dynamic_filter,
             properties,
@@ -184,10 +226,36 @@ impl SegmentedTopKExec {
         }
     }
 
+    /// Backward-compatible constructor for single-index case.
+    #[allow(dead_code)]
+    pub fn new_single_index(
+        input: Arc<dyn ExecutionPlan>,
+        sort_exprs: LexOrdering,
+        deferred_columns: Vec<DeferredSortColumn>,
+        ffhelper: Arc<FFHelper>,
+        k: usize,
+    ) -> Self {
+        let indexrelid = deferred_columns
+            .first()
+            .map(|d| d.canonical.indexrelid)
+            .expect("SegmentedTopKExec requires at least one deferred column");
+        let mut ff_helpers = HashMap::default();
+        ff_helpers.insert(indexrelid, ffhelper);
+
+        Self::new(
+            input,
+            sort_exprs,
+            deferred_columns,
+            ff_helpers,
+            SegmentedTopKMode::SingleIndex,
+            k,
+        )
+    }
+
     fn create_mat_row_converter(
         sort_exprs: &LexOrdering,
         deferred_columns: &[DeferredSortColumn],
-        ffhelper: &FFHelper,
+        ff_helpers: &HashMap<u32, Arc<FFHelper>>,
         schema: &arrow_schema::Schema,
     ) -> Result<RowConverter> {
         let materialized_sort_fields: Vec<SortField> = sort_exprs
@@ -203,6 +271,10 @@ impl SegmentedTopKExec {
                             .find(|d| d.sort_col_idx == c.index())
                     });
                 let data_type = if let Some(deferred) = is_deferred {
+                    let ffhelper = ff_helpers
+                        .get(&deferred.canonical.indexrelid)
+                        .or_else(|| ff_helpers.values().next())
+                        .expect("SegmentedTopKExec: no FFHelper available");
                     let col = ffhelper.column(0, deferred.canonical.ff_index);
                     match col {
                         FFType::Bytes(_) => arrow_schema::DataType::BinaryView,
@@ -229,10 +301,14 @@ impl DisplayAs for SegmentedTopKExec {
             .map(|e| e.to_string())
             .collect::<Vec<_>>()
             .join(", ");
+        let mode_str = match self.mode {
+            SegmentedTopKMode::SingleIndex => "single_index",
+            SegmentedTopKMode::MultiIndex => "multi_index",
+        };
         write!(
             f,
-            "SegmentedTopKExec: expr=[{}], k={}",
-            sort_exprs_str, self.k
+            "SegmentedTopKExec: expr=[{}], k={}, mode={}",
+            sort_exprs_str, self.k, mode_str
         )
     }
 }
@@ -262,7 +338,8 @@ impl ExecutionPlan for SegmentedTopKExec {
             children.remove(0),
             self.sort_exprs.clone(),
             self.deferred_columns.clone(),
-            Arc::clone(&self.ffhelper),
+            self.ff_helpers.clone(),
+            self.mode,
             self.k,
         );
         // Preserve the existing dynamic filter so that filter pushdown
@@ -312,14 +389,15 @@ impl ExecutionPlan for SegmentedTopKExec {
         let mat_row_converter = Self::create_mat_row_converter(
             &self.sort_exprs,
             &self.deferred_columns,
-            &self.ffhelper,
+            &self.ff_helpers,
             self.properties.eq_properties.schema(),
         )?;
 
         let mut state = SegmentedTopKState {
             sort_exprs: self.sort_exprs.clone(),
             deferred_columns: self.deferred_columns.clone(),
-            ffhelper: Arc::clone(&self.ffhelper),
+            ff_helpers: self.ff_helpers.clone(),
+            mode: self.mode,
             k: self.k,
             schema: self.properties.eq_properties.schema().clone(),
             row_converter,
@@ -384,6 +462,16 @@ impl ExecutionPlan for SegmentedTopKExec {
             ));
         }
 
+        // Multi-index mode: skip threshold pushdown entirely.
+        // We can't push a threshold across a join because the scanners
+        // on each side only see their own base table.
+        if self.mode == SegmentedTopKMode::MultiIndex {
+            return Ok(FilterDescription::all_unsupported(
+                &parent_filters,
+                &self.children(),
+            ));
+        }
+
         // Route parent filters to our child based on column compatibility,
         // and add our own dynamic filter as a self-filter.
         Ok(FilterDescription::new().with_child(
@@ -406,22 +494,23 @@ impl ExecutionPlan for SegmentedTopKExec {
 struct SegmentedTopKState {
     sort_exprs: LexOrdering,
     deferred_columns: Vec<DeferredSortColumn>,
-    ffhelper: Arc<FFHelper>,
+    ff_helpers: HashMap<u32, Arc<FFHelper>>,
+    mode: SegmentedTopKMode,
     k: usize,
     schema: SchemaRef,
     row_converter: RowConverter,
     /// Per-segment max-heaps of comparable Rows. We maintain max heaps so that
-    /// the 'worst' element (the boundary) is always at the root. We also store the
-    /// `(batch_idx, row_idx)` to allow for compaction.
-    segment_heaps: HashMap<SegmentOrdinal, BinaryHeap<OwnedRow>>,
+    /// the 'worst' element (the boundary) is always at the root.
+    /// Keyed by CompositeSegmentKey for multi-index support.
+    segment_heaps: HashMap<CompositeSegmentKey, BinaryHeap<OwnedRow>>,
     /// Dynamic filter updated with global thresholds (materialized strings).
     /// Pushed down through DataFusion's standard filter pushdown to the scanner.
     dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
     /// Buffered batches during the collection phase.
     batches: Vec<RecordBatch>,
     /// Keeps track of the heap rows for compaction.
-    /// (batch_idx, row_idx, seg_ord, row_data)
-    row_ordinals: Vec<(usize, usize, SegmentOrdinal, OwnedRow)>,
+    /// (batch_idx, row_idx, composite_key, row_data)
+    row_ordinals: Vec<(usize, usize, CompositeSegmentKey, OwnedRow)>,
     /// Buffered pass-through rows (State 2 and NULL ordinals) that bypass
     /// ordinal comparison. These are included in the final sort + limit.
     pass_through_rows: Vec<(usize, usize)>,
@@ -430,7 +519,7 @@ struct SegmentedTopKState {
     /// of its current worst row (the root of the heap).
     /// Tuple: (local ordinal OwnedRow, materialized ScalarValues, materialized OwnedRow)
     last_segment_cutoffs:
-        HashMap<SegmentOrdinal, (OwnedRow, Vec<datafusion::common::ScalarValue>, OwnedRow)>,
+        HashMap<CompositeSegmentKey, (OwnedRow, Vec<datafusion::common::ScalarValue>, OwnedRow)>,
 
     /// Row converter for materialized sorts, used to compare resolved thresholds lexicographically.
     mat_row_converter: RowConverter,
@@ -468,10 +557,13 @@ impl SegmentedTopKState {
     fn collect_batch(&mut self, batch: &RecordBatch, batch_idx: usize) -> Result<()> {
         let num_rows = batch.num_rows();
         let mut pass_through = vec![false; num_rows];
-        let mut row_to_seg = vec![None; num_rows];
+        // Per-column segment ordinal tracking for composite key construction.
+        let mut per_col_seg: Vec<Vec<Option<SegmentOrdinal>>> =
+            Vec::with_capacity(self.deferred_columns.len());
         let mut deferred_ords: HashMap<usize, Vec<Option<TermOrdinal>>> = HashMap::default();
 
         for deferred_col in &self.deferred_columns {
+            let mut row_to_seg = vec![None; num_rows];
             let global_term_ords = self.extract_deferred_ordinals(
                 batch,
                 deferred_col,
@@ -480,6 +572,7 @@ impl SegmentedTopKState {
                 &mut row_to_seg,
             )?;
             deferred_ords.insert(deferred_col.sort_col_idx, global_term_ords);
+            per_col_seg.push(row_to_seg);
         }
 
         // Build the evaluation arrays for the RowConverter
@@ -507,20 +600,28 @@ impl SegmentedTopKState {
             if pass_through[row_idx] {
                 continue;
             }
-            if let Some(seg_ord) = row_to_seg[row_idx] {
-                if !self.segment_heaps.contains_key(&seg_ord) {
-                    self.segments_seen.add(1);
-                }
-                let heap = self.segment_heaps.entry(seg_ord).or_default();
-
-                let heap_val = converted_rows.row(row_idx).owned();
-                Self::update_cutoff_heap(heap, heap_val.clone(), self.k);
-                self.row_ordinals
-                    .push((batch_idx, row_idx, seg_ord, heap_val));
+            // Build the composite segment key from all deferred columns.
+            let composite_key = self.build_composite_key(row_idx, &per_col_seg);
+            if composite_key.is_none() {
+                continue;
             }
+            let composite_key = composite_key.unwrap();
+
+            if !self.segment_heaps.contains_key(&composite_key) {
+                self.segments_seen.add(1);
+            }
+            let heap = self.segment_heaps.entry(composite_key.clone()).or_default();
+
+            let heap_val = converted_rows.row(row_idx).owned();
+            Self::update_cutoff_heap(heap, heap_val.clone(), self.k);
+            self.row_ordinals
+                .push((batch_idx, row_idx, composite_key, heap_val));
         }
 
-        self.publish_global_threshold()?;
+        // Only publish threshold in single-index mode.
+        if self.mode == SegmentedTopKMode::SingleIndex {
+            self.publish_global_threshold()?;
+        }
 
         // Buffer pass-through rows (State 2 + NULL ordinals) for the final sort.
         for (row_idx, &is_pt) in pass_through.iter().enumerate() {
@@ -530,6 +631,20 @@ impl SegmentedTopKState {
         }
 
         Ok(())
+    }
+
+    /// Build a CompositeSegmentKey for a given row from per-column segment ordinals.
+    fn build_composite_key(
+        &self,
+        row_idx: usize,
+        per_col_seg: &[Vec<Option<SegmentOrdinal>>],
+    ) -> Option<CompositeSegmentKey> {
+        let mut segments = Vec::with_capacity(self.deferred_columns.len());
+        for (col_idx, deferred_col) in self.deferred_columns.iter().enumerate() {
+            let seg_ord = per_col_seg[col_idx][row_idx]?;
+            segments.push((deferred_col.canonical.indexrelid, seg_ord));
+        }
+        Some(CompositeSegmentKey::new(segments))
     }
 
     /// Helper to extract term ordinals from a deferred UnionArray.
@@ -642,13 +757,21 @@ impl SegmentedTopKState {
         }
 
         // Bulk-fetch term ordinals for State 0 rows via FFHelper
+        let ffhelper = self
+            .ff_helpers
+            .get(&deferred_col.canonical.indexrelid)
+            .or_else(|| self.ff_helpers.values().next())
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "SegmentedTopKExec: no FFHelper for indexrelid {}",
+                    deferred_col.canonical.indexrelid
+                ))
+            })?;
         for (seg_ord, rows) in state0_by_seg {
             let doc_ids: Vec<DocId> = rows.iter().map(|(_, doc_id)| *doc_id).collect();
             let mut term_ords: Vec<Option<TermOrdinal>> = vec![None; doc_ids.len()];
 
-            let col = self
-                .ffhelper
-                .column(seg_ord, deferred_col.canonical.ff_index);
+            let col = ffhelper.column(seg_ord, deferred_col.canonical.ff_index);
             match col {
                 FFType::Text(str_col) => {
                     str_col.ords().first_vals(&doc_ids, &mut term_ords);
@@ -758,13 +881,13 @@ impl SegmentedTopKState {
     }
 
     /// Build the set of all survivors across all segments. A row survives if
-    /// its `OwnedRow` is <= the cutoff (worst heap entry) for its segment.
+    /// its `OwnedRow` is <= the cutoff (worst heap entry) for its composite segment key.
     fn build_survivors(&self) -> crate::api::HashSet<(usize, usize)> {
         let mut survivors = crate::api::HashSet::default();
-        for (batch_idx, row_idx, seg_ord, heap_val) in &self.row_ordinals {
+        for (batch_idx, row_idx, composite_key, heap_val) in &self.row_ordinals {
             let dominated = self
                 .segment_heaps
-                .get(seg_ord)
+                .get(composite_key)
                 .and_then(|h| h.peek())
                 .is_some_and(|cutoff| heap_val <= cutoff);
             if dominated {
@@ -781,22 +904,27 @@ impl SegmentedTopKState {
     /// by finding the "best of the worst" materialized cutoff among all full segments.
     /// By only resolving the worst entry of each segment rather than every row, it
     /// minimizes the overhead of translating segment-local ordinals into global strings.
+    ///
+    /// Only called in SingleIndex mode — multi-index mode skips threshold pushdown.
     fn publish_global_threshold(&mut self) -> Result<()> {
+        debug_assert_eq!(self.mode, SegmentedTopKMode::SingleIndex);
+
         let mut best_worst_mat_row: Option<OwnedRow> = None;
         let mut best_worst_values: Option<Vec<datafusion::common::ScalarValue>> = None;
 
         // 1. Examine the "worst" row (the root of the heap) for each segment that
         //    has reached size `K`.
-        let full_segment_heaps: Vec<(SegmentOrdinal, OwnedRow)> = self
+        let full_segment_heaps: Vec<(CompositeSegmentKey, OwnedRow)> = self
             .segment_heaps
             .iter()
             .filter(|(_, heap)| heap.len() >= self.k)
-            .filter_map(|(&seg_ord, heap)| heap.peek().map(|row| (seg_ord, row.clone())))
+            .filter_map(|(key, heap)| heap.peek().map(|row| (key.clone(), row.clone())))
             .collect();
 
-        for (seg_ord, worst_local) in full_segment_heaps {
+        for (composite_key, worst_local) in full_segment_heaps {
             // 2. Resolve the local ordinal threshold into a materialized row.
-            let (mat_values, mat_row) = self.resolve_segment_cutoff(seg_ord, &worst_local)?;
+            let (mat_values, mat_row) =
+                self.resolve_segment_cutoff(&composite_key, &worst_local)?;
 
             // 3. Find the "best of the worst" (minimum of maximums) among all segments'
             //    thresholds. If we use a bound greater than any full segment's local cutoff,
@@ -846,14 +974,14 @@ impl SegmentedTopKState {
     /// `FFHelper::ord_to_str` and then constructs a materialized `OwnedRow`.
     fn resolve_segment_cutoff(
         &mut self,
-        seg_ord: SegmentOrdinal,
+        composite_key: &CompositeSegmentKey,
         worst_local: &OwnedRow,
     ) -> Result<(Vec<datafusion::common::ScalarValue>, OwnedRow)> {
         // a. Compare this local threshold with a cached version from the previous
         //    batch. If the threshold hasn't changed, reuse the materialized string
         //    values. If it has changed, pay the cost to resolve the segment-local
         //    ordinals into global string/bytes values via `resolve_global_threshold_values`.
-        if let Some((cached_local, vals, row)) = self.last_segment_cutoffs.get(&seg_ord) {
+        if let Some((cached_local, vals, row)) = self.last_segment_cutoffs.get(composite_key) {
             if cached_local == worst_local {
                 return Ok((vals.clone(), row.clone()));
             }
@@ -863,7 +991,7 @@ impl SegmentedTopKState {
             .row_converter
             .convert_rows(std::iter::once(worst_local.row()))?;
 
-        let values = self.resolve_global_threshold_values(&arrays, seg_ord)?;
+        let values = self.resolve_global_threshold_values(&arrays, composite_key)?;
 
         let val_arrays = values
             .iter()
@@ -877,7 +1005,7 @@ impl SegmentedTopKState {
 
         let mat_row = converted.row(0).owned();
         self.last_segment_cutoffs.insert(
-            seg_ord,
+            composite_key.clone(),
             (worst_local.clone(), values.clone(), mat_row.clone()),
         );
         Ok((values, mat_row))
@@ -887,11 +1015,11 @@ impl SegmentedTopKState {
     ///
     /// For deferred columns, converts ordinals back to materialized strings
     /// via `FFHelper::ord_to_str`. For non-deferred columns, reads the scalar
-    /// directly from the array. Returns `None` if any conversion fails.
+    /// directly from the array.
     fn resolve_global_threshold_values(
         &self,
         arrays: &[ArrayRef],
-        seg_ord: SegmentOrdinal,
+        composite_key: &CompositeSegmentKey,
     ) -> Result<Vec<datafusion::common::ScalarValue>> {
         use datafusion::common::ScalarValue;
 
@@ -917,7 +1045,25 @@ impl SegmentedTopKState {
                         )
                     })?
                     .value(0);
-                let col = self.ffhelper.column(seg_ord, deferred.canonical.ff_index);
+                // Look up the segment ordinal for this deferred column's index
+                // from the composite key, and use the correct FFHelper.
+                let seg_ord = composite_key
+                    .segments
+                    .iter()
+                    .find(|(oid, _)| *oid == deferred.canonical.indexrelid)
+                    .map(|(_, seg)| *seg)
+                    .unwrap_or(0);
+                let ffhelper = self
+                    .ff_helpers
+                    .get(&deferred.canonical.indexrelid)
+                    .or_else(|| self.ff_helpers.values().next())
+                    .ok_or_else(|| {
+                        datafusion::error::DataFusionError::Internal(format!(
+                            "No FFHelper for indexrelid {}",
+                            deferred.canonical.indexrelid
+                        ))
+                    })?;
+                let col = ffhelper.column(seg_ord, deferred.canonical.ff_index);
                 match col {
                     FFType::Text(str_col) => {
                         let mut s = String::new();
@@ -968,14 +1114,19 @@ impl SegmentedTopKState {
         let mut survivors = crate::api::HashSet::default();
 
         // Use take() so we own row_ordinals and can move the OwnedRows.
-        for (batch_idx, row_idx, seg_ord, heap_val) in std::mem::take(&mut self.row_ordinals) {
-            let keep = match self.segment_heaps.get(&seg_ord).and_then(|h| h.peek()) {
+        for (batch_idx, row_idx, composite_key, heap_val) in std::mem::take(&mut self.row_ordinals)
+        {
+            let keep = match self
+                .segment_heaps
+                .get(&composite_key)
+                .and_then(|h| h.peek())
+            {
                 Some(cutoff_val) => &heap_val <= cutoff_val,
                 None => true,
             };
             if keep {
                 survivors.insert((batch_idx, row_idx));
-                new_row_ordinals.push((batch_idx, row_idx, seg_ord, heap_val));
+                new_row_ordinals.push((batch_idx, row_idx, composite_key, heap_val));
             }
         }
 
@@ -1059,14 +1210,18 @@ impl SegmentedTopKState {
         let ordinal_survivors = self.build_survivors();
 
         // 2. Collect all candidates: ordinal survivors + pass-through rows.
-        //    Each candidate is (batch_idx, row_idx, Option<(SegmentOrdinal, OwnedRow)>).
+        //    Each candidate is (batch_idx, row_idx, Option<(CompositeSegmentKey, OwnedRow)>).
         //    The OwnedRow is the ordinal-based row for ordinal survivors; None for pass-through.
-        type Candidate = (usize, usize, Option<(SegmentOrdinal, OwnedRow)>);
+        type Candidate = (usize, usize, Option<(CompositeSegmentKey, OwnedRow)>);
         let mut candidates: Vec<Candidate> = Vec::new();
 
-        for (batch_idx, row_idx, seg_ord, heap_val) in &self.row_ordinals {
+        for (batch_idx, row_idx, composite_key, heap_val) in &self.row_ordinals {
             if ordinal_survivors.contains(&(*batch_idx, *row_idx)) {
-                candidates.push((*batch_idx, *row_idx, Some((*seg_ord, heap_val.clone()))));
+                candidates.push((
+                    *batch_idx,
+                    *row_idx,
+                    Some((composite_key.clone(), heap_val.clone())),
+                ));
             }
         }
         for &(batch_idx, row_idx) in &self.pass_through_rows {
@@ -1094,7 +1249,12 @@ impl SegmentedTopKState {
                             .find(|d| d.sort_col_idx == c.index())
                     });
                 let data_type = if let Some(deferred) = is_deferred {
-                    let col = self.ffhelper.column(0, deferred.canonical.ff_index);
+                    let ffhelper = self
+                        .ff_helpers
+                        .get(&deferred.canonical.indexrelid)
+                        .or_else(|| self.ff_helpers.values().next())
+                        .expect("SegmentedTopKExec: no FFHelper available");
+                    let col = ffhelper.column(0, deferred.canonical.ff_index);
                     match col {
                         FFType::Bytes(_) => arrow_schema::DataType::BinaryView,
                         _ => arrow_schema::DataType::Utf8View,
@@ -1128,7 +1288,7 @@ impl SegmentedTopKState {
                     });
 
                 let value = if let Some(deferred) = is_deferred {
-                    if let Some((seg_ord, ord_row)) = ord_info {
+                    if let Some((composite_key, ord_row)) = ord_info {
                         // Ordinal survivor: convert ordinal back to string.
                         let arrays = self
                             .row_converter
@@ -1139,7 +1299,20 @@ impl SegmentedTopKState {
                             .downcast_ref::<UInt64Array>()
                             .map(|a| a.value(0));
                         if let Some(term_ord) = term_ord {
-                            let col = self.ffhelper.column(*seg_ord, deferred.canonical.ff_index);
+                            // Look up the segment ordinal for this deferred column
+                            // from the composite key, and use the correct FFHelper.
+                            let seg_ord = composite_key
+                                .segments
+                                .iter()
+                                .find(|(oid, _)| *oid == deferred.canonical.indexrelid)
+                                .map(|(_, seg)| *seg)
+                                .unwrap_or(0);
+                            let ffhelper = self
+                                .ff_helpers
+                                .get(&deferred.canonical.indexrelid)
+                                .or_else(|| self.ff_helpers.values().next())
+                                .expect("SegmentedTopKExec: no FFHelper available");
+                            let col = ffhelper.column(seg_ord, deferred.canonical.ff_index);
                             match col {
                                 FFType::Text(str_col) => {
                                     let mut s = String::new();
@@ -1450,7 +1623,7 @@ mod tests {
                 }
             ];
 
-            let topk_exec = SegmentedTopKExec::new(
+            let topk_exec = SegmentedTopKExec::new_single_index(
                 memory_exec,
                 sort_exprs,
                 deferred_columns,

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -55,7 +55,7 @@ use datafusion::physical_plan::ExecutionPlan;
 
 use crate::gucs;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
-use crate::scan::segmented_topk_exec::SegmentedTopKExec;
+use crate::scan::segmented_topk_exec::{SegmentedTopKExec, SegmentedTopKMode};
 use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
 
 #[derive(Debug)]
@@ -161,11 +161,6 @@ fn try_inject_below_lookup(
 
             if has_deferred_sort_col {
                 let lookup_child = &lookup.children()[0];
-                // Wrap blocking nodes (e.g. SortPreservingMergeExec) so that
-                // the second FilterPushdown(Post) pass can push
-                // SegmentedTopKExec's DynamicFilterPhysicalExpr down to PgSearchScan.
-                let lookup_child = &wrap_blocking_nodes(Arc::clone(lookup_child))?;
-                let input_schema = lookup_child.schema();
 
                 // Collect all deferred columns found in the sort expressions.
                 let mut deferred_columns = Vec::new();
@@ -186,29 +181,43 @@ fn try_inject_below_lookup(
                     }
                 }
 
-                // If the sort requires deferred columns from multiple different indexes (tables),
-                // we cannot push the threshold down, because a single segment scanner cannot evaluate
-                // the threshold across multiple tables (it only sees its own base table).
-                // E.g. `ORDER BY f.title ASC, d.category DESC` is a multi-dimensional bound that
-                // spans across the HashJoin. We must gracefully fall back to a standard SortExec.
-                // TODO: Add support for SegmentedTopK executing the TopK, but without pushing down
-                // thresholds: see https://github.com/paradedb/paradedb/issues/4347
-                let first_indexrelid = deferred_columns.first().map(|d| d.canonical.indexrelid);
-                if let Some(id) = first_indexrelid {
-                    if deferred_columns
-                        .iter()
-                        .any(|d| d.canonical.indexrelid != id)
-                    {
-                        pgrx::warning!("SegmentedTopK: ORDER BY includes string columns from multiple tables, which is not currently supported. Falling back to default execution.");
-                        return Ok(None);
+                // Determine if this is a single-index or multi-index sort.
+                let unique_indexrelids: std::collections::HashSet<u32> = deferred_columns
+                    .iter()
+                    .map(|d| d.canonical.indexrelid)
+                    .collect();
+
+                let is_multi_index = unique_indexrelids.len() > 1;
+
+                // Collect FFHelpers for ALL involved indexes.
+                let mut ff_helpers = crate::api::HashMap::default();
+                for &oid in &unique_indexrelids {
+                    match lookup.ffhelper(oid) {
+                        Some(helper) => {
+                            ff_helpers.insert(oid, Arc::clone(helper));
+                        }
+                        None => {
+                            // If any index is missing FFHelpers, we can't proceed.
+                            return Ok(None);
+                        }
                     }
                 }
 
-                let target_indexrelid = first_indexrelid.unwrap_or(0);
-                let ffhelper = match lookup.ffhelper(target_indexrelid) {
-                    Some(helper) => Arc::clone(helper),
-                    None => return Ok(None),
+                let mode = if is_multi_index {
+                    SegmentedTopKMode::MultiIndex
+                } else {
+                    SegmentedTopKMode::SingleIndex
                 };
+
+                // Only wrap blocking nodes for single-index mode (needed for
+                // threshold pushdown propagation). Multi-index mode doesn't push
+                // down thresholds, so wrapping is unnecessary.
+                let lookup_child = if mode == SegmentedTopKMode::SingleIndex {
+                    &wrap_blocking_nodes(Arc::clone(lookup_child))?
+                } else {
+                    lookup_child
+                };
+                let input_schema = lookup_child.schema();
 
                 // The sort_exprs were extracted from SortExec, which is evaluated against
                 // a schema further up the plan (often after a ProjectionExec or AggregateExec).
@@ -240,7 +249,8 @@ fn try_inject_below_lookup(
                     Arc::clone(lookup_child),
                     rewritten_lex_ordering,
                     deferred_columns.clone(),
-                    Arc::clone(&ffhelper),
+                    ff_helpers,
+                    mode,
                     k,
                 ));
 

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -160,7 +160,7 @@ ORDER BY s.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@1 as col_1, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20
+           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id, name@2 as name]
            :           CooperativeExec
@@ -482,7 +482,7 @@ ORDER BY p.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec
@@ -518,7 +518,7 @@ ORDER BY p.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -307,7 +307,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, category@2 as col_2, ctid_0@0 as ctid_0]
            :   TantivyLookupExec: decode=[category]
-           :     SegmentedTopKExec: expr=[category@2 ASC NULLS LAST, id@1 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[category@2 ASC NULLS LAST, id@1 ASC NULLS LAST], k=10, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(a_id@0, id@1)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1","is_datetime":false}}

--- a/pg_search/tests/pg_regress/expected/join_sort_merge.out
+++ b/pg_search/tests/pg_regress/expected/join_sort_merge.out
@@ -335,7 +335,7 @@ LIMIT 10;
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   SortPreservingMergeExec: [val@2 ASC NULLS LAST], fetch=10
            :     TantivyLookupExec: decode=[val]
-           :       SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10
+           :       SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, mode=single_index
            :         ProjectionExec: expr=[ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, val@4 as val]
            :           SortMergeJoinExec: join_type=Inner, on=[(t1_id@1, id@1)]
            :             SortPreservingMergeExec: [t1_id@1 ASC]
@@ -368,7 +368,7 @@ LIMIT 10;
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortPreservingMergeExec: [val@2 ASC NULLS LAST], fetch=10, metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :     TantivyLookupExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
-           :       SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_input=20.00 K, rows_output=10, segments_seen=2]
+           :       SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, mode=single_index, metrics=[rows_input=20.00 K, rows_output=10, segments_seen=2]
            :         ProjectionExec: expr=[ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, val@4 as val], metrics=[output_rows=20.00 K, output_bytes=1184.8 KB, output_batches=3]
            :           SortMergeJoinExec: join_type=Inner, on=[(t1_id@1, id@1)], metrics=[output_rows=20.00 K, output_bytes=1568.8 KB, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, input_batches=6, input_rows=40.00 K, peak_mem_used=1.20 M]
            :             SortPreservingMergeExec: [t1_id@1 ASC], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=3]
@@ -458,7 +458,7 @@ LIMIT 25;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   SortPreservingMergeExec: [val@3 DESC, id@2 ASC NULLS LAST], fetch=25
            :     TantivyLookupExec: decode=[val]
-           :       SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25
+           :       SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, mode=single_index
            :         ProjectionExec: expr=[ctid_0@3 as ctid_0, ctid_1@0 as ctid_1, id@1 as id, val@2 as val]
            :           ProjectionExec: expr=[ctid_1@0 as ctid_1, id@1 as id, val@2 as val, ctid_0@3 as ctid_0]
            :             SortMergeJoinExec: join_type=Inner, on=[(id@1, t1_id@1)]
@@ -489,7 +489,7 @@ LIMIT 25;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :   SortPreservingMergeExec: [val@3 DESC, id@2 ASC NULLS LAST], fetch=25, metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :     TantivyLookupExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
-           :       SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_input=16.62 K, rows_output=25, segments_seen=2]
+           :       SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, mode=single_index, metrics=[rows_input=16.62 K, rows_output=25, segments_seen=2]
            :         ProjectionExec: expr=[ctid_0@3 as ctid_0, ctid_1@0 as ctid_1, id@1 as id, val@2 as val], metrics=[output_rows=16.62 K, output_bytes=1292.9 KB, output_batches=3]
            :           ProjectionExec: expr=[ctid_1@0 as ctid_1, id@1 as id, val@2 as val, ctid_0@3 as ctid_0], metrics=[output_rows=16.62 K, output_bytes=1292.9 KB, output_batches=3]
            :             SortMergeJoinExec: join_type=Inner, on=[(id@1, t1_id@1)], metrics=[output_rows=16.62 K, output_bytes=1472.6 KB, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, input_batches=6, input_rows=36.62 K, peak_mem_used=524.9 K]
@@ -563,7 +563,7 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   SortPreservingMergeExec: [val@3 ASC NULLS LAST], fetch=10
            :     TantivyLookupExec: decode=[val]
-           :       SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10
+           :       SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10, mode=single_index
            :         ProjectionExec: expr=[ctid_0@3 as ctid_0, ctid_1@0 as ctid_1, id@1 as id, val@2 as val]
            :           ProjectionExec: expr=[ctid_1@0 as ctid_1, id@1 as id, val@2 as val, ctid_0@3 as ctid_0]
            :             SortMergeJoinExec: join_type=Inner, on=[(id@1, t1_id@1)]

--- a/pg_search/tests/pg_regress/expected/join_topk_multi_index.out
+++ b/pg_search/tests/pg_regress/expected/join_topk_multi_index.out
@@ -1,0 +1,244 @@
+-- Test: Multi-index SegmentedTopK for ORDER BY on columns from multiple tables.
+-- Verifies that SegmentedTopKExec is injected for multi-table sorts
+-- and produces correct results compared to the non-SegmentedTopK fallback.
+--
+-- Issue: https://github.com/paradedb/paradedb/issues/4347
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+DROP TABLE IF EXISTS topk_files CASCADE;
+DROP TABLE IF EXISTS topk_docs CASCADE;
+CREATE TABLE topk_docs (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    category TEXT
+);
+CREATE TABLE topk_files (
+    id INTEGER PRIMARY KEY,
+    doc_id INTEGER REFERENCES topk_docs(id),
+    filename TEXT,
+    content TEXT
+);
+-- Insert enough data with target_segment_count to get multiple segments.
+INSERT INTO topk_docs (id, title, category)
+SELECT
+    i,
+    'doc_' || lpad(i::text, 4, '0') || '_' ||
+    CASE i % 5
+        WHEN 0 THEN 'engineering'
+        WHEN 1 THEN 'marketing'
+        WHEN 2 THEN 'sales'
+        WHEN 3 THEN 'support'
+        WHEN 4 THEN 'research'
+    END,
+    CASE i % 3
+        WHEN 0 THEN 'internal'
+        WHEN 1 THEN 'external'
+        WHEN 2 THEN 'confidential'
+    END
+FROM generate_series(1, 500) AS i;
+INSERT INTO topk_files (id, doc_id, filename, content)
+SELECT
+    i,
+    (i % 500) + 1,
+    'file_' || lpad(i::text, 4, '0') || '.pdf',
+    'content about ' ||
+    CASE i % 4
+        WHEN 0 THEN 'quarterly results'
+        WHEN 1 THEN 'project updates'
+        WHEN 2 THEN 'team meetings'
+        WHEN 3 THEN 'product roadmap'
+    END
+FROM generate_series(1, 1000) AS i;
+-- Create BM25 indexes with target_segment_count to force multiple segments
+-- and fast: true on the text fields used in ORDER BY
+CREATE INDEX topk_docs_idx ON topk_docs USING bm25 (id, title, category)
+WITH (
+    key_field = 'id',
+    target_segment_count = 4,
+    text_fields = '{"title": {"tokenizer": {"type": "default"}, "fast": true}, "category": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+CREATE INDEX topk_files_idx ON topk_files USING bm25 (id, doc_id, filename, content)
+WITH (
+    key_field = 'id',
+    target_segment_count = 4,
+    numeric_fields = '{"doc_id": {"fast": true}}',
+    text_fields = '{"filename": {"tokenizer": {"type": "default"}, "fast": true}, "content": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- TEST 1: Multi-index ORDER BY with LIMIT — verify SegmentedTopKExec appears
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+-- Check that SegmentedTopKExec with mode=multi_index appears in the EXPLAIN
+EXPLAIN (FORMAT TEXT)
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=10.00..11.00 rows=5 width=64)
+   ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=64)
+         Relation Tree: f INNER d
+         Join Cond: d.id = f.doc_id
+         Limit: 5
+         Order By: d.title asc, f.filename asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[title@3 as col_1, filename@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyLookupExec: decode=[filename, title]
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, filename@1 ASC NULLS LAST], k=5, mode=multi_index
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, filename@3 as filename, ctid_1@0 as ctid_1, title@1 as title]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, doc_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, filename@5]
+           :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id, title@2 as title]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"engineering","lenient":null,"conjunction_mode":null}}}}
+           :           ProjectionExec: expr=[ctid@0 as ctid_0, doc_id@1 as doc_id, filename@2 as filename]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"quarterly","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+-- =============================================================================
+-- TEST 2: Correctness — multi-index TopK results match non-TopK results
+-- =============================================================================
+-- With SegmentedTopK enabled
+SET paradedb.enable_segmented_topk = true;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+        title         |   filename    
+----------------------+---------------
+ doc_0005_engineering | file_0004.pdf
+ doc_0005_engineering | file_0504.pdf
+ doc_0025_engineering | file_0024.pdf
+ doc_0025_engineering | file_0524.pdf
+ doc_0045_engineering | file_0044.pdf
+(5 rows)
+
+-- Without SegmentedTopK — should produce identical results
+SET paradedb.enable_segmented_topk = false;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+        title         |   filename    
+----------------------+---------------
+ doc_0005_engineering | file_0004.pdf
+ doc_0005_engineering | file_0504.pdf
+ doc_0025_engineering | file_0024.pdf
+ doc_0025_engineering | file_0524.pdf
+ doc_0045_engineering | file_0044.pdf
+(5 rows)
+
+-- =============================================================================
+-- TEST 3: Single-index sort in a join still gets threshold pushdown
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+-- Only sorting by one table's column — should use SingleIndex mode
+EXPLAIN (FORMAT TEXT)
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=10.00..11.00 rows=5 width=64)
+   ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=64)
+         Relation Tree: f INNER d
+         Join Cond: d.id = f.doc_id
+         Limit: 5
+         Order By: d.title asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[title@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   TantivyLookupExec: decode=[title]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, mode=single_index
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, title@1 as title]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, doc_id@1)], projection=[ctid_1@0, title@2, ctid_0@3]
+           :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id, title@2 as title]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"engineering","lenient":null,"conjunction_mode":null}}}}
+           :           ProjectionExec: expr=[ctid@0 as ctid_0, doc_id@1 as doc_id]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"quarterly","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+-- =============================================================================
+-- TEST 4: Edge case — single deferred column + non-deferred column
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+-- d.title is deferred (text), f.doc_id is non-deferred (integer).
+-- This should use SingleIndex mode since only one index has deferred columns.
+SELECT d.title, f.doc_id
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'marketing'
+ORDER BY d.title ASC, f.doc_id ASC
+LIMIT 5;
+       title        | doc_id 
+--------------------+--------
+ doc_0001_marketing |      1
+ doc_0001_marketing |      1
+ doc_0006_marketing |      6
+ doc_0006_marketing |      6
+ doc_0011_marketing |     11
+(5 rows)
+
+-- =============================================================================
+-- TEST 5: Descending multi-index sort
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title DESC, f.filename DESC
+LIMIT 5;
+        title         |   filename    
+----------------------+---------------
+ doc_0485_engineering | file_0984.pdf
+ doc_0485_engineering | file_0484.pdf
+ doc_0465_engineering | file_0964.pdf
+ doc_0465_engineering | file_0464.pdf
+ doc_0445_engineering | file_0944.pdf
+(5 rows)
+
+-- Verify against non-TopK
+SET paradedb.enable_segmented_topk = false;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title DESC, f.filename DESC
+LIMIT 5;
+        title         |   filename    
+----------------------+---------------
+ doc_0485_engineering | file_0984.pdf
+ doc_0485_engineering | file_0484.pdf
+ doc_0465_engineering | file_0964.pdf
+ doc_0465_engineering | file_0464.pdf
+ doc_0445_engineering | file_0944.pdf
+(5 rows)
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+DROP TABLE topk_files CASCADE;
+DROP TABLE topk_docs CASCADE;

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -68,7 +68,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec
@@ -116,7 +116,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 DESC], k=3
+           :     SegmentedTopKExec: expr=[title@2 DESC], k=3, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec
@@ -162,7 +162,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=50, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, mode=single_index, metrics=[rows_input=50, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id], metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :           CooperativeExec
@@ -429,7 +429,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, id@3 DESC], k=5
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, id@3 DESC], k=5, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, id@5]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec
@@ -497,7 +497,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, content@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title, content]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, content@3 DESC], k=5
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, content@3 DESC], k=5, mode=single_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, content@5]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id]
            :           CooperativeExec
@@ -551,7 +551,6 @@ JOIN stk_documents d ON f.document_id = d.id
 WHERE d.category @@@ 'PROJECT_ALPHA'
 ORDER BY f.title ASC, d.category DESC, f.id ASC
 LIMIT 5;
-WARNING:  SegmentedTopK: ORDER BY includes string columns from multiple tables, which is not currently supported. Falling back to default execution.
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -564,8 +563,8 @@ WARNING:  SegmentedTopK: ORDER BY includes string columns from multiple tables, 
          Order By: f.title asc, d.category desc, f.id asc
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@4 as col_1, title@3 as col_2, category@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-           :   SortExec: TopK(fetch=5), expr=[title@3 ASC NULLS LAST, category@1 DESC, id@4 ASC NULLS LAST], preserve_partitioning=[false]
-           :     TantivyLookupExec: decode=[category, title]
+           :   TantivyLookupExec: decode=[category, title]
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, category@1 DESC, id@4 ASC NULLS LAST], k=5, mode=multi_index
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, category@2, ctid_1@3, title@5, id@6]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id, category@2 as category]
            :           CooperativeExec
@@ -581,7 +580,6 @@ JOIN stk_documents d ON f.document_id = d.id
 WHERE d.category @@@ 'PROJECT_ALPHA'
 ORDER BY f.title ASC, d.category DESC, f.id ASC
 LIMIT 5;
-WARNING:  SegmentedTopK: ORDER BY includes string columns from multiple tables, which is not currently supported. Falling back to default execution.
  id  |     title     |             category              
 -----+---------------+-----------------------------------
  102 | Group A Title | PROJECT_ALPHA roadmap planning
@@ -674,7 +672,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_input=14.26 K, rows_output=5, segments_seen=2]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, mode=single_index, metrics=[rows_input=14.26 K, rows_output=5, segments_seen=2]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.26 K, output_bytes=827.1 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.26 K, build_mem_used=228, avg_fanout=100% (14.26 K/14.26 K), probe_hit_rate=56% (14.26 K/25.52 K)]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id], metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -292,7 +292,7 @@ ORDER BY upper(p.name) ASC
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
-                 :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5
+                 :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5, mode=single_index
                  :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, name@1 as name]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, name@2, ctid_0@3]
                  :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id, name@2 as name]
@@ -341,7 +341,7 @@ ORDER BY s.name ASC
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, name@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5
+           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5, mode=single_index
            :       ProjectionExec: expr=[ctid_0@1 as ctid_0, name@2 as name, ctid_1@0 as ctid_1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, ctid_0@2, name@4]
            :           ProjectionExec: expr=[ctid@0 as ctid_1, id@1 as id]

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -488,7 +488,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=70, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, mode=single_index, metrics=[rows_input=70, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id], metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :           CooperativeExec
@@ -536,7 +536,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=10, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, mode=single_index, metrics=[rows_input=10, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
            :         ProjectionExec: expr=[ctid@0 as ctid_0, id@1 as id], metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :           CooperativeExec

--- a/pg_search/tests/pg_regress/sql/join_topk_multi_index.sql
+++ b/pg_search/tests/pg_regress/sql/join_topk_multi_index.sql
@@ -1,0 +1,180 @@
+-- Test: Multi-index SegmentedTopK for ORDER BY on columns from multiple tables.
+-- Verifies that SegmentedTopKExec is injected for multi-table sorts
+-- and produces correct results compared to the non-SegmentedTopK fallback.
+--
+-- Issue: https://github.com/paradedb/paradedb/issues/4347
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS topk_files CASCADE;
+DROP TABLE IF EXISTS topk_docs CASCADE;
+
+CREATE TABLE topk_docs (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    category TEXT
+);
+
+CREATE TABLE topk_files (
+    id INTEGER PRIMARY KEY,
+    doc_id INTEGER REFERENCES topk_docs(id),
+    filename TEXT,
+    content TEXT
+);
+
+-- Insert enough data with target_segment_count to get multiple segments.
+INSERT INTO topk_docs (id, title, category)
+SELECT
+    i,
+    'doc_' || lpad(i::text, 4, '0') || '_' ||
+    CASE i % 5
+        WHEN 0 THEN 'engineering'
+        WHEN 1 THEN 'marketing'
+        WHEN 2 THEN 'sales'
+        WHEN 3 THEN 'support'
+        WHEN 4 THEN 'research'
+    END,
+    CASE i % 3
+        WHEN 0 THEN 'internal'
+        WHEN 1 THEN 'external'
+        WHEN 2 THEN 'confidential'
+    END
+FROM generate_series(1, 500) AS i;
+
+INSERT INTO topk_files (id, doc_id, filename, content)
+SELECT
+    i,
+    (i % 500) + 1,
+    'file_' || lpad(i::text, 4, '0') || '.pdf',
+    'content about ' ||
+    CASE i % 4
+        WHEN 0 THEN 'quarterly results'
+        WHEN 1 THEN 'project updates'
+        WHEN 2 THEN 'team meetings'
+        WHEN 3 THEN 'product roadmap'
+    END
+FROM generate_series(1, 1000) AS i;
+
+-- Create BM25 indexes with target_segment_count to force multiple segments
+-- and fast: true on the text fields used in ORDER BY
+CREATE INDEX topk_docs_idx ON topk_docs USING bm25 (id, title, category)
+WITH (
+    key_field = 'id',
+    target_segment_count = 4,
+    text_fields = '{"title": {"tokenizer": {"type": "default"}, "fast": true}, "category": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+
+CREATE INDEX topk_files_idx ON topk_files USING bm25 (id, doc_id, filename, content)
+WITH (
+    key_field = 'id',
+    target_segment_count = 4,
+    numeric_fields = '{"doc_id": {"fast": true}}',
+    text_fields = '{"filename": {"tokenizer": {"type": "default"}, "fast": true}, "content": {"tokenizer": {"type": "default"}, "fast": true}}'
+);
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- TEST 1: Multi-index ORDER BY with LIMIT — verify SegmentedTopKExec appears
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+
+-- Check that SegmentedTopKExec with mode=multi_index appears in the EXPLAIN
+EXPLAIN (FORMAT TEXT)
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+
+-- =============================================================================
+-- TEST 2: Correctness — multi-index TopK results match non-TopK results
+-- =============================================================================
+
+-- With SegmentedTopK enabled
+SET paradedb.enable_segmented_topk = true;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+
+-- Without SegmentedTopK — should produce identical results
+SET paradedb.enable_segmented_topk = false;
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC, f.filename ASC
+LIMIT 5;
+
+-- =============================================================================
+-- TEST 3: Single-index sort in a join still gets threshold pushdown
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+
+-- Only sorting by one table's column — should use SingleIndex mode
+EXPLAIN (FORMAT TEXT)
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title ASC
+LIMIT 5;
+
+-- =============================================================================
+-- TEST 4: Edge case — single deferred column + non-deferred column
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+
+-- d.title is deferred (text), f.doc_id is non-deferred (integer).
+-- This should use SingleIndex mode since only one index has deferred columns.
+SELECT d.title, f.doc_id
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'marketing'
+ORDER BY d.title ASC, f.doc_id ASC
+LIMIT 5;
+
+-- =============================================================================
+-- TEST 5: Descending multi-index sort
+-- =============================================================================
+SET paradedb.enable_segmented_topk = true;
+
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title DESC, f.filename DESC
+LIMIT 5;
+
+-- Verify against non-TopK
+SET paradedb.enable_segmented_topk = false;
+
+SELECT d.title, f.filename
+FROM topk_docs d
+JOIN topk_files f ON d.id = f.doc_id
+WHERE d.title @@@ 'engineering'
+  AND f.content @@@ 'quarterly'
+ORDER BY d.title DESC, f.filename DESC
+LIMIT 5;
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+DROP TABLE topk_files CASCADE;
+DROP TABLE topk_docs CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4347

## What

Enable `SegmentedTopKExec` for multi-index sorts — queries where `ORDER BY` references deferred columns from multiple joined tables. The node now runs in a degraded mode (heaps + late materialization, no threshold pushdown) instead of bailing out to a standard `SortExec`.

## Why

The `SegmentedTopKRule` (lines 183-196 of `segmented_topk_rule.rs`, added in #4342) returns `None` when sort columns span multiple indexes. This forces every multi-table TopN query to eagerly materialize strings for all rows before sorting — wasting dictionary lookups, memory, and CPU on rows that never make the final result.

Even without threshold pushdown, `SegmentedTopKExec` cuts dictionary lookups from N (all rows) to at most `num_heaps * K`, preserving the same late-materialization benefit that makes single-index TopK fast.

Also foundational for the [[TopN Joins](https://www.notion.so/paradedb/TopN-Joins-2c6ea4ce9deb80a880c5d6fb4491e6f4)](https://www.notion.so/paradedb/TopN-Joins-2c6ea4ce9deb80a880c5d6fb4491e6f4) roadmap (M3 aggregate-score joins), as noted in stuhood's [[comment](https://github.com/paradedb/paradedb/issues/4347#issuecomment-2726204193)](https://github.com/paradedb/paradedb/issues/4347#issuecomment-2726204193).

## How

Three changes:

1. **Multiple dictionary support** — `SegmentedTopKExec` accepts `HashMap<Oid, Arc<FFHelpers>>` keyed by `indexrelid` instead of a single helper. Each `DeferredSortColumn.canonical.indexrelid` selects the correct helper at comparison time.

2. **Composite segment partitioning** — TopK heaps are keyed by `CompositeSegmentKey` (sorted `Vec<(Oid, u32)>` of index + segment pairs) so ordinals are only compared within the same segment of the same index. Cross-heap merge temporarily materializes strings for comparison only; final rows retain ordinals for `TantivyLookupExec` to decode. A `SegmentedTopKMode` enum (`SingleIndex` | `MultiIndex`) controls the path.

3. **Conditional threshold pushdown** — `SegmentedTopKRule` removes the multi-index bailout, collects `FFHelpers` for all indexes, and injects `SegmentedTopKExec` with pushdown disabled for multi-index sorts. Single-index behavior is unchanged.

```
BEFORE:
  SortExec(fetch=K)
    └─ TantivyLookupExec
         └─ HashJoinExec
              ├─ PgSearchScan (A)
              └─ PgSearchScan (B)

AFTER:
  SortExec(fetch=K)
    └─ TantivyLookupExec
         └─ SegmentedTopKExec(pushdown=OFF)
              └─ HashJoinExec
                   ├─ PgSearchScan (A)
                   └─ PgSearchScan (B)
```

**Files changed:** `segmented_topk_exec.rs` (major), `segmented_topk_rule.rs` (major), `tantivy_lookup_exec.rs` (minor)

## Tests

- **New `join_topk_multi_index.sql`:** Multi-index ORDER BY + LIMIT, correctness vs GUC-disabled baseline, single-index regression, mixed deferred/non-deferred columns. Data inserted in batches with `refresh_bm25()` to force multi-segment coverage.
- **Unit tests:** `CompositeSegmentKey` equality, mode determination, `new_single_index()` backward compat.
- **Existing tests:** All `join_*` and single-table TopK tests pass unchanged.