### PR TITLE
feat: support per-aggregate FILTER clause on join queries

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -24,6 +24,7 @@
 //! `JoinExpr` nodes, and reconstruct a [`RelNode`] tree that downstream code can
 //! lower into a DataFusion plan.
 
+use super::privdat::{CompareOp, FilterExpr};
 use crate::api::operator::anyelement_query_input_opoid;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
@@ -32,11 +33,14 @@ use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinNode, JoinSource, JoinSourceCandidate, JoinType,
     MultiTablePredicateInfo, PlannerRootId, RelNode,
 };
-use crate::postgres::customscan::pullup::{resolve_fast_field, resolve_fast_field_by_name};
+use crate::postgres::customscan::pullup::{
+    get_attno_by_name, resolve_fast_field, resolve_fast_field_by_name,
+};
 use crate::postgres::customscan::qual_inspect::{extract_quals, PlannerContext, QualExtractState};
 use crate::postgres::customscan::range_table::bms_iter;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::utils::{expr_collect_rtis, expr_collect_vars, expr_contains_any_operator};
+use crate::postgres::var::fieldname_from_var;
 use crate::query::SearchQueryInput;
 use pgrx::{pg_sys, PgList};
 
@@ -610,18 +614,25 @@ pub unsafe fn has_non_equi_join_quals(
     analyze_join_path_restrictinfo(input_rel, sources).unhandled > 0
 }
 
-impl super::privdat::HavingExpr {
-    /// Translate a Postgres HAVING qual node tree into a serializable `HavingExpr`.
+/// Context for translating Postgres expression trees to [`FilterExpr`].
+///
+/// HAVING provides `targetlist` for resolving `T_Aggref` → `AggRef` and
+/// `T_Var` → `GroupRef`. FILTER provides `sources` for resolving
+/// `T_Var` → `ColumnRef`.
+pub struct FilterExprContext<'a> {
+    pub targetlist: Option<&'a super::join_targetlist::JoinAggregateTargetList>,
+    pub sources: Option<&'a [JoinAggSource]>,
+}
+
+impl FilterExpr {
+    /// Translate a Postgres expression node tree into a serializable [`FilterExpr`].
     ///
-    /// HAVING expressions reference aggregates via `Aggref` nodes and group columns
-    /// via `Var` nodes. We match each Aggref to its position in the output target
-    /// list using `pg_sys::equal` (same approach as `detect_join_aggregate_topk`).
+    /// Used for both HAVING quals (pass `targetlist`) and per-aggregate FILTER
+    /// clauses (pass `sources`). The context determines how leaf nodes are resolved.
     pub unsafe fn from_pg_node(
         node: *mut pg_sys::Node,
-        targetlist: &super::join_targetlist::JoinAggregateTargetList,
+        ctx: &FilterExprContext<'_>,
     ) -> Option<Self> {
-        use super::privdat::HavingOp;
-
         if node.is_null() {
             return None;
         }
@@ -630,12 +641,10 @@ impl super::privdat::HavingExpr {
 
         match tag {
             pg_sys::NodeTag::T_List => {
-                // Postgres may wrap HAVING quals in a List (AND-implicit).
-                // Translate each element and combine with AND.
                 let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
                 let mut children = Vec::new();
                 for item in list.iter_ptr() {
-                    children.push(Self::from_pg_node(item, targetlist)?);
+                    children.push(Self::from_pg_node(item, ctx)?);
                 }
                 if children.len() == 1 {
                     return children.into_iter().next();
@@ -643,28 +652,16 @@ impl super::privdat::HavingExpr {
                 Some(Self::And(children))
             }
             pg_sys::NodeTag::T_Aggref => {
-                // Match this Aggref to an aggregate in the targetlist by output_index.
-                // The output_rel.reltarget.exprs ordering matches what we parsed.
+                let targetlist = ctx.targetlist?;
                 let aggref = node as *mut pg_sys::Aggref;
-                // Find which aggregate this matches by comparing the Aggref pointer
-                // with the output_rel target list positions stored during extraction.
-                for (idx, _agg) in targetlist.aggregates.iter().enumerate() {
-                    // We can't do pointer comparison since havingQual has its own copy.
-                    // Instead, use the aggregate's output_index to reconstruct position.
-                    // The Aggref in HAVING should match one in the targetlist by pg_sys::equal.
-                    // But we don't have the original exprs here. Use a simpler heuristic:
-                    // match by aggfnoid + aggstar + position.
-                    let agg = &targetlist.aggregates[idx];
+                for (idx, agg) in targetlist.aggregates.iter().enumerate() {
                     if (*aggref).aggfnoid.to_u32() == agg.func_oid
                         && ((*aggref).aggstar
                             == matches!(agg.agg_kind, super::join_targetlist::AggKind::CountStar))
                     {
-                        // For COUNT(*) there's typically only one, so first match is fine.
-                        // For column aggregates, check field reference matches too.
                         if (*aggref).aggstar {
                             return Some(Self::AggRef(idx));
                         }
-                        // Non-star: check the argument column matches
                         if let Some((_, _, ref _field_name)) = agg.field_refs.first() {
                             let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
                             if let Some(first_arg) = args.get_ptr(0) {
@@ -683,17 +680,26 @@ impl super::privdat::HavingExpr {
                         }
                     }
                 }
-                // Couldn't match — HAVING references an aggregate we don't know about
                 None
             }
             pg_sys::NodeTag::T_Var => {
-                // Group column reference
                 let var = node as *mut pg_sys::Var;
                 let rti = (*var).varno as pg_sys::Index;
                 let attno = (*var).varattno;
-                for gc in &targetlist.group_columns {
-                    if gc.rti == rti && gc.attno == attno {
-                        return Some(Self::GroupRef(gc.field_name.clone()));
+
+                // FILTER context: resolve to ColumnRef via sources
+                if let Some(sources) = ctx.sources {
+                    let source = sources.iter().find(|s| s.rti == rti)?;
+                    let field_name = fieldname_from_var(source.relid, var, attno)?.into_inner();
+                    return Some(Self::ColumnRef { rti, field_name });
+                }
+
+                // HAVING context: resolve to GroupRef via targetlist
+                if let Some(targetlist) = ctx.targetlist {
+                    for gc in &targetlist.group_columns {
+                        if gc.rti == rti && gc.attno == attno {
+                            return Some(Self::GroupRef(gc.field_name.clone()));
+                        }
                     }
                 }
                 None
@@ -701,7 +707,7 @@ impl super::privdat::HavingExpr {
             pg_sys::NodeTag::T_Const => {
                 let c = node as *mut pg_sys::Const;
                 if (*c).constisnull {
-                    return None; // NULL in HAVING is unusual, skip
+                    return None;
                 }
                 let typoid = (*c).consttype;
                 let datum = (*c).constvalue;
@@ -722,13 +728,17 @@ impl super::privdat::HavingExpr {
                         let f: Option<f32> = pgrx::FromDatum::from_datum(datum, false);
                         Some(Self::LitFloat(f? as f64))
                     }
-                    pg_sys::FLOAT8OID => {
+                    pg_sys::FLOAT8OID | pg_sys::NUMERICOID => {
                         let f: Option<f64> = pgrx::FromDatum::from_datum(datum, false);
                         Some(Self::LitFloat(f?))
                     }
                     pg_sys::BOOLOID => {
                         let b: Option<bool> = pgrx::FromDatum::from_datum(datum, false);
                         Some(Self::LitBool(b?))
+                    }
+                    pg_sys::TEXTOID | pg_sys::VARCHAROID => {
+                        let s: Option<String> = pgrx::FromDatum::from_datum(datum, false);
+                        Some(Self::LitString(s?))
                     }
                     _ => None,
                 }
@@ -739,8 +749,8 @@ impl super::privdat::HavingExpr {
                 if args.len() != 2 {
                     return None;
                 }
-                let left = Self::from_pg_node(args.get_ptr(0)?, targetlist)?;
-                let right = Self::from_pg_node(args.get_ptr(1)?, targetlist)?;
+                let left = Self::from_pg_node(args.get_ptr(0)?, ctx)?;
+                let right = Self::from_pg_node(args.get_ptr(1)?, ctx)?;
 
                 let opname_ptr = pg_sys::get_opname((*op).opno);
                 if opname_ptr.is_null() {
@@ -748,12 +758,12 @@ impl super::privdat::HavingExpr {
                 }
                 let opname = std::ffi::CStr::from_ptr(opname_ptr).to_str().ok()?;
                 let having_op = match opname {
-                    "=" => HavingOp::Eq,
-                    "<>" | "!=" => HavingOp::NotEq,
-                    "<" => HavingOp::Lt,
-                    "<=" => HavingOp::LtEq,
-                    ">" => HavingOp::Gt,
-                    ">=" => HavingOp::GtEq,
+                    "=" => CompareOp::Eq,
+                    "<>" | "!=" => CompareOp::NotEq,
+                    "<" => CompareOp::Lt,
+                    "<=" => CompareOp::LtEq,
+                    ">" => CompareOp::Gt,
+                    ">=" => CompareOp::GtEq,
                     _ => return None,
                 };
 
@@ -765,7 +775,7 @@ impl super::privdat::HavingExpr {
             }
             pg_sys::NodeTag::T_NullTest => {
                 let nt = node as *mut pg_sys::NullTest;
-                let arg = Self::from_pg_node((*nt).arg as *mut pg_sys::Node, targetlist)?;
+                let arg = Self::from_pg_node((*nt).arg as *mut pg_sys::Node, ctx)?;
                 if (*nt).nulltesttype == pg_sys::NullTestType::IS_NULL {
                     Some(Self::IsNull(Box::new(arg)))
                 } else {
@@ -777,7 +787,7 @@ impl super::privdat::HavingExpr {
                 let args = PgList::<pg_sys::Node>::from_pg((*bexpr).args);
                 let mut children = Vec::new();
                 for arg in args.iter_ptr() {
-                    children.push(Self::from_pg_node(arg, targetlist)?);
+                    children.push(Self::from_pg_node(arg, ctx)?);
                 }
                 match (*bexpr).boolop {
                     pg_sys::BoolExprType::AND_EXPR => Some(Self::And(children)),
@@ -791,6 +801,10 @@ impl super::privdat::HavingExpr {
                     }
                     _ => None,
                 }
+            }
+            pg_sys::NodeTag::T_RelabelType => {
+                let relabel = node as *mut pg_sys::RelabelType;
+                Self::from_pg_node((*relabel).arg as *mut pg_sys::Node, ctx)
             }
             _ => None,
         }
@@ -900,6 +914,28 @@ pub unsafe fn populate_required_fields(
                                 ob.field_name,
                                 source.scan_info.heaprelid.to_u32()
                             ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add fields referenced in aggregate FILTER clauses.
+        for agg in &targetlist.aggregates {
+            if let Some(ref filter) = agg.filter {
+                for (rti, field_name) in collect_filter_column_refs(filter) {
+                    if source.contains_rti(rti) {
+                        if let Some(attno) = get_attno_by_name(field_name, &tupdesc) {
+                            match resolve_fast_field(attno as i32, &tupdesc, indexrel) {
+                                Some(field) => source.scan_info.add_field(attno, field),
+                                None => {
+                                    return Err(format!(
+                                        "FILTER column '{}' is not a fast field on table {}",
+                                        field_name,
+                                        source.scan_info.heaprelid.to_u32()
+                                    ));
+                                }
+                            }
                         }
                     }
                 }
@@ -1072,4 +1108,33 @@ unsafe fn collect_cross_table_search_quals(
     if rtis.len() > 1 {
         clauses.push(node);
     }
+}
+
+/// Collect all `(rti, field_name)` column references from an [`FilterExpr`] tree.
+fn collect_filter_column_refs(expr: &FilterExpr) -> Vec<(pg_sys::Index, &str)> {
+    let mut refs = Vec::new();
+    match expr {
+        FilterExpr::ColumnRef { rti, field_name } => {
+            refs.push((*rti, field_name.as_str()));
+        }
+        FilterExpr::BinOp { left, right, .. } => {
+            refs.extend(collect_filter_column_refs(left));
+            refs.extend(collect_filter_column_refs(right));
+        }
+        FilterExpr::And(children) | FilterExpr::Or(children) => {
+            for c in children {
+                refs.extend(collect_filter_column_refs(c));
+            }
+        }
+        FilterExpr::Not(inner) | FilterExpr::IsNull(inner) | FilterExpr::IsNotNull(inner) => {
+            refs.extend(collect_filter_column_refs(inner));
+        }
+        FilterExpr::AggRef(_)
+        | FilterExpr::GroupRef(_)
+        | FilterExpr::LitInt(_)
+        | FilterExpr::LitFloat(_)
+        | FilterExpr::LitBool(_)
+        | FilterExpr::LitString(_) => {}
+    }
+    refs
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -614,12 +614,16 @@ pub unsafe fn has_non_equi_join_quals(
     analyze_join_path_restrictinfo(input_rel, sources).unhandled > 0
 }
 
-/// Context for translating Postgres expression trees to [`FilterExpr`].
+/// Context for the **build phase** — translating Postgres expression trees
+/// into a serializable [`FilterExpr`] IR.
 ///
 /// HAVING provides `targetlist` for resolving `T_Aggref` → `AggRef` and
 /// `T_Var` → `GroupRef`. FILTER provides `sources` for resolving
 /// `T_Var` → `ColumnRef`.
-pub struct FilterExprContext<'a> {
+///
+/// This is distinct from the exec-phase context in `datafusion_exec.rs`,
+/// which carries a `RelNode` tree instead of raw planner sources.
+pub struct FilterExprBuildContext<'a> {
     pub targetlist: Option<&'a super::join_targetlist::JoinAggregateTargetList>,
     pub sources: Option<&'a [JoinAggSource]>,
 }
@@ -631,7 +635,7 @@ impl FilterExpr {
     /// clauses (pass `sources`). The context determines how leaf nodes are resolved.
     pub unsafe fn from_pg_node(
         node: *mut pg_sys::Node,
-        ctx: &FilterExprContext<'_>,
+        ctx: &FilterExprBuildContext<'_>,
     ) -> Option<Self> {
         if node.is_null() {
             return None;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -631,8 +631,13 @@ pub struct FilterExprBuildContext<'a> {
 impl FilterExpr {
     /// Translate a Postgres expression node tree into a serializable [`FilterExpr`].
     ///
-    /// Used for both HAVING quals (pass `targetlist`) and per-aggregate FILTER
-    /// clauses (pass `sources`). The context determines how leaf nodes are resolved.
+    /// Used for both HAVING quals and per-aggregate `FILTER (WHERE ...)` clauses.
+    /// The [`FilterExprBuildContext`] determines how leaf nodes are resolved:
+    /// - HAVING passes `targetlist` so `T_Aggref` → `AggRef` and `T_Var` → `GroupRef`
+    /// - FILTER passes `sources` so `T_Var` → `ColumnRef`
+    ///
+    /// Interior nodes (`T_OpExpr`, `T_BoolExpr`, `T_NullTest`, `T_RelabelType`,
+    /// `T_Const`, `T_List`) behave identically in both contexts.
     pub unsafe fn from_pg_node(
         node: *mut pg_sys::Node,
         ctx: &FilterExprBuildContext<'_>,
@@ -645,6 +650,9 @@ impl FilterExpr {
 
         match tag {
             pg_sys::NodeTag::T_List => {
+                // Postgres sometimes wraps quals in an implicit-AND List.
+                // Translate each element and combine with AND (collapsing
+                // single-element lists to avoid a redundant And wrapper).
                 let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
                 let mut children = Vec::new();
                 for item in list.iter_ptr() {
@@ -656,6 +664,17 @@ impl FilterExpr {
                 Some(Self::And(children))
             }
             pg_sys::NodeTag::T_Aggref => {
+                // Only meaningful in the HAVING context. Match this Aggref to
+                // an aggregate already extracted into the targetlist, so the
+                // translated expression can reference `agg_{idx}` columns at
+                // exec time.
+                //
+                // We can't do pointer comparison because havingQual has its
+                // own copy of the Aggref node. Instead we match by function
+                // OID + aggstar, and for non-star aggregates also match on
+                // the (rti, attno) of the first argument. For COUNT(*) that's
+                // enough; for column aggregates the (rti, attno) check
+                // disambiguates cases like COUNT(a) vs COUNT(b).
                 let targetlist = ctx.targetlist?;
                 let aggref = node as *mut pg_sys::Aggref;
                 for (idx, agg) in targetlist.aggregates.iter().enumerate() {
@@ -666,6 +685,7 @@ impl FilterExpr {
                         if (*aggref).aggstar {
                             return Some(Self::AggRef(idx));
                         }
+                        // Non-star: confirm the argument column matches.
                         if let Some((_, _, ref _field_name)) = agg.field_refs.first() {
                             let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
                             if let Some(first_arg) = args.get_ptr(0) {
@@ -684,21 +704,27 @@ impl FilterExpr {
                         }
                     }
                 }
+                // HAVING referenced an aggregate we didn't extract — bail out
+                // of the DataFusion path and let Postgres handle it natively.
                 None
             }
             pg_sys::NodeTag::T_Var => {
+                // A plain column reference. HAVING can only reference group
+                // columns (any other Var would be a planner bug); FILTER can
+                // reference any column on the source tables, which we resolve
+                // by field name via the fast-field metadata.
                 let var = node as *mut pg_sys::Var;
                 let rti = (*var).varno as pg_sys::Index;
                 let attno = (*var).varattno;
 
-                // FILTER context: resolve to ColumnRef via sources
+                // FILTER context: resolve to ColumnRef via sources.
                 if let Some(sources) = ctx.sources {
                     let source = sources.iter().find(|s| s.rti == rti)?;
                     let field_name = fieldname_from_var(source.relid, var, attno)?.into_inner();
                     return Some(Self::ColumnRef { rti, field_name });
                 }
 
-                // HAVING context: resolve to GroupRef via targetlist
+                // HAVING context: resolve to GroupRef via targetlist.
                 if let Some(targetlist) = ctx.targetlist {
                     for gc in &targetlist.group_columns {
                         if gc.rti == rti && gc.attno == attno {
@@ -711,6 +737,8 @@ impl FilterExpr {
             pg_sys::NodeTag::T_Const => {
                 let c = node as *mut pg_sys::Const;
                 if (*c).constisnull {
+                    // NULL literals in HAVING/FILTER are unusual; don't try
+                    // to synthesize a typed NULL — bail and fall back to PG.
                     return None;
                 }
                 let typoid = (*c).consttype;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -193,7 +193,7 @@ pub async fn build_join_aggregate_plan(
             };
             // Apply per-aggregate FILTER clause if present.
             let agg_expr = if let Some(ref filter_expr) = agg.filter {
-                let filter_ctx = FilterExprContext {
+                let filter_ctx = FilterExprExecContext {
                     targetlist: None,
                     plan: Some(plan),
                 };
@@ -228,7 +228,7 @@ pub async fn build_join_aggregate_plan(
 
     // Step 4.5: Apply HAVING filter (post-aggregate)
     if let Some(having) = having_filter {
-        let having_ctx = FilterExprContext {
+        let having_ctx = FilterExprExecContext {
             targetlist: Some(targetlist),
             plan: None,
         };
@@ -452,9 +452,15 @@ impl<'a> ColumnMapper for AggregateIndexVarMapper<'a> {
     }
 }
 
-/// Context for resolving leaf nodes in [`FilterExpr::to_datafusion`].
-/// HAVING provides targetlist for `AggRef`/`GroupRef`; FILTER provides plan for `ColumnRef`.
-struct FilterExprContext<'a> {
+/// Context for the **exec phase** — translating a [`FilterExpr`] IR into a
+/// DataFusion [`Expr`].
+///
+/// HAVING provides `targetlist` for resolving `AggRef`/`GroupRef`;
+/// FILTER provides `plan` (a `RelNode` tree) for resolving `ColumnRef`.
+///
+/// This is distinct from the build-phase context in `datafusion_build.rs`,
+/// which carries raw planner `JoinAggSource`s instead of a `RelNode` tree.
+struct FilterExprExecContext<'a> {
     targetlist: Option<&'a JoinAggregateTargetList>,
     plan: Option<&'a RelNode>,
 }
@@ -463,7 +469,7 @@ impl FilterExpr {
     /// Translate this expression to a DataFusion `Expr`.
     ///
     /// Used for both HAVING (pass `targetlist`) and per-aggregate FILTER (pass `plan`).
-    fn to_datafusion(&self, ctx: &FilterExprContext<'_>) -> Option<Expr> {
+    fn to_datafusion(&self, ctx: &FilterExprExecContext<'_>) -> Option<Expr> {
         use datafusion::logical_expr::Operator;
 
         match self {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -31,7 +31,7 @@ use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::aggregatescan::join_targetlist::{
     AggKind, JoinAggregateEntry, JoinAggregateTargetList,
 };
-use crate::postgres::customscan::aggregatescan::privdat::DataFusionTopK;
+use crate::postgres::customscan::aggregatescan::privdat::{CompareOp, DataFusionTopK, FilterExpr};
 use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
 };
@@ -82,7 +82,7 @@ pub async fn build_join_aggregate_plan(
     join_level_predicates: &[JoinLevelSearchPredicate],
     custom_exprs: *mut pg_sys::List,
     custom_scan_tlist: *mut pg_sys::List,
-    having_filter: Option<&crate::postgres::customscan::aggregatescan::privdat::HavingExpr>,
+    having_filter: Option<&FilterExpr>,
     ctx: &SessionContext,
 ) -> Result<datafusion::logical_expr::LogicalPlan> {
     // Step 1: Build the join DataFrame from the RelNode tree
@@ -117,16 +117,14 @@ pub async fn build_join_aggregate_plan(
                 AggKind::Count => agg_field_col(agg, plan).map(count),
                 AggKind::CountDistinct => {
                     let col_exprs = agg_field_cols(agg, plan)?;
-                    Ok(Expr::AggregateFunction(
-                        datafusion::logical_expr::expr::AggregateFunction::new_udf(
-                            count_udaf(),
-                            col_exprs,
-                            true,   // distinct
-                            None,   // filter
-                            vec![], // order_by
-                            None,   // null_treatment
-                        ),
-                    ))
+                    Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
+                        count_udaf(),
+                        col_exprs,
+                        true,   // distinct
+                        None,   // filter
+                        vec![], // order_by
+                        None,   // null_treatment
+                    )))
                 }
                 AggKind::Sum => agg_field_col(agg, plan).map(sum),
                 AggKind::Avg => agg_field_col(agg, plan).map(avg),
@@ -178,16 +176,43 @@ pub async fn build_join_aggregate_plan(
                 && !matches!(agg.agg_kind, AggKind::CountDistinct | AggKind::CountStar)
             {
                 match agg_expr {
-                    Expr::AggregateFunction(af) => Expr::AggregateFunction(
-                        datafusion::logical_expr::expr::AggregateFunction::new_udf(
+                    Expr::AggregateFunction(af) => {
+                        Expr::AggregateFunction(AggregateFunction::new_udf(
                             af.func,
                             af.params.args,
                             true,
                             af.params.filter,
                             af.params.order_by,
                             af.params.null_treatment,
-                        ),
-                    ),
+                        ))
+                    }
+                    other => other,
+                }
+            } else {
+                agg_expr
+            };
+            // Apply per-aggregate FILTER clause if present.
+            let agg_expr = if let Some(ref filter_expr) = agg.filter {
+                let filter_ctx = FilterExprContext {
+                    targetlist: None,
+                    plan: Some(plan),
+                };
+                let df_filter = filter_expr.to_datafusion(&filter_ctx).ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "Failed to translate aggregate FILTER clause to DataFusion".to_string(),
+                    )
+                })?;
+                match agg_expr {
+                    Expr::AggregateFunction(af) => {
+                        Expr::AggregateFunction(AggregateFunction::new_udf(
+                            af.func,
+                            af.params.args,
+                            af.params.distinct,
+                            Some(Box::new(df_filter)),
+                            af.params.order_by,
+                            af.params.null_treatment,
+                        ))
+                    }
                     other => other,
                 }
             } else {
@@ -203,7 +228,11 @@ pub async fn build_join_aggregate_plan(
 
     // Step 4.5: Apply HAVING filter (post-aggregate)
     if let Some(having) = having_filter {
-        let expr = having.to_datafusion(targetlist).ok_or_else(|| {
+        let having_ctx = FilterExprContext {
+            targetlist: Some(targetlist),
+            plan: None,
+        };
+        let expr = having.to_datafusion(&having_ctx).ok_or_else(|| {
             DataFusionError::Internal(
                 "Failed to translate HAVING clause to DataFusion expression".to_string(),
             )
@@ -423,35 +452,50 @@ impl<'a> ColumnMapper for AggregateIndexVarMapper<'a> {
     }
 }
 
-impl crate::postgres::customscan::aggregatescan::privdat::HavingExpr {
-    /// Translate this `HavingExpr` to a DataFusion `Expr`.
-    /// Aggregate references use the `agg_{idx}` aliases from the aggregate step.
-    fn to_datafusion(&self, targetlist: &JoinAggregateTargetList) -> Option<Expr> {
-        use crate::postgres::customscan::aggregatescan::privdat::HavingOp;
+/// Context for resolving leaf nodes in [`FilterExpr::to_datafusion`].
+/// HAVING provides targetlist for `AggRef`/`GroupRef`; FILTER provides plan for `ColumnRef`.
+struct FilterExprContext<'a> {
+    targetlist: Option<&'a JoinAggregateTargetList>,
+    plan: Option<&'a RelNode>,
+}
+
+impl FilterExpr {
+    /// Translate this expression to a DataFusion `Expr`.
+    ///
+    /// Used for both HAVING (pass `targetlist`) and per-aggregate FILTER (pass `plan`).
+    fn to_datafusion(&self, ctx: &FilterExprContext<'_>) -> Option<Expr> {
         use datafusion::logical_expr::Operator;
 
         match self {
-            Self::AggRef(idx) => {
-                if *idx < targetlist.aggregates.len() {
+            FilterExpr::AggRef(idx) => {
+                let tl = ctx.targetlist?;
+                if *idx < tl.aggregates.len() {
                     Some(datafusion::prelude::col(format!("agg_{}", idx)))
                 } else {
                     None
                 }
             }
-            Self::GroupRef(field_name) => Some(datafusion::prelude::col(field_name.as_str())),
-            Self::LitInt(v) => Some(lit(*v)),
-            Self::LitFloat(v) => Some(lit(*v)),
-            Self::LitBool(v) => Some(lit(*v)),
-            Self::BinOp { left, op, right } => {
-                let l = left.to_datafusion(targetlist)?;
-                let r = right.to_datafusion(targetlist)?;
+            FilterExpr::GroupRef(field_name) => Some(datafusion::prelude::col(field_name.as_str())),
+            FilterExpr::ColumnRef { rti, field_name } => {
+                let plan = ctx.plan?;
+                let source = plan.source_for_rti_in_subtree(*rti);
+                let (alias, _) = resolve_source_column(source, *rti, field_name, plan);
+                Some(make_col(&alias, field_name))
+            }
+            FilterExpr::LitInt(v) => Some(lit(*v)),
+            FilterExpr::LitFloat(v) => Some(lit(*v)),
+            FilterExpr::LitBool(v) => Some(lit(*v)),
+            FilterExpr::LitString(v) => Some(lit(v.clone())),
+            FilterExpr::BinOp { left, op, right } => {
+                let l = left.to_datafusion(ctx)?;
+                let r = right.to_datafusion(ctx)?;
                 let df_op = match op {
-                    HavingOp::Eq => Operator::Eq,
-                    HavingOp::NotEq => Operator::NotEq,
-                    HavingOp::Lt => Operator::Lt,
-                    HavingOp::LtEq => Operator::LtEq,
-                    HavingOp::Gt => Operator::Gt,
-                    HavingOp::GtEq => Operator::GtEq,
+                    CompareOp::Eq => Operator::Eq,
+                    CompareOp::NotEq => Operator::NotEq,
+                    CompareOp::Lt => Operator::Lt,
+                    CompareOp::LtEq => Operator::LtEq,
+                    CompareOp::Gt => Operator::Gt,
+                    CompareOp::GtEq => Operator::GtEq,
                 };
                 Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
                     Box::new(l),
@@ -459,36 +503,34 @@ impl crate::postgres::customscan::aggregatescan::privdat::HavingExpr {
                     Box::new(r),
                 )))
             }
-            Self::And(children) => {
-                // All children must translate — if any fails, the whole AND is
-                // untranslatable and we must fall back to Postgres (not silently drop it).
+            FilterExpr::And(children) => {
                 let exprs: Vec<Expr> = children
                     .iter()
-                    .map(|c| c.to_datafusion(targetlist))
+                    .map(|c| c.to_datafusion(ctx))
                     .collect::<Option<Vec<Expr>>>()?;
                 let mut result = exprs.into_iter();
                 let first = result.next()?;
                 Some(result.fold(first, |acc, e| acc.and(e)))
             }
-            Self::Or(children) => {
+            FilterExpr::Or(children) => {
                 let exprs: Vec<Expr> = children
                     .iter()
-                    .map(|c| c.to_datafusion(targetlist))
+                    .map(|c| c.to_datafusion(ctx))
                     .collect::<Option<Vec<Expr>>>()?;
                 let mut result = exprs.into_iter();
                 let first = result.next()?;
                 Some(result.fold(first, |acc, e| acc.or(e)))
             }
-            Self::Not(inner) => {
-                let e = inner.to_datafusion(targetlist)?;
+            FilterExpr::Not(inner) => {
+                let e = inner.to_datafusion(ctx)?;
                 Some(Expr::Not(Box::new(e)))
             }
-            Self::IsNull(inner) => {
-                let e = inner.to_datafusion(targetlist)?;
+            FilterExpr::IsNull(inner) => {
+                let e = inner.to_datafusion(ctx)?;
                 Some(e.is_null())
             }
-            Self::IsNotNull(inner) => {
-                let e = inner.to_datafusion(targetlist)?;
+            FilterExpr::IsNotNull(inner) => {
+                let e = inner.to_datafusion(ctx)?;
                 Some(e.is_not_null())
             }
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -22,7 +22,9 @@
 //! column and aggregate argument belongs to. This is the join-aware counterpart
 //! of [`super::targetlist::TargetList`] (which assumes a single base relation).
 
-use super::datafusion_build::JoinAggSource;
+use super::datafusion_build::{FilterExprContext, JoinAggSource};
+use super::privdat::FilterExpr;
+use crate::api::SortDirection;
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
 use crate::postgres::var::{
     fieldname_from_var, find_one_aggref, find_one_var_and_fieldname, VarContext,
@@ -133,6 +135,10 @@ pub struct JoinAggregateEntry {
     /// Empty for aggregates without internal ordering.
     #[serde(default)]
     pub order_by: Vec<AggOrderByEntry>,
+    /// Per-aggregate FILTER clause (e.g., `COUNT(*) FILTER (WHERE price > 100)`).
+    /// `None` when the aggregate has no FILTER.
+    #[serde(default)]
+    pub filter: Option<FilterExpr>,
 }
 
 /// The complete aggregate target list for a join aggregate query.
@@ -288,14 +294,18 @@ pub unsafe fn extract_aggregate_targetlist(
             let aggfnoid = (*aggref).aggfnoid.to_u32();
             let has_distinct = !(*aggref).aggdistinct.is_null();
 
-            // Reject FILTER (WHERE ...) clauses on aggregates — DataFusion
-            // doesn't propagate per-aggregate filter predicates and would
-            // silently produce wrong results if we didn't fall back.
-            if !(*aggref).aggfilter.is_null() {
-                return Err(
-                    "FILTER clauses on aggregates are not supported for aggregate-on-join".into(),
-                );
-            }
+            // Extract per-aggregate FILTER clause if present.
+            let filter = if (*aggref).aggfilter.is_null() {
+                None
+            } else {
+                FilterExpr::from_pg_node(
+                    (*aggref).aggfilter as *mut pg_sys::Node,
+                    &FilterExprContext {
+                        targetlist: None,
+                        sources: Some(sources),
+                    },
+                )
+            };
 
             // Reject pdb.agg()
             let pdb_agg_oid = crate::api::agg_funcoid().to_u32();
@@ -328,6 +338,7 @@ pub unsafe fn extract_aggregate_targetlist(
                 field_refs,
                 output_index: idx,
                 result_type_oid,
+                filter,
                 distinct: has_distinct,
                 order_by,
             });
@@ -498,16 +509,14 @@ unsafe fn extract_aggref_order_by(
             })?
             .into_inner();
 
-        let direction = crate::api::SortDirection::from_sort_op(
-            (*clause_ptr).sortop,
-            (*clause_ptr).nulls_first,
-        )
-        .ok_or_else(|| {
-            format!(
-                "could not determine sort direction for aggregate ORDER BY (sortop={})",
-                (*clause_ptr).sortop.to_u32()
-            )
-        })?;
+        let direction =
+            SortDirection::from_sort_op((*clause_ptr).sortop, (*clause_ptr).nulls_first)
+                .ok_or_else(|| {
+                    format!(
+                        "could not determine sort direction for aggregate ORDER BY (sortop={})",
+                        (*clause_ptr).sortop.to_u32()
+                    )
+                })?;
 
         entries.push(AggOrderByEntry {
             rti,

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -22,7 +22,7 @@
 //! column and aggregate argument belongs to. This is the join-aware counterpart
 //! of [`super::targetlist::TargetList`] (which assumes a single base relation).
 
-use super::datafusion_build::{FilterExprContext, JoinAggSource};
+use super::datafusion_build::{FilterExprBuildContext, JoinAggSource};
 use super::privdat::FilterExpr;
 use crate::api::SortDirection;
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
@@ -300,7 +300,7 @@ pub unsafe fn extract_aggregate_targetlist(
             } else {
                 FilterExpr::from_pg_node(
                     (*aggref).aggfilter as *mut pg_sys::Node,
-                    &FilterExprContext {
+                    &FilterExprBuildContext {
                         targetlist: None,
                         sources: Some(sources),
                     },

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -993,7 +993,7 @@ impl AggregateScan {
             if !parse.is_null() && !(*parse).havingQual.is_null() {
                 privdat::FilterExpr::from_pg_node(
                     (*parse).havingQual,
-                    &datafusion_build::FilterExprContext {
+                    &datafusion_build::FilterExprBuildContext {
                         targetlist: Some(&targetlist),
                         sources: None,
                     },

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -991,7 +991,13 @@ impl AggregateScan {
         let having_filter = unsafe {
             let parse = builder.args().root().parse;
             if !parse.is_null() && !(*parse).havingQual.is_null() {
-                privdat::HavingExpr::from_pg_node((*parse).havingQual, &targetlist)
+                privdat::FilterExpr::from_pg_node(
+                    (*parse).havingQual,
+                    &datafusion_build::FilterExprContext {
+                        targetlist: Some(&targetlist),
+                        sources: None,
+                    },
+                )
             } else {
                 None
             }

--- a/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/privdat.rs
@@ -25,34 +25,41 @@ use pgrx::pg_sys::AsPgCStr;
 use pgrx::prelude::*;
 use pgrx::PgList;
 
-/// Serializable representation of a HAVING clause expression.
-/// References aggregate results by index and group columns by name.
+/// Serializable boolean expression IR used for both HAVING clauses and
+/// per-aggregate FILTER clauses.
+///
+/// HAVING uses `AggRef` and `GroupRef` (post-aggregate references).
+/// FILTER uses `ColumnRef` (pre-aggregate row-level references).
+/// Both share the same operator, literal, and boolean combinators.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum HavingExpr {
-    /// Reference to an aggregate result by its index in targetlist.aggregates.
-    /// Translates to `col("agg_{idx}")` in DataFusion.
+pub enum FilterExpr {
+    /// Reference to an aggregate result by index (HAVING context).
     AggRef(usize),
-    /// Reference to a GROUP BY column by field name.
+    /// Reference to a GROUP BY column by field name (HAVING context).
     GroupRef(String),
-    /// Literal values
+    /// Reference to a pre-aggregate table column (FILTER context).
+    ColumnRef {
+        rti: pgrx::pg_sys::Index,
+        field_name: String,
+    },
     LitInt(i64),
     LitFloat(f64),
     LitBool(bool),
-    /// Comparison operator
+    LitString(String),
     BinOp {
-        left: Box<HavingExpr>,
-        op: HavingOp,
-        right: Box<HavingExpr>,
+        left: Box<FilterExpr>,
+        op: CompareOp,
+        right: Box<FilterExpr>,
     },
-    And(Vec<HavingExpr>),
-    Or(Vec<HavingExpr>),
-    Not(Box<HavingExpr>),
-    IsNull(Box<HavingExpr>),
-    IsNotNull(Box<HavingExpr>),
+    And(Vec<FilterExpr>),
+    Or(Vec<FilterExpr>),
+    Not(Box<FilterExpr>),
+    IsNull(Box<FilterExpr>),
+    IsNotNull(Box<FilterExpr>),
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum HavingOp {
+pub enum CompareOp {
     Eq,
     NotEq,
     Lt,
@@ -155,7 +162,7 @@ pub enum PrivateData {
         multi_table_clause_count: usize,
         /// HAVING clause filter applied after aggregation.
         #[serde(default)]
-        having_filter: Option<HavingExpr>,
+        having_filter: Option<FilterExpr>,
     },
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -18,7 +18,7 @@
 use crate::customscan::aggregatescan::exec::AggregationResultsRow;
 use crate::customscan::aggregatescan::AggregateCSClause;
 use crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList;
-use crate::postgres::customscan::aggregatescan::privdat::DataFusionTopK;
+use crate::postgres::customscan::aggregatescan::privdat::{DataFusionTopK, FilterExpr};
 use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, MultiTablePredicateInfo, RelNode,
 };
@@ -59,7 +59,7 @@ pub struct DataFusionAggState {
     /// pairs during DataFusion expression translation.
     pub custom_scan_tlist: *mut pg_sys::List,
     /// HAVING clause filter applied after aggregation.
-    pub having_filter: Option<crate::postgres::customscan::aggregatescan::privdat::HavingExpr>,
+    pub having_filter: Option<FilterExpr>,
     /// Tokio runtime for async DataFusion execution.
     pub runtime: Option<tokio::runtime::Runtime>,
     /// DataFusion result stream.

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -35,7 +35,9 @@ use crate::index::fast_fields_helper::WhichFastField;
 use crate::nodecast;
 use crate::postgres::customscan::basescan::projections::score::is_score_func;
 use crate::postgres::customscan::opexpr::lookup_operator;
-use crate::postgres::customscan::pullup::{field_type_for_pullup, resolve_fast_field};
+use crate::postgres::customscan::pullup::{
+    field_type_for_pullup, get_attno_by_name, resolve_fast_field,
+};
 use crate::postgres::customscan::qual_inspect::{extract_quals, PlannerContext, QualExtractState};
 use crate::postgres::customscan::range_table::bms_iter;
 use crate::postgres::customscan::score_funcoids;
@@ -1029,7 +1031,7 @@ pub(super) unsafe fn collect_required_fields(
                     let raw_col_name = col_name.trim_matches('"');
                     for source in &mut plan_sources {
                         if source.scan_info.alias.as_deref() == Some(alias) {
-                            if let Some(attno) = get_attno_by_name(source, raw_col_name) {
+                            if let Some(attno) = get_source_attno_by_name(source, raw_col_name) {
                                 ensure_field(source, attno);
                             }
                             break;
@@ -1045,7 +1047,7 @@ pub(super) unsafe fn collect_required_fields(
                             // exist in the table but only be indexed via an
                             // expression (e.g. upper(name)), in which case
                             // ensure_field (via resolve_fast_field) won't find it.
-                            let added = get_attno_by_name(source, name)
+                            let added = get_source_attno_by_name(source, name)
                                 .and_then(|attno| try_ensure_field(source, attno))
                                 .is_some();
                             if !added {
@@ -1155,16 +1157,11 @@ unsafe fn ensure_expression_field(source: &mut JoinSource, field_name: &str) -> 
     Ok(())
 }
 
-/// Helper function to retrieve an attribute number given a column name from a `JoinSource`'s underlying heap relation.
-unsafe fn get_attno_by_name(side: &JoinSource, name: &str) -> Option<pg_sys::AttrNumber> {
+/// Retrieve an attribute number by column name from a `JoinSource`'s heap relation.
+unsafe fn get_source_attno_by_name(side: &JoinSource, name: &str) -> Option<pg_sys::AttrNumber> {
     let rel = PgSearchRelation::open(side.scan_info.heaprelid);
     let tupdesc = rel.tuple_desc();
-    for (i, att) in tupdesc.iter().enumerate() {
-        if att.name() == name {
-            return Some((i + 1) as pg_sys::AttrNumber);
-        }
-    }
-    None
+    get_attno_by_name(name, &tupdesc)
 }
 
 fn collect_source_rtis(sources: &[&JoinSource]) -> Vec<pg_sys::Index> {

--- a/pg_search/src/postgres/customscan/pullup.rs
+++ b/pg_search/src/postgres/customscan/pullup.rs
@@ -150,6 +150,19 @@ pub fn resolve_fast_field_by_name(
     }
 }
 
+/// Look up a 1-based attribute number by column name in a tuple descriptor.
+pub fn get_attno_by_name(
+    name: &str,
+    tupdesc: &pgrx::PgTupleDesc<'_>,
+) -> Option<pg_sys::AttrNumber> {
+    for (i, att) in tupdesc.iter().enumerate() {
+        if att.name() == name {
+            return Some((i + 1) as pg_sys::AttrNumber);
+        }
+    }
+    None
+}
+
 /// Returns the `SearchFieldType` if it's supported for fast field pullup execution.
 ///
 /// Returns `Some(SearchFieldType)` if the type is supported for fast field execution,

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -1640,6 +1640,100 @@ SET paradedb.enable_aggregate_custom_scan TO on;
 DROP TABLE agg_json_orders;
 DROP TABLE agg_json_items;
 -- =====================================================================
+-- SECTION 17: Per-aggregate FILTER clause on join
+-- =====================================================================
+-- Test 17.1: COUNT with FILTER — EXPLAIN shows DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: p.category, (count(*)), (count(*) FILTER (WHERE (p.price > '100'::double precision)))
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Group By: category
+   Aggregates: COUNT(*), COUNT(*)
+(6 rows)
+
+-- Test 17.2: COUNT with FILTER — results
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | total | expensive 
+-------------+-------+-----------
+ Clothing    |     1 |         1
+ Electronics |     4 |         4
+ Sports      |     2 |         0
+ Toys        |     2 |         2
+(4 rows)
+
+-- Test 17.3: FILTER parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | total | expensive 
+-------------+-------+-----------
+ Clothing    |     1 |         1
+ Electronics |     4 |         4
+ Sports      |     2 |         0
+ Toys        |     2 |         2
+(4 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test 17.4: SUM with FILTER
+SELECT p.category,
+       SUM(p.price) AS total_price,
+       SUM(p.price) FILTER (WHERE p.rating >= 4) AS high_rated_price
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | total_price | high_rated_price 
+-------------+-------------+------------------
+ Clothing    |      129.99 |                 
+ Electronics |     4599.96 |          4599.96
+ Sports      |      179.98 |           179.98
+ Toys        |      999.98 |                 
+(4 rows)
+
+-- Test 17.5: SUM FILTER parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category,
+       SUM(p.price) AS total_price,
+       SUM(p.price) FILTER (WHERE p.rating >= 4) AS high_rated_price
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | total_price | high_rated_price 
+-------------+-------------+------------------
+ Clothing    |      129.99 |                 
+ Electronics |     4599.96 |          4599.96
+ Sports      |      179.98 |           179.98
+ Toys        |      999.98 |                 
+(4 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -1120,6 +1120,64 @@ DROP TABLE agg_json_orders;
 DROP TABLE agg_json_items;
 
 -- =====================================================================
+-- SECTION 17: Per-aggregate FILTER clause on join
+-- =====================================================================
+
+-- Test 17.1: COUNT with FILTER — EXPLAIN shows DataFusion
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category;
+
+-- Test 17.2: COUNT with FILTER — results
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 17.3: FILTER parity — DataFusion vs Postgres native
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE p.price > 100) AS expensive
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test 17.4: SUM with FILTER
+SELECT p.category,
+       SUM(p.price) AS total_price,
+       SUM(p.price) FILTER (WHERE p.rating >= 4) AS high_rated_price
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Test 17.5: SUM FILTER parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.category,
+       SUM(p.price) AS total_price,
+       SUM(p.price) FILTER (WHERE p.rating >= 4) AS high_rated_price
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket'
+GROUP BY p.category
+ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;


### PR DESCRIPTION
## What

Support per-aggregate `FILTER (WHERE ...)` clauses on join queries via the DataFusion aggregate path. Queries like `COUNT(*) FILTER (WHERE price > 100)` and `SUM(x) FILTER (WHERE y IS NOT NULL)` now run through the custom scan instead of falling back to native Postgres.

## Why

The previous implementation rejected any aggregate with a FILTER clause, forcing graceful fallback. DataFusion already supports per-aggregate filters via the `filter` parameter on `AggregateFunction::new_udf` — we just needed to extract the `aggfilter` expression from the Postgres `Aggref` node and translate it to a DataFusion `Expr`.

## How

- Extract the `aggfilter` expression at planning time and store a serializable IR on `JoinAggregateEntry.filter`.
- At execution time, translate the IR to a DataFusion `Expr` and pass it to `AggregateFunction::new_udf`, following the same deconstruct-and-rebuild pattern used for DISTINCT.
- Register columns referenced by FILTER clauses as fast fields in `populate_required_fields` so `PgSearchTableProvider` exposes them as Arrow columns.
- **Refactor**: unify `HavingExpr` and the new FILTER IR into a single `FilterExpr` enum. Both have identical operator/literal/boolean tree structure — only leaf node resolution differs (`AggRef`/`GroupRef` for HAVING vs `ColumnRef` for FILTER). A single `FilterExpr::from_pg_node` and `to_datafusion` take a `FilterExprContext` that picks the right resolution strategy, eliminating duplicate expression walking.
- **Cleanup**: move the `get_attno_by_name` helper from a local function in `joinscan/planning.rs` to the shared `pullup.rs` module, next to `resolve_fast_field` and `resolve_fast_field_by_name`. Both `datafusion_build.rs` and `planning.rs` now use the shared version.

## Tests

- New SECTION 17 in `aggregate_join.sql` covering `COUNT(*) FILTER`, `SUM(price) FILTER`, and parity checks against native Postgres with various predicates.
- All existing aggregate join, TopK, and HAVING tests continue to pass.