### PR TITLE
refactor: round 3 — long-function splits in JoinScan and AggregateScan

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -49,7 +49,9 @@ use crate::postgres::customscan::aggregatescan::datafusion_exec::{
     build_join_aggregate_plan, create_aggregate_session_context,
 };
 use crate::postgres::customscan::aggregatescan::datafusion_project::project_aggregate_row_to_slot;
-use crate::postgres::customscan::aggregatescan::exec::aggregation_results_iter;
+use crate::postgres::customscan::aggregatescan::exec::{
+    aggregation_results_iter, AggregationResultsRow,
+};
 use crate::postgres::customscan::aggregatescan::groupby::GroupByClause;
 use crate::postgres::customscan::aggregatescan::join_targetlist::extract_aggregate_targetlist;
 use crate::postgres::customscan::aggregatescan::privdat::PrivateData;
@@ -513,273 +515,10 @@ impl CustomScan for AggregateScan {
     }
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
-        // DataFusion backend: consume Arrow RecordBatches
         if state.custom_state().is_datafusion_backend() {
-            return Self::exec_datafusion_aggregate(state);
-        }
-
-        // Tantivy backend: existing path
-        let next = match &mut state.custom_state_mut().state {
-            ExecutionState::Completed => {
-                return std::ptr::null_mut();
-            }
-            ExecutionState::NotStarted => {
-                // Execute the aggregate, and change the state to Emitting.
-                let mut row_iter = aggregation_results_iter(state);
-                let next = row_iter.next();
-                state.custom_state_mut().state = ExecutionState::Emitting(row_iter);
-                next
-            }
-            ExecutionState::Emitting(row_iter) => {
-                // Emit the next row.
-                row_iter.next()
-            }
-        };
-
-        let Some(row) = next else {
-            state.custom_state_mut().state = ExecutionState::Completed;
-            return std::ptr::null_mut();
-        };
-
-        unsafe {
-            let tupdesc = PgTupleDesc::from_pg_unchecked((*state.planstate()).ps_ResultTupleDesc);
-            // Use the reusable slot created in begin_custom_scan to avoid per-row memory leaks
-            let slot = state
-                .custom_state()
-                .scan_slot
-                .expect("scan_slot should be initialized in begin_custom_scan");
-            pg_sys::ExecClearTuple(slot);
-
-            let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
-            let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
-            let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
-
-            let mut aggregates = row.aggregates.clone().into_iter();
-            let mut natts_processed = 0;
-
-            // Fill in values according to the target list
-            for (i, entry) in state.custom_state().aggregate_clause.entries().enumerate() {
-                let attr = tupdesc.get(i).expect("missing attribute");
-                let expected_typoid = attr.type_oid().value();
-
-                let datum = match (entry, row.is_empty()) {
-                    (TargetListEntry::GroupingColumn(gc_idx), false) => {
-                        let key = row.group_keys[*gc_idx].clone();
-                        // Check if this is a NULL sentinel (handles both MIN and MAX sentinels).
-                        // U64 uses string sentinel for MIN (since 0 is valid); u64::MAX for MAX.
-                        // Bool uses string sentinels for both MIN and MAX.
-                        // DateTime columns don't have a missing sentinel (NULLs are excluded).
-                        let is_datetime = is_datetime_type(expected_typoid);
-                        let is_null_sentinel = match &key.0 {
-                            OwnedValue::Str(s) => s == NULL_SENTINEL_MIN || s == NULL_SENTINEL_MAX,
-                            OwnedValue::I64(v) => *v == i64::MAX || *v == i64::MIN,
-                            OwnedValue::U64(v) => *v == u64::MAX,
-                            OwnedValue::F64(v) => *v == f64::MAX || *v == f64::MIN,
-                            _ => false,
-                        };
-                        if is_null_sentinel {
-                            None
-                        } else if is_datetime {
-                            // For datetime types, Tantivy's terms aggregation returns the date as
-                            // an ISO 8601 string (e.g., "2025-12-26T00:00:00Z"). We need to parse
-                            // this string and convert it to the appropriate PostgreSQL date type.
-                            match &key.0 {
-                                OwnedValue::Str(date_str) => {
-                                    // Parse ISO 8601 datetime string using chrono
-                                    match date_str.parse::<ChronoDateTime<Utc>>() {
-                                        Ok(chrono_dt) => {
-                                            // Convert to nanoseconds since epoch for Tantivy DateTime
-                                            let nanos =
-                                                chrono_dt.timestamp_nanos_opt().unwrap_or(0);
-                                            let datetime =
-                                                tantivy::DateTime::from_timestamp_nanos(nanos);
-                                            TantivyValue(OwnedValue::Date(datetime))
-                                                .try_into_datum(pgrx::PgOid::from(expected_typoid))
-                                                .expect(
-                                                    "should be able to convert datetime to datum",
-                                                )
-                                        }
-                                        Err(e) => {
-                                            pgrx::error!(
-                                                "Failed to parse datetime string '{}': {}",
-                                                date_str,
-                                                e
-                                            );
-                                        }
-                                    }
-                                }
-                                OwnedValue::I64(nanos) => {
-                                    // Fallback for I64 (nanoseconds timestamp)
-                                    let datetime = tantivy::DateTime::from_timestamp_nanos(*nanos);
-                                    TantivyValue(OwnedValue::Date(datetime))
-                                        .try_into_datum(pgrx::PgOid::from(expected_typoid))
-                                        .expect("should be able to convert datetime to datum")
-                                }
-                                _ => key
-                                    .try_into_datum(pgrx::PgOid::from(expected_typoid))
-                                    .expect("should be able to convert to datum"),
-                            }
-                        } else {
-                            key.try_into_datum(pgrx::PgOid::from(expected_typoid))
-                                .expect("should be able to convert to datum")
-                        }
-                    }
-                    (TargetListEntry::GroupingColumn(_), true) => None,
-                    (TargetListEntry::Aggregate(agg_type), false) => {
-                        if agg_type.can_use_doc_count()
-                            && !state.custom_state().aggregate_clause.has_filter()
-                            && state.custom_state().aggregate_clause.has_groupby()
-                        {
-                            row.doc_count()
-                                .try_into_datum(pgrx::PgOid::from(expected_typoid))
-                                .expect("should be able to convert to datum")
-                        } else {
-                            exec::aggregate_result_to_datum(
-                                aggregates.next().and_then(|v| v),
-                                agg_type,
-                                expected_typoid,
-                            )
-                        }
-                    }
-                    (TargetListEntry::Aggregate(agg_type), true) => {
-                        agg_type.nullish().value.and_then(|value| {
-                            TantivyValue(OwnedValue::F64(value))
-                                .try_into_datum(expected_typoid.into())
-                                .unwrap()
-                        })
-                    }
-                };
-
-                if let Some(datum) = datum {
-                    datums[i] = datum;
-                    isnull[i] = false;
-                } else {
-                    datums[i] = pg_sys::Datum::null();
-                    isnull[i] = true;
-                }
-
-                natts_processed += 1;
-            }
-
-            assert_eq!(natts, natts_processed, "target list length mismatch",);
-
-            // Simple finalization - just set the flags and return the slot (no ExecStoreVirtualTuple needed)
-            // Note: We don't set TTS_FLAG_SHOULDFREE since we're reusing this slot across rows
-            (*slot).tts_flags &= !(pg_sys::TTS_FLAG_EMPTY as u16);
-            (*slot).tts_nvalid = natts as i16;
-
-            // If we have wrapped aggregates, project the expressions using basescan pattern:
-            // 1. Mutate Const nodes with actual aggregate values (directly, not from slot)
-            // 2. Build projection in per-tuple memory context (bakes Const values in)
-            // 3. ExecProject
-            // Snapshot the projection state into locals so the immutable borrow
-            // on `state.custom_state()` ends before the mutable `state.planstate()`
-            // call below. The targetlist is a raw pointer (Copy) and the const-node
-            // vec is small (one entry per output column).
-            let projection_snapshot: Option<(*mut pg_sys::List, Vec<Option<*mut pg_sys::Const>>)> =
-                state
-                    .custom_state()
-                    .wrapped_projection
-                    .as_ref()
-                    .map(|w| (w.targetlist, w.const_nodes.clone()));
-            if let Some((placeholder_tlist, const_nodes)) = projection_snapshot {
-                let planstate = state.planstate();
-                let expr_context = (*planstate).ps_ExprContext;
-
-                // Switch to per-tuple memory context and reset it to avoid memory leaks
-                // from ExecBuildProjectionInfo allocations and wrapper functions
-                let mut per_tuple_context =
-                    PgMemoryContexts::For((*expr_context).ecxt_per_tuple_memory);
-                per_tuple_context.reset();
-
-                // Mutate Const nodes with values directly from the row results.
-                // We DON'T use the slot's datums for aggregates because those were converted
-                // using the output tuple descriptor's types (e.g., TEXT for jsonb_pretty output),
-                // but we need the native aggregate type (e.g., JSONB for pdb.agg).
-                // This matches basescan's approach of setting Const values directly.
-                let mut agg_iter = row.aggregates.iter();
-                for (i, entry) in state.custom_state().aggregate_clause.entries().enumerate() {
-                    let Some(const_node) = const_nodes.get(i).copied().flatten() else {
-                        // No Const node for this entry, skip the aggregate iterator if it's an aggregate
-                        if matches!(entry, TargetListEntry::Aggregate(_)) {
-                            agg_iter.next();
-                        }
-                        continue;
-                    };
-
-                    let (datum, is_null) = match entry {
-                        TargetListEntry::Aggregate(agg_type) => {
-                            // Get the next aggregate result
-                            let agg_result = agg_iter.next().and_then(|v| v.clone());
-
-                            // Convert to datum using the Const node's type (native aggregate type)
-                            // not the output tuple descriptor's type
-                            if row.is_empty() {
-                                // Empty result - use nullish value
-                                let nullish_datum = agg_type.nullish().value.and_then(|value| {
-                                    TantivyValue(OwnedValue::F64(value))
-                                        .try_into_datum((*const_node).consttype.into())
-                                        .unwrap()
-                                });
-                                (
-                                    nullish_datum.unwrap_or(pg_sys::Datum::null()),
-                                    nullish_datum.is_none(),
-                                )
-                            } else if agg_type.can_use_doc_count()
-                                && !state.custom_state().aggregate_clause.has_filter()
-                                && state.custom_state().aggregate_clause.has_groupby()
-                            {
-                                let d = row
-                                    .doc_count()
-                                    .try_into_datum(pgrx::PgOid::from((*const_node).consttype));
-                                match d {
-                                    Ok(Some(datum)) => (datum, false),
-                                    _ => (pg_sys::Datum::null(), true),
-                                }
-                            } else {
-                                // Use the native aggregate result type (from the Const node)
-                                let d = exec::aggregate_result_to_datum(
-                                    agg_result,
-                                    agg_type,
-                                    (*const_node).consttype, // Use Const's type, not output type
-                                );
-                                match d {
-                                    Some(datum) => (datum, false),
-                                    None => (pg_sys::Datum::null(), true),
-                                }
-                            }
-                        }
-                        TargetListEntry::GroupingColumn(_) => {
-                            debug_assert!(
-                                i < natts,
-                                "aggregate clause entry index out of bounds for tuple descriptor"
-                            );
-                            (datums[i], isnull[i])
-                        }
-                    };
-
-                    (*const_node).constvalue = datum;
-                    (*const_node).constisnull = is_null;
-                }
-
-                // Set the scan tuple for expression evaluation context
-                (*expr_context).ecxt_scantuple = slot;
-
-                // Build projection and execute in per-tuple memory context (basescan pattern)
-                // This ensures ExecBuildProjectionInfo allocations are cleaned up each row
-                return per_tuple_context.switch_to(|_| {
-                    let proj_info = pg_sys::ExecBuildProjectionInfo(
-                        placeholder_tlist,
-                        expr_context,
-                        (*planstate).ps_ResultTupleSlot,
-                        planstate,
-                        (*slot).tts_tupleDescriptor,
-                    );
-                    pg_sys::ExecProject(proj_info)
-                });
-            }
-
-            slot
+            Self::exec_datafusion_aggregate(state)
+        } else {
+            Self::exec_tantivy_aggregate(state)
         }
     }
 
@@ -1061,6 +800,180 @@ impl AggregateScan {
         Ok(custom_path)
     }
 
+    /// Execute the Tantivy aggregate path: drive the existing
+    /// `aggregation_results_iter` one row at a time, fill the scan slot, and
+    /// optionally project wrapped aggregates on top.
+    fn exec_tantivy_aggregate(
+        state: &mut CustomScanStateWrapper<Self>,
+    ) -> *mut pg_sys::TupleTableSlot {
+        let Some(row) = Self::advance_tantivy_state(state) else {
+            return std::ptr::null_mut();
+        };
+
+        unsafe {
+            let tupdesc = PgTupleDesc::from_pg_unchecked((*state.planstate()).ps_ResultTupleDesc);
+            // Use the reusable slot created in begin_custom_scan to avoid per-row memory leaks
+            let slot = state
+                .custom_state()
+                .scan_slot
+                .expect("scan_slot should be initialized in begin_custom_scan");
+            pg_sys::ExecClearTuple(slot);
+
+            fill_slot_from_row(slot, &tupdesc, &row, &state.custom_state().aggregate_clause);
+
+            Self::project_wrapped_aggregates(state, slot, &row)
+        }
+    }
+
+    /// Drive the Tantivy execution state machine: lazily kick off the
+    /// aggregate iterator on the first call, return the next row on
+    /// subsequent calls, and transition to `Completed` when the iterator
+    /// is exhausted.
+    fn advance_tantivy_state(
+        state: &mut CustomScanStateWrapper<Self>,
+    ) -> Option<AggregationResultsRow> {
+        let row = match &mut state.custom_state_mut().state {
+            ExecutionState::Completed => return None,
+            ExecutionState::NotStarted => {
+                // Execute the aggregate, and change the state to Emitting.
+                let mut row_iter = aggregation_results_iter(state);
+                let first = row_iter.next();
+                state.custom_state_mut().state = ExecutionState::Emitting(row_iter);
+                first
+            }
+            ExecutionState::Emitting(row_iter) => row_iter.next(),
+        };
+        if row.is_none() {
+            state.custom_state_mut().state = ExecutionState::Completed;
+        }
+        row
+    }
+
+    /// If `wrapped_projection` is set on the scan state, mutate the
+    /// pre-baked Const nodes with the row's native aggregate values, switch
+    /// into the per-tuple memory context, and `ExecProject` to materialize
+    /// the wrapped expressions. Returns the projected slot. When no wrapped
+    /// projection is configured, returns the input slot unchanged.
+    unsafe fn project_wrapped_aggregates(
+        state: &mut CustomScanStateWrapper<Self>,
+        slot: *mut pg_sys::TupleTableSlot,
+        row: &AggregationResultsRow,
+    ) -> *mut pg_sys::TupleTableSlot {
+        // Snapshot the projection state into locals so the immutable borrow
+        // on `state.custom_state()` ends before the mutable `state.planstate()`
+        // call below. The targetlist is a raw pointer (Copy) and the const-node
+        // vec is small (one entry per output column).
+        let projection_snapshot: Option<(*mut pg_sys::List, Vec<Option<*mut pg_sys::Const>>)> =
+            state
+                .custom_state()
+                .wrapped_projection
+                .as_ref()
+                .map(|w| (w.targetlist, w.const_nodes.clone()));
+        let Some((placeholder_tlist, const_nodes)) = projection_snapshot else {
+            return slot;
+        };
+
+        let planstate = state.planstate();
+        let expr_context = (*planstate).ps_ExprContext;
+
+        // Switch to per-tuple memory context and reset it to avoid memory leaks
+        // from ExecBuildProjectionInfo allocations and wrapper functions
+        let mut per_tuple_context = PgMemoryContexts::For((*expr_context).ecxt_per_tuple_memory);
+        per_tuple_context.reset();
+
+        // Read the slot's already-filled datums for the GroupingColumn fallback
+        // arm in the loop below.
+        let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
+        let datums = std::slice::from_raw_parts((*slot).tts_values, natts);
+        let isnull = std::slice::from_raw_parts((*slot).tts_isnull, natts);
+
+        // Mutate Const nodes with values directly from the row results.
+        // We DON'T use the slot's datums for aggregates because those were converted
+        // using the output tuple descriptor's types (e.g., TEXT for jsonb_pretty output),
+        // but we need the native aggregate type (e.g., JSONB for pdb.agg).
+        // This matches basescan's approach of setting Const values directly.
+        let mut agg_iter = row.aggregates.iter();
+        for (i, entry) in state.custom_state().aggregate_clause.entries().enumerate() {
+            let Some(const_node) = const_nodes.get(i).copied().flatten() else {
+                // No Const node for this entry, skip the aggregate iterator if it's an aggregate
+                if matches!(entry, TargetListEntry::Aggregate(_)) {
+                    agg_iter.next();
+                }
+                continue;
+            };
+
+            let (datum, is_null) = match entry {
+                TargetListEntry::Aggregate(agg_type) => {
+                    // Get the next aggregate result
+                    let agg_result = agg_iter.next().and_then(|v| v.clone());
+
+                    // Convert to datum using the Const node's type (native aggregate type)
+                    // not the output tuple descriptor's type
+                    if row.is_empty() {
+                        // Empty result - use nullish value
+                        let nullish_datum = agg_type.nullish().value.and_then(|value| {
+                            TantivyValue(OwnedValue::F64(value))
+                                .try_into_datum((*const_node).consttype.into())
+                                .unwrap()
+                        });
+                        (
+                            nullish_datum.unwrap_or(pg_sys::Datum::null()),
+                            nullish_datum.is_none(),
+                        )
+                    } else if agg_type.can_use_doc_count()
+                        && !state.custom_state().aggregate_clause.has_filter()
+                        && state.custom_state().aggregate_clause.has_groupby()
+                    {
+                        let d = row
+                            .doc_count()
+                            .try_into_datum(pgrx::PgOid::from((*const_node).consttype));
+                        match d {
+                            Ok(Some(datum)) => (datum, false),
+                            _ => (pg_sys::Datum::null(), true),
+                        }
+                    } else {
+                        // Use the native aggregate result type (from the Const node)
+                        let d = exec::aggregate_result_to_datum(
+                            agg_result,
+                            agg_type,
+                            (*const_node).consttype, // Use Const's type, not output type
+                        );
+                        match d {
+                            Some(datum) => (datum, false),
+                            None => (pg_sys::Datum::null(), true),
+                        }
+                    }
+                }
+                TargetListEntry::GroupingColumn(_) => {
+                    debug_assert!(
+                        i < natts,
+                        "aggregate clause entry index out of bounds for tuple descriptor"
+                    );
+                    (datums[i], isnull[i])
+                }
+            };
+
+            (*const_node).constvalue = datum;
+            (*const_node).constisnull = is_null;
+        }
+
+        // Set the scan tuple for expression evaluation context
+        (*expr_context).ecxt_scantuple = slot;
+
+        // Build projection and execute in per-tuple memory context (basescan pattern)
+        // This ensures ExecBuildProjectionInfo allocations are cleaned up each row
+        per_tuple_context.switch_to(|_| {
+            let proj_info = pg_sys::ExecBuildProjectionInfo(
+                placeholder_tlist,
+                expr_context,
+                (*planstate).ps_ResultTupleSlot,
+                planstate,
+                (*slot).tts_tupleDescriptor,
+            );
+            pg_sys::ExecProject(proj_info)
+        })
+    }
+
     /// Execute the DataFusion aggregate path: build plan, consume Arrow batches,
     /// project each row to a Postgres TupleTableSlot.
     fn exec_datafusion_aggregate(
@@ -1170,6 +1083,149 @@ impl AggregateScan {
                 }
             }
         }
+    }
+}
+
+/// Fill the scan slot's `tts_values` / `tts_isnull` arrays from a single
+/// `AggregationResultsRow`. Walks the aggregate clause's target list once and
+/// dispatches to one of four shapes:
+///
+/// 1. `GroupingColumn` with a non-empty row → decode the group key (handles
+///    NULL sentinels and ISO-8601 datetime parsing) via [`group_key_to_datum`].
+/// 2. `GroupingColumn` with an empty row → NULL.
+/// 3. `Aggregate` with a non-empty row → either reuse the doc-count fast
+///    path or convert the next aggregate result to a Postgres datum.
+/// 4. `Aggregate` with an empty row → use the agg type's `nullish` value.
+///
+/// Finalizes by setting `tts_flags` and `tts_nvalid` so the slot is in the
+/// "virtual tuple stored" state.
+unsafe fn fill_slot_from_row(
+    slot: *mut pg_sys::TupleTableSlot,
+    tupdesc: &PgTupleDesc<'_>,
+    row: &AggregationResultsRow,
+    aggregate_clause: &AggregateCSClause,
+) {
+    let natts = (*(*slot).tts_tupleDescriptor).natts as usize;
+    let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
+    let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
+
+    let mut aggregates = row.aggregates.clone().into_iter();
+    let mut natts_processed = 0;
+
+    // Fill in values according to the target list
+    for (i, entry) in aggregate_clause.entries().enumerate() {
+        let attr = tupdesc.get(i).expect("missing attribute");
+        let expected_typoid = attr.type_oid().value();
+
+        let datum = match (entry, row.is_empty()) {
+            (TargetListEntry::GroupingColumn(gc_idx), false) => {
+                group_key_to_datum(row.group_keys[*gc_idx].clone(), expected_typoid)
+            }
+            (TargetListEntry::GroupingColumn(_), true) => None,
+            (TargetListEntry::Aggregate(agg_type), false) => {
+                if agg_type.can_use_doc_count()
+                    && !aggregate_clause.has_filter()
+                    && aggregate_clause.has_groupby()
+                {
+                    row.doc_count()
+                        .try_into_datum(pgrx::PgOid::from(expected_typoid))
+                        .expect("should be able to convert to datum")
+                } else {
+                    exec::aggregate_result_to_datum(
+                        aggregates.next().and_then(|v| v),
+                        agg_type,
+                        expected_typoid,
+                    )
+                }
+            }
+            (TargetListEntry::Aggregate(agg_type), true) => {
+                agg_type.nullish().value.and_then(|value| {
+                    TantivyValue(OwnedValue::F64(value))
+                        .try_into_datum(expected_typoid.into())
+                        .unwrap()
+                })
+            }
+        };
+
+        if let Some(datum) = datum {
+            datums[i] = datum;
+            isnull[i] = false;
+        } else {
+            datums[i] = pg_sys::Datum::null();
+            isnull[i] = true;
+        }
+
+        natts_processed += 1;
+    }
+
+    assert_eq!(natts, natts_processed, "target list length mismatch",);
+
+    // Simple finalization - just set the flags and return the slot (no
+    // ExecStoreVirtualTuple needed). Note: we don't set TTS_FLAG_SHOULDFREE
+    // since we're reusing this slot across rows.
+    (*slot).tts_flags &= !(pg_sys::TTS_FLAG_EMPTY as u16);
+    (*slot).tts_nvalid = natts as i16;
+}
+
+/// Convert a Tantivy group key to a Postgres datum, handling NULL sentinels
+/// (used for I64/U64/F64/Bool when the aggregator omits a row) and the
+/// datetime decoding path (Tantivy returns ISO-8601 strings; we parse them
+/// with chrono and re-pack as `tantivy::DateTime` before round-tripping
+/// through `try_into_datum`).
+///
+/// Returns `None` for NULL sentinels; otherwise the converted datum.
+unsafe fn group_key_to_datum(
+    key: TantivyValue,
+    expected_typoid: pg_sys::Oid,
+) -> Option<pg_sys::Datum> {
+    // Check if this is a NULL sentinel (handles both MIN and MAX sentinels).
+    // U64 uses string sentinel for MIN (since 0 is valid); u64::MAX for MAX.
+    // Bool uses string sentinels for both MIN and MAX.
+    // DateTime columns don't have a missing sentinel (NULLs are excluded).
+    let is_null_sentinel = match &key.0 {
+        OwnedValue::Str(s) => s == NULL_SENTINEL_MIN || s == NULL_SENTINEL_MAX,
+        OwnedValue::I64(v) => *v == i64::MAX || *v == i64::MIN,
+        OwnedValue::U64(v) => *v == u64::MAX,
+        OwnedValue::F64(v) => *v == f64::MAX || *v == f64::MIN,
+        _ => false,
+    };
+    if is_null_sentinel {
+        return None;
+    }
+
+    if !is_datetime_type(expected_typoid) {
+        return key
+            .try_into_datum(pgrx::PgOid::from(expected_typoid))
+            .expect("should be able to convert to datum");
+    }
+
+    // For datetime types, Tantivy's terms aggregation returns the date as
+    // an ISO 8601 string (e.g., "2025-12-26T00:00:00Z"). We need to parse
+    // this string and convert it to the appropriate PostgreSQL date type.
+    match &key.0 {
+        OwnedValue::Str(date_str) => match date_str.parse::<ChronoDateTime<Utc>>() {
+            Ok(chrono_dt) => {
+                // Convert to nanoseconds since epoch for Tantivy DateTime
+                let nanos = chrono_dt.timestamp_nanos_opt().unwrap_or(0);
+                let datetime = tantivy::DateTime::from_timestamp_nanos(nanos);
+                TantivyValue(OwnedValue::Date(datetime))
+                    .try_into_datum(pgrx::PgOid::from(expected_typoid))
+                    .expect("should be able to convert datetime to datum")
+            }
+            Err(e) => {
+                pgrx::error!("Failed to parse datetime string '{}': {}", date_str, e);
+            }
+        },
+        OwnedValue::I64(nanos) => {
+            // Fallback for I64 (nanoseconds timestamp)
+            let datetime = tantivy::DateTime::from_timestamp_nanos(*nanos);
+            TantivyValue(OwnedValue::Date(datetime))
+                .try_into_datum(pgrx::PgOid::from(expected_typoid))
+                .expect("should be able to convert datetime to datum")
+        }
+        _ => key
+            .try_into_datum(pgrx::PgOid::from(expected_typoid))
+            .expect("should be able to convert to datum"),
     }
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -858,232 +858,36 @@ impl CustomScan for JoinScan {
 
         unsafe {
             // For joins, we need to set custom_scan_tlist to describe the output columns.
-            // Create a fresh copy of the target list to avoid corrupting the original
+            // Create a fresh copy of the target list to avoid corrupting the original.
             let original_tlist = node.scan.plan.targetlist;
             let copied_tlist = pg_sys::copyObjectImpl(original_tlist.cast()).cast::<pg_sys::List>();
             let tlist = PgList::<pg_sys::TargetEntry>::from_pg(copied_tlist);
 
             // For join custom scans, PostgreSQL doesn't pass clauses via the usual parameter.
-            // We stored the restrictlist in custom_private during create_custom_path
+            // We stored the restrictlist in custom_private during create_custom_path.
             //
             // Note: We do NOT add restrictlist clauses to custom_exprs because setrefs would try
             // to resolve their Vars using the child plans' target lists, which may not have all
             // the needed columns. Instead, we keep the restrictlist in custom_private and handle
-            // join condition evaluation manually during execution using the original Var references.
+            // join condition evaluation manually during execution using the original Var
+            // references.
 
-            // Extract the column mappings from the ORIGINAL targetlist (before we add restrictlist Vars).
-            // The original_tlist has the SELECT's output columns, which is what ps_ResultTupleSlot is based on.
-            // We store this mapping in PrivateData so build_result_tuple can use it during execution.
-            let mut output_columns = Vec::new();
+            // Extract the column mappings from the ORIGINAL targetlist (before we add restrictlist
+            // Vars). The original_tlist has the SELECT's output columns, which is what
+            // ps_ResultTupleSlot is based on. We store this mapping in PrivateData so
+            // build_result_tuple can use it during execution.
             let mut private_data = PrivateData::from(node.custom_private);
             let original_entries = PgList::<pg_sys::TargetEntry>::from_pg(original_tlist);
 
-            for te in original_entries.iter_ptr() {
-                if (*(*te).expr).type_ == pg_sys::NodeTag::T_Var {
-                    let var = (*te).expr as *mut pg_sys::Var;
-                    let rti = (*var).varno as pg_sys::Index;
-                    let attno = (*var).varattno;
-                    if let Some(plan_position) =
-                        private_data
-                            .join_clause
-                            .plan_position(root.into(), rti, attno)
-                    {
-                        output_columns.push(privdat::OutputColumnInfo::Var {
-                            plan_position,
-                            rti,
-                            original_attno: attno,
-                        });
-                    } else {
-                        // Var references a relation pruned by an internal Semi/Anti
-                        // join (e.g., the inner side of a flattened EXISTS).
-                        // PostgreSQL's reltarget may include these Vars even though
-                        // they are not accessible after the Semi/Anti. Emit NULL;
-                        // the parent plan will not read this position.
-                        output_columns.push(privdat::OutputColumnInfo::Pruned);
-                    }
-                } else {
-                    let mut found_score = false;
-                    for source in private_data.join_clause.plan.sources() {
-                        if expr_uses_scores_from_source((*te).expr.cast(), source) {
-                            let rti = get_score_func_rti((*te).expr.cast()).unwrap_or(0);
-                            output_columns.push(privdat::OutputColumnInfo::Score {
-                                plan_position: source.plan_position,
-                                rti,
-                            });
-                            found_score = true;
-                            break;
-                        }
-                    }
-                    if !found_score {
-                        output_columns.push(privdat::OutputColumnInfo::Pruned);
-                    }
-                }
-            }
+            private_data.output_columns =
+                compute_output_columns(&private_data.join_clause, original_tlist, root);
 
-            private_data.output_columns = output_columns;
+            build_output_projection(&mut private_data, &original_entries, root);
 
-            let parse = (*root).parse;
-            let distinct_list_len =
-                if private_data.join_clause.has_distinct && !(*parse).distinctClause.is_null() {
-                    PgList::<pg_sys::SortGroupClause>::from_pg((*parse).distinctClause)
-                        .iter_ptr()
-                        .count()
-                } else {
-                    0
-                };
-
-            // Custom scan tlist can be shorter than parse DISTINCT (parent evaluates some exprs).
-            // Then DataFusion GROUP BY can't match all pathkeys; defer DISTINCT and sort only by
-            // parse sortClause inside JoinScan.
-            //
-            // Limitation: if distinctClause and scan tlist happen to have equal length but
-            // contain different expressions, this heuristic won't fire and the non-deferred
-            // path runs.  In practice the scan tlist is a strict subset of distinctClause
-            // columns, so a length mismatch is the reliable signal for "extra" expressions.
-            let scan_tlist_len = original_entries.len();
-            let defer_distinct_to_parent =
-                private_data.join_clause.has_distinct && distinct_list_len > scan_tlist_len;
-
-            if defer_distinct_to_parent {
-                private_data.join_clause.has_distinct = false;
-                let output_rtis = private_data.join_clause.plan.output_rtis();
-                let current_sources = private_data.join_clause.plan.sources();
-                private_data.join_clause.order_by =
-                    extract_orderby_from_parse_sort_clause(root, &current_sources, &output_rtis)
-                        .unwrap_or_else(|| {
-                            let sort_count = if (*parse).sortClause.is_null() {
-                                0
-                            } else {
-                                PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause)
-                                    .iter_ptr()
-                                    .count()
-                            };
-                            panic!(
-                                "JoinScan: ORDER BY from sortClause failed after DISTINCT/tlist \
-                             mismatch (sortClause has {} entries, scan_tlist_len={}, \
-                             distinct_list_len={})",
-                                sort_count, scan_tlist_len, distinct_list_len
-                            )
-                        });
-                // Non-Var, non-score expressions have rti=0, attno=0 here.  That is safe:
-                // has_distinct is cleared above, so DataFusion skips GROUP BY and
-                // build_projection_expr yields NULL for these slots.  build_result_tuple
-                // also treats rti=0 as NULL.  Postgres re-evaluates the real expressions
-                // on top of the result slot, so the NULLs are overwritten.
-                private_data.join_clause.output_projection = Some(
-                    private_data
-                        .output_columns
-                        .iter()
-                        .map(build::ChildProjection::from)
-                        .collect(),
-                );
-            } else {
-                // Build output_projection, enriching expression entries with metadata
-                // when DISTINCT is active.
-                //
-                // TODO(#4604): This is the second call to distinct_columns_are_fast_fields
-                // in the same planning phase (first in validate_and_build_clause). Both
-                // calls walk the same parse tree. Consider caching the result in a
-                // planning-phase-scoped structure to avoid redundant work.
-                let distinct_entries = if private_data.join_clause.has_distinct {
-                    let all_sources = private_data.join_clause.plan.sources();
-                    distinct_columns_are_fast_fields(root, &all_sources)
-                } else {
-                    None
-                };
-
-                // Map ResolvedExpr to output columns by walking the parse tree's
-                // target list (which has original expressions and valid ressortgroupref).
-                // For ALL entries (Column, Score, Expression), use the parse-tree
-                // varnos so that distinct_col_map keys are consistent with
-                // extract_orderby's pathkey varnos.
-                let mut entry_by_output_idx: crate::api::HashMap<usize, &planning::ResolvedExpr> =
-                    Default::default();
-                if let Some(ref entries) = distinct_entries {
-                    let parse_tlist = PgList::<pg_sys::TargetEntry>::from_pg((*parse).targetList);
-                    let distinct_list =
-                        PgList::<pg_sys::SortGroupClause>::from_pg((*parse).distinctClause);
-
-                    for (clause_ptr, entry) in distinct_list.iter_ptr().zip(entries.iter()) {
-                        let tle_ref = (*clause_ptr).tleSortGroupRef;
-                        if let Some(parse_te) = parse_tlist
-                            .iter_ptr()
-                            .find(|te| (**te).ressortgroupref == tle_ref)
-                        {
-                            let output_idx = ((*parse_te).resno - 1) as usize;
-                            if output_idx < private_data.output_columns.len() {
-                                entry_by_output_idx.insert(output_idx, entry);
-                            }
-                        }
-                    }
-                }
-
-                // Key `entry_by_output_idx` by each scan tlist entry's `resno`, not list position.
-                let scan_target_entries: Vec<*mut pg_sys::TargetEntry> =
-                    original_entries.iter_ptr().collect();
-                private_data.join_clause.output_projection = Some(
-                    private_data
-                        .output_columns
-                        .iter()
-                        .zip(scan_target_entries.iter().copied())
-                        .map(|(info, te)| {
-                            let output_idx = ((*te).resno - 1) as usize;
-                            match entry_by_output_idx.get(&output_idx) {
-                                Some(planning::ResolvedExpr::Expression {
-                                    expr_node,
-                                    input_vars,
-                                    result_type,
-                                }) => {
-                                    let expr_string = {
-                                        let node_str = pg_sys::nodeToString((*expr_node).cast());
-                                        std::ffi::CStr::from_ptr(node_str)
-                                            .to_string_lossy()
-                                            .into_owned()
-                                    };
-                                    let primary_rti = input_vars.first().map_or(0, |v| v.rti);
-                                    build::ChildProjection::Expression {
-                                        rti: primary_rti,
-                                        pg_expr_string: expr_string,
-                                        input_vars: input_vars.clone(),
-                                        result_type_oid: *result_type,
-                                    }
-                                }
-                                Some(planning::ResolvedExpr::Column { rti, attno }) => {
-                                    build::ChildProjection::Column {
-                                        rti: *rti,
-                                        attno: *attno,
-                                    }
-                                }
-                                Some(planning::ResolvedExpr::Score { rti }) => {
-                                    build::ChildProjection::Score { rti: *rti }
-                                }
-                                Some(planning::ResolvedExpr::IndexedExpression { rti }) => {
-                                    let attno = match info {
-                                        privdat::OutputColumnInfo::Var {
-                                            original_attno, ..
-                                        } => *original_attno,
-                                        _ => 0,
-                                    };
-                                    build::ChildProjection::IndexedExpression { rti: *rti, attno }
-                                }
-                                None => info.into(),
-                            }
-                        })
-                        .collect(),
-                );
-            }
-
-            // Add heap condition clauses to custom_exprs so they get transformed by set_customscan_references.
-            // The Vars in these expressions will be converted to INDEX_VAR references into custom_scan_tlist.
-            let path_private_full = PgList::<pg_sys::Node>::from_pg((*best_path).custom_private);
-            let mut custom_exprs_list = PgList::<pg_sys::Node>::from_pg(node.custom_exprs);
-            // Skip index 0 (PrivateData)
-            for i in 1..path_private_full.len() {
-                if let Some(node_ptr) = path_private_full.get_ptr(i) {
-                    custom_exprs_list.push(node_ptr);
-                }
-            }
-            node.custom_exprs = custom_exprs_list.into_pg();
+            // Add heap condition clauses to custom_exprs so they get transformed by
+            // set_customscan_references. The Vars in these expressions will be converted to
+            // INDEX_VAR references into custom_scan_tlist.
+            node.custom_exprs = splice_path_private_into_list(node.custom_exprs, best_path);
 
             // Collect all required fields for execution
             collect_required_fields(
@@ -1092,31 +896,11 @@ impl CustomScan for JoinScan {
                 node.custom_exprs,
             );
 
-            // Build, serialize and store the logical plan
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Failed to create tokio runtime");
-            let logical_plan = runtime
-                .block_on(build_joinscan_logical_plan(
-                    &private_data.join_clause,
-                    &private_data,
-                    node.custom_exprs,
-                ))
-                .expect("Failed to build DataFusion logical plan");
-            private_data.logical_plan = Some(
-                serialize_logical_plan(&logical_plan)
-                    .expect("Failed to serialize DataFusion logical plan"),
-            );
+            bake_logical_plan(&mut private_data, node.custom_exprs);
 
-            // Convert PrivateData back to a list and preserve the restrictlist
-            let mut new_private = PgList::<pg_sys::Node>::from_pg(PrivateData::into(private_data));
-            let path_private_full = PgList::<pg_sys::Node>::from_pg((*best_path).custom_private);
-            for i in 1..path_private_full.len() {
-                if let Some(node_ptr) = path_private_full.get_ptr(i) {
-                    new_private.push(node_ptr);
-                }
-            }
-            node.custom_private = new_private.into_pg();
+            // Convert PrivateData back to a list and preserve the restrictlist.
+            let private_list = PrivateData::into(private_data);
+            node.custom_private = splice_path_private_into_list(private_list, best_path);
 
             // Set custom_scan_tlist with all needed columns
             node.custom_scan_tlist = tlist.into_pg();
@@ -1478,6 +1262,266 @@ impl CustomScan for JoinScan {
             &mut state.custom_state_mut().source_manifests,
         ));
     }
+}
+
+/// Walk a target list and classify each entry into the corresponding
+/// [`privdat::OutputColumnInfo`]: a `Var` resolves to a plan position via the
+/// join clause, a `paradedb.score()` call becomes a `Score` sentinel, and any
+/// expression that cannot be located emits `Pruned` so the parent plan slot
+/// stays NULL.
+unsafe fn compute_output_columns(
+    join_clause: &JoinCSClause,
+    original_tlist: *mut pg_sys::List,
+    root: *mut pg_sys::PlannerInfo,
+) -> Vec<privdat::OutputColumnInfo> {
+    let mut output_columns = Vec::new();
+    let original_entries = PgList::<pg_sys::TargetEntry>::from_pg(original_tlist);
+
+    for te in original_entries.iter_ptr() {
+        if (*(*te).expr).type_ == pg_sys::NodeTag::T_Var {
+            let var = (*te).expr as *mut pg_sys::Var;
+            let rti = (*var).varno as pg_sys::Index;
+            let attno = (*var).varattno;
+            if let Some(plan_position) = join_clause.plan_position(root.into(), rti, attno) {
+                output_columns.push(privdat::OutputColumnInfo::Var {
+                    plan_position,
+                    rti,
+                    original_attno: attno,
+                });
+            } else {
+                // Var references a relation pruned by an internal Semi/Anti
+                // join (e.g., the inner side of a flattened EXISTS).
+                // PostgreSQL's reltarget may include these Vars even though
+                // they are not accessible after the Semi/Anti. Emit NULL;
+                // the parent plan will not read this position.
+                output_columns.push(privdat::OutputColumnInfo::Pruned);
+            }
+        } else {
+            let mut found_score = false;
+            for source in join_clause.plan.sources() {
+                if expr_uses_scores_from_source((*te).expr.cast(), source) {
+                    let rti = get_score_func_rti((*te).expr.cast()).unwrap_or(0);
+                    output_columns.push(privdat::OutputColumnInfo::Score {
+                        plan_position: source.plan_position,
+                        rti,
+                    });
+                    found_score = true;
+                    break;
+                }
+            }
+            if !found_score {
+                output_columns.push(privdat::OutputColumnInfo::Pruned);
+            }
+        }
+    }
+
+    output_columns
+}
+
+/// Build `private_data.join_clause.output_projection` from the scan target
+/// list, picking one of two strategies:
+///
+/// 1. **Defer to parent** when the parse-tree DISTINCT clause is wider than
+///    the scan target list. JoinScan strips DISTINCT, sorts by the parse
+///    `sortClause`, and emits a passthrough projection so the parent plan can
+///    re-evaluate the missing expressions.
+/// 2. **Normal** when DISTINCT (if any) fits inside the scan target list.
+///    Project each output column with metadata enriched from
+///    `distinct_columns_are_fast_fields` so GROUP BY column matching works
+///    against parse-tree varnos.
+unsafe fn build_output_projection(
+    private_data: &mut PrivateData,
+    original_entries: &PgList<pg_sys::TargetEntry>,
+    root: *mut pg_sys::PlannerInfo,
+) {
+    let parse = (*root).parse;
+    let scan_tlist_len = original_entries.len();
+    let distinct_list_len =
+        if private_data.join_clause.has_distinct && !(*parse).distinctClause.is_null() {
+            PgList::<pg_sys::SortGroupClause>::from_pg((*parse).distinctClause)
+                .iter_ptr()
+                .count()
+        } else {
+            0
+        };
+
+    // Custom scan tlist can be shorter than parse DISTINCT (parent evaluates some exprs).
+    // Then DataFusion GROUP BY can't match all pathkeys; defer DISTINCT and sort only by
+    // parse sortClause inside JoinScan.
+    //
+    // Limitation: if distinctClause and scan tlist happen to have equal length but
+    // contain different expressions, this heuristic won't fire and the non-deferred
+    // path runs.  In practice the scan tlist is a strict subset of distinctClause
+    // columns, so a length mismatch is the reliable signal for "extra" expressions.
+    let defer_distinct_to_parent =
+        private_data.join_clause.has_distinct && distinct_list_len > scan_tlist_len;
+
+    if defer_distinct_to_parent {
+        private_data.join_clause.has_distinct = false;
+        let output_rtis = private_data.join_clause.plan.output_rtis();
+        let current_sources = private_data.join_clause.plan.sources();
+        private_data.join_clause.order_by =
+            extract_orderby_from_parse_sort_clause(root, &current_sources, &output_rtis)
+                .unwrap_or_else(|| {
+                    let sort_count = if (*parse).sortClause.is_null() {
+                        0
+                    } else {
+                        PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause)
+                            .iter_ptr()
+                            .count()
+                    };
+                    panic!(
+                        "JoinScan: ORDER BY from sortClause failed after DISTINCT/tlist \
+                     mismatch (sortClause has {} entries, scan_tlist_len={}, \
+                     distinct_list_len={})",
+                        sort_count, scan_tlist_len, distinct_list_len
+                    )
+                });
+        // Non-Var, non-score expressions have rti=0, attno=0 here.  That is safe:
+        // has_distinct is cleared above, so DataFusion skips GROUP BY and
+        // build_projection_expr yields NULL for these slots.  build_result_tuple
+        // also treats rti=0 as NULL.  Postgres re-evaluates the real expressions
+        // on top of the result slot, so the NULLs are overwritten.
+        private_data.join_clause.output_projection = Some(
+            private_data
+                .output_columns
+                .iter()
+                .map(build::ChildProjection::from)
+                .collect(),
+        );
+        return;
+    }
+
+    // Normal path: build output_projection, enriching expression entries with
+    // metadata when DISTINCT is active.
+    //
+    // TODO(#4604): This is the second call to distinct_columns_are_fast_fields
+    // in the same planning phase (first in validate_and_build_clause). Both
+    // calls walk the same parse tree. Consider caching the result in a
+    // planning-phase-scoped structure to avoid redundant work.
+    let distinct_entries = if private_data.join_clause.has_distinct {
+        let all_sources = private_data.join_clause.plan.sources();
+        distinct_columns_are_fast_fields(root, &all_sources)
+    } else {
+        None
+    };
+
+    // Map ResolvedExpr to output columns by walking the parse tree's
+    // target list (which has original expressions and valid ressortgroupref).
+    // For ALL entries (Column, Score, Expression), use the parse-tree
+    // varnos so that distinct_col_map keys are consistent with
+    // extract_orderby's pathkey varnos.
+    let mut entry_by_output_idx: crate::api::HashMap<usize, &planning::ResolvedExpr> =
+        Default::default();
+    if let Some(ref entries) = distinct_entries {
+        let parse_tlist = PgList::<pg_sys::TargetEntry>::from_pg((*parse).targetList);
+        let distinct_list = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).distinctClause);
+
+        for (clause_ptr, entry) in distinct_list.iter_ptr().zip(entries.iter()) {
+            let tle_ref = (*clause_ptr).tleSortGroupRef;
+            if let Some(parse_te) = parse_tlist
+                .iter_ptr()
+                .find(|te| (**te).ressortgroupref == tle_ref)
+            {
+                let output_idx = ((*parse_te).resno - 1) as usize;
+                if output_idx < private_data.output_columns.len() {
+                    entry_by_output_idx.insert(output_idx, entry);
+                }
+            }
+        }
+    }
+
+    // Key `entry_by_output_idx` by each scan tlist entry's `resno`, not list position.
+    let scan_target_entries: Vec<*mut pg_sys::TargetEntry> = original_entries.iter_ptr().collect();
+    private_data.join_clause.output_projection = Some(
+        private_data
+            .output_columns
+            .iter()
+            .zip(scan_target_entries.iter().copied())
+            .map(|(info, te)| {
+                let output_idx = ((*te).resno - 1) as usize;
+                match entry_by_output_idx.get(&output_idx) {
+                    Some(planning::ResolvedExpr::Expression {
+                        expr_node,
+                        input_vars,
+                        result_type,
+                    }) => {
+                        let expr_string = {
+                            let node_str = pg_sys::nodeToString((*expr_node).cast());
+                            std::ffi::CStr::from_ptr(node_str)
+                                .to_string_lossy()
+                                .into_owned()
+                        };
+                        let primary_rti = input_vars.first().map_or(0, |v| v.rti);
+                        build::ChildProjection::Expression {
+                            rti: primary_rti,
+                            pg_expr_string: expr_string,
+                            input_vars: input_vars.clone(),
+                            result_type_oid: *result_type,
+                        }
+                    }
+                    Some(planning::ResolvedExpr::Column { rti, attno }) => {
+                        build::ChildProjection::Column {
+                            rti: *rti,
+                            attno: *attno,
+                        }
+                    }
+                    Some(planning::ResolvedExpr::Score { rti }) => {
+                        build::ChildProjection::Score { rti: *rti }
+                    }
+                    Some(planning::ResolvedExpr::IndexedExpression { rti }) => {
+                        let attno = match info {
+                            privdat::OutputColumnInfo::Var { original_attno, .. } => {
+                                *original_attno
+                            }
+                            _ => 0,
+                        };
+                        build::ChildProjection::IndexedExpression { rti: *rti, attno }
+                    }
+                    None => info.into(),
+                }
+            })
+            .collect(),
+    );
+}
+
+/// Build the DataFusion logical plan for the JoinScan, serialize it, and store
+/// the bytes inside `private_data.logical_plan` so the executor can rehydrate
+/// it during scan startup.
+fn bake_logical_plan(private_data: &mut PrivateData, custom_exprs: *mut pg_sys::List) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("Failed to create tokio runtime");
+    let logical_plan = runtime
+        .block_on(build_joinscan_logical_plan(
+            &private_data.join_clause,
+            &*private_data,
+            custom_exprs,
+        ))
+        .expect("Failed to build DataFusion logical plan");
+    private_data.logical_plan = Some(
+        serialize_logical_plan(&logical_plan).expect("Failed to serialize DataFusion logical plan"),
+    );
+}
+
+/// Append every entry in `best_path.custom_private` (skipping index 0, which
+/// holds the serialized `PrivateData`) onto `list`. Used twice in
+/// `plan_custom_path`: once to splice the trailing restrictlist clauses onto
+/// `node.custom_exprs`, and once to preserve them when re-serializing
+/// `PrivateData` back into `node.custom_private`.
+unsafe fn splice_path_private_into_list(
+    list: *mut pg_sys::List,
+    best_path: *mut pg_sys::CustomPath,
+) -> *mut pg_sys::List {
+    let mut combined = PgList::<pg_sys::Node>::from_pg(list);
+    let path_private_full = PgList::<pg_sys::Node>::from_pg((*best_path).custom_private);
+    // Skip index 0 (PrivateData)
+    for i in 1..path_private_full.len() {
+        if let Some(node_ptr) = path_private_full.get_ptr(i) {
+            combined.push(node_ptr);
+        }
+    }
+    combined.into_pg()
 }
 
 impl JoinScan {

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -24,7 +24,8 @@
 //! - Handle ORDER BY score pathkeys
 
 use super::build::{
-    InputVarInfo, JoinCSClause, JoinKeyPair, JoinSource, JoinSourceCandidate, RelNode,
+    self as build, FilterNode, InputVarInfo, JoinCSClause, JoinKeyPair, JoinLevelExpr, JoinNode,
+    JoinSource, JoinSourceCandidate, JoinType, RelNode,
 };
 use super::predicate::find_base_info_recursive;
 use super::privdat::{OutputColumnInfo, PrivateData};
@@ -204,17 +205,16 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     rel: *mut pg_sys::RelOptInfo,
     rti: pg_sys::Index,
 ) -> Option<(RelNode, Vec<JoinKeyPair>)> {
-    let (relid, alias, _bm25_opt) = super::build::lookup_base_rel_info(root, rti)?;
+    let (relid, alias, _bm25_opt) = build::lookup_base_rel_info(root, rti)?;
 
     let mut side_info = JoinSourceCandidate::new(root.into(), rti).with_heaprelid(relid);
     if let Some(alias) = alias {
         side_info = side_info.with_alias(alias);
     }
 
-    // Top-level SubPlans (e.g. `col IN (SELECT ...)`)
-    let mut extracted_subqueries = Vec::new();
-    // SubPlans nested inside OR expressions (e.g. `col IS NULL OR col IN (SELECT ...)`)
-    let mut extracted_or_subqueries: Vec<OrSubPlanExtraction> = Vec::new();
+    // Subquery extraction is meaningful only when the base side has a BM25 index;
+    // otherwise the Semi/Anti/LeftMark wrapping has nothing useful to wrap.
+    let mut classified = ClassifiedBaseRestrictInfo::empty();
 
     if let Some((_, bm25_index)) = rel_get_bm25_index(relid) {
         side_info = side_info.with_indexrelid(bm25_index.oid());
@@ -230,69 +230,31 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         };
         side_info = side_info.with_sort_order(sort_order);
 
-        // Extract single-table predicates from baserestrictinfo.
-        // These are predicates like `p.description @@@ 'wireless'` that PostgreSQL
-        // has pushed down to the base relation level.
-        //
-        // Note: Cross-table predicates (e.g., involving multiple tables in a join)
-        // are handled separately via SearchPredicateUDF through filter pushdown.
-        let baserestrictinfo = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+        classified = classify_base_restrictinfo(root, (*rel).baserestrictinfo);
 
-        if !baserestrictinfo.is_empty() {
+        if !classified.search_ri.is_empty() {
             let context = PlannerContext::from_planner(root);
-
-            // Separate subplans (SEMI/ANTI joins) from search-capable predicates.
-            // Subplans are collected and later handled by wrapping the current
-            // scan's RelNode in additional Join nodes (see `RelNode::Join` below).
-            // This separation ensures `extract_quals` only receives clauses it
-            // can fully convert to a Tantivy query.
-            let mut search_ri = PgList::<pg_sys::RestrictInfo>::new();
-            for ri in baserestrictinfo.iter_ptr() {
-                if let Some((subplan, is_anti, inner_root)) =
-                    extract_subplan_from_clause(root, (*ri).clause.cast())
-                {
-                    // Top-level SubPlan (e.g. `col IN (SELECT ...)`) → Semi/Anti join.
-                    extracted_subqueries.push((subplan, is_anti, inner_root));
-                } else {
-                    // Try to extract SubPlan from inside an OR expression.
-                    // Handles patterns like `col IS NULL OR col IN (SELECT ...)`.
-                    let clause = if !(*ri).orclause.is_null() {
-                        (*ri).orclause.cast()
-                    } else {
-                        (*ri).clause.cast()
-                    };
-                    if let Some(or_extraction) = extract_subplan_from_or_clause(root, clause) {
-                        extracted_or_subqueries.push(or_extraction);
-                    } else {
-                        // Not a SubPlan — pass to extract_quals for search predicate extraction.
-                        search_ri.push(ri);
-                    }
+            let mut state = QualExtractState::default();
+            // Extract search-capable predicates all at once. This is required
+            // for score filters, which must wrap the rest of the search query.
+            if let Some(qual) = extract_quals(
+                &context,
+                rti,
+                classified.search_ri.as_ptr().cast(),
+                crate::postgres::customscan::builders::custom_path::RestrictInfoType::BaseRelation,
+                &bm25_index,
+                false,
+                &mut state,
+                true,
+            ) {
+                let query = SearchQueryInput::from(&qual);
+                side_info = side_info.with_query(query);
+                if state.uses_our_operator {
+                    side_info = side_info.with_search_predicate();
                 }
-            }
-
-            if !search_ri.is_empty() {
-                let mut state = QualExtractState::default();
-                // Extract search-capable predicates all at once. This is required
-                // for score filters, which must wrap the rest of the search query.
-                if let Some(qual) = extract_quals(
-                    &context,
-                    rti,
-                    search_ri.as_ptr().cast(),
-                    crate::postgres::customscan::builders::custom_path::RestrictInfoType::BaseRelation,
-                    &bm25_index,
-                    false,
-                    &mut state,
-                    true,
-                ) {
-                    let query = SearchQueryInput::from(&qual);
-                    side_info = side_info.with_query(query);
-                    if state.uses_our_operator {
-                        side_info = side_info.with_search_predicate();
-                    }
-                } else {
-                    // Fail the JoinScan if any search predicate cannot be extracted.
-                    return None;
-                }
+            } else {
+                // Fail the JoinScan if any search predicate cannot be extracted.
+                return None;
             }
         }
     }
@@ -303,8 +265,99 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     let mut current_node = RelNode::Scan(Box::new(source));
     let mut all_keys = Vec::new();
 
-    // Wrap current_node in Join nodes for each top-level extracted subquery (Semi/Anti)
-    for (subplan, is_anti, inner_root) in extracted_subqueries {
+    current_node = wrap_with_semi_anti(current_node, classified.top_level_subplans, &mut all_keys);
+    current_node = wrap_with_mark_filter(current_node, classified.or_subplans, &mut all_keys);
+
+    Some((current_node, all_keys))
+}
+
+/// Buckets that [`classify_base_restrictinfo`] sorts a relation's
+/// `baserestrictinfo` clauses into.
+struct ClassifiedBaseRestrictInfo {
+    /// Clauses that are not subplans and should be batched into `extract_quals`
+    /// for search predicate extraction.
+    search_ri: PgList<pg_sys::RestrictInfo>,
+    /// Top-level SubPlans (e.g. `col IN (SELECT ...)`) that should become
+    /// Semi/Anti joins wrapping the base scan.
+    top_level_subplans: Vec<(*mut pg_sys::SubPlan, bool, *mut pg_sys::PlannerInfo)>,
+    /// SubPlans nested inside an OR (e.g. `col IS NULL OR col IN (SELECT ...)`)
+    /// that should become LeftMark joins followed by a Filter.
+    or_subplans: Vec<OrSubPlanExtraction>,
+}
+
+impl ClassifiedBaseRestrictInfo {
+    fn empty() -> Self {
+        Self {
+            search_ri: PgList::<pg_sys::RestrictInfo>::new(),
+            top_level_subplans: Vec::new(),
+            or_subplans: Vec::new(),
+        }
+    }
+}
+
+/// Walk a relation's `baserestrictinfo` and split each clause into one of three
+/// buckets: search-extractable predicates, top-level SubPlans, or OR-nested
+/// SubPlans. Subplans are pulled out so the remaining `search_ri` can be passed
+/// to `extract_quals` as a fully-search-capable batch.
+unsafe fn classify_base_restrictinfo(
+    root: *mut pg_sys::PlannerInfo,
+    baserestrictinfo: *mut pg_sys::List,
+) -> ClassifiedBaseRestrictInfo {
+    let mut classified = ClassifiedBaseRestrictInfo::empty();
+
+    // Extract single-table predicates from baserestrictinfo.
+    // These are predicates like `p.description @@@ 'wireless'` that PostgreSQL
+    // has pushed down to the base relation level.
+    //
+    // Note: Cross-table predicates (e.g., involving multiple tables in a join)
+    // are handled separately via SearchPredicateUDF through filter pushdown.
+    let baserestrictinfo = PgList::<pg_sys::RestrictInfo>::from_pg(baserestrictinfo);
+    if baserestrictinfo.is_empty() {
+        return classified;
+    }
+
+    // Separate subplans (SEMI/ANTI joins) from search-capable predicates.
+    // Subplans are collected and later handled by wrapping the current
+    // scan's RelNode in additional Join nodes. This separation ensures
+    // `extract_quals` only receives clauses it can fully convert to a
+    // Tantivy query.
+    for ri in baserestrictinfo.iter_ptr() {
+        if let Some((subplan, is_anti, inner_root)) =
+            extract_subplan_from_clause(root, (*ri).clause.cast())
+        {
+            // Top-level SubPlan (e.g. `col IN (SELECT ...)`) → Semi/Anti join.
+            classified
+                .top_level_subplans
+                .push((subplan, is_anti, inner_root));
+        } else {
+            // Try to extract SubPlan from inside an OR expression.
+            // Handles patterns like `col IS NULL OR col IN (SELECT ...)`.
+            let clause = if !(*ri).orclause.is_null() {
+                (*ri).orclause.cast()
+            } else {
+                (*ri).clause.cast()
+            };
+            if let Some(or_extraction) = extract_subplan_from_or_clause(root, clause) {
+                classified.or_subplans.push(or_extraction);
+            } else {
+                // Not a SubPlan — pass to extract_quals for search predicate extraction.
+                classified.search_ri.push(ri);
+            }
+        }
+    }
+
+    classified
+}
+
+/// Wrap a base scan node with Semi/Anti joins, one per top-level extracted
+/// SubPlan. Equi-keys produced by each SubPlan are appended to `all_keys` so
+/// the caller can return the full set alongside the wrapped node.
+unsafe fn wrap_with_semi_anti(
+    mut current_node: RelNode,
+    top_level_subplans: Vec<(*mut pg_sys::SubPlan, bool, *mut pg_sys::PlannerInfo)>,
+    all_keys: &mut Vec<JoinKeyPair>,
+) -> RelNode {
+    for (subplan, is_anti, inner_root) in top_level_subplans {
         // Find the final rel for the inner subquery
         let inner_rel = find_final_rel(inner_root);
         if inner_rel.is_null() {
@@ -321,11 +374,11 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         let equi_keys =
             extract_equi_keys_from_subplan(subplan, inner_root, &current_node, &inner_node);
 
-        let join_node = crate::postgres::customscan::joinscan::build::JoinNode {
+        let join_node = JoinNode {
             join_type: if is_anti {
-                crate::postgres::customscan::joinscan::build::JoinType::Anti
+                JoinType::Anti
             } else {
-                crate::postgres::customscan::joinscan::build::JoinType::Semi
+                JoinType::Semi
             },
             left: current_node,
             right: inner_node,
@@ -337,11 +390,19 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         current_node = RelNode::Join(Box::new(join_node));
     }
 
-    // Wrap current_node in LeftMark join + Filter for each OR-extracted subquery.
-    // These come from patterns like `col IS NULL OR col IN (SELECT ...)`.
-    // The LeftMark join produces all left rows + a boolean "mark" column.
-    // The Filter keeps rows where `mark = true OR col IS NULL`.
-    for or_ext in extracted_or_subqueries {
+    current_node
+}
+
+/// Wrap a base scan node with a `LeftMark` join + Filter for each OR-extracted
+/// SubPlan (`col IS NULL OR col IN (SELECT ...)` style). The LeftMark join
+/// produces all left rows plus a boolean "mark" column; the Filter then keeps
+/// rows where `mark = true OR col IS NULL` (or the inverted form for NOT IN).
+unsafe fn wrap_with_mark_filter(
+    mut current_node: RelNode,
+    or_subplans: Vec<OrSubPlanExtraction>,
+    all_keys: &mut Vec<JoinKeyPair>,
+) -> RelNode {
+    for or_ext in or_subplans {
         let inner_rel = find_final_rel(or_ext.inner_root);
         if inner_rel.is_null() {
             continue;
@@ -365,10 +426,8 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         // Both `IN (...) OR IS NULL` and `NOT IN (...) OR IS NULL` use LeftMark;
         // the anti vs non-anti distinction is carried through `or_ext.is_anti`
         // and applied at filter-evaluation time as a mark-check inversion.
-        let join_type = crate::postgres::customscan::joinscan::build::JoinType::LeftMark;
-
-        let join_node = crate::postgres::customscan::joinscan::build::JoinNode {
-            join_type,
+        let join_node = JoinNode {
+            join_type: JoinType::LeftMark,
             left: current_node,
             right: inner_node,
             equi_keys: equi_keys.clone(),
@@ -384,9 +443,9 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         //
         // The filter is stored as a MarkOrNullFilter which is handled specially
         // during DataFusion plan building (see scan_state.rs).
-        let filter_node = crate::postgres::customscan::joinscan::build::FilterNode {
+        let filter_node = FilterNode {
             input: join_rel,
-            predicate: crate::postgres::customscan::joinscan::build::JoinLevelExpr::MarkOrNull {
+            predicate: JoinLevelExpr::MarkOrNull {
                 is_anti: or_ext.is_anti,
                 null_test_varno: or_ext.null_test_varno,
                 null_test_attno: or_ext.null_test_attno,
@@ -396,7 +455,7 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         current_node = RelNode::Filter(Box::new(filter_node));
     }
 
-    Some((current_node, all_keys))
+    current_node
 }
 
 /// Recursively reconstructs the intermediate relational tree from standard PostgreSQL join paths.

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -556,6 +556,12 @@ fn build_relnode_df<'a>(
     f.boxed_local()
 }
 
+/// Maps `(rti, attno)` to a `col_N` alias after a DISTINCT-style GROUP BY
+/// rewrite. The score column uses sentinel `attno = 0`. When DISTINCT is not
+/// active the map is empty and downstream stages preserve their original
+/// qualified column references.
+type DistinctColMap = crate::api::HashMap<(pg_sys::Index, pg_sys::AttrNumber), String>;
+
 /// Recursively builds a DataFusion `DataFrame` for a given join clause.
 ///
 /// This function constructs the logical plan for a join by:
@@ -578,38 +584,22 @@ fn build_clause_df<'a>(
             ));
         }
 
-        let plan = &join_clause.plan;
-
         let partitioning_plan_position = join_clause.partitioning_source_index();
 
         let mapper = CombinedMapper {
             sources: &plan_sources,
             output_columns: &private_data.output_columns,
         };
-
         let translator = PredicateTranslator::new(&plan_sources).with_mapper(Box::new(mapper));
+        let translated_exprs = unsafe { translate_custom_exprs(&translator, custom_exprs)? };
+        // Drop the translator (and its borrow on `plan_sources`) before downstream
+        // stages re-borrow `plan_sources` for projection / output assembly.
+        drop(translator);
 
-        // Translate all custom_exprs first
-        let mut translated_exprs = Vec::new();
-        unsafe {
-            use pgrx::PgList;
-            let expr_list = PgList::<pg_sys::Node>::from_pg(custom_exprs);
-            for (i, expr_node) in expr_list.iter_ptr().enumerate() {
-                let expr = translator.translate(expr_node).ok_or_else(|| {
-                    DataFusionError::Internal(format!(
-                        "Failed to translate custom expression at index {}",
-                        i
-                    ))
-                })?;
-                translated_exprs.push(expr);
-            }
-        }
-
-        let mut ctid_map = crate::api::HashMap::default();
+        let mut ctid_map: crate::api::HashMap<pg_sys::Index, Expr> = Default::default();
         for (i, _) in plan_sources.iter().enumerate() {
             let ctid_name = CtidColumn::new(i).to_string();
-            let expr = col(&ctid_name);
-            ctid_map.insert(i as pg_sys::Index, expr);
+            ctid_map.insert(i as pg_sys::Index, col(&ctid_name));
         }
 
         let rctx = RelNodeBuildCtx {
@@ -619,232 +609,295 @@ fn build_clause_df<'a>(
             translated_exprs: &translated_exprs,
             ctid_map: &ctid_map,
         };
-        let mut df = build_relnode_df(&rctx, plan).await?;
-
-        // Maps (rti, attno) → col_N alias, populated only when has_distinct is true.
-        // For regular columns: (rti, attno) → col_N
-        // For score columns:   (rti, 0)     → col_N  (attno=0 is the score sentinel)
-        // When has_distinct is false, map is empty and sort uses existing qualified path.
-        let mut distinct_col_map: crate::api::HashMap<(pg_sys::Index, pg_sys::AttrNumber), String> =
-            Default::default();
+        let df = build_relnode_df(&rctx, &join_clause.plan).await?;
 
         // 4. Apply DISTINCT via GROUP BY
-        if join_clause.has_distinct {
-            if let Some(projection) = &join_clause.output_projection {
-                let mut group_exprs: Vec<Expr> = Vec::new();
+        let (df, distinct_col_map) = apply_distinct_group_by(df, join_clause, &ctid_map)?;
 
-                for (i, proj) in projection.iter().enumerate() {
-                    let col_alias = format!("col_{}", i + 1);
+        // 5. Apply Sort
+        let df = apply_sort(df, join_clause, &distinct_col_map)?;
 
-                    let (expr, map_key) = match proj {
-                        build::ChildProjection::Expression {
-                            pg_expr_string,
-                            input_vars,
-                            result_type_oid,
-                            ..
-                        } => {
-                            let udf_name = format!(
-                                "{}{}",
-                                crate::postgres::customscan::pg_expr_udf::PG_EXPR_UDF_PREFIX,
-                                i
-                            );
+        // 6. Apply Limit
+        let df = if let Some(fetch) = join_clause.limit_offset.fetch() {
+            df.limit(0, Some(fetch))?
+        } else {
+            df
+        };
 
-                            let input_exprs: Vec<Expr> = input_vars
-                                .iter()
-                                .filter_map(|var_info| {
-                                    resolve_var_to_df_col(join_clause, var_info.rti, var_info.attno)
-                                })
-                                .collect();
+        // 7. Apply Output Projection
+        apply_output_projection(df, join_clause, &distinct_col_map, &plan_sources)
+    };
+    f.boxed_local()
+}
 
-                            if input_exprs.len() != input_vars.len() {
-                                return Err(DataFusionError::Internal(format!(
-                                    "PgExprUdf: could not resolve all input columns \
-                                     (resolved {} of {})",
-                                    input_exprs.len(),
-                                    input_vars.len()
-                                )));
-                            }
+/// Translate every clause in `custom_exprs` (a Postgres `List*`) into a
+/// DataFusion `Expr` using the provided `PredicateTranslator`.
+unsafe fn translate_custom_exprs(
+    translator: &PredicateTranslator,
+    custom_exprs: *mut pg_sys::List,
+) -> Result<Vec<Expr>> {
+    use pgrx::PgList;
+    let mut translated = Vec::new();
+    let expr_list = PgList::<pg_sys::Node>::from_pg(custom_exprs);
+    for (i, expr_node) in expr_list.iter_ptr().enumerate() {
+        let expr = translator.translate(expr_node).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "Failed to translate custom expression at index {}",
+                i
+            ))
+        })?;
+        translated.push(expr);
+    }
+    Ok(translated)
+}
 
-                            let udf = crate::postgres::customscan::pg_expr_udf::PgExprUdf::new(
-                                udf_name,
-                                pg_expr_string.clone(),
-                                input_vars.clone(),
-                                *result_type_oid,
-                            );
+/// Apply a DISTINCT rewrite as `GROUP BY` over `output_projection`, taking the
+/// MIN of each ctid column as a stable representative. Returns the rewritten
+/// `DataFrame` plus the populated [`DistinctColMap`] used by the sort and
+/// projection stages to resolve column references against the new aliases.
+///
+/// When DISTINCT is not active (or there is no `output_projection`) the input
+/// frame is returned unchanged with an empty map.
+fn apply_distinct_group_by(
+    df: DataFrame,
+    join_clause: &JoinCSClause,
+    ctid_map: &crate::api::HashMap<pg_sys::Index, Expr>,
+) -> Result<(DataFrame, DistinctColMap)> {
+    let mut distinct_col_map: DistinctColMap = Default::default();
 
-                            let e = Expr::ScalarFunction(
-                                datafusion::logical_expr::expr::ScalarFunction::new_udf(
-                                    Arc::new(datafusion::logical_expr::ScalarUDF::new_from_impl(
-                                        udf,
-                                    )),
-                                    input_exprs,
-                                ),
-                            );
-                            // Expressions don't participate in sort-step column mapping
-                            (e, None)
-                        }
-                        build::ChildProjection::Score { rti } => {
-                            let e = build_projection_expr(proj, join_clause);
-                            (e, Some((*rti, 0)))
-                        }
-                        build::ChildProjection::Column { rti, attno }
-                        | build::ChildProjection::IndexedExpression { rti, attno } => {
-                            let e = build_projection_expr(proj, join_clause);
-                            (e, Some((*rti, *attno)))
-                        }
-                    };
+    if !join_clause.has_distinct {
+        return Ok((df, distinct_col_map));
+    }
+    let Some(projection) = &join_clause.output_projection else {
+        return Ok((df, distinct_col_map));
+    };
 
-                    group_exprs.push(expr.alias(&col_alias));
+    let mut group_exprs: Vec<Expr> = Vec::new();
 
-                    if let Some(key) = map_key {
-                        distinct_col_map.insert(key, col_alias);
-                    }
-                }
+    for (i, proj) in projection.iter().enumerate() {
+        let col_alias = format!("col_{}", i + 1);
 
-                let agg_exprs: Vec<Expr> = ctid_map
-                    .values()
-                    .map(|expr| {
-                        let ctid_name = match expr {
-                            Expr::Column(col) => col.name.clone(),
-                            _ => unreachable!("ctid_map always contains Column expressions"),
-                        };
-                        min(expr.clone()).alias(&ctid_name)
+        let (expr, map_key) = match proj {
+            build::ChildProjection::Expression {
+                pg_expr_string,
+                input_vars,
+                result_type_oid,
+                ..
+            } => {
+                let udf_name = format!(
+                    "{}{}",
+                    crate::postgres::customscan::pg_expr_udf::PG_EXPR_UDF_PREFIX,
+                    i
+                );
+
+                let input_exprs: Vec<Expr> = input_vars
+                    .iter()
+                    .filter_map(|var_info| {
+                        resolve_var_to_df_col(join_clause, var_info.rti, var_info.attno)
                     })
                     .collect();
 
-                df = df.aggregate(group_exprs, agg_exprs)?;
-            }
-        }
+                if input_exprs.len() != input_vars.len() {
+                    return Err(DataFusionError::Internal(format!(
+                        "PgExprUdf: could not resolve all input columns \
+                         (resolved {} of {})",
+                        input_exprs.len(),
+                        input_vars.len()
+                    )));
+                }
 
-        // Closure to resolve a column reference after GROUP BY.
-        // When distinct_col_map is populated, all columns are renamed to col_N.
-        // Score uses sentinel (rti, 0) — we iterate rather than exact key match
-        // because proj.rti may not match in cross-table OR predicate cases.
-        let resolve_distinct_col = |is_score: bool,
-                                    rti: pg_sys::Index,
-                                    attno: pg_sys::AttrNumber,
-                                    col_alias: &str|
-         -> Expr {
-            if is_score {
-                distinct_col_map
-                    .iter()
-                    .find(|((_, a), _)| *a == 0)
-                    .map(|(_, alias)| col(alias.as_str()))
-                    .unwrap_or_else(|| col(col_alias))
-            } else {
-                distinct_col_map
-                    .get(&(rti, attno))
-                    .map(|alias| col(alias.as_str()))
-                    .unwrap_or_else(|| col(col_alias))
+                let udf = crate::postgres::customscan::pg_expr_udf::PgExprUdf::new(
+                    udf_name,
+                    pg_expr_string.clone(),
+                    input_vars.clone(),
+                    *result_type_oid,
+                );
+
+                let e =
+                    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                        Arc::new(datafusion::logical_expr::ScalarUDF::new_from_impl(udf)),
+                        input_exprs,
+                    ));
+                // Expressions don't participate in sort-step column mapping
+                (e, None)
+            }
+            build::ChildProjection::Score { rti } => {
+                let e = build_projection_expr(proj, join_clause);
+                (e, Some((*rti, 0)))
+            }
+            build::ChildProjection::Column { rti, attno }
+            | build::ChildProjection::IndexedExpression { rti, attno } => {
+                let e = build_projection_expr(proj, join_clause);
+                (e, Some((*rti, *attno)))
             }
         };
 
-        // 5. Apply Sort
-        if !join_clause.order_by.is_empty() {
-            let mut sort_exprs = Vec::new();
-            for info in &join_clause.order_by {
-                let expr = match &info.feature {
-                    OrderByFeature::Score { rti } => {
-                        if !distinct_col_map.is_empty() {
-                            resolve_distinct_col(true, 0, 0, "")
-                        } else {
-                            // TODO: this heap_rti lookup has the same collision
-                            // risk as the partitioning check fixed above — if a
-                            // NOT IN subquery source shares the same RTI as the
-                            // outer table, the wrong score column could be
-                            // selected. Low risk since ORDER BY scores typically
-                            // reference outer-query tables. Fix by switching
-                            // OrderByFeature::Score to carry plan_position.
-                            join_clause
-                                .plan
-                                .sources()
-                                .iter()
-                                .enumerate()
-                                .find(|(_, s)| s.scan_info.heap_rti == *rti)
-                                .map(|(idx, source)| make_source_score_col(source, idx))
-                                .unwrap_or_else(|| col("unknown_score"))
-                        }
-                    }
-                    OrderByFeature::Field { name, rti } => join_clause
+        group_exprs.push(expr.alias(&col_alias));
+
+        if let Some(key) = map_key {
+            distinct_col_map.insert(key, col_alias);
+        }
+    }
+
+    let agg_exprs: Vec<Expr> = ctid_map
+        .values()
+        .map(|expr| {
+            let ctid_name = match expr {
+                Expr::Column(col) => col.name.clone(),
+                _ => unreachable!("ctid_map always contains Column expressions"),
+            };
+            min(expr.clone()).alias(&ctid_name)
+        })
+        .collect();
+
+    let df = df.aggregate(group_exprs, agg_exprs)?;
+    Ok((df, distinct_col_map))
+}
+
+/// Resolve a column reference after the DISTINCT GROUP BY has rewritten every
+/// projection into a `col_N` alias. Score lookups iterate the map (rather than
+/// exact-match) because the parse-time `rti` may not survive cross-table OR
+/// predicate handling. When `distinct_col_map` is empty (DISTINCT not active),
+/// callers should not invoke this — `col_alias` is returned only as a fallback
+/// in case the requested key is missing.
+fn resolve_distinct_col(
+    distinct_col_map: &DistinctColMap,
+    is_score: bool,
+    rti: pg_sys::Index,
+    attno: pg_sys::AttrNumber,
+    col_alias: &str,
+) -> Expr {
+    if is_score {
+        distinct_col_map
+            .iter()
+            .find(|((_, a), _)| *a == 0)
+            .map(|(_, alias)| col(alias.as_str()))
+            .unwrap_or_else(|| col(col_alias))
+    } else {
+        distinct_col_map
+            .get(&(rti, attno))
+            .map(|alias| col(alias.as_str()))
+            .unwrap_or_else(|| col(col_alias))
+    }
+}
+
+/// Apply the join clause's `ORDER BY` to the data frame, choosing column
+/// references from `distinct_col_map` when DISTINCT is active and from the
+/// per-source resolution paths otherwise.
+fn apply_sort(
+    df: DataFrame,
+    join_clause: &JoinCSClause,
+    distinct_col_map: &DistinctColMap,
+) -> Result<DataFrame> {
+    if join_clause.order_by.is_empty() {
+        return Ok(df);
+    }
+
+    let mut sort_exprs = Vec::new();
+    for info in &join_clause.order_by {
+        let expr = match &info.feature {
+            OrderByFeature::Score { rti } => {
+                if !distinct_col_map.is_empty() {
+                    resolve_distinct_col(distinct_col_map, true, 0, 0, "")
+                } else {
+                    // TODO: this heap_rti lookup has the same collision
+                    // risk as the partitioning check fixed above — if a
+                    // NOT IN subquery source shares the same RTI as the
+                    // outer table, the wrong score column could be
+                    // selected. Low risk since ORDER BY scores typically
+                    // reference outer-query tables. Fix by switching
+                    // OrderByFeature::Score to carry plan_position.
+                    join_clause
                         .plan
                         .sources()
                         .iter()
                         .enumerate()
-                        .find(|(_, s)| s.contains_rti(*rti))
-                        .map(|(idx, source)| make_source_col(source, idx, name.as_ref()))
-                        .unwrap_or_else(|| {
-                            pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
-                            col(name.as_ref())
-                        }),
-                    OrderByFeature::Var { rti, attno, .. } => {
-                        if !distinct_col_map.is_empty() {
-                            resolve_distinct_col(false, *rti, *attno, "")
-                        } else {
-                            resolve_var_to_df_col(join_clause, *rti, *attno)
-                                .unwrap_or_else(|| col("unknown_col"))
-                        }
-                    }
-                };
-
-                let asc = matches!(
-                    info.direction,
-                    SortDirection::AscNullsFirst | SortDirection::AscNullsLast
-                );
-                let nulls_first = matches!(
-                    info.direction,
-                    SortDirection::AscNullsFirst | SortDirection::DescNullsFirst
-                );
-                sort_exprs.push(expr.sort(asc, nulls_first));
-            }
-            df = df.sort(sort_exprs)?;
-        }
-
-        // 6. Apply Limit
-        if let Some(fetch) = join_clause.limit_offset.fetch() {
-            df = df.limit(0, Some(fetch))?;
-        }
-
-        // 7. Apply Output Projection
-        let mut final_cols = Vec::new();
-
-        if let Some(projection) = &join_clause.output_projection {
-            for (i, proj) in projection.iter().enumerate() {
-                let col_alias = format!("col_{}", i + 1);
-                let expr = if !distinct_col_map.is_empty() {
-                    match proj {
-                        build::ChildProjection::Expression { .. } => col(&col_alias),
-                        build::ChildProjection::Score { rti } => {
-                            resolve_distinct_col(true, *rti, 0, &col_alias)
-                        }
-                        build::ChildProjection::Column { rti, attno }
-                        | build::ChildProjection::IndexedExpression { rti, attno } => {
-                            resolve_distinct_col(false, *rti, *attno, &col_alias)
-                        }
-                    }
-                } else {
-                    build_projection_expr(proj, join_clause)
-                };
-                final_cols.push(expr.alias(col_alias));
-            }
-
-            // ALWAYS carry forward all CTID columns from both sides
-            for (i, _) in plan_sources.iter().enumerate() {
-                let ctid_name = CtidColumn::new(i).to_string();
-                if df.schema().field_with_unqualified_name(&ctid_name).is_ok() {
-                    final_cols.push(col(&ctid_name));
+                        .find(|(_, s)| s.scan_info.heap_rti == *rti)
+                        .map(|(idx, source)| make_source_score_col(source, idx))
+                        .unwrap_or_else(|| col("unknown_score"))
                 }
             }
-        } else {
-            for field in df.schema().fields() {
-                final_cols.push(col(field.name()));
+            OrderByFeature::Field { name, rti } => join_clause
+                .plan
+                .sources()
+                .iter()
+                .enumerate()
+                .find(|(_, s)| s.contains_rti(*rti))
+                .map(|(idx, source)| make_source_col(source, idx, name.as_ref()))
+                .unwrap_or_else(|| {
+                    pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
+                    col(name.as_ref())
+                }),
+            OrderByFeature::Var { rti, attno, .. } => {
+                if !distinct_col_map.is_empty() {
+                    resolve_distinct_col(distinct_col_map, false, *rti, *attno, "")
+                } else {
+                    resolve_var_to_df_col(join_clause, *rti, *attno)
+                        .unwrap_or_else(|| col("unknown_col"))
+                }
             }
+        };
+
+        let asc = matches!(
+            info.direction,
+            SortDirection::AscNullsFirst | SortDirection::AscNullsLast
+        );
+        let nulls_first = matches!(
+            info.direction,
+            SortDirection::AscNullsFirst | SortDirection::DescNullsFirst
+        );
+        sort_exprs.push(expr.sort(asc, nulls_first));
+    }
+    df.sort(sort_exprs)
+}
+
+/// Build the final SELECT list. When `output_projection` is set, every
+/// projected column is aliased to `col_{i+1}` (the convention the result
+/// builder expects), and any CTID columns still present in the schema are
+/// carried forward unchanged. Without an `output_projection`, the entire
+/// schema is selected as-is.
+fn apply_output_projection(
+    df: DataFrame,
+    join_clause: &JoinCSClause,
+    distinct_col_map: &DistinctColMap,
+    plan_sources: &[&JoinSource],
+) -> Result<DataFrame> {
+    let mut final_cols = Vec::new();
+
+    if let Some(projection) = &join_clause.output_projection {
+        for (i, proj) in projection.iter().enumerate() {
+            let col_alias = format!("col_{}", i + 1);
+            let expr = if !distinct_col_map.is_empty() {
+                match proj {
+                    build::ChildProjection::Expression { .. } => col(&col_alias),
+                    build::ChildProjection::Score { rti } => {
+                        resolve_distinct_col(distinct_col_map, true, *rti, 0, &col_alias)
+                    }
+                    build::ChildProjection::Column { rti, attno }
+                    | build::ChildProjection::IndexedExpression { rti, attno } => {
+                        resolve_distinct_col(distinct_col_map, false, *rti, *attno, &col_alias)
+                    }
+                }
+            } else {
+                build_projection_expr(proj, join_clause)
+            };
+            final_cols.push(expr.alias(col_alias));
         }
 
-        df = df.select(final_cols)?;
+        // ALWAYS carry forward all CTID columns from both sides
+        for (i, _) in plan_sources.iter().enumerate() {
+            let ctid_name = CtidColumn::new(i).to_string();
+            if df.schema().field_with_unqualified_name(&ctid_name).is_ok() {
+                final_cols.push(col(&ctid_name));
+            }
+        }
+    } else {
+        for field in df.schema().fields() {
+            final_cols.push(col(field.name()));
+        }
+    }
 
-        Ok(df)
-    };
-    f.boxed_local()
+    df.select(final_cols)
 }
 
 /// Builds a DataFusion projection expression for a given child projection info.


### PR DESCRIPTION
## What

Splits the four longest functions in the JoinScan / AggregateScan modules into focused helpers.

- **`joinscan/planning.rs`** — `collect_join_sources_base_rel` (~200 LOC) becomes a 60-LOC entry function dispatching to `classify_base_restrictinfo`, `wrap_with_semi_anti`, and `wrap_with_mark_filter`.
- **`joinscan/scan_state.rs`** — `build_clause_df` (~280 LOC, async closure with six-level nesting in the DISTINCT branch) becomes a sequence of `let df = stage(df, ...)` shadowings driving `translate_custom_exprs`, `apply_distinct_group_by`, `apply_sort`, and `apply_output_projection`. The previous in-body `resolve_distinct_col` closure is hoisted to a free function taking the new `DistinctColMap` type alias.
- **`joinscan/mod.rs`** — `plan_custom_path` (~280 LOC) shrinks to a linear sequence calling `compute_output_columns`, `build_output_projection`, `bake_logical_plan`, and `splice_path_private_into_list` (the last deduplicates two near-identical `best_path.custom_private` walks).
- **`aggregatescan/mod.rs`** — `exec_custom_scan` Tantivy path (~260 LOC) splits into `exec_tantivy_aggregate` driving `advance_tantivy_state`, `fill_slot_from_row`, `group_key_to_datum`, and `project_wrapped_aggregates`.

## Why

Each of these functions had grown past the point where the local logic could be held in a single mental model: the longest had nine sub-phases inline, six levels of nesting, and per-tuple raw-pointer machinery interleaved with state-machine code. Cognitive complexity was the bottleneck for further work in these modules; the per-stage helpers make the next round of changes (and the next round of reviewers) materially easier.

## How

Mechanical extraction with no behavior change. Each commit covers one function and stages the helpers as either free functions in the same module or methods on `impl JoinScan` / `impl AggregateScan`, matching the existing pattern in each module. References were re-routed to the new helpers and the entry functions read top-to-bottom as a sequence of named stages.

## Tests

- \`cargo check -p pg_search --no-default-features --features pg18\`
- \`cargo clippy -p pg_search --no-default-features --features pg18 -- -D warnings\`
- Pre-commit hooks (fmt, clippy, cargo check) all pass for every commit