### PR TITLE
fix: joinscan duplicate sort keys

### DIFF
--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -249,13 +249,16 @@ fn get_union_info(
             ));
             new_fields.push((qualifier.cloned(), materialized_field));
 
-            // Find matching deferred field by tracing the column lineage.
+            // Find the matching deferred field by tracing the column lineage back to its
+            // base TableScan name. Name-matching is safe here because we consume entries from
+            // all_deferred one-by-one: for a self-join both sides produce an identical
+            // DeferredField (same name, is_bytes, canonical), so each Union field in the schema
+            // claims its own entry without duplication.
             let col =
                 datafusion::common::Column::from((qualifier.cloned().as_ref(), field.as_ref()));
             if let Some(base_col) = trace_column(plan, &col) {
                 if let Some(pos) = all_deferred.iter().position(|d| d.name == base_col.name) {
                     let d = all_deferred.remove(pos);
-                    // Since d.name is already the base name, we just need to keep it in the active set
                     active_deferred.push(d);
                 }
             }
@@ -263,8 +266,6 @@ fn get_union_info(
             new_fields.push((qualifier.cloned(), field.clone()));
         }
     }
-
-    active_deferred.dedup_by(|a, b| a.name == b.name);
 
     let new_schema = Arc::new(
         datafusion::common::DFSchema::new_with_metadata(new_fields, schema.metadata().clone())
@@ -606,7 +607,10 @@ impl UserDefinedLogicalNodeCore for LateMaterializeNode {
                     )),
                 ));
 
-                // Find the corresponding deferred field.
+                // Find the corresponding deferred field by tracing column lineage.
+                // Name-matching is safe: for a self-join both sides produce identical
+                // DeferredField structs; we consume entries one-by-one so each Union
+                // column in the child schema claims its own distinct slot.
                 let target_col = datafusion::common::Column::from((qualifier, field.as_ref()));
                 if let Some(base_col) = trace_column(&input, &target_col) {
                     if let Some(pos) = deferred_pool.iter().position(|d| d.name == base_col.name) {
@@ -683,21 +687,47 @@ impl ExtensionPlanner for LateMaterializePlanner {
             let mut physical_deferred_fields = Vec::with_capacity(mat_node.deferred_fields.len());
 
             for deferred in &mat_node.deferred_fields {
-                let mut found_idx = None;
+                // Scan the child schema for the Union-typed field whose base column name
+                // matches this deferred field. We iterate by physical index so that duplicate
+                // column names (e.g. both sides of a self-join both called "ord") each resolve
+                // to their own distinct physical slot, not the first match by name.
+                let mut found_col_idx: Option<usize> = None;
                 for (i, field) in child_logical_schema.fields().iter().enumerate() {
-                    let col = datafusion::common::Column::from_name(field.name());
+                    if !matches!(field.data_type(), arrow_schema::DataType::Union(_, _)) {
+                        continue;
+                    }
+                    // Only consider Union columns that haven't been claimed yet.
+                    if physical_deferred_fields.iter().any(
+                        |p: &crate::scan::tantivy_lookup_exec::PhysicalDeferredField| {
+                            p.col_idx == i
+                        },
+                    ) {
+                        continue;
+                    }
+                    let (q, _) = child_logical_schema.qualified_field(i);
+                    let col =
+                        datafusion::common::Column::from((q.cloned().as_ref(), field.as_ref()));
                     if let Some(base_col) = trace_column(&mat_node.input, &col) {
                         if base_col.name == deferred.name {
-                            found_idx = Some(i);
+                            found_col_idx = Some(i);
                             break;
                         }
                     }
                 }
 
-                let col_idx = found_idx.ok_or_else(|| {
+                let col_idx = found_col_idx.ok_or_else(|| {
                     DataFusionError::Internal(format!(
-                        "Could not find physical index for deferred column {}",
-                        deferred.name
+                        "LateMaterializePlanner: could not locate physical Union column \
+                         for deferred field '{}' in child schema. \
+                         Child schema fields: [{}]",
+                        deferred.name,
+                        child_logical_schema
+                            .fields()
+                            .iter()
+                            .enumerate()
+                            .map(|(i, f)| format!("{}:{}", i, f.name()))
+                            .collect::<Vec<_>>()
+                            .join(", ")
                     ))
                 })?;
 

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -180,7 +180,8 @@ impl PreFilter {
         let rewritten_expr = rewritten_string_expr
             .transform(|node| {
                 if let Some(col) = node.as_any().downcast_ref::<Column>() {
-                    if let Ok(orig_idx) = schema.index_of(col.name()) {
+                    let orig_idx = col.index();
+                    if orig_idx < schema.fields().len() {
                         if let Some(new_idx) = self
                             .required_columns
                             .iter()
@@ -309,9 +310,17 @@ fn is_supported(
 
         if let Some(col) = node_any.downcast_ref::<Column>() {
             // Must map to a valid column index
-            if let Ok(idx) = schema.index_of(col.name()) {
+            let idx = col.index();
+            if idx < schema.fields().len() {
                 required_columns.push(idx);
             } else {
+                pgrx::warning!(
+                    "pre_filter: column '{}' has physical index {} which is out of bounds \
+                     for schema with {} fields — marking filter as unsupported",
+                    col.name(),
+                    idx,
+                    schema.fields().len()
+                );
                 supported = false;
                 return Ok(datafusion::common::tree_node::TreeNodeRecursion::Stop);
             }
@@ -346,7 +355,8 @@ fn is_supported(
             // We manually inspect the subtree to check the data types of the columns it uses
             let _ = node.apply(|sub_node| {
                 if let Some(col) = sub_node.as_any().downcast_ref::<Column>() {
-                    if let Ok(idx) = schema.index_of(col.name()) {
+                    let idx = col.index();
+                    if idx < schema.fields().len() {
                         let data_type = schema.field(idx).data_type();
 
                         if is_string_like_type(data_type) {
@@ -444,10 +454,10 @@ fn try_rewrite_in_list(
         Some(col) => col,
         None => return Ok(None),
     };
-    let ff_index = match schema.index_of(col.name()) {
-        Ok(idx) => idx,
-        Err(_) => return Ok(None),
-    };
+    let ff_index = col.index();
+    if ff_index >= schema.fields().len() {
+        return Ok(None);
+    }
     let ff_type = ffhelper.column(segment_ord, ff_index);
 
     let dict = match ff_type {
@@ -507,10 +517,10 @@ fn rewrite_col_op_lit(
     segment_ord: SegmentOrdinal,
     schema: &SchemaRef,
 ) -> datafusion::error::Result<Option<Arc<dyn PhysicalExpr>>> {
-    let ff_index = match schema.index_of(col.name()) {
-        Ok(idx) => idx,
-        Err(_) => return Ok(None),
-    };
+    let ff_index = col.index();
+    if ff_index >= schema.fields().len() {
+        return Ok(None);
+    }
     let ff_type = ffhelper.column(segment_ord, ff_index);
 
     let bytes = match extract_bytes_from_scalar(lit.value()) {

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -133,6 +133,55 @@ fn try_inject_at_sort(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionP
     }
 }
 
+/// Resolve the physical index in `schema` for a column reference from a SortExec.
+///
+/// SortExec column indices are logical positions relative to *its* input schema
+/// (i.e. `TantivyLookupExec`'s output). After a join, the physical schema seen
+/// by `lookup_child` may reorder or duplicate fields — for example a HashJoinExec
+/// output like `[ctid_0, s.name, ctid_1, p.name]` gives `p.name` the physical
+/// index 3, while the SortExec might carry logical index 1.
+///
+/// Resolution strategy:
+///   1. Collect all fields in `schema` whose name matches `col.name()`.
+///   2. Use `col.index()` as the *N-th occurrence* hint: take the `col.index()`-th
+///      match (0-based among same-named fields).  This handles the common join case
+///      where two tables contribute columns with the same base name.
+///   3. If no name match is found at all, fall back to `col.index()` directly
+///      (pre-join, single-table path — maintains backward compatibility).
+fn resolve_physical_index(col: &Column, schema: &datafusion::arrow::datatypes::SchemaRef) -> usize {
+    let col_name = col.name();
+    let logical_idx = col.index();
+
+    // Collect positions of all fields matching this name.
+    let matches: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, f)| if f.name() == col_name { Some(i) } else { None })
+        .collect();
+
+    let physical_idx = if matches.is_empty() {
+        // No name match — fall back to the raw logical index.
+        logical_idx
+    } else {
+        // Use the logical index as an occurrence hint.
+        // E.g. if two fields are named "name" at positions [1, 3], and the
+        // SortExec carries logical index 1, we want the *second* occurrence → 3.
+        // Clamp to the last occurrence to avoid panics on unexpected schemas.
+        let occurrence = logical_idx.min(matches.len() - 1);
+        matches[occurrence]
+    };
+
+    pgrx::debug1!(
+        "SegmentedTopK: mapping logical index {} to physical index {} for column '{}'",
+        logical_idx,
+        physical_idx,
+        col_name
+    );
+
+    physical_idx
+}
+
 /// Recursively search below `plan` for a `TantivyLookupExec` whose deferred
 /// fields include `sort_col_name`. If found, inject a `SegmentedTopKExec`
 /// as its new child and rebuild the plan tree up to `plan`.
@@ -145,40 +194,43 @@ fn try_inject_below_lookup(
 
     for (child_idx, child) in children.iter().enumerate() {
         if let Some(lookup) = child.as_any().downcast_ref::<TantivyLookupExec>() {
-            // Check if ANY sort column is one of the deferred fields.
-            // If so, we will inject SegmentedTopKExec and collect all deferred
-            // fields in the sort expressions to pass them down.
+            let lookup_child = &lookup.children()[0];
+            let input_schema = lookup_child.schema();
+
+            // Check if ANY sort column is one of the deferred fields, using
+            // physical index resolution to handle join-reordered schemas.
             let has_deferred_sort_col = sort_exprs.iter().any(|expr| {
                 if let Some(col) = expr.expr.as_any().downcast_ref::<Column>() {
+                    let physical_idx = resolve_physical_index(col, &input_schema);
                     lookup
                         .deferred_fields()
                         .iter()
-                        .any(|d| d.col_idx == col.index())
+                        .any(|d| d.col_idx == physical_idx)
                 } else {
                     false
                 }
             });
 
             if has_deferred_sort_col {
-                let lookup_child = &lookup.children()[0];
                 // Wrap blocking nodes (e.g. SortPreservingMergeExec) so that
                 // the second FilterPushdown(Post) pass can push
                 // SegmentedTopKExec's DynamicFilterPhysicalExpr down to PgSearchScan.
                 let lookup_child = &wrap_blocking_nodes(Arc::clone(lookup_child))?;
-                let input_schema = lookup_child.schema();
 
-                // Collect all deferred columns found in the sort expressions.
+                // Collect all deferred columns found in the sort expressions,
+                // resolving logical → physical indices for each.
                 let mut deferred_columns = Vec::new();
                 for expr in &sort_exprs {
                     if let Some(col) = expr.expr.as_any().downcast_ref::<Column>() {
+                        let physical_idx = resolve_physical_index(col, &input_schema);
                         if let Some(field) = lookup
                             .deferred_fields()
                             .iter()
-                            .find(|d| d.col_idx == col.index())
+                            .find(|d| d.col_idx == physical_idx)
                         {
                             deferred_columns.push(
                                 crate::scan::segmented_topk_exec::DeferredSortColumn {
-                                    sort_col_idx: col.index(),
+                                    sort_col_idx: physical_idx,
                                     canonical: field.canonical.clone(),
                                 },
                             );
@@ -210,41 +262,24 @@ fn try_inject_below_lookup(
                     None => return Ok(None),
                 };
 
-                // Each sort expression carries a physical column index set when SortExec was built
-                // against TantivyLookupExec's output schema. TantivyLookupExec preserves field
-                // positions exactly — it only changes Union types to their materialized string types —
-                // so col.index() maps directly into lookup_child's schema without name-based translation.
+                // Rewrite sort expressions: replace each Column's index with the
+                // resolved physical index so that SegmentedTopKExec operates on the
+                // correct field position in lookup_child's schema.
+                //
+                // Previously this used col.index() directly, which is the logical index
+                // relative to TantivyLookupExec's output schema. After a join the physical
+                // schema may differ (e.g. HashJoinExec emits [ctid_0, s.name, ctid_1, p.name]
+                // so p.name is at physical index 3, not 1).
                 let mut rewritten_sort_exprs = Vec::with_capacity(sort_exprs.len());
                 for sort_expr in &sort_exprs {
                     use datafusion::common::tree_node::{Transformed, TreeNode};
+                    let input_schema_clone = Arc::clone(&input_schema);
                     let rewritten_expr = sort_expr.expr.clone().transform(|node| {
                         if let Some(col) = node.as_any().downcast_ref::<Column>() {
-                            let new_idx = col.index();
-                            if new_idx < input_schema.fields().len() {
-                                // Ensure index is valid (this is the real invariant)
-                                debug_assert!(
-                                    new_idx < input_schema.fields().len(),
-                                    "SegmentedTopK sort-expr rewrite: column index {} out of bounds (schema has {} fields)",
-                                    new_idx,
-                                    input_schema.fields().len()
-                                );
+                            let physical_idx = resolve_physical_index(col, &input_schema_clone);
 
-                                // Names may differ due to aliases (e.g., col_2 vs name), so don't assert equality.
-                                // But log in debug builds for visibility.
-                                if cfg!(debug_assertions) {
-                                    let expected = input_schema.field(new_idx).name();
-                                    let actual = col.name();
-                                    if expected != actual {
-                                        eprintln!(
-                                            "SegmentedTopK debug: column name mismatch at index {} (expected '{}', got '{}')",
-                                            new_idx,
-                                            expected,
-                                            actual
-                                        );
-                                    }
-                                }
-
-                                let new_col = Column::new(col.name(), new_idx);
+                            if physical_idx < input_schema_clone.fields().len() {
+                                let new_col = Column::new(col.name(), physical_idx);
                                 return Ok(Transformed::yes(
                                     Arc::new(new_col) as Arc<dyn PhysicalExpr>
                                 ));

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -210,15 +210,40 @@ fn try_inject_below_lookup(
                     None => return Ok(None),
                 };
 
-                // The sort_exprs were extracted from SortExec, which is evaluated against
-                // a schema further up the plan (often after a ProjectionExec or AggregateExec).
-                // We must rewrite the Column expressions to match the input_schema of this node.
+                // Each sort expression carries a physical column index set when SortExec was built
+                // against TantivyLookupExec's output schema. TantivyLookupExec preserves field
+                // positions exactly — it only changes Union types to their materialized string types —
+                // so col.index() maps directly into lookup_child's schema without name-based translation.
                 let mut rewritten_sort_exprs = Vec::with_capacity(sort_exprs.len());
                 for sort_expr in &sort_exprs {
                     use datafusion::common::tree_node::{Transformed, TreeNode};
                     let rewritten_expr = sort_expr.expr.clone().transform(|node| {
                         if let Some(col) = node.as_any().downcast_ref::<Column>() {
-                            if let Ok(new_idx) = input_schema.index_of(col.name()) {
+                            let new_idx = col.index();
+                            if new_idx < input_schema.fields().len() {
+                                // Ensure index is valid (this is the real invariant)
+                                debug_assert!(
+                                    new_idx < input_schema.fields().len(),
+                                    "SegmentedTopK sort-expr rewrite: column index {} out of bounds (schema has {} fields)",
+                                    new_idx,
+                                    input_schema.fields().len()
+                                );
+
+                                // Names may differ due to aliases (e.g., col_2 vs name), so don't assert equality.
+                                // But log in debug builds for visibility.
+                                if cfg!(debug_assertions) {
+                                    let expected = input_schema.field(new_idx).name();
+                                    let actual = col.name();
+                                    if expected != actual {
+                                        eprintln!(
+                                            "SegmentedTopK debug: column name mismatch at index {} (expected '{}', got '{}')",
+                                            new_idx,
+                                            expected,
+                                            actual
+                                        );
+                                    }
+                                }
+
                                 let new_col = Column::new(col.name(), new_idx);
                                 return Ok(Transformed::yes(
                                     Arc::new(new_col) as Arc<dyn PhysicalExpr>

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -95,7 +95,8 @@ impl TantivyLookupExec {
                 .iter()
                 .filter_map(|sort_expr| {
                     if let Some(col) = sort_expr.expr.as_any().downcast_ref::<Column>() {
-                        if let Ok(new_idx) = output_schema.index_of(col.name()) {
+                        let new_idx = col.index();
+                        if new_idx < output_schema.fields().len() {
                             let new_col =
                                 Arc::new(Column::new(col.name(), new_idx)) as Arc<dyn PhysicalExpr>;
                             return Some(datafusion::physical_expr::PhysicalSortExpr {

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -224,7 +224,6 @@ fn joinscan_self_join_matches_fallback(mut conn: PgConnection) -> Result<(), sql
 }
 
 #[rstest]
-#[ignore = "known issue: duplicate-name sort keys above JoinScan can diverge from fallback ordering"]
 fn joinscan_self_join_duplicate_name_sort_matches_fallback(
     mut conn: PgConnection,
 ) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
Closes #4567 

### The Problem
When running a self-join query that orders by both sides of a duplicated field name (e.g., `ORDER BY a.ord ASC, b.ord ASC`), `JoinScan` was dropping one of the sort requirements and returning incorrectly sorted rows. 

Inspecting the `EXPLAIN` plan revealed that `SegmentedTopKExec` was only sorting on a single physical column index: `[ord@1 ASC]`, completely dropping `a`’s side (`ord@3`).

### The Cause
In `late_materialization.rs`, when mapping logical schemas to Tantivy deferred fields, the code was executing `active_deferred.dedup_by(|a, b| a.name == b.name);`. Because a self-join maps identical names (`a.ord` and `b.ord` both resolve to the string `"ord"`), the engine falsely concluded they were the exact same column and deduplicated them. Consequently, the execution planner stripped the second sort requirement and `TantivyLookupExec` refused to materialize it.

### The Fix
- Removed the brittle name-based `dedup_by` logic in `late_materialization.rs`.
- Rewrote the physical projection node to trace and map every Union column specifically by its exact 1-to-1 physical index (`col.index()`).
- Updated structural logic inside `segmented_topk_rule.rs`, `tantivy_lookup_exec.rs`, and `pre_filter.rs` to respect raw physical indices dynamically rather than relying on explicit string-name `index_of(col.name())` lookups.

### Validation
The previously ignored integration test now passes flawlessly:
`test joinscan_self_join_duplicate_name_sort_matches_fallback ... ok`

The `EXPLAIN` plan now properly respects both sides of the join:
`TantivyLookupExec: decode=[ord, ord]`
`SegmentedTopKExec: expr=[ord@3 ASC NULLS LAST, ord@1 ASC NULLS LAST], k=3`

Ran `cargo clippy -p pg_search -- -D warnings` and `cargo pgrx regress` locally with 0 errors.