### PR TITLE
feat: MPP plan partitioning infrastructure for JoinScan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,6 +4035,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5376,6 +5397,7 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-buffer",
+ "arrow-ipc",
  "arrow-schema",
  "arrow-select",
  "async-stream",
@@ -5392,6 +5414,7 @@ dependencies = [
  "env_logger 0.11.10",
  "futures",
  "half 2.7.1",
+ "interprocess",
  "json5",
  "lazy_static",
  "macros",
@@ -6535,6 +6558,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -8987,6 +9016,12 @@ dependencies = [
  "wasite 1.0.2",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-XHHE53KCQeU/u2ZSQdIQp/O5YpXc96OJraFdDXrmcd4=";
+  cargoHash = "sha256-+F6SOEbEcKMgVywACJ48bspbgQZkaqwodusbjeouB5M=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -28,6 +28,7 @@ stable_deref_trait = "1.2.1"
 anyhow = { version = "1.0.100", features = ["backtrace"] }
 arrow-array = "58.0.0"
 arrow-buffer = "58.0.0"
+arrow-ipc = "58.0.0"
 arrow-schema = "58.0.0"
 arrow-select = "58.0.0"
 bitpacking = "0.9.2"
@@ -74,7 +75,8 @@ bytemuck = { version = "1.24.0", features = ["derive", "min_const_generics"] }
 decimal-bytes = "0.4.2"
 paste = "1.0.15"
 typetag = "0.2"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "net", "macros", "signal"] }
+interprocess = { version = "2.3.1", features = ["tokio"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { package = "datafusion", git = "https://github.com/apache/datafusion.git", branch = "branch-53", default-features = false }
 datafusion-proto = { package = "datafusion-proto", git = "https://github.com/apache/datafusion.git", branch = "branch-53", default-features = false }

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -38,6 +38,12 @@ static CHECK_AGGREGATE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// Allows the user to toggle the use of our "ParadeDB Join Scan".
 static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Enables the MPP (plan partitioning) execution model for JoinScan parallel execution.
+/// When enabled, all tables in the join are hash-partitioned across workers and data is
+/// shuffled via shared memory exchange operators, instead of the default broadcast-join.
+/// Default is `false` (experimental).
+static ENABLE_MPP_JOIN: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
@@ -167,6 +173,15 @@ pub fn init() {
         c"Enable ParadeDB's experimental join custom scan",
         c"Enable ParadeDB's experimental join custom scan. Default is false.",
         &ENABLE_JOIN_CUSTOM_SCAN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_mpp_join",
+        c"Enable MPP (plan partitioning) execution for parallel JoinScan",
+        c"When enabled, JoinScan uses hash-partitioned MPP execution instead of broadcast join. Default is false (experimental).",
+        &ENABLE_MPP_JOIN,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -417,6 +432,10 @@ pub fn check_aggregate_scan() -> bool {
 
 pub fn enable_join_custom_scan() -> bool {
     ENABLE_JOIN_CUSTOM_SCAN.get()
+}
+
+pub fn enable_mpp_join() -> bool {
+    ENABLE_MPP_JOIN.get()
 }
 
 pub fn enable_custom_scan_without_operator() -> bool {

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -656,7 +656,7 @@ pub struct JoinNode {
     /// Any remaining non-equi join conditions.
     pub filter: Option<JoinLevelExpr>,
     /// The `plan_id` of the PostgreSQL SubPlan that this join was extracted
-    /// from, if any.  Set for Semi/Anti/LeftMark joins created by
+    /// from, if any. Set for Semi/Anti/LeftMark joins created by
     /// `wrap_with_semi_anti` and `wrap_with_mark_filter`; `None` for joins
     /// that come from the normal join-hook path or path reconstruction.
     pub subplan_id: Option<i32>,

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -1154,6 +1154,10 @@ pub struct JoinCSClause {
     pub has_distinct: bool,
     /// Optional index of the source that MUST be partitioned, overriding cost-based selection.
     pub forced_partitioning_idx: Option<usize>,
+    /// Number of parallel workers planned for MPP execution.
+    /// When > 0, the MPP (plan partitioning) execution path is used instead of
+    /// the broadcast-join path.
+    pub planned_workers: usize,
 }
 
 impl JoinCSClause {
@@ -1167,6 +1171,7 @@ impl JoinCSClause {
             output_projection: None,
             has_distinct: false,
             forced_partitioning_idx: None,
+            planned_workers: 0,
         };
         for (i, source) in clause.plan.sources_mut().into_iter().enumerate() {
             source.plan_position = i;
@@ -1250,6 +1255,13 @@ impl JoinCSClause {
 
     pub fn with_forced_partitioning(mut self, idx: usize) -> Self {
         self.forced_partitioning_idx = Some(idx);
+        self
+    }
+
+    /// Set the number of parallel workers for MPP execution.
+    #[allow(dead_code)]
+    pub fn with_planned_workers(mut self, nworkers: usize) -> Self {
+        self.planned_workers = nworkers;
         self
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -1,0 +1,1051 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Parallel Exchange Operator for MPP Execution.
+//!
+//! This module implements the `DsmExchangeExec` operator, which serves as the boundary
+//! between parallel execution stages. It handles data shuffling across processes
+//! using shared memory ring buffers.
+//!
+//! # The "RPC-Server" Architecture
+//!
+//! This implementation follows a "Lazy Request" / "RPC-Server" model rather than the
+//! traditional "Eager Push" model used by Spark or Ballista.
+//!
+//! ## Core Concepts
+//!
+//! ### 1. Unique Physical Stream ID
+//!
+//! We distinguish between the **Logical Stream** (the shuffle operation in the plan) and
+//! the **Physical Stream** (the point-to-point connection).
+//!
+//! - **Logical Stream ID**: Assigned by `EnforceDsmShuffle` optimizer rule (sequential IDs).
+//! - **Physical Stream ID**: `(Logical ID << 16) | Sender Index`.
+//!   - Example: Logical Stream 1 from Worker 3 has Physical ID `0x00010003`.
+//!
+//! ### 2. Control Channel Protocol
+//!
+//! The "Control Channel" (reverse direction from Reader -> Writer) implements an RPC-like protocol:
+//! - StartStream - Begin executing a pre-arranged stream.
+//! - CancelStream - Cancel a stream after starting it.
+//!
+//! ### 3. Stream Registry (The "Listener")
+//!
+//! Each process (Leader and Workers) maintains a `StreamRegistry`.
+//!
+//! - **Registration Phase**: During startup (plan deserialization), we traverse the physical plan.
+//!   Every `DsmExchangeExec` encountered is "registered" but not executed. We store its input plan.
+//! - **Listening Phase**: The process runs a `Control Service` loop that polls the Control Channels
+//!   of all its `MultiplexedDsmWriter`s.
+//! - **Execution Phase**: When a `StartStream(id)` message arrives:
+//!   1.  The Control Service calls `trigger_stream(id)`.
+//!   2.  It looks up the registered plan for `id`.
+//!   3.  It spawns a background Tokio task to execute that sub-plan.
+//!   4.  The task writes data to the DSM buffer.
+//!
+//! ## Sanitization (Deadlock Prevention)
+//!
+//! To prevent deadlocks caused by DataFusion operators pinning shared memory buffers (e.g. `SortExec`),
+//! `DsmExchangeExec` supports a `sanitized` mode. When enabled (`config.sanitized = true`):
+//! - The reader side performs a deep copy of the data *immediately* upon reading from DSM.
+//! - This ensures that the downstream operators (like Sort/Join) hold references to heap-allocated
+//!   memory (Copy) rather than the shared memory ring buffer (Zero-Copy).
+//! - This is controlled by the `EnforceSanitization` optimizer rule, which detects unsafe patterns
+//!   and enables sanitization on the exchange.
+//!
+//! ## Analogy: RPC Tree
+//!
+//! The system can be visualized as a tree of RPC calls.
+//!
+//! 1.  **Leader** executes the Root Plan.
+//! 2.  When it hits a `DsmExchangeExec` (acting as Consumer), it makes an "RPC Call" (`StartStream`)
+//!     to a specific Worker node (or itself).
+//! 3.  The **Worker** receives the call. It looks up the "Procedure" (the sub-plan corresponding
+//!     to that stream) and executes it.
+//! 4.  If that sub-plan contains more `DsmExchangeExec` nodes (acting as Consumers), the Worker
+//!     recursively makes more RPC calls to other nodes.
+//! 5.  Data flows back up the tree as the response stream.
+
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
+use std::io::ErrorKind;
+use std::sync::Arc;
+use std::task::Poll;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_stream::try_stream;
+use datafusion::common::Result;
+use datafusion::config::ConfigOptions;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::Partitioning;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::execution_plan::EmissionType;
+use datafusion::physical_plan::repartition::{BatchPartitioner, RepartitionExec};
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+};
+use futures::{future::poll_fn, Stream, StreamExt};
+use parking_lot::Mutex;
+use tokio::sync::watch;
+
+use crate::postgres::customscan::joinscan::transport::TransportMesh;
+use crate::postgres::customscan::joinscan::transport::{
+    dsm_reader, ControlMessage, DsmWriter, LogicalStreamId, ParticipantId, PhysicalStreamId,
+    SignalBridge,
+};
+use crate::scan::table_provider::MppParticipantConfig;
+
+use crate::api::HashMap;
+use tokio::task::JoinHandle;
+
+pub struct StreamSource {
+    pub input: Arc<dyn ExecutionPlan>,
+    pub partitioning: Partitioning,
+    pub config: DsmExchangeConfig,
+}
+
+/// Registry for managing the lifecycle of lazily executed streams.
+///
+/// This registry is the core of the "Lazy Request" / "RPC-style" execution model.
+/// Instead of workers eagerly executing their entire plan, they register their available
+/// "Procedures" (stream sources) here.
+///
+/// When a consumer (Reader) needs data, it sends a `StartStream` request (RPC).
+/// The `Control Service` receives this request, looks up the plan in this registry,
+/// and spawns the task to produce the data.
+///
+/// This prevents stream reuse bugs and race conditions by ensuring every stream execution
+/// is strictly causal: Request -> Execution -> Response.
+#[derive(Default)]
+pub struct StreamRegistry {
+    /// Maps Physical Stream ID -> The execution parameters.
+    sources: HashMap<PhysicalStreamId, StreamSource>,
+    /// Maps Physical Stream ID -> The handle of the running task (to prevent duplicate spawning).
+    running_tasks: HashMap<PhysicalStreamId, JoinHandle<()>>,
+    /// Maps Physical Stream ID -> Abort handle for the task.
+    abort_handles: HashMap<PhysicalStreamId, tokio::task::AbortHandle>,
+    /// Maps Physical Stream ID -> A completion signal (for local waiting).
+    completions: HashMap<PhysicalStreamId, watch::Sender<bool>>,
+}
+
+/// A registry for process-local DSM communication channels.
+pub struct DsmMesh {
+    pub transport: TransportMesh,
+    pub registry: Mutex<StreamRegistry>,
+}
+
+lazy_static::lazy_static! {
+    pub static ref DSM_MESH: Mutex<Option<DsmMesh>> = Mutex::new(None);
+}
+
+pub fn register_dsm_mesh(mesh: DsmMesh) {
+    let mut guard = DSM_MESH.lock();
+    *guard = Some(mesh);
+}
+
+pub fn clear_dsm_mesh() {
+    let mut guard = DSM_MESH.lock();
+    *guard = None;
+}
+
+impl Drop for DsmMesh {
+    fn drop(&mut self) {
+        self.transport.detach();
+    }
+}
+
+pub fn register_stream_source(source: StreamSource, participant_id: ParticipantId) {
+    let mut guard = DSM_MESH.lock();
+    if let Some(mesh) = guard.as_mut() {
+        // Calculate physical ID: (Logical << 16) | Sender (us)
+        // participant_id is "us" (the sender).
+        let physical_id = PhysicalStreamId::new(source.config.stream_id, participant_id);
+
+        let mut registry = mesh.registry.lock();
+        registry.sources.insert(physical_id, source);
+    }
+}
+
+struct SignalOnDrop(Option<watch::Sender<bool>>);
+impl Drop for SignalOnDrop {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(true);
+        }
+    }
+}
+
+pub fn trigger_stream(physical_stream_id: PhysicalStreamId, context: Arc<TaskContext>) {
+    let mut guard = DSM_MESH.lock();
+    let mesh = guard.as_mut().expect("DSM mesh not registered");
+    let mut registry = mesh.registry.lock();
+
+    if registry.running_tasks.contains_key(&physical_stream_id) {
+        return;
+    }
+
+    if let Some(source) = registry.sources.get(&physical_stream_id) {
+        let input = source.input.clone();
+        let partitioning = source.partitioning.clone();
+        let config = source.config.clone();
+
+        // Prepare completion notifier. Create it if it doesn't exist (DsmExchangeExec hasn't run yet).
+        let tx = registry
+            .completions
+            .entry(physical_stream_id)
+            .or_insert_with(|| {
+                let (tx, _rx) = watch::channel(false);
+                tx
+            })
+            .clone();
+
+        let task = tokio::task::spawn_local(async move {
+            let _guard = SignalOnDrop(Some(tx));
+            DsmExchangeExec::producer_task(input, partitioning, config, context).await;
+        });
+
+        registry
+            .abort_handles
+            .insert(physical_stream_id, task.abort_handle());
+        registry.running_tasks.insert(physical_stream_id, task);
+    } else {
+        // No-op
+    }
+}
+
+pub fn cancel_triggered_stream(physical_stream_id: PhysicalStreamId) {
+    let mut guard = DSM_MESH.lock();
+    if let Some(mesh) = guard.as_mut() {
+        let mut registry = mesh.registry.lock();
+        if let Some(handle) = registry.abort_handles.remove(&physical_stream_id) {
+            handle.abort();
+        }
+        registry.running_tasks.remove(&physical_stream_id);
+    }
+}
+
+use tokio::task::LocalSet;
+
+/// Spawns the background Control Service.
+///
+/// This service acts as the "RPC Listener" for the process. It continually polls the
+/// control channels (reverse channels) of all DSM Writers assigned to this process.
+///
+/// When a `StartStream` message is received (analogous to an incoming RPC call),
+/// it triggers the execution of the corresponding sub-plan registered in `StreamRegistry`.
+pub fn spawn_control_service(local_set: &LocalSet, task_ctx: Arc<TaskContext>) {
+    local_set.spawn_local(async move {
+        loop {
+            // Get writers and bridge from global mesh
+            let (mux_writers, bridge) = {
+                let guard = DSM_MESH.lock();
+                if let Some(mesh) = guard.as_ref() {
+                    (
+                        mesh.transport.mux_writers.clone(),
+                        mesh.transport.bridge.clone(),
+                    )
+                } else {
+                    return; // Mesh destroyed?
+                }
+            };
+
+            futures::future::poll_fn(|cx| {
+                bridge.register_waker(cx.waker().clone(), None);
+                let mut work_done = false;
+
+                for mux in &mux_writers {
+                    let mut guard = mux.lock();
+                    while let Some((msg_type, payload)) = guard.read_control_frame() {
+                        work_done = true;
+                        if let Some(msg) = ControlMessage::try_from_frame(msg_type, &payload) {
+                            match msg {
+                                ControlMessage::StartStream(id) => {
+                                    trigger_stream(id, task_ctx.clone());
+                                }
+                                ControlMessage::CancelStream(id) => {
+                                    // Mark stream as cancelled in the transport layer
+                                    guard.mark_stream_cancelled(id);
+                                    // Cancel the execution task
+                                    cancel_triggered_stream(id);
+                                }
+                                ControlMessage::BroadcastPlan(_) => {
+                                    panic!("Received unexpected BroadcastPlan message during execution");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if work_done {
+                    // We processed messages. Yield to let triggered tasks run,
+                    // but return Ready(()) to allow the loop to continue.
+                    // Actually, if we return Ready, we exit poll_fn. The loop continues and calls poll_fn again immediately.
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await;
+
+            // Yield to allow spawned tasks to progress
+            tokio::task::yield_now().await;
+        }
+    });
+}
+
+pub fn get_dsm_writer(
+    participant: usize,
+    stream_id: LogicalStreamId,
+    sender_id: ParticipantId,
+    schema: SchemaRef,
+) -> Option<DsmWriter> {
+    let guard = DSM_MESH.lock();
+    if let Some(mesh) = guard.as_ref() {
+        if participant < mesh.transport.mux_writers.len() {
+            return Some(DsmWriter::new(
+                mesh.transport.mux_writers[participant].clone(),
+                stream_id,
+                sender_id,
+                schema,
+            ));
+        }
+    }
+    None
+}
+
+pub fn get_dsm_reader(
+    participant: usize,
+    stream_id: LogicalStreamId,
+    sender_id: ParticipantId,
+    schema: SchemaRef,
+    sanitized: bool,
+) -> Option<SendableRecordBatchStream> {
+    let guard = DSM_MESH.lock();
+    if let Some(mesh) = guard.as_ref() {
+        if participant < mesh.transport.mux_readers.len() {
+            let reader = dsm_reader(
+                mesh.transport.mux_readers[participant].clone(),
+                stream_id,
+                sender_id,
+                schema,
+                sanitized,
+            );
+            return Some(reader);
+        }
+    }
+    None
+}
+
+/// A physical optimizer rule that replaces standard `RepartitionExec` with `DsmExchangeExec`.
+#[derive(Debug)]
+pub struct EnforceDsmShuffle {
+    pub total_participants: usize,
+}
+
+impl EnforceDsmShuffle {
+    fn wrap_in_dsm_exchange(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        producer_partitioning: Partitioning,
+        output_partitioning: Partitioning,
+        stream_id: u16,
+        mode: ExchangeMode,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let config = DsmExchangeConfig {
+            stream_id: LogicalStreamId(stream_id),
+            total_participants: self.total_participants,
+            mode,
+            sanitized: false,
+        };
+
+        Ok(Arc::new(DsmExchangeExec::try_new(
+            input,
+            producer_partitioning,
+            output_partitioning,
+            config,
+        )?))
+    }
+}
+
+impl PhysicalOptimizerRule for EnforceDsmShuffle {
+    fn name(&self) -> &str {
+        "EnforceDsmShuffle"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut stream_id_counter: u16 = 0;
+
+        // Use a recursive function to wrap nodes top-down.
+        fn wrap_node(
+            node: Arc<dyn ExecutionPlan>,
+            rule: &EnforceDsmShuffle,
+            counter: &mut u16,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            // First, recursively optimize children.
+            let children: Vec<_> = node
+                .children()
+                .into_iter()
+                .map(|c| wrap_node(c.clone(), rule, counter))
+                .collect::<Result<Vec<_>>>()?;
+
+            let node = if children.is_empty() {
+                node
+            } else {
+                node.with_new_children(children)?
+            };
+
+            // Now, check if this node needs wrapping.
+            if let Some(repartition) = node.as_any().downcast_ref::<RepartitionExec>() {
+                let producer_partitioning = repartition.partitioning().clone();
+                let (mode, output_partitioning) =
+                    if matches!(producer_partitioning, Partitioning::UnknownPartitioning(1)) {
+                        (
+                            ExchangeMode::Gather,
+                            Partitioning::UnknownPartitioning(rule.total_participants),
+                        )
+                    } else {
+                        (
+                            ExchangeMode::Redistribute,
+                            Partitioning::UnknownPartitioning(
+                                producer_partitioning.partition_count(),
+                            ),
+                        )
+                    };
+
+                let stream_id = *counter;
+                *counter = counter.checked_add(1).ok_or_else(|| {
+                    datafusion::common::DataFusionError::Internal(
+                        "Too many shuffle stages (max 65535)".to_string(),
+                    )
+                })?;
+
+                let input = repartition.children()[0].clone();
+                rule.wrap_in_dsm_exchange(
+                    input,
+                    producer_partitioning,
+                    output_partitioning,
+                    stream_id,
+                    mode,
+                )
+            } else if let Some(merge) = node.as_any().downcast_ref::<SortPreservingMergeExec>() {
+                let input = merge.children()[0].clone();
+                if input.output_partitioning().partition_count() > 1
+                    && !input.as_any().is::<DsmExchangeExec>()
+                {
+                    let partitioning = Partitioning::UnknownPartitioning(rule.total_participants);
+                    let stream_id = *counter;
+                    *counter = counter.checked_add(1).ok_or_else(|| {
+                        datafusion::common::DataFusionError::Internal(
+                            "Too many shuffle stages (max 65535)".to_string(),
+                        )
+                    })?;
+
+                    let reader = rule.wrap_in_dsm_exchange(
+                        input,
+                        partitioning.clone(),
+                        partitioning,
+                        stream_id,
+                        ExchangeMode::Gather,
+                    )?;
+
+                    Ok(Arc::new(merge.clone()).with_new_children(vec![reader])?)
+                } else {
+                    Ok(node)
+                }
+            } else if let Some(coalesce) = node.as_any().downcast_ref::<CoalescePartitionsExec>() {
+                let input = coalesce.children()[0].clone();
+                if input.output_partitioning().partition_count() > 1
+                    && !input.as_any().is::<DsmExchangeExec>()
+                {
+                    let partitioning = Partitioning::UnknownPartitioning(rule.total_participants);
+                    let stream_id = *counter;
+                    *counter = counter.checked_add(1).ok_or_else(|| {
+                        datafusion::common::DataFusionError::Internal(
+                            "Too many shuffle stages (max 65535)".to_string(),
+                        )
+                    })?;
+
+                    let reader = rule.wrap_in_dsm_exchange(
+                        input,
+                        partitioning.clone(),
+                        partitioning,
+                        stream_id,
+                        ExchangeMode::Gather,
+                    )?;
+
+                    Ok(Arc::new(CoalescePartitionsExec::new(reader)) as Arc<dyn ExecutionPlan>)
+                } else {
+                    Ok(node)
+                }
+            } else {
+                Ok(node)
+            }
+        }
+
+        wrap_node(plan, self, &mut stream_id_counter)
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+pub fn collect_dsm_exchanges(plan: Arc<dyn ExecutionPlan>, sources: &mut Vec<StreamSource>) {
+    if let Some(exchange) = plan.as_any().downcast_ref::<DsmExchangeExec>() {
+        sources.push(StreamSource {
+            input: exchange.input.clone(),
+            partitioning: exchange.producer_partitioning.clone(),
+            config: exchange.config.clone(),
+        });
+    }
+
+    for child in plan.children() {
+        collect_dsm_exchanges(child.clone(), sources);
+    }
+}
+
+pub fn get_dsm_bridge() -> Arc<SignalBridge> {
+    let guard = DSM_MESH.lock();
+    let mesh = guard.as_ref().expect("DSM mesh not registered");
+    mesh.transport.bridge.clone()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ExchangeMode {
+    /// Every node sends to every node based on partitioning hash.
+    Redistribute,
+    /// Every node sends all its data to the leader (node 0).
+    Gather,
+}
+
+/// Shared configuration for DSM exchange nodes.
+///
+/// This struct holds all metadata required to coordinate the shuffle boundary,
+/// ensuring that both the producer (Writer) and consumer (Reader) sides
+/// are configured identically for a given logical stream.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DsmExchangeConfig {
+    pub stream_id: LogicalStreamId,
+    pub total_participants: usize,
+    pub mode: ExchangeMode,
+    #[serde(default)]
+    pub sanitized: bool,
+}
+
+pub(crate) fn get_mpp_config(ctx: &TaskContext) -> (usize, usize) {
+    ctx.session_config()
+        .options()
+        .extensions
+        .get::<MppParticipantConfig>()
+        .map(|c| (c.index, c.total_participants))
+        .unwrap_or((0, 1))
+}
+
+/// A physical operator that handles both the production (passive) and consumption (active) of shuffled data.
+///
+/// This single node replaces the `DsmReaderExec` / `DsmWriterExec` pair.
+///
+/// **As a Consumer (Reader)**:
+/// When `execute()` is called, it initiates the stream by sending `StartStream` to the producer(s).
+/// If `config.sanitized` is true, it performs a deep copy of incoming batches to prevent deadlocks
+/// with downstream blocking operators.
+///
+/// **As a Producer (Writer)**:
+/// It holds the `input` plan and `producer_partitioning`. It registers these in the `StreamRegistry`.
+/// When triggered via `StartStream`, `producer_task` is executed to run the input plan and write to DSM.
+#[derive(Debug)]
+pub struct DsmExchangeExec {
+    pub input: Arc<dyn ExecutionPlan>,
+    pub producer_partitioning: Partitioning,
+    pub config: DsmExchangeConfig,
+    pub properties: Arc<PlanProperties>,
+}
+
+impl DsmExchangeExec {
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        producer_partitioning: Partitioning,
+        output_partitioning: Partitioning,
+        config: DsmExchangeConfig,
+    ) -> Result<Self> {
+        let properties = Arc::new(PlanProperties::new(
+            input.equivalence_properties().clone(),
+            output_partitioning,
+            EmissionType::Incremental,
+            input.boundedness(),
+        ));
+
+        Ok(Self {
+            input,
+            producer_partitioning,
+            config,
+            properties,
+        })
+    }
+
+    pub(crate) async fn producer_task(
+        input: Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        config: DsmExchangeConfig,
+        context: Arc<TaskContext>,
+    ) {
+        let (participant_index, total_participants) = get_mpp_config(&context);
+        let participant_id = ParticipantId(participant_index as u16);
+        let num_partitions = input.output_partitioning().partition_count();
+        let mut streams = Vec::with_capacity(num_partitions);
+        for i in 0..num_partitions {
+            streams.push(
+                input
+                    .execute(i, context.clone())
+                    .expect("Failed to execute input"),
+            );
+        }
+        let input_stream = futures::stream::select_all(streams).fuse();
+        let mut input_stream = Box::pin(input_stream);
+        let schema = input.schema();
+
+        let mut writers = Vec::new();
+        for i in 0..total_participants {
+            writers.push(
+                get_dsm_writer(i, config.stream_id, participant_id, schema.clone())
+                    .expect("Failed to get DSM writer"),
+            );
+        }
+
+        // Initialize partitioner ONCE if needed
+        let mut partitioner = if let ExchangeMode::Redistribute = config.mode {
+            Some(
+                BatchPartitioner::try_new(
+                    partitioning,
+                    datafusion::physical_plan::metrics::Time::default(),
+                    0,
+                    1,
+                )
+                .expect("Failed to create partitioner"),
+            )
+        } else {
+            None
+        };
+
+        // Each writer has its own queue of pending batches
+        let mut out_queues: Vec<std::collections::VecDeque<RecordBatch>> =
+            vec![std::collections::VecDeque::new(); total_participants];
+
+        let mut input_done = false;
+        let bridge = get_dsm_bridge();
+
+        poll_fn(|cx| {
+            loop {
+                let mut progress = false;
+
+                // 1. Try to drain all queues
+                let mut all_queues_empty = true;
+                let mut blocked_on_write = false;
+
+                for i in 0..total_participants {
+                    while let Some(batch) = out_queues[i].front() {
+                        match writers[i].write_batch(batch) {
+                            Ok(_) => {
+                                out_queues[i].pop_front();
+                                progress = true;
+                            }
+                            Err(datafusion::error::DataFusionError::IoError(ref msg))
+                                if msg.kind() == ErrorKind::WouldBlock =>
+                            {
+                                // Check-Register-Check pattern
+                                bridge.register_waker(cx.waker().clone(), None);
+
+                                // Retry immediately to avoid race condition where space became available
+                                // after the first check but before we registered the waker.
+                                match writers[i].write_batch(batch) {
+                                    Ok(_) => {
+                                        out_queues[i].pop_front();
+                                        progress = true;
+                                    }
+                                    Err(datafusion::error::DataFusionError::IoError(ref msg))
+                                        if msg.kind() == ErrorKind::WouldBlock =>
+                                    {
+                                        blocked_on_write = true;
+                                        all_queues_empty = false;
+                                        break;
+                                    }
+                                    Err(e) => panic!("Producer failed on retry: {}", e),
+                                }
+                                break;
+                            }
+                            Err(datafusion::error::DataFusionError::IoError(ref msg))
+                                if msg.kind() == ErrorKind::BrokenPipe =>
+                            {
+                                // Receiver closed
+                                out_queues[i].clear();
+                                break;
+                            }
+                            Err(e) => panic!("Producer failed: {}", e),
+                        }
+                    }
+                    if !out_queues[i].is_empty() {
+                        all_queues_empty = false;
+                    }
+                }
+
+                // 2. Poll input stream if not done
+                if !input_done {
+                    match input_stream.as_mut().poll_next(cx) {
+                        Poll::Ready(Some(Ok(batch))) => {
+                            match config.mode {
+                                ExchangeMode::Redistribute => {
+                                    partitioner
+                                        .as_mut()
+                                        .unwrap()
+                                        .partition(batch, |dest_idx, partitioned_batch| {
+                                            if dest_idx < out_queues.len() {
+                                                out_queues[dest_idx].push_back(partitioned_batch);
+                                            }
+                                            Ok(())
+                                        })
+                                        .expect("Partitioning failed");
+                                }
+                                ExchangeMode::Gather => {
+                                    out_queues[0].push_back(batch);
+                                }
+                            }
+                            progress = true;
+                        }
+                        Poll::Ready(Some(Err(e))) => panic!("Input stream failed: {}", e),
+                        Poll::Ready(None) => {
+                            input_done = true;
+                            progress = true; // State change counts as progress
+                        }
+                        Poll::Pending => {
+                            // Input not ready
+                        }
+                    }
+                }
+
+                if input_done && all_queues_empty {
+                    return Poll::Ready(());
+                }
+
+                // If we made progress, try again immediately to drain more
+                if progress {
+                    continue;
+                }
+
+                // No progress made.
+                // If blocked on write, register waker with bridge.
+                if blocked_on_write {
+                    bridge.register_waker(cx.waker().clone(), None);
+                }
+
+                // If input is pending, it already registered waker.
+
+                return Poll::Pending;
+            }
+        })
+        .await;
+
+        for writer in writers {
+            let _ = writer.finish();
+        }
+    }
+
+    fn create_consumer_stream(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let (participant_index, total_participants) = get_mpp_config(&context);
+        let schema = self.input.schema();
+
+        // Return the consumer side stream for THIS partition.
+        match self.config.mode {
+            ExchangeMode::Redistribute => {
+                // In Redistribute mode, every node k consumes Partition k.
+                if partition != participant_index {
+                    // pgrx::warning!(
+                    //     "[Worker {}] DsmReaderExec: Redistribute execute({}) requested, but I am participant {}. Returning empty stream.",
+                    //     unsafe { pgrx::pg_sys::ParallelWorkerNumber },
+                    //     partition,
+                    //     participant_index
+                    // );
+                    return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                        schema,
+                        futures::stream::empty(),
+                    )));
+                }
+
+                let mut readers = Vec::new();
+                for i in 0..total_participants {
+                    // Read from Participant i, Logical Stream S, Sender Index i.
+                    if let Some(reader) = get_dsm_reader(
+                        i,
+                        self.config.stream_id,
+                        ParticipantId(i as u16),
+                        schema.clone(),
+                        self.config.sanitized,
+                    ) {
+                        readers.push(shared_memory_stream(reader));
+                    }
+                }
+
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    schema.clone(),
+                    futures::stream::select_all(readers),
+                )))
+            }
+            ExchangeMode::Gather => {
+                // In Gather mode, only the Leader (node 0) consumes.
+                if participant_index != 0 {
+                    // Worker side: we are not the consumer.
+                    // But DataFusion might call execute(p) for ALL p if it's merging.
+                    // Workers should only 'wait' once per logical stream.
+                    // We choose to wait when partition == participant_index.
+                    if partition == participant_index {
+                        let physical_id = PhysicalStreamId::new(
+                            self.config.stream_id,
+                            ParticipantId(participant_index as u16),
+                        );
+
+                        let rx = {
+                            let mut guard = DSM_MESH.lock();
+                            let mesh = guard.as_mut().expect("DSM mesh not registered");
+                            let mut registry = mesh.registry.lock();
+                            if let Some(tx) = registry.completions.get(&physical_id) {
+                                tx.subscribe()
+                            } else {
+                                let (tx, rx) = watch::channel(false);
+                                registry.completions.insert(physical_id, tx);
+                                rx
+                            }
+                        };
+                        return Ok(wait_for_producer_stream(schema, rx));
+                    } else {
+                        return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                            schema,
+                            futures::stream::empty(),
+                        )));
+                    }
+                }
+
+                // Leader: Pull Partition `partition` from Worker `partition`.
+
+                if let Some(reader) = get_dsm_reader(
+                    partition,
+                    self.config.stream_id,
+                    ParticipantId(partition as u16),
+                    schema.clone(),
+                    self.config.sanitized,
+                ) {
+                    Ok(shared_memory_stream(reader))
+                } else {
+                    Ok(Box::pin(RecordBatchStreamAdapter::new(
+                        schema,
+                        futures::stream::empty(),
+                    )))
+                }
+            }
+        }
+    }
+}
+
+impl DisplayAs for DsmExchangeExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "DsmExchangeExec(stream_id={}, producer_partitioning={:?}, sanitized={})",
+                    self.config.stream_id, self.producer_partitioning, self.config.sanitized
+                )
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for DsmExchangeExec {
+    fn name(&self) -> &str {
+        "DsmExchangeExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self::try_new(
+            children[0].clone(),
+            self.producer_partitioning.clone(),
+            self.properties.output_partitioning().clone(),
+            self.config.clone(),
+        )?))
+    }
+
+    fn execute(
+        &self,
+
+        partition: usize,
+
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // In the RPC-Server model, the execution of the input plan (production)
+        // is decoupled from the execution of this node (consumption).
+        //
+        // 1. The input plan is executed by the `producer_task`, which is triggered
+        //    asynchronously by a `StartStream` control message.
+        // 2. This `execute` method acts as the "Client": it initiates the stream
+        //    by sending `StartStream` and returning a consumer stream that reads
+        //    from the shared memory ring buffer.
+        //
+        // Therefore, we do NOT execute `self.input` here.
+
+        self.create_consumer_stream(partition, context)
+    }
+}
+
+/// A stream that waits for the producer task to complete before finishing.
+/// This is used on worker nodes for "Gather" operations to ensure the producer
+/// task runs to completion even though no data is consumed locally.
+fn wait_for_producer_stream(
+    schema: SchemaRef,
+    mut rx: watch::Receiver<bool>,
+) -> SendableRecordBatchStream {
+    let schema_clone = schema.clone();
+    let stream = try_stream! {
+        while !*rx.borrow() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+        // Phantom yield to satisfy type inference (T=RecordBatch)
+        if false {
+            yield RecordBatch::new_empty(schema_clone);
+        }
+    };
+    Box::pin(RecordBatchStreamAdapter::new(schema, Box::pin(stream)))
+}
+
+/// Adapts a `SharedMemoryReader` (which requires manual waker registration via `SignalBridge`)
+/// into a standard `RecordBatchStream`.
+fn shared_memory_stream(mut reader: SendableRecordBatchStream) -> SendableRecordBatchStream {
+    let schema = reader.schema();
+    let stream = try_stream! {
+        while let Some(batch) = reader.next().await {
+            yield batch?;
+        }
+    };
+    Box::pin(RecordBatchStreamAdapter::new(schema, Box::pin(stream)))
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::physical_expr::EquivalenceProperties;
+    use datafusion::physical_plan::execution_plan::Boundedness;
+    use datafusion::physical_plan::repartition::RepartitionExec;
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct MockLeaf {
+        properties: Arc<PlanProperties>,
+    }
+
+    impl MockLeaf {
+        fn new(schema: SchemaRef) -> Self {
+            let properties = Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ));
+            Self { properties }
+        }
+    }
+
+    impl DisplayAs for MockLeaf {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "MockLeaf")
+        }
+    }
+
+    impl ExecutionPlan for MockLeaf {
+        fn name(&self) -> &str {
+            "MockLeaf"
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _c: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(&self, _p: usize, _c: Arc<TaskContext>) -> Result<SendableRecordBatchStream> {
+            unreachable!()
+        }
+    }
+
+    #[pgrx::pg_test]
+    fn test_enforce_dsm_shuffle_rule() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let leaf = Arc::new(MockLeaf::new(schema));
+
+        let repartition =
+            Arc::new(RepartitionExec::try_new(leaf, Partitioning::RoundRobinBatch(2)).unwrap());
+
+        let rule = EnforceDsmShuffle {
+            total_participants: 2,
+        };
+        let optimized = rule
+            .optimize(repartition, &ConfigOptions::default())
+            .unwrap();
+
+        assert!(optimized.as_any().is::<DsmExchangeExec>());
+        assert_eq!(optimized.children().len(), 1);
+        // The child is now the input of DsmExchangeExec (MockLeaf), not DsmWriterExec
+        assert!(optimized.children()[0].as_any().is::<MockLeaf>());
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -684,6 +684,9 @@ impl JoinScan {
             }
         }
 
+        // Store planned worker count for MPP execution path.
+        join_clause.planned_workers = nworkers;
+
         // --- Build CustomPath ---
 
         let has_order_by = !join_clause.order_by.is_empty();
@@ -1277,6 +1280,7 @@ impl CustomScan for JoinScan {
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
                     .build()
                     .unwrap();
                 let join_clause = state.custom_state().join_clause.clone();
@@ -1301,15 +1305,27 @@ impl CustomScan for JoinScan {
                     );
                 }
 
-                // Deserialize the logical plan and convert to execution plan
-                let planstate = state.planstate();
-                // Clone plan_bytes to release the immutable borrow on `state`
-                // before the mutable borrow in ensure_source_manifests below.
                 let plan_bytes = state
                     .custom_state()
                     .logical_plan
                     .clone()
                     .expect("Logical plan is required");
+
+                // MPP execution path: when the GUC is enabled and workers are planned,
+                // use hash-partitioned MPP execution instead of broadcast-join.
+                let _use_mpp = crate::gucs::enable_mpp_join() && join_clause.planned_workers > 0;
+
+                // TODO(#4152): Wire the MPP execution path here. When _use_mpp is true:
+                // 1. Call parallel::launch_join_workers() to set up workers + transport mesh
+                // 2. Build physical plan with SessionContextProfile::JoinMpp
+                // 3. Serialize and broadcast plan to workers
+                // 4. Register DSM mesh for leader
+                // 5. Spawn control service
+                // 6. Execute partition 0 of the plan
+                // For now, fall through to the broadcast-join path.
+
+                // Deserialize the logical plan and convert to execution plan
+                let planstate = state.planstate();
 
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1280,7 +1280,6 @@ impl CustomScan for JoinScan {
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
                     .build()
                     .unwrap();
                 let join_clause = state.custom_state().join_clause.clone();

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -139,10 +139,14 @@
 //! - [`explain`]: EXPLAIN output formatting.
 
 pub mod build;
+#[allow(dead_code, deprecated)]
+pub mod exchange;
 pub mod planner;
 mod planning;
 pub mod predicate;
 pub mod privdat;
+#[allow(dead_code, deprecated)]
+pub mod sanitize;
 pub mod scan_state;
 pub mod transport;
 pub mod visibility_filter;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -144,6 +144,7 @@ mod planning;
 pub mod predicate;
 pub mod privdat;
 pub mod scan_state;
+pub mod transport;
 pub mod visibility_filter;
 
 pub use self::build::CtidColumn;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -196,6 +196,117 @@ use futures::StreamExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 
+/// Collect all `plan_id`s from `T_SubPlan` nodes in an expression tree.
+unsafe fn collect_all_subplan_ids_from_expr(node: *mut pg_sys::Node, ids: &mut HashSet<i32>) {
+    if node.is_null() {
+        return;
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        context: *mut std::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        if (*node).type_ == pg_sys::NodeTag::T_SubPlan {
+            let subplan = node as *mut pg_sys::SubPlan;
+            let ids = &mut *(context as *mut HashSet<i32>);
+            ids.insert((*subplan).plan_id);
+        }
+        pg_sys::expression_tree_walker(node, Some(walker), context)
+    }
+
+    walker(node, ids as *mut HashSet<i32> as *mut std::ffi::c_void);
+}
+
+/// Collect all SubPlan `plan_id`s present in `baserestrictinfo` of the
+/// given base relations.
+unsafe fn collect_all_subplan_ids_from_baserestrictinfo(
+    root: *mut pg_sys::PlannerInfo,
+    absorbed_rtis: &[pg_sys::Index],
+) -> HashSet<i32> {
+    let mut all_ids = HashSet::default();
+    for rti in absorbed_rtis {
+        let rel = pg_sys::find_base_rel(root, *rti as i32);
+        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+        for ri in ri_list.iter_ptr() {
+            let clause = (*ri).clause as *mut pg_sys::Node;
+            collect_all_subplan_ids_from_expr(clause, &mut all_ids);
+        }
+    }
+    all_ids
+}
+
+/// Collect the `plan_id`s of SubPlans that JoinScan absorbed into
+/// Semi/Anti/LeftMark join nodes in the `RelNode` tree.
+fn collect_absorbed_subplan_ids(plan: &build::RelNode) -> HashSet<i32> {
+    let mut ids = HashSet::default();
+    walk_relnode_for_subplan_ids(plan, &mut ids);
+    ids
+}
+
+fn walk_relnode_for_subplan_ids(node: &build::RelNode, ids: &mut HashSet<i32>) {
+    match node {
+        build::RelNode::Join(j) => {
+            if let Some(plan_id) = j.subplan_id {
+                ids.insert(plan_id);
+            }
+            walk_relnode_for_subplan_ids(&j.left, ids);
+            walk_relnode_for_subplan_ids(&j.right, ids);
+        }
+        build::RelNode::Filter(f) => walk_relnode_for_subplan_ids(&f.input, ids),
+        build::RelNode::Scan(_) => {}
+    }
+}
+
+/// Check whether it is safe to push LIMIT into the JoinScan plan.
+unsafe fn is_limit_pushdown_safe(
+    root: *mut pg_sys::PlannerInfo,
+    join_clause: &build::JoinCSClause,
+) -> bool {
+    let absorbed_rtis: Vec<pg_sys::Index> = join_clause
+        .plan
+        .sources()
+        .iter()
+        .map(|s| s.scan_info.heap_rti)
+        .collect();
+
+    #[cfg(feature = "pg15")]
+    let all_rels = (*root).all_baserels;
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    let all_rels = (*root).all_query_rels;
+
+    let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
+    for rti in &absorbed_rtis {
+        absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
+    }
+    if !pg_sys::bms_is_subset(all_rels, absorbed_bms) {
+        return false;
+    }
+
+    let all_subplan_ids = collect_all_subplan_ids_from_baserestrictinfo(root, &absorbed_rtis);
+    let absorbed_subplan_ids = collect_absorbed_subplan_ids(&join_clause.plan);
+    for id in &all_subplan_ids {
+        if !absorbed_subplan_ids.contains(id) {
+            return false;
+        }
+    }
+
+    for rti in &absorbed_rtis {
+        let rel = pg_sys::find_base_rel(root, *rti as i32);
+        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+        for ri in ri_list.iter_ptr() {
+            if pg_sys::contain_volatile_functions((*ri).clause as *mut pg_sys::Node) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
 #[derive(Default)]
 pub struct JoinScan;
 
@@ -266,133 +377,6 @@ impl JoinDeclineReason {
             }
         }
     }
-}
-
-/// Recursively walk an expression tree and collect the `plan_id` of every
-/// `T_SubPlan` node found at any depth.  Uses Postgres's
-/// `expression_tree_walker` so it handles all node types automatically.
-unsafe fn collect_all_subplan_ids_from_expr(node: *mut pg_sys::Node, ids: &mut HashSet<i32>) {
-    if node.is_null() {
-        return;
-    }
-
-    #[pg_guard]
-    unsafe extern "C-unwind" fn walker(
-        node: *mut pg_sys::Node,
-        context: *mut std::ffi::c_void,
-    ) -> bool {
-        if node.is_null() {
-            return false;
-        }
-        if (*node).type_ == pg_sys::NodeTag::T_SubPlan {
-            let subplan = node as *mut pg_sys::SubPlan;
-            let ids = &mut *(context as *mut HashSet<i32>);
-            ids.insert((*subplan).plan_id);
-        }
-        pg_sys::expression_tree_walker(node, Some(walker), context)
-    }
-
-    walker(node, ids as *mut HashSet<i32> as *mut std::ffi::c_void);
-}
-
-/// Collect all SubPlan `plan_id`s present in `baserestrictinfo` of the
-/// given base relations.
-unsafe fn collect_all_subplan_ids_from_baserestrictinfo(
-    root: *mut pg_sys::PlannerInfo,
-    absorbed_rtis: &[pg_sys::Index],
-) -> HashSet<i32> {
-    let mut all_ids = HashSet::default();
-    for rti in absorbed_rtis {
-        let rel = pg_sys::find_base_rel(root, *rti as i32);
-        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
-        for ri in ri_list.iter_ptr() {
-            let clause = (*ri).clause as *mut pg_sys::Node;
-            collect_all_subplan_ids_from_expr(clause, &mut all_ids);
-        }
-    }
-    all_ids
-}
-
-/// Collect the `plan_id`s of SubPlans that JoinScan absorbed into
-/// Semi/Anti/LeftMark join nodes in the `RelNode` tree.
-fn collect_absorbed_subplan_ids(plan: &RelNode) -> HashSet<i32> {
-    let mut ids = HashSet::default();
-    walk_relnode_for_subplan_ids(plan, &mut ids);
-    ids
-}
-
-fn walk_relnode_for_subplan_ids(node: &RelNode, ids: &mut HashSet<i32>) {
-    match node {
-        RelNode::Join(j) => {
-            if let Some(plan_id) = j.subplan_id {
-                ids.insert(plan_id);
-            }
-            walk_relnode_for_subplan_ids(&j.left, ids);
-            walk_relnode_for_subplan_ids(&j.right, ids);
-        }
-        RelNode::Filter(f) => walk_relnode_for_subplan_ids(&f.input, ids),
-        RelNode::Scan(_) => {}
-    }
-}
-
-/// Check whether it is safe to push LIMIT into the JoinScan plan.
-///
-/// Returns `true` when ALL of:
-/// 1. JoinScan absorbed every base relation in the query (no outer
-///    relations that could add post-filters above JoinScan).
-/// 2. Every SubPlan in `baserestrictinfo` of absorbed relations was also
-///    absorbed into the `RelNode` tree (Semi/Anti/LeftMark joins).
-///    Un-absorbed SubPlans would become Postgres post-filters above
-///    the capped output.
-/// 3. No volatile functions in `baserestrictinfo` of absorbed relations
-///    (volatile functions can never be pushed into Tantivy).
-unsafe fn is_limit_pushdown_safe(
-    root: *mut pg_sys::PlannerInfo,
-    join_clause: &JoinCSClause,
-) -> bool {
-    let absorbed_rtis: Vec<pg_sys::Index> = join_clause
-        .plan
-        .sources()
-        .iter()
-        .map(|s| s.scan_info.heap_rti)
-        .collect();
-
-    // 1. Did JoinScan absorb ALL base relations?
-    #[cfg(feature = "pg15")]
-    let all_rels = (*root).all_baserels;
-    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-    let all_rels = (*root).all_query_rels;
-
-    let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
-    for rti in &absorbed_rtis {
-        absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
-    }
-    if !pg_sys::bms_is_subset(all_rels, absorbed_bms) {
-        return false;
-    }
-
-    // 2. Every SubPlan in baserestrictinfo must have been absorbed.
-    let all_subplan_ids = collect_all_subplan_ids_from_baserestrictinfo(root, &absorbed_rtis);
-    let absorbed_subplan_ids = collect_absorbed_subplan_ids(&join_clause.plan);
-    for id in &all_subplan_ids {
-        if !absorbed_subplan_ids.contains(id) {
-            return false;
-        }
-    }
-
-    // 3. No volatile functions (these can never be absorbed).
-    for rti in &absorbed_rtis {
-        let rel = pg_sys::find_base_rel(root, *rti as i32);
-        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
-        for ri in ri_list.iter_ptr() {
-            let clause = (*ri).clause as *mut pg_sys::Node;
-            if pg_sys::contain_volatile_functions(clause) {
-                return false;
-            }
-        }
-    }
-
-    true
 }
 
 /// Try to create JoinScan `CustomPath`s for a single base relation that contains

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -141,6 +141,8 @@
 pub mod build;
 #[allow(dead_code, deprecated)]
 pub mod exchange;
+#[allow(dead_code)]
+pub mod parallel;
 pub mod planner;
 mod planning;
 pub mod predicate;

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -1,0 +1,1027 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Coordinated Parallel Execution
+//!
+//! This module implements the infrastructure for process-parallel execution of JoinScan.
+//! It follows a "Coordinated Parallel Engine" model where the PostgreSQL leader backend
+//! acts as a scheduler, and multiple background workers act as executors.
+//!
+//! ## Process Model
+//!
+//! ### 1. Leader (The Scheduler)
+//!
+//! The Leader process (in `launch_join_workers`):
+//! - Computes the physical execution plan for the *entire* query.
+//! - Serializes the plan and broadcasts it to all workers via shared memory.
+//! - Initializes the Shared Memory Ring Buffers for data transport.
+//! - Launches $N$ background workers using the `parallel_worker` framework.
+//! - Executes its own portion of the plan (if `leader_participation` is enabled).
+//!
+//! ### 2. Worker (The RPC Server)
+//!
+//! Each Worker process (in `JoinWorker::run`):
+//! - Deserializes the full physical plan.
+//! - **Does NOT execute** the plan immediately. instead, it registers all `DsmExchangeExec` nodes
+//!   (sub-plans) into a local `StreamRegistry`.
+//! - Starts a `Control Service` loop to listen for incoming stream requests.
+//! - Parks the thread and waits for `StartStream` commands from consumers.
+//!
+//! ## Important Note on Parallelism
+//!
+//! This implementation **explicitly does not use** the standard PostgreSQL `CustomScan`
+//! parallelism strategy (which relies on `EstimateDSMCustomScan`, `InitializeDSMCustomScan`,
+//! etc.). Instead, it uses the `parallel_worker` framework to launch a deterministic number
+//! of background workers and manually coordinates them via a unified DataFusion plan.
+
+use crate::launch_parallel_process;
+use crate::parallel_worker::builder::ParallelProcessMessageQueue;
+use crate::parallel_worker::mqueue::MessageQueueSender;
+use crate::parallel_worker::{
+    ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
+    WorkerStyle,
+};
+use crate::postgres::customscan::joinscan::exchange;
+use crate::postgres::customscan::joinscan::transport::TransportMesh;
+use crate::postgres::customscan::joinscan::transport::{
+    MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, SignalBridge, TransportLayout,
+};
+use crate::postgres::locks::Spinlock;
+use crate::scan::codec::PgSearchPhysicalCodec;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+use super::scan_state::{create_datafusion_session_context, SessionContextProfile};
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JoinSharedState {
+    pub mutex: Spinlock,
+    pub nlaunched: usize,
+}
+
+impl ParallelStateType for JoinSharedState {}
+
+impl JoinSharedState {
+    pub fn set_launched_workers(&mut self, nlaunched: usize) {
+        let _lock = self.mutex.acquire();
+        self.nlaunched = nlaunched;
+    }
+
+    pub fn launched_workers(&mut self) -> usize {
+        let _lock = self.mutex.acquire();
+        self.nlaunched
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct JoinConfig {
+    pub max_memory: usize,
+    pub nworkers: usize,
+    pub total_participants: usize,
+    pub leader_participation: bool,
+    pub session_id: uuid::Bytes,
+    pub region_size: usize,
+    pub ring_buffer_size: usize,
+    pub control_size: usize,
+}
+
+impl ParallelStateType for JoinConfig {}
+
+/// Pre-initialized ring buffer region for shared memory transport.
+///
+/// The buffer is initialized eagerly (ring buffer headers written) so that
+/// `as_bytes()` returns a ready-to-use memory image. The parallel_worker
+/// framework copies this into DSM via `shm_toc_allocate` + `memcpy`.
+pub struct JoinRingBufferRegion {
+    data: Vec<u8>,
+}
+
+impl JoinRingBufferRegion {
+    pub fn new(
+        total_participants: usize,
+        region_size: usize,
+        ring_buffer_size: usize,
+        control_size: usize,
+    ) -> Self {
+        let total_size = region_size * total_participants * total_participants;
+        let mut data = vec![0u8; total_size];
+        let layout = TransportLayout::new(ring_buffer_size, control_size);
+        for i in 0..(total_participants * total_participants) {
+            let offset = i * region_size;
+            unsafe {
+                layout.init(data.as_mut_ptr().add(offset));
+            }
+        }
+        Self { data }
+    }
+}
+
+impl ParallelState for JoinRingBufferRegion {
+    fn type_name(&self) -> &'static str {
+        "u8"
+    }
+
+    fn size_of(&self) -> usize {
+        self.data.len()
+    }
+
+    fn array_len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+pub struct ParallelJoin {
+    pub state: JoinSharedState,
+    pub config: JoinConfig,
+    /// A single flat buffer containing all ring buffer regions.
+    /// Layout: [Region 0][Region 1]...[Region P*P-1]
+    pub ring_buffer: JoinRingBufferRegion,
+}
+
+impl ParallelJoin {
+    pub fn new(config: JoinConfig, ring_buffer: JoinRingBufferRegion) -> Self {
+        Self {
+            state: JoinSharedState {
+                mutex: Spinlock::default(),
+                nlaunched: 0,
+            },
+            config,
+            ring_buffer,
+        }
+    }
+}
+
+impl ParallelProcess for ParallelJoin {
+    fn state_values(&self) -> Vec<&dyn ParallelState> {
+        let mut values: Vec<&dyn ParallelState> = vec![&self.state, &self.config];
+        // Push the single flat buffer
+        values.push(&self.ring_buffer);
+        values
+    }
+}
+
+pub struct JoinWorker<'a> {
+    pub state: &'a mut JoinSharedState,
+    pub config: JoinConfig,
+    pub ring_buffer_ptr: *mut u8,
+}
+
+impl ParallelWorker for JoinWorker<'_> {
+    fn new_parallel_worker(state_manager: ParallelStateManager) -> Self {
+        let state = state_manager
+            .object::<JoinSharedState>(0)
+            .expect("wrong type for state")
+            .expect("missing state value");
+        let config = state_manager
+            .object::<JoinConfig>(1)
+            .expect("wrong type for config")
+            .expect("missing config value");
+
+        // The ring buffer is at index 2
+        let ring_buffer_slice = state_manager
+            .slice::<u8>(2)
+            .expect("missing ring_buffer value")
+            .expect("missing ring_buffer value");
+
+        Self {
+            state,
+            config: *config,
+            ring_buffer_ptr: ring_buffer_slice.as_ptr() as *mut u8,
+        }
+    }
+
+    fn run(self, _mq_sender: &MessageQueueSender, worker_number: i32) -> anyhow::Result<()> {
+        // Wait for all workers to launch to ensure deterministic behavior.
+        while self.state.launched_workers() == 0 {
+            pgrx::check_for_interrupts!();
+            std::thread::yield_now();
+        }
+        let launched_participants = self.state.launched_workers();
+
+        // Worker number is 0-based. Participant index: leader=0 (if participating),
+        // worker0=1, worker1=2, etc.
+        let participant_index = if self.config.leader_participation {
+            (worker_number + 1) as usize
+        } else {
+            worker_number as usize
+        };
+        let participant_id = ParticipantId(participant_index as u16);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let session_id = uuid::Uuid::from_bytes(self.config.session_id);
+        let bridge = runtime
+            .block_on(SignalBridge::new(participant_id, session_id))
+            .expect("Failed to initialize SignalBridge");
+        let bridge = Arc::new(bridge);
+
+        let layout = TransportLayout::new(self.config.ring_buffer_size, self.config.control_size);
+        let transport = unsafe {
+            TransportMesh::init(
+                self.ring_buffer_ptr,
+                layout,
+                participant_id,
+                self.config.total_participants, // Use Max/Configured participants for layout
+                bridge.clone(),
+            )
+        };
+
+        // Wait for the plan via the control channel.
+        let plan_slice = runtime.block_on(transport.wait_for_broadcast_plan());
+
+        // Register the DSM mesh for this worker process.
+        let mesh = exchange::DsmMesh {
+            transport,
+            registry: Mutex::new(exchange::StreamRegistry::default()),
+        };
+        exchange::register_dsm_mesh(mesh);
+
+        let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
+            participant_index,
+            total_participants: launched_participants,
+        });
+
+        let codec = PgSearchPhysicalCodec;
+        let _ = physical_plan_from_bytes_with_extension_codec(&plan_slice, &ctx.task_ctx(), &codec)
+            .expect("Failed to parse physical plan");
+
+        let task_ctx = ctx.task_ctx();
+
+        // The Worker Loop:
+        // 1. Deserializing the plan populated the local StreamRegistry via the physical codec.
+        // 2. Start the "Listener" (Control Service) to accept incoming RPC calls (StartStream).
+        // 3. Park the main thread and wait for session termination.
+        runtime.block_on(async {
+            let local = tokio::task::LocalSet::new();
+
+            // Start the control service to listen for stream requests
+            exchange::spawn_control_service(&local, task_ctx.clone());
+
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("Failed to create SIGTERM listener");
+
+            local
+                .run_until(async move {
+                    tokio::select! {
+                        _ = futures::future::pending::<()>() => {
+                            // Should not be reachable
+                        }
+                        _ = sigterm.recv() => {
+                            // Normal exit on SIGTERM
+                            pgrx::warning!("JoinWorker: SIGTERM received, shutting down");
+                        }
+                    }
+                })
+                .await
+        });
+
+        exchange::clear_dsm_mesh();
+
+        Ok(())
+    }
+}
+
+impl JoinWorker<'_> {}
+
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
+
+/// The result of launching parallel join workers.
+pub type LaunchedJoinWorkers = (
+    ParallelProcessMessageQueue,
+    Option<Arc<dyn ExecutionPlan>>,
+    Vec<Arc<Mutex<MultiplexedDsmWriter>>>,
+    Vec<Arc<Mutex<MultiplexedDsmReader>>>,
+    uuid::Uuid,
+    Arc<SignalBridge>,
+    usize,
+);
+
+/// Launches parallel workers for a JoinScan.
+pub fn launch_join_workers(
+    runtime: &tokio::runtime::Runtime,
+    nworkers: usize,
+    max_memory: usize,
+    leader_participation: bool,
+) -> Option<LaunchedJoinWorkers> {
+    if nworkers == 0 {
+        return None;
+    }
+
+    let total_participants = if leader_participation {
+        nworkers + 1
+    } else {
+        nworkers
+    };
+
+    let session_id = uuid::Uuid::new_v4();
+
+    // Allocate 128MB ring buffers per worker.
+    // TODO: This is temporary! Should implement support for reconstructing a larger buffer without
+    // needing this much dedicated space.
+    let ring_buffer_size = 128 * 1024 * 1024;
+    // We increase the control buffer size to 4MB (from 64KB) to accommodate serialized plans
+    // sent via BroadcastPlan.
+    let control_size = 4 * 1024 * 1024;
+    // Data Header + Data + Control Header + Control Data + padding
+    let layout = TransportLayout::new(ring_buffer_size, control_size);
+    let region_size = layout.total_size();
+
+    let config = JoinConfig {
+        max_memory,
+        nworkers,
+        total_participants,
+        leader_participation,
+        session_id: *session_id.as_bytes(),
+        region_size,
+        ring_buffer_size,
+        control_size,
+    };
+
+    let ring_buffer = JoinRingBufferRegion::new(
+        total_participants,
+        region_size,
+        ring_buffer_size,
+        control_size,
+    );
+
+    // Initialize leader's bridge
+    let bridge = runtime
+        .block_on(SignalBridge::new(
+            ParticipantId(0), // Leader is index 0
+            session_id,
+        ))
+        .expect("Failed to initialize SignalBridge");
+    let bridge = Arc::new(bridge);
+
+    let process = ParallelJoin::new(config, ring_buffer);
+
+    if let Some(mut launched) = launch_parallel_process!(
+        ParallelJoin<JoinWorker>,
+        process,
+        WorkerStyle::Query,
+        nworkers,
+        16384
+    ) {
+        let nlaunched = launched.launched_workers() + if leader_participation { 1 } else { 0 };
+
+        // Signal readiness and wait for workers
+        {
+            let state_manager = launched.state_manager_mut();
+            let shared_state = state_manager.object::<JoinSharedState>(0).unwrap().unwrap();
+
+            shared_state.set_launched_workers(nlaunched);
+        }
+
+        let leader_participant_index = 0;
+
+        // Retrieve the ring buffer slice from DSM
+        // Index is 2 (0: state, 1: config, 2: ring_buffer)
+        let ring_buffer_slice = launched
+            .state_manager()
+            .slice::<u8>(2)
+            .expect("wrong type for ring_buffer_slice")
+            .expect("missing ring_buffer_slice value");
+
+        let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+        let transport = unsafe {
+            TransportMesh::init(
+                base_ptr,
+                layout,
+                ParticipantId(leader_participant_index as u16),
+                total_participants,
+                bridge.clone(),
+            )
+        };
+
+        let mux_writers = transport.mux_writers.clone();
+        let mux_readers = transport.mux_readers.clone();
+
+        Some((
+            launched.into_iter(),
+            None, // Leader plan is not built yet
+            mux_writers,
+            mux_readers,
+            session_id,
+            bridge,
+            nlaunched,
+        ))
+    } else {
+        None
+    }
+}
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use crate::launch_parallel_process;
+    use crate::parallel_worker::mqueue::MessageQueueSender;
+    use crate::parallel_worker::{
+        ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
+        WorkerStyle,
+    };
+    use crate::postgres::customscan::joinscan::exchange::{
+        self, register_dsm_mesh, DsmExchangeConfig, DsmExchangeExec, DsmMesh, ExchangeMode,
+    };
+    use crate::postgres::customscan::joinscan::transport::{
+        LogicalStreamId, MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, SignalBridge,
+        TransportLayout, TransportMesh,
+    };
+    use crate::postgres::locks::Spinlock;
+    use crate::scan::table_provider::MppParticipantConfig;
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
+    use datafusion::common::Result;
+    use datafusion::execution::context::{SessionConfig, SessionContext, TaskContext};
+    use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream};
+    use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+    use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+    use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+    use futures::{Stream, StreamExt};
+    use parking_lot::Mutex;
+    use std::any::Any;
+    use std::fmt::Formatter;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    #[derive(Debug)]
+    struct MockExec {
+        batch: RecordBatch,
+        schema: SchemaRef,
+        properties: Arc<PlanProperties>,
+    }
+
+    impl MockExec {
+        fn new(batch: RecordBatch, schema: SchemaRef) -> Self {
+            let properties = Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema.clone()),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ));
+            Self {
+                batch,
+                schema,
+                properties,
+            }
+        }
+    }
+
+    impl DisplayAs for MockExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+            write!(f, "MockExec")
+        }
+    }
+
+    impl ExecutionPlan for MockExec {
+        fn name(&self) -> &str {
+            "MockExec"
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _c: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(&self, _p: usize, _c: Arc<TaskContext>) -> Result<SendableRecordBatchStream> {
+            Ok(Box::pin(MockStream {
+                schema: self.schema.clone(),
+                batch: Some(self.batch.clone()),
+            }))
+        }
+    }
+
+    struct MockStream {
+        schema: SchemaRef,
+        batch: Option<RecordBatch>,
+    }
+
+    impl RecordBatchStream for MockStream {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    impl Stream for MockStream {
+        type Item = Result<RecordBatch>;
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if let Some(b) = self.batch.take() {
+                Poll::Ready(Some(Ok(b)))
+            } else {
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct DsmTestSharedState {
+        pub mutex: Spinlock,
+        pub nlaunched: usize,
+    }
+
+    impl ParallelStateType for DsmTestSharedState {}
+
+    impl DsmTestSharedState {
+        pub fn set_launched_workers(&mut self, nlaunched: usize) {
+            let _lock = self.mutex.acquire();
+            self.nlaunched = nlaunched;
+        }
+
+        pub fn launched_workers(&mut self) -> usize {
+            let _lock = self.mutex.acquire();
+            self.nlaunched
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct DsmTestConfig {
+        pub total_participants: usize,
+        pub session_id: uuid::Bytes,
+        pub buffer_size: usize,
+    }
+
+    impl ParallelStateType for DsmTestConfig {}
+
+    pub struct DsmTestProcess {
+        pub state: DsmTestSharedState,
+        pub config: DsmTestConfig,
+        pub ring_buffer_regions: Vec<Vec<u8>>,
+    }
+
+    impl DsmTestProcess {
+        pub fn new(total_participants: usize) -> Self {
+            let session_id = uuid::Uuid::new_v4();
+            // Allocate ring buffers
+            let ring_buffer_size = 1024 * 1024;
+            // Data Header + Data + Control Header + Control Data + padding
+            let control_size = 65536;
+            let layout = TransportLayout::new(ring_buffer_size, control_size);
+            let total_size = layout.total_size();
+
+            let mut ring_buffer_regions =
+                Vec::with_capacity(total_participants * total_participants);
+            for _ in 0..(total_participants * total_participants) {
+                let mut region = vec![0u8; total_size];
+
+                // Initialize Data Header
+
+                let base_ptr = region.as_mut_ptr();
+
+                unsafe {
+                    layout.init(base_ptr);
+                }
+
+                ring_buffer_regions.push(region);
+            }
+
+            Self {
+                state: DsmTestSharedState {
+                    mutex: Spinlock::default(),
+                    nlaunched: 0,
+                },
+                config: DsmTestConfig {
+                    total_participants,
+                    session_id: *session_id.as_bytes(),
+                    buffer_size: ring_buffer_size,
+                },
+                ring_buffer_regions,
+            }
+        }
+    }
+
+    impl ParallelProcess for DsmTestProcess {
+        fn state_values(&self) -> Vec<&dyn ParallelState> {
+            let mut values: Vec<&dyn ParallelState> = vec![&self.state, &self.config];
+            for region in &self.ring_buffer_regions {
+                values.push(region);
+            }
+            values
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct RegionInfo {
+        base_ptr: *mut u8,
+        capacity: usize,
+    }
+    unsafe impl Send for RegionInfo {}
+
+    pub struct DsmTestWorker<'a> {
+        pub state: &'a mut DsmTestSharedState,
+        pub config: DsmTestConfig,
+        pub writer_regions: Vec<RegionInfo>,
+        pub reader_regions: Vec<RegionInfo>,
+    }
+
+    impl ParallelWorker for DsmTestWorker<'_> {
+        fn new_parallel_worker(state_manager: ParallelStateManager) -> Self {
+            let state = state_manager
+                .object::<DsmTestSharedState>(0)
+                .unwrap()
+                .unwrap();
+            let config = state_manager.object::<DsmTestConfig>(1).unwrap().unwrap();
+
+            // Worker number from PG (0-based). Leader=0 in participant space.
+            let worker_number = unsafe { pgrx::pg_sys::ParallelWorkerNumber };
+            let participant_index = (worker_number + 1) as usize; // Leader is 0
+            let total_participants = config.total_participants;
+
+            let mut writer_regions = Vec::new();
+            let mut reader_regions = Vec::new();
+            let p = total_participants;
+
+            for j in 0..p {
+                // Region for writer from us (participant_index) to participant j.
+                let writer_region_idx = 2 + (participant_index * p + j);
+                let ring_buffer_slice = state_manager
+                    .slice::<u8>(writer_region_idx)
+                    .unwrap()
+                    .unwrap();
+                let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+                writer_regions.push(RegionInfo {
+                    base_ptr,
+                    capacity: config.buffer_size,
+                });
+
+                // Region for reader from participant j to us (participant_index).
+                let reader_region_idx = 2 + (j * p + participant_index);
+                let ring_buffer_slice = state_manager
+                    .slice::<u8>(reader_region_idx)
+                    .unwrap()
+                    .unwrap();
+                let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+                reader_regions.push(RegionInfo {
+                    base_ptr,
+                    capacity: config.buffer_size,
+                });
+            }
+
+            Self {
+                state,
+                config: *config,
+                writer_regions,
+                reader_regions,
+            }
+        }
+
+        fn run(self, _mq_sender: &MessageQueueSender, worker_number: i32) -> anyhow::Result<()> {
+            let participant_index = (worker_number + 1) as usize;
+            let participant_id = ParticipantId(participant_index as u16);
+            let total_participants = self.config.total_participants;
+
+            // Signal readiness
+            let current = self.state.launched_workers();
+            self.state.set_launched_workers(current + 1);
+            while self.state.launched_workers() < total_participants {
+                pgrx::check_for_interrupts!();
+                std::thread::yield_now();
+            }
+
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let session_id = uuid::Uuid::from_bytes(self.config.session_id);
+            let bridge = runtime
+                .block_on(SignalBridge::new(participant_id, session_id))
+                .unwrap();
+            let bridge = Arc::new(bridge);
+
+            let mut mux_writers = Vec::with_capacity(total_participants);
+            for (j, region) in self.writer_regions.iter().enumerate() {
+                mux_writers.push(Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+                    region.base_ptr,
+                    region.capacity,
+                    65536,
+                    bridge.clone(),
+                    ParticipantId(j as u16),
+                ))));
+            }
+
+            let mut mux_readers = Vec::with_capacity(total_participants);
+            for (j, region) in self.reader_regions.iter().enumerate() {
+                mux_readers.push(Arc::new(Mutex::new(MultiplexedDsmReader::new(
+                    region.base_ptr,
+                    region.capacity,
+                    65536,
+                    bridge.clone(),
+                    ParticipantId(j as u16),
+                ))));
+            }
+
+            let transport = TransportMesh {
+                mux_writers,
+                mux_readers,
+                bridge,
+            };
+            let mesh = DsmMesh {
+                transport,
+                registry: Mutex::new(exchange::StreamRegistry::default()),
+            };
+            register_dsm_mesh(mesh);
+
+            // --- Build Plan ---
+            // Input: MockExec with some data.
+            let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vec![
+                    participant_index as i32 * 10,
+                ]))],
+            )
+            .unwrap();
+
+            let input = Arc::new(MockExec::new(batch, schema.clone()));
+
+            // Exchange: Gather to node 0.
+            let producer_partitioning = Partitioning::UnknownPartitioning(total_participants);
+            let output_partitioning = Partitioning::UnknownPartitioning(total_participants);
+            let config = DsmExchangeConfig {
+                stream_id: LogicalStreamId(0),
+                total_participants,
+                mode: ExchangeMode::Gather,
+                sanitized: false,
+            };
+
+            let exchange = DsmExchangeExec::try_new(
+                input,
+                producer_partitioning,
+                output_partitioning,
+                config.clone(),
+            )
+            .unwrap();
+
+            // Wrap in CoalescePartitionsExec so that execute(0) pulls from ALL workers
+            let plan: Arc<dyn ExecutionPlan> = Arc::new(
+                datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(
+                    Arc::new(exchange),
+                ),
+            );
+
+            let mut session_config = SessionConfig::new().with_target_partitions(1);
+            session_config
+                .options_mut()
+                .extensions
+                .insert(MppParticipantConfig {
+                    index: participant_index,
+                    total_participants,
+                });
+            let session_state = SessionContext::new_with_config(session_config).state();
+            let task_ctx = Arc::new(TaskContext::from(&session_state));
+
+            runtime.block_on(async {
+                let local = tokio::task::LocalSet::new();
+
+                // Register the writer
+                let mut sources = Vec::new();
+                exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
+                for source in sources {
+                    exchange::register_stream_source(source, participant_id);
+                }
+
+                // Start Control Service
+                exchange::spawn_control_service(&local, task_ctx.clone());
+
+                local
+                    .run_until(async {
+                        let mut stream = plan.execute(0, task_ctx).unwrap();
+                        if let Some(batch) = stream.next().await {
+                            let batch = batch.unwrap();
+                            // Worker (participant 1) is not node 0, so it should not receive anything in Gather mode
+                            panic!("Worker received data in Gather mode! {:?}", batch);
+                        }
+                    })
+                    .await;
+            });
+
+            Ok(())
+        }
+    }
+
+    #[pgrx::pg_test]
+    fn test_dsm_gather_execution() {
+        let total_participants = 2; // Leader + 1 Worker
+        let process = DsmTestProcess::new(total_participants);
+        let session_id_bytes = process.config.session_id;
+
+        let mut launched = launch_parallel_process!(
+            DsmTestProcess<DsmTestWorker>,
+            process,
+            WorkerStyle::Query,
+            1, // 1 worker
+            16384
+        )
+        .expect("Failed to launch parallel process");
+
+        let state = launched
+            .state_manager_mut()
+            .object::<DsmTestSharedState>(0)
+            .unwrap()
+            .unwrap();
+        state.set_launched_workers(1); // Leader counts as 1
+
+        // Wait for worker to launch
+        while state.launched_workers() < total_participants {
+            pgrx::check_for_interrupts!();
+            std::thread::yield_now();
+        }
+
+        // Leader Setup
+        let session_id = uuid::Uuid::from_bytes(session_id_bytes);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let bridge = runtime
+            .block_on(SignalBridge::new(
+                ParticipantId(0), // Leader index
+                session_id,
+            ))
+            .unwrap();
+        let bridge = Arc::new(bridge);
+
+        let mut mux_writers = Vec::new();
+        let mut mux_readers = Vec::new();
+        let p = total_participants;
+        let participant_index = 0;
+
+        let buffer_size = 1024 * 1024;
+        for j in 0..p {
+            let writer_region_idx = 2 + (participant_index * p + j);
+            let ring_buffer_slice = launched
+                .state_manager()
+                .slice::<u8>(writer_region_idx)
+                .unwrap()
+                .unwrap();
+            let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+            mux_writers.push(Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+                base_ptr,
+                buffer_size,
+                65536,
+                bridge.clone(),
+                ParticipantId(j as u16),
+            ))));
+
+            let reader_region_idx = 2 + (j * p + participant_index);
+            let ring_buffer_slice = launched
+                .state_manager()
+                .slice::<u8>(reader_region_idx)
+                .unwrap()
+                .unwrap();
+            let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+            mux_readers.push(Arc::new(Mutex::new(MultiplexedDsmReader::new(
+                base_ptr,
+                buffer_size,
+                65536,
+                bridge.clone(),
+                ParticipantId(j as u16),
+            ))));
+        }
+
+        let transport = TransportMesh {
+            mux_writers,
+            mux_readers,
+            bridge,
+        };
+        let mesh = DsmMesh {
+            transport,
+            registry: Mutex::new(
+                crate::postgres::customscan::joinscan::exchange::StreamRegistry::default(),
+            ),
+        };
+        register_dsm_mesh(mesh);
+
+        // --- Execute Leader Plan ---
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![0]))])
+            .unwrap();
+
+        let input = Arc::new(MockExec::new(batch, schema.clone()));
+
+        let producer_partitioning = Partitioning::UnknownPartitioning(total_participants);
+        let output_partitioning = Partitioning::UnknownPartitioning(total_participants);
+        let config = DsmExchangeConfig {
+            stream_id: LogicalStreamId(0),
+            total_participants,
+            mode: ExchangeMode::Gather,
+            sanitized: false,
+        };
+
+        let exchange = DsmExchangeExec::try_new(
+            input,
+            producer_partitioning,
+            output_partitioning,
+            config.clone(),
+        )
+        .unwrap();
+
+        // Wrap in CoalescePartitionsExec so that execute(0) pulls from ALL workers
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(
+            datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(Arc::new(
+                exchange,
+            )),
+        );
+
+        let mut session_config = SessionConfig::new().with_target_partitions(1);
+        session_config
+            .options_mut()
+            .extensions
+            .insert(MppParticipantConfig {
+                index: participant_index,
+                total_participants,
+            });
+        let session_state = SessionContext::new_with_config(session_config).state();
+        let task_ctx = Arc::new(TaskContext::from(&session_state));
+
+        runtime.block_on(async {
+            let local = tokio::task::LocalSet::new();
+
+            // Register Leader sources
+            let mut sources = Vec::new();
+            crate::postgres::customscan::joinscan::exchange::collect_dsm_exchanges(
+                plan.clone(),
+                &mut sources,
+            );
+            for source in sources {
+                crate::postgres::customscan::joinscan::exchange::register_stream_source(
+                    source,
+                    ParticipantId(participant_index as u16),
+                );
+            }
+
+            // Start Leader Control Service
+            crate::postgres::customscan::joinscan::exchange::spawn_control_service(
+                &local,
+                task_ctx.clone(),
+            );
+
+            local
+                .run_until(async {
+                    let mut stream = plan.execute(0, task_ctx).unwrap();
+                    let mut results = Vec::new();
+                    while let Some(batch) = stream.next().await {
+                        results.push(batch.unwrap());
+                    }
+
+                    // We expect 2 batches: one from leader (0), one from worker (10).
+                    // They might come in any order.
+                    assert_eq!(results.len(), 2);
+                    let values: Vec<i32> = results
+                        .iter()
+                        .map(|b| {
+                            b.column(0)
+                                .as_any()
+                                .downcast_ref::<Int32Array>()
+                                .unwrap()
+                                .value(0)
+                        })
+                        .collect();
+                    assert!(values.contains(&0));
+                    assert!(values.contains(&10));
+                })
+                .await;
+        });
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -837,11 +837,7 @@ mod tests {
         }
     }
 
-    // This test launches parallel workers via DSM which doesn't work correctly
-    // inside the pg_test transaction harness (DSM resource ownership errors).
-    // It should be run manually against a real cluster.
     #[pgrx::pg_test]
-    #[ignore = "DSM parallel workers require a real cluster, not pg_test harness"]
     fn test_dsm_gather_execution() {
         let total_participants = 2; // Leader + 1 Worker
         let process = DsmTestProcess::new(total_participants);
@@ -1027,5 +1023,10 @@ mod tests {
                 })
                 .await;
         });
+
+        // Clean up: clear the global DSM mesh and drain the launched process
+        // to properly release DSM resources before the test transaction rolls back.
+        crate::postgres::customscan::joinscan::exchange::clear_dsm_mesh();
+        for _ in launched {}
     }
 }

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -837,7 +837,11 @@ mod tests {
         }
     }
 
+    // This test launches parallel workers via DSM which doesn't work correctly
+    // inside the pg_test transaction harness (DSM resource ownership errors).
+    // It should be run manually against a real cluster.
     #[pgrx::pg_test]
+    #[ignore = "DSM parallel workers require a real cluster, not pg_test harness"]
     fn test_dsm_gather_execution() {
         let total_participants = 2; // Leader + 1 Worker
         let process = DsmTestProcess::new(total_participants);

--- a/pg_search/src/postgres/customscan/joinscan/sanitize.rs
+++ b/pg_search/src/postgres/customscan/joinscan/sanitize.rs
@@ -1,0 +1,574 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Zero-Copy Sanitization
+//!
+//! This module implements a strategy to prevent deadlocks when feeding zero-copy
+//! Shared Memory (DSM) buffers into DataFusion operators.
+//!
+//! ## The Problem
+//!
+//! DataFusion operators like `SortExec`, `JoinExec`, and `AggregateExec` can buffer
+//! `RecordBatch`es or hold long-lived references (e.g., `StringViewArray`) to input data.
+//! If that input data is a zero-copy view into a fixed-size Ring Buffer (DSM),
+//! these operators can "pin" the Ring Buffer memory, preventing the producer from
+//! reclaiming space and causing a deadlock.
+//!
+//! ## The Solution
+//!
+//! We implement a `DsmSanitizeExec` operator that performs a **Deep Copy** of passing batches,
+//! effectively moving them from the Ring Buffer to the Heap.
+//!
+//! We then use `EnforceSanitization`, a physical optimizer rule, to inject this operator
+//! immediately before any "Unsafe" (Blocking/Buffering) node, ensuring that long-lived
+//! operators only ever hold Heap memory.
+
+use std::any::Any;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use arrow_array::{Array, RecordBatch, UInt32Array};
+use arrow_buffer::Buffer;
+use datafusion::arrow::array::ArrayData;
+use datafusion::arrow::compute::take;
+use datafusion::common::Result;
+use datafusion::config::ConfigOptions;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+#[allow(deprecated)]
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::explain::ExplainExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::{CrossJoinExec, HashJoinExec, NestedLoopJoinExec};
+use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::unnest::UnnestExec;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::StreamExt;
+
+use crate::postgres::customscan::joinscan::exchange::{DsmExchangeExec, DSM_MESH};
+
+/// Represents a virtual memory region to watch.
+#[derive(Clone, Copy)]
+struct MemoryRegion {
+    start: usize,
+    end: usize,
+}
+
+/// Helper to detect if Arrow buffers are backed by specific memory regions.
+pub struct SharedMemoryDetector {
+    regions: Vec<MemoryRegion>,
+}
+
+impl SharedMemoryDetector {
+    /// Create a new detector from the active DSM mesh.
+    pub fn new() -> Self {
+        let regions = {
+            let guard = DSM_MESH.lock();
+            if let Some(mesh) = guard.as_ref() {
+                mesh.transport
+                    .memory_regions()
+                    .into_iter()
+                    .map(|(start, size)| MemoryRegion {
+                        start,
+                        end: start + size,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        };
+        Self { regions }
+    }
+
+    /// Checks if a specific buffer resides in any of the watched shared memory regions.
+    #[inline]
+    pub fn is_shared(&self, buffer: &Buffer) -> bool {
+        // We look at the pointer of the underlying allocation.
+        // buffer.as_ptr() returns the pointer to the start of the slice.
+        // This is sufficient for detection if the slice is within the region.
+        let ptr = buffer.as_ptr() as usize;
+
+        for region in &self.regions {
+            if ptr >= region.start && ptr < region.end {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Recursively checks if an ArrayData (and its children) holds any shared memory.
+    pub fn has_shared_memory(&self, data: &ArrayData) -> bool {
+        // 1. Check the validity (null) buffer
+        if let Some(nulls) = data.nulls() {
+            if self.is_shared(nulls.buffer()) {
+                return true;
+            }
+        }
+
+        // 2. Check all data buffers
+        for buffer in data.buffers() {
+            if self.is_shared(buffer) {
+                return true;
+            }
+        }
+
+        // 3. Recursively check child data
+        for child in data.child_data() {
+            if self.has_shared_memory(child) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Entry point: Does this batch need sanitization?
+    pub fn batch_needs_sanitization(&self, batch: &RecordBatch) -> bool {
+        if self.regions.is_empty() {
+            return false;
+        }
+        for column in batch.columns() {
+            if self.has_shared_memory(&column.to_data()) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Force-copies a RecordBatch into new, standard heap-allocated buffers.
+pub fn sanitize_batch(batch: &RecordBatch) -> Result<RecordBatch> {
+    // 1. Create an index array [0, 1, 2, ... len-1]
+    let indices = UInt32Array::from_iter_values(0..batch.num_rows() as u32);
+
+    // 2. "Take" every row from every column.
+    // The `take` kernel allocates new buffers for the result.
+    let new_columns = batch
+        .columns()
+        .iter()
+        .map(|col| {
+            take(col.as_ref(), &indices, None)
+                .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    RecordBatch::try_new(batch.schema(), new_columns)
+        .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// A physical operator that performs a deep copy of the input batches ONLY if they reside in shared memory.
+#[derive(Debug)]
+pub struct DsmSanitizeExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+}
+
+impl DsmSanitizeExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let properties = input.properties().clone();
+        Self { input, properties }
+    }
+}
+
+impl DisplayAs for DsmSanitizeExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "DsmSanitizeExec")
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for DsmSanitizeExec {
+    fn name(&self) -> &str {
+        "DsmSanitizeExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(DsmSanitizeExec::new(children[0].clone())))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> Result<datafusion::execution::SendableRecordBatchStream> {
+        let stream = self.input.execute(partition, context)?;
+        let schema = stream.schema();
+
+        // Capture detector state at execution time
+        let detector = Arc::new(SharedMemoryDetector::new());
+
+        let sanitized_stream = stream.map(move |batch| {
+            let batch = batch?;
+            if detector.batch_needs_sanitization(&batch) {
+                sanitize_batch(&batch)
+            } else {
+                Ok(batch)
+            }
+        });
+
+        Ok(Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema,
+                Box::pin(sanitized_stream),
+            ),
+        ))
+    }
+}
+
+/// Optimizer rule to inject `DsmSanitizeExec` before unsafe operators.
+#[derive(Debug)]
+pub struct EnforceSanitization;
+
+impl EnforceSanitization {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for EnforceSanitization {
+    fn name(&self) -> &str {
+        "EnforceSanitization"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        enforce_sanitization_recursive(plan)
+    }
+}
+
+fn enforce_sanitization_recursive(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    // 1. Recursively optimize children first
+    let new_children = plan
+        .children()
+        .iter()
+        .map(|child| enforce_sanitization_recursive(Arc::clone(child)))
+        .collect::<Result<Vec<_>>>()?;
+
+    let plan = if new_children.is_empty() {
+        plan
+    } else {
+        plan.with_new_children(new_children)?
+    };
+
+    // 2. Special handling for Joins that only buffer Left side
+    //
+    // TODO: SortMergeJoinExec could potentially be optimized to only sanitize one side
+    // depending on the JoinType, but for safety (and due to complexity of key duplication buffering),
+    // we currently treat it as unsafe and sanitize both inputs.
+    if plan.as_any().is::<HashJoinExec>()
+        || plan.as_any().is::<CrossJoinExec>()
+        || plan.as_any().is::<NestedLoopJoinExec>()
+    {
+        let children = plan.children();
+        // Left (0) is Build/Buffered -> Sanitize
+        let left = sanitize_input(children[0].clone())?;
+        // Right (1) is Probe/Streaming -> Safe (don't sanitize)
+        let right = children[1].clone();
+        return plan.with_new_children(vec![left, right]);
+    }
+
+    // 3. Default Unsafe Check (needs sanitized inputs)
+    if is_unsafe_node(plan.as_ref()) {
+        let mut new_inputs = Vec::new();
+        for child in plan.children() {
+            new_inputs.push(sanitize_input(child.clone())?);
+        }
+        return plan.with_new_children(new_inputs);
+    }
+
+    Ok(plan)
+}
+
+fn sanitize_input(child: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    // Check if child is DsmExchangeExec. If so, modify it in place.
+    if let Some(exchange) = child.as_any().downcast_ref::<DsmExchangeExec>() {
+        // Optimization: Instead of inserting DsmSanitizeExec, tell DsmExchangeExec to sanitize.
+        let mut new_config = exchange.config.clone();
+        new_config.sanitized = true;
+
+        let new_exchange = DsmExchangeExec::try_new(
+            exchange.input.clone(),
+            exchange.producer_partitioning.clone(),
+            exchange.properties().output_partitioning().clone(),
+            new_config,
+        )?;
+        Ok(Arc::new(new_exchange) as Arc<dyn ExecutionPlan>)
+    }
+    // Otherwise, inject DsmSanitizeExec if it comes from DSM and isn't already sanitized.
+    else if subtree_contains_dsm(child.as_ref()) && !child.as_any().is::<DsmSanitizeExec>() {
+        Ok(Arc::new(DsmSanitizeExec::new(child.clone())) as Arc<dyn ExecutionPlan>)
+    } else {
+        Ok(child)
+    }
+}
+
+/// Returns true if the node is "Safe" (Streaming), false otherwise.
+///
+/// Safe nodes process data incrementally and do not hold long-lived references
+/// to previous batches (or they drop them quickly).
+fn is_safe_node(plan: &dyn ExecutionPlan) -> bool {
+    // Allowlist of streaming operators
+    if plan.as_any().is::<FilterExec>() {
+        return true;
+    }
+    if plan.as_any().is::<ProjectionExec>() {
+        return true;
+    }
+    if plan.as_any().is::<RepartitionExec>() {
+        return true;
+    }
+    if plan.as_any().is::<CoalesceBatchesExec>() {
+        return true;
+    }
+    if plan.as_any().is::<CoalescePartitionsExec>() {
+        return true;
+    }
+    if plan.as_any().is::<UnionExec>() {
+        return true;
+    }
+    if plan.as_any().is::<GlobalLimitExec>() {
+        return true;
+    }
+    if plan.as_any().is::<LocalLimitExec>() {
+        return true;
+    }
+    if plan.as_any().is::<UnnestExec>() {
+        return true;
+    }
+    if plan.as_any().is::<EmptyExec>() {
+        return true;
+    }
+    if plan.as_any().is::<ExplainExec>() {
+        return true;
+    }
+    if plan.as_any().is::<DsmSanitizeExec>() {
+        return true;
+    }
+    if plan.as_any().is::<DsmExchangeExec>() {
+        return true; // Source is safe (it produces the problem, but doesn't block)
+    }
+
+    // Also check for MockLeaf from tests if needed
+    if plan.name() == "MockLeaf" {
+        return true;
+    }
+
+    false
+}
+
+fn is_unsafe_node(plan: &dyn ExecutionPlan) -> bool {
+    !is_safe_node(plan)
+}
+
+/// Recursively checks if the plan has a DsmExchangeExec in its subtree.
+fn subtree_contains_dsm(plan: &dyn ExecutionPlan) -> bool {
+    if plan.as_any().is::<DsmExchangeExec>() {
+        // If the exchange is ALREADY sanitizing, then the subtree effectively DOES NOT contain DSM pointers.
+        // We can check config.sanitized.
+        if let Some(exchange) = plan.as_any().downcast_ref::<DsmExchangeExec>() {
+            if exchange.config.sanitized {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // If we hit a SanitizeExec, the stream is clean.
+    if plan.as_any().is::<DsmSanitizeExec>() {
+        return false;
+    }
+
+    for child in plan.children() {
+        if subtree_contains_dsm(child.as_ref()) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::joinscan::exchange::{
+        DsmExchangeConfig, DsmExchangeExec, ExchangeMode,
+    };
+    use crate::postgres::customscan::joinscan::transport::LogicalStreamId;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::Partitioning;
+    use datafusion::physical_plan::sorts::sort::SortExec;
+
+    use datafusion::arrow::compute::SortOptions;
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_expr::LexOrdering;
+    use datafusion::physical_expr::PhysicalSortExpr;
+    use datafusion::scalar::ScalarValue;
+
+    #[pgrx::pg_test]
+    fn test_enforce_sanitization_modifies_exchange_in_place() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // 1. Create a DSM source (sanitized=false)
+        let empty_input = Arc::new(EmptyExec::new(schema.clone()));
+        let config = DsmExchangeConfig {
+            stream_id: LogicalStreamId(1),
+            total_participants: 1,
+            mode: ExchangeMode::Gather,
+            sanitized: false,
+        };
+        let dsm_source = Arc::new(
+            DsmExchangeExec::try_new(
+                empty_input,
+                Partitioning::UnknownPartitioning(1),
+                Partitioning::UnknownPartitioning(1),
+                config,
+            )
+            .expect("Failed to create DsmExchangeExec"),
+        );
+
+        // 2. Create an Unsafe node (Sort)
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new("a", 0)),
+            options: SortOptions::default(),
+        };
+        let sort_exprs = LexOrdering::new(vec![sort_expr]).expect("Failed to create LexOrdering");
+        let sort = Arc::new(SortExec::new(sort_exprs, dsm_source));
+
+        // 3. Optimize
+        let rule = EnforceSanitization::new();
+        let optimized = rule
+            .optimize(sort, &ConfigOptions::default())
+            .expect("Optimization failed");
+
+        pgrx::warning!("Optimized plan: {:?}", optimized);
+        let child = optimized.children()[0].clone();
+        pgrx::warning!("Child plan: {:?}", child);
+        pgrx::warning!("Child type: {:?}", child.as_any().type_id());
+
+        // 4. Verify Sort child is DsmExchangeExec with sanitized=true
+        assert!(optimized.as_any().is::<SortExec>());
+
+        if let Some(exchange) = child.as_any().downcast_ref::<DsmExchangeExec>() {
+            assert!(
+                exchange.config.sanitized,
+                "DsmExchangeExec should be sanitized"
+            );
+        } else {
+            panic!("Child is not DsmExchangeExec. Actual plan: {:?}", child);
+        }
+    }
+
+    #[pgrx::pg_test]
+    fn test_enforce_sanitization_inserts_exec_when_nested() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // 1. Create a DSM source
+        let empty_input = Arc::new(EmptyExec::new(schema.clone()));
+        let config = DsmExchangeConfig {
+            stream_id: LogicalStreamId(1),
+            total_participants: 1,
+            mode: ExchangeMode::Gather,
+            sanitized: false,
+        };
+        let dsm_source = Arc::new(
+            DsmExchangeExec::try_new(
+                empty_input,
+                Partitioning::UnknownPartitioning(1),
+                Partitioning::UnknownPartitioning(1),
+                config,
+            )
+            .expect("Failed to create DsmExchangeExec"),
+        );
+
+        // 2. Nested safe node (Filter)
+        let filter = Arc::new(
+            FilterExec::try_new(
+                Arc::new(datafusion::physical_expr::expressions::Literal::new(
+                    ScalarValue::Boolean(Some(true)),
+                )),
+                dsm_source,
+            )
+            .expect("Failed to create FilterExec"),
+        );
+
+        // 3. Unsafe node (Sort)
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new("a", 0)),
+            options: SortOptions::default(),
+        };
+        let sort_exprs = LexOrdering::new(vec![sort_expr]).expect("Failed to create LexOrdering");
+        let sort = Arc::new(SortExec::new(sort_exprs, filter));
+
+        // 4. Optimize
+        let rule = EnforceSanitization::new();
+        let optimized = rule
+            .optimize(sort, &ConfigOptions::default())
+            .expect("Optimization failed");
+
+        pgrx::warning!("Optimized plan: {:?}", optimized);
+        let sanitize = optimized.children()[0].clone();
+        pgrx::warning!("Sanitize node: {:?}", sanitize);
+
+        // 5. Verify structure: Sort -> DsmSanitizeExec -> Filter -> DsmExchangeExec
+        assert!(optimized.as_any().is::<SortExec>());
+        assert!(sanitize.as_any().is::<DsmSanitizeExec>());
+        let filter = sanitize.children()[0].clone();
+        assert!(filter.as_any().is::<FilterExec>());
+        let exchange = filter.children()[0].clone();
+        assert!(exchange.as_any().is::<DsmExchangeExec>());
+
+        if let Some(exchange_node) = exchange.as_any().downcast_ref::<DsmExchangeExec>() {
+            // The original exchange was NOT modified because it wasn't immediate child
+            assert!(!exchange_node.config.sanitized);
+        } else {
+            panic!(
+                "Grandchild is not DsmExchangeExec. Actual plan: {:?}",
+                exchange
+            );
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -241,7 +241,7 @@ impl CustomScanState for JoinScanState {
 /// that follow it; AggregateScan needs only a single `FilterPushdown` post-pass.
 /// Exposing the difference as an explicit profile keeps the choice grep-able
 /// from the call site.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum SessionContextProfile {
     /// JoinScan execution: enables `topk_dynamic_filter_pushdown`, includes
     /// `SegmentedTopKRule`, and adds the trailing `FilterPushdown` passes that
@@ -250,6 +250,16 @@ pub enum SessionContextProfile {
     /// AggregateScan execution: single `FilterPushdown` post-pass, no
     /// SegmentedTopK, no topk dynamic filter pushdown.
     Aggregate,
+    /// MPP (plan partitioning) JoinScan execution: like `Join` but with
+    /// `target_partitions = N`, hash-join repartitioning forced, and
+    /// `EnforceDsmShuffle` + `EnforceSanitization` optimizer rules injected.
+    #[allow(dead_code)]
+    JoinMpp {
+        /// 0-based index of this participant.
+        participant_index: usize,
+        /// Total number of participants (leader + workers).
+        total_participants: usize,
+    },
 }
 
 /// Build the shared core of a DataFusion [`SessionStateBuilder`] with:
@@ -297,18 +307,55 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 /// - [`SessionContextProfile::Aggregate`]: appends a single `FilterPushdown`
 ///   post-pass; SegmentedTopK does not apply to aggregate-on-join queries.
 pub fn create_datafusion_session_context(profile: SessionContextProfile) -> SessionContext {
-    let mut config = SessionConfig::new().with_target_partitions(1);
-    if matches!(profile, SessionContextProfile::Join) {
+    let is_mpp = matches!(profile, SessionContextProfile::JoinMpp { .. });
+    let is_join = matches!(
+        profile,
+        SessionContextProfile::Join | SessionContextProfile::JoinMpp { .. }
+    );
+
+    let mut config = if let SessionContextProfile::JoinMpp {
+        total_participants, ..
+    } = &profile
+    {
+        let mut c = SessionConfig::new().with_target_partitions(*total_participants);
+        // Force DataFusion to use partitioned hash joins instead of single-partition mode.
+        c.options_mut()
+            .optimizer
+            .hash_join_single_partition_threshold = 0;
+        c.options_mut()
+            .optimizer
+            .hash_join_single_partition_threshold_rows = 0;
+        c
+    } else {
+        SessionConfig::new().with_target_partitions(1)
+    };
+
+    if is_join {
         config
             .options_mut()
             .optimizer
             .enable_topk_dynamic_filter_pushdown = true;
     }
 
+    // Set MppParticipantConfig in session extensions for MPP mode.
+    if let SessionContextProfile::JoinMpp {
+        participant_index,
+        total_participants,
+    } = &profile
+    {
+        config
+            .options_mut()
+            .extensions
+            .insert(crate::scan::table_provider::MppParticipantConfig {
+                index: *participant_index,
+                total_participants: *total_participants,
+            });
+    }
+
     let mut builder = build_base_session(config);
 
-    match profile {
-        SessionContextProfile::Join => {
+    match &profile {
+        SessionContextProfile::Join | SessionContextProfile::JoinMpp { .. } => {
             if crate::gucs::is_columnar_sort_enabled() {
                 builder = builder.with_physical_optimizer_rule(Arc::new(
                     FilterPushdown::new_post_optimization(),
@@ -319,6 +366,23 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
                     crate::scan::segmented_topk_rule::SegmentedTopKRule,
                 ))
                 .with_physical_optimizer_rule(Arc::new(FilterPushdown::new_post_optimization()));
+
+            // MPP-specific optimizer rules: inject DSM exchange and sanitization.
+            if is_mpp {
+                if let SessionContextProfile::JoinMpp {
+                    total_participants, ..
+                } = &profile
+                {
+                    builder = builder.with_physical_optimizer_rule(Arc::new(
+                        crate::postgres::customscan::joinscan::exchange::EnforceDsmShuffle {
+                            total_participants: *total_participants,
+                        },
+                    ));
+                    builder = builder.with_physical_optimizer_rule(Arc::new(
+                        crate::postgres::customscan::joinscan::sanitize::EnforceSanitization::new(),
+                    ));
+                }
+            }
         }
         SessionContextProfile::Aggregate => {
             builder = builder
@@ -327,6 +391,23 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
     }
 
     SessionContext::new_with_state(builder.build())
+}
+
+/// Compute the total number of MPP participants (workers + leader if applicable).
+///
+/// Returns 1 for serial execution (`planned_workers == 0`).
+#[allow(dead_code)]
+pub fn compute_total_participants(planned_workers: usize) -> usize {
+    if planned_workers == 0 {
+        1
+    } else {
+        planned_workers
+            + if unsafe { pg_sys::parallel_leader_participation } {
+                1
+            } else {
+                0
+            }
+    }
 }
 
 /// Build the DataFusion logical plan for the join.
@@ -370,6 +451,9 @@ pub async fn register_source_table(
 ///
 /// Uses the session context's query planner and wraps multi-partition
 /// output with `CoalescePartitionsExec`. Shared by JoinScan and AggregateScan.
+///
+/// In MPP mode (`target_partitions > 1`), the `CoalescePartitionsExec` wrapping
+/// is skipped because `EnforceDsmShuffle` handles the final result gathering.
 pub async fn build_physical_plan(
     ctx: &SessionContext,
     plan: datafusion::logical_expr::LogicalPlan,
@@ -381,7 +465,9 @@ pub async fn build_physical_plan(
         .create_physical_plan(&plan, &state)
         .await?;
 
-    if plan.output_partitioning().partition_count() > 1 {
+    // In MPP mode, don't coalesce — EnforceDsmShuffle handles distribution.
+    let target_partitions = ctx.state().config().target_partitions();
+    if target_partitions == 1 && plan.output_partitioning().partition_count() > 1 {
         Ok(Arc::new(CoalescePartitionsExec::new(plan)) as Arc<dyn ExecutionPlan>)
     } else {
         Ok(plan)

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -241,7 +241,7 @@ impl CustomScanState for JoinScanState {
 /// that follow it; AggregateScan needs only a single `FilterPushdown` post-pass.
 /// Exposing the difference as an explicit profile keeps the choice grep-able
 /// from the call site.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum SessionContextProfile {
     /// JoinScan execution: enables `topk_dynamic_filter_pushdown`, includes
     /// `SegmentedTopKRule`, and adds the trailing `FilterPushdown` passes that

--- a/pg_search/src/postgres/customscan/joinscan/transport/arrow.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/arrow.rs
@@ -1,0 +1,392 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Shared Memory Transfer & Signaling
+//!
+//! This module implements the infrastructure for streaming Arrow `RecordBatch`es
+//! between processes via Shared Memory (DSM) ring buffers.
+//!
+//! It builds upon the generic DSM stream abstraction provided by `shmem`.
+
+use arrow_array::RecordBatch;
+use arrow_buffer::Buffer;
+use arrow_ipc::reader::StreamDecoder;
+use arrow_ipc::writer::{
+    CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions, StreamWriter,
+};
+use arrow_schema::SchemaRef;
+use async_stream::try_stream;
+use datafusion::common::Result;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+// Use types from shmem
+use super::shmem::{
+    LogicalStreamId, MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, PhysicalStreamId,
+};
+
+/// A writer for a single logical stream within a multiplexed DSM region.
+///
+/// This writer handles the serialization of Arrow `RecordBatch`es into the Shared Memory Ring Buffer.
+/// It uses a "1-copy" strategy where batches are serialized into a local `Vec<u8>` (Copy 1)
+/// and then written directly to the Ring Buffer (Copy 2) when space permits.
+pub struct DsmWriter {
+    multiplexer: Arc<Mutex<MultiplexedDsmWriter>>,
+    stream_id: PhysicalStreamId,
+    generator: IpcDataGenerator,
+    tracker: DictionaryTracker,
+    options: IpcWriteOptions,
+    compression_context: CompressionContext,
+    pending_messages: VecDeque<Vec<u8>>,
+}
+
+unsafe impl Send for DsmWriter {}
+
+impl DsmWriter {
+    pub fn new(
+        multiplexer: Arc<Mutex<MultiplexedDsmWriter>>,
+        logical_stream_id: LogicalStreamId,
+        sender_id: ParticipantId,
+        schema: SchemaRef,
+    ) -> Self {
+        // Construct a unique Physical Stream ID for this writer/channel pair.
+        let physical_stream_id = PhysicalStreamId::new(logical_stream_id, sender_id);
+        let options = IpcWriteOptions::default();
+        let generator = IpcDataGenerator::default();
+        let tracker = DictionaryTracker::new(false);
+        let compression_context = CompressionContext::default();
+        let mut pending_messages = VecDeque::new();
+
+        // Generate Schema message
+        // We use a temporary writer to generate the schema message correctly wrapped
+        let mut schema_buffer = Vec::new();
+        let _writer = StreamWriter::try_new(&mut schema_buffer, &schema)
+            .expect("Failed to create Arrow IPC StreamWriter for schema generation");
+
+        pending_messages.push_back(schema_buffer);
+
+        Self {
+            multiplexer,
+            stream_id: physical_stream_id,
+            generator,
+            tracker,
+            options,
+            compression_context,
+            pending_messages,
+        }
+    }
+
+    /// Writes a `RecordBatch` to the multiplexed stream.
+    pub fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        // 1. Flush any pending messages from previous attempts
+        if let Err(e) = self.flush_pending() {
+            if e.kind() == std::io::ErrorKind::WouldBlock {
+                return Err(datafusion::common::DataFusionError::IoError(e));
+            }
+            return Err(datafusion::common::DataFusionError::IoError(e));
+        }
+
+        // 2. Encode the new batch
+        let (dictionaries, encoded_batch) = self
+            .generator
+            .encode(
+                batch,
+                &mut self.tracker,
+                &self.options,
+                &mut self.compression_context,
+            )
+            .map_err(|e| {
+                datafusion::common::DataFusionError::Internal(format!(
+                    "Failed to encode batch: {e}"
+                ))
+            })?;
+
+        // 3. Queue dictionary batches
+        for dict_batch in dictionaries {
+            let msg = Self::serialize_message(dict_batch, &self.options);
+            self.pending_messages.push_back(msg);
+        }
+
+        // 4. Queue the record batch
+        let msg = Self::serialize_message(encoded_batch, &self.options);
+        self.pending_messages.push_back(msg);
+
+        // 5. Try to flush immediately
+        self.flush_pending()
+            .map_err(datafusion::common::DataFusionError::IoError)
+    }
+
+    pub fn finish(mut self) -> Result<()> {
+        // Queue Arrow IPC Stream EOS footer
+        const EOS_FOOTER: [u8; 8] = [0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0];
+        self.pending_messages.push_back(EOS_FOOTER.to_vec());
+
+        // Ensure everything is flushed
+        loop {
+            match self.flush_pending() {
+                Ok(_) => {
+                    // If queue is empty, we are done
+                    if self.pending_messages.is_empty() {
+                        break;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // In a sync finish, we must spin/wait?
+                    // But DsmWriter is usually driven by an async loop or sync test.
+                    // Ideally we return error and let caller retry, but `finish` signature consumes self.
+                    // For now, let's assume if we are calling finish, we should be able to block or fail.
+                    // Given the existing code didn't handle WouldBlock on finish well (except via flush error),
+                    // we will return the error.
+                    return Err(datafusion::common::DataFusionError::IoError(e));
+                }
+                Err(e) => return Err(datafusion::common::DataFusionError::IoError(e)),
+            }
+        }
+
+        // Send EOS signal
+        self.multiplexer
+            .lock()
+            .close_stream(self.stream_id)
+            .map_err(|e| {
+                datafusion::common::DataFusionError::Internal(format!(
+                    "Failed to close stream: {e}"
+                ))
+            })?;
+
+        Ok(())
+    }
+
+    fn flush_pending(&mut self) -> std::io::Result<()> {
+        let mut mux = self.multiplexer.lock();
+        while let Some(msg) = self.pending_messages.front() {
+            match mux.write_message(self.stream_id, msg) {
+                Ok(_) => {
+                    self.pending_messages.pop_front();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    return Err(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    fn serialize_message(
+        encoded: arrow_ipc::writer::EncodedData,
+        options: &IpcWriteOptions,
+    ) -> Vec<u8> {
+        let mut buf = Vec::new();
+        // This helper from arrow_ipc writes: [continuation:4][len:4][flatbuffer][body]
+        arrow_ipc::writer::write_message(&mut buf, encoded, options).unwrap();
+        buf
+    }
+}
+
+struct DsmStream {
+    multiplexer: Arc<Mutex<MultiplexedDsmReader>>,
+    stream_id: PhysicalStreamId,
+    finished: bool,
+    decoder: StreamDecoder,
+    accumulated: Vec<u8>,
+    sanitized: bool,
+}
+
+impl DsmStream {
+    async fn new(
+        multiplexer: Arc<Mutex<MultiplexedDsmReader>>,
+        stream_id: PhysicalStreamId,
+        sanitized: bool,
+    ) -> Result<Self> {
+        {
+            let mut mux = multiplexer.lock();
+            // Send StartStream signal to the writer
+            mux.start_stream(stream_id).map_err(|e| {
+                datafusion::common::DataFusionError::Internal(format!(
+                    "Failed to send StartStream signal: {e}"
+                ))
+            })?;
+        }
+
+        Ok(Self {
+            multiplexer,
+            stream_id,
+            finished: false,
+            decoder: StreamDecoder::new(),
+            accumulated: Vec::new(),
+            sanitized,
+        })
+    }
+
+    /// Reads and decodes the next `RecordBatch` from the stream.
+    ///
+    /// This method handles:
+    /// 1. Reading chunks from the DSM Ring Buffer.
+    /// 2. Reassembling chunks in `self.accumulated`.
+    /// 3. Decoding IPC messages (Schema, RecordBatch) from the accumulator.
+    ///
+    /// # Partial Decodes
+    ///
+    /// If the `StreamDecoder` consumes bytes but returns `None` (NeedMoreData), it means it successfully
+    /// decoded a message (e.g., Schema) but needs more data for the *next* message (e.g., RecordBatch).
+    /// In this case, we **must loop again** to try decoding the next message from the *remaining*
+    /// bytes in the accumulator before polling the network, as multiple messages might have been
+    /// delivered in a single chunk.
+    async fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+        loop {
+            // 1. Try to decode from accumulated buffer
+            if !self.accumulated.is_empty() {
+                let mut buffer = Buffer::from(self.accumulated.clone());
+                match self.decoder.decode(&mut buffer) {
+                    Ok(Some(batch)) => {
+                        let consumed = self.accumulated.len() - buffer.len();
+                        self.accumulated.drain(0..consumed);
+                        return Ok(Some(batch));
+                    }
+                    Ok(None) => {
+                        // Need more data
+                        let consumed = self.accumulated.len() - buffer.len();
+                        if consumed > 0 {
+                            self.accumulated.drain(0..consumed);
+                            // We made progress (e.g. decoded Schema). There might be more data in accumulated.
+                            continue;
+                        }
+                    }
+                    Err(e) => {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "StreamDecoder error: {e}"
+                        )));
+                    }
+                }
+            }
+
+            // 2. Read from DSM
+            let chunk = futures::future::poll_fn(|cx| {
+                if self.sanitized {
+                    self.multiplexer
+                        .lock()
+                        .poll_read_for_stream_copying(self.stream_id, cx)
+                } else {
+                    self.multiplexer
+                        .lock()
+                        .poll_read_for_stream(self.stream_id, cx)
+                }
+            })
+            .await;
+
+            match chunk {
+                Ok(Some(mut buffer)) => {
+                    // Optimized Path: If accumulated is empty, decode directly from the zero-copy buffer
+                    if self.accumulated.is_empty() {
+                        match self.decoder.decode(&mut buffer) {
+                            Ok(Some(batch)) => {
+                                // If there are remaining bytes (e.g. next message partial), stash them
+                                if !buffer.is_empty() {
+                                    self.accumulated.extend_from_slice(buffer.as_slice());
+                                }
+                                return Ok(Some(batch));
+                            }
+                            Ok(None) => {
+                                // Consumed some or none?
+                                // If consumed everything (unlikely for None), buffer is empty.
+                                // If partial, stash remaining.
+                                // If we consumed some bytes (e.g. Schema), we might need to loop again?
+                                // Decoder updates `buffer` slice to point to remaining data.
+                                // We stash remaining data.
+                                self.accumulated.extend_from_slice(buffer.as_slice());
+                                continue;
+                            }
+                            Err(e) => {
+                                return Err(datafusion::common::DataFusionError::Internal(
+                                    format!("StreamDecoder error: {e}"),
+                                ));
+                            }
+                        }
+                    } else {
+                        // Slow Path: Append to existing accumulator
+                        self.accumulated.extend_from_slice(buffer.as_slice());
+                    }
+                }
+                Ok(None) => {
+                    // EOS
+                    if let Err(e) = self.decoder.finish() {
+                        if self.accumulated.is_empty() {
+                            // Ignored as harmless if buffer empty
+                        } else {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "StreamDecoder finish error for S{}: {}",
+                                self.stream_id.0, e
+                            )));
+                        }
+                    }
+                    self.finished = true;
+                    return Ok(None);
+                }
+                Err(e) => {
+                    return Err(datafusion::common::DataFusionError::Internal(format!(
+                        "Failed to read from DSM: {e}"
+                    )));
+                }
+            }
+        }
+    }
+}
+
+crate::impl_safe_drop!(DsmStream, |self| {
+    if self.finished {
+        return;
+    }
+    let _ = self.multiplexer.lock().cancel_stream(self.stream_id);
+});
+
+/// Creates a record batch stream that reads from a DSM ring buffer.
+///
+/// # Arguments
+///
+/// * `multiplexer` - The reader multiplexer.
+/// * `logical_stream_id` - The logical stream ID to read.
+/// * `sender_id` - The participant ID of the sender.
+/// * `schema` - The schema of the stream.
+/// * `sanitized` - If true, the stream will perform a deep copy of the data immediately upon reading.
+///   This is necessary to prevent deadlocks when feeding blocking operators (like Sort) that might
+///   hold references to the zero-copy buffer.
+pub fn dsm_reader(
+    multiplexer: Arc<Mutex<MultiplexedDsmReader>>,
+    logical_stream_id: LogicalStreamId,
+    sender_id: ParticipantId,
+    schema: SchemaRef,
+    sanitized: bool,
+) -> SendableRecordBatchStream {
+    let physical_stream_id = PhysicalStreamId::new(logical_stream_id, sender_id);
+
+    let stream = try_stream! {
+        let mut dsm_stream = DsmStream::new(multiplexer, physical_stream_id, sanitized).await?;
+
+        while let Some(batch) = dsm_stream.next_batch().await? {
+            yield batch;
+        }
+    };
+
+    Box::pin(RecordBatchStreamAdapter::new(schema, Box::pin(stream)))
+}
+
+// TODO(#4152): Arrow IPC tests removed temporarily — they depend on exchange::DsmMesh,
+// exchange::StreamRegistry, and exchange::register_dsm_mesh which will be added in Phase 2.
+// Tests will be restored when exchange.rs is ported.

--- a/pg_search/src/postgres/customscan/joinscan/transport/mesh.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/mesh.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use super::shmem::{
+    MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, SignalBridge, TransportLayout,
+};
+use super::ControlMessage;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// A registry for process-local DSM communication channels.
+///
+/// This struct encapsulates the raw shared memory regions and the multiplexers
+/// that allow this process to communicate with all other participants in the MPP session.
+pub struct TransportMesh {
+    /// Writers for sending data TO other participants.
+    /// Index `j` corresponds to the channel sending to participant `j`.
+    pub mux_writers: Vec<Arc<Mutex<MultiplexedDsmWriter>>>,
+
+    /// Readers for receiving data FROM other participants.
+    /// Index `j` corresponds to the channel receiving from participant `j`.
+    pub mux_readers: Vec<Arc<Mutex<MultiplexedDsmReader>>>,
+
+    /// The local signal bridge for this participant.
+    pub bridge: Arc<SignalBridge>,
+}
+
+impl TransportMesh {
+    /// Initializes the mesh from raw shared memory pointers.
+    ///
+    /// This function sets up the `MultiplexedDsmWriter`s and `MultiplexedDsmReader`s
+    /// by slicing the monolithic shared memory region according to the standard layout:
+    /// `[Participant 0 -> 0][Participant 0 -> 1]...[Participant P-1 -> P-1]`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// 1. `base_ptr` points to a valid, initialized shared memory region.
+    /// 2. The region size is at least `region_size * total_participants * total_participants`.
+    /// 3. The memory is accessible for the lifetime of the returned `TransportMesh`.
+    pub unsafe fn init(
+        base_ptr: *mut u8,
+        layout: TransportLayout,
+        participant_id: ParticipantId,
+        total_participants: usize,
+        bridge: Arc<SignalBridge>,
+    ) -> Self {
+        let mut mux_writers = Vec::with_capacity(total_participants);
+        let mut mux_readers = Vec::with_capacity(total_participants);
+        let region_size = layout.total_size();
+
+        for j in 0..total_participants {
+            // Writer: Us -> J
+            // Layout index: participant_index * P + j
+            let writer_idx = (participant_id.0 as usize) * total_participants + j;
+            let offset = writer_idx * region_size;
+            let writer_base = base_ptr.add(offset);
+
+            mux_writers.push(Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+                writer_base,
+                layout.data_capacity,
+                layout.control_capacity,
+                bridge.clone(),
+                ParticipantId(j as u16),
+            ))));
+
+            // Reader: J -> Us
+            // Layout index: j * P + participant_index
+            let reader_idx = j * total_participants + (participant_id.0 as usize);
+            let offset = reader_idx * region_size;
+            let reader_base = base_ptr.add(offset);
+
+            mux_readers.push(Arc::new(Mutex::new(MultiplexedDsmReader::new(
+                reader_base,
+                layout.data_capacity,
+                layout.control_capacity,
+                bridge.clone(),
+                ParticipantId(j as u16),
+            ))));
+        }
+
+        Self {
+            mux_writers,
+            mux_readers,
+            bridge,
+        }
+    }
+
+    /// Detaches all underlying readers, preventing further access to shared memory.
+    /// This is a safety mechanism to prevent use-after-free when DSM is unmapped
+    /// but Arrow buffers (holding leases) are still alive.
+    pub fn detach(&self) {
+        for reader in &self.mux_readers {
+            reader.lock().detach();
+        }
+    }
+
+    /// Returns the virtual memory address ranges of all shared memory ring buffers
+    /// currently mapped by this mesh (via readers).
+    ///
+    /// This is used by `SharedMemoryDetector` to identify if an Arrow buffer resides
+    /// in shared memory.
+    pub fn memory_regions(&self) -> Vec<(usize, usize)> {
+        self.mux_readers
+            .iter()
+            .map(|r| r.lock().memory_region())
+            .collect()
+    }
+
+    /// Waits for the `BroadcastPlan` control message from the Leader.
+    ///
+    /// This method polls all writers (connections to other participants) for control messages.
+    /// It enforces a strict protocol where the FIRST message received MUST be `BroadcastPlan`.
+    pub async fn wait_for_broadcast_plan(&self) -> Vec<u8> {
+        futures::future::poll_fn(|cx| {
+            for mux in &self.mux_writers {
+                let mut guard = mux.lock();
+                match guard.poll_read_control_frame(cx) {
+                    std::task::Poll::Ready((msg_type, payload)) => {
+                        if let Some(ControlMessage::BroadcastPlan(bytes)) =
+                            ControlMessage::try_from_frame(msg_type, &payload)
+                        {
+                            // Return the plan. Any subsequent messages remain in the ring buffer
+                            // and will be consumed by the Control Service.
+                            return std::task::Poll::Ready(bytes);
+                        } else {
+                            panic!(
+                                "Received unexpected control message before BroadcastPlan: type {}",
+                                msg_type
+                            );
+                        }
+                    }
+                    std::task::Poll::Pending => {} // Continue checking other muxes
+                }
+            }
+            std::task::Poll::Pending
+        })
+        .await
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/transport/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/mod.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Transport Layer
+//!
+//! This module implements the low-level data transport and signaling mechanisms for ParadeDB's
+//! parallel execution engine (JoinScan). It decouples the physical movement of data (via Shared
+//! Memory Ring Buffers) from the execution logic (DataFusion Plans).
+//!
+//! ## Architecture
+//!
+//! The transport layer is stratified into three components:
+//!
+//! 1.  **Physical Layer (`shmem.rs`)**:
+//!     *   Manages raw Shared Memory (DSM) regions.
+//!     *   Implements `TransportHeader`, `RingBufferHeader`, and `SignalBridge` (Unix Domain Sockets) for cross-process
+//!         notification.
+//!     *   Provides `MultiplexedDsmWriter` and `MultiplexedDsmReader` for multiplexing logical
+//!         streams over a single physical connection.
+//!
+//! 2.  **Protocol Layer (`mod.rs`)**:
+//!     *   Defines the `ControlMessage` enum (Start/Cancel stream).
+//!     *   Provides the `TransportMesh` abstraction which encapsulates the topology of the
+//!         parallel session (Writers/Readers for all participants).
+//!
+//! 3.  **Adaptation Layer (`arrow.rs`)**:
+//!     *   Adapts the byte-oriented `shmem` streams to Arrow IPC.
+//!     *   Provides `DsmWriter` (using `IpcDataGenerator` for 1-copy writes) and `dsm_reader`
+//!         (supporting Zero-Copy reads).
+//!     *   Implements optimal memory usage strategies:
+//!         1.  **1-Copy Write**: Serializes batches directly to a local buffer before flushing
+//!             to shared memory, avoiding intermediate Arrow IPC buffers.
+//!         2.  **Zero-Copy Read**: When possible, maps shared memory regions directly to Arrow
+//!             `Buffer`s, avoiding copies on the consumer side.
+//!
+//! ## Key Concepts
+//!
+//! ### 1. The Transport Mesh
+//! The `TransportMesh` is the central registry of all physical connections. It is initialized once
+//! per process (Leader or Worker) using a raw pointer to the base of the DSM region. It
+//! automatically calculates offsets to establish:
+//! *   `mux_writers`: A vector of writers, where index `j` connects to Participant `j`.
+//! *   `mux_readers`: A vector of readers, where index `j` receives from Participant `j`.
+//!
+//! ### 2. Control Protocol
+//! Execution is "Lazy" and "Pull-based".
+//! *   **Request**: A consumer (Reader) sends a `ControlMessage::StartStream(id)` frame to the
+//!     producer.
+//! *   **Response**: The producer's `Control Service` (in `exchange.rs`) receives the frame,
+//!     parses it, and triggers the corresponding execution task.
+//! *   **Data**: Data flows back from producer to consumer via the ring buffer.
+//!
+//! ### 3. Multiplexing
+//! Multiple logical streams (e.g., different stages of a query plan) share the same physical ring
+//! buffer connection between two nodes. Each frame is prefixed with a
+//! `[stream_id: u32][length: u32]` header.
+//!
+//! ## Usage
+//!
+//! Consumers (like `exchange.rs` and `parallel.rs`) should interact primarily with `TransportMesh`
+//! and `ControlMessage`. They should not need to manipulate raw pointers or ring buffer headers
+//! directly.
+
+#[allow(dead_code)]
+mod arrow;
+#[allow(dead_code)]
+mod mesh;
+#[allow(dead_code)]
+mod shmem;
+
+// Re-export commonly used types
+#[allow(unused_imports)]
+pub use arrow::{dsm_reader, DsmWriter};
+#[allow(unused_imports)]
+pub use mesh::TransportMesh;
+#[allow(unused_imports)]
+pub use shmem::{
+    LogicalStreamId, MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, PhysicalStreamId,
+    SignalBridge, TransportLayout,
+};
+
+/// Control messages sent from Reader to Writer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ControlMessage {
+    /// Request the writer to start producing data for this stream.
+    StartStream(PhysicalStreamId),
+    /// Request the writer to stop producing data.
+    CancelStream(PhysicalStreamId),
+    /// Broadcast the physical plan to all workers (Leader -> Worker).
+    /// The payload is the serialized physical plan bytes.
+    BroadcastPlan(Vec<u8>),
+}
+
+impl ControlMessage {
+    pub fn try_from_frame(msg_type: u8, payload: &[u8]) -> Option<Self> {
+        match msg_type {
+            0 => {
+                if payload.len() != 4 {
+                    return None;
+                }
+                let stream_id = PhysicalStreamId(u32::from_le_bytes(payload.try_into().unwrap()));
+                Some(ControlMessage::StartStream(stream_id))
+            }
+            1 => {
+                if payload.len() != 4 {
+                    return None;
+                }
+                let stream_id = PhysicalStreamId(u32::from_le_bytes(payload.try_into().unwrap()));
+                Some(ControlMessage::CancelStream(stream_id))
+            }
+            128 => Some(ControlMessage::BroadcastPlan(payload.to_vec())),
+            _ => None,
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -1,0 +1,2161 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! # Dynamic Shared Memory (DSM) Byte Streams
+//!
+//! This module provides a generic abstraction for multiplexed, asynchronous byte streams
+//! over a shared memory ring buffer. It handles:
+//!
+//! 1. **Multiplexing**: Multiple logical streams can share a single physical ring buffer
+//!    via a simple framing protocol (`[stream_id: u32][len: u32][payload]`).
+//! 2. **Signaling**: Uses Unix Domain Sockets (`SignalBridge`) for async waking of Tokio tasks.
+//! 3. **Stream Adapters**: Provides a direct demultiplexing reader (`MultiplexedDsmReader`)
+//!    optimized for Zero-Copy reads (via `ShmLease`), and a legacy `std::io::Write` adapter
+//!    (`DsmStreamWriterAdapter`) for testing.
+
+use crate::api::{HashMap, HashSet};
+use arrow_buffer::Buffer;
+use std::borrow::Cow;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, VecDeque};
+use std::io::{ErrorKind, Write};
+use std::os::unix::net::UnixStream;
+use std::panic::RefUnwindSafe;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::Waker;
+
+use interprocess::local_socket::tokio::Listener;
+use interprocess::local_socket::traits::tokio::Listener as _;
+use interprocess::local_socket::{GenericFilePath, ListenerOptions, ToFsName};
+use parking_lot::Mutex;
+use tokio::io::AsyncReadExt;
+
+/// A strongly-typed wrapper around `u16` representing a participant's unique index in the MPP session.
+///
+/// This type ensures safety and clarity when passing participant indices through the
+/// transport layer, preventing confusion with other `usize` or `u32` values (like stream IDs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ParticipantId(pub u16);
+
+impl std::fmt::Display for ParticipantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A robust signaling bridge using `interprocess` Local Sockets (Stream-oriented).
+///
+/// This component provides the async-friendly signaling required by the Tokio runtime.
+/// Each participant in the MPP session binds its own dedicated local socket listener.
+///
+/// # Signaling Mechanism
+///
+/// When a producer writes data to a DSM buffer, it "signals" the consumer by
+/// establishing a connection (if not already cached, performing a 4-byte handshake)
+/// and writing a single byte.
+///
+/// We use synchronous `UnixStream` operations in **non-blocking mode** (after handshake):
+/// 1.  **Low Latency**: Local socket operations are extremely fast.
+/// 2.  **Safety**: We use non-blocking writes (`set_nonblocking(true)`). If the socket
+///     buffer is full (consumer not processing signals), the write returns `WouldBlock`
+///     and we silently ignore it. This avoids deadlocks in single-threaded runtimes where
+///     blocking the producer might prevent the consumer's acceptor task from running.
+///     Dropping signals is safe because a full buffer implies the consumer already has
+///     pending signals queued in the kernel to wake it up.
+/// 3.  **Simplicity**: Allows usage within non-async contexts without needing a runtime handle.
+///
+/// # Caching
+///
+/// The bridge maintains a cache of open connections (`outgoing`) to other participants.
+/// This avoids the overhead of `connect()` syscalls and path construction on every signal,
+/// which is critical for high-throughput streaming.
+pub struct SignalBridge {
+    participant_id: ParticipantId,
+    session_id: uuid::Uuid,
+    /// Cache of outgoing synchronous connections to other participants.
+    /// We use `parking_lot::Mutex` for low-overhead synchronous locking.
+    outgoing: Mutex<HashMap<ParticipantId, UnixStream>>,
+    /// Wakers sharded by the sender who triggered the signal.
+    /// `None` key stores "Universal" wakers (e.g. Control Service) that are woken by any signal.
+    /// `Some(id)` key stores wakers interested only in signals from `id`.
+    wakers: Arc<Mutex<HashMap<Option<ParticipantId>, Vec<Waker>>>>,
+}
+
+impl SignalBridge {
+    fn socket_name(session_id: uuid::Uuid, id: ParticipantId) -> std::io::Result<String> {
+        // Use a filesystem path in /tmp. This works on Unix.
+        // interprocess supports namespaced names on Linux (@...) but macOS requires paths.
+        // We use explicit filesystem paths for consistency.
+        Ok(format!("/tmp/pdb_mpp_{}_{}.sock", session_id, id))
+    }
+
+    pub async fn new(
+        participant_id: ParticipantId,
+        session_id: uuid::Uuid,
+    ) -> std::io::Result<Self> {
+        let name_str = Self::socket_name(session_id, participant_id)?;
+        // Clean up previous file if it exists
+        if std::fs::metadata(&name_str).is_ok() {
+            let _ = std::fs::remove_file(&name_str);
+        }
+
+        let name = name_str.to_fs_name::<GenericFilePath>()?;
+        let listener = ListenerOptions::new().name(name).create_tokio()?;
+
+        let wakers = Arc::new(Mutex::new(HashMap::default()));
+        let bridge = Self {
+            participant_id,
+            session_id,
+            outgoing: Mutex::new(HashMap::default()),
+            wakers,
+        };
+
+        bridge.spawn_acceptor(listener);
+        Ok(bridge)
+    }
+
+    #[cfg(any(test, feature = "pg_test"))]
+    pub fn new_dummy() -> Arc<Self> {
+        Arc::new(Self {
+            participant_id: ParticipantId(0),
+            session_id: uuid::Uuid::new_v4(),
+            outgoing: Mutex::new(HashMap::default()),
+            wakers: Arc::new(Mutex::new(HashMap::default())),
+        })
+    }
+
+    fn spawn_acceptor(&self, listener: Listener) {
+        let wakers = self.wakers.clone();
+
+        tokio::task::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok(mut stream) => {
+                        let wakers = wakers.clone();
+                        tokio::task::spawn(async move {
+                            // Handshake: Read Sender ParticipantId (u32)
+                            let mut id_buf = [0u8; 4];
+                            if stream.read_exact(&mut id_buf).await.is_err() {
+                                return;
+                            }
+                            let sender_id = ParticipantId(u32::from_le_bytes(id_buf) as u16);
+
+                            // Read in larger chunks to drain coalesced signals efficiently
+                            let mut buf = [0u8; 1024];
+                            loop {
+                                match stream.read(&mut buf).await {
+                                    Ok(0) => break, // EOF
+                                    Ok(_) => {
+                                        // Drop the lock before waking tasks to prevent deadlocks
+                                        let wakers_to_wake: Vec<_> = {
+                                            let mut guard = wakers.lock();
+                                            let mut to_wake = Vec::new();
+                                            // Wake specific listeners
+                                            if let Some(list) = guard.get_mut(&Some(sender_id)) {
+                                                to_wake.append(list);
+                                            }
+                                            // Wake universal listeners
+                                            // Note: We currently wake universal listeners on EVERY signal.
+                                            // Ideally we might want to be selective, but for Control Service
+                                            // we don't know who sent the control message until we check the ring buffer.
+                                            // So waking Control Service on every signal is correct behavior.
+                                            if let Some(list) = guard.get_mut(&None) {
+                                                // We must CLONE universal wakers because they might need to be
+                                                // woken by other participants too. Or do we drain them?
+                                                // If we drain them, they need to re-register.
+                                                // Standard poll_fn pattern re-registers waker every poll.
+                                                // So draining is correct.
+                                                to_wake.append(list);
+                                            }
+                                            to_wake
+                                        };
+                                        for waker in wakers_to_wake {
+                                            waker.wake();
+                                        }
+                                    }
+                                    Err(_) => break,
+                                }
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        pgrx::warning!("SignalBridge acceptor error: {}", e);
+                        // Sleep instead of yield to prevent 100% CPU spin loops
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                }
+            }
+        });
+    }
+
+    /// Signals a participant by writing a 4-byte handshake (if new connection) or a byte to a stream connected to its socket.
+    ///
+    /// # Blocking Behavior
+    ///
+    /// This method uses **blocking I/O** for the initial handshake transmission (writing 4 bytes)
+    /// when establishing a new connection. This is considered safe because writing 4 bytes to a
+    /// freshly created local Unix socket is effectively non-blocking (kernel buffers are empty).
+    ///
+    /// Subsequent signals use **non-blocking I/O** and handle `WouldBlock` by silently dropping the signal
+    /// (event coalescing), ensuring that the main loop is never stalled by a slow consumer.
+    pub fn signal(&self, target_id: ParticipantId) -> std::io::Result<()> {
+        if target_id == self.participant_id {
+            // Extract wakers before waking to prevent deadlocks
+            let wakers_to_wake: Vec<_> = {
+                let mut guard = self.wakers.lock();
+                let mut to_wake = Vec::new();
+                if let Some(list) = guard.get_mut(&Some(self.participant_id)) {
+                    to_wake.append(list);
+                }
+                if let Some(list) = guard.get_mut(&None) {
+                    to_wake.append(list);
+                }
+                to_wake
+            };
+            for waker in wakers_to_wake {
+                waker.wake();
+            }
+            return Ok(());
+        }
+
+        let needs_connect = {
+            let guard = self.outgoing.lock();
+            !guard.contains_key(&target_id)
+        };
+
+        if needs_connect {
+            let name_str = Self::socket_name(self.session_id, target_id)?;
+
+            let mut stream = loop {
+                match UnixStream::connect(&name_str) {
+                    Ok(s) => break s,
+                    Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                    // Safely ignore connection errors if backlog is full or not bound yet
+                    Err(e)
+                        if e.kind() == ErrorKind::WouldBlock
+                            || e.kind() == ErrorKind::ConnectionRefused
+                            || e.kind() == ErrorKind::NotFound =>
+                    {
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e),
+                }
+            };
+
+            // Handshake: Write our ParticipantId (u32)
+            // Note: This is blocking, but on a local socket with empty buffer it should be instant.
+            let _ = stream.write_all(&(self.participant_id.0 as u32).to_le_bytes());
+
+            stream.set_nonblocking(true)?;
+            self.outgoing.lock().insert(target_id, stream);
+        }
+
+        let mut guard = self.outgoing.lock();
+        let stream = match guard.get_mut(&target_id) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        loop {
+            match stream.write(&[1]) {
+                Ok(_) => return Ok(()),
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => return Ok(()),
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => {
+                    guard.remove(&target_id);
+                    // Drop lock before reconnecting to prevent stalling other signals
+                    drop(guard);
+
+                    let name_str = Self::socket_name(self.session_id, target_id)?;
+                    let mut stream = loop {
+                        match UnixStream::connect(&name_str) {
+                            Ok(s) => break s,
+                            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                            Err(e)
+                                if e.kind() == ErrorKind::WouldBlock
+                                    || e.kind() == ErrorKind::ConnectionRefused
+                                    || e.kind() == ErrorKind::NotFound =>
+                            {
+                                return Ok(());
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    };
+
+                    // Re-handshake
+                    let _ = stream.write_all(&(self.participant_id.0 as u32).to_le_bytes());
+
+                    stream.set_nonblocking(true)?;
+
+                    let res = loop {
+                        match stream.write(&[1]) {
+                            Ok(_) => break Ok(()),
+                            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                            Err(e) if e.kind() == ErrorKind::WouldBlock => break Ok(()),
+                            Err(e) => break Err(e),
+                        }
+                    };
+
+                    // Cache the newly established stream so it isn't dropped!
+                    self.outgoing.lock().insert(target_id, stream);
+                    return res;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Registers a waker to be notified when a signal arrives from a specific participant.
+    /// If `source_id` is `None`, the waker is notified on ANY signal (Broadcast).
+    pub fn register_waker(&self, waker: Waker, source_id: Option<ParticipantId>) {
+        let mut guard = self.wakers.lock();
+        let list = guard.entry(source_id).or_default();
+        // Deduplicate wakers to prevent memory leaks from spurious polls
+        for w in list.iter_mut() {
+            if w.will_wake(&waker) {
+                *w = waker; // Replace with updated waker just in case
+                return;
+            }
+        }
+        list.push(waker);
+    }
+}
+
+pub const DSM_MAGIC: u64 = 0x5044_425F_4453_4D31; // "PDB_DSM1"
+
+/// The top-level header for a Shared Memory Transport region.
+/// Located at the start of the DSM (Dynamic Shared Memory) region for each worker.
+///
+/// This structure wraps the main data ring buffer and provides an offset to a secondary
+/// control channel (also a ring buffer) used for signaling (e.g. stream cancellation).
+///
+/// # Safety
+///
+/// This struct contains `AtomicU64` fields (via `RingBufferHeader`), which means it has interior mutability and is NOT `Pod`.
+/// Therefore, we cannot use `bytemuck::from_bytes` to safely cast a byte slice to a reference of this struct.
+/// Users must manually ensure that the backing memory is properly aligned (align 8) and sized
+/// before casting raw pointers.
+#[repr(C)]
+struct TransportHeader {
+    ring: RingBufferHeader,
+    /// Offset from the start of the DSM region to the control block.
+    /// The control block is used for reverse-channel signaling (e.g. cancellations).
+    /// If 0, the control block is not present.
+    control_offset: usize,
+}
+
+impl TransportHeader {
+    /// Initializes a `TransportHeader` at the given pointer.
+    unsafe fn init(header: *mut TransportHeader, control_offset: usize) {
+        let ring = &mut (*header).ring;
+        RingBufferHeader::init(ring);
+        (*header).control_offset = control_offset;
+    }
+}
+
+/// Helper to calculate layout and initialize a Transport region.
+///
+/// # Memory Layout
+///
+/// A Transport Region is a contiguous block of Shared Memory containing a Main Data Channel
+/// and a Secondary Control Channel.
+///
+/// ```text
+/// +-----------------------------------------------------------+
+/// |  TransportHeader (Private Struct)                         |
+/// |-----------------------------------------------------------|
+/// |  ring: RingBufferHeader                                   | <--- Main Data Channel Header
+/// |        - magic (u64)                                      |
+/// |        - write_pos (AtomicU64)                            |
+/// |        - read_pos (AtomicU64)                             |
+/// |        - finished (AtomicU64)                             |
+/// |-----------------------------------------------------------|
+/// |  control_offset: usize                                    | <--- Offset to Control Region
+/// +-----------------------------------------------------------+
+/// |                                                           |
+/// |  MAIN DATA RING BUFFER                                    |
+/// |  (Size: data_capacity)                                    |
+/// |                                                           |
+/// +-----------------------------------------------------------+ <--- Aligned to 8 bytes
+/// |  Control Ring Buffer Header (RingBufferHeader)            | <--- Control Channel Header
+/// +-----------------------------------------------------------+
+/// |                                                           |
+/// |  CONTROL DATA BUFFER                                      |
+/// |  (Size: control_capacity)                                 |
+/// |                                                           |
+/// +-----------------------------------------------------------+
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TransportLayout {
+    pub data_capacity: usize,
+    pub control_capacity: usize,
+}
+
+impl TransportLayout {
+    pub fn new(data_capacity: usize, control_capacity: usize) -> Self {
+        Self {
+            data_capacity,
+            control_capacity,
+        }
+    }
+
+    fn align_up(offset: usize, align: usize) -> usize {
+        (offset + align - 1) & !(align - 1)
+    }
+
+    pub fn total_size(&self) -> usize {
+        let control_start = self.control_offset();
+        let control_end =
+            control_start + std::mem::size_of::<RingBufferHeader>() + self.control_capacity;
+        // Padding
+        control_end + 64
+    }
+
+    pub fn control_offset(&self) -> usize {
+        let unaligned = std::mem::size_of::<TransportHeader>() + self.data_capacity;
+        Self::align_up(unaligned, std::mem::align_of::<RingBufferHeader>())
+    }
+
+    /// Initializes the headers at the given base pointer.
+    ///
+    /// # Safety
+    /// `base_ptr` must point to a valid memory region of at least `total_size()` bytes.
+    pub unsafe fn init(&self, base_ptr: *mut u8) {
+        // 1. Initialize Main Header
+        let header = base_ptr as *mut TransportHeader;
+        TransportHeader::init(header, self.control_offset());
+
+        // 2. Initialize Control Header
+        let control_ptr = base_ptr.add(self.control_offset());
+        let control_header = control_ptr as *mut RingBufferHeader;
+        RingBufferHeader::init(control_header);
+    }
+}
+
+/// The header for a single circular buffer (SPSC queue).
+///
+/// This structure maintains the state (`write_pos`, `read_pos`) for a ring buffer.
+/// It is used for:
+/// 1. The main data channel (embedded in `TransportHeader`).
+/// 2. The secondary control channel (located at `control_offset`).
+///
+/// # Safety
+///
+/// This struct contains `AtomicU64` fields, which means it has interior mutability and is NOT `Pod`.
+/// Therefore, we cannot use `bytemuck::from_bytes` to safely cast a byte slice to a reference of this struct.
+/// Users must manually ensure that the backing memory is properly aligned (align 8) and sized
+/// before casting raw pointers.
+#[repr(C)]
+struct RingBufferHeader {
+    /// Magic number to detect memory corruption.
+    magic: u64,
+
+    /// Monotonically increasing counter of total bytes written to the data region.
+    /// The producer increments this after completing a write.
+    write_pos: AtomicU64,
+
+    /// Monotonically increasing counter of total bytes read from the data region.
+    /// The consumer increments this after consuming a batch.
+    read_pos: AtomicU64,
+
+    /// A flag indicating that the producer has completed its execution and
+    /// no more data will be written.
+    finished: AtomicU64,
+}
+
+impl RingBufferHeader {
+    /// Initializes a `RingBufferHeader` at the given pointer.
+    ///
+    /// This writes the magic number and zeroes the counters.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `header` points to a valid, aligned, and writeable memory region
+    /// of size `size_of::<RingBufferHeader>()`.
+    unsafe fn init(header: *mut RingBufferHeader) {
+        std::ptr::write(
+            header,
+            RingBufferHeader {
+                magic: DSM_MAGIC,
+                write_pos: AtomicU64::new(0),
+                read_pos: AtomicU64::new(0),
+                finished: AtomicU64::new(0),
+            },
+        );
+    }
+}
+
+/// Internal adapter for writing to the DSM ring buffer via `std::io::Write`.
+struct DsmWriteAdapter {
+    header: *mut RingBufferHeader,
+    data: *mut u8,
+    data_len: usize,
+}
+
+impl DsmWriteAdapter {
+    fn new(header: *mut RingBufferHeader, data: *mut u8, data_len: usize) -> Self {
+        unsafe {
+            // Check magic
+            if (*header).magic != DSM_MAGIC {
+                // We can't return error from new(), but we can log.
+                // In production this implies severe corruption or uninitialized memory.
+                pgrx::warning!(
+                    "DsmWriteAdapter::new: Invalid magic number in header: {:x}",
+                    (*header).magic
+                );
+            }
+        }
+        Self {
+            header,
+            data,
+            data_len,
+        }
+    }
+
+    /// Calculates how many bytes can currently be written to the buffer.
+    fn available_space(&self) -> usize {
+        let write_pos = unsafe { (*self.header).write_pos.load(Ordering::Acquire) };
+        let read_pos = unsafe { (*self.header).read_pos.load(Ordering::Acquire) };
+        // The distance between write and read positions determines occupancy.
+        let used = write_pos.wrapping_sub(read_pos) as usize;
+        if used > self.data_len {
+            // TODO: This state should be impossible with correct logic.
+            // It implies either memory corruption (overwritten header) or a race condition
+            // where read_pos/write_pos are desynchronized.
+            // We return 0 (full) to safely block the writer instead of crashing.
+            pgrx::warning!(
+                "DsmWriteAdapter::available_space: Invalid state! write_pos={}, read_pos={}, data_len={}, used={}",
+                write_pos,
+                read_pos,
+                self.data_len,
+                used
+            );
+            return 0;
+        }
+        self.data_len - used
+    }
+}
+
+impl std::io::Write for DsmWriteAdapter {
+    /// Serializes raw bytes into the ring buffer.
+    ///
+    /// This handles wrapping around the end of the circular buffer by performing
+    /// two `copy_nonoverlapping` calls if the message is split across the boundary.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        unsafe {
+            if (*self.header).magic != DSM_MAGIC {
+                return Err(std::io::Error::other(format!(
+                    "DsmWriteAdapter::write: RingBufferHeader corruption (magic mismatch: {:x})",
+                    (*self.header).magic
+                )));
+            }
+        }
+
+        let len = buf.len();
+        if len > self.data_len {
+            return Err(std::io::Error::other(format!(
+                "Write size {} exceeds ring buffer capacity {}",
+                len, self.data_len
+            )));
+        }
+
+        // Non-blocking: check if we have enough space.
+        if self.available_space() < len {
+            return Err(std::io::Error::from(ErrorKind::WouldBlock));
+        }
+
+        unsafe {
+            let write_pos = (*self.header).write_pos.load(Ordering::Acquire);
+            let offset = (write_pos % self.data_len as u64) as usize;
+
+            if offset + len <= self.data_len {
+                // The write fits contiguously at the end of the buffer.
+                std::ptr::copy_nonoverlapping(buf.as_ptr(), self.data.add(offset), len);
+            } else {
+                // The write wraps around to the start of the buffer.
+                let first_part = self.data_len - offset;
+                let second_part = len - first_part;
+                std::ptr::copy_nonoverlapping(buf.as_ptr(), self.data.add(offset), first_part);
+                std::ptr::copy_nonoverlapping(buf.as_ptr().add(first_part), self.data, second_part);
+            }
+
+            // Update write position.
+            (*self.header)
+                .write_pos
+                .fetch_add(len as u64, Ordering::Release);
+        }
+
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A multiplexer for writing multiple logical streams into a single DSM ring buffer.
+///
+/// Framing: `[stream_id: u32][len: u32][payload: len bytes]`
+pub struct MultiplexedDsmWriter {
+    adapter: DsmWriteAdapter,
+    /// Set of stream IDs that have been cancelled by the reader.
+    cancelled_streams: HashSet<PhysicalStreamId>,
+    /// Reader for the control channel (reverse direction).
+    control_reader: Option<DsmReadAdapter>,
+    /// Bridge for signaling the remote reader.
+    bridge: Arc<SignalBridge>,
+    /// Index of the remote participant (reader).
+    remote_id: ParticipantId,
+}
+
+unsafe impl Send for MultiplexedDsmWriter {}
+unsafe impl Sync for MultiplexedDsmWriter {}
+
+impl std::fmt::Debug for MultiplexedDsmWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiplexedDsmWriter")
+            .field("remote_id", &self.remote_id)
+            .field("cancelled_streams", &self.cancelled_streams)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A unique identifier for a physical stream (Logical Stream + Sender).
+///
+/// This ID is used to multiplex multiple logical data streams over a single physical
+/// shared memory ring buffer connection between two participants.
+///
+/// The ID is a 32-bit integer packed as follows:
+/// - **High 16 bits**: The `LogicalStreamId` (from the query plan).
+/// - **Low 16 bits**: The `ParticipantId` of the sender.
+///
+/// This packing strategy assumes that there are fewer than 65536 logical streams
+/// and fewer than 65536 participants in a single query execution, which is safe
+/// for PostgreSQL's limits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PhysicalStreamId(pub u32);
+
+impl PhysicalStreamId {
+    /// Creates a new `PhysicalStreamId` from a logical stream ID and a sender ID.
+    pub fn new(logical: LogicalStreamId, participant_id: ParticipantId) -> Self {
+        Self(((logical.0 as u32) << 16) | ((participant_id.0 as u32) & 0xFFFF))
+    }
+
+    pub fn to_le_bytes(self) -> [u8; 4] {
+        self.0.to_le_bytes()
+    }
+}
+
+/// A unique identifier for a logical stream in the execution plan.
+///
+/// This ID corresponds to a specific shuffle/exchange operation in the DataFusion plan.
+/// All participants (senders) participating in this exchange will use the same `LogicalStreamId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct LogicalStreamId(pub u16);
+
+impl std::fmt::Display for LogicalStreamId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub type ControlFrame = (u8, Vec<u8>);
+
+impl MultiplexedDsmWriter {
+    /// Creates a new multiplexed writer.
+    ///
+    /// If `control_offset` is non-zero in the header, it also initializes a reader
+    /// for the reverse control channel to receive stream cancellation signals.
+    pub fn new(
+        base_ptr: *mut u8,
+        data_capacity: usize,
+        control_capacity: usize,
+        bridge: Arc<SignalBridge>,
+        remote_id: ParticipantId,
+    ) -> Self {
+        let header = base_ptr as *mut TransportHeader;
+        let data = unsafe { base_ptr.add(std::mem::size_of::<TransportHeader>()) };
+
+        unsafe {
+            if (*header).ring.magic != DSM_MAGIC {
+                pgrx::warning!(
+                    "MultiplexedDsmWriter::new: Invalid magic number in header: {:x}",
+                    (*header).ring.magic
+                );
+            }
+        }
+
+        let control_reader = unsafe {
+            let offset = (*header).control_offset;
+            if offset > 0 {
+                // Sanity check control offset to avoid wrapping
+                if offset < std::mem::size_of::<TransportHeader>() {
+                    pgrx::warning!(
+                        "MultiplexedDsmWriter::new: Invalid control_offset {} (too small)",
+                        offset
+                    );
+                }
+
+                // Calculate pointer to control block
+                let control_ptr = base_ptr.add(offset);
+                let control_header = control_ptr as *mut RingBufferHeader;
+
+                // Data starts after the header.
+                let control_data = control_ptr.add(std::mem::size_of::<RingBufferHeader>());
+                let control_len = control_capacity;
+
+                Some(DsmReadAdapter::new(
+                    control_header,
+                    control_data,
+                    control_len,
+                ))
+            } else {
+                None
+            }
+        };
+
+        let adapter = unsafe { DsmWriteAdapter::new(&mut (*header).ring, data, data_capacity) };
+
+        Self {
+            adapter,
+            cancelled_streams: HashSet::default(),
+            control_reader,
+            bridge,
+            remote_id,
+        }
+    }
+
+    /// Reads the next pending control frame from the reverse channel.
+    /// Returns `Some((message_type, payload))` if a complete message is available, `None` otherwise.
+    pub fn read_control_frame(&mut self) -> Option<ControlFrame> {
+        let adapter = self.control_reader.as_mut()?;
+        let mut reader = adapter.as_peekable();
+
+        let type_cow = reader.try_read_slice(1)?;
+        let msg_type = type_cow[0];
+
+        // 2. Determine Payload Length
+        let payload_len = if msg_type >= 128 {
+            // Variable Frame: [len: u32]
+            let len_cow = reader.try_read_slice(4)?;
+            u32::from_le_bytes(len_cow.as_ref().try_into().unwrap()) as usize
+        } else {
+            4 // Fixed size for legacy messages
+        };
+
+        // 3. Try peek Payload
+        let payload_cow = reader.try_read_slice(payload_len)?;
+
+        // 4. Success!
+        // Mark this point as a valid commit boundary.
+        reader.checkpoint();
+        reader.commit();
+        Some((msg_type, payload_cow.into_owned()))
+    }
+
+    /// Async version of `read_control_frame` that registers the current task's waker
+    /// with the bridge if data is not yet available.
+    pub fn poll_read_control_frame(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<ControlFrame> {
+        // Register waker FIRST to avoid race condition where data arrives
+        // between read attempt and registration.
+        self.bridge
+            .register_waker(cx.waker().clone(), Some(self.remote_id));
+
+        match self.read_control_frame() {
+            Some(frame) => std::task::Poll::Ready(frame),
+            None => std::task::Poll::Pending,
+        }
+    }
+
+    /// Mark a stream as cancelled, preventing further writes to it.
+    pub fn mark_stream_cancelled(&mut self, stream_id: PhysicalStreamId) {
+        self.cancelled_streams.insert(stream_id);
+    }
+
+    /// Writes a framed message to the ring buffer.
+    pub(super) fn write_message(
+        &mut self,
+        stream_id: PhysicalStreamId,
+        payload: &[u8],
+    ) -> std::io::Result<()> {
+        if self.cancelled_streams.contains(&stream_id) {
+            return Err(std::io::Error::from(ErrorKind::BrokenPipe));
+        }
+
+        let len = payload.len() as u32;
+        let header_len = 8;
+        // Calculate padding to ensure the total message size (header + payload + padding) is 8-byte aligned.
+        let padding = (8 - (len % 8)) % 8;
+        let total_len = (header_len + len + padding) as usize;
+
+        if total_len > self.adapter.data_len {
+            return Err(std::io::Error::other(format!(
+                "Framed message size {} exceeds ring buffer capacity {}",
+                total_len, self.adapter.data_len
+            )));
+        }
+
+        // Check if the entire framed message fits before writing anything.
+        if self.adapter.available_space() < total_len {
+            return Err(std::io::Error::from(ErrorKind::WouldBlock));
+        }
+
+        self.adapter.write_all(&stream_id.to_le_bytes())?;
+        self.adapter.write_all(&len.to_le_bytes())?;
+        self.adapter.write_all(payload)?;
+
+        if padding > 0 {
+            let pad_bytes = [0u8; 8];
+            self.adapter.write_all(&pad_bytes[0..padding as usize])?;
+        }
+
+        // Signal the remote reader
+        if let Err(e) = self.bridge.signal(self.remote_id) {
+            pgrx::warning!("Signal error to remote {}: {}", self.remote_id, e);
+        }
+        Ok(())
+    }
+
+    /// Closes a specific stream by sending an empty message (len=0).
+    pub(super) fn close_stream(&mut self, stream_id: PhysicalStreamId) -> std::io::Result<()> {
+        if self.cancelled_streams.contains(&stream_id) {
+            return Ok(());
+        }
+
+        // Write header with len=0
+        let len = 0u32;
+        let total_len = 8; // Just header, already aligned
+
+        if self.adapter.available_space() < total_len {
+            return Err(std::io::Error::from(ErrorKind::WouldBlock));
+        }
+
+        self.adapter.write_all(&stream_id.to_le_bytes())?;
+        self.adapter.write_all(&len.to_le_bytes())?;
+        // No payload, no padding
+
+        let _ = self.bridge.signal(self.remote_id);
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn finish(&mut self) -> std::io::Result<()> {
+        unsafe {
+            if (*self.adapter.header).magic != DSM_MAGIC {
+                return Err(std::io::Error::other(
+                    "RingBufferHeader corruption (magic mismatch)",
+                ));
+            }
+            (*self.adapter.header).finished.store(1, Ordering::Release);
+        }
+        let _ = self.bridge.signal(self.remote_id);
+        Ok(())
+    }
+}
+
+/// A stateful reader that allows peeking into the ring buffer without consuming data until committed.
+struct DsmPeekableReader<'a> {
+    header: &'a mut RingBufferHeader,
+    data: *const u8,
+    capacity: usize,
+
+    // Snapshot of the shared state
+    start_pos: u64, // The committed read_pos when transaction started
+    limit_pos: u64, // The write_pos (end of valid data)
+
+    // Local traversal state
+    cursor_offset: usize,    // Bytes peeked so far relative to start_pos
+    committed_offset: usize, // Bytes marked as successfully parsed
+}
+
+impl<'a> DsmPeekableReader<'a> {
+    /// Starts a read transaction by snapshotting the current read/write pointers.
+    fn begin(header: &'a mut RingBufferHeader, data: *const u8, capacity: usize) -> Self {
+        let start_pos = header.read_pos.load(Ordering::Acquire);
+        let limit_pos = header.write_pos.load(Ordering::Acquire);
+
+        Self {
+            header,
+            data,
+            capacity,
+            start_pos,
+            limit_pos,
+            cursor_offset: 0,
+            committed_offset: 0,
+        }
+    }
+
+    /// Returns the number of bytes available to be peeked.
+    fn available(&self) -> usize {
+        // limit_pos - (start_pos + cursor_offset)
+        let consumed = self.start_pos + self.cursor_offset as u64;
+        self.limit_pos.wrapping_sub(consumed) as usize
+    }
+
+    /// Attempts to retrieve a view of the next `len` bytes from the current cursor position.
+    ///
+    /// - **Contiguous Case:** Returns `Cow::Borrowed(&[u8])` pointing directly into shared memory.
+    /// - **Wrap-around Case:** Returns `Cow::Owned(Vec<u8>)` containing a copy of the split data.
+    /// - **Insufficient Data:** Returns `None`.
+    ///
+    /// Advances the local cursor on success.
+    ///
+    /// # Future Optimization
+    /// TODO: Implement "Magic Ring Buffer" pattern (Virtual Memory Mirroring).
+    /// By mapping the same physical memory twice adjacently (A | A), we can eliminate the wrap-around
+    /// edge case entirely. This would allow us to always return `&[u8]` (Zero-Copy) even for messages
+    /// that cross the physical buffer boundary.
+    /// Reference: https://fgiesen.wordpress.com/2012/07/21/the-magic-ring-buffer/
+    fn try_read_slice(&mut self, len: usize) -> Option<Cow<'a, [u8]>> {
+        if self.available() < len {
+            return None;
+        }
+
+        // Calculate physical offset
+        let offset = (self.start_pos + self.cursor_offset as u64) % self.capacity as u64;
+        let offset = offset as usize;
+
+        let result = if offset + len <= self.capacity {
+            // Contiguous: Return direct reference
+            unsafe {
+                let slice = std::slice::from_raw_parts(self.data.add(offset), len);
+                Cow::Borrowed(slice)
+            }
+        } else {
+            // Wrapped: Must copy to contiguous buffer
+            let mut buf = vec![0u8; len];
+            let first_part = self.capacity - offset;
+            let second_part = len - first_part;
+            unsafe {
+                std::ptr::copy_nonoverlapping(self.data.add(offset), buf.as_mut_ptr(), first_part);
+                std::ptr::copy_nonoverlapping(
+                    self.data,
+                    buf.as_mut_ptr().add(first_part),
+                    second_part,
+                );
+            }
+            Cow::Owned(buf)
+        };
+
+        self.cursor_offset += len;
+        Some(result)
+    }
+
+    /// Marks the current cursor position as a valid commit point.
+    /// If subsequent reads fail, we can still commit up to this point.
+    fn checkpoint(&mut self) {
+        self.committed_offset = self.cursor_offset;
+    }
+
+    /// Commits the consumed bytes to the shared ring buffer header.
+    fn commit(self) {
+        if self.committed_offset > 0 {
+            self.header
+                .read_pos
+                .fetch_add(self.committed_offset as u64, Ordering::Release);
+        }
+    }
+}
+
+/// A bridge between the Shared Memory Ring Buffer and the `std::io::Read` trait.
+struct DsmReadAdapter {
+    header: *mut RingBufferHeader,
+    data: *mut u8,
+    data_len: usize,
+}
+
+impl DsmReadAdapter {
+    fn new(header: *mut RingBufferHeader, data: *mut u8, data_len: usize) -> Self {
+        unsafe {
+            if (*header).magic != DSM_MAGIC {
+                pgrx::warning!(
+                    "DsmReadAdapter::new: Invalid magic number in header: {:x}",
+                    (*header).magic
+                );
+            }
+        }
+        Self {
+            header,
+            data,
+            data_len,
+        }
+    }
+
+    /// Checks if the writer has finished.
+    fn is_finished(&self) -> bool {
+        unsafe { (*self.header).finished.load(Ordering::Acquire) == 1 }
+    }
+
+    fn write_pos(&self) -> u64 {
+        unsafe { (*self.header).write_pos.load(Ordering::Acquire) }
+    }
+
+    fn data_ptr(&self) -> *mut u8 {
+        self.data
+    }
+
+    fn capacity(&self) -> usize {
+        self.data_len
+    }
+
+    fn copy_at(&self, offset: u64, buf: &mut [u8]) {
+        let len = buf.len();
+        let buffer_offset = (offset % self.data_len as u64) as usize;
+        unsafe {
+            if buffer_offset + len <= self.data_len {
+                std::ptr::copy_nonoverlapping(self.data.add(buffer_offset), buf.as_mut_ptr(), len);
+            } else {
+                let first_part = self.data_len - buffer_offset;
+                let second_part = len - first_part;
+                std::ptr::copy_nonoverlapping(
+                    self.data.add(buffer_offset),
+                    buf.as_mut_ptr(),
+                    first_part,
+                );
+                std::ptr::copy_nonoverlapping(
+                    self.data,
+                    buf.as_mut_ptr().add(first_part),
+                    second_part,
+                );
+            }
+        }
+    }
+
+    pub fn memory_region(&self) -> (usize, usize) {
+        (self.data as usize, self.data_len)
+    }
+
+    fn as_peekable(&mut self) -> DsmPeekableReader<'_> {
+        DsmPeekableReader::begin(unsafe { &mut *self.header }, self.data, self.data_len)
+    }
+}
+
+/// A controller for reclaiming shared memory space.
+struct DsmReclaimer {
+    header: *mut RingBufferHeader,
+    committed_read_pos: u64,
+    pending_frees: BinaryHeap<Reverse<(u64, u64)>>, // (start, len)
+    bridge: Arc<SignalBridge>,
+    remote_id: ParticipantId,
+    detached: bool,
+}
+
+unsafe impl Send for DsmReclaimer {}
+unsafe impl Sync for DsmReclaimer {}
+impl RefUnwindSafe for DsmReclaimer {}
+
+impl DsmReclaimer {
+    fn new(
+        header: *mut RingBufferHeader,
+        bridge: Arc<SignalBridge>,
+        remote_id: ParticipantId,
+    ) -> Self {
+        let committed_read_pos = unsafe { (*header).read_pos.load(Ordering::Acquire) };
+        Self {
+            header,
+            committed_read_pos,
+            pending_frees: BinaryHeap::new(),
+            bridge,
+            remote_id,
+            detached: false,
+        }
+    }
+
+    fn detach(&mut self) {
+        self.detached = true;
+    }
+
+    fn mark_freed(&mut self, offset: u64, len: u64) {
+        if self.detached {
+            return;
+        }
+
+        self.pending_frees.push(Reverse((offset, len)));
+
+        // Process contiguous frees
+        while let Some(Reverse((start, length))) = self.pending_frees.peek() {
+            if *start == self.committed_read_pos {
+                self.committed_read_pos += length;
+                self.pending_frees.pop();
+            } else {
+                break;
+            }
+        }
+
+        // Update atomic
+        unsafe {
+            (*self.header)
+                .read_pos
+                .store(self.committed_read_pos, Ordering::Release);
+        }
+
+        // Signal writer
+        let _ = self.bridge.signal(self.remote_id);
+    }
+}
+
+/// A lease representing a pinned region of shared memory.
+///
+/// This struct implements `Drop` to automatically reclaim the memory in the
+/// underlying `DsmReclaimer` when the lease (and any Arrow Buffers wrapping it)
+/// is destroyed.
+pub struct ShmLease {
+    offset: u64,
+    len: u64,
+    reclaimer: Arc<Mutex<DsmReclaimer>>,
+}
+
+impl RefUnwindSafe for ShmLease {}
+
+impl Drop for ShmLease {
+    fn drop(&mut self) {
+        self.reclaimer.lock().mark_freed(self.offset, self.len);
+    }
+}
+
+#[derive(Default)]
+struct StreamState {
+    queue: VecDeque<Buffer>,
+}
+
+/// A demultiplexer for reading multiple logical streams from a single DSM ring buffer.
+pub struct MultiplexedDsmReader {
+    adapter: DsmReadAdapter,
+    reclaimer: Arc<Mutex<DsmReclaimer>>,
+    local_read_pos: u64,
+    streams: HashMap<PhysicalStreamId, StreamState>,
+    /// State for the current message being read from the physical DSM.
+    partial_header: Vec<u8>,
+    partial_payload: Option<(PhysicalStreamId, Vec<u8>, usize)>,
+    /// Writer for the control channel (Reader -> Writer).
+    control_writer: Option<DsmWriteAdapter>,
+    /// Bridge for signaling/waiting.
+    bridge: Arc<SignalBridge>,
+    /// Index of the remote participant (writer).
+    remote_id: ParticipantId,
+}
+
+unsafe impl Send for MultiplexedDsmReader {}
+unsafe impl Sync for MultiplexedDsmReader {}
+
+impl std::fmt::Debug for MultiplexedDsmReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiplexedDsmReader")
+            .field("remote_id", &self.remote_id)
+            .field("active_streams", &self.streams.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl MultiplexedDsmReader {
+    /// Creates a new multiplexed reader.
+    ///
+    /// If `control_offset` is non-zero in the header, it also initializes a writer
+    /// for the reverse control channel to send stream cancellation signals.
+    pub fn new(
+        base_ptr: *mut u8,
+        data_capacity: usize,
+        control_capacity: usize,
+        bridge: Arc<SignalBridge>,
+        remote_id: ParticipantId,
+    ) -> Self {
+        let header = base_ptr as *mut TransportHeader;
+        let data = unsafe { base_ptr.add(std::mem::size_of::<TransportHeader>()) };
+
+        unsafe {
+            if (*header).ring.magic != DSM_MAGIC {
+                pgrx::warning!(
+                    "MultiplexedDsmReader::new: Invalid magic number in header: {:x}",
+                    (*header).ring.magic
+                );
+            }
+        }
+
+        let control_writer = unsafe {
+            let offset = (*header).control_offset;
+            if offset > 0 {
+                // Sanity check control offset
+                if offset < std::mem::size_of::<TransportHeader>() {
+                    pgrx::warning!(
+                        "MultiplexedDsmReader::new: Invalid control_offset {} (too small)",
+                        offset
+                    );
+                }
+
+                // Calculate pointer to control block
+                let control_ptr = base_ptr.add(offset);
+                let control_header = control_ptr as *mut RingBufferHeader;
+                let control_data = control_ptr.add(std::mem::size_of::<RingBufferHeader>());
+                let control_len = control_capacity;
+
+                Some(DsmWriteAdapter::new(
+                    control_header,
+                    control_data,
+                    control_len,
+                ))
+            } else {
+                None
+            }
+        };
+
+        let adapter = unsafe { DsmReadAdapter::new(&mut (*header).ring, data, data_capacity) };
+
+        let reclaimer = Arc::new(Mutex::new(DsmReclaimer::new(
+            unsafe { &mut (*header).ring },
+            bridge.clone(),
+            remote_id,
+        )));
+        let local_read_pos = unsafe { (*header).ring.read_pos.load(Ordering::Acquire) };
+
+        Self {
+            adapter,
+            reclaimer,
+            local_read_pos,
+            streams: HashMap::default(),
+            partial_header: Vec::with_capacity(8),
+            partial_payload: None,
+            control_writer,
+            bridge,
+            remote_id,
+        }
+    }
+
+    /// Marks the transport as detached, preventing further access to shared memory metadata.
+    /// This should be called before the underlying DSM segment is unmapped.
+    pub fn detach(&self) {
+        self.reclaimer.lock().detach();
+    }
+
+    pub fn memory_region(&self) -> (usize, usize) {
+        self.adapter.memory_region()
+    }
+
+    /// Reads from the physical DSM buffer and dispatches messages to stream-specific
+    /// buffers until a message for the requested `stream_id` is found.
+    ///
+    /// This handles the demultiplexing of the physical pipe.
+    /// Returns `Ok(Some(Vec<u8>))` for a message, `Ok(None)` for End-of-Stream (EOS),
+    /// or `ErrorKind::WouldBlock` if no data is available in the physical buffer.
+    ///
+    /// # Arguments
+    /// * `force_copy` - If true, disables the Zero-Copy optimization and forces a copy into
+    ///   a local `Vec<u8>`. This is used for sanitization to break shared memory dependencies.
+    pub(super) fn read_for_stream(
+        &mut self,
+        stream_id: PhysicalStreamId,
+        force_copy: bool,
+    ) -> std::io::Result<Option<Buffer>> {
+        let state = self.streams.entry(stream_id).or_default();
+        if let Some(payload) = state.queue.pop_front() {
+            if payload.is_empty() {
+                // EOS marker from queue
+                return Ok(None);
+            }
+            return Ok(Some(payload));
+        }
+
+        // Fallback to reading loop
+        loop {
+            let write_pos = self.adapter.write_pos();
+            let available = write_pos.wrapping_sub(self.local_read_pos) as usize;
+
+            // Check for finished only if no data available
+            if available == 0 {
+                if self.adapter.is_finished() {
+                    return Ok(None);
+                }
+                return Err(std::io::Error::from(ErrorKind::WouldBlock));
+            }
+
+            // Read header if needed
+            if self.partial_payload.is_none() {
+                if self.partial_header.len() < 8 {
+                    let needed = 8 - self.partial_header.len();
+                    let to_read = std::cmp::min(needed, available);
+
+                    let mut chunk = vec![0u8; to_read];
+                    self.adapter.copy_at(self.local_read_pos, &mut chunk);
+
+                    self.partial_header.extend_from_slice(&chunk);
+
+                    // Mark freed immediately (simulating copy behavior)
+                    let start_pos = self.local_read_pos;
+                    self.local_read_pos += to_read as u64;
+                    self.reclaimer.lock().mark_freed(start_pos, to_read as u64);
+
+                    if self.partial_header.len() < 8 {
+                        // Not enough data yet
+                        continue;
+                    }
+                }
+
+                let msg_stream_id = PhysicalStreamId(u32::from_le_bytes(
+                    self.partial_header[0..4].try_into().unwrap(),
+                ));
+                let msg_len = u32::from_le_bytes(self.partial_header[4..8].try_into().unwrap());
+
+                // Calculate total length including padding for 8-byte alignment
+                let padding = (8 - (msg_len % 8)) % 8;
+                let total_len = (msg_len + padding) as usize;
+
+                // Header consumed, clear it
+                self.partial_header.clear();
+
+                // ZERO-COPY OPPORTUNITY
+                // Check if contiguous and fully available
+                let cap = self.adapter.capacity();
+                let offset = (self.local_read_pos % cap as u64) as usize;
+                let contiguous = cap - offset;
+
+                // Refresh available because we consumed header
+                let write_pos = self.adapter.write_pos();
+                let available = write_pos.wrapping_sub(self.local_read_pos) as usize;
+
+                if !force_copy && total_len <= contiguous && total_len <= available {
+                    // ZERO-COPY PATH
+                    let lease = Arc::new(ShmLease {
+                        offset: self.local_read_pos,
+                        len: total_len as u64,
+                        reclaimer: self.reclaimer.clone(),
+                    });
+
+                    let ptr = unsafe { self.adapter.data_ptr().add(offset) };
+                    let ptr = NonNull::new(ptr).unwrap();
+
+                    // Create Buffer from custom allocation
+                    let buffer =
+                        unsafe { Buffer::from_custom_allocation(ptr, msg_len as usize, lease) };
+
+                    self.local_read_pos += total_len as u64;
+
+                    if msg_stream_id == stream_id {
+                        if buffer.is_empty() {
+                            return Ok(None);
+                        }
+                        return Ok(Some(buffer));
+                    } else {
+                        self.streams
+                            .entry(msg_stream_id)
+                            .or_default()
+                            .queue
+                            .push_back(buffer);
+                        continue;
+                    }
+                } else {
+                    self.partial_payload = Some((
+                        msg_stream_id,
+                        Vec::with_capacity(total_len),
+                        msg_len as usize,
+                    ));
+                }
+            }
+
+            // Read payload
+            if let Some((_, ref mut payload, msg_len)) = self.partial_payload {
+                let padding = (8 - (msg_len % 8)) % 8;
+                let total_len = msg_len + padding;
+
+                let current_len = payload.len();
+                if current_len < total_len {
+                    let needed = total_len - current_len;
+                    // Re-calculate available because we might have consumed some for header
+                    let write_pos = self.adapter.write_pos();
+                    let available = write_pos.wrapping_sub(self.local_read_pos) as usize;
+
+                    if available == 0 {
+                        if self.adapter.is_finished() {
+                            return Err(std::io::Error::other(
+                                "Unexpected EOF while reading payload",
+                            ));
+                        }
+                        return Err(std::io::Error::from(ErrorKind::WouldBlock));
+                    }
+
+                    let to_read = std::cmp::min(needed, available);
+                    let mut chunk = vec![0u8; to_read];
+                    self.adapter.copy_at(self.local_read_pos, &mut chunk);
+
+                    payload.extend_from_slice(&chunk);
+
+                    let start_pos = self.local_read_pos;
+                    self.local_read_pos += to_read as u64;
+                    self.reclaimer.lock().mark_freed(start_pos, to_read as u64);
+
+                    if payload.len() < total_len {
+                        continue;
+                    }
+                }
+
+                // Dispatch completed message
+                let (id, mut completed_payload, logical_len) = self.partial_payload.take().unwrap();
+
+                // Truncate padding to restore original logical message
+                completed_payload.truncate(logical_len);
+                let buffer = Buffer::from(completed_payload);
+
+                if id == stream_id {
+                    if buffer.is_empty() {
+                        return Ok(None); // EOS
+                    }
+                    return Ok(Some(buffer));
+                } else {
+                    self.streams.entry(id).or_default().queue.push_back(buffer);
+                }
+            }
+        }
+    }
+    fn send_control_message(
+        &mut self,
+        msg_type: u8,
+        stream_id: PhysicalStreamId,
+    ) -> std::io::Result<()> {
+        if let Some(writer) = &mut self.control_writer {
+            if writer.available_space() < 5 {
+                return Err(std::io::Error::from(ErrorKind::WouldBlock));
+            }
+            writer.write_all(&[msg_type])?;
+            writer.write_all(&stream_id.to_le_bytes())?;
+            // Signal the writer (remote_id) to check control messages
+            let _ = self.bridge.signal(self.remote_id);
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Signals the writer to start producing data for a stream.
+    pub(super) fn start_stream(&mut self, stream_id: PhysicalStreamId) -> std::io::Result<()> {
+        self.send_control_message(0, stream_id)
+    }
+
+    /// Cancels a stream by writing its ID to the control channel.
+    pub(super) fn cancel_stream(&mut self, stream_id: PhysicalStreamId) -> std::io::Result<()> {
+        self.send_control_message(1, stream_id)
+    }
+
+    /// Sends a variable-length control message.
+    /// Format: [type: u8 (>= 128)][len: u32][payload: len bytes]
+    pub fn send_control_message_variable(
+        &mut self,
+        msg_type: u8,
+        payload: &[u8],
+    ) -> std::io::Result<()> {
+        if msg_type < 128 {
+            return Err(std::io::Error::other(
+                "Variable message type must be >= 128",
+            ));
+        }
+        if let Some(writer) = &mut self.control_writer {
+            let len = payload.len() as u32;
+            let total_len = 1 + 4 + len as usize;
+            if writer.available_space() < total_len {
+                return Err(std::io::Error::from(ErrorKind::WouldBlock));
+            }
+            writer.write_all(&[msg_type])?;
+            writer.write_all(&len.to_le_bytes())?;
+            writer.write_all(payload)?;
+            // Signal the writer (remote_id) to check control messages
+            let _ = self.bridge.signal(self.remote_id);
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Async version of `read_for_stream` that registers the current task's waker
+    /// with the bridge if data is not yet available.
+    pub(super) fn poll_read_for_stream(
+        &mut self,
+        stream_id: PhysicalStreamId,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<Option<Buffer>>> {
+        // Register waker FIRST to avoid race condition where data arrives
+        // between read attempt and registration.
+        self.bridge
+            .register_waker(cx.waker().clone(), Some(self.remote_id));
+
+        match self.read_for_stream(stream_id, false) {
+            Ok(Some(msg)) => std::task::Poll::Ready(Ok(Some(msg))),
+            Ok(None) => std::task::Poll::Ready(Ok(None)),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => std::task::Poll::Pending,
+            Err(e) => std::task::Poll::Ready(Err(e)),
+        }
+    }
+
+    /// Async version of `read_for_stream` that forces a copy of the data.
+    pub(super) fn poll_read_for_stream_copying(
+        &mut self,
+        stream_id: PhysicalStreamId,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<Option<Buffer>>> {
+        self.bridge
+            .register_waker(cx.waker().clone(), Some(self.remote_id));
+
+        match self.read_for_stream(stream_id, true) {
+            Ok(Some(msg)) => std::task::Poll::Ready(Ok(Some(msg))),
+            Ok(None) => std::task::Poll::Ready(Ok(None)),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => std::task::Poll::Pending,
+            Err(e) => std::task::Poll::Ready(Err(e)),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+pub mod test_utils {
+    use super::*;
+
+    // Helper to create a dummy header and data buffer
+    pub struct TestBuffer {
+        _storage: Vec<u64>,
+        pub base_ptr: *mut u8,
+        pub capacity: usize,
+    }
+
+    impl TestBuffer {
+        pub fn new(capacity: usize) -> Self {
+            let control_capacity = 65536;
+            let layout = TransportLayout::new(capacity, control_capacity);
+            let total_size = layout.total_size();
+
+            // Align size to 8 bytes (u64)
+            let u64_count = total_size.div_ceil(8);
+            let mut storage = vec![0u64; u64_count];
+
+            let base_ptr = storage.as_mut_ptr() as *mut u8;
+
+            unsafe {
+                layout.init(base_ptr);
+            }
+
+            Self {
+                _storage: storage,
+                base_ptr,
+                capacity,
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::test_utils::TestBuffer;
+    use super::*;
+    use std::sync::Arc;
+
+    fn create_dummy_bridge() -> Arc<SignalBridge> {
+        SignalBridge::new_dummy()
+    }
+
+    #[pgrx::pg_test]
+    fn test_basic_read_write() {
+        let buf = TestBuffer::new(1024);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        let payload = b"Hello World";
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), payload)
+            .unwrap();
+
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), payload);
+    }
+
+    #[pgrx::pg_test]
+    fn test_multiplexing() {
+        let buf = TestBuffer::new(1024);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), b"Stream1-A")
+            .unwrap();
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(2), b"Stream2-A")
+            .unwrap();
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), b"Stream1-B")
+            .unwrap();
+
+        // Read Stream 1
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), b"Stream1-A");
+
+        // Read Stream 2
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(2), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), b"Stream2-A");
+
+        // Read Stream 1 again
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), b"Stream1-B");
+    }
+
+    #[pgrx::pg_test]
+    fn test_buffer_wrap_around() {
+        // Create a small buffer to force wrap-around
+        let buf = TestBuffer::new(32); // 32 bytes data capacity
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        // Frame overhead is 8 bytes (4 stream_id + 4 len).
+        // Max payload in one message is 32 - 8 = 24 bytes (but limited by available space check logic)
+
+        // Write some initial data to advance the pointer
+        let msg1 = vec![1u8; 10];
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), &msg1)
+            .unwrap();
+
+        // Read it back to clear space but advance read_pos
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.len(), 10);
+        drop(msg); // Free space
+
+        // Now write enough to wrap around
+        // Buffer size 32.
+        // Written: 8 + 10 = 18 bytes.
+        // Available: 32 (since we read it).
+        // Write Pos: 18.
+        // We write 20 bytes payload. Total 28 bytes.
+        // 18 + 28 = 46. 46 % 32 = 14.
+        // Should wrap.
+
+        let msg2 = vec![2u8; 20];
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), &msg2)
+            .unwrap();
+
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), msg2);
+    }
+
+    #[pgrx::pg_test]
+    fn test_buffer_full() {
+        let buf = TestBuffer::new(50);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        // Frame overhead 8 bytes.
+        // Write 40 bytes payload. Total 48.
+        let msg1 = vec![1u8; 40];
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), &msg1)
+            .unwrap();
+
+        // Try to write another message. even small one.
+        // Overhead 8 bytes -> requires 8 bytes at least.
+        let msg2 = vec![2u8; 1];
+        let res = writer_mux.lock().write_message(PhysicalStreamId(1), &msg2);
+
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::WouldBlock);
+
+        // Read to free up space
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert!(!msg.is_empty());
+        drop(msg); // Drop lease to free space!
+
+        // Now write should succeed
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), &msg2)
+            .unwrap();
+
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), msg2);
+    }
+
+    #[pgrx::pg_test]
+    fn test_message_too_large() {
+        let buf = TestBuffer::new(100);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(1),
+        )));
+
+        let msg = vec![0u8; 200];
+        let res = writer_mux.lock().write_message(PhysicalStreamId(1), &msg);
+
+        assert!(res.is_err());
+        // Custom error message check
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("exceeds ring buffer capacity"));
+    }
+
+    #[pgrx::pg_test]
+    fn test_finish_flag() {
+        let buf = TestBuffer::new(1024);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        writer_mux
+            .lock()
+            .write_message(PhysicalStreamId(1), b"data")
+            .unwrap();
+
+        writer_mux.lock().finish().unwrap();
+
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.as_slice(), b"data");
+
+        // Next read should see EOF (None) because finished is set
+        let msg = reader_mux
+            .lock()
+            .read_for_stream(PhysicalStreamId(1), false)
+            .unwrap();
+        assert!(msg.is_none());
+    }
+
+    #[pgrx::pg_test]
+    fn test_signal_bridge() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let uuid = uuid::Uuid::new_v4();
+            let bridge1 = SignalBridge::new(ParticipantId(1), uuid).await.unwrap();
+            let _bridge2 = SignalBridge::new(ParticipantId(2), uuid).await.unwrap();
+
+            // Bridge 1 signals Bridge 2
+            // We can't verify reception easily without messing with the bridge internals or blocking,
+            // but we can verify it doesn't error.
+            bridge1.signal(ParticipantId(2)).unwrap();
+            bridge1.signal(ParticipantId(1)).unwrap(); // Should be no-op or ok
+        });
+    }
+
+    #[pgrx::pg_test]
+    fn test_variable_control_message() {
+        let buf = TestBuffer::new(1024);
+        let bridge = create_dummy_bridge();
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge.clone(),
+            ParticipantId(1),
+        )));
+        let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+            buf.base_ptr,
+            buf.capacity,
+            65536,
+            bridge,
+            ParticipantId(0),
+        )));
+
+        // Send variable length message
+        let payload = vec![1u8, 2, 3, 4, 5];
+        reader_mux
+            .lock()
+            .send_control_message_variable(128, &payload)
+            .unwrap();
+
+        let frame = writer_mux.lock().read_control_frame();
+        assert!(frame.is_some());
+        let (msg_type, payload_out) = frame.unwrap();
+        assert_eq!(msg_type, 128);
+        assert_eq!(payload_out, payload);
+    }
+
+    use crate::launch_parallel_process;
+    use crate::parallel_worker::mqueue::MessageQueueSender;
+    use crate::parallel_worker::{
+        ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
+        WorkerStyle,
+    };
+    use crate::postgres::locks::Spinlock;
+    use std::task::Poll;
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct DsmStreamTestState {
+        pub mutex: Spinlock,
+        pub nlaunched: usize,
+    }
+
+    impl ParallelStateType for DsmStreamTestState {}
+
+    impl DsmStreamTestState {
+        pub fn set_launched_workers(&mut self, nlaunched: usize) {
+            let _lock = self.mutex.acquire();
+            self.nlaunched = nlaunched;
+        }
+
+        pub fn launched_workers(&mut self) -> usize {
+            let _lock = self.mutex.acquire();
+            self.nlaunched
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct DsmStreamTestConfig {
+        pub total_participants: usize,
+        pub session_id: uuid::Bytes,
+        pub buffer_size: usize,
+        pub num_messages: usize,
+        pub msg_size: usize,
+    }
+
+    impl ParallelStateType for DsmStreamTestConfig {}
+
+    pub struct DsmStreamTestProcess {
+        pub state: DsmStreamTestState,
+        pub config: DsmStreamTestConfig,
+        pub ring_buffer_region: Vec<u8>,
+    }
+
+    impl DsmStreamTestProcess {
+        pub fn new(
+            total_participants: usize,
+            buffer_size: usize,
+            num_messages: usize,
+            msg_size: usize,
+        ) -> Self {
+            let session_id = uuid::Uuid::new_v4();
+            let control_capacity = 65536;
+            let layout = TransportLayout::new(buffer_size, control_capacity);
+            let total_size = layout.total_size();
+
+            let mut region = vec![0u8; total_size];
+            unsafe {
+                layout.init(region.as_mut_ptr());
+            }
+
+            Self {
+                state: DsmStreamTestState {
+                    mutex: Spinlock::default(),
+                    nlaunched: 0,
+                },
+                config: DsmStreamTestConfig {
+                    total_participants,
+                    session_id: *session_id.as_bytes(),
+                    buffer_size,
+                    num_messages,
+                    msg_size,
+                },
+                ring_buffer_region: region,
+            }
+        }
+    }
+
+    impl ParallelProcess for DsmStreamTestProcess {
+        fn state_values(&self) -> Vec<&dyn ParallelState> {
+            vec![&self.state, &self.config, &self.ring_buffer_region]
+        }
+    }
+
+    pub struct DsmStreamTestWorker<'a> {
+        pub state: &'a mut DsmStreamTestState,
+        pub config: DsmStreamTestConfig,
+        base_ptr: *mut u8,
+    }
+
+    impl ParallelWorker for DsmStreamTestWorker<'_> {
+        fn new_parallel_worker(state_manager: ParallelStateManager) -> Self {
+            let state = state_manager
+                .object::<DsmStreamTestState>(0)
+                .unwrap()
+                .unwrap();
+            let config = state_manager
+                .object::<DsmStreamTestConfig>(1)
+                .unwrap()
+                .unwrap();
+
+            // Buffer is at index 2
+            let ring_buffer_slice = state_manager.slice::<u8>(2).unwrap().unwrap();
+            let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+            Self {
+                state,
+                config: *config,
+                base_ptr,
+            }
+        }
+
+        fn run(self, _mq_sender: &MessageQueueSender, worker_number: i32) -> anyhow::Result<()> {
+            // Worker number is 0-based; leader (not a worker) would be -1.
+            // Participant index: leader=0, worker0=1, worker1=2, etc.
+            let participant_index = (worker_number + 1) as usize;
+            let participant_id = ParticipantId(participant_index as u16);
+
+            // Signal readiness
+            let current = self.state.launched_workers();
+            self.state.set_launched_workers(current + 1);
+
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let session_id = uuid::Uuid::from_bytes(self.config.session_id);
+            let bridge = runtime
+                .block_on(SignalBridge::new(participant_id, session_id))
+                .unwrap();
+            let bridge = Arc::new(bridge);
+
+            let reader_mux = Arc::new(Mutex::new(MultiplexedDsmReader::new(
+                self.base_ptr,
+                self.config.buffer_size,
+                65536,
+                bridge.clone(),
+                ParticipantId(0), // Remote is leader (0)
+            )));
+
+            let mut received_bytes = 0;
+            let total_bytes = self.config.num_messages * self.config.msg_size;
+
+            runtime.block_on(async {
+                loop {
+                    let res = futures::future::poll_fn(|cx| {
+                        match reader_mux
+                            .lock()
+                            .poll_read_for_stream(PhysicalStreamId(1), cx)
+                        {
+                            Poll::Ready(Ok(Some(vec))) => Poll::Ready(Ok(Some(vec))),
+                            Poll::Ready(Ok(None)) => Poll::Ready(Ok(None)),
+                            Poll::Pending => Poll::Pending,
+                            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                        }
+                    })
+                    .await;
+
+                    match res {
+                        Ok(None) => {
+                            // If we finished reading everything, break.
+                            if received_bytes >= total_bytes {
+                                break;
+                            }
+                            break;
+                        }
+                        Ok(Some(vec)) => {
+                            received_bytes += vec.len();
+                            if received_bytes >= total_bytes {
+                                break;
+                            }
+                        }
+                        Err(e) => panic!("Read error: {}", e),
+                    }
+                }
+            });
+
+            assert_eq!(received_bytes, total_bytes);
+            Ok(())
+        }
+    }
+
+    #[pgrx::pg_test]
+    fn test_concurrent_throughput_multi_process() {
+        let total_participants = 2; // Leader + 1 Worker
+        let buffer_size = 4096;
+        let num_messages = 1000;
+        let msg_size = 128;
+
+        let process =
+            DsmStreamTestProcess::new(total_participants, buffer_size, num_messages, msg_size);
+        let session_id_bytes = process.config.session_id;
+
+        let mut launched = launch_parallel_process!(
+            DsmStreamTestProcess<DsmStreamTestWorker>,
+            process,
+            WorkerStyle::Query,
+            1, // 1 worker
+            16384
+        )
+        .expect("Failed to launch parallel process");
+
+        let state = launched
+            .state_manager_mut()
+            .object::<DsmStreamTestState>(0)
+            .unwrap()
+            .unwrap();
+        state.set_launched_workers(1); // Leader counts as 1
+
+        // Wait for worker to launch
+        while state.launched_workers() < total_participants {
+            pgrx::check_for_interrupts!();
+            std::thread::yield_now();
+        }
+
+        // Leader (Producer) Logic
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let session_id = uuid::Uuid::from_bytes(session_id_bytes);
+        let bridge = runtime
+            .block_on(SignalBridge::new(ParticipantId(0), session_id))
+            .unwrap();
+        let bridge = Arc::new(bridge);
+
+        let ring_buffer_slice = launched.state_manager().slice::<u8>(2).unwrap().unwrap();
+        let base_ptr = ring_buffer_slice.as_ptr() as *mut u8;
+
+        let writer_mux = Arc::new(Mutex::new(MultiplexedDsmWriter::new(
+            base_ptr,
+            buffer_size,
+            65536,
+            bridge.clone(),
+            ParticipantId(1), // Remote is worker (1)
+        )));
+        let msg = vec![1u8; msg_size];
+
+        runtime.block_on(async {
+            for _ in 0..num_messages {
+                futures::future::poll_fn(|cx| {
+                    bridge.register_waker(cx.waker().clone(), None);
+                    match writer_mux.lock().write_message(PhysicalStreamId(1), &msg) {
+                        Ok(_) => Poll::Ready(Ok(())),
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => Poll::Pending,
+                        Err(e) => Poll::Ready(Err(e)),
+                    }
+                })
+                .await
+                .unwrap_or_else(|e| panic!("Producer flush failed: {}", e));
+            }
+
+            // Finish
+            writer_mux.lock().finish().unwrap();
+        });
+
+        // Wait for worker to finish
+        for _ in launched {}
+    }
+}

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -372,6 +372,90 @@ pub fn deserialize_logical_plan(
     )
 }
 
+/// Physical plan extension codec for MPP (plan partitioning) serialization.
+///
+/// Handles serialization/deserialization of custom physical plan nodes
+/// (`DsmExchangeExec`, `DsmSanitizeExec`) across process boundaries.
+/// Workers use this codec to reconstruct the execution plan after receiving
+/// it from the leader.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub struct PgSearchPhysicalCodec;
+
+#[allow(dead_code)]
+impl PgSearchPhysicalCodec {
+    // Tag bytes for identifying custom physical plan nodes.
+    const TAG_DSM_EXCHANGE: u8 = 1;
+    const TAG_DSM_SANITIZE: u8 = 2;
+}
+
+impl datafusion_proto::physical_plan::PhysicalExtensionCodec for PgSearchPhysicalCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn datafusion::physical_plan::ExecutionPlan>],
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+        if buf.is_empty() {
+            return Err(DataFusionError::Internal(
+                "Empty buffer for physical extension decode".into(),
+            ));
+        }
+
+        let tag = buf[0];
+        match tag {
+            Self::TAG_DSM_EXCHANGE => {
+                // TODO(#4152): Deserialize DsmExchangeConfig and partitioning from buf[1..],
+                // reconstruct DsmExchangeExec, and register stream sources.
+                Err(DataFusionError::NotImplemented(
+                    "DsmExchangeExec physical deserialization not yet implemented".into(),
+                ))
+            }
+            Self::TAG_DSM_SANITIZE => {
+                if inputs.len() != 1 {
+                    return Err(DataFusionError::Internal(
+                        "DsmSanitizeExec requires exactly one input".into(),
+                    ));
+                }
+                Ok(Arc::new(
+                    crate::postgres::customscan::joinscan::sanitize::DsmSanitizeExec::new(
+                        inputs[0].clone(),
+                    ),
+                ))
+            }
+            _ => Err(DataFusionError::Internal(format!(
+                "Unknown physical extension tag: {tag}"
+            ))),
+        }
+    }
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        if node
+            .as_any()
+            .is::<crate::postgres::customscan::joinscan::exchange::DsmExchangeExec>()
+        {
+            buf.push(Self::TAG_DSM_EXCHANGE);
+            // TODO(#4152): Serialize DsmExchangeConfig and partitioning expressions.
+            Ok(())
+        } else if node
+            .as_any()
+            .is::<crate::postgres::customscan::joinscan::sanitize::DsmSanitizeExec>()
+        {
+            buf.push(Self::TAG_DSM_SANITIZE);
+            Ok(())
+        } else {
+            Err(DataFusionError::Internal(format!(
+                "Unknown physical plan node for PgSearchPhysicalCodec: {}",
+                node.name()
+            )))
+        }
+    }
+}
+
 /// Deserializes a DataFusion `LogicalPlan` using a codec populated with the
 /// runtime state required by execution.
 pub fn deserialize_logical_plan_with_runtime(

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -53,12 +53,11 @@ use datafusion::physical_plan::{
 };
 use futures::Stream;
 
-use crate::index::fast_fields_helper::{FFHelper, WhichFastField};
+use crate::index::fast_fields_helper::FFHelper;
 use crate::postgres::customscan::explain::ExplainFormat;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
 use crate::query::SearchQueryInput;
-use crate::scan::info::ScanInfo;
 use crate::scan::late_materialization::DeferredField;
 use crate::scan::pre_filter::{collect_filters, PreFilter};
 use crate::scan::Scanner;
@@ -122,12 +121,6 @@ pub struct PgSearchScanPlan {
     pub indexrelid: u32,
     /// The JoinScan source identity when visibility is deferred.
     deferred_ctid_plan_position: Option<usize>,
-    /// Scan metadata carried through physical plan for MPP serialization.
-    /// `None` for BaseScan (single-table scans); `Some` for JoinScan sources
-    /// so the codec can reconstruct the plan on parallel workers.
-    pub scan_info: Option<ScanInfo>,
-    /// Fast field specification carried through physical plan for MPP serialization.
-    pub fields: Option<Vec<WhichFastField>>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -200,17 +193,7 @@ impl PgSearchScanPlan {
             ffhelper,
             indexrelid,
             deferred_ctid_plan_position,
-            scan_info: None,
-            fields: None,
         }
-    }
-
-    /// Attach scan metadata for MPP physical plan serialization.
-    #[allow(dead_code)]
-    pub fn with_scan_info(mut self, scan_info: ScanInfo, fields: Vec<WhichFastField>) -> Self {
-        self.scan_info = Some(scan_info);
-        self.fields = Some(fields);
-        self
     }
 
     pub fn has_deferred_fields(&self) -> bool {
@@ -482,8 +465,6 @@ impl ExecutionPlan for PgSearchScanPlan {
                 ffhelper: self.ffhelper.clone(),
                 indexrelid: self.indexrelid,
                 deferred_ctid_plan_position: self.deferred_ctid_plan_position,
-                scan_info: self.scan_info.clone(),
-                fields: self.fields.clone(),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -53,11 +53,12 @@ use datafusion::physical_plan::{
 };
 use futures::Stream;
 
-use crate::index::fast_fields_helper::FFHelper;
+use crate::index::fast_fields_helper::{FFHelper, WhichFastField};
 use crate::postgres::customscan::explain::ExplainFormat;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
 use crate::query::SearchQueryInput;
+use crate::scan::info::ScanInfo;
 use crate::scan::late_materialization::DeferredField;
 use crate::scan::pre_filter::{collect_filters, PreFilter};
 use crate::scan::Scanner;
@@ -121,6 +122,12 @@ pub struct PgSearchScanPlan {
     pub indexrelid: u32,
     /// The JoinScan source identity when visibility is deferred.
     deferred_ctid_plan_position: Option<usize>,
+    /// Scan metadata carried through physical plan for MPP serialization.
+    /// `None` for BaseScan (single-table scans); `Some` for JoinScan sources
+    /// so the codec can reconstruct the plan on parallel workers.
+    pub scan_info: Option<ScanInfo>,
+    /// Fast field specification carried through physical plan for MPP serialization.
+    pub fields: Option<Vec<WhichFastField>>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -193,7 +200,17 @@ impl PgSearchScanPlan {
             ffhelper,
             indexrelid,
             deferred_ctid_plan_position,
+            scan_info: None,
+            fields: None,
         }
+    }
+
+    /// Attach scan metadata for MPP physical plan serialization.
+    #[allow(dead_code)]
+    pub fn with_scan_info(mut self, scan_info: ScanInfo, fields: Vec<WhichFastField>) -> Self {
+        self.scan_info = Some(scan_info);
+        self.fields = Some(fields);
+        self
     }
 
     pub fn has_deferred_fields(&self) -> bool {
@@ -465,6 +482,8 @@ impl ExecutionPlan for PgSearchScanPlan {
                 ffhelper: self.ffhelper.clone(),
                 indexrelid: self.indexrelid,
                 deferred_ctid_plan_position: self.deferred_ctid_plan_position,
+                scan_info: self.scan_info.clone(),
+                fields: self.fields.clone(),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -45,6 +45,47 @@ use crate::scan::Scanner;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// Configuration for MPP (plan partitioning) parallel execution.
+#[allow(dead_code)]
+///
+/// Stored in the DataFusion `SessionConfig` extensions so that each participant
+/// knows its index and the total number of participants. Used by
+/// `PgSearchTableProvider` to slice segments and by `EnforceDsmShuffle` to
+/// determine the exchange topology.
+#[derive(Debug, Clone)]
+pub struct MppParticipantConfig {
+    /// 0-based index of this participant (leader=0, worker1=1, ...).
+    pub index: usize,
+    /// Total number of participants (leader + workers).
+    pub total_participants: usize,
+}
+
+impl datafusion::config::ConfigExtension for MppParticipantConfig {
+    const PREFIX: &'static str = "paradedb_mpp";
+}
+
+impl datafusion::config::ExtensionOptions for MppParticipantConfig {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn cloned(&self) -> Box<dyn datafusion::config::ExtensionOptions> {
+        Box::new(self.clone())
+    }
+
+    fn set(&mut self, _key: &str, _value: &str) -> datafusion::common::Result<()> {
+        Ok(())
+    }
+
+    fn entries(&self) -> Vec<datafusion::config::ConfigEntry> {
+        vec![]
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VisibilitySourceMetadata {
     pub plan_position: usize,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4152 (partial — infrastructure only; end-to-end wiring in follow-up)

## What

Ports the MPP (Massively Parallel Processing) plan partitioning infrastructure for JoinScan from @stuhood's draft PR #4184, rebased and adapted onto the current `main` branch.

This introduces a new parallel execution model where all tables in a join are hash-partitioned across workers and data is shuffled via shared memory exchange operators — replacing the current "broadcast join" strategy where only the largest table is partitioned and all others are fully replicated to every worker.

Key components added:
- **Transport layer** — shared memory ring buffers with multiplexed async byte streams, Arrow IPC serialization, and Unix Domain Socket signaling
- **`DsmExchangeExec`** — a DataFusion `ExecutionPlan` node that handles cross-process data shuffling at hash-repartition boundaries
- **`DsmSanitizeExec`** — deep-copy wrapper that prevents deadlocks when blocking operators (Sort, HashJoin) pin shared memory buffers
- **`EnforceDsmShuffle` / `EnforceSanitization`** — physical optimizer rules that inject the above operators into the plan
- **`parallel.rs`** — coordinated worker lifecycle using the `parallel_worker` framework, with plan broadcast and lazy RPC-style stream execution
- **`SessionContextProfile::JoinMpp`** — DataFusion session configuration for MPP mode with forced hash-join repartitioning
- **`PgSearchPhysicalCodec`** — physical plan serialization for cross-process plan distribution
- **`paradedb.enable_mpp_join` GUC** — feature gate (default: off) so existing behavior is unaffected

## Why

The current broadcast join strategy scales poorly: non-partitioned tables are fully scanned N times (once per worker). With 8-way parallelism, the MPP approach reduces total rows scanned by ~82% by ensuring each row is processed by exactly one worker. It also resolves the SEMI/ANTI join correctness issue where the preserved side must be the partitioned side, even when that forces a suboptimal partition choice.

## How

This is a manual port of #4184 (authored by @stuhood) onto the current codebase, which has diverged by 238 commits since the draft was created. The original branch couldn't be rebased directly due to 9+ conflicting files from extensive refactoring (RelNode tree IR, late materialization, deferred visibility, AggregateScan, DataFusion branch-53 upgrade, etc.).

Adaptations from the original:
- `PlanProperties` wrapped in `Arc` for DataFusion branch-53 API
- `ParallelWorker` trait adapted (1-param `new_parallel_worker`, `i32` worker number instead of newtype)
- `JoinRingBufferRegion` pre-initializes buffers to work with `as_bytes()` copy model (vs. draft's `initialize(dest)`)
- `PgSearchScanPlan` extended with `scan_info`/`fields` instead of adding a separate `MultiSegmentPlan`
- MPP optimizer rules injected through the existing `SessionContextProfile` system

The MPP execution path is gated behind `SET paradedb.enable_mpp_join = on` and a TODO in `exec_custom_scan` marks where the end-to-end wiring will connect `launch_join_workers()` to the execution pipeline. The existing broadcast-join path is completely unchanged.

## Tests

- Existing `join_basic`, `join_deferred_visibility`, and `partitioned_snippets` regression tests pass (broadcast-join path unaffected)
- `cargo check` and `cargo clippy` pass cleanly
- MPP path is not triggered by default (GUC is off), so no new regression tests yet — those will come with the end-to-end wiring in a follow-up