### PR TITLE
perf: conditionally enable scoring in row estimation

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -1265,14 +1265,8 @@ impl SearchIndexReader {
             )
             .expect("converting query for estimation should not fail");
 
-        // Use EnableScoring::Enabled because some queries (e.g., MoreLikeThisQuery)
-        // require access to the searcher to build their internal query structure.
-        // We're not using the actual scores, just counting documents.
         let weight = tantivy_query
-            .weight(EnableScoring::Enabled {
-                searcher: &self.searcher,
-                statistics_provider: &self.searcher,
-            })
+            .weight(enable_scoring(node.query.need_scores(), &self.searcher))
             .expect("creating weight for estimation should not fail");
 
         let mut scorer = weight


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Use `enable_scoring(node.query.need_scores())` instead of unconditionally enabling scoring, so only queries that structurally require it (e.g. MoreLikeThis, ScoreFilter) pay the cost.

## Why

Perf optimization

## How

## Tests
