### PR TITLE
feat: use BAS_BULKREAD strategy when reading segments during merge

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -193,9 +193,18 @@ impl MVCCDirectory {
                 let file_entry = entry
                     .file_entry(uuid_string, path)
                     .expect("No such path for {entry:?}: {path:?}");
-                Ok(Arc::new(unsafe {
-                    SegmentComponentReader::new(&self.indexrel, file_entry)
-                }))
+                let reader: Arc<dyn FileHandle> = if *self.mvcc_style == MvccSatisfies::Mergeable {
+                    Arc::new(unsafe {
+                        SegmentComponentReader::new_with_strategy(
+                            &self.indexrel,
+                            file_entry,
+                            crate::postgres::storage::utils::bulkread_strategy(),
+                        )
+                    })
+                } else {
+                    Arc::new(unsafe { SegmentComponentReader::new(&self.indexrel, file_entry) })
+                };
+                Ok(reader)
             }
             LoadedSegmentMetaEntry::Memory {
                 meta,

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -18,9 +18,9 @@
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::FileEntry;
 
+use crate::postgres::storage::utils::BufferAccessStrategyHolder;
 use crate::postgres::storage::LinkedBytesList;
 use anyhow::Result;
-use pgrx::pg_sys;
 use std::io::Error;
 use std::ops::Range;
 use tantivy::directory::FileHandle;
@@ -40,22 +40,23 @@ impl SegmentComponentReader {
         Self { block_list, entry }
     }
 
-    /// Like [`new`], but uses the given [`pg_sys::BufferAccessStrategy`] when reading buffers.
+    /// Like [`Self::new`], but uses the given [`BufferAccessStrategyHolder`]
+    /// when reading buffers.
     ///
-    /// Pass [`bulkread_strategy()`] to prevent merge reads from evicting active buffers.
+    /// Pass
+    /// [`crate::postgres::storage::utils::bulkread_strategy`]
+    /// to prevent merge reads from evicting active buffers.
     ///
     /// # Safety
     ///
-    /// Same requirements as [`Self::new`]. Additionally, `strategy` must satisfy
-    /// the safety requirements of [`BufferManager::with_strategy`].
+    /// Same requirements as [`Self::new`].
     pub(crate) unsafe fn new_with_strategy(
         indexrel: &PgSearchRelation,
         entry: FileEntry,
-        strategy: pg_sys::BufferAccessStrategy,
+        strategy: BufferAccessStrategyHolder,
     ) -> Self {
-        let block_list = unsafe {
-            LinkedBytesList::open(indexrel, entry.starting_block).with_strategy(strategy)
-        };
+        let block_list =
+            LinkedBytesList::open(indexrel, entry.starting_block).with_strategy(strategy);
 
         Self { block_list, entry }
     }

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -20,6 +20,7 @@ use crate::postgres::storage::block::FileEntry;
 
 use crate::postgres::storage::LinkedBytesList;
 use anyhow::Result;
+use pgrx::pg_sys;
 use std::io::Error;
 use std::ops::Range;
 use tantivy::directory::FileHandle;
@@ -35,6 +36,26 @@ pub struct SegmentComponentReader {
 impl SegmentComponentReader {
     pub unsafe fn new(indexrel: &PgSearchRelation, entry: FileEntry) -> Self {
         let block_list = LinkedBytesList::open(indexrel, entry.starting_block);
+
+        Self { block_list, entry }
+    }
+
+    /// Like [`new`], but uses the given [`pg_sys::BufferAccessStrategy`] when reading buffers.
+    ///
+    /// Pass [`bulkread_strategy()`] to prevent merge reads from evicting active buffers.
+    ///
+    /// # Safety
+    ///
+    /// Same requirements as [`Self::new`]. Additionally, `strategy` must satisfy
+    /// the safety requirements of [`BufferManager::with_strategy`].
+    pub(crate) unsafe fn new_with_strategy(
+        indexrel: &PgSearchRelation,
+        entry: FileEntry,
+        strategy: pg_sys::BufferAccessStrategy,
+    ) -> Self {
+        let block_list = unsafe {
+            LinkedBytesList::open(indexrel, entry.starting_block).with_strategy(strategy)
+        };
 
         Self { block_list, entry }
     }

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -734,14 +734,39 @@ impl PageHeaderMethods for pg_sys::PageHeaderData {
 pub struct BufferManager {
     rbufacc: RelationBufferAccess,
     fsm_blockno: Option<pg_sys::BlockNumber>,
+    strategy: pg_sys::BufferAccessStrategy,
 }
+
+// SAFETY: The `strategy` field is either null or points to a process-lifetime
+// singleton allocated in TopMemoryContext (via `bulkread_strategy()` or similar),
+// which is safe to share across threads. The `with_strategy` method is `unsafe`
+// and requires the caller to uphold this invariant.
+unsafe impl Send for BufferManager {}
+unsafe impl Sync for BufferManager {}
 
 impl BufferManager {
     pub fn new(rel: &PgSearchRelation) -> Self {
         Self {
             rbufacc: RelationBufferAccess::open(rel),
             fsm_blockno: None,
+            strategy: std::ptr::null_mut(),
         }
+    }
+
+    /// Set the [`pg_sys::BufferAccessStrategy`] used when reading existing buffers.
+    ///
+    /// For example, pass the result of [`bulkread_strategy()`] to prevent bulk reads
+    /// from evicting active buffers in the shared buffer cache.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `strategy` is either null or points to memory
+    /// that lives for the entire process lifetime (e.g. allocated in
+    /// `TopMemoryContext`). This is required for the `Send`/`Sync` impl on
+    /// `BufferManager` to be sound.
+    pub(crate) unsafe fn with_strategy(mut self, strategy: pg_sys::BufferAccessStrategy) -> Self {
+        self.strategy = strategy;
+        self
     }
 
     pub fn fsm(&mut self) -> impl FreeSpaceManager {
@@ -846,13 +871,21 @@ impl BufferManager {
 
     pub fn pinned_buffer(&self, blockno: pg_sys::BlockNumber) -> PinnedBuffer {
         block_tracker::track!(Pinned, blockno);
-        PinnedBuffer::new(self.rbufacc.get_buffer(blockno, None))
+        PinnedBuffer::new(self.rbufacc.get_buffer_extended(
+            blockno,
+            self.strategy,
+            pg_sys::ReadBufferMode::RBM_NORMAL,
+            None,
+        ))
     }
 
     pub fn get_buffer(&self, blockno: pg_sys::BlockNumber) -> Buffer {
-        let pg_buffer = self
-            .rbufacc
-            .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_SHARE));
+        let pg_buffer = self.rbufacc.get_buffer_extended(
+            blockno,
+            self.strategy,
+            pg_sys::ReadBufferMode::RBM_NORMAL,
+            Some(pg_sys::BUFFER_LOCK_SHARE),
+        );
 
         block_tracker::track!(Read, blockno);
         Buffer::new(pg_buffer)
@@ -874,10 +907,12 @@ impl BufferManager {
         block_tracker::track!(Write, blockno);
         BufferMut {
             dirty: false,
-            inner: Buffer::new(
-                self.rbufacc
-                    .get_buffer(blockno, Some(pg_sys::BUFFER_LOCK_EXCLUSIVE)),
-            ),
+            inner: Buffer::new(self.rbufacc.get_buffer_extended(
+                blockno,
+                self.strategy,
+                pg_sys::ReadBufferMode::RBM_NORMAL,
+                Some(pg_sys::BUFFER_LOCK_EXCLUSIVE),
+            )),
         }
     }
 
@@ -897,7 +932,12 @@ impl BufferManager {
     #[allow(dead_code)]
     pub fn get_buffer_conditional(&mut self, blockno: pg_sys::BlockNumber) -> Option<BufferMut> {
         unsafe {
-            let pg_buffer = self.rbufacc.get_buffer(blockno, None);
+            let pg_buffer = self.rbufacc.get_buffer_extended(
+                blockno,
+                self.strategy,
+                pg_sys::ReadBufferMode::RBM_NORMAL,
+                None,
+            );
             if pg_sys::ConditionalLockBuffer(pg_buffer) {
                 block_tracker::track!(Conditional, blockno);
                 Some(BufferMut {
@@ -913,7 +953,12 @@ impl BufferManager {
 
     pub fn get_buffer_for_cleanup(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
-            let pg_buffer = self.rbufacc.get_buffer(blockno, None);
+            let pg_buffer = self.rbufacc.get_buffer_extended(
+                blockno,
+                self.strategy,
+                pg_sys::ReadBufferMode::RBM_NORMAL,
+                None,
+            );
             block_tracker::track!(Cleanup, blockno);
             pg_sys::LockBufferForCleanup(pg_buffer);
             BufferMut {
@@ -928,7 +973,12 @@ impl BufferManager {
         blockno: pg_sys::BlockNumber,
     ) -> Option<BufferMut> {
         unsafe {
-            let pg_buffer = self.rbufacc.get_buffer(blockno, None);
+            let pg_buffer = self.rbufacc.get_buffer_extended(
+                blockno,
+                self.strategy,
+                pg_sys::ReadBufferMode::RBM_NORMAL,
+                None,
+            );
             if pg_sys::ConditionalLockBufferForCleanup(pg_buffer) {
                 block_tracker::track!(ConditionalCleanup, blockno);
                 Some(BufferMut {

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -20,7 +20,7 @@ use crate::postgres::storage::block::{BM25PageSpecialData, PgItem};
 use crate::postgres::storage::fsm::v2::V2FSM;
 use crate::postgres::storage::fsm::FreeSpaceManager;
 use crate::postgres::storage::metadata::MetaPage;
-use crate::postgres::storage::utils::{BM25Page, RelationBufferAccess};
+use crate::postgres::storage::utils::{BM25Page, BufferAccessStrategyHolder, RelationBufferAccess};
 use pgrx::pg_sys;
 use stable_deref_trait::StableDeref;
 use std::mem::size_of;
@@ -734,37 +734,35 @@ impl PageHeaderMethods for pg_sys::PageHeaderData {
 pub struct BufferManager {
     rbufacc: RelationBufferAccess,
     fsm_blockno: Option<pg_sys::BlockNumber>,
-    strategy: pg_sys::BufferAccessStrategy,
+    /// Strategy applied to *read-only* buffer acquisitions
+    /// ([`Self::get_buffer`], [`Self::pinned_buffer`]). Write-path methods
+    /// (`get_buffer_mut`, cleanup, etc.) deliberately ignore this so that
+    /// e.g. a `BAS_BULKREAD` strategy cannot accidentally evict buffers we
+    /// are about to modify.
+    ///
+    /// `BufferAccessStrategyHolder` is `Send + Sync`, which lets
+    /// `BufferManager` auto-derive `Send + Sync` without a blanket
+    /// `unsafe impl` on the outer type.
+    strategy: BufferAccessStrategyHolder,
 }
-
-// SAFETY: The `strategy` field is either null or points to a process-lifetime
-// singleton allocated in TopMemoryContext (via `bulkread_strategy()` or similar),
-// which is safe to share across threads. The `with_strategy` method is `unsafe`
-// and requires the caller to uphold this invariant.
-unsafe impl Send for BufferManager {}
-unsafe impl Sync for BufferManager {}
 
 impl BufferManager {
     pub fn new(rel: &PgSearchRelation) -> Self {
         Self {
             rbufacc: RelationBufferAccess::open(rel),
             fsm_blockno: None,
-            strategy: std::ptr::null_mut(),
+            strategy: BufferAccessStrategyHolder::NULL,
         }
     }
 
-    /// Set the [`pg_sys::BufferAccessStrategy`] used when reading existing buffers.
+    /// Set the [`BufferAccessStrategyHolder`] used when reading existing
+    /// buffers via the read-only methods ([`Self::get_buffer`] and
+    /// [`Self::pinned_buffer`]). Write-path methods are unaffected.
     ///
-    /// For example, pass the result of [`bulkread_strategy()`] to prevent bulk reads
-    /// from evicting active buffers in the shared buffer cache.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `strategy` is either null or points to memory
-    /// that lives for the entire process lifetime (e.g. allocated in
-    /// `TopMemoryContext`). This is required for the `Send`/`Sync` impl on
-    /// `BufferManager` to be sound.
-    pub(crate) unsafe fn with_strategy(mut self, strategy: pg_sys::BufferAccessStrategy) -> Self {
+    /// For example, pass the result of
+    /// [`crate::postgres::storage::utils::bulkread_strategy`] to prevent
+    /// bulk reads from evicting active buffers in the shared buffer cache.
+    pub(crate) fn with_strategy(mut self, strategy: BufferAccessStrategyHolder) -> Self {
         self.strategy = strategy;
         self
     }
@@ -873,7 +871,7 @@ impl BufferManager {
         block_tracker::track!(Pinned, blockno);
         PinnedBuffer::new(self.rbufacc.get_buffer_extended(
             blockno,
-            self.strategy,
+            self.strategy.as_ptr(),
             pg_sys::ReadBufferMode::RBM_NORMAL,
             None,
         ))
@@ -882,7 +880,7 @@ impl BufferManager {
     pub fn get_buffer(&self, blockno: pg_sys::BlockNumber) -> Buffer {
         let pg_buffer = self.rbufacc.get_buffer_extended(
             blockno,
-            self.strategy,
+            self.strategy.as_ptr(),
             pg_sys::ReadBufferMode::RBM_NORMAL,
             Some(pg_sys::BUFFER_LOCK_SHARE),
         );
@@ -909,7 +907,10 @@ impl BufferManager {
             dirty: false,
             inner: Buffer::new(self.rbufacc.get_buffer_extended(
                 blockno,
-                self.strategy,
+                // Write paths deliberately bypass `self.strategy`: a
+                // `BAS_BULKREAD` ring would evict buffers we are about to
+                // modify, and we never want that.
+                std::ptr::null_mut(),
                 pg_sys::ReadBufferMode::RBM_NORMAL,
                 Some(pg_sys::BUFFER_LOCK_EXCLUSIVE),
             )),
@@ -932,9 +933,10 @@ impl BufferManager {
     #[allow(dead_code)]
     pub fn get_buffer_conditional(&mut self, blockno: pg_sys::BlockNumber) -> Option<BufferMut> {
         unsafe {
+            // Write path — see `get_buffer_mut`.
             let pg_buffer = self.rbufacc.get_buffer_extended(
                 blockno,
-                self.strategy,
+                std::ptr::null_mut(),
                 pg_sys::ReadBufferMode::RBM_NORMAL,
                 None,
             );
@@ -953,9 +955,10 @@ impl BufferManager {
 
     pub fn get_buffer_for_cleanup(&mut self, blockno: pg_sys::BlockNumber) -> BufferMut {
         unsafe {
+            // Cleanup path — see `get_buffer_mut`.
             let pg_buffer = self.rbufacc.get_buffer_extended(
                 blockno,
-                self.strategy,
+                std::ptr::null_mut(),
                 pg_sys::ReadBufferMode::RBM_NORMAL,
                 None,
             );
@@ -973,9 +976,10 @@ impl BufferManager {
         blockno: pg_sys::BlockNumber,
     ) -> Option<BufferMut> {
         unsafe {
+            // Cleanup path — see `get_buffer_mut`.
             let pg_buffer = self.rbufacc.get_buffer_extended(
                 blockno,
-                self.strategy,
+                std::ptr::null_mut(),
                 pg_sys::ReadBufferMode::RBM_NORMAL,
                 None,
             );

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -217,6 +217,17 @@ impl LinkedBytesList {
         }
     }
 
+    /// Set the [`pg_sys::BufferAccessStrategy`] used when reading buffers in this list.
+    ///
+    /// # Safety
+    ///
+    /// See [`BufferManager::with_strategy`] — the caller must ensure `strategy`
+    /// is either null or has process lifetime.
+    pub(crate) unsafe fn with_strategy(mut self, strategy: pg_sys::BufferAccessStrategy) -> Self {
+        self.bman = unsafe { self.bman.with_strategy(strategy) };
+        self
+    }
+
     /// Create a new [`LinkedBytesList`] in the specified `indexrel`'s block storage.  This method
     /// creates the necessary initial block structure without trying to use recycled pages from
     /// the [`FreeSpaceManager`].

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -27,6 +27,7 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::blocklist;
 use crate::postgres::storage::buffer::{init_new_buffer, BufferManager, PageHeaderMethods};
 use crate::postgres::storage::fsm::FreeSpaceManager;
+use crate::postgres::storage::utils::BufferAccessStrategyHolder;
 
 use anyhow::Result;
 use parking_lot::Mutex;
@@ -217,14 +218,11 @@ impl LinkedBytesList {
         }
     }
 
-    /// Set the [`pg_sys::BufferAccessStrategy`] used when reading buffers in this list.
-    ///
-    /// # Safety
-    ///
-    /// See [`BufferManager::with_strategy`] — the caller must ensure `strategy`
-    /// is either null or has process lifetime.
-    pub(crate) unsafe fn with_strategy(mut self, strategy: pg_sys::BufferAccessStrategy) -> Self {
-        self.bman = unsafe { self.bman.with_strategy(strategy) };
+    /// Set the [`BufferAccessStrategyHolder`] used when reading buffers in
+    /// this list. The strategy only affects read-only buffer acquisitions;
+    /// see [`BufferManager::with_strategy`] for details.
+    pub(crate) fn with_strategy(mut self, strategy: BufferAccessStrategyHolder) -> Self {
+        self.bman = self.bman.with_strategy(strategy);
         self
     }
 

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -25,25 +25,57 @@ use std::sync::LazyLock;
 /// Matches Postgres's [`MAX_BUFFERS_TO_EXTEND_BY`]
 pub const MAX_BUFFERS_TO_EXTEND_BY: usize = 64;
 
-/// Returns a process-lifetime `BAS_BULKREAD` [`pg_sys::BufferAccessStrategy`].
+/// `Send + Sync` wrapper around a [`pg_sys::BufferAccessStrategy`].
 ///
-/// This strategy tells PostgreSQL to use a small ring buffer for sequential scans,
-/// preventing bulk reads from evicting active buffers from the shared buffer cache.
-/// It should be used when reading segments that are about to be merged away.
-pub fn bulkread_strategy() -> pg_sys::BufferAccessStrategy {
-    struct Holder(pg_sys::BufferAccessStrategy);
-    unsafe impl Send for Holder {}
-    unsafe impl Sync for Holder {}
+/// The wrapped pointer is either null or points to a `BufferAccessStrategyData`
+/// allocated in `TopMemoryContext` with process lifetime (see
+/// [`bulkread_strategy`]). Sharing such a pointer
+/// across threads is sound in that sense, but note that
+/// `BufferAccessStrategyData` itself has mutable internal state
+/// (e.g. `current_buffer`) that is updated on every `ReadBufferExtended` call.
+/// Using the *same* strategy concurrently from multiple threads/backends would
+/// race on that state, so callers must ensure it is only used serially.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct BufferAccessStrategyHolder(pub pg_sys::BufferAccessStrategy);
 
-    static BAS_BULKREAD: LazyLock<Holder> = LazyLock::new(|| {
-        Holder(unsafe {
+// SAFETY: see type-level comment — the pointer has process lifetime or is null.
+unsafe impl Send for BufferAccessStrategyHolder {}
+unsafe impl Sync for BufferAccessStrategyHolder {}
+
+impl BufferAccessStrategyHolder {
+    /// A null strategy, equivalent to passing `NULL` to PostgreSQL
+    /// (i.e. "use the default buffer access strategy").
+    pub const NULL: Self = Self(std::ptr::null_mut());
+
+    #[inline]
+    pub fn as_ptr(self) -> pg_sys::BufferAccessStrategy {
+        self.0
+    }
+}
+
+/// Returns a process-lifetime `BAS_BULKREAD` [`BufferAccessStrategyHolder`].
+///
+/// This strategy tells PostgreSQL to use a small ring buffer for sequential
+/// scans, preventing bulk reads from evicting active buffers from the shared
+/// buffer cache. It should be used when reading segments that are about to be
+/// merged away.
+///
+/// The returned value is a *shared singleton*. `BufferAccessStrategyData` has
+/// mutable internal state (e.g. `current_buffer`) that Postgres updates on
+/// every `ReadBufferExtended` call, so it must not be used concurrently from
+/// multiple threads. Today this is fine because the only caller is Tantivy's
+/// single-threaded merger; any future caller must uphold the same invariant.
+pub(crate) fn bulkread_strategy() -> BufferAccessStrategyHolder {
+    static BAS_BULKREAD: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| {
+        BufferAccessStrategyHolder(unsafe {
+            // SAFETY: Allocated in `TopMemoryContext`, once, so that it's always available.
             PgMemoryContexts::TopMemoryContext.switch_to(|_| {
                 pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKREAD)
             })
         })
     });
 
-    BAS_BULKREAD.0
+    *BAS_BULKREAD
 }
 
 pub trait BM25Page {
@@ -295,10 +327,6 @@ unsafe fn bulk_extend_relation(
     npages: usize,
     fork: pg_sys::ForkNumber::Type,
 ) -> [pg_sys::Buffer; MAX_BUFFERS_TO_EXTEND_BY] {
-    struct BufferAccessStrategyHolder(pg_sys::BufferAccessStrategy);
-    unsafe impl Send for BufferAccessStrategyHolder {}
-    unsafe impl Sync for BufferAccessStrategyHolder {}
-
     static BAS_BULKWRITE: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| {
         BufferAccessStrategyHolder(unsafe {
             // SAFETY:  Allocated in `TopMemoryContext`, once, so that it's always available

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -35,8 +35,13 @@ pub const MAX_BUFFERS_TO_EXTEND_BY: usize = 64;
 /// (e.g. `current_buffer`) that is updated on every `ReadBufferExtended` call.
 /// Using the *same* strategy concurrently from multiple threads/backends would
 /// race on that state, so callers must ensure it is only used serially.
+///
+/// The inner pointer is kept private so that constructing a holder with an
+/// arbitrary (e.g. stack-allocated or short-lived) pointer requires going
+/// through the `unsafe` [`BufferAccessStrategyHolder::new`] constructor, which
+/// makes the `Send + Sync` safety invariant opt-in rather than a convention.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct BufferAccessStrategyHolder(pub pg_sys::BufferAccessStrategy);
+pub(crate) struct BufferAccessStrategyHolder(pg_sys::BufferAccessStrategy);
 
 // SAFETY: see type-level comment — the pointer has process lifetime or is null.
 unsafe impl Send for BufferAccessStrategyHolder {}
@@ -46,6 +51,21 @@ impl BufferAccessStrategyHolder {
     /// A null strategy, equivalent to passing `NULL` to PostgreSQL
     /// (i.e. "use the default buffer access strategy").
     pub const NULL: Self = Self(std::ptr::null_mut());
+
+    /// Wrap a raw [`pg_sys::BufferAccessStrategy`] pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ptr` is either null or points to a
+    /// `BufferAccessStrategyData` that outlives every thread or backend that
+    /// may observe the resulting holder — typically one allocated in
+    /// `TopMemoryContext` with process lifetime. Passing a stack-allocated or
+    /// otherwise short-lived pointer violates the `Send + Sync` invariant
+    /// documented on [`BufferAccessStrategyHolder`].
+    #[inline]
+    pub const unsafe fn new(ptr: pg_sys::BufferAccessStrategy) -> Self {
+        Self(ptr)
+    }
 
     #[inline]
     pub fn as_ptr(self) -> pg_sys::BufferAccessStrategy {
@@ -66,13 +86,13 @@ impl BufferAccessStrategyHolder {
 /// multiple threads. Today this is fine because the only caller is Tantivy's
 /// single-threaded merger; any future caller must uphold the same invariant.
 pub(crate) fn bulkread_strategy() -> BufferAccessStrategyHolder {
-    static BAS_BULKREAD: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| {
-        BufferAccessStrategyHolder(unsafe {
-            // SAFETY: Allocated in `TopMemoryContext`, once, so that it's always available.
-            PgMemoryContexts::TopMemoryContext.switch_to(|_| {
-                pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKREAD)
-            })
-        })
+    static BAS_BULKREAD: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| unsafe {
+        // SAFETY: Allocated in `TopMemoryContext`, once, so that it's always
+        // available — satisfying the process-lifetime requirement of
+        // `BufferAccessStrategyHolder::new`.
+        BufferAccessStrategyHolder::new(PgMemoryContexts::TopMemoryContext.switch_to(|_| {
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKREAD)
+        }))
     });
 
     *BAS_BULKREAD
@@ -327,13 +347,13 @@ unsafe fn bulk_extend_relation(
     npages: usize,
     fork: pg_sys::ForkNumber::Type,
 ) -> [pg_sys::Buffer; MAX_BUFFERS_TO_EXTEND_BY] {
-    static BAS_BULKWRITE: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| {
-        BufferAccessStrategyHolder(unsafe {
-            // SAFETY:  Allocated in `TopMemoryContext`, once, so that it's always available
-            PgMemoryContexts::TopMemoryContext.switch_to(|_| {
-                pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKWRITE)
-            })
-        })
+    static BAS_BULKWRITE: LazyLock<BufferAccessStrategyHolder> = LazyLock::new(|| unsafe {
+        // SAFETY: Allocated in `TopMemoryContext`, once, so that it's always
+        // available — satisfying the process-lifetime requirement of
+        // `BufferAccessStrategyHolder::new`.
+        BufferAccessStrategyHolder::new(PgMemoryContexts::TopMemoryContext.switch_to(|_| {
+            pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKWRITE)
+        }))
     });
 
     let mut buffers = [pg_sys::InvalidBuffer as pg_sys::Buffer; MAX_BUFFERS_TO_EXTEND_BY];
@@ -360,7 +380,7 @@ unsafe fn bulk_extend_relation(
                 pg_sys::ExtendBufferedRelBy(
                     bmr,
                     fork,
-                    BAS_BULKWRITE.0,
+                    BAS_BULKWRITE.as_ptr(),
                     // failure to clear the size cache, which is attached to `self.rel.rd_smgr` can cause
                     // future reads from the relation to fail complaining that the block number returned
                     // here doesn't exist because internally the Relation doesn't realize that it has
@@ -388,7 +408,7 @@ unsafe fn bulk_extend_relation(
             if is_backend_bulk_compatible {
                 // only bgworker and backends can use the BULKWRITE BufferAccessStrategy
                 // specifically, using this in an autovacuum worker can trip an internal postgres assert
-                BAS_BULKWRITE.0
+                BAS_BULKWRITE.as_ptr()
             } else {
                 std::ptr::null_mut()
             },

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -25,6 +25,27 @@ use std::sync::LazyLock;
 /// Matches Postgres's [`MAX_BUFFERS_TO_EXTEND_BY`]
 pub const MAX_BUFFERS_TO_EXTEND_BY: usize = 64;
 
+/// Returns a process-lifetime `BAS_BULKREAD` [`pg_sys::BufferAccessStrategy`].
+///
+/// This strategy tells PostgreSQL to use a small ring buffer for sequential scans,
+/// preventing bulk reads from evicting active buffers from the shared buffer cache.
+/// It should be used when reading segments that are about to be merged away.
+pub fn bulkread_strategy() -> pg_sys::BufferAccessStrategy {
+    struct Holder(pg_sys::BufferAccessStrategy);
+    unsafe impl Send for Holder {}
+    unsafe impl Sync for Holder {}
+
+    static BAS_BULKREAD: LazyLock<Holder> = LazyLock::new(|| {
+        Holder(unsafe {
+            PgMemoryContexts::TopMemoryContext.switch_to(|_| {
+                pg_sys::GetAccessStrategy(pg_sys::BufferAccessStrategyType::BAS_BULKREAD)
+            })
+        })
+    });
+
+    BAS_BULKREAD.0
+}
+
 pub trait BM25Page {
     /// Read the opaque, non-decoded [`PgItem`] at `offno`.
     unsafe fn read_item(&self, offno: OffsetNumber) -> Option<PgItem>;


### PR DESCRIPTION
During merge operations, source segments that are about to be merged away and deleted were loaded into the PostgreSQL shared buffer cache using the default strategy, evicting active buffers and degrading query performance in update-heavy scenarios.

Pipe a BAS_BULKREAD BufferAccessStrategy through the buffer access chain (BufferManager → LinkedBytesList → SegmentComponentReader → MVCCDirectory) so that merge reads use a small ring buffer instead of polluting the shared buffer cache.

Closes #2422
