### PR TITLE
fix: restore PVC_RECURSE_PLACEHOLDERS in JoinScan planning

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -50,6 +50,10 @@ use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_match
 use crate::schema::SearchIndexSchema;
 use pgrx::{pg_sys, PgList};
 
+const PVC_RECURSE_ALL: i32 = (pg_sys::PVC_RECURSE_AGGREGATES
+    | pg_sys::PVC_RECURSE_WINDOWFUNCS
+    | pg_sys::PVC_RECURSE_PLACEHOLDERS) as i32;
+
 /// Check if an expression uses paradedb.score() for any relation in the JoinSource.
 pub(super) unsafe fn expr_uses_scores_from_source(
     node: *mut pg_sys::Node,
@@ -1197,10 +1201,7 @@ unsafe fn pathkey_is_outer_only(
                 return false;
             }
         } else {
-            let var_list = pg_sys::pull_var_clause(
-                check_expr,
-                (pg_sys::PVC_RECURSE_AGGREGATES | pg_sys::PVC_RECURSE_WINDOWFUNCS) as i32,
-            );
+            let var_list = pg_sys::pull_var_clause(check_expr, PVC_RECURSE_ALL);
             let vars = PgList::<pg_sys::Var>::from_pg(var_list);
             for var_ptr in vars.iter_ptr() {
                 if source_rtis.contains(&((*var_ptr).varno as pg_sys::Index)) {
@@ -1319,10 +1320,7 @@ unsafe fn expression_vars_all_fast(expr: *mut pg_sys::Node, sources: &[&JoinSour
         return false;
     }
 
-    let var_list = pg_sys::pull_var_clause(
-        expr,
-        (pg_sys::PVC_RECURSE_AGGREGATES | pg_sys::PVC_RECURSE_WINDOWFUNCS) as i32,
-    );
+    let var_list = pg_sys::pull_var_clause(expr, PVC_RECURSE_ALL);
     let vars = PgList::<pg_sys::Var>::from_pg(var_list);
     if vars.is_empty() {
         return false;
@@ -1526,10 +1524,7 @@ pub(super) unsafe fn distinct_columns_are_fast_fields(
             return None;
         }
 
-        let var_list = pg_sys::pull_var_clause(
-            expr,
-            (pg_sys::PVC_RECURSE_AGGREGATES | pg_sys::PVC_RECURSE_WINDOWFUNCS) as i32,
-        );
+        let var_list = pg_sys::pull_var_clause(expr, PVC_RECURSE_ALL);
         let vars = PgList::<pg_sys::Var>::from_pg(var_list);
 
         if vars.is_empty() {

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -1,0 +1,154 @@
+-- Reproducer for "PlaceHolderVar found where not expected" error.
+-- A 3-way join with pdb.score() summed across all three tables and
+-- ORDER BY + LIMIT triggers PlaceHolderVar wrapping that the JoinScan
+-- custom scan tlist did not handle.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO off;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- =============================================================================
+-- SETUP: minimal 3-table docs schema
+-- =============================================================================
+DROP TABLE IF EXISTS pages CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+CREATE TABLE documents (
+    id TEXT PRIMARY KEY,
+    parents TEXT,
+    content TEXT,
+    title TEXT
+);
+CREATE TABLE files (
+    id TEXT PRIMARY KEY,
+    "documentId" TEXT,
+    content TEXT,
+    title TEXT
+);
+CREATE TABLE pages (
+    id TEXT PRIMARY KEY,
+    "fileId" TEXT,
+    content TEXT,
+    title TEXT
+);
+INSERT INTO documents (id, parents, content, title) VALUES
+('doc-1', 'project alpha notes', 'Document about project alpha', 'Alpha Doc'),
+('doc-2', 'project beta notes', 'Document about project beta', 'Beta Doc');
+INSERT INTO files (id, "documentId", content, title) VALUES
+('file-1', 'doc-1', 'File content for alpha', 'collab12 alpha file'),
+('file-2', 'doc-1', 'File content misc', 'collab12 misc file'),
+('file-3', 'doc-2', 'File content for beta', 'beta file');
+INSERT INTO pages (id, "fileId", content, title) VALUES
+('page-1', 'file-1', 'Single Number Reach configuration', 'Page A'),
+('page-2', 'file-1', 'Other page content', 'Page B'),
+('page-3', 'file-2', 'Single Number Reach details', 'Page C'),
+('page-4', 'file-3', 'Beta page content', 'Page D');
+CREATE INDEX pages_bm25 ON pages
+USING bm25 (id, content, title, "fileId")
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "fileId": {"tokenizer": {"type": "keyword"}, "fast": true},
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+CREATE INDEX files_bm25 ON files
+USING bm25 (id, content, "documentId", title)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "documentId": {"tokenizer": {"type": "keyword"}, "fast": true},
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+CREATE INDEX documents_bm25 ON documents
+USING bm25 (id, content, title, parents)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true},
+        "parents": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- TEST: 3-way join with summed scores and ORDER BY score DESC LIMIT
+-- This is the exact query pattern from the benchmark that triggers the error.
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.parents @@@ 'project alpha'
+  AND files.title @@@ 'collab12'
+  AND pages.content @@@ 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: documents, files, pages)
+                                                                                                                                               QUERY PLAN                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+   ->  Sort
+         Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id))))
+         Sort Key: ((((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))) DESC
+         ->  Nested Loop
+               Output: documents.id, documents.parents, documents.content, documents.title, files.id, files."documentId", files.content, files.title, pages.id, pages."fileId", pages.content, pages.title, (((paradedb.score(documents.id)) + (paradedb.score(files.id))) + (paradedb.score(pages.id)))
+               Inner Unique: true
+               Join Filter: (documents.id = files."documentId")
+               ->  Hash Join
+                     Output: files.id, files."documentId", files.content, files.title, (paradedb.score(files.id)), pages.id, pages."fileId", pages.content, pages.title, (paradedb.score(pages.id))
+                     Inner Unique: true
+                     Hash Cond: (pages."fileId" = files.id)
+                     ->  Custom Scan (ParadeDB Base Scan) on public.pages
+                           Output: pages.id, pages."fileId", pages.content, pages.title, paradedb.score(pages.id), paradedb.score(pages.id)
+                           Table: pages
+                           Index: pages_bm25
+                           Exec Method: NormalScanExecState
+                           Scores: true
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Single Number Reach","lenient":null,"conjunction_mode":null}}}}
+                     ->  Hash
+                           Output: files.id, files."documentId", files.content, files.title, (paradedb.score(files.id)), (paradedb.score(files.id))
+                           ->  Custom Scan (ParadeDB Base Scan) on public.files
+                                 Output: files.id, files."documentId", files.content, files.title, paradedb.score(files.id), paradedb.score(files.id)
+                                 Table: files
+                                 Index: files_bm25
+                                 Exec Method: NormalScanExecState
+                                 Scores: true
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"collab12","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.documents
+                     Output: documents.id, documents.parents, documents.content, documents.title, paradedb.score(documents.id), paradedb.score(documents.id)
+                     Table: documents
+                     Index: documents_bm25
+                     Exec Method: NormalScanExecState
+                     Scores: true
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"project alpha","lenient":null,"conjunction_mode":null}}}}
+(36 rows)
+
+SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.parents @@@ 'project alpha'
+  AND files.title @@@ 'collab12'
+  AND pages.content @@@ 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: documents, files, pages)
+  id   |       parents       |           content            |   title   |   id   | documentId |        content         |        title        |   id   | fileId |              content              | title  |   score   
+-------+---------------------+------------------------------+-----------+--------+------------+------------------------+---------------------+--------+--------+-----------------------------------+--------+-----------
+ doc-1 | project alpha notes | Document about project alpha | Alpha Doc | file-1 | doc-1      | File content for alpha | collab12 alpha file | page-1 | file-1 | Single Number Reach configuration | Page A | 3.2872329
+ doc-1 | project alpha notes | Document about project alpha | Alpha Doc | file-2 | doc-1      | File content misc      | collab12 misc file  | page-3 | file-2 | Single Number Reach details       | Page C | 3.2872329
+(2 rows)
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+DROP TABLE IF EXISTS pages CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_sortby_score.sql
@@ -1,0 +1,126 @@
+-- Reproducer for "PlaceHolderVar found where not expected" error.
+-- A 3-way join with pdb.score() summed across all three tables and
+-- ORDER BY + LIMIT triggers PlaceHolderVar wrapping that the JoinScan
+-- custom scan tlist did not handle.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO off;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- =============================================================================
+-- SETUP: minimal 3-table docs schema
+-- =============================================================================
+
+DROP TABLE IF EXISTS pages CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+
+CREATE TABLE documents (
+    id TEXT PRIMARY KEY,
+    parents TEXT,
+    content TEXT,
+    title TEXT
+);
+
+CREATE TABLE files (
+    id TEXT PRIMARY KEY,
+    "documentId" TEXT,
+    content TEXT,
+    title TEXT
+);
+
+CREATE TABLE pages (
+    id TEXT PRIMARY KEY,
+    "fileId" TEXT,
+    content TEXT,
+    title TEXT
+);
+
+INSERT INTO documents (id, parents, content, title) VALUES
+('doc-1', 'project alpha notes', 'Document about project alpha', 'Alpha Doc'),
+('doc-2', 'project beta notes', 'Document about project beta', 'Beta Doc');
+
+INSERT INTO files (id, "documentId", content, title) VALUES
+('file-1', 'doc-1', 'File content for alpha', 'collab12 alpha file'),
+('file-2', 'doc-1', 'File content misc', 'collab12 misc file'),
+('file-3', 'doc-2', 'File content for beta', 'beta file');
+
+INSERT INTO pages (id, "fileId", content, title) VALUES
+('page-1', 'file-1', 'Single Number Reach configuration', 'Page A'),
+('page-2', 'file-1', 'Other page content', 'Page B'),
+('page-3', 'file-2', 'Single Number Reach details', 'Page C'),
+('page-4', 'file-3', 'Beta page content', 'Page D');
+
+CREATE INDEX pages_bm25 ON pages
+USING bm25 (id, content, title, "fileId")
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "fileId": {"tokenizer": {"type": "keyword"}, "fast": true},
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+
+CREATE INDEX files_bm25 ON files
+USING bm25 (id, content, "documentId", title)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "documentId": {"tokenizer": {"type": "keyword"}, "fast": true},
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+
+CREATE INDEX documents_bm25 ON documents
+USING bm25 (id, content, title, parents)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "content": {"tokenizer": {"type": "default"}, "fast": true},
+        "title": {"tokenizer": {"type": "default"}, "fast": true},
+        "parents": {"tokenizer": {"type": "default"}, "fast": true}
+    }'
+);
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- TEST: 3-way join with summed scores and ORDER BY score DESC LIMIT
+-- This is the exact query pattern from the benchmark that triggers the error.
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.parents @@@ 'project alpha'
+  AND files.title @@@ 'collab12'
+  AND pages.content @@@ 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;
+
+SELECT *, paradedb.score(documents.id) + paradedb.score(files.id) + paradedb.score(pages.id) AS score
+FROM documents
+JOIN files ON documents.id = files."documentId"
+JOIN pages ON pages."fileId" = files.id
+WHERE documents.parents @@@ 'project alpha'
+  AND files.title @@@ 'collab12'
+  AND pages.content @@@ 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS pages CASCADE;
+DROP TABLE IF EXISTS files CASCADE;
+DROP TABLE IF EXISTS documents CASCADE;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;


### PR DESCRIPTION
## Summary

- PR #4687 accidentally reverted the fix from PR #4685 during merge conflict resolution, dropping `PVC_RECURSE_PLACEHOLDERS` from three `pull_var_clause` calls in `joinscan/planning.rs`
- Without this flag, 3-way join queries that `ORDER BY` summed `pdb.score()` values hit `PlaceHolderVar found where not expected` because `pull_var_clause` encounters `PlaceHolderVar` nodes and panics instead of recursing through them
- Restores the `PVC_RECURSE_ALL` constant and applies it to all three call sites: `pathkey_is_outer_only()`, `expression_vars_all_fast()`, `distinct_columns_are_fast_fields()`

## Test plan

- [ ] Existing `joinscan_sortby_score` regression test covers this exact scenario
- [ ] Run docs benchmarks with 25M+ row 3-way join query to confirm the error is resolved