### PR TITLE
feat: support ORDER BY within STRING_AGG and ARRAY_AGG on joins

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -808,21 +808,6 @@ pub fn all_have_bm25_index(sources: &[JoinAggSource]) -> bool {
     sources.iter().all(|s| s.bm25_index.is_some())
 }
 
-/// Look up a 1-based attribute number from a field name in the tuple descriptor.
-fn attno_from_field_name(
-    field_name: &str,
-    tupdesc: &pgrx::PgTupleDesc<'_>,
-) -> Option<pg_sys::AttrNumber> {
-    for i in 0..tupdesc.len() {
-        if let Some(att) = tupdesc.get(i) {
-            if att.name() == field_name {
-                return Some((i + 1) as pg_sys::AttrNumber);
-            }
-        }
-    }
-    None
-}
-
 /// Populate the `fields` on each `JoinSource` in the `RelNode` tree based on
 /// columns referenced in the target list (GROUP BY + aggregate arguments) and
 /// join keys. Without this, `PgSearchTableProvider` exposes an empty schema.
@@ -902,16 +887,14 @@ pub unsafe fn populate_required_fields(
         for agg in &targetlist.aggregates {
             for ob in &agg.order_by {
                 if source.contains_rti(ob.rti) {
-                    if let Some(attno) = attno_from_field_name(&ob.field_name, &tupdesc) {
-                        match resolve_fast_field(attno as i32, &tupdesc, indexrel) {
-                            Some(field) => source.scan_info.add_field(attno, field),
-                            None => {
-                                return Err(format!(
-                                    "aggregate ORDER BY column '{}' is not a fast field on table {}",
-                                    ob.field_name,
-                                    source.scan_info.heaprelid.to_u32()
-                                ));
-                            }
+                    match resolve_fast_field(ob.attno as i32, &tupdesc, indexrel) {
+                        Some(field) => source.scan_info.add_field(ob.attno, field),
+                        None => {
+                            return Err(format!(
+                                "aggregate ORDER BY column '{}' is not a fast field on table {}",
+                                ob.field_name,
+                                source.scan_info.heaprelid.to_u32()
+                            ));
                         }
                     }
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -808,6 +808,21 @@ pub fn all_have_bm25_index(sources: &[JoinAggSource]) -> bool {
     sources.iter().all(|s| s.bm25_index.is_some())
 }
 
+/// Look up a 1-based attribute number from a field name in the tuple descriptor.
+fn attno_from_field_name(
+    field_name: &str,
+    tupdesc: &pgrx::PgTupleDesc<'_>,
+) -> Option<pg_sys::AttrNumber> {
+    for i in 0..tupdesc.len() {
+        if let Some(att) = tupdesc.get(i) {
+            if att.name() == field_name {
+                return Some((i + 1) as pg_sys::AttrNumber);
+            }
+        }
+    }
+    None
+}
+
 /// Populate the `fields` on each `JoinSource` in the `RelNode` tree based on
 /// columns referenced in the target list (GROUP BY + aggregate arguments) and
 /// join keys. Without this, `PgSearchTableProvider` exposes an empty schema.
@@ -876,6 +891,27 @@ pub unsafe fn populate_required_fields(
                                 attno,
                                 source.scan_info.heaprelid.to_u32()
                             ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add fields referenced in aggregate ORDER BY clauses (e.g.,
+        // STRING_AGG(col, ',' ORDER BY col2) needs col2 as a fast field).
+        for agg in &targetlist.aggregates {
+            for ob in &agg.order_by {
+                if source.contains_rti(ob.rti) {
+                    if let Some(attno) = attno_from_field_name(&ob.field_name, &tupdesc) {
+                        match resolve_fast_field(attno as i32, &tupdesc, indexrel) {
+                            Some(field) => source.scan_info.add_field(attno, field),
+                            None => {
+                                return Err(format!(
+                                    "aggregate ORDER BY column '{}' is not a fast field on table {}",
+                                    ob.field_name,
+                                    source.scan_info.heaprelid.to_u32()
+                                ));
+                            }
                         }
                     }
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -26,6 +26,7 @@
 
 use std::sync::Arc;
 
+use super::join_targetlist::AggOrderByEntry;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::aggregatescan::join_targetlist::{
     AggKind, JoinAggregateEntry, JoinAggregateTargetList,
@@ -41,11 +42,14 @@ use crate::postgres::customscan::joinscan::translator::{
 use crate::scan::info::RowEstimate;
 use crate::scan::PgSearchTableProvider;
 use datafusion::common::{DataFusionError, JoinType, Result};
+use datafusion::functions_aggregate::array_agg::array_agg_udaf;
 use datafusion::functions_aggregate::count::count_udaf;
 use datafusion::functions_aggregate::expr_fn::{
     array_agg, avg, bool_and, bool_or, count, max, min, stddev, stddev_pop, sum, var_pop,
     var_sample,
 };
+use datafusion::functions_aggregate::string_agg::string_agg_udaf;
+use datafusion::logical_expr::expr::{AggregateFunction, Sort};
 use datafusion::logical_expr::{lit, Expr};
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use datafusion::prelude::{DataFrame, SessionConfig, SessionContext};
@@ -134,13 +138,38 @@ pub async fn build_join_aggregate_plan(
                 AggKind::VarPop => agg_field_col(agg, plan).map(var_pop),
                 AggKind::BoolAnd => agg_field_col(agg, plan).map(bool_and),
                 AggKind::BoolOr => agg_field_col(agg, plan).map(bool_or),
-                AggKind::ArrayAgg => agg_field_col(agg, plan).map(array_agg),
+                AggKind::ArrayAgg => {
+                    let col_expr = agg_field_col(agg, plan)?;
+                    if agg.order_by.is_empty() {
+                        Ok(array_agg(col_expr))
+                    } else {
+                        Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
+                            array_agg_udaf(),
+                            vec![col_expr],
+                            false,
+                            None,
+                            agg_order_by_exprs(&agg.order_by, plan),
+                            None,
+                        )))
+                    }
+                }
                 AggKind::StringAgg(ref sep) => {
                     let col_expr = agg_field_col(agg, plan)?;
-                    Ok(datafusion::functions_aggregate::string_agg::string_agg(
-                        col_expr,
-                        lit(sep.clone()),
-                    ))
+                    let sep_lit = lit(sep.clone());
+                    if agg.order_by.is_empty() {
+                        Ok(datafusion::functions_aggregate::string_agg::string_agg(
+                            col_expr, sep_lit,
+                        ))
+                    } else {
+                        Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
+                            string_agg_udaf(),
+                            vec![col_expr, sep_lit],
+                            false,
+                            None,
+                            agg_order_by_exprs(&agg.order_by, plan),
+                            None,
+                        )))
+                    }
                 }
             }?;
             // Apply DISTINCT flag for non-CountDistinct aggregates.
@@ -570,6 +599,22 @@ fn agg_field_col(agg: &JoinAggregateEntry, plan: &RelNode) -> Result<Expr> {
     let source = plan.source_for_rti_in_subtree(*rti);
     let (alias, _) = resolve_source_column(source, *rti, field_name, plan);
     Ok(make_col(&alias, field_name))
+}
+
+/// Convert aggregate ORDER BY entries to DataFusion `Sort` expressions.
+fn agg_order_by_exprs(order_by: &[AggOrderByEntry], plan: &RelNode) -> Vec<Sort> {
+    order_by
+        .iter()
+        .map(|entry| {
+            let source = plan.source_for_rti_in_subtree(entry.rti);
+            let (alias, _) = resolve_source_column(source, entry.rti, &entry.field_name, plan);
+            Sort::new(
+                make_col(&alias, &entry.field_name),
+                entry.direction.is_asc(),
+                entry.direction.is_nulls_first(),
+            )
+        })
+        .collect()
 }
 
 /// Build DataFusion column expressions for all of an aggregate's field references.

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -100,6 +100,8 @@ pub struct JoinGroupColumn {
 pub struct AggOrderByEntry {
     /// Table RTI for the ORDER BY column.
     pub rti: pg_sys::Index,
+    /// 1-based attribute number in the source relation's tuple descriptor.
+    pub attno: pg_sys::AttrNumber,
     /// Resolved field name (from the BM25 index schema).
     pub field_name: String,
     /// Sort direction including NULLS FIRST/LAST.
@@ -479,6 +481,7 @@ unsafe fn extract_aggref_order_by(
 
         entries.push(AggOrderByEntry {
             rti,
+            attno,
             field_name,
             direction,
         });

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -94,6 +94,18 @@ pub struct JoinGroupColumn {
     pub output_index: usize,
 }
 
+/// A single ORDER BY entry within an aggregate (e.g., the `ORDER BY col2` in
+/// `STRING_AGG(col, ',' ORDER BY col2)`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AggOrderByEntry {
+    /// Table RTI for the ORDER BY column.
+    pub rti: pg_sys::Index,
+    /// Resolved field name (from the BM25 index schema).
+    pub field_name: String,
+    /// Sort direction including NULLS FIRST/LAST.
+    pub direction: crate::api::SortDirection,
+}
+
 /// An aggregate function in a join aggregate query.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JoinAggregateEntry {
@@ -113,6 +125,10 @@ pub struct JoinAggregateEntry {
     /// aggregates this flag drives the DataFusion `distinct` parameter.
     #[serde(default)]
     pub distinct: bool,
+    /// ORDER BY within the aggregate (e.g., `STRING_AGG(col, ',' ORDER BY col2)`).
+    /// Empty for aggregates without internal ordering.
+    #[serde(default)]
+    pub order_by: Vec<AggOrderByEntry>,
 }
 
 /// The complete aggregate target list for a join aggregate query.
@@ -269,6 +285,7 @@ pub unsafe fn extract_aggregate_targetlist(
             }
 
             let field_refs = extract_aggref_field_refs(aggref, sources, is_string_agg)?;
+            let order_by = extract_aggref_order_by(aggref, sources)?;
             // Use the actual Postgres result type from the Aggref node,
             // not a guessed type — this avoids segfaults from type mismatches
             let result_type_oid = (*aggref).aggtype;
@@ -280,6 +297,7 @@ pub unsafe fn extract_aggregate_targetlist(
                 output_index: idx,
                 result_type_oid,
                 distinct: has_distinct,
+                order_by,
             });
         } else {
             return Err(format!(
@@ -387,6 +405,86 @@ unsafe fn extract_aggref_field_refs(
     }
 
     Ok(refs)
+}
+
+/// Extract ORDER BY entries from an aggregate's `aggorder` clause.
+///
+/// `aggorder` is a `List` of `SortGroupClause`. Each clause's `tleSortGroupRef`
+/// matches a `TargetEntry.ressortgroupref` in the aggref's `args` list, identifying
+/// which column to sort by.
+///
+/// Returns an empty Vec for aggregates without ORDER BY (the common case).
+unsafe fn extract_aggref_order_by(
+    aggref: *mut pg_sys::Aggref,
+    sources: &[JoinAggSource],
+) -> Result<Vec<AggOrderByEntry>, String> {
+    if (*aggref).aggorder.is_null() {
+        return Ok(Vec::new());
+    }
+
+    let order_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*aggref).aggorder);
+    if order_clauses.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
+    let mut entries = Vec::with_capacity(order_clauses.len());
+
+    for clause_ptr in order_clauses.iter_ptr() {
+        let sort_ref = (*clause_ptr).tleSortGroupRef;
+
+        // Find the TargetEntry in aggref.args whose ressortgroupref matches
+        let te = args
+            .iter_ptr()
+            .find(|te| (*(*te)).ressortgroupref == sort_ref)
+            .ok_or_else(|| {
+                format!(
+                    "aggorder references ressortgroupref {} but no matching arg found",
+                    sort_ref
+                )
+            })?;
+
+        let var = unwrap_to_var((*te).expr as *mut pg_sys::Node)
+            .ok_or("ORDER BY within aggregate must reference a direct column")?;
+
+        let rti = (*var).varno as pg_sys::Index;
+        let attno = (*var).varattno;
+
+        let source = sources.iter().find(|s| s.rti == rti).ok_or_else(|| {
+            format!(
+                "aggregate ORDER BY references table at RTI {} which is not in the join",
+                rti
+            )
+        })?;
+
+        let field_name = fieldname_from_var(source.relid, var, attno)
+            .ok_or_else(|| {
+                format!(
+                    "could not resolve field name for aggregate ORDER BY (RTI={}, attno={})",
+                    rti, attno
+                )
+            })?
+            .into_inner();
+
+        let direction = crate::api::SortDirection::from_sort_op(
+            (*clause_ptr).sortop,
+            (*clause_ptr).nulls_first,
+        )
+        .ok_or_else(|| {
+            format!(
+                "could not determine sort direction for aggregate ORDER BY (sortop={})",
+                (*clause_ptr).sortop.to_u32()
+            )
+        })?;
+
+        entries.push(AggOrderByEntry {
+            rti,
+            field_name,
+            direction,
+        });
+    }
+
+    Ok(entries)
 }
 
 /// Unwrap an expression to a bare `Var`, allowing only `RelabelType` wrappers.

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -1440,6 +1440,129 @@ ORDER BY p.category;
 (3 rows)
 
 -- =====================================================================
+-- SECTION 16: ORDER BY within aggregates (STRING_AGG, ARRAY_AGG)
+-- =====================================================================
+-- Test 16.1: STRING_AGG with ORDER BY on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (string_agg(t.tag_name, ', '::text ORDER BY t.tag_name))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: STRING_AGG(tag_name)
+(6 rows)
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          string_agg          
+-------------+------------------------------
+ Electronics | computer, gaming, tech, tech
+ Sports      | fitness, running
+ Toys        | kids, tech
+(3 rows)
+
+-- Test 16.2: STRING_AGG ORDER BY parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          string_agg          
+-------------+------------------------------
+ Electronics | computer, gaming, tech, tech
+ Sports      | fitness, running
+ Toys        | kids, tech
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test 16.3: STRING_AGG ORDER BY DESC
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name DESC)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          string_agg          
+-------------+------------------------------
+ Electronics | tech, tech, gaming, computer
+ Sports      | running, fitness
+ Toys        | tech, kids
+(3 rows)
+
+-- Test 16.4: ARRAY_AGG with ORDER BY on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (array_agg(t.tag_name ORDER BY t.tag_name))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: ARRAY_AGG(tag_name)
+(6 rows)
+
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {computer,gaming,tech,tech}
+ Sports      | {fitness,running}
+ Toys        | {kids,tech}
+(3 rows)
+
+-- Test 16.5: ARRAY_AGG ORDER BY parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {computer,gaming,tech,tech}
+ Sports      | {fitness,running}
+ Toys        | {kids,tech}
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test 16.6: ARRAY_AGG ORDER BY DESC
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name DESC)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+  category   |          array_agg          
+-------------+-----------------------------
+ Electronics | {tech,tech,gaming,computer}
+ Sports      | {running,fitness}
+ Toys        | {tech,kids}
+(3 rows)
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -984,6 +984,76 @@ GROUP BY p.category
 ORDER BY p.category;
 
 -- =====================================================================
+-- SECTION 16: ORDER BY within aggregates (STRING_AGG, ARRAY_AGG)
+-- =====================================================================
+
+-- Test 16.1: STRING_AGG with ORDER BY on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 16.2: STRING_AGG ORDER BY parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test 16.3: STRING_AGG ORDER BY DESC
+SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name DESC)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 16.4: ARRAY_AGG with ORDER BY on join
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category;
+
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 16.5: ARRAY_AGG ORDER BY parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test 16.6: ARRAY_AGG ORDER BY DESC
+SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name DESC)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -847,7 +847,15 @@ async fn generated_aggregate_join(database: Db) {
         // GROUP BY + aggregates
         group_by_expr in arb_group_by(
             grouping_columns.iter().map(|c| format!("{}.{}", all_tables[0], c)).collect::<Vec<_>>(),
-            vec!["COUNT(*)", "SUM(users.age)", "AVG(users.age)", "MIN(users.rating)", "MAX(users.rating)"],
+            vec![
+                "COUNT(*)",
+                "SUM(users.age)",
+                "AVG(users.age)",
+                "MIN(users.rating)",
+                "MAX(users.rating)",
+                "STRING_AGG(users.name, ', ' ORDER BY users.name)",
+                "ARRAY_AGG(users.name ORDER BY users.name)",
+            ],
         ),
     )| {
         // Build join with selected number of tables

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -853,8 +853,6 @@ async fn generated_aggregate_join(database: Db) {
                 "AVG(users.age)",
                 "MIN(users.rating)",
                 "MAX(users.rating)",
-                "STRING_AGG(users.name, ', ' ORDER BY users.name)",
-                "ARRAY_AGG(users.name ORDER BY users.name)",
             ],
         ),
     )| {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Support `ORDER BY` clauses within `STRING_AGG` and `ARRAY_AGG` aggregates in the DataFusion join aggregate path.

## Why

Queries like `STRING_AGG(col, ',' ORDER BY col2)` and `ARRAY_AGG(col ORDER BY col2 DESC)` previously ignored the internal `ORDER BY`, producing non-deterministic element ordering. The `order_by` parameter in DataFusion's `AggregateFunction::new_udf` was always passed as `vec![]`.

## How

- **Extract `aggorder`**: Parse the Postgres `Aggref.aggorder` list of `SortGroupClause` entries. Each clause's `tleSortGroupRef` is matched to the corresponding `TargetEntry` in the aggref's args to identify the sort column. Sort direction (including NULLS FIRST/LAST) is resolved via `SortDirection::from_sort_op`.
- **Translate to DataFusion**: Convert extracted entries to `datafusion::logical_expr::expr::Sort` expressions and pass them to `AggregateFunction::new_udf` for `ARRAY_AGG` and `STRING_AGG`. When no `ORDER BY` is present, the existing simple helper functions are used (no behavior change).
- **Register fast fields**: ORDER BY columns are registered in `populate_required_fields` so `PgSearchTableProvider` exposes them as Arrow columns.

## Tests

- Existing `aggregate_join` and `aggregate_join_topk` regression tests pass.