### PR TITLE
chore: Fix `aggregate_topk_count` work_mem.

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_topk_count.sql
@@ -18,7 +18,7 @@ ORDER BY
 LIMIT 10;
 
 -- Tantivy TopK aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT
     f.title,
     COUNT(*)
 FROM files f


### PR DESCRIPTION
## What

Add a `work_mem` override for `aggregate_topk_count`

## Why

It's currently failing in the benchmark suite after #4573.