### PR TITLE
fix: install libsecret-1-dev for Mintlify CLI in test-docs workflow

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
+      - name: Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Install Mintlify CLI
         run: npm install -g mintlify
 


### PR DESCRIPTION
## Summary
- The `test-docs` workflow fails because the Mintlify CLI depends on the `keytar` native Node module, which requires `libsecret-1.so.0` — a library not present on the `ubuntu-latest` runner.
- Adds `sudo apt-get install -y libsecret-1-dev` before the Mintlify CLI install step to provide the missing shared library.

Fixes the failure in https://github.com/paradedb/paradedb/actions/runs/23875562630/job/69617615405

## Test plan
- [x] Verify the `Test Docs` workflow passes on this PR