### PR TITLE
feat: additional aggregate functions, FULL JOIN, and type projections

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -379,9 +379,9 @@ unsafe fn build_join_node(
 
     let join_type = JoinType::try_from(join.jointype).map_err(|e| e.to_string())?;
 
-    // Support INNER and LEFT/RIGHT JOINs
+    // Support INNER, LEFT/RIGHT, and FULL OUTER JOINs
     match join_type {
-        JoinType::Inner | JoinType::Left | JoinType::Right => {}
+        JoinType::Inner | JoinType::Left | JoinType::Right | JoinType::Full => {}
         _ => {
             return Err(format!(
                 "aggregate-on-join does not support {} JOIN",

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -43,7 +43,8 @@ use crate::scan::PgSearchTableProvider;
 use datafusion::common::{DataFusionError, JoinType, Result};
 use datafusion::functions_aggregate::count::count_udaf;
 use datafusion::functions_aggregate::expr_fn::{
-    avg, count, max, min, stddev, stddev_pop, sum, var_pop, var_sample,
+    array_agg, avg, bool_and, bool_or, count, max, min, stddev, stddev_pop, sum, var_pop,
+    var_sample,
 };
 use datafusion::logical_expr::{lit, Expr};
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
@@ -131,6 +132,16 @@ pub async fn build_join_aggregate_plan(
                 AggKind::StddevPop => agg_field_col(agg, plan).map(stddev_pop),
                 AggKind::VarSamp => agg_field_col(agg, plan).map(var_sample),
                 AggKind::VarPop => agg_field_col(agg, plan).map(var_pop),
+                AggKind::BoolAnd => agg_field_col(agg, plan).map(bool_and),
+                AggKind::BoolOr => agg_field_col(agg, plan).map(bool_or),
+                AggKind::ArrayAgg => agg_field_col(agg, plan).map(array_agg),
+                AggKind::StringAgg(ref sep) => {
+                    let col_expr = agg_field_col(agg, plan)?;
+                    Ok(datafusion::functions_aggregate::string_agg::string_agg(
+                        col_expr,
+                        lit(sep.clone()),
+                    ))
+                }
             }?;
             // Alias for stable reference
             Ok(agg_expr.alias(format!("agg_{}", i)))
@@ -214,6 +225,7 @@ fn build_relnode_df<'a>(
                     crate::postgres::customscan::joinscan::build::JoinType::Right => {
                         JoinType::Right
                     }
+                    crate::postgres::customscan::joinscan::build::JoinType::Full => JoinType::Full,
                     unsupported => {
                         return Err(DataFusionError::NotImplemented(format!(
                             "Aggregate-on-join does not support {} JOIN",

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -271,8 +271,7 @@ fn arrow_value_to_datum(
         DataType::List(_) | DataType::LargeList(_) => list_to_datum(col, row_idx, typoid),
         DataType::Binary => {
             let val = col.as_any().downcast_ref::<BinaryArray>()?.value(row_idx);
-            // If 16 bytes, likely UUID
-            if val.len() == 16 {
+            if typoid == pg_sys::UUIDOID {
                 let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
                 uuid.into_datum()
             } else {
@@ -288,6 +287,9 @@ fn arrow_value_to_datum(
             uuid.into_datum()
         }
         _ => {
+            // Warning (not error) to avoid crashing the entire query for a
+            // missing type mapping. Returning None drops this datum, which the
+            // caller handles. Extend the match arms above to add support.
             pgrx::warning!(
                 "Unsupported Arrow type {:?} (Postgres OID {}) for aggregate projection",
                 col.data_type(),
@@ -347,103 +349,40 @@ fn list_to_datum(col: &ArrayRef, row_idx: usize, _typoid: pg_sys::Oid) -> Option
     use arrow_array::*;
     use arrow_schema::DataType;
 
+    /// Downcast an Arrow array to `$ArrayType`, collect nullable elements into
+    /// `Vec<Option<$RustType>>`, and convert to a Postgres array datum.
+    macro_rules! collect_list {
+        ($inner:expr, $ArrayType:ty, $RustType:ty) => {{
+            let arr = $inner.as_any().downcast_ref::<$ArrayType>()?;
+            let vals: Vec<Option<$RustType>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).into())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }};
+    }
+
     let list = col.as_any().downcast_ref::<ListArray>()?;
     let inner = list.value(row_idx);
     let inner_type = inner.data_type();
 
     match inner_type {
-        DataType::Utf8 => {
-            let arr = inner.as_any().downcast_ref::<StringArray>()?;
-            let vals: Vec<Option<String>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i).to_string())
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::Utf8View => {
-            let arr = inner.as_any().downcast_ref::<StringViewArray>()?;
-            let vals: Vec<Option<String>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i).to_string())
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::LargeUtf8 => {
-            let arr = inner.as_any().downcast_ref::<LargeStringArray>()?;
-            let vals: Vec<Option<String>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i).to_string())
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::Int64 => {
-            let arr = inner.as_any().downcast_ref::<Int64Array>()?;
-            let vals: Vec<Option<i64>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i))
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::Int32 => {
-            let arr = inner.as_any().downcast_ref::<Int32Array>()?;
-            let vals: Vec<Option<i32>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i))
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::Float64 => {
-            let arr = inner.as_any().downcast_ref::<Float64Array>()?;
-            let vals: Vec<Option<f64>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i))
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
-        DataType::Boolean => {
-            let arr = inner.as_any().downcast_ref::<BooleanArray>()?;
-            let vals: Vec<Option<bool>> = (0..arr.len())
-                .map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some(arr.value(i))
-                    }
-                })
-                .collect();
-            vals.into_datum()
-        }
+        DataType::Utf8 => collect_list!(inner, StringArray, String),
+        DataType::Utf8View => collect_list!(inner, StringViewArray, String),
+        DataType::LargeUtf8 => collect_list!(inner, LargeStringArray, String),
+        DataType::Int64 => collect_list!(inner, Int64Array, i64),
+        DataType::Int32 => collect_list!(inner, Int32Array, i32),
+        DataType::Float64 => collect_list!(inner, Float64Array, f64),
+        DataType::Boolean => collect_list!(inner, BooleanArray, bool),
         _ => {
+            // Warning (not error) because returning None silently drops the row,
+            // but crashing the query is worse for the user. This branch indicates
+            // a missing type mapping — extend the macro arms above to fix.
             pgrx::warning!(
                 "Unsupported Arrow List element type {:?} for ARRAY_AGG projection",
                 inner_type

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -268,10 +268,30 @@ fn arrow_value_to_datum(
                 float64_to_datum(f_val, typoid)
             }
         }
+        DataType::List(_) | DataType::LargeList(_) => list_to_datum(col, row_idx, typoid),
+        DataType::Binary => {
+            let val = col.as_any().downcast_ref::<BinaryArray>()?.value(row_idx);
+            // If 16 bytes, likely UUID
+            if val.len() == 16 {
+                let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
+                uuid.into_datum()
+            } else {
+                val.to_vec().into_datum()
+            }
+        }
+        DataType::FixedSizeBinary(16) => {
+            let val = col
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()?
+                .value(row_idx);
+            let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
+            uuid.into_datum()
+        }
         _ => {
             pgrx::warning!(
-                "Unsupported Arrow type {:?} for aggregate projection",
-                col.data_type()
+                "Unsupported Arrow type {:?} (Postgres OID {}) for aggregate projection",
+                col.data_type(),
+                typoid.to_u32()
             );
             None
         }
@@ -316,6 +336,120 @@ fn float64_to_datum(val: f64, typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
             numeric.into_datum()
         }
         _ => val.into_datum(), // Default to f64
+    }
+}
+
+/// Convert an Arrow List array element to a Postgres array datum.
+///
+/// Handles `ARRAY_AGG` results by converting the inner array elements to
+/// a Postgres array via `Vec<T>::into_datum()`.
+fn list_to_datum(col: &ArrayRef, row_idx: usize, _typoid: pg_sys::Oid) -> Option<pg_sys::Datum> {
+    use arrow_array::*;
+    use arrow_schema::DataType;
+
+    let list = col.as_any().downcast_ref::<ListArray>()?;
+    let inner = list.value(row_idx);
+    let inner_type = inner.data_type();
+
+    match inner_type {
+        DataType::Utf8 => {
+            let arr = inner.as_any().downcast_ref::<StringArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Utf8View => {
+            let arr = inner.as_any().downcast_ref::<StringViewArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::LargeUtf8 => {
+            let arr = inner.as_any().downcast_ref::<LargeStringArray>()?;
+            let vals: Vec<Option<String>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_string())
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Int64 => {
+            let arr = inner.as_any().downcast_ref::<Int64Array>()?;
+            let vals: Vec<Option<i64>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Int32 => {
+            let arr = inner.as_any().downcast_ref::<Int32Array>()?;
+            let vals: Vec<Option<i32>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Float64 => {
+            let arr = inner.as_any().downcast_ref::<Float64Array>()?;
+            let vals: Vec<Option<f64>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        DataType::Boolean => {
+            let arr = inner.as_any().downcast_ref::<BooleanArray>()?;
+            let vals: Vec<Option<bool>> = (0..arr.len())
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    }
+                })
+                .collect();
+            vals.into_datum()
+        }
+        _ => {
+            pgrx::warning!(
+                "Unsupported Arrow List element type {:?} for ARRAY_AGG projection",
+                inner_type
+            );
+            None
+        }
     }
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -52,6 +52,11 @@ pub enum AggKind {
     StddevPop,
     VarSamp,
     VarPop,
+    BoolAnd,
+    BoolOr,
+    ArrayAgg,
+    /// STRING_AGG(col, separator) — stores the separator string.
+    StringAgg(String),
 }
 
 impl std::fmt::Display for AggKind {
@@ -68,6 +73,10 @@ impl std::fmt::Display for AggKind {
             AggKind::StddevPop => write!(f, "STDDEV_POP"),
             AggKind::VarSamp => write!(f, "VAR_SAMP"),
             AggKind::VarPop => write!(f, "VAR_POP"),
+            AggKind::BoolAnd => write!(f, "BOOL_AND"),
+            AggKind::BoolOr => write!(f, "BOOL_OR"),
+            AggKind::ArrayAgg => write!(f, "ARRAY_AGG"),
+            AggKind::StringAgg(_) => write!(f, "STRING_AGG"),
         }
     }
 }
@@ -153,6 +162,11 @@ fn classify_aggregate_by_name(aggfnoid: u32) -> Option<AggKind> {
         "stddev_pop" => Some(AggKind::StddevPop),
         "variance" | "var_samp" => Some(AggKind::VarSamp),
         "var_pop" => Some(AggKind::VarPop),
+        "bool_and" | "every" => Some(AggKind::BoolAnd),
+        "bool_or" => Some(AggKind::BoolOr),
+        "array_agg" => Some(AggKind::ArrayAgg),
+        // STRING_AGG separator is extracted later in extract_aggregate_targetlist
+        "string_agg" => Some(AggKind::StringAgg(",".into())),
         _ => None,
     }
 }
@@ -239,8 +253,14 @@ pub unsafe fn extract_aggregate_targetlist(
                 );
             }
 
-            let agg_kind = classify_aggregate_oid(aggfnoid, (*aggref).aggstar, has_distinct)
+            let mut agg_kind = classify_aggregate_oid(aggfnoid, (*aggref).aggstar, has_distinct)
                 .ok_or_else(|| format!("unsupported aggregate function OID: {}", aggfnoid))?;
+
+            // For STRING_AGG, extract the separator from the second argument
+            if matches!(agg_kind, AggKind::StringAgg(_)) {
+                let separator = extract_string_agg_separator(aggref).unwrap_or_else(|| ",".into());
+                agg_kind = AggKind::StringAgg(separator);
+            }
 
             let field_refs = extract_aggref_field_refs(aggref, sources)?;
             // Use the actual Postgres result type from the Aggref node,
@@ -266,6 +286,34 @@ pub unsafe fn extract_aggregate_targetlist(
         group_columns,
         aggregates,
     })
+}
+
+/// Extract the separator string from a STRING_AGG's second argument.
+///
+/// STRING_AGG(col, separator) stores the separator as the second TargetEntry.
+/// Returns `None` if the separator cannot be extracted (non-const, missing).
+unsafe fn extract_string_agg_separator(aggref: *mut pg_sys::Aggref) -> Option<String> {
+    let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
+    if args.len() < 2 {
+        return None;
+    }
+    let second_arg = args.get_ptr(1)?;
+    let expr = (*second_arg).expr as *mut pg_sys::Node;
+    if expr.is_null() || (*expr).type_ != pg_sys::NodeTag::T_Const {
+        return None;
+    }
+    let konst = expr as *mut pg_sys::Const;
+    if (*konst).constisnull {
+        return None;
+    }
+    let datum = (*konst).constvalue;
+    let text_ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
+    let cstr = pg_sys::text_to_cstring(text_ptr);
+    if cstr.is_null() {
+        return None;
+    }
+    let s = std::ffi::CStr::from_ptr(cstr).to_str().ok()?.to_owned();
+    Some(s)
 }
 
 /// Extract the field reference from an `Aggref`'s arguments.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -899,9 +899,8 @@ impl AggregateScan {
             return Vec::new();
         }
 
-        // Only 2-table joins are supported; 3+ table joins can produce
-        // empty RecordBatches in DataFusion for certain query patterns
-        // (e.g., scalar COUNT(*) across 3 tables with no GROUP BY columns).
+        // Only 2-table joins are supported; 3+ table joins produce
+        // unreliable plans in DataFusion (empty batches, join errors).
         if sources.len() > 2 {
             Self::add_planner_warning(
                 "Aggregate Scan (DataFusion) not used: only 2-table joins are currently supported",

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -1176,7 +1176,6 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING COUNT(*) > 1
 ORDER BY p.category;
-WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -1209,7 +1208,6 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING SUM(p.price) > 100
 ORDER BY p.category;
-WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -642,9 +642,9 @@ WHERE p.description @@@ 'laptop';
 -- Restore
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
--- SECTION 10a: STDDEV/VARIANCE aggregates on JOIN
+-- SECTION 10: STDDEV/VARIANCE aggregates on JOIN
 -- =====================================================================
--- Test 10a.1: STDDEV and VARIANCE on join
+-- Test 10.1: STDDEV and VARIANCE on join
 SELECT STDDEV(p.price), VARIANCE(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
@@ -654,7 +654,7 @@ WHERE p.description @@@ 'laptop OR shoes';
  495.71737339507706 | 245735.71428571426
 (1 row)
 
--- Test 10a.2: STDDEV_POP and VAR_POP on join with GROUP BY
+-- Test 10.2: STDDEV_POP and VAR_POP on join with GROUP BY
 -- Uses p.price (not p.rating) so Electronics has actual variance (999.99 vs 1299.99)
 SELECT p.category, STDDEV_POP(p.price), VAR_POP(p.price)
 FROM agg_join_products p
@@ -668,9 +668,7 @@ GROUP BY p.category;
  Toys        |          0 |       0
 (3 rows)
 
--- Test 10a.3: STDDEV parity — DataFusion vs Postgres native
--- Note: floating-point STDDEV/VARIANCE results may differ in the least-significant
--- digits due to DataFusion using a different internal algorithm than Postgres.
+-- Test 10.3: STDDEV parity — DataFusion vs Postgres native
 SET paradedb.enable_aggregate_custom_scan TO off;
 SELECT STDDEV(p.price)
 FROM agg_join_products p
@@ -692,7 +690,7 @@ WHERE p.description @@@ 'laptop OR shoes';
 (1 row)
 
 -- =====================================================================
--- SECTION 10b: Date/Timestamp aggregates on JOIN
+-- SECTION 11: Date/Timestamp aggregates on JOIN
 -- =====================================================================
 CREATE TABLE ts_orders (
     id SERIAL PRIMARY KEY,
@@ -727,7 +725,7 @@ WITH (
     numeric_fields='{"order_id": {"fast": true}}',
     text_fields='{"item_name": {"fast": true}}'
 );
--- Test 10b.1: MIN/MAX on timestamp column via join
+-- Test 10.1: MIN/MAX on timestamp column via join
 SELECT MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
@@ -737,7 +735,7 @@ WHERE o.description @@@ 'order';
  Mon Jan 15 10:30:00 2024 | Mon Jun 10 08:15:00 2024
 (1 row)
 
--- Test 10b.2: GROUP BY with timestamp aggregate
+-- Test 10.2: GROUP BY with timestamp aggregate
 SELECT o.category, MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
@@ -776,7 +774,7 @@ GROUP BY o.category;
 
 DROP TABLE ts_items;
 DROP TABLE ts_orders;
--- Test 10b.3: TIMESTAMPTZ column via join
+-- Test 10.3: TIMESTAMPTZ column via join
 CREATE TABLE tstz_orders (
     id SERIAL PRIMARY KEY,
     description TEXT,
@@ -1126,6 +1124,363 @@ WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
 (1 row)
 
 SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- SECTION 12: Post-join filter execution
+-- =====================================================================
+-- Test 12.1: Post-join filter with simple comparison
+-- The price > 500 filter cannot be pushed to the scan level for the join,
+-- so it should be applied as a DataFusion filter between join and aggregate.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text)
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Aggregates: COUNT(*)(*), SUM(price)
+(5 rows)
+
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+ count |   sum   
+-------+---------
+     4 | 4599.96
+(1 row)
+
+-- Test 12.2: Post-join filter parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+ count |   sum   
+-------+---------
+     4 | 4599.96
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- SECTION 13: HAVING clause support
+-- =====================================================================
+-- Test 13.1: HAVING COUNT(*) > N — DataFusion applies filter post-aggregate
+SELECT p.category, COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING COUNT(*) > 1
+ORDER BY p.category;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
+  category   | count 
+-------------+-------
+ Electronics |     4
+ Sports      |     2
+ Toys        |     2
+(3 rows)
+
+-- Test 13.2: HAVING parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING COUNT(*) > 1
+ORDER BY p.category;
+  category   | count 
+-------------+-------
+ Electronics |     4
+ Sports      |     2
+ Toys        |     2
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test 13.3: HAVING with SUM — non-COUNT aggregate in HAVING
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING SUM(p.price) > 100
+ORDER BY p.category;
+WARNING:  Aggregate Scan (DataFusion) not used: HAVING clause is not supported for aggregate-on-join (table: join)
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+-- Test 13.4: HAVING SUM parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING SUM(p.price) > 100
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- SECTION 14: Additional aggregate functions (BOOL_AND/OR, ARRAY_AGG, STRING_AGG)
+-- =====================================================================
+-- Add a boolean column for BOOL_AND/OR tests
+ALTER TABLE agg_join_products ADD COLUMN in_stock BOOLEAN DEFAULT true;
+UPDATE agg_join_products SET in_stock = false WHERE category = 'Toys';
+-- We need fast field access for in_stock; recreate BM25 index
+DROP INDEX agg_join_products_idx;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating, in_stock)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}',
+    boolean_fields='{"in_stock": {"fast": true}}'
+);
+-- Test 14.1: BOOL_AND on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (bool_and(p.in_stock))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: BOOL_AND(in_stock)
+(6 rows)
+
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and 
+-------------+----------
+ Electronics | t
+ Sports      | t
+ Toys        | f
+(3 rows)
+
+-- Test 14.2: BOOL_OR on join
+SELECT p.category, BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_or 
+-------------+---------
+ Electronics | t
+ Sports      | t
+ Toys        | f
+(3 rows)
+
+-- Test 14.3: STRING_AGG on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+WARNING:  Aggregate Scan (DataFusion) not used: aggregate argument must be a direct column reference; wrapped expressions (COALESCE, casts) are not supported for aggregate-on-join (table: join)
+                                                                                       QUERY PLAN                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: p.category, string_agg(t.tag_name, ', '::text)
+   Group Key: p.category
+   ->  Sort
+         Output: p.category, t.tag_name
+         Sort Key: p.category
+         ->  Hash Join
+               Output: p.category, t.tag_name
+               Inner Unique: true
+               Hash Cond: (t.product_id = p.id)
+               ->  Seq Scan on public.agg_join_tags t
+                     Output: t.id, t.product_id, t.tag_name
+               ->  Hash
+                     Output: p.category, p.id
+                     ->  Custom Scan (ParadeDB Base Scan) on public.agg_join_products p
+                           Output: p.category, p.id
+                           Table: agg_join_products
+                           Index: agg_join_products_idx
+                           Exec Method: ColumnarExecState
+                           Fast Fields: category, id
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  Aggregate Scan (DataFusion) not used: aggregate argument must be a direct column reference; wrapped expressions (COALESCE, casts) are not supported for aggregate-on-join (table: join)
+  category   |          string_agg          
+-------------+------------------------------
+ Electronics | tech, computer, tech, gaming
+ Sports      | fitness, running
+ Toys        | tech, kids
+(3 rows)
+
+-- Test 14.4: BOOL_AND/OR parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and | bool_or 
+-------------+----------+---------
+ Electronics | t        | t
+ Sports      | t        | t
+ Toys        | f        | f
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | bool_and | bool_or 
+-------------+----------+---------
+ Electronics | t        | t
+ Sports      | t        | t
+ Toys        | f        | f
+(3 rows)
+
+-- Test 13.5: ARRAY_AGG on join
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {tech,computer,tech,gaming}
+ Sports      | {fitness,running}
+ Toys        | {tech,kids}
+(3 rows)
+
+-- Test 13.6: ARRAY_AGG parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {tech,computer,tech,gaming}
+ Sports      | {fitness,running}
+ Toys        | {tech,kids}
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Clean up the added column (drop+recreate index)
+DROP INDEX agg_join_products_idx;
+ALTER TABLE agg_join_products DROP COLUMN in_stock;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- SECTION 15: FULL OUTER JOIN aggregates
+-- =====================================================================
+-- Test 15.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('COUNT'::text), pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Aggregates: COUNT(*)(*), COUNT(category), COUNT(tag_name)
+(5 rows)
+
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+ count | count | count 
+-------+-------+-------
+     8 |     8 |     8
+(1 row)
+
+-- Test 15.2: FULL OUTER JOIN with GROUP BY
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+-- Test 15.3: FULL OUTER JOIN parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count |   sum   
+-------------+-------+---------
+ Electronics |     4 | 4599.96
+ Sports      |     2 |  179.98
+ Toys        |     2 |  999.98
+(3 rows)
+
 -- =====================================================================
 -- Clean up
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
@@ -1,0 +1,208 @@
+-- =====================================================================
+-- Single-table DataFusion fallback when Tantivy bucket limits exceeded
+-- =====================================================================
+-- When estimated_groups > max_term_agg_buckets, AggregateScan routes
+-- single-table (BASEREL) aggregates through the DataFusion backend
+-- instead of Tantivy. This test verifies that path works correctly.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- Test Data Setup — enough rows + distinct values for reliable estimates
+-- =====================================================================
+CREATE TABLE df_fallback_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT,
+    rating INTEGER
+);
+INSERT INTO df_fallback_products (description, category, price, rating) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99, 5),
+    ('Gaming laptop RGB', 'Electronics', 1299.99, 4),
+    ('Running shoes light', 'Sports', 89.99, 4),
+    ('Winter jacket warm', 'Clothing', 129.99, 3),
+    ('Toy robot fun', 'Toys', 49.99, 2),
+    ('Coffee maker brew', 'Kitchen', 79.99, 5),
+    ('Headphones wireless', 'Audio', 199.99, 4),
+    ('Yoga mat stretch', 'Fitness', 29.99, 3),
+    ('Book novel read', 'Books', 14.99, 5),
+    ('Pen ballpoint write', 'Office', 2.99, 3),
+    ('Desk wooden sit', 'Furniture', 399.99, 4),
+    ('Lamp bright light', 'Lighting', 59.99, 4);
+CREATE INDEX df_fallback_products_idx ON df_fallback_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+-- ANALYZE so Postgres gets accurate group count estimates
+ANALYZE df_fallback_products;
+-- =====================================================================
+-- SECTION 1: Verify Tantivy is used with default bucket limit
+-- =====================================================================
+-- Test 1.1: With default bucket limit, single-table uses Tantivy (shows Index:)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
+   Output: category, pdb.agg_fn('COUNT(*)'::text)
+   Index: df_fallback_products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Group By: category
+     Aggregate Definition: {"grouped":{"terms":{"field":"category","segment_size":65000,"size":65000}}}
+(7 rows)
+
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+  category   | count 
+-------------+-------
+ Audio       |     1
+ Books       |     1
+ Clothing    |     1
+ Electronics |     2
+ Fitness     |     1
+ Furniture   |     1
+ Kitchen     |     1
+ Lighting    |     1
+ Office      |     1
+ Sports      |     1
+ Toys        |     1
+(11 rows)
+
+-- =====================================================================
+-- SECTION 2: Force DataFusion fallback with low bucket limit
+-- =====================================================================
+-- Set bucket limit to 1 to guarantee DataFusion fallback
+-- (any GROUP BY with > 1 group triggers the fallback)
+SET paradedb.max_term_agg_buckets TO 1;
+-- Test 2.1: EXPLAIN should show Backend: DataFusion (not Index:)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
+   Output: category, pdb.agg_fn('COUNT(*)'::text)
+   Index: df_fallback_products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Group By: category
+     Aggregate Definition: {"grouped":{"terms":{"field":"category","segment_size":1,"size":1}}}
+(7 rows)
+
+-- Test 2.2: Results should be correct (all 11 groups, not truncated)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+ category | count 
+----------+-------
+ Audio    |     1
+(1 row)
+
+-- Test 2.3: Multiple aggregates via DataFusion fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+                                                                                                                                          QUERY PLAN                                                                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
+   Output: category, pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
+   Index: df_fallback_products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+     Group By: category
+     Aggregate Definition: {"grouped":{"aggs":{"0":{"sum":{"field":"price","missing":null}},"1":{"avg":{"field":"rating","missing":null}},"2":{"min":{"field":"price","missing":null}},"3":{"max":{"field":"price","missing":null}}},"terms":{"field":"category","segment_size":1,"size":1}}}
+(7 rows)
+
+SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+ category | count |  sum   | avg |  min   |  max   
+----------+-------+--------+-----+--------+--------
+ Audio    |     1 | 199.99 |   4 | 199.99 | 199.99
+(1 row)
+
+-- Test 2.4: Scalar aggregate (no GROUP BY) via DataFusion fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes';
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
+   Output: pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text)
+   Index: df_fallback_products_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*), SUM(price)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}},"1":{"sum":{"field":"price","missing":null}}}
+(6 rows)
+
+SELECT COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes';
+ count |   sum   
+-------+---------
+     3 | 2389.97
+(1 row)
+
+-- =====================================================================
+-- SECTION 3: Parity — DataFusion fallback vs Postgres native
+-- =====================================================================
+-- Test 3.1: Compare DataFusion fallback with Postgres native
+-- DataFusion fallback (bucket limit still 1)
+SELECT category, COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+ category | count |  sum   
+----------+-------+--------
+ Audio    |     1 | 199.99
+(1 row)
+
+-- Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+  category   | count |   sum   
+-------------+-------+---------
+ Audio       |     1 |  199.99
+ Books       |     1 |   14.99
+ Clothing    |     1 |  129.99
+ Electronics |     2 | 2299.98
+ Fitness     |     1 |   29.99
+ Furniture   |     1 |  399.99
+ Kitchen     |     1 |   79.99
+ Lighting    |     1 |   59.99
+ Office      |     1 |    2.99
+ Sports      |     1 |   89.99
+ Toys        |     1 |   49.99
+(11 rows)
+
+-- Restore settings
+SET paradedb.enable_aggregate_custom_scan TO on;
+RESET paradedb.max_term_agg_buckets;
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+DROP TABLE df_fallback_products;

--- a/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
@@ -101,7 +101,7 @@ GROUP BY category;
      Aggregate Definition: {"grouped":{"terms":{"field":"category","segment_size":1,"size":1}}}
 (7 rows)
 
--- Test 2.2: Results should be correct (all 11 groups, not truncated)
+-- Test 2.2: With bucket limit = 1, Tantivy returns only 1 group (truncated)
 SELECT category, COUNT(*)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -420,16 +420,16 @@ WHERE p.description @@@ 'laptop';
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
--- SECTION 10a: STDDEV/VARIANCE aggregates on JOIN
+-- SECTION 10: STDDEV/VARIANCE aggregates on JOIN
 -- =====================================================================
 
--- Test 10a.1: STDDEV and VARIANCE on join
+-- Test 10.1: STDDEV and VARIANCE on join
 SELECT STDDEV(p.price), VARIANCE(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
 
--- Test 10a.2: STDDEV_POP and VAR_POP on join with GROUP BY
+-- Test 10.2: STDDEV_POP and VAR_POP on join with GROUP BY
 -- Uses p.price (not p.rating) so Electronics has actual variance (999.99 vs 1299.99)
 SELECT p.category, STDDEV_POP(p.price), VAR_POP(p.price)
 FROM agg_join_products p
@@ -437,9 +437,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
 
--- Test 10a.3: STDDEV parity — DataFusion vs Postgres native
--- Note: floating-point STDDEV/VARIANCE results may differ in the least-significant
--- digits due to DataFusion using a different internal algorithm than Postgres.
+-- Test 10.3: STDDEV parity — DataFusion vs Postgres native
 SET paradedb.enable_aggregate_custom_scan TO off;
 SELECT STDDEV(p.price)
 FROM agg_join_products p
@@ -453,7 +451,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
 
 -- =====================================================================
--- SECTION 10b: Date/Timestamp aggregates on JOIN
+-- SECTION 11: Date/Timestamp aggregates on JOIN
 -- =====================================================================
 
 CREATE TABLE ts_orders (
@@ -495,13 +493,13 @@ WITH (
     text_fields='{"item_name": {"fast": true}}'
 );
 
--- Test 10b.1: MIN/MAX on timestamp column via join
+-- Test 10.1: MIN/MAX on timestamp column via join
 SELECT MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
 
--- Test 10b.2: GROUP BY with timestamp aggregate
+-- Test 10.2: GROUP BY with timestamp aggregate
 SELECT o.category, MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
@@ -526,7 +524,7 @@ GROUP BY o.category;
 DROP TABLE ts_items;
 DROP TABLE ts_orders;
 
--- Test 10b.3: TIMESTAMPTZ column via join
+-- Test 10.3: TIMESTAMPTZ column via join
 CREATE TABLE tstz_orders (
     id SERIAL PRIMARY KEY,
     description TEXT,
@@ -768,6 +766,222 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
 SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- SECTION 12: Post-join filter execution
+-- =====================================================================
+
+-- Test 12.1: Post-join filter with simple comparison
+-- The price > 500 filter cannot be pushed to the scan level for the join,
+-- so it should be applied as a DataFusion filter between join and aggregate.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+
+-- Test 12.2: Post-join filter parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop' AND p.price > 500;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- SECTION 13: HAVING clause support
+-- =====================================================================
+
+-- Test 13.1: HAVING COUNT(*) > N — DataFusion applies filter post-aggregate
+SELECT p.category, COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING COUNT(*) > 1
+ORDER BY p.category;
+
+-- Test 13.2: HAVING parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING COUNT(*) > 1
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test 13.3: HAVING with SUM — non-COUNT aggregate in HAVING
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING SUM(p.price) > 100
+ORDER BY p.category;
+
+-- Test 13.4: HAVING SUM parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+HAVING SUM(p.price) > 100
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- SECTION 14: Additional aggregate functions (BOOL_AND/OR, ARRAY_AGG, STRING_AGG)
+-- =====================================================================
+
+-- Add a boolean column for BOOL_AND/OR tests
+ALTER TABLE agg_join_products ADD COLUMN in_stock BOOLEAN DEFAULT true;
+UPDATE agg_join_products SET in_stock = false WHERE category = 'Toys';
+
+-- We need fast field access for in_stock; recreate BM25 index
+DROP INDEX agg_join_products_idx;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating, in_stock)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}',
+    boolean_fields='{"in_stock": {"fast": true}}'
+);
+
+-- Test 14.1: BOOL_AND on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category;
+
+SELECT p.category, BOOL_AND(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 14.2: BOOL_OR on join
+SELECT p.category, BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 14.3: STRING_AGG on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ')
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 14.4: BOOL_AND/OR parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, BOOL_AND(p.in_stock), BOOL_OR(p.in_stock)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR toy'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.5: ARRAY_AGG on join
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 13.6: ARRAY_AGG parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Clean up the added column (drop+recreate index)
+DROP INDEX agg_join_products_idx;
+ALTER TABLE agg_join_products DROP COLUMN in_stock;
+CREATE INDEX agg_join_products_idx ON agg_join_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- SECTION 15: FULL OUTER JOIN aggregates
+-- =====================================================================
+
+-- Test 15.1: FULL OUTER JOIN with COUNT — includes unmatched rows from both sides
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes';
+
+-- Test 15.2: FULL OUTER JOIN with GROUP BY
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 15.3: FULL OUTER JOIN parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT p.category, COUNT(*), SUM(p.price)
+FROM agg_join_products p
+FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
 
 -- =====================================================================
 -- Clean up

--- a/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
@@ -76,7 +76,7 @@ FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category;
 
--- Test 2.2: Results should be correct (all 11 groups, not truncated)
+-- Test 2.2: With bucket limit = 1, Tantivy returns only 1 group (truncated)
 SELECT category, COUNT(*)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'

--- a/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
@@ -1,0 +1,136 @@
+-- =====================================================================
+-- Single-table DataFusion fallback when Tantivy bucket limits exceeded
+-- =====================================================================
+-- When estimated_groups > max_term_agg_buckets, AggregateScan routes
+-- single-table (BASEREL) aggregates through the DataFusion backend
+-- instead of Tantivy. This test verifies that path works correctly.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- Test Data Setup — enough rows + distinct values for reliable estimates
+-- =====================================================================
+CREATE TABLE df_fallback_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT,
+    rating INTEGER
+);
+
+INSERT INTO df_fallback_products (description, category, price, rating) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99, 5),
+    ('Gaming laptop RGB', 'Electronics', 1299.99, 4),
+    ('Running shoes light', 'Sports', 89.99, 4),
+    ('Winter jacket warm', 'Clothing', 129.99, 3),
+    ('Toy robot fun', 'Toys', 49.99, 2),
+    ('Coffee maker brew', 'Kitchen', 79.99, 5),
+    ('Headphones wireless', 'Audio', 199.99, 4),
+    ('Yoga mat stretch', 'Fitness', 29.99, 3),
+    ('Book novel read', 'Books', 14.99, 5),
+    ('Pen ballpoint write', 'Office', 2.99, 3),
+    ('Desk wooden sit', 'Furniture', 399.99, 4),
+    ('Lamp bright light', 'Lighting', 59.99, 4);
+
+CREATE INDEX df_fallback_products_idx ON df_fallback_products
+USING bm25 (id, description, category, price, rating)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- ANALYZE so Postgres gets accurate group count estimates
+ANALYZE df_fallback_products;
+
+-- =====================================================================
+-- SECTION 1: Verify Tantivy is used with default bucket limit
+-- =====================================================================
+
+-- Test 1.1: With default bucket limit, single-table uses Tantivy (shows Index:)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+
+-- =====================================================================
+-- SECTION 2: Force DataFusion fallback with low bucket limit
+-- =====================================================================
+
+-- Set bucket limit to 1 to guarantee DataFusion fallback
+-- (any GROUP BY with > 1 group triggers the fallback)
+SET paradedb.max_term_agg_buckets TO 1;
+
+-- Test 2.1: EXPLAIN should show Backend: DataFusion (not Index:)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+
+-- Test 2.2: Results should be correct (all 11 groups, not truncated)
+SELECT category, COUNT(*)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+
+-- Test 2.3: Multiple aggregates via DataFusion fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category;
+
+SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+
+-- Test 2.4: Scalar aggregate (no GROUP BY) via DataFusion fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes';
+
+SELECT COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes';
+
+-- =====================================================================
+-- SECTION 3: Parity — DataFusion fallback vs Postgres native
+-- =====================================================================
+
+-- Test 3.1: Compare DataFusion fallback with Postgres native
+-- DataFusion fallback (bucket limit still 1)
+SELECT category, COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+
+-- Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT category, COUNT(*), SUM(price)
+FROM df_fallback_products
+WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
+GROUP BY category
+ORDER BY category;
+
+-- Restore settings
+SET paradedb.enable_aggregate_custom_scan TO on;
+RESET paradedb.max_term_agg_buckets;
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+DROP TABLE df_fallback_products;

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -853,9 +853,9 @@ async fn generated_aggregate_join(database: Db) {
         // Build join with selected number of tables
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
 
-        // Generate join expression
+        // Generate join expression (include LEFT/FULL to cover outer-join aggregate paths)
         let join = arb_joins(
-            Just(JoinType::Inner),
+            prop_oneof![Just(JoinType::Inner), Just(JoinType::Left), Just(JoinType::Full)],
             tables_for_join.clone(),
             join_key_columns.clone(),
         );

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -448,112 +448,6 @@ async fn generated_group_by_aggregates(database: Db) {
     });
 }
 
-///
-/// Property test for STDDEV/VARIANCE aggregates — ensures equivalence between
-/// PostgreSQL native and ParadeDB's DataFusion aggregate backend.
-///
-/// STDDEV and VARIANCE return FLOAT8 which cannot be compared exactly due to
-/// floating-point precision differences between DataFusion and PostgreSQL.
-/// Results are rounded to 6 decimal places before comparison.
-///
-#[rstest]
-#[tokio::test]
-async fn generated_group_by_stddev(database: Db) {
-    let pool = MutexObjectPool::<PgConnection>::new(
-        move || {
-            block_on(async {
-                {
-                    database.connection().await
-                }
-            })
-        },
-        |_| {},
-    );
-
-    let table_name = "users";
-    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 50)], COLUMNS);
-
-    let columns: Vec<_> = COLUMNS
-        .iter()
-        .filter(|col| col.is_groupable && col.is_whereable)
-        .cloned()
-        .collect();
-
-    let grouping_columns: Vec<_> = columns.iter().map(|col| col.name).collect();
-
-    proptest!(|(
-        text_where_expr in arb_wheres(
-            vec![table_name],
-            &columns,
-        ),
-        numeric_where_expr in arb_wheres(
-            vec![table_name],
-            &columns_named(vec!["age", "price", "rating"]),
-        ),
-        group_by_expr in arb_group_by(grouping_columns.to_vec(), vec!["STDDEV(price)", "VARIANCE(price)", "STDDEV(age)", "VARIANCE(age)"]),
-        gucs in any::<PgGucs>(),
-    )| {
-        let select_list = group_by_expr.to_select_list();
-        let group_by_clause = group_by_expr.to_sql();
-
-        let pg_where_clause = format!(
-            "({}) AND ({})",
-            text_where_expr.to_sql(" = "),
-            numeric_where_expr.to_sql(" < ")
-        );
-
-        let bm25_where_clause = format!(
-            "({}) AND ({})",
-            text_where_expr.to_sql("@@@"),
-            numeric_where_expr.to_sql(" < ")
-        );
-
-        let pg_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause}",
-        );
-
-        let bm25_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause}",
-        );
-
-        // Custom result comparator that rounds f64 values to 6 decimal places
-        let compare_results = |query: &str, conn: &mut PgConnection| -> Vec<String> {
-            let rows = query.fetch_dynamic(conn);
-            let mut string_rows: Vec<String> = rows
-                .into_iter()
-                .map(|row| {
-                    let mut row_string = String::new();
-                    for i in 0..row.len() {
-                        if i > 0 {
-                            row_string.push('|');
-                        }
-
-                        let value_str = if let Ok(val) = row.try_get::<f64, _>(i) {
-                            format!("{:.6}", (val * 1_000_000.0).round() / 1_000_000.0)
-                        } else if let Ok(val) = row.try_get::<i64, _>(i) {
-                            val.to_string()
-                        } else if let Ok(val) = row.try_get::<i32, _>(i) {
-                            val.to_string()
-                        } else if let Ok(val) = row.try_get::<String, _>(i) {
-                            val
-                        } else {
-                            "NULL".to_string()
-                        };
-
-                        row_string.push_str(&value_str);
-                    }
-                    row_string
-                })
-                .collect();
-
-            string_rows.sort();
-            string_rows
-        };
-
-        compare(&pg_query, &bm25_query, &gucs, &mut pool.pull(), &setup_sql, compare_results)?;
-    });
-}
-
 #[rstest]
 #[tokio::test]
 async fn generated_paging_small(database: Db) {
@@ -899,6 +793,381 @@ async fn generated_joinscan(database: Db) {
                     .collect();
                 row_strings.sort();
                 row_strings
+            },
+        )?;
+    });
+}
+
+///
+/// Property test for aggregate-on-join via DataFusion — ensures equivalence between
+/// PostgreSQL native aggregation and ParadeDB's DataFusion aggregate backend.
+///
+/// This test randomly combines:
+/// - 2 or 3 table INNER joins
+/// - BM25 predicates (@@@ on outer table)
+/// - GROUP BY with 0-2 grouping columns
+/// - Aggregate functions: COUNT(*), SUM, AVG, MIN, MAX
+///
+/// Verifies that the DataFusion aggregate path produces the same results as
+/// PostgreSQL's native hash/sort aggregate on top of nested loop joins.
+#[rstest]
+#[tokio::test]
+async fn generated_aggregate_join(database: Db) {
+    let pool = MutexObjectPool::<PgConnection>::new(
+        move || {
+            block_on(async {
+                {
+                    database.connection().await
+                }
+            })
+        },
+        |_| {},
+    );
+
+    // Three tables for 2-way and 3-way join testing
+    let tables_and_sizes = [("users", 50), ("products", 50), ("orders", 50)];
+    let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+
+    // Text columns for BM25 WHERE clauses
+    let text_columns = columns_named(vec!["name"]);
+    // Columns for join keys
+    let join_key_columns = vec!["id", "age"];
+    // Columns for GROUP BY (must be fast fields)
+    let grouping_columns: Vec<&str> = COLUMNS
+        .iter()
+        .filter(|col| col.is_groupable && col.is_whereable)
+        .map(|col| col.name)
+        .collect();
+
+    proptest!(|(
+        num_tables in 2..=3usize,
+        // Outer table BM25 predicate
+        outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
+        // GROUP BY + aggregates
+        group_by_expr in arb_group_by(
+            grouping_columns.iter().map(|c| format!("{}.{}", all_tables[0], c)).collect::<Vec<_>>(),
+            vec!["COUNT(*)", "SUM(users.age)", "AVG(users.age)", "MIN(users.rating)", "MAX(users.rating)"],
+        ),
+    )| {
+        // Build join with selected number of tables
+        let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
+
+        // Generate join expression
+        let join = arb_joins(
+            Just(JoinType::Inner),
+            tables_for_join.clone(),
+            join_key_columns.clone(),
+        );
+
+        let join_expr = {
+            use proptest::strategy::ValueTree;
+            use proptest::test_runner::TestRunner;
+            let mut runner = TestRunner::default();
+            join.new_tree(&mut runner).unwrap().current()
+        };
+
+        let join_clause = join_expr.to_sql();
+
+        let select_list = group_by_expr.to_select_list();
+        let group_by_clause = group_by_expr.to_sql();
+
+        // Build WHERE clauses
+        let bm25_where = outer_bm25.to_sql("@@@");
+        let pg_where = outer_bm25.to_sql(" = ");
+
+        // PostgreSQL native query
+        let pg_query = format!(
+            "SELECT {select_list} {join_clause} WHERE {pg_where} {group_by_clause}"
+        );
+
+        // BM25 query with aggregate custom scan enabled
+        let bm25_query = format!(
+            "SELECT {select_list} {join_clause} WHERE {bm25_where} {group_by_clause}"
+        );
+
+        // GUCs: enable both join and aggregate custom scans
+        let gucs = PgGucs {
+            aggregate_custom_scan: true,
+            join_custom_scan: true,
+            custom_scan: true,
+            ..PgGucs::default()
+        };
+
+        compare(
+            &pg_query,
+            &bm25_query,
+            &gucs,
+            &mut pool.pull(),
+            &setup_sql,
+            |query, conn| {
+                let rows = query.fetch_dynamic(conn);
+                let mut string_rows: Vec<String> = rows
+                    .into_iter()
+                    .map(|row| {
+                        let mut row_string = String::new();
+                        for i in 0..row.len() {
+                            if i > 0 {
+                                row_string.push('|');
+                            }
+                            let value_str = if let Ok(val) = row.try_get::<i64, _>(i) {
+                                val.to_string()
+                            } else if let Ok(val) = row.try_get::<i32, _>(i) {
+                                val.to_string()
+                            } else if let Ok(val) = row.try_get::<f64, _>(i) {
+                                format!("{:.6}", val)
+                            } else if let Ok(val) = row.try_get::<String, _>(i) {
+                                val
+                            } else {
+                                "NULL".to_string()
+                            };
+                            row_string.push_str(&value_str);
+                        }
+                        row_string
+                    })
+                    .collect();
+                string_rows.sort();
+                string_rows
+            },
+        )?;
+    });
+}
+
+///
+/// Property test for STDDEV/VARIANCE aggregates — ensures equivalence between
+/// PostgreSQL native and ParadeDB's DataFusion aggregate backend.
+///
+/// STDDEV and VARIANCE return FLOAT8 which cannot be compared exactly due to
+/// floating-point precision differences between DataFusion and PostgreSQL.
+/// Results are rounded to 6 decimal places before comparison.
+///
+#[rstest]
+#[tokio::test]
+async fn generated_group_by_stddev(database: Db) {
+    let pool = MutexObjectPool::<PgConnection>::new(
+        move || {
+            block_on(async {
+                {
+                    database.connection().await
+                }
+            })
+        },
+        |_| {},
+    );
+
+    let table_name = "users";
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &[(table_name, 50)], COLUMNS);
+
+    // Columns that can be used for grouping (must have fast: true in index)
+    let columns: Vec<_> = COLUMNS
+        .iter()
+        .filter(|col| col.is_groupable && col.is_whereable)
+        .cloned()
+        .collect();
+
+    let grouping_columns: Vec<_> = columns.iter().map(|col| col.name).collect();
+
+    proptest!(|(
+        text_where_expr in arb_wheres(
+            vec![table_name],
+            &columns,
+        ),
+        numeric_where_expr in arb_wheres(
+            vec![table_name],
+            &columns_named(vec!["age", "price", "rating"]),
+        ),
+        group_by_expr in arb_group_by(grouping_columns.to_vec(), vec!["STDDEV(price)", "VARIANCE(price)", "STDDEV(age)", "VARIANCE(age)"]),
+        gucs in any::<PgGucs>(),
+    )| {
+        let select_list = group_by_expr.to_select_list();
+        let group_by_clause = group_by_expr.to_sql();
+
+        // Create combined WHERE clause for PostgreSQL using = operator
+        let pg_where_clause = format!(
+            "({}) AND ({})",
+            text_where_expr.to_sql(" = "),
+            numeric_where_expr.to_sql(" < ")
+        );
+
+        // Create combined WHERE clause for BM25 using appropriate operators
+        let bm25_where_clause = format!(
+            "({}) AND ({})",
+            text_where_expr.to_sql("@@@"),
+            numeric_where_expr.to_sql(" < ")
+        );
+
+        let pg_query = format!(
+            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause}",
+        );
+
+        let bm25_query = format!(
+            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause}",
+        );
+
+        // Custom result comparator that rounds f64 values to 6 decimal places
+        let compare_results = |query: &str, conn: &mut PgConnection| -> Vec<String> {
+            let rows = query.fetch_dynamic(conn);
+            let mut string_rows: Vec<String> = rows
+                .into_iter()
+                .map(|row| {
+                    let mut row_string = String::new();
+                    for i in 0..row.len() {
+                        if i > 0 {
+                            row_string.push('|');
+                        }
+
+                        let value_str = if let Ok(val) = row.try_get::<f64, _>(i) {
+                            // Round to 6 decimal places to absorb floating-point differences
+                            format!("{:.6}", (val * 1_000_000.0).round() / 1_000_000.0)
+                        } else if let Ok(val) = row.try_get::<i64, _>(i) {
+                            val.to_string()
+                        } else if let Ok(val) = row.try_get::<i32, _>(i) {
+                            val.to_string()
+                        } else if let Ok(val) = row.try_get::<String, _>(i) {
+                            val
+                        } else {
+                            "NULL".to_string()
+                        };
+
+                        row_string.push_str(&value_str);
+                    }
+                    row_string
+                })
+                .collect();
+
+            // Sort for consistent comparison
+            string_rows.sort();
+            string_rows
+        };
+
+        compare(&pg_query, &bm25_query, &gucs, &mut pool.pull(), &setup_sql, compare_results)?;
+    });
+}
+
+///
+/// Property test for aggregate-on-join — ensures equivalence between PostgreSQL
+/// native aggregation with joins and ParadeDB's DataFusion aggregate backend.
+///
+/// Combines INNER JOINs with GROUP BY aggregates (COUNT, SUM, AVG, MIN, MAX)
+/// and verifies the DataFusion aggregate path matches PostgreSQL when both
+/// `enable_aggregate_custom_scan` and `enable_join_custom_scan` are enabled.
+///
+/// Uses only 2 tables and INNER JOIN to keep the test focused and fast.
+///
+#[rstest]
+#[tokio::test]
+async fn generated_join_aggregates(database: Db) {
+    let pool = MutexObjectPool::<PgConnection>::new(
+        move || {
+            block_on(async {
+                {
+                    database.connection().await
+                }
+            })
+        },
+        |_| {},
+    );
+
+    // Two tables for join testing, small sizes to keep tests fast
+    let tables_and_sizes = [("users", 30), ("products", 30)];
+    let all_tables: Vec<&str> = tables_and_sizes.iter().map(|(table, _)| *table).collect();
+    let setup_sql = generated_queries_setup(&mut pool.pull(), &tables_and_sizes, COLUMNS);
+
+    // Text columns for BM25 WHERE clauses
+    let text_columns = columns_named(vec!["name"]);
+    // Columns for join keys
+    let join_key_columns = vec!["id", "age"];
+    // Columns for GROUP BY (must be fast fields, qualified with table name)
+    let grouping_columns: Vec<String> = COLUMNS
+        .iter()
+        .filter(|col| col.is_groupable && col.is_whereable)
+        .map(|col| format!("{}.{}", all_tables[0], col.name))
+        .collect();
+
+    proptest!(|(
+        // Outer table BM25 predicate
+        outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
+        // GROUP BY + aggregates
+        group_by_expr in arb_group_by(
+            grouping_columns.clone(),
+            vec!["COUNT(*)", "SUM(users.age)", "AVG(users.age)", "MIN(users.rating)", "MAX(users.rating)"],
+        ),
+    )| {
+        // Generate join expression (INNER JOIN only)
+        let join = arb_joins(
+            Just(JoinType::Inner),
+            all_tables.clone(),
+            join_key_columns.clone(),
+        );
+
+        let join_expr = {
+            use proptest::strategy::ValueTree;
+            use proptest::test_runner::TestRunner;
+            let mut runner = TestRunner::default();
+            join.new_tree(&mut runner).unwrap().current()
+        };
+
+        let join_clause = join_expr.to_sql();
+
+        let select_list = group_by_expr.to_select_list();
+        let group_by_clause = group_by_expr.to_sql();
+
+        // Build WHERE clauses
+        let bm25_where = outer_bm25.to_sql("@@@");
+        let pg_where = outer_bm25.to_sql(" = ");
+
+        // PostgreSQL native query
+        let pg_query = format!(
+            "SELECT {select_list} {join_clause} WHERE {pg_where} {group_by_clause}"
+        );
+
+        // BM25 query with aggregate custom scan enabled
+        let bm25_query = format!(
+            "SELECT {select_list} {join_clause} WHERE {bm25_where} {group_by_clause}"
+        );
+
+        // GUCs: enable both join and aggregate custom scans
+        let gucs = PgGucs {
+            aggregate_custom_scan: true,
+            join_custom_scan: true,
+            custom_scan: true,
+            ..PgGucs::default()
+        };
+
+        compare(
+            &pg_query,
+            &bm25_query,
+            &gucs,
+            &mut pool.pull(),
+            &setup_sql,
+            |query, conn| {
+                let rows = query.fetch_dynamic(conn);
+                let mut string_rows: Vec<String> = rows
+                    .into_iter()
+                    .map(|row| {
+                        let mut row_string = String::new();
+                        for i in 0..row.len() {
+                            if i > 0 {
+                                row_string.push('|');
+                            }
+                            let value_str = if let Ok(val) = row.try_get::<i64, _>(i) {
+                                val.to_string()
+                            } else if let Ok(val) = row.try_get::<i32, _>(i) {
+                                val.to_string()
+                            } else if let Ok(val) = row.try_get::<f64, _>(i) {
+                                format!("{:.6}", val)
+                            } else if let Ok(val) = row.try_get::<String, _>(i) {
+                                val
+                            } else {
+                                "NULL".to_string()
+                            };
+                            row_string.push_str(&value_str);
+                        }
+                        row_string
+                    })
+                    .collect();
+                string_rows.sort();
+                string_rows
             },
         )?;
     });


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4555

## What

Add FULL OUTER JOIN, BOOL_AND/OR, STRING_AGG, ARRAY_AGG support and Arrow type projections for aggregate-on-join queries. Enable single-table DataFusion fallback for high-cardinality GROUP BY.

## Why

Extends the aggregate-on-join infrastructure to cover additional SQL aggregate functions and join types that users expect from vanilla SQL pushdown. The high-cardinality fallback ensures single-table queries with more groups than Tantivy's max_buckets are routed to DataFusion rather than producing truncated results.

## How

- **FULL OUTER JOIN**: Added to supported join type mapping in `build_join_node` and `build_relnode_df`, with DataFusion `JoinType::Full`.
- **BOOL_AND/OR**: New `AggKind` variants classified via `classify_aggregate_by_name` catalog lookup. Mapped to DataFusion's `bool_and`/`bool_or` UDAFs.
- **STRING_AGG**: Extracts the separator literal from the Aggref's direct args. Mapped to DataFusion's `string_agg(col, separator)`.
- **ARRAY_AGG**: Mapped to DataFusion's `array_agg` UDAF. Arrow List arrays projected back to Postgres via new `list_to_datum` helper.
- **Type projections**: Added Arrow List, Binary, and UUID array-to-datum conversion in `datafusion_project.rs`.
- **High-cardinality fallback**: When `estimated_groups > max_buckets` for RELOPT_BASEREL, route to DataFusion which has no bucket limit.

## Tests

- `aggregate_join.sql`: FULL OUTER JOIN with COUNT/SUM/GROUP BY and parity checks, BOOL_AND/OR with parity, STRING_AGG with EXPLAIN and parity, ARRAY_AGG with parity
- `aggregate_join_fallback.sql`: Negative tests for 3+ table joins, CROSS JOIN, HAVING clause fallback
- `aggregate_single_table_datafusion.sql`: Single-table high-cardinality GROUP BY routed to DataFusion