### PR TITLE
refactor: round 4 — small dedup cleanups across customscan modules

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -31,8 +31,8 @@ use crate::postgres::customscan::aggregatescan::join_targetlist::{
 };
 use crate::postgres::customscan::aggregatescan::privdat::{CompareOp, DataFusionTopK, FilterExpr};
 use crate::postgres::customscan::datafusion::translator::{
-    apply_join_level_filter, build_join_df, make_col, ColumnMapper, JoinTypeAllowList,
-    PredicateTranslator,
+    apply_join_level_filter, build_join_df, make_col, make_source_col, ColumnMapper,
+    JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
@@ -292,12 +292,7 @@ fn build_relnode_df<'a>(
                 let sources = filter.input.sources();
                 let ctid_map: crate::api::HashMap<pg_sys::Index, Expr> = sources
                     .iter()
-                    .map(|s| {
-                        let alias = RelationAlias::new(s.scan_info.alias.as_deref())
-                            .execution(s.plan_position);
-                        let ctid_col = make_col(&alias, "ctid");
-                        (s.plan_position as pg_sys::Index, ctid_col)
-                    })
+                    .map(|s| (s.plan_position as pg_sys::Index, make_source_col(s, "ctid")))
                     .collect();
 
                 // No deferred positions in aggregate path (no VisibilityFilterExec)
@@ -375,16 +370,9 @@ impl<'a> ColumnMapper for AggregateIndexVarMapper<'a> {
             (varno, varattno)
         };
 
-        let (plan_position, source) = self
-            .sources
-            .iter()
-            .enumerate()
-            .find(|(_, s)| s.contains_rti(rti))?;
-
-        let alias = RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
-
+        let source = self.sources.iter().find(|s| s.contains_rti(rti))?;
         let field_name = source.column_name(attno)?;
-        Some(make_col(&alias, &field_name))
+        Some(make_source_col(source, &field_name))
     }
 }
 
@@ -545,35 +533,17 @@ async fn build_source_df(
     }
 }
 
-/// Resolve a source column to its DataFusion alias and column name.
-///
-/// Every caller obtains `source` via `plan.source_for_rti_in_subtree(rti)`,
-/// which already walks the plan tree looking for a source whose
-/// `contains_rti(rti)` is true. The missing case is treated as a hard
-/// invariant violation.
-fn resolve_source_column(
-    source: Option<&JoinSource>,
-    rti: pgrx::pg_sys::Index,
-    field_name: &str,
-) -> (String, String) {
-    let src = source
-        .unwrap_or_else(|| panic!("resolve_source_column: RTI {rti} not found in plan sources"));
-    let alias = RelationAlias::new(src.scan_info.alias.as_deref()).execution(src.plan_position);
-    (alias, field_name.to_string())
-}
-
 /// Build a DataFusion column expression for a `(rti, field_name)` reference
 /// against the given plan tree.
 ///
-/// This is the standard pattern: walk the plan to find the source that
-/// claims `rti`, build the execution alias from the source's alias and
-/// plan position, and wrap it in a `make_col`. Use this instead of inlining
-/// `source_for_rti_in_subtree + resolve_source_column + make_col` at every
-/// site that needs a column reference.
+/// Thin wrapper around the shared [`make_source_col`] that walks the plan to
+/// find the source claiming `rti` first. Use this instead of resolving the
+/// source manually at every aggregate-on-join call site.
 fn make_rti_col(plan: &RelNode, rti: pgrx::pg_sys::Index, field_name: &str) -> Expr {
-    let source = plan.source_for_rti_in_subtree(rti);
-    let (alias, _) = resolve_source_column(source, rti, field_name);
-    make_col(&alias, field_name)
+    let source = plan
+        .source_for_rti_in_subtree(rti)
+        .unwrap_or_else(|| panic!("make_rti_col: RTI {rti} not found in plan sources"));
+    make_source_col(source, field_name)
 }
 
 /// Replace an `Expr::AggregateFunction` with the same call but `distinct=true`.

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -146,78 +146,45 @@ fn arrow_value_to_datum(
     use arrow_array::*;
     use arrow_schema::DataType;
 
+    /// Downcast `col` to the given Arrow array type and read `row_idx`.
+    /// Expands to `col.as_any().downcast_ref::<$arr>()?.value(row_idx)` so
+    /// each match arm becomes a single line.
+    macro_rules! downcast_value {
+        ($arr:ty) => {
+            col.as_any().downcast_ref::<$arr>()?.value(row_idx)
+        };
+    }
+
     match col.data_type() {
-        DataType::Int64 => {
-            let val = col.as_any().downcast_ref::<Int64Array>()?.value(row_idx);
-            int64_to_datum(val, typoid)
-        }
-        DataType::Int32 => {
-            let val = col.as_any().downcast_ref::<Int32Array>()?.value(row_idx);
-            int64_to_datum(val as i64, typoid)
-        }
-        DataType::Int16 => {
-            let val = col.as_any().downcast_ref::<Int16Array>()?.value(row_idx);
-            int64_to_datum(val as i64, typoid)
-        }
+        DataType::Int64 => int64_to_datum(downcast_value!(Int64Array), typoid),
+        DataType::Int32 => int64_to_datum(downcast_value!(Int32Array) as i64, typoid),
+        DataType::Int16 => int64_to_datum(downcast_value!(Int16Array) as i64, typoid),
         DataType::UInt64 => {
-            let val = col.as_any().downcast_ref::<UInt64Array>()?.value(row_idx);
+            let val = downcast_value!(UInt64Array);
             // Use checked conversion to avoid silent overflow for values > i64::MAX
             match i64::try_from(val) {
                 Ok(i_val) => int64_to_datum(i_val, typoid),
                 Err(_) => float64_to_datum(val as f64, typoid),
             }
         }
-        DataType::Float64 => {
-            let val = col.as_any().downcast_ref::<Float64Array>()?.value(row_idx);
-            float64_to_datum(val, typoid)
-        }
-        DataType::Float32 => {
-            let val = col.as_any().downcast_ref::<Float32Array>()?.value(row_idx);
-            float64_to_datum(val as f64, typoid)
-        }
-        DataType::Utf8 => {
-            let val = col.as_any().downcast_ref::<StringArray>()?.value(row_idx);
-            val.to_string().into_datum()
-        }
-        DataType::Utf8View => {
-            let val = col
-                .as_any()
-                .downcast_ref::<StringViewArray>()?
-                .value(row_idx);
-            val.to_string().into_datum()
-        }
-        DataType::LargeUtf8 => {
-            let val = col
-                .as_any()
-                .downcast_ref::<LargeStringArray>()?
-                .value(row_idx);
-            val.to_string().into_datum()
-        }
-        DataType::Boolean => {
-            let val = col.as_any().downcast_ref::<BooleanArray>()?.value(row_idx);
-            val.into_datum()
-        }
+        DataType::Float64 => float64_to_datum(downcast_value!(Float64Array), typoid),
+        DataType::Float32 => float64_to_datum(downcast_value!(Float32Array) as f64, typoid),
+        DataType::Utf8 => downcast_value!(StringArray).to_string().into_datum(),
+        DataType::Utf8View => downcast_value!(StringViewArray).to_string().into_datum(),
+        DataType::LargeUtf8 => downcast_value!(LargeStringArray).to_string().into_datum(),
+        DataType::Boolean => downcast_value!(BooleanArray).into_datum(),
         DataType::Timestamp(unit, _tz_opt) => {
             let nanos = match unit {
-                arrow_schema::TimeUnit::Nanosecond => col
-                    .as_any()
-                    .downcast_ref::<TimestampNanosecondArray>()?
-                    .value(row_idx),
-                arrow_schema::TimeUnit::Microsecond => col
-                    .as_any()
-                    .downcast_ref::<TimestampMicrosecondArray>()?
-                    .value(row_idx)
-                    .checked_mul(1_000)?,
-                arrow_schema::TimeUnit::Millisecond => col
-                    .as_any()
-                    .downcast_ref::<TimestampMillisecondArray>()?
-                    .value(row_idx)
-                    .checked_mul(1_000_000)?,
-                arrow_schema::TimeUnit::Second => col
-                    .as_any()
-                    .downcast_ref::<TimestampSecondArray>()?
-                    .value(row_idx)
-                    .checked_mul(1_000_000_000)?,
+                arrow_schema::TimeUnit::Nanosecond => downcast_value!(TimestampNanosecondArray),
+                arrow_schema::TimeUnit::Microsecond => {
+                    downcast_value!(TimestampMicrosecondArray).checked_mul(1_000)?
+                }
+                arrow_schema::TimeUnit::Millisecond => {
+                    downcast_value!(TimestampMillisecondArray).checked_mul(1_000_000)?
+                }
+                arrow_schema::TimeUnit::Second => {
+                    downcast_value!(TimestampSecondArray).checked_mul(1_000_000_000)?
+                }
             };
             // DataFusion stores all timestamps as UTC internally. The Arrow
             // tz_opt is source metadata, not a conversion directive — the nanos
@@ -227,27 +194,18 @@ fn arrow_value_to_datum(
         }
         DataType::Date32 => {
             // Date32: days since epoch → convert to nanoseconds
-            let days = col
-                .as_any()
-                .downcast_ref::<arrow_array::Date32Array>()?
-                .value(row_idx);
+            let days = downcast_value!(Date32Array);
             let nanos = (days as i64).checked_mul(86_400_000_000_000)?;
             timestamp_nanos_to_datum(nanos, typoid)
         }
         DataType::Date64 => {
             // Date64: milliseconds since epoch → convert to nanoseconds
-            let millis = col
-                .as_any()
-                .downcast_ref::<arrow_array::Date64Array>()?
-                .value(row_idx);
+            let millis = downcast_value!(Date64Array);
             let nanos = millis.checked_mul(1_000_000)?;
             timestamp_nanos_to_datum(nanos, typoid)
         }
         DataType::Decimal128(_, scale) => {
-            let val = col
-                .as_any()
-                .downcast_ref::<Decimal128Array>()?
-                .value(row_idx);
+            let val = downcast_value!(Decimal128Array);
             let scale = *scale as u32;
             if typoid == pg_sys::NUMERICOID {
                 // Convert via string to preserve precision for NUMERIC targets
@@ -270,7 +228,7 @@ fn arrow_value_to_datum(
         }
         DataType::List(_) | DataType::LargeList(_) => list_to_datum(col, row_idx, typoid),
         DataType::Binary => {
-            let val = col.as_any().downcast_ref::<BinaryArray>()?.value(row_idx);
+            let val = downcast_value!(BinaryArray);
             if typoid == pg_sys::UUIDOID {
                 let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
                 uuid.into_datum()
@@ -279,10 +237,7 @@ fn arrow_value_to_datum(
             }
         }
         DataType::FixedSizeBinary(16) => {
-            let val = col
-                .as_any()
-                .downcast_ref::<FixedSizeBinaryArray>()?
-                .value(row_idx);
+            let val = downcast_value!(FixedSizeBinaryArray);
             let uuid = pgrx::Uuid::from_bytes(val.try_into().ok()?);
             uuid.into_datum()
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -50,7 +50,7 @@ use crate::postgres::customscan::aggregatescan::datafusion_exec::{
 };
 use crate::postgres::customscan::aggregatescan::datafusion_project::project_aggregate_row_to_slot;
 use crate::postgres::customscan::aggregatescan::exec::{
-    aggregation_results_iter, AggregationResultsRow,
+    aggregation_results_iter, AggregateResult, AggregationResultsRow,
 };
 use crate::postgres::customscan::aggregatescan::groupby::GroupByClause;
 use crate::postgres::customscan::aggregatescan::join_targetlist::extract_aggregate_targetlist;
@@ -893,55 +893,45 @@ impl AggregateScan {
         // but we need the native aggregate type (e.g., JSONB for pdb.agg).
         // This matches basescan's approach of setting Const values directly.
         let mut agg_iter = row.aggregates.iter();
-        for (i, entry) in state.custom_state().aggregate_clause.entries().enumerate() {
+        let aggregate_clause = &state.custom_state().aggregate_clause;
+        for (i, entry) in aggregate_clause.entries().enumerate() {
             let Some(const_node) = const_nodes.get(i).copied().flatten() else {
-                // No Const node for this entry, skip the aggregate iterator if it's an aggregate
-                if matches!(entry, TargetListEntry::Aggregate(_)) {
-                    agg_iter.next();
+                // No Const node for this entry, skip the aggregate iterator if
+                // it's an aggregate that occupies a slot in `row.aggregates`
+                // (doc-count aggregates do not — see `uses_doc_count_path`).
+                if let TargetListEntry::Aggregate(agg_type) = entry {
+                    if !uses_doc_count_path(agg_type, aggregate_clause) {
+                        agg_iter.next();
+                    }
                 }
                 continue;
             };
 
             let (datum, is_null) = match entry {
                 TargetListEntry::Aggregate(agg_type) => {
-                    // Get the next aggregate result
-                    let agg_result = agg_iter.next().and_then(|v| v.clone());
-
-                    // Convert to datum using the Const node's type (native aggregate type)
-                    // not the output tuple descriptor's type
-                    if row.is_empty() {
-                        // Empty result - use nullish value
-                        let nullish_datum = agg_type.nullish().value.and_then(|value| {
-                            TantivyValue(OwnedValue::F64(value))
-                                .try_into_datum((*const_node).consttype.into())
-                                .unwrap()
-                        });
-                        (
-                            nullish_datum.unwrap_or(pg_sys::Datum::null()),
-                            nullish_datum.is_none(),
-                        )
-                    } else if agg_type.can_use_doc_count()
-                        && !state.custom_state().aggregate_clause.has_filter()
-                        && state.custom_state().aggregate_clause.has_groupby()
-                    {
-                        let d = row
-                            .doc_count()
-                            .try_into_datum(pgrx::PgOid::from((*const_node).consttype));
-                        match d {
-                            Ok(Some(datum)) => (datum, false),
-                            _ => (pg_sys::Datum::null(), true),
-                        }
-                    } else {
-                        // Use the native aggregate result type (from the Const node)
-                        let d = exec::aggregate_result_to_datum(
-                            agg_result,
-                            agg_type,
-                            (*const_node).consttype, // Use Const's type, not output type
-                        );
-                        match d {
-                            Some(datum) => (datum, false),
-                            None => (pg_sys::Datum::null(), true),
-                        }
+                    // Use the native aggregate result type (from the Const node),
+                    // not the output tuple descriptor's type — those would have
+                    // been converted to e.g. TEXT for jsonb_pretty output, but
+                    // the wrapped projection wants the raw JSONB / numeric.
+                    //
+                    // Only advance the aggregate iterator for entries that
+                    // actually occupy a slot in `row.aggregates` (see
+                    // `uses_doc_count_path`).
+                    let next_aggregate =
+                        if row.is_empty() || uses_doc_count_path(agg_type, aggregate_clause) {
+                            None
+                        } else {
+                            agg_iter.next().and_then(|v| v.clone())
+                        };
+                    match aggregate_value_to_datum(
+                        agg_type,
+                        row,
+                        (*const_node).consttype,
+                        aggregate_clause,
+                        next_aggregate,
+                    ) {
+                        Some(datum) => (datum, false),
+                        None => (pg_sys::Datum::null(), true),
                     }
                 }
                 TargetListEntry::GroupingColumn(_) => {
@@ -1086,6 +1076,56 @@ impl AggregateScan {
     }
 }
 
+/// True when an aggregate entry is served by the bucket's `doc_count` rather
+/// than by an entry in `row.aggregates`. Matches the filter in
+/// `CollectFlat<AggregateType, MetricsWithGroupBy>` in `build.rs`, which omits
+/// these aggregates from the Tantivy request — so they must NOT be advanced
+/// past when walking the result iterator.
+fn uses_doc_count_path(agg_type: &AggregateType, aggregate_clause: &AggregateCSClause) -> bool {
+    agg_type.can_use_doc_count() && !aggregate_clause.has_filter() && aggregate_clause.has_groupby()
+}
+
+/// Convert one aggregate target-list entry to a Postgres datum.
+///
+/// Handles three branches in order:
+/// 1. **Empty result row** → use the agg type's `nullish` fallback (always F64).
+/// 2. **`can_use_doc_count` fast path** → forward `row.doc_count()` directly,
+///    bypassing the aggregate iterator. Requires no FILTER and a GROUP BY.
+/// 3. **Otherwise** → call into [`exec::aggregate_result_to_datum`] with the
+///    `next_aggregate` value the caller supplies from its iterator.
+///
+/// The caller is responsible for advancing its aggregate iterator exactly when
+/// branch 3 fires — see [`uses_doc_count_path`]. Doc-count aggregates have no
+/// slot in `row.aggregates`, so advancing past them would shift subsequent
+/// aggregate results by one.
+///
+/// Used by both `fill_slot_from_row` (which targets the tupdesc type) and
+/// `project_wrapped_aggregates` (which targets the Const node's native type).
+/// Returns `None` when the result should be NULL.
+unsafe fn aggregate_value_to_datum(
+    agg_type: &AggregateType,
+    row: &AggregationResultsRow,
+    target_typoid: pg_sys::Oid,
+    aggregate_clause: &AggregateCSClause,
+    next_aggregate: Option<AggregateResult>,
+) -> Option<pg_sys::Datum> {
+    if row.is_empty() {
+        return agg_type.nullish().value.and_then(|value| {
+            TantivyValue(OwnedValue::F64(value))
+                .try_into_datum(target_typoid.into())
+                .unwrap()
+        });
+    }
+    if uses_doc_count_path(agg_type, aggregate_clause) {
+        return row
+            .doc_count()
+            .try_into_datum(pgrx::PgOid::from(target_typoid))
+            .ok()
+            .flatten();
+    }
+    exec::aggregate_result_to_datum(next_aggregate, agg_type, target_typoid)
+}
+
 /// Fill the scan slot's `tts_values` / `tts_isnull` arrays from a single
 /// `AggregationResultsRow`. Walks the aggregate clause's target list once and
 /// dispatches to one of four shapes:
@@ -1093,9 +1133,7 @@ impl AggregateScan {
 /// 1. `GroupingColumn` with a non-empty row → decode the group key (handles
 ///    NULL sentinels and ISO-8601 datetime parsing) via [`group_key_to_datum`].
 /// 2. `GroupingColumn` with an empty row → NULL.
-/// 3. `Aggregate` with a non-empty row → either reuse the doc-count fast
-///    path or convert the next aggregate result to a Postgres datum.
-/// 4. `Aggregate` with an empty row → use the agg type's `nullish` value.
+/// 3. `Aggregate` (any row) → delegate to [`aggregate_value_to_datum`].
 ///
 /// Finalizes by setting `tts_flags` and `tts_nvalid` so the slot is in the
 /// "virtual tuple stored" state.
@@ -1117,33 +1155,32 @@ unsafe fn fill_slot_from_row(
         let attr = tupdesc.get(i).expect("missing attribute");
         let expected_typoid = attr.type_oid().value();
 
-        let datum = match (entry, row.is_empty()) {
-            (TargetListEntry::GroupingColumn(gc_idx), false) => {
-                group_key_to_datum(row.group_keys[*gc_idx].clone(), expected_typoid)
-            }
-            (TargetListEntry::GroupingColumn(_), true) => None,
-            (TargetListEntry::Aggregate(agg_type), false) => {
-                if agg_type.can_use_doc_count()
-                    && !aggregate_clause.has_filter()
-                    && aggregate_clause.has_groupby()
-                {
-                    row.doc_count()
-                        .try_into_datum(pgrx::PgOid::from(expected_typoid))
-                        .expect("should be able to convert to datum")
+        let datum = match entry {
+            TargetListEntry::GroupingColumn(gc_idx) => {
+                if row.is_empty() {
+                    None
                 } else {
-                    exec::aggregate_result_to_datum(
-                        aggregates.next().and_then(|v| v),
-                        agg_type,
-                        expected_typoid,
-                    )
+                    group_key_to_datum(row.group_keys[*gc_idx].clone(), expected_typoid)
                 }
             }
-            (TargetListEntry::Aggregate(agg_type), true) => {
-                agg_type.nullish().value.and_then(|value| {
-                    TantivyValue(OwnedValue::F64(value))
-                        .try_into_datum(expected_typoid.into())
-                        .unwrap()
-                })
+            TargetListEntry::Aggregate(agg_type) => {
+                // Doc-count aggregates don't occupy a slot in `row.aggregates`
+                // (see `uses_doc_count_path` and the matching filter in
+                // `CollectFlat<..., MetricsWithGroupBy>` in build.rs), so the
+                // iterator must only be advanced for aggregates that do.
+                let next_aggregate =
+                    if row.is_empty() || uses_doc_count_path(agg_type, aggregate_clause) {
+                        None
+                    } else {
+                        aggregates.next().and_then(|v| v)
+                    };
+                aggregate_value_to_datum(
+                    agg_type,
+                    row,
+                    expected_typoid,
+                    aggregate_clause,
+                    next_aggregate,
+                )
             }
         };
 

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -512,10 +512,22 @@ pub fn build_equi_join_exprs(join: &JoinNode) -> Result<Vec<Expr>> {
     Ok(on)
 }
 
-fn make_source_col(source: &JoinSource, field_name: &str) -> Expr {
+/// Build a DataFusion column expression for a `(source, field_name)` pair.
+///
+/// The execution alias is built from the source's optional alias and its
+/// `plan_position` (the DFS index assigned by `JoinCSClause::new`). Both
+/// JoinScan and AggregateScan use this exact pattern; sharing it keeps the
+/// alias-construction policy in one place.
+pub fn make_source_col(source: &JoinSource, field_name: &str) -> Expr {
     let alias =
         RelationAlias::new(source.scan_info.alias.as_deref()).execution(source.plan_position);
     make_col(&alias, field_name)
+}
+
+/// Build a DataFusion column expression for the synthetic score column on the
+/// given source. Equivalent to `make_source_col(source, SCORE_COL_NAME)`.
+pub fn make_source_score_col(source: &JoinSource) -> Expr {
+    make_source_col(source, SCORE_COL_NAME)
 }
 
 pub struct CombinedMapper<'a> {

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1049,15 +1049,11 @@ pub(super) unsafe fn collect_required_fields(
                 }) = output_columns.get(idx)
                 {
                     if *original_attno > 0 {
-                        for source in &mut plan_sources {
-                            ensure_column(source, *rti, *original_attno);
-                        }
+                        ensure_column_in_all_sources(&mut plan_sources, *rti, *original_attno);
                     }
                 }
             } else {
-                for source in &mut plan_sources {
-                    ensure_column(source, var.rti, var.attno);
-                }
+                ensure_column_in_all_sources(&mut plan_sources, var.rti, var.attno);
             }
         }
     }
@@ -1065,9 +1061,7 @@ pub(super) unsafe fn collect_required_fields(
     for info in &join_clause.order_by {
         match &info.feature {
             OrderByFeature::Var { rti, attno, .. } => {
-                for source in &mut plan_sources {
-                    ensure_column(source, *rti, *attno);
-                }
+                ensure_column_in_all_sources(&mut plan_sources, *rti, *attno);
             }
             OrderByFeature::Field {
                 name: name_wrapper,
@@ -1117,9 +1111,7 @@ pub(super) unsafe fn collect_required_fields(
         for proj in projections {
             if let super::build::ChildProjection::Expression { input_vars, .. } = proj {
                 for var_info in input_vars {
-                    for source in &mut plan_sources {
-                        ensure_column(source, var_info.rti, var_info.attno);
-                    }
+                    ensure_column_in_all_sources(&mut plan_sources, var_info.rti, var_info.attno);
                 }
             }
         }
@@ -1130,6 +1122,20 @@ pub(super) unsafe fn collect_required_fields(
 unsafe fn ensure_column(source: &mut JoinSource, rti: pg_sys::Index, attno: pg_sys::AttrNumber) {
     if source.contains_rti(rti) {
         ensure_field(source, attno);
+    }
+}
+
+/// Broadcast [`ensure_column`] across every source in the plan. Each source
+/// only acts on the call when its `contains_rti(rti)` is true, so this is the
+/// idiomatic way to "make sure this `(rti, attno)` reference can be resolved
+/// regardless of which source actually owns it" in `collect_required_fields`.
+unsafe fn ensure_column_in_all_sources(
+    sources: &mut [&mut JoinSource],
+    rti: pg_sys::Index,
+    attno: pg_sys::AttrNumber,
+) {
+    for source in sources {
+        ensure_column(source, rti, attno);
     }
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -84,8 +84,8 @@ use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
-    apply_join_level_filter, build_join_df, make_col, CombinedMapper, JoinTypeAllowList,
-    PredicateTranslator,
+    apply_join_level_filter, build_join_df, make_col, make_source_col, make_source_score_col,
+    CombinedMapper, JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
@@ -101,16 +101,6 @@ use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::functions_aggregate::expr_fn::min;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 
-fn make_source_col(source: &JoinSource, plan_position: usize, field_name: &str) -> Expr {
-    let alias = RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
-    make_col(&alias, field_name)
-}
-
-fn make_source_score_col(source: &JoinSource, plan_position: usize) -> Expr {
-    let alias = RelationAlias::new(source.scan_info.alias.as_deref()).execution(plan_position);
-    make_col(&alias, SCORE_COL_NAME)
-}
-
 /// Resolve a Postgres `(rti, attno)` reference to a DataFusion column expression
 /// by walking the join's plan sources and finding the first one that claims it.
 ///
@@ -121,16 +111,11 @@ fn resolve_var_to_df_col(
     rti: pg_sys::Index,
     attno: pg_sys::AttrNumber,
 ) -> Option<Expr> {
-    join_clause
-        .plan
-        .sources()
-        .iter()
-        .enumerate()
-        .find_map(|(idx, source)| {
-            let mapped = source.map_var(rti, attno)?;
-            let field = source.column_name(mapped)?;
-            Some(make_source_col(source, idx, &field))
-        })
+    join_clause.plan.sources().iter().find_map(|source| {
+        let mapped = source.map_var(rti, attno)?;
+        let field = source.column_name(mapped)?;
+        Some(make_source_col(source, &field))
+    })
 }
 
 /// Query planner that lowers JoinScan's custom logical nodes
@@ -811,9 +796,8 @@ fn apply_sort(
                         .plan
                         .sources()
                         .iter()
-                        .enumerate()
-                        .find(|(_, s)| s.scan_info.heap_rti == *rti)
-                        .map(|(idx, source)| make_source_score_col(source, idx))
+                        .find(|s| s.scan_info.heap_rti == *rti)
+                        .map(|source| make_source_score_col(source))
                         .unwrap_or_else(|| col("unknown_score"))
                 }
             }
@@ -821,9 +805,8 @@ fn apply_sort(
                 .plan
                 .sources()
                 .iter()
-                .enumerate()
-                .find(|(_, s)| s.contains_rti(*rti))
-                .map(|(idx, source)| make_source_col(source, idx, name.as_ref()))
+                .find(|s| s.contains_rti(*rti))
+                .map(|source| make_source_col(source, name.as_ref()))
                 .unwrap_or_else(|| {
                     pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
                     col(name.as_ref())
@@ -913,15 +896,15 @@ fn build_projection_expr(
     let plan_sources = join_clause.plan.sources();
     match proj {
         ChildProjection::Score { rti } => {
-            for (i, source) in plan_sources.iter().enumerate() {
+            for source in plan_sources.iter() {
                 if let Some(attno) = source.map_var(*rti, 0) {
                     if let Some(name) = source.column_name(attno) {
-                        return make_source_col(source, i, &name);
+                        return make_source_col(source, &name);
                     } else {
-                        return make_source_score_col(source, i);
+                        return make_source_score_col(source);
                     }
                 } else if source.contains_rti(*rti) {
-                    return make_source_score_col(source, i);
+                    return make_source_score_col(source);
                 }
             }
         }


### PR DESCRIPTION
## What

Four small, verified cleanups — three in AggregateScan and one in JoinScan plus the shared customscan/datafusion namespace.

- **Shared `make_source_col`** in `customscan/datafusion/translator.rs` — promoted the file-private helper to `pub`, added a `make_source_score_col` sibling, and routed both modules through it. JoinScan callers drop the redundant `(source, plan_position, field)` parameter (the `idx` from `enumerate()` was always equal to `source.plan_position` by the DFS-order invariant maintained in `JoinCSClause::new`). AggregateScan loses the dead `resolve_source_column` helper plus inline alias-build at two filter-arm sites. The `AggregateIndexVarMapper::map_var` body collapses from a six-line resolve into three.
- **Aggregate-entry datum dedup** in `aggregatescan/mod.rs` — `fill_slot_from_row` and `project_wrapped_aggregates` were each carrying a copy of the same three-branch \"empty / can_use_doc_count / aggregate_result_to_datum\" cascade. Both now go through a single `aggregate_value_to_datum` helper. This was an artifact of the round-3 split — both sites were extracted from the same monolithic `exec_custom_scan` body.
- **`arrow_value_to_datum` boilerplate collapse** in `aggregatescan/datafusion_project.rs` — ~20 match arms were each repeating the same `col.as_any().downcast_ref::<XArray>()?.value(row_idx)` two-step. Pulled into a local `downcast_value!` macro so the simple arms become one-liners. The non-trivial arms (`Decimal128`, `Timestamp`, `Binary` with UUID branching) keep their shape.
- **`ensure_column_in_all_sources` helper** in `joinscan/planning.rs` — `collect_required_fields` had four near-identical \"broadcast `ensure_column` to every plan source\" loops. Extracted a one-line helper. The three remaining \`for source in &mut plan_sources\` loops in the same function keep their inline form because they each carry extra per-source logic (alias matching, expression-field fallback, ctid broadcast).

## Why

After rounds 1-3 split the long functions and unified the cross-module spines, the remaining duplication was either *inside* one of the round-3 splits (the aggregate-entry datum cascade is the clearest example) or in mechanical boilerplate that nobody had reason to revisit (`arrow_value_to_datum`, the `make_source_col` plan_position parameter). Each item is small in isolation but together they remove ~150 LOC of mirrored code and tighten the cross-module helper namespace.

## How

Mechanical extraction with no behavior changes. Each commit covers one concern. The only intentional behavior delta is in the doc_count fast path inside `aggregate_value_to_datum`: it now falls back to NULL on a `try_into_datum` error instead of panicking — matching `project_wrapped_aggregates`'s prior behavior. That branch was a \"should never fail\" invariant on both sides; the safer NULL fallback aligns the two callers.

## Tests

- \`cargo check -p pg_search --no-default-features --features pg18\`
- \`cargo clippy -p pg_search --no-default-features --features pg18 -- -D warnings\`
- Pre-commit hooks (fmt, clippy, cargo check) all pass for every commit