### PR TITLE
ci: Update antithesis duration for pull requests to 60mins

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -155,6 +155,6 @@ jobs:
           description: "[${{ github.repository }}] CI for ${{ github.ref_name }} (commit ${{ github.sha }})"
           email_recipients: ${{ github.event.inputs.emails || 'developers@paradedb.com' }}
           additional_parameters: |-
-            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '30') || '480' }}
+            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '480' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We didn't find much bugs from 30 minutes. 60 is a better default for PRs.

## Why
^

## How
^

## Tests
^