### PR TITLE
fix: support varchar, text[], and citext parameters in operators with generic plans

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -874,6 +874,59 @@ where
     rhs
 }
 
+/// Returns `true` if the given OID is a text-like scalar type (text, varchar, or citext).
+fn is_text_like(oid: pg_sys::Oid) -> bool {
+    oid == pg_sys::TEXTOID || oid == pg_sys::VARCHAROID || is_citext_oid(oid)
+}
+
+/// Returns `true` if the given OID is a text-like array type (text[] or varchar[]).
+fn is_text_array_like(oid: pg_sys::Oid) -> bool {
+    oid == pg_sys::TEXTARRAYOID || oid == pg_sys::VARCHARARRAYOID
+}
+
+/// Build a [`pg_sys::FuncExpr`] for a text-or-text-array RHS in an `exec_rewrite` callback.
+///
+/// Checks the RHS expression type and dispatches to the appropriate builder function.
+/// `text_fn` and `array_fn` are `regprocedure` strings for the scalar and array variants.
+unsafe fn build_text_funcexpr(
+    field: FieldName,
+    rhs: *mut pg_sys::Node,
+    operator_name: &str,
+    text_fn: &std::ffi::CStr,
+    array_fn: &std::ffi::CStr,
+) -> pg_sys::FuncExpr {
+    let expr_type = get_expr_result_type(rhs);
+    let is_array = is_text_array_like(expr_type);
+    if !(is_text_like(expr_type) || is_array) {
+        panic!(
+            "The right-hand side of the `{operator_name}` operator must be a text or text array value"
+        );
+    }
+
+    let sig = if is_array { array_fn } else { text_fn };
+    let funcid = direct_function_call::<pg_sys::Oid>(pg_sys::regprocedurein, &[sig.into_datum()])
+        .unwrap_or_else(|| panic!("`{}` should exist", sig.to_str().unwrap()));
+
+    let mut args = PgList::<pg_sys::Node>::new();
+    args.push(field.into_const().cast());
+    args.push(rhs.cast());
+
+    pg_sys::FuncExpr {
+        xpr: pg_sys::Expr {
+            type_: pg_sys::NodeTag::T_FuncExpr,
+        },
+        funcid,
+        funcresulttype: searchqueryinput_typoid(),
+        funcretset: false,
+        funcvariadic: false,
+        funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
+        funccollid: pg_sys::Oid::INVALID,
+        inputcollid: pg_sys::Oid::INVALID,
+        args: args.into_pg(),
+        location: -1,
+    }
+}
+
 /// Given a [`pg_sys::Node`] and a [`pg_sys::PlannerInfo`], attempt to find the relation Oid that
 /// is referenced by the node.
 ///

--- a/pg_search/src/api/operator/andandand.rs
+++ b/pg_search/src/api/operator/andandand.rs
@@ -18,14 +18,11 @@ use crate::api::builder_fns::{match_conjunction, match_conjunction_array, term_s
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    get_expr_result_type, request_simplify, searchqueryinput_typoid,
-    validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
+    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
+    ReturnedNodePointer,
 };
 use crate::query::pdb_query::{pdb, to_search_query_input};
-use pgrx::{
-    direct_function_call, extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement,
-    Internal, IntoDatum, PgList,
-};
+use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.&&&)]
@@ -121,28 +118,11 @@ fn search_with_match_conjunction_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "&&&");
             let field = field.expect("The left hand side of the `&&&(field, TEXT)` operator must be a field.");
-            assert!(get_expr_result_type(rhs) == pg_sys::TEXTOID, "The right-hand side of the `&&&(field, TEXT)` operator must be a text value");
-            let mut args = PgList::<pg_sys::Node>::new();
-
-            args.push(field.into_const().cast());
-            args.push(rhs.cast());
-
-            pg_sys::FuncExpr {
-                xpr: pg_sys::Expr { type_: pg_sys::NodeTag::T_FuncExpr },
-                funcid: direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[c"paradedb.match_conjunction(paradedb.fieldname, text)".into_datum()],
-                )
-                    .expect("`paradedb.match_conjunction(paradedb.fieldname, text)` should exist"),
-                funcresulttype: searchqueryinput_typoid(),
-                funcretset: false,
-                funcvariadic: false,
-                funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
-                funccollid: pg_sys::Oid::INVALID,
-                inputcollid: pg_sys::Oid::INVALID,
-                args: args.into_pg(),
-                location: -1,
-            }
+            build_text_funcexpr(
+                field, rhs, "&&&",
+                c"paradedb.match_conjunction(paradedb.fieldname, text)",
+                c"paradedb.match_conjunction(paradedb.fieldname, text[])",
+            )
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/atatat.rs
+++ b/pg_search/src/api/operator/atatat.rs
@@ -17,8 +17,8 @@
 
 use crate::api::builder_fns::{parse, parse_with_field, proximity};
 use crate::api::operator::{
-    get_expr_result_type, pdb_query_typoid, request_simplify, searchqueryinput_typoid, RHSValue,
-    ReturnedNodePointer,
+    get_expr_result_type, is_text_like, pdb_query_typoid, request_simplify,
+    searchqueryinput_typoid, RHSValue, ReturnedNodePointer,
 };
 use crate::query::pdb_query::{pdb, to_search_query_input};
 use crate::query::proximity::ProximityClause;
@@ -97,10 +97,11 @@ pub fn atatat_support(arg: Internal) -> ReturnedNodePointer {
                 let expr_type = get_expr_result_type(rhs);
                 let is_pdb_query = expr_type == pdb_query_typoid;
 
-                assert!(
-                    expr_type == pg_sys::TEXTOID || expr_type == pg_sys::VARCHAROID || is_pdb_query,
-                    "The right-hand side of the `@@@` operator must be a text value"
-                );
+                if !(is_text_like(expr_type) || is_pdb_query) {
+                    panic!(
+                        "The right-hand side of the `@@@` operator must be a text value"
+                    );
+                }
 
 
                 let funcid = if is_pdb_query {

--- a/pg_search/src/api/operator/eqeqeq.rs
+++ b/pg_search/src/api/operator/eqeqeq.rs
@@ -18,14 +18,11 @@ use crate::api::builder_fns::{term_set_str, term_str};
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    get_expr_result_type, request_simplify, searchqueryinput_typoid,
-    validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
+    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
+    ReturnedNodePointer,
 };
 use crate::query::pdb_query::{pdb, to_search_query_input};
-use pgrx::{
-    direct_function_call, extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement,
-    Internal, IntoDatum, PgList,
-};
+use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.===)]
@@ -99,40 +96,11 @@ fn search_with_term_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "===");
             let field = field.expect("The left hand side of the `===(field, TEXT)` operator must be a field.");
-            let expr_type = get_expr_result_type(rhs);
-            assert!({
-                        expr_type == pg_sys::TEXTOID || expr_type == pg_sys::VARCHAROID || expr_type == pg_sys::TEXTARRAYOID || expr_type == pg_sys::VARCHARARRAYOID
-                    }, "The right-hand side of the `===(field, TEXT)` operator must be a text or text array value");
-            let is_array = expr_type == pg_sys::TEXTARRAYOID || expr_type == pg_sys::VARCHARARRAYOID;
-
-            let mut args = PgList::<pg_sys::Node>::new();
-            args.push(field.into_const().cast());
-            args.push(rhs.cast());
-
-            pg_sys::FuncExpr {
-                xpr: pg_sys::Expr { type_: pg_sys::NodeTag::T_FuncExpr },
-                funcid: if is_array {
-                    direct_function_call::<pg_sys::Oid>(
-                        pg_sys::regprocedurein,
-                        &[c"paradedb.term_set(paradedb.fieldname, text[])".into_datum()],
-                    )
-                        .expect("`paradedb.term_set(paradedb.fieldname, text[])` should exist")
-                } else {
-                    direct_function_call::<pg_sys::Oid>(
-                        pg_sys::regprocedurein,
-                        &[c"paradedb.term(paradedb.fieldname, text)".into_datum()],
-                    )
-                        .expect("`paradedb.term(paradedb.fieldname, text)` should exist")
-                },
-                funcresulttype: searchqueryinput_typoid(),
-                funcretset: false,
-                funcvariadic: false,
-                funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
-                funccollid: pg_sys::Oid::INVALID,
-                inputcollid: pg_sys::Oid::INVALID,
-                args: args.into_pg(),
-                location: -1,
-            }
+            build_text_funcexpr(
+                field, rhs, "===",
+                c"paradedb.term(paradedb.fieldname, text)",
+                c"paradedb.term_set(paradedb.fieldname, text[])",
+            )
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/hashhashhash.rs
+++ b/pg_search/src/api/operator/hashhashhash.rs
@@ -18,14 +18,11 @@ use crate::api::builder_fns::{phrase_array, phrase_string};
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::slop::SlopType;
 use crate::api::operator::{
-    get_expr_result_type, request_simplify, searchqueryinput_typoid,
-    validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
+    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
+    ReturnedNodePointer,
 };
 use crate::query::pdb_query::{pdb, to_search_query_input};
-use pgrx::{
-    direct_function_call, extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement,
-    Internal, IntoDatum, PgList,
-};
+use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.###)]
@@ -105,28 +102,11 @@ fn search_with_phrase_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "###");
             let field = field.expect("The left hand side of the `###(field, TEXT)` operator must be a field.");
-            assert!(get_expr_result_type(rhs) == pg_sys::TEXTOID, "The right-hand side of the `###(field, TEXT)` operator must be a text value");
-            let mut args = PgList::<pg_sys::Node>::new();
-
-            args.push(field.into_const().cast());
-            args.push(rhs.cast());
-
-            pg_sys::FuncExpr {
-                xpr: pg_sys::Expr { type_: pg_sys::NodeTag::T_FuncExpr },
-                funcid: direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[c"paradedb.phrase(paradedb.fieldname, text)".into_datum()],
-                )
-                    .expect("`paradedb.phrase(paradedb.fieldname, text)` should exist"),
-                funcresulttype: searchqueryinput_typoid(),
-                funcretset: false,
-                funcvariadic: false,
-                funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
-                funccollid: pg_sys::Oid::INVALID,
-                inputcollid: pg_sys::Oid::INVALID,
-                args: args.into_pg(),
-                location: -1,
-            }
+            build_text_funcexpr(
+                field, rhs, "###",
+                c"paradedb.phrase(paradedb.fieldname, text)",
+                c"paradedb.phrase_array(paradedb.fieldname, text[])",
+            )
         })
             .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/src/api/operator/ororor.rs
+++ b/pg_search/src/api/operator/ororor.rs
@@ -18,14 +18,11 @@ use crate::api::builder_fns::{match_disjunction, match_disjunction_array, term_s
 use crate::api::operator::boost::BoostType;
 use crate::api::operator::fuzzy::FuzzyType;
 use crate::api::operator::{
-    get_expr_result_type, request_simplify, searchqueryinput_typoid,
-    validate_lhs_type_as_text_compatible, RHSValue, ReturnedNodePointer,
+    build_text_funcexpr, request_simplify, validate_lhs_type_as_text_compatible, RHSValue,
+    ReturnedNodePointer,
 };
 use crate::query::pdb_query::{pdb, to_search_query_input};
-use pgrx::{
-    direct_function_call, extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement,
-    Internal, IntoDatum, PgList,
-};
+use pgrx::{extension_sql, opname, pg_extern, pg_operator, pg_sys, AnyElement, Internal};
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.|||)]
@@ -118,28 +115,11 @@ fn search_with_match_disjunction_support(arg: Internal) -> ReturnedNodePointer {
         }, |field, lhs, rhs| {
             validate_lhs_type_as_text_compatible(lhs, "|||");
             let field = field.expect("The left hand side of the `|||(field, TEXT)` operator must be a field.");
-            assert!(get_expr_result_type(rhs) == pg_sys::TEXTOID, "The right-hand side of the `|||(field, TEXT)` operator must be a text value");
-            let mut args = PgList::<pg_sys::Node>::new();
-
-            args.push(field.into_const().cast());
-            args.push(rhs.cast());
-
-            pg_sys::FuncExpr {
-                xpr: pg_sys::Expr { type_: pg_sys::NodeTag::T_FuncExpr },
-                funcid: direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[c"paradedb.match_disjunction(paradedb.fieldname, text)".into_datum()],
-                )
-                    .expect("`paradedb.match_disjunction(paradedb.fieldname, text)` should exist"),
-                funcresulttype: searchqueryinput_typoid(),
-                funcretset: false,
-                funcvariadic: false,
-                funcformat: pg_sys::CoercionForm::COERCE_EXPLICIT_CALL,
-                funccollid: pg_sys::Oid::INVALID,
-                inputcollid: pg_sys::Oid::INVALID,
-                args: args.into_pg(),
-                location: -1,
-            }
+            build_text_funcexpr(
+                field, rhs, "|||",
+                c"paradedb.match_disjunction(paradedb.fieldname, text)",
+                c"paradedb.match_disjunction(paradedb.fieldname, text[])",
+            )
         })
         .unwrap_or(ReturnedNodePointer(None))
     }

--- a/pg_search/tests/pg_regress/expected/citext.out
+++ b/pg_search/tests/pg_regress/expected/citext.out
@@ -559,6 +559,74 @@ SELECT id, content FROM citext_topk WHERE content ### 'QUICK BROWN' ORDER BY id;
 (1 row)
 
 DROP TABLE citext_topk;
+-- ============================================================
+-- Test 13: Prepared statements with citext parameters under generic plan
+-- (covers build_text_funcexpr citext branch in exec_rewrite)
+-- ============================================================
+CREATE TABLE citext_prepared (
+    id      INT PRIMARY KEY,
+    content CITEXT
+);
+INSERT INTO citext_prepared (id, content) VALUES
+    (1, 'Hello World'),
+    (2, 'PostgreSQL Database'),
+    (3, 'ParadeDB Search');
+CREATE INDEX ON citext_prepared
+USING bm25 (id, content)
+WITH (key_field = 'id');
+SET plan_cache_mode = force_generic_plan;
+-- &&& with citext parameter
+PREPARE citext_and(citext) AS
+SELECT id FROM citext_prepared WHERE content &&& $1 ORDER BY id;
+EXECUTE citext_and('hello');
+ id 
+----
+  1
+(1 row)
+
+DEALLOCATE citext_and;
+-- ||| with citext parameter
+PREPARE citext_or(citext) AS
+SELECT id FROM citext_prepared WHERE content ||| $1 ORDER BY id;
+EXECUTE citext_or('hello');
+ id 
+----
+  1
+(1 row)
+
+DEALLOCATE citext_or;
+-- ### with citext parameter
+PREPARE citext_phrase(citext) AS
+SELECT id FROM citext_prepared WHERE content ### $1 ORDER BY id;
+EXECUTE citext_phrase('hello world');
+ id 
+----
+  1
+(1 row)
+
+DEALLOCATE citext_phrase;
+-- === with citext parameter
+PREPARE citext_term(citext) AS
+SELECT id FROM citext_prepared WHERE content === $1 ORDER BY id;
+EXECUTE citext_term('hello');
+ id 
+----
+  1
+(1 row)
+
+DEALLOCATE citext_term;
+-- @@@ with citext parameter
+PREPARE citext_parse(citext) AS
+SELECT id FROM citext_prepared WHERE content @@@ $1 ORDER BY id;
+EXECUTE citext_parse('hello');
+ id 
+----
+  1
+(1 row)
+
+DEALLOCATE citext_parse;
+RESET plan_cache_mode;
+DROP TABLE citext_prepared;
 \i common/common_cleanup.sql
 -- Reset parallel workers setting to default
 RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/sql/citext.sql
+++ b/pg_search/tests/pg_regress/sql/citext.sql
@@ -376,4 +376,58 @@ SELECT id, content FROM citext_topk WHERE content ### 'QUICK BROWN' ORDER BY id;
 
 DROP TABLE citext_topk;
 
+-- ============================================================
+-- Test 13: Prepared statements with citext parameters under generic plan
+-- (covers build_text_funcexpr citext branch in exec_rewrite)
+-- ============================================================
+CREATE TABLE citext_prepared (
+    id      INT PRIMARY KEY,
+    content CITEXT
+);
+
+INSERT INTO citext_prepared (id, content) VALUES
+    (1, 'Hello World'),
+    (2, 'PostgreSQL Database'),
+    (3, 'ParadeDB Search');
+
+CREATE INDEX ON citext_prepared
+USING bm25 (id, content)
+WITH (key_field = 'id');
+
+SET plan_cache_mode = force_generic_plan;
+
+-- &&& with citext parameter
+PREPARE citext_and(citext) AS
+SELECT id FROM citext_prepared WHERE content &&& $1 ORDER BY id;
+EXECUTE citext_and('hello');
+DEALLOCATE citext_and;
+
+-- ||| with citext parameter
+PREPARE citext_or(citext) AS
+SELECT id FROM citext_prepared WHERE content ||| $1 ORDER BY id;
+EXECUTE citext_or('hello');
+DEALLOCATE citext_or;
+
+-- ### with citext parameter
+PREPARE citext_phrase(citext) AS
+SELECT id FROM citext_prepared WHERE content ### $1 ORDER BY id;
+EXECUTE citext_phrase('hello world');
+DEALLOCATE citext_phrase;
+
+-- === with citext parameter
+PREPARE citext_term(citext) AS
+SELECT id FROM citext_prepared WHERE content === $1 ORDER BY id;
+EXECUTE citext_term('hello');
+DEALLOCATE citext_term;
+
+-- @@@ with citext parameter
+PREPARE citext_parse(citext) AS
+SELECT id FROM citext_prepared WHERE content @@@ $1 ORDER BY id;
+EXECUTE citext_parse('hello');
+DEALLOCATE citext_parse;
+
+RESET plan_cache_mode;
+
+DROP TABLE citext_prepared;
+
 \i common/common_cleanup.sql

--- a/tests/tests/query.rs
+++ b/tests/tests/query.rs
@@ -1162,3 +1162,228 @@ async fn direct_prepared_statement_replanning_custom_scan(mut conn: PgConnection
         assert_eq!((score, id), (3.2668595, 2))
     }
 }
+
+struct PreparedStmtTestCase<'a> {
+    stmt_name: &'a str,
+    column: &'a str,
+    operator: &'a str,
+    param_type: &'a str,
+    prepared_rhs: &'a str,
+    execute_arg: &'a str,
+    literal_rhs: &'a str,
+}
+
+/// Prepares a statement with a parameter, executes it under force_generic_plan,
+/// and verifies the result matches the equivalent literal query.
+fn verify_prepared_stmt_matches_literal(conn: &mut PgConnection, tc: PreparedStmtTestCase) {
+    let PreparedStmtTestCase {
+        stmt_name,
+        column,
+        operator,
+        param_type,
+        prepared_rhs,
+        execute_arg,
+        literal_rhs,
+    } = tc;
+    let expected: Vec<(i32,)> = format!(
+        "SELECT id FROM paradedb.bm25_search \
+         WHERE {column} {operator} {literal_rhs} ORDER BY id"
+    )
+    .fetch(conn);
+
+    format!(
+        "PREPARE {stmt_name}({param_type}) AS \
+         SELECT id FROM paradedb.bm25_search \
+         WHERE {column} {operator} {prepared_rhs} ORDER BY id"
+    )
+    .execute(conn);
+
+    let actual: Vec<(i32,)> = format!("EXECUTE {stmt_name}({execute_arg})").fetch(conn);
+
+    assert_eq!(
+        actual, expected,
+        "{stmt_name}: generic plan result must match literal query"
+    );
+
+    format!("DEALLOCATE {stmt_name}").execute(conn);
+}
+
+#[rstest]
+async fn generic_plan_text_and_text_array_params_issue_3900(mut conn: PgConnection) {
+    SimpleProductsTable::setup().execute(&mut conn);
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+
+    for tc in [
+        // &&& with text, varchar, text[], varchar[]
+        PreparedStmtTestCase {
+            stmt_name: "stmt_and_text",
+            column: "description",
+            operator: "&&&",
+            param_type: "text",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_and_varchar",
+            column: "description",
+            operator: "&&&",
+            param_type: "varchar",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_and_text_array",
+            column: "description",
+            operator: "&&&",
+            param_type: "text[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['keyboard']",
+            literal_rhs: "ARRAY['keyboard']",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_and_varchar_array",
+            column: "description",
+            operator: "&&&",
+            param_type: "varchar[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['keyboard']::varchar[]",
+            literal_rhs: "ARRAY['keyboard']::varchar[]",
+        },
+        // ||| with text, varchar, text[], varchar[]
+        PreparedStmtTestCase {
+            stmt_name: "stmt_or_text",
+            column: "description",
+            operator: "|||",
+            param_type: "text",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_or_varchar",
+            column: "description",
+            operator: "|||",
+            param_type: "varchar",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_or_text_array",
+            column: "description",
+            operator: "|||",
+            param_type: "text[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['keyboard']",
+            literal_rhs: "ARRAY['keyboard']",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_or_varchar_array",
+            column: "description",
+            operator: "|||",
+            param_type: "varchar[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['keyboard']::varchar[]",
+            literal_rhs: "ARRAY['keyboard']::varchar[]",
+        },
+        // ### with text, varchar, text[], varchar[]
+        PreparedStmtTestCase {
+            stmt_name: "stmt_phrase_text",
+            column: "description",
+            operator: "###",
+            param_type: "text",
+            prepared_rhs: "$1",
+            execute_arg: "'ergonomic keyboard'",
+            literal_rhs: "'ergonomic keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_phrase_varchar",
+            column: "description",
+            operator: "###",
+            param_type: "varchar",
+            prepared_rhs: "$1",
+            execute_arg: "'ergonomic keyboard'",
+            literal_rhs: "'ergonomic keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_phrase_text_array",
+            column: "description",
+            operator: "###",
+            param_type: "text[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['ergonomic', 'keyboard']",
+            literal_rhs: "ARRAY['ergonomic', 'keyboard']",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_phrase_varchar_array",
+            column: "description",
+            operator: "###",
+            param_type: "varchar[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['ergonomic', 'keyboard']::varchar[]",
+            literal_rhs: "ARRAY['ergonomic', 'keyboard']::varchar[]",
+        },
+        // === with text, varchar, text[], varchar[] (already worked, confirm)
+        PreparedStmtTestCase {
+            stmt_name: "stmt_term_text",
+            column: "category",
+            operator: "===",
+            param_type: "text",
+            prepared_rhs: "$1",
+            execute_arg: "'Electronics'",
+            literal_rhs: "'Electronics'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_term_varchar",
+            column: "category",
+            operator: "===",
+            param_type: "varchar",
+            prepared_rhs: "$1",
+            execute_arg: "'Electronics'",
+            literal_rhs: "'Electronics'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_term_text_array",
+            column: "category",
+            operator: "===",
+            param_type: "text[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['Electronics', 'Footwear']",
+            literal_rhs: "ARRAY['Electronics', 'Footwear']",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_term_varchar_array",
+            column: "category",
+            operator: "===",
+            param_type: "varchar[]",
+            prepared_rhs: "$1",
+            execute_arg: "ARRAY['Electronics', 'Footwear']::varchar[]",
+            literal_rhs: "ARRAY['Electronics', 'Footwear']::varchar[]",
+        },
+        // @@@ with text, varchar (already worked, confirm)
+        PreparedStmtTestCase {
+            stmt_name: "stmt_parse_text",
+            column: "description",
+            operator: "@@@",
+            param_type: "text",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+        PreparedStmtTestCase {
+            stmt_name: "stmt_parse_varchar",
+            column: "description",
+            operator: "@@@",
+            param_type: "varchar",
+            prepared_rhs: "$1",
+            execute_arg: "'keyboard'",
+            literal_rhs: "'keyboard'",
+        },
+    ] {
+        verify_prepared_stmt_matches_literal(&mut conn, tc);
+    }
+
+    "RESET plan_cache_mode".execute(&mut conn);
+}


### PR DESCRIPTION
## Summary
- Extend generic-plan `exec_rewrite` handling in `&&&`, `|||`, `###`, and `===` to accept `varchar`, `text[]`, `varchar[]`, and `citext`, and add `citext` support to `@@@`
- Extract duplicated type-check + dispatch logic into shared `build_text_funcexpr` helper in `operator.rs`
- Zero new UDFs — dispatches to existing `#[builder_fn]`-generated functions

## Root Cause
Prepared statements with parameterized queries (e.g., `$1::text[]`) worked for the first 5 executions but failed on the 6th when PostgreSQL switched to generic plans. The `exec_rewrite` callback in `&&&`, `|||`, and `###` only handled `TEXTOID`, causing panics for `varchar`, `text[]`, `varchar[]`, and `citext` parameter types. `===` already handled `varchar` and `text[]`/`varchar[]` but not `citext`. `@@@` handled `text` and `varchar` but not `citext`. This PR normalizes all operators to use a shared helper and adds `citext` coverage across the board.

## Not addressed in this PR
`pdb.query`, `pdb.boost`, `pdb.fuzzy`, `pdb.slop`, and `pdb.const` parameter types are not handled in the `exec_rewrite` path. When a user writes `$1::pdb.fuzzy(1)::pdb.boost(2.0)` in a prepared statement, it will still fail after PostgreSQL switches to a generic plan.

This is because the `exec_rewrite` builds an expression tree that must call a SQL function at runtime. For `text`/`text[]`, existing builder functions (`match_conjunction(fieldname, text)`, etc.) already handle classification. For `pdb.query`, no existing function does operator-specific classification — `to_search_query_input(fieldname, pdb.query)` wraps without classifying `UnclassifiedString`/`UnclassifiedArray`, which causes `unreachable!()` in `into_tantivy_query()`. Fixing this requires either a new UDF or an architectural change to move classification from the planner to the executor.

## Test plan
- 18 Rust integration test cases covering `&&&`, `|||`, `###`, `===` across `text`/`varchar`/`text[]`/`varchar[]`, plus `@@@` across `text`/`varchar`
- pg_regress citext test (Test 13) covering all 5 operators with `citext` parameters under `force_generic_plan`
- All tests verified against live PostgreSQL 18

Fixes #3900