### PR TITLE
ci: Use x86_64 runner for Antithesis workflow

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
-    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    runs-on: ubicloud-standard-8-ubuntu-2404
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'antithesis')
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
             PG_VERSION_MAJOR=${{ matrix.pg_version }}
             COMMIT_SHA=${{ github.sha }}
             ENABLE_ANTITHESIS_INSTRUMENTATION=true
-          platforms: linux/arm64
+          platforms: linux/amd64
           file: docker/Dockerfile
           push: true
           tags: ${{ steps.extract-workload-metadata.outputs.tags }}
@@ -112,7 +112,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           file: docker/Dockerfile.config
           push: true
           tags: ${{ steps.extract-config-metadata.outputs.tags }}
@@ -133,7 +133,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           file: docker/Dockerfile.stressgres
           push: true
           tags: ${{ steps.extract-stressgres-metadata.outputs.tags }}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Switch the Antithesis workflow back to an x86_64 runner (`ubicloud-standard-8-ubuntu-2404`) and keep `linux/amd64` as the target platform.

## Why
Antithesis only supports x86_64 container images. The previous change to ARM runners caused the build to fail because `libvoidstar.so` (Antithesis instrumentation library) is x86_64-only, and the ARM linker rejected it as incompatible.

## How
- Reverted runner from `ubicloud-standard-8-arm-ubuntu-2404` to `ubicloud-standard-8-ubuntu-2404`
- Reverted all three Docker build platforms from `linux/arm64` back to `linux/amd64`

## Tests
CI should pass with the Antithesis label.