### PR TITLE
chore: Fix the unsupported-query link

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/targetlist.rs
@@ -163,7 +163,7 @@ impl CustomScanClause<AggregateScan> for TargetList {
         unsafe {
             let parse = args.root().parse;
             if !parse.is_null() && (!(*parse).distinctClause.is_null() || (*parse).hasDistinctOn) {
-                return Err("Query has DISTINCT clause (see https://github.com/orgs/paradedb/discussions/3678)".into());
+                return Err("Query has DISTINCT clause (see https://github.com/paradedb/paradedb/issues/new/choose)".into());
             }
         }
 
@@ -235,7 +235,7 @@ impl CustomScanClause<AggregateScan> for TargetList {
                     // Found an Aggref (either top-level or wrapped in COALESCE, NULLIF, etc.)
                     // TODO: Support DISTINCT
                     if !(*aggref).aggdistinct.is_null() {
-                        return Err("DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678)".into());
+                        return Err("DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose)".into());
                     }
 
                     let mut qual_state = QualExtractState::default();

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -28,7 +28,7 @@ mod pdb {
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
     fn score_from_relation(relation_reference: AnyElement) -> f32 {
-        panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     extension_sql!(
@@ -46,7 +46,7 @@ mod pdb {
 #[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
-    panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -269,7 +269,7 @@ pub mod pdb {
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> String {
-        panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     #[allow(unused_variables)]
@@ -283,7 +283,7 @@ pub mod pdb {
         offset: default!(Option<i32>, "NULL"),
         sort_by: default!(String, "'score'"),
     ) -> Vec<String> {
-        panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     #[allow(unused_variables)]
@@ -307,7 +307,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
-        panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 }
 
@@ -324,7 +324,7 @@ fn paradedb_snippet_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> Option<String> {
-    panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 #[warn(deprecated)]
@@ -339,7 +339,7 @@ fn paradedb_snippets_from_relation(
     offset: default!(Option<i32>, "NULL"),
     sort_by: default!(String, "'score'"),
 ) -> Option<Vec<String>> {
-    panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 #[warn(deprecated)]
@@ -364,7 +364,7 @@ fn paradedb_snippet_positions_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
-    panic!("Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678");
+    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 extension_sql!(

--- a/pg_search/tests/pg_regress/expected/aggregate.out
+++ b/pg_search/tests/pg_regress/expected/aggregate.out
@@ -432,7 +432,7 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -453,7 +453,7 @@ WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github
 SELECT COUNT(DISTINCT category), SUM(price)
 FROM products
 WHERE description @@@ 'laptop';
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
  count |        sum         
 -------+--------------------
      2 | 2799.9700000000003

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -629,7 +629,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 'Product' as type, name as item_name, description as content

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -121,7 +121,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -146,7 +146,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -227,7 +227,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/empty_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/empty_aggregate.out
@@ -517,7 +517,7 @@ SELECT
 FROM empty_test
 WHERE id @@@ paradedb.all()
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: empty_test)
  category | total_count | distinct_values | high_values | doubled_avg 
 ----------+-------------+-----------------+-------------+-------------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
+++ b/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
@@ -1031,7 +1031,7 @@ SELECT
     COUNT(DISTINCT category) AS unique_categories,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
  unique_categories | apple_count 
 -------------------+-------------
                  4 |           3

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate.out
@@ -480,7 +480,7 @@ SELECT category, COUNT(DISTINCT rating), SUM(price)
 FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -503,7 +503,7 @@ FROM products
 WHERE description @@@ 'laptop OR keyboard'
 GROUP BY category
 ORDER BY category;
-WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/orgs/paradedb/discussions/3678). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
+WARNING:  Aggregate Scan not used: DISTINCT is not supported (see https://github.com/paradedb/paradedb/issues/new/choose). To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     2 | 2529.96

--- a/pg_search/tests/pg_regress/expected/issue_3678.out
+++ b/pg_search/tests/pg_regress/expected/issue_3678.out
@@ -12,7 +12,7 @@
 -- before adding our custom path so neither regular nor partial native
 -- alternatives can outcompete it.
 --
--- See: https://github.com/orgs/paradedb/discussions/3678
+-- See: https://github.com/paradedb/paradedb/issues/new/choose
 CREATE EXTENSION IF NOT EXISTS pg_search;
 DROP TABLE IF EXISTS nhfs_big CASCADE;
 CREATE TABLE nhfs_big (

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -184,7 +184,7 @@ FROM authors a
 INNER JOIN books b ON a.id = b.author_id AND a.birth_year < 2000
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 2: Non-equi joins and problematic conditions
 -- =============================================================================
@@ -278,7 +278,7 @@ FROM authors a
 INNER JOIN books b ON b.price BETWEEN 20.00 AND 30.00 AND a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 3: CROSS-TABLE OR TESTS
 -- =============================================================================
@@ -418,7 +418,7 @@ JOIN reviews r ON b.id = r.book_id
 WHERE (a.bio @@@ 'British' AND b.is_published = true) 
    OR (b.content @@@ 'horror' AND r.score >= 4)
 ORDER BY a.id, b.id, r.id, author_score DESC, book_score DESC, review_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 4.4: Intelligent partial salvage of AND expressions
 SELECT 
     a.name as author_name,
@@ -460,7 +460,7 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' AND b.category_id = 1
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5.3: LEFT JOIN semantics test
 SELECT 
     a.name as author_name,
@@ -566,7 +566,7 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'story')
   AND (a.is_active = true OR b.is_published = true);
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 6.3: Unsafe conditions that cannot be pushed down
 SELECT 
     a.name as author_name,
@@ -610,7 +610,7 @@ WHERE (
 )
 ORDER BY a.id, b.id, r.id, author_score DESC, book_score DESC
 LIMIT 10;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 7.2: Conservative OR handling demonstration
 SELECT 
     a.name as author_name,

--- a/pg_search/tests/pg_regress/expected/partitioned_snippets.out
+++ b/pg_search/tests/pg_regress/expected/partitioned_snippets.out
@@ -113,7 +113,7 @@ FROM logs
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 \echo 'Test 3: UNNEST(pdb.snippets(...)) on a child table'
 Test 3: UNNEST(pdb.snippets(...)) on a child table
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -241,5 +241,5 @@ FROM logs_2020
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 DROP TABLE IF EXISTS logs CASCADE;

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -135,7 +135,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -160,7 +160,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -241,7 +241,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
@@ -88,7 +88,7 @@ SELECT
 FROM products 
 WHERE category_name = 'Electronics'
 ORDER BY id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 1.6: Simple test with just non-indexed predicate to isolate the issue
 SELECT 
     id,
@@ -255,7 +255,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -776,7 +776,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -1060,7 +1060,7 @@ FROM products
 WHERE description @@@ 'Apple'
   AND category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test edge case: Query with only indexed predicates should still work when GUC is disabled
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -166,7 +166,7 @@ LEFT JOIN reviews r ON r.book_id = b.id
 WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;
 DROP TABLE IF EXISTS books;

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -227,7 +227,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -748,7 +748,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/orgs/paradedb/discussions/3678
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/issue_3678.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3678.sql
@@ -12,7 +12,7 @@
 -- before adding our custom path so neither regular nor partial native
 -- alternatives can outcompete it.
 --
--- See: https://github.com/orgs/paradedb/discussions/3678
+-- See: https://github.com/paradedb/paradedb/issues/new/choose
 
 CREATE EXTENSION IF NOT EXISTS pg_search;
 


### PR DESCRIPTION
## What

Switch the unsupported query link to point to the "new issue" page.

## Why

https://github.com/orgs/paradedb/discussions/3678 has not proven to be a useful way to deduplicate issues, because they are almost all unique.