### PR TITLE
fix: replace deprecated validate_checksum with pdb.verify_index

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -176,7 +176,7 @@ jobs:
         working-directory: pg_search/
         run: |
           psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM paradedb.validate_checksum('search_idx');"
+          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
 
       # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
       - name: Run pg_search Integration Tests

--- a/tests/tests/cleanup.rs
+++ b/tests/tests/cleanup.rs
@@ -22,10 +22,10 @@ use rstest::*;
 use sqlx::PgConnection;
 
 #[rstest]
-fn validate_checksum(mut conn: PgConnection) {
+fn verify_index(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
     let (count,) =
-        "select count(*) from paradedb.validate_checksum('paradedb.bm25_search_bm25_index')"
+        "SELECT count(*) FROM pdb.verify_index('paradedb.bm25_search_bm25_index') WHERE NOT passed"
             .fetch_one::<(i64,)>(&mut conn);
     assert_eq!(count, 0);
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `paradedb.validate_checksum()` calls with `pdb.verify_index()` in the upgrade CI test and cleanup integration test
- `verify_index` includes checksum validation along with additional integrity checks

## Test plan
- [ ] Verify upgrade CI workflow passes without the deprecation warning
- [ ] Verify `cleanup::verify_index` integration test passes