### PR TITLE
fix: resolve equi-key projections structurally in collect_required_fields

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -892,6 +892,41 @@ impl RelNode {
         }
     }
 
+    /// Resolve every equi-join key in this tree structurally against the
+    /// specific join node that owns it, and return `(plan_position, attno)`
+    /// pairs identifying the exact sources that must project each key column.
+    ///
+    /// A flat lookup keyed on `(rti, attno)` can pick the wrong source when a
+    /// SubPlan's inner relation shares an RTI value with an outer relation
+    /// (inner queries have their own RTI numbering). By resolving each key
+    /// against its owning `JoinNode`'s own `left`/`right` subtrees with the
+    /// same logic used at execution time (`JoinKeyPair::resolve_against`),
+    /// we bind each key to the correct `JoinSource` unambiguously.
+    pub fn join_key_projections(&self) -> Vec<(usize, pg_sys::AttrNumber)> {
+        let mut result = Vec::new();
+        self.collect_join_key_projections(&mut result);
+        result
+    }
+
+    fn collect_join_key_projections(&self, acc: &mut Vec<(usize, pg_sys::AttrNumber)>) {
+        match self {
+            RelNode::Scan(_) => {}
+            RelNode::Join(j) => {
+                for jk in &j.equi_keys {
+                    if let Some(((left_src, left_att), (right_src, right_att))) =
+                        jk.resolve_against(&j.left, &j.right)
+                    {
+                        acc.push((left_src.plan_position, left_att));
+                        acc.push((right_src.plan_position, right_att));
+                    }
+                }
+                j.left.collect_join_key_projections(acc);
+                j.right.collect_join_key_projections(acc);
+            }
+            RelNode::Filter(f) => f.input.collect_join_key_projections(acc),
+        }
+    }
+
     /// Distribute equi-join keys to the correct join level in the tree.
     ///
     /// For 2-table joins all keys land on the single JoinNode. For 3+ table

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -951,7 +951,12 @@ pub(super) unsafe fn collect_required_fields(
     output_columns: &[OutputColumnInfo],
     custom_exprs: *mut pg_sys::List,
 ) {
-    let join_keys = join_clause.plan.join_keys();
+    // Resolve each equi-join key against the join node that owns it so we
+    // bind to the correct `JoinSource` by `plan_position`. A flat
+    // `(rti, attno)` scan can pick the wrong source when a SubPlan's inner
+    // relation shares an RTI value with an outer relation (inner queries
+    // have their own RTI numbering space), forcing us to over-project.
+    let join_key_projections = join_clause.plan.join_key_projections();
     let mut plan_sources = join_clause.plan.sources_mut();
 
     for source in &mut plan_sources {
@@ -959,27 +964,13 @@ pub(super) unsafe fn collect_required_fields(
     }
 
     if plan_sources.len() >= 2 {
-        let mut ensure_join_key_side = |rti: pg_sys::Index, attno: pg_sys::AttrNumber| {
-            // Ensure the field on ALL sources that match this RTI+attno.
-            // Multiple sources can share the same RTI when they originate
-            // from different planner roots (e.g., main query vs SubPlan).
-            let mut found = false;
-            for source in plan_sources.iter_mut() {
-                if source.contains_rti(rti) && source.has_attno(attno) {
-                    ensure_field(source, attno);
-                    found = true;
-                }
+        for (plan_position, attno) in &join_key_projections {
+            if let Some(source) = plan_sources
+                .iter_mut()
+                .find(|s| s.plan_position == *plan_position)
+            {
+                ensure_field(source, *attno);
             }
-            if !found {
-                for source in &mut plan_sources {
-                    ensure_column(source, rti, attno);
-                }
-            }
-        };
-
-        for jk in &join_keys {
-            ensure_join_key_side(jk.outer_rti, jk.outer_attno);
-            ensure_join_key_side(jk.inner_rti, jk.inner_attno);
         }
     }
 

--- a/pg_search/tests/pg_regress/expected/issue_4719.out
+++ b/pg_search/tests/pg_regress/expected/issue_4719.out
@@ -1,0 +1,184 @@
+-- Regression test for https://github.com/paradedb/paradedb/issues/4719
+--
+-- JoinScan used to fail with:
+--   ERROR:  Failed to build DataFusion logical plan: Internal("Missing right join-key column")
+-- when a query combined `NOT IN (SELECT ...)` with a
+-- `(col IS NULL OR col IN (SELECT ...))` pattern on the same outer relation.
+--
+-- Each inner subplan is planned with its own PlannerInfo and numbers its
+-- range table starting from 1, so the inner relations collide with the outer
+-- relation's RTI. collect_required_fields used a flat `(rti, attno)` lookup
+-- that could match the wrong source, leaving the right-side join column
+-- unprojected — and execution later failed when resolving the join key.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS issue_4719_people CASCADE;
+DROP TABLE IF EXISTS issue_4719_experiences CASCADE;
+DROP TABLE IF EXISTS issue_4719_companies CASCADE;
+CREATE TABLE issue_4719_people (
+    id integer PRIMARY KEY,
+    company_id integer,
+    body text
+);
+CREATE TABLE issue_4719_experiences (
+    id integer PRIMARY KEY,
+    person_id integer,
+    company_id integer,
+    body text
+);
+CREATE TABLE issue_4719_companies (
+    id integer PRIMARY KEY,
+    body text
+);
+INSERT INTO issue_4719_people (id, company_id, body) VALUES
+    (1, 10,   'hit'),
+    (2, 20,   'hit'),
+    (3, 30,   'hit'),
+    (4, NULL, 'hit'),
+    (5, 99,   'hit');
+INSERT INTO issue_4719_experiences (id, person_id, company_id, body) VALUES
+    (1, 2, 10, 'exp'),
+    (2, 5, 20, 'exp'),
+    (3, 3, 50, 'exp');
+INSERT INTO issue_4719_companies (id, body) VALUES
+    (10, 'co'), (20, 'co'), (30, 'co');
+CREATE INDEX issue_4719_people_idx
+    ON issue_4719_people
+    USING bm25 (id, company_id, body)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"company_id": {"fast": true}}',
+        text_fields = '{"body": {"fast": true}}'
+    );
+CREATE INDEX issue_4719_experiences_idx
+    ON issue_4719_experiences
+    USING bm25 (id, person_id, company_id, body)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"person_id": {"fast": true}, "company_id": {"fast": true}}',
+        text_fields = '{"body": {"fast": true}}'
+    );
+CREATE INDEX issue_4719_companies_idx
+    ON issue_4719_companies
+    USING bm25 (id, body)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"body": {"fast": true}}'
+    );
+ANALYZE issue_4719_people;
+ANALYZE issue_4719_experiences;
+ANALYZE issue_4719_companies;
+SET paradedb.enable_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 0;
+-- The failing query: NOT IN (SubPlan) + (IS NULL OR IN (SubPlan)).
+-- Before the fix, this errored during DataFusion logical plan building.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id
+         Relation Tree: (p ANTI x) LEFTMARK c
+         Join Cond: p.company_id = c.id, p.id = x.person_id
+         Join Predicate: (mark = true OR col IS NULL)
+         Limit: 26
+         Order By: p.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=26), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     FilterExec: mark@3 OR company_id@1 IS NULL, projection=[ctid_0@0, id@2]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftMark, on=[(company_id@1, id@1)]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@2, person_id@0)]
+           :           VisibilityFilterExec: tables=[p]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"term_set":{"terms":[{"field":"company_id","value":10,"is_datetime":false},{"field":"company_id","value":20,"is_datetime":false},{"field":"company_id","value":50,"is_datetime":false}]}}
+           :         VisibilityFilterExec: tables=[c]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+(23 rows)
+
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+ id 
+----
+  4
+  1
+(2 rows)
+
+-- Same query with JoinScan disabled, as a correctness cross-check.
+SET paradedb.enable_join_custom_scan TO off;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id
+   ->  Sort
+         Output: p.id
+         Sort Key: p.id DESC
+         ->  Seq Scan on public.issue_4719_people p
+               Output: p.id
+               Filter: ((NOT (ANY (p.id = (hashed SubPlan 1).col1))) AND ((p.company_id IS NULL) OR (ANY (p.company_id = (hashed SubPlan 2).col1))))
+               SubPlan 1
+                 ->  Seq Scan on public.issue_4719_experiences x
+                       Output: x.person_id
+                       Filter: (x.company_id = ANY ('{10,20,50}'::integer[]))
+               SubPlan 2
+                 ->  Seq Scan on public.issue_4719_companies c
+                       Output: c.id
+(15 rows)
+
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+ id 
+----
+  4
+  1
+(2 rows)
+
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE issue_4719_people CASCADE;
+DROP TABLE issue_4719_experiences CASCADE;
+DROP TABLE issue_4719_companies CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_4719.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4719.sql
@@ -1,0 +1,146 @@
+-- Regression test for https://github.com/paradedb/paradedb/issues/4719
+--
+-- JoinScan used to fail with:
+--   ERROR:  Failed to build DataFusion logical plan: Internal("Missing right join-key column")
+-- when a query combined `NOT IN (SELECT ...)` with a
+-- `(col IS NULL OR col IN (SELECT ...))` pattern on the same outer relation.
+--
+-- Each inner subplan is planned with its own PlannerInfo and numbers its
+-- range table starting from 1, so the inner relations collide with the outer
+-- relation's RTI. collect_required_fields used a flat `(rti, attno)` lookup
+-- that could match the wrong source, leaving the right-side join column
+-- unprojected — and execution later failed when resolving the join key.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS issue_4719_people CASCADE;
+DROP TABLE IF EXISTS issue_4719_experiences CASCADE;
+DROP TABLE IF EXISTS issue_4719_companies CASCADE;
+
+CREATE TABLE issue_4719_people (
+    id integer PRIMARY KEY,
+    company_id integer,
+    body text
+);
+
+CREATE TABLE issue_4719_experiences (
+    id integer PRIMARY KEY,
+    person_id integer,
+    company_id integer,
+    body text
+);
+
+CREATE TABLE issue_4719_companies (
+    id integer PRIMARY KEY,
+    body text
+);
+
+INSERT INTO issue_4719_people (id, company_id, body) VALUES
+    (1, 10,   'hit'),
+    (2, 20,   'hit'),
+    (3, 30,   'hit'),
+    (4, NULL, 'hit'),
+    (5, 99,   'hit');
+
+INSERT INTO issue_4719_experiences (id, person_id, company_id, body) VALUES
+    (1, 2, 10, 'exp'),
+    (2, 5, 20, 'exp'),
+    (3, 3, 50, 'exp');
+
+INSERT INTO issue_4719_companies (id, body) VALUES
+    (10, 'co'), (20, 'co'), (30, 'co');
+
+CREATE INDEX issue_4719_people_idx
+    ON issue_4719_people
+    USING bm25 (id, company_id, body)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"company_id": {"fast": true}}',
+        text_fields = '{"body": {"fast": true}}'
+    );
+
+CREATE INDEX issue_4719_experiences_idx
+    ON issue_4719_experiences
+    USING bm25 (id, person_id, company_id, body)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"person_id": {"fast": true}, "company_id": {"fast": true}}',
+        text_fields = '{"body": {"fast": true}}'
+    );
+
+CREATE INDEX issue_4719_companies_idx
+    ON issue_4719_companies
+    USING bm25 (id, body)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"body": {"fast": true}}'
+    );
+
+ANALYZE issue_4719_people;
+ANALYZE issue_4719_experiences;
+ANALYZE issue_4719_companies;
+
+SET paradedb.enable_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 0;
+
+-- The failing query: NOT IN (SubPlan) + (IS NULL OR IN (SubPlan)).
+-- Before the fix, this errored during DataFusion logical plan building.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+
+-- Same query with JoinScan disabled, as a correctness cross-check.
+SET paradedb.enable_join_custom_scan TO off;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+
+SELECT p.id
+FROM issue_4719_people p
+WHERE p.id NOT IN (
+    SELECT x.person_id
+    FROM issue_4719_experiences x
+    WHERE x.company_id IN (10, 20, 50)
+)
+  AND (p.company_id IS NULL
+       OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
+ORDER BY p.id DESC
+LIMIT 26;
+
+RESET paradedb.enable_join_custom_scan;
+
+DROP TABLE issue_4719_people CASCADE;
+DROP TABLE issue_4719_experiences CASCADE;
+DROP TABLE issue_4719_companies CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4719

## What

Replaces the flat `(rti, attno)` scan in `collect_required_fields` with a structural walk of the `RelNode` tree that resolves each `JoinKeyPair` against the specific `JoinNode` that owns it, using the same `resolve_against` logic the executor uses at runtime.

## Why

When JoinScan extracts SubPlans for patterns like `NOT IN (SELECT ...)` and `col IS NULL OR col IN (SELECT ...)`, each inner subquery gets its own `PlannerInfo` that numbers its range table independently — so the inner relations typically land at RTI 1 and collide with the outer relation's RTI. The previous flat scan addressed that by projecting the field onto every source that matched `(rti, attno)`, which is correct but over-projects columns that aren't actually needed by the key.

Binding each key to the exact `JoinSource` by `plan_position` is precise and lines up with how execution resolves the same keys via `JoinKeyPair::resolve_against`, so planning and execution stay in sync.

## How

- Adds `RelNode::join_key_projections()` in `joinscan/build.rs`, which walks the tree and for each `JoinNode` resolves its own `equi_keys` against its `left`/`right` subtrees, returning a list of `(plan_position, attno)` pairs.
- Rewrites `collect_required_fields` in `joinscan/planning.rs` to iterate those pairs and call `ensure_field` on the source identified by `plan_position`, dropping the `ensure_join_key_side` closure and the flat fallback.

## Tests

- New pg_regress test `issue_4719` covers the `NOT IN + OR IS NULL` SubPlan pattern, runs it with JoinScan both on and off, and captures the resulting `Relation Tree: (p ANTI x) LEFTMARK c` plan in the expected output.
- `cargo check --features pg18 -p pg_search` clean.
- `cargo pgrx regress --package pg_search --resetdb --auto pg18 issue_4719` → PASS.