### PR TITLE
ci: Streamline caching

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -194,6 +194,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Install & Configure Supported PostgreSQL Version

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -208,6 +208,7 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "v1-benchmarks-rust-cache"
@@ -220,15 +221,8 @@ jobs:
         id: pgrx
         run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug --locked
 
       - name: Initialize pgrx environment

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -208,7 +208,6 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "v1-benchmarks-rust-cache"
@@ -222,7 +221,6 @@ jobs:
         run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug --locked
 
       - name: Initialize pgrx environment

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -192,6 +192,7 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "v1-stressgres-rust-cache"
@@ -204,15 +205,8 @@ jobs:
         id: pgrx
         run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug --locked
 
       - name: Initialize pgrx environment

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -192,7 +192,6 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "v1-stressgres-rust-cache"
@@ -206,7 +205,6 @@ jobs:
         run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug --locked
 
       - name: Initialize pgrx environment

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -175,6 +175,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Install required system tools

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -47,7 +47,6 @@ jobs:
       # See test-pg_search.yml for rationale.
       # Only save cache on non-PR events; PRs restore from the default branch.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -64,7 +63,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -47,6 +47,7 @@ jobs:
       # See test-pg_search.yml for rationale.
       # Only save cache on non-PR events; PRs restore from the default branch.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -62,15 +63,8 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libfontconfig1-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           components: rustfmt, clippy
           cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Check Cargo.lock
         run: cargo metadata --format-version 1 --locked > /dev/null

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -195,7 +195,6 @@ jobs:
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -123,7 +123,6 @@ jobs:
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -232,7 +232,6 @@ jobs:
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -49,7 +49,6 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -65,7 +64,6 @@ jobs:
           echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -49,6 +49,7 @@ jobs:
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -63,15 +64,8 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }}
           echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -174,7 +174,6 @@ jobs:
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -56,7 +56,6 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -78,7 +77,6 @@ jobs:
           cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -56,6 +56,7 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -76,15 +77,8 @@ jobs:
           sudo apt install clang llvm diffutils
           cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -129,6 +129,7 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -137,15 +138,8 @@ jobs:
           cache-all-crates: true
           save-if: ${{ github.event_name != 'pull_request' }}
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -118,6 +118,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -129,7 +129,6 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -139,7 +138,6 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' }}
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
 
       - name: Initialize pgrx environment

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -56,6 +56,7 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -128,15 +129,7 @@ jobs:
         working-directory: pg_search/
         run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ matrix.pg_version }}
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install the pgrx version for ParadeDB
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
 
       - name: Initialize pgrx environment for ParadeDB

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -85,7 +85,7 @@ jobs:
 
       # This is the pgrx version compatible with ParadeDB $PRIOR_PG_SEARCH_VERSION
       - name: Install pgrx for ParadeDB $PRIOR_PG_SEARCH_VERSION
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.16.1 --debug
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.16.1 --force --debug
 
       - name: Initialize pgrx environment for ParadeDB $PRIOR_PG_SEARCH_VERSION
         run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install the pgrx version for ParadeDB
         if: steps.cache-pgrx.outputs.cache-hit != 'true'
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
 
       - name: Initialize pgrx environment for ParadeDB
         run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -56,7 +56,6 @@ jobs:
       # Only save cache on non-PR events; PRs restore from the default branch.
       # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -103,6 +103,7 @@ jobs:
       # every entry to be evicted before reuse. The nightly schedule run warms caches
       # for all PG versions on the default branch.
       - name: Install Rust Cache
+        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -121,15 +122,8 @@ jobs:
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
-      - name: Cache pgrx binary
-        id: cache-pgrx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
-
       - name: Install pgrx
-        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -103,7 +103,6 @@ jobs:
       # every entry to be evicted before reuse. The nightly schedule run warms caches
       # for all PG versions on the default branch.
       - name: Install Rust Cache
-        id: rust-cache
         uses: swatinem/rust-cache@v2
         with:
           prefix-key: "rust-cache"
@@ -123,7 +122,6 @@ jobs:
         run: rustup component add llvm-tools-preview
 
       - name: Install pgrx
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -250,6 +250,9 @@ jobs:
         working-directory: tests/
         run: |
           RUST_BACKTRACE=1 cargo pgrx start pg${{ matrix.pg_version }}
+          # The cached ~/.pgrx directory includes the data directory, so restore hits
+          # can already contain a pg_search database from a previous run.
+          ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/dropdb --if-exists -p 288${{ matrix.pg_version }} -h localhost pg_search
           ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/createdb -p 288${{ matrix.pg_version }} -h localhost pg_search
 
       # ---------- Tests ----------


### PR DESCRIPTION
# Ticket(s) Closed

- Use --force when installing pgrx on the upgrade workflow so that an incorrect version from cache is not installed.
- Remove duplicate caching on Install Rust step.  
  - We have to use the separate rust cache step instead of Install Rust's default caching because the latter does not support `save-if`.
- Remove pgrx binary caching; it's already cached by the rust cache step.
  - It turns out we don't even need an if condition on these steps because the install command is already a no-op if pgrx is already installed there.
- Now that the pgrx-managed Postgres is cached, when it's restored the data directory still exists. I added a command to drop the database if there is one so that createdb still succeeds.
 
## What

## Why

## How

## Tests
