### PR TITLE
docs: document aggregate pushdown across joins

### DIFF
--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -66,7 +66,7 @@ If your query does not contain a ParadeDB operator, a way to "force" aggregate p
 
 ## Join Support
 
-Aggregate pushdown works across joins as well as single tables. When every participating table has a BM25 index and the custom aggregate scan is enabled, ParadeDB lifts the aggregate into Apache DataFusion and computes the result directly from the index fast fields — no row materialization from the heap.
+Aggregate pushdown works across joins as well as single tables. When every participating table has a BM25 index and the custom aggregate scan is enabled, ParadeDB computes the result directly from the index's columnar storage, without scanning the underlying table rows.
 
 ```sql
 SET paradedb.enable_aggregate_custom_scan TO on;
@@ -88,16 +88,16 @@ The following join shapes are supported:
 ParadeDB falls back to native Postgres execution when any of the following are true:
 
 - One or more tables in the join lacks a BM25 index
-- The join has no equi-join key (e.g. `CROSS JOIN`)
-- Join keys, `GROUP BY` columns, or aggregate arguments are not fast fields
+- The join has no equality join condition (e.g. `CROSS JOIN`)
+- Join keys, `GROUP BY` columns, or aggregate arguments are not indexed columns
 - The query uses window functions (`OVER ...`), `ROLLUP`, `CUBE`, `GROUPING SETS`, `LATERAL`, or `DISTINCT ON`
 - `GROUP BY` uses a scalar function like `date_trunc(...)` or `lower(...)` (JSON sub-field access via `->>` is supported)
 - The aggregate argument is wrapped in an expression such as `COALESCE(...)` or a cast
 
-When a fallback happens, the query still runs correctly through Postgres' native planner — ParadeDB simply does not accelerate it.
+When a fallback happens, the query still runs correctly through Postgres' native planner. ParadeDB simply does not accelerate it.
 
 <Note>
-  Aggregate-on-join execution is currently single-threaded. Parallel execution is on the [roadmap](/welcome/roadmap).
+  Aggregate pushdown across joins is currently single-threaded. Parallel execution is on the [roadmap](/welcome/roadmap).
 </Note>
 
 ## NUMERIC Columns

--- a/docs/documentation/aggregates/limitations.mdx
+++ b/docs/documentation/aggregates/limitations.mdx
@@ -66,7 +66,39 @@ If your query does not contain a ParadeDB operator, a way to "force" aggregate p
 
 ## Join Support
 
-ParadeDB is currently only able to push down aggregates over a single table. JOINs are not yet pushed down but are on the [roadmap](/welcome/roadmap).
+Aggregate pushdown works across joins as well as single tables. When every participating table has a BM25 index and the custom aggregate scan is enabled, ParadeDB lifts the aggregate into Apache DataFusion and computes the result directly from the index fast fields — no row materialization from the heap.
+
+```sql
+SET paradedb.enable_aggregate_custom_scan TO on;
+```
+
+The following join shapes are supported:
+
+| Feature | Supported |
+| --- | --- |
+| Join types | `INNER`, `LEFT`, `RIGHT`, `FULL OUTER` |
+| Number of tables | Two or more (arbitrary join trees) |
+| Aggregate functions | `COUNT`, `COUNT(DISTINCT ...)`, `SUM`, `SUM(DISTINCT ...)`, `AVG`, `AVG(DISTINCT ...)`, `MIN`, `MAX`, `STDDEV`, `STDDEV_POP`, `VARIANCE`, `VAR_POP`, `BOOL_AND`, `BOOL_OR`, `ARRAY_AGG`, `STRING_AGG` |
+| `GROUP BY` | Columns from any table in the join, including JSON sub-fields via `metadata->>'key'` |
+| `HAVING` clause | Comparisons against aggregate results and group columns |
+| Per-aggregate `FILTER (WHERE ...)` | Yes |
+| `ORDER BY ... LIMIT K` | Pushed down as TopK when the sort target is an aggregate, a group column, or `MIN(col)` / `MAX(col)` |
+| `ORDER BY` inside `STRING_AGG` / `ARRAY_AGG` | Yes (produces deterministic element ordering) |
+
+ParadeDB falls back to native Postgres execution when any of the following are true:
+
+- One or more tables in the join lacks a BM25 index
+- The join has no equi-join key (e.g. `CROSS JOIN`)
+- Join keys, `GROUP BY` columns, or aggregate arguments are not fast fields
+- The query uses window functions (`OVER ...`), `ROLLUP`, `CUBE`, `GROUPING SETS`, `LATERAL`, or `DISTINCT ON`
+- `GROUP BY` uses a scalar function like `date_trunc(...)` or `lower(...)` (JSON sub-field access via `->>` is supported)
+- The aggregate argument is wrapped in an expression such as `COALESCE(...)` or a cast
+
+When a fallback happens, the query still runs correctly through Postgres' native planner — ParadeDB simply does not accelerate it.
+
+<Note>
+  Aggregate-on-join execution is currently single-threaded. Parallel execution is on the [roadmap](/welcome/roadmap).
+</Note>
 
 ## NUMERIC Columns
 

--- a/docs/documentation/joins/overview.mdx
+++ b/docs/documentation/joins/overview.mdx
@@ -47,7 +47,6 @@ Join pushdown is automatically used when a query meets several conditions. If an
 | Equi-join key       | The join must contain at least one equality condition such as `a.id = b.id`.                                                                                 |
 | Indexed fields      | All join keys, filters, and `ORDER BY` columns must be present in the BM25 index. Text and JSON fields must be [columnar](/documentation/indexing/columnar). |
 | LIMIT clause        | The query must include a `LIMIT`.                                                                                                                            |
-| No aggregates       | Queries containing aggregates (`GROUP BY`, `COUNT`, etc.) are not currently supported.                                                                       |
 
 If any checks fail, ParadeDB will emit a `NOTICE` explaining why and fall back to Postgres' native join execution.
 

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -26,7 +26,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 ### Deeper Analytics Improvements
 
 - **Push Postgres visibility rules into the index**. This is currently a filter applied post index scan that adds overhead to large scans.
-- **DataFusion-powered aggregates**. Migrate aggregate query execution from Tantivy to Apache DataFusion to broaden SQL aggregate coverage and improve performance.
+- **Parallel aggregate execution**. Aggregate-on-join currently runs single-threaded on the DataFusion path. Two-phase parallel aggregation (partial + final) will unlock multi-core execution for high-cardinality GROUP BY on joined tables.
 
 ### Vector Search Improvements
 
@@ -40,8 +40,8 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 
 ### Analytics
 
-- **A custom scan node for aggregates**. This will allow "plain SQL" aggregates to go through the same fast execution path as
-  our [aggregate UDFs](/documentation/aggregates/tantivy), further accelerating aggregates like `COUNT`, and SQL clauses like `GROUP BY`.
+- **A custom scan node for aggregates**. Plain SQL aggregates like `COUNT`, and clauses like `GROUP BY`, go through the same fast execution path as our [aggregate UDFs](/documentation/aggregates/tantivy).
+- **Aggregate pushdown across joins**. Aggregates over multi-table joins are executed via Apache DataFusion when every joined table has a BM25 index.
 
 ### Write Throughput
 

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -26,7 +26,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 ### Deeper Analytics Improvements
 
 - **Push Postgres visibility rules into the index**. This is currently a filter applied post index scan that adds overhead to large scans.
-- **Parallel aggregate execution**. Aggregate-on-join currently runs single-threaded on the DataFusion path. Two-phase parallel aggregation (partial + final) will unlock multi-core execution for high-cardinality GROUP BY on joined tables.
+- **Parallel aggregate execution**. Aggregate pushdown across joins currently runs single-threaded. Two-phase parallel aggregation (partial + final) will unlock multi-core execution for high-cardinality GROUP BY on joined tables.
 
 ### Vector Search Improvements
 
@@ -41,7 +41,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 ### Analytics
 
 - **A custom scan node for aggregates**. Plain SQL aggregates like `COUNT`, and clauses like `GROUP BY`, go through the same fast execution path as our [aggregate UDFs](/documentation/aggregates/tantivy).
-- **Aggregate pushdown across joins**. Aggregates over multi-table joins are executed via Apache DataFusion when every joined table has a BM25 index.
+- **Aggregate pushdown across joins**. Aggregates over multi-table joins are pushed down into the index when every joined table has a BM25 index.
 
 ### Write Throughput
 


### PR DESCRIPTION
## What

Updates the user-facing documentation to reflect that custom aggregate scan now executes aggregates over multi-table joins via Apache DataFusion.

## Why

Documentation.

## Tests

Docs-only change. No code paths touched, no tests required.