### PR TITLE
feat: support `IS NULL`/`IS NOT NULL` in Top K joinscan

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -381,6 +381,36 @@ pub enum OrderByFeature {
         attno: pg_sys::AttrNumber,
         name: Option<String>,
     },
+    NullTest {
+        inner: Box<OrderByFeature>,
+        nulltesttype: NullTestKind,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum NullTestKind {
+    IsNull,
+    IsNotNull,
+}
+
+impl std::fmt::Display for OrderByFeature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Score { .. } => write!(f, "pdb.score()"),
+            Self::Field { name, .. } => write!(f, "{name}"),
+            Self::Var { name, .. } => write!(f, "{}", name.as_deref().unwrap_or("?")),
+            Self::NullTest {
+                inner,
+                nulltesttype,
+            } => {
+                let test = match nulltesttype {
+                    NullTestKind::IsNull => "IS NULL",
+                    NullTestKind::IsNotNull => "IS NOT NULL",
+                };
+                write!(f, "{inner} {test}")
+            }
+        }
+    }
 }
 
 /// Simple ORDER BY information for serialization in PrivateData

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -910,6 +910,10 @@ impl SearchIndexReader {
                 // TODO: See method docs.
                 self.top_by_score_in_segments(segment_ids, *direction, n, offset, aux_collector)
             }
+            OrderByInfo {
+                feature: OrderByFeature::NullTest { .. },
+                ..
+            } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
         }
     }
 
@@ -1386,6 +1390,10 @@ impl SearchIndexReader {
                     feature: OrderByFeature::Var { .. },
                     ..
                 } => unimplemented!("Sorting by variable is not supported in raw index search"),
+                OrderByInfo {
+                    feature: OrderByFeature::NullTest { .. },
+                    ..
+                } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
             }
         }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -361,7 +361,9 @@ impl AggregateCSClause {
             })
             .filter_map(|info| match &info.feature {
                 OrderByFeature::Field { name, .. } => Some(name.to_string()),
-                OrderByFeature::Score { .. } | OrderByFeature::Var { .. } => None,
+                OrderByFeature::Score { .. }
+                | OrderByFeature::Var { .. }
+                | OrderByFeature::NullTest { .. } => None,
             })
             .collect()
     }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::Ordering;
 
 use crate::api::operator::estimate_selectivity;
 use crate::api::window_aggregate::window_agg_oid;
-use crate::api::{HashMap, HashSet, OrderByFeature, OrderByInfo, Varno};
+use crate::api::{HashMap, HashSet, Varno};
 use crate::gucs;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::MvccSatisfies;
@@ -1264,32 +1264,7 @@ impl CustomScan for BaseScan {
                 "   TopK Order By",
                 orderby_info
                     .iter()
-                    .map(|oi| match oi {
-                        OrderByInfo {
-                            feature:
-                                OrderByFeature::Field {
-                                    name: fieldname, ..
-                                },
-                            direction,
-                            ..
-                        } => {
-                            format!("{fieldname} {}", direction.as_ref())
-                        }
-                        OrderByInfo {
-                            feature: OrderByFeature::Var { name, .. },
-                            direction,
-                            ..
-                        } => {
-                            format!("{} {}", name.as_deref().unwrap_or("?"), direction.as_ref())
-                        }
-                        OrderByInfo {
-                            feature: OrderByFeature::Score { .. },
-                            direction,
-                            ..
-                        } => {
-                            format!("pdb.score() {}", direction.as_ref())
-                        }
-                    })
+                    .map(|oi| format!("{} {}", oi.feature, oi.direction.as_ref()))
                     .collect::<Vec<_>>()
                     .join(", "),
             );

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1030,8 +1030,8 @@ impl CustomScan for JoinScan {
                                 )
                             }
                         }
-                        OrderByFeature::Score { .. } => {
-                            format!("pdb.score() {}", oi.direction.as_ref())
+                        other => {
+                            format!("{other} {}", oi.direction.as_ref())
                         }
                     })
                     .collect::<Vec<_>>()

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -31,7 +31,7 @@ use super::predicate::find_base_info_recursive;
 use super::privdat::{OutputColumnInfo, PrivateData};
 
 use crate::api::operator::anyelement_query_input_opoid;
-use crate::api::{OrderByFeature, OrderByInfo, SortDirection};
+use crate::api::{NullTestKind, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::nodecast;
 use crate::postgres::customscan::basescan::projections::score::is_score_func;
@@ -1059,7 +1059,11 @@ pub(super) unsafe fn collect_required_fields(
     }
 
     for info in &join_clause.order_by {
-        match &info.feature {
+        let feature = match &info.feature {
+            OrderByFeature::NullTest { inner, .. } => inner.as_ref(),
+            other => other,
+        };
+        match feature {
             OrderByFeature::Var { rti, attno, .. } => {
                 ensure_column_in_all_sources(&mut plan_sources, *rti, *attno);
             }
@@ -1299,7 +1303,12 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
 
         for member in members.iter_ptr() {
             let expr = (*member).em_expr;
-            let check_expr = strip_wrappers(expr.cast());
+            let mut check_expr = strip_wrappers(expr.cast());
+
+            // Unwrap NullTest to inspect the inner expression
+            if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {
+                check_expr = strip_wrappers((*nt).arg.cast());
+            }
 
             if sources
                 .iter()
@@ -1788,6 +1797,31 @@ impl JoinSortExprKind {
         output_rtis: &[pg_sys::Index],
         pathkey_equivalence_member: bool,
     ) -> Self {
+        if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {
+            let inner_expr = strip_wrappers((*nt).arg.cast()).cast::<pg_sys::Expr>();
+            let nulltesttype = if (*nt).nulltesttype == pg_sys::NullTestType::IS_NULL {
+                NullTestKind::IsNull
+            } else {
+                NullTestKind::IsNotNull
+            };
+            return match Self::classify(
+                inner_expr,
+                direction,
+                sources,
+                output_rtis,
+                pathkey_equivalence_member,
+            ) {
+                Self::Resolved(inner_info) => Self::Resolved(OrderByInfo {
+                    feature: OrderByFeature::NullTest {
+                        inner: Box::new(inner_info.feature),
+                        nulltesttype,
+                    },
+                    direction,
+                }),
+                other => other,
+            };
+        }
+
         for source in sources.iter() {
             if is_score_func_recursive(check_expr.cast(), source) {
                 if !output_rtis.contains(&source.scan_info.heap_rti) {
@@ -1991,8 +2025,16 @@ pub(super) unsafe fn extract_orderby(
 
             match JoinSortExprKind::classify(check_expr, direction, sources, output_rtis, true) {
                 JoinSortExprKind::Resolved(info) => {
-                    result.push(info);
-                    pathkey_resolved = true;
+                    // For DISTINCT queries, NullTest pathkeys come from the
+                    // DISTINCT target list — they are handled by the GROUP BY,
+                    // not the sort. Acknowledge the pathkey but don't add it to
+                    // the ORDER BY list.
+                    if has_distinct && matches!(info.feature, OrderByFeature::NullTest { .. }) {
+                        pathkey_resolved = true;
+                    } else {
+                        result.push(info);
+                        pathkey_resolved = true;
+                    }
                 }
                 JoinSortExprKind::SkipMember => continue,
                 JoinSortExprKind::NoMatch => {}

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -71,7 +71,7 @@ use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
-use crate::api::{OrderByFeature, SortDirection};
+use crate::api::{NullTestKind, OrderByFeature, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::joinscan::build::{
@@ -766,6 +766,50 @@ fn resolve_distinct_col(
     }
 }
 
+/// Resolve a non-NullTest `OrderByFeature` to a DataFusion `Expr`.
+fn resolve_orderby_feature(
+    feature: &OrderByFeature,
+    join_clause: &JoinCSClause,
+    distinct_col_map: &DistinctColMap,
+) -> Expr {
+    match feature {
+        OrderByFeature::Score { rti } => {
+            if !distinct_col_map.is_empty() {
+                resolve_distinct_col(distinct_col_map, true, 0, 0, "")
+            } else {
+                join_clause
+                    .plan
+                    .sources()
+                    .iter()
+                    .find(|s| s.scan_info.heap_rti == *rti)
+                    .map(|source| make_source_score_col(source))
+                    .unwrap_or_else(|| col("unknown_score"))
+            }
+        }
+        OrderByFeature::Field { name, rti } => join_clause
+            .plan
+            .sources()
+            .iter()
+            .find(|s| s.contains_rti(*rti))
+            .map(|source| make_source_col(source, name.as_ref()))
+            .unwrap_or_else(|| {
+                pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
+                col(name.as_ref())
+            }),
+        OrderByFeature::Var { rti, attno, .. } => {
+            if !distinct_col_map.is_empty() {
+                resolve_distinct_col(distinct_col_map, false, *rti, *attno, "")
+            } else {
+                resolve_var_to_df_col(join_clause, *rti, *attno)
+                    .unwrap_or_else(|| col("unknown_col"))
+            }
+        }
+        OrderByFeature::NullTest { .. } => {
+            unreachable!("NullTest is handled by apply_sort directly")
+        }
+    }
+}
+
 /// Apply the join clause's `ORDER BY` to the data frame, choosing column
 /// references from `distinct_col_map` when DISTINCT is active and from the
 /// per-source resolution paths otherwise.
@@ -781,44 +825,17 @@ fn apply_sort(
     let mut sort_exprs = Vec::new();
     for info in &join_clause.order_by {
         let expr = match &info.feature {
-            OrderByFeature::Score { rti } => {
-                if !distinct_col_map.is_empty() {
-                    resolve_distinct_col(distinct_col_map, true, 0, 0, "")
-                } else {
-                    // TODO: this heap_rti lookup has the same collision
-                    // risk as the partitioning check fixed above — if a
-                    // NOT IN subquery source shares the same RTI as the
-                    // outer table, the wrong score column could be
-                    // selected. Low risk since ORDER BY scores typically
-                    // reference outer-query tables. Fix by switching
-                    // OrderByFeature::Score to carry plan_position.
-                    join_clause
-                        .plan
-                        .sources()
-                        .iter()
-                        .find(|s| s.scan_info.heap_rti == *rti)
-                        .map(|source| make_source_score_col(source))
-                        .unwrap_or_else(|| col("unknown_score"))
+            OrderByFeature::NullTest {
+                inner,
+                nulltesttype,
+            } => {
+                let inner_expr = resolve_orderby_feature(inner, join_clause, distinct_col_map);
+                match nulltesttype {
+                    NullTestKind::IsNull => inner_expr.is_null(),
+                    NullTestKind::IsNotNull => inner_expr.is_not_null(),
                 }
             }
-            OrderByFeature::Field { name, rti } => join_clause
-                .plan
-                .sources()
-                .iter()
-                .find(|s| s.contains_rti(*rti))
-                .map(|source| make_source_col(source, name.as_ref()))
-                .unwrap_or_else(|| {
-                    pgrx::warning!("JoinScan: could not find source for RTI {rti} when building sort expression for field '{name}'");
-                    col(name.as_ref())
-                }),
-            OrderByFeature::Var { rti, attno, .. } => {
-                if !distinct_col_map.is_empty() {
-                    resolve_distinct_col(distinct_col_map, false, *rti, *attno, "")
-                } else {
-                    resolve_var_to_df_col(join_clause, *rti, *attno)
-                        .unwrap_or_else(|| col("unknown_col"))
-                }
-            }
+            other => resolve_orderby_feature(other, join_clause, distinct_col_map),
         };
 
         let asc = matches!(
@@ -992,9 +1009,22 @@ fn build_source_df<'a>(
                             }
                         }
                     }
-                    OrderByFeature::Score { .. } => {
-                        // Score is not a late-materialized column, skip
-                    }
+                    OrderByFeature::Score { .. } => {}
+                    OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
+                        OrderByFeature::Field { name, rti } => {
+                            if source.contains_rti(*rti) {
+                                required_early.insert(name.as_ref().to_string());
+                            }
+                        }
+                        OrderByFeature::Var { rti, attno, .. } => {
+                            if source.contains_rti(*rti) {
+                                if let Some(col_name) = source.column_name(*attno) {
+                                    required_early.insert(col_name);
+                                }
+                            }
+                        }
+                        _ => {}
+                    },
                 }
             }
         }

--- a/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
@@ -1,0 +1,152 @@
+-- Regression test for GitHub issue #4751:
+-- Join pushdown not applied when ORDER BY contains IS NULL expression.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+DROP TABLE IF EXISTS test_people CASCADE;
+DROP TABLE IF EXISTS test_companies CASCADE;
+CREATE TABLE test_companies (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+CREATE TABLE test_people (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER
+);
+INSERT INTO test_companies (id, name) VALUES
+(101, 'Acme'), (102, 'Globex'), (103, NULL), (104, 'Initech'), (105, NULL);
+INSERT INTO test_people (id, company_id) VALUES
+(201, 101), (202, 101), (203, 102), (204, 104);
+CREATE INDEX test_companies_bm25 ON test_companies USING bm25 (id, name)
+    WITH (key_field = 'id', text_fields = '{"name": {"fast": true}}');
+CREATE INDEX test_people_bm25 ON test_people USING bm25 (id, company_id)
+    WITH (key_field = 'id', numeric_fields = '{"company_id": {"fast": true}}');
+ANALYZE test_companies;
+ANALYZE test_people;
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- TEST 1: ORDER BY col IS NULL ASC should get join pushdown
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, ((c.name IS NULL)), c.name
+   ->  Result
+         Output: c.id, (c.name IS NULL), c.name
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: p INNER c
+               Join Cond: c.id = p.company_id
+               Limit: 26
+               Order By: name IS NULL asc, c.name asc, p.company_id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyLookupExec: decode=[name]
+                 :     SegmentedTopKExec: expr=[name@4 IS NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
+                 :       VisibilityFilterExec: tables=[p, c]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+(20 rows)
+
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+ id  
+-----
+ 101
+ 101
+ 102
+ 104
+(4 rows)
+
+-- =============================================================================
+-- TEST 2: Verify results match fallback (non-JoinScan) path
+-- =============================================================================
+SET paradedb.enable_join_custom_scan = off;
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+ id  
+-----
+ 101
+ 101
+ 102
+ 104
+(4 rows)
+
+-- =============================================================================
+-- TEST 3: ORDER BY col IS NOT NULL should also get join pushdown
+-- =============================================================================
+SET paradedb.enable_join_custom_scan = on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NOT NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, ((c.name IS NOT NULL)), c.name
+   ->  Result
+         Output: c.id, (c.name IS NOT NULL), c.name
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: p INNER c
+               Join Cond: c.id = p.company_id
+               Limit: 26
+               Order By: name IS NOT NULL asc, c.name asc, p.company_id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyLookupExec: decode=[name]
+                 :     SegmentedTopKExec: expr=[name@4 IS NOT NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
+                 :       VisibilityFilterExec: tables=[p, c]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+(20 rows)
+
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NOT NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+ id  
+-----
+ 101
+ 101
+ 102
+ 104
+(4 rows)
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+DROP TABLE IF EXISTS test_people CASCADE;
+DROP TABLE IF EXISTS test_companies CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/join_order_by_is_null.sql
+++ b/pg_search/tests/pg_regress/sql/join_order_by_is_null.sql
@@ -1,0 +1,104 @@
+-- Regression test for GitHub issue #4751:
+-- Join pushdown not applied when ORDER BY contains IS NULL expression.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS test_people CASCADE;
+DROP TABLE IF EXISTS test_companies CASCADE;
+
+CREATE TABLE test_companies (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+CREATE TABLE test_people (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER
+);
+
+INSERT INTO test_companies (id, name) VALUES
+(101, 'Acme'), (102, 'Globex'), (103, NULL), (104, 'Initech'), (105, NULL);
+
+INSERT INTO test_people (id, company_id) VALUES
+(201, 101), (202, 101), (203, 102), (204, 104);
+
+CREATE INDEX test_companies_bm25 ON test_companies USING bm25 (id, name)
+    WITH (key_field = 'id', text_fields = '{"name": {"fast": true}}');
+CREATE INDEX test_people_bm25 ON test_people USING bm25 (id, company_id)
+    WITH (key_field = 'id', numeric_fields = '{"company_id": {"fast": true}}');
+
+ANALYZE test_companies;
+ANALYZE test_people;
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- TEST 1: ORDER BY col IS NULL ASC should get join pushdown
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+
+-- =============================================================================
+-- TEST 2: Verify results match fallback (non-JoinScan) path
+-- =============================================================================
+
+SET paradedb.enable_join_custom_scan = off;
+
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+
+-- =============================================================================
+-- TEST 3: ORDER BY col IS NOT NULL should also get join pushdown
+-- =============================================================================
+
+SET paradedb.enable_join_custom_scan = on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NOT NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+
+SELECT c.id
+FROM test_companies AS c
+JOIN test_people AS p ON p.company_id = c.id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.name IS NOT NULL ASC, c.name ASC, c.id ASC
+LIMIT 26;
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS test_people CASCADE;
+DROP TABLE IF EXISTS test_companies CASCADE;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_join_custom_scan;


### PR DESCRIPTION
Closes #4751

# Ticket(s) Closed

- Closes #

## What

Handle `NullTest` expression nodes in the join pushdown `ORDER BY` classification pipeline. Previously, `ORDER BY col IS NULL` caused the join pushdown to be rejected because the `NullTest` was unrecognized by both the fast-field activation check and the sort expression classifier.

## Why

## How

## Tests
