### PR TITLE
ci: swap ubicloud AMD/ARM runners for cost savings

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
-    runs-on: ubicloud-standard-4-arm-ubuntu-2404
+    runs-on: ubicloud-standard-8-arm-ubuntu-2404
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'antithesis')
     strategy:
       matrix:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   lint-rust:
     name: Lint Rust Files
-    runs-on: ubicloud-standard-2-arm
+    runs-on: ubicloud-standard-4-arm
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   schemabot-generate-diff:
     name: SchemaBot
-    runs-on: ubicloud-standard-4-arm-ubuntu-2404
+    runs-on: ubicloud-standard-8-arm-ubuntu-2404
     defaults:
       run:
         shell: bash -eo pipefail {0}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image
-    runs-on: ubicloud-standard-4-arm-ubuntu-2404
+    runs-on: ubicloud-standard-8-arm-ubuntu-2404
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   test-pg_search-upgrade:
     name: Test upgrading pg_search via ALTER EXTENSION
-    runs-on: ubicloud-standard-4-arm-ubuntu-2404
+    runs-on: ubicloud-standard-8-arm-ubuntu-2404
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -59,13 +59,13 @@ jobs:
         # Base: system Postgres on regular runner for all versions
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         pg_impl: [system]
-        runner: [ubicloud-standard-4-arm-ubuntu-2404]
+        runner: [ubicloud-standard-8-arm-ubuntu-2404]
         arch: [arm64]
         include:
           # Add pgrx-managed Postgres for PG 18 (regular runner)
           - pg_version: 18
             pg_impl: pgrx
-            runner: ubicloud-standard-4-arm-ubuntu-2404
+            runner: ubicloud-standard-8-arm-ubuntu-2404
             arch: arm64
           # Add AMD run for PG 18 (system Postgres)
           - pg_version: 18

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
-    runs-on: ubicloud-standard-4-arm
+    runs-on: ubicloud-standard-8-arm
 
     steps:
       - name: Checkout Git Repository

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -392,6 +392,7 @@ pub(crate) mod pdb {
                 // Convert the text varlena to a string using pgrx utilities
                 let text_len = pgrx::varlena::varsize_any_exhdr(ptr);
                 let text_data = pgrx::varlena::vardata_any(ptr);
+                #[allow(clippy::unnecessary_cast)]
                 let text_slice = std::slice::from_raw_parts(text_data as *const u8, text_len);
                 let text_str = std::str::from_utf8_unchecked(text_slice);
                 std::ffi::CString::new(text_str)

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -229,6 +229,7 @@ pub mod pdb {
                     pg_sys::INT4OID, // element type OID (integer)
                     4,               // typlen (int4 is 4 bytes)
                     true,            // typbyval (int4 is passed by value)
+                    #[allow(clippy::useless_conversion)]
                     pg_sys::TYPALIGN_INT.try_into().unwrap(), // typalign (char type, architecture-specific)
                 );
 

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -662,6 +662,7 @@ impl<'a> PageMut<'a> {
                 // bytes won't fit here
                 return None;
             }
+            #[allow(clippy::unnecessary_cast)]
             std::slice::from_raw_parts_mut(
                 (self.pg_page as *mut u8).add(start as usize),
                 len as usize,
@@ -683,6 +684,7 @@ impl<'a> PageMut<'a> {
                 // bytes won't fit here
                 return false;
             }
+            #[allow(clippy::unnecessary_cast)]
             std::slice::from_raw_parts_mut(
                 (self.pg_page as *mut u8).add(start as usize),
                 len as usize,


### PR DESCRIPTION
## Summary
- Ubicloud ARM runners are 50% cheaper than AMD runners
- Swaps all primary runners from AMD (8-core) to ARM (8-core) for cost optimization
- Swaps all secondary runners from ARM (4-core) to AMD (4-core) to maintain cross-architecture test coverage

## Files changed (12 workflows)
- **Single-runner jobs** (8 files): `lint-rust`, `test-pg_search-upgrade`, `schemabot-generate-diff`, `antithesis-trigger-test-run`, `publish-stressgres-docker`, `test-stressgres-docker`, `test-pg_search-docker`, `publish-pg_search-schema` — all switched from AMD to ARM
- **Matrix jobs** (4 files): `publish-pg_search-ubuntu`, `publish-pg_search-rhel`, `publish-pg_search-debian`, `test-pg_search` — AMD↔ARM swapped with corresponding arch labels (`amd64`↔`arm64`, `x86_64`↔`aarch64`)

## Test plan
- [x] Verify CI workflows run successfully on the new runner types
- [x] Confirm published packages have correct architecture labels
- [x] Spot-check that both AMD and ARM builds still produce valid artifacts