### PR TITLE
fix: suppress LIMIT pushdown when non-pushable post-filters

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -240,6 +240,7 @@ unsafe fn build_relnode_from_fromexpr(
             right,
             equi_keys: Vec::new(),
             filter: None,
+            subplan_id: None,
         }));
     }
 
@@ -394,6 +395,7 @@ unsafe fn build_join_node(
         right,
         equi_keys,
         filter: None,
+        subplan_id: None,
     })))
 }
 

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -457,6 +457,35 @@ unsafe fn maybe_limit_from_parse(root: *mut pg_sys::PlannerInfo) -> Option<f64> 
     }
 }
 
+/// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
+/// evaluated inside Tantivy — meaning Postgres will apply a post-filter
+/// above the scan. Pushing LIMIT into the scan in that case would cap
+/// the output before post-filtering, producing fewer rows than correct.
+unsafe fn has_non_pushable_predicates(
+    rel: *mut pg_sys::RelOptInfo,
+    quals_pushed: &Option<Qual>,
+) -> bool {
+    let restrict_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+
+    for ri in restrict_list.iter_ptr() {
+        let clause = (*ri).clause as *mut pg_sys::Node;
+        if pg_sys::contain_subplans(clause) {
+            return true;
+        }
+        if pg_sys::contain_volatile_functions(clause) {
+            return true;
+        }
+    }
+
+    // If qual extraction returned None but restrictions exist,
+    // something is being left as a post-filter.
+    if quals_pushed.is_none() && !restrict_list.is_empty() {
+        return true;
+    }
+
+    false
+}
+
 impl CustomScan for BaseScan {
     const NAME: &'static CStr = c"ParadeDB Base Scan";
 
@@ -658,18 +687,21 @@ impl CustomScan for BaseScan {
                     && where_clause_only_references_left(builder.args().root, rti);
 
                 if rel_is_single_or_partitioned || is_left_driven_lateral {
-                    // We can use the limit for estimates if:
-                    // a) we have a limit, and
-                    // b) we're either:
-                    //    * querying a single relation OR
-                    //    * querying partitions of a partitioned table OR
-                    //    * we're in a LEFT JOIN LATERAL where the left side drives the query
-                    Some((*builder.args().root).limit_tuples)
+                    if has_non_pushable_predicates(rel, &Some(quals.clone())) {
+                        None
+                    } else {
+                        Some((*builder.args().root).limit_tuples)
+                    }
                 } else {
                     None
                 }
             } else {
-                maybe_limit_from_parse(builder.args().root)
+                let raw = maybe_limit_from_parse(builder.args().root);
+                if raw.is_some() && has_non_pushable_predicates(rel, &Some(quals.clone())) {
+                    None
+                } else {
+                    raw
+                }
             };
 
             let limit = if let Some(l) = limit {

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -655,6 +655,14 @@ pub struct JoinNode {
     pub equi_keys: Vec<JoinKeyPair>,
     /// Any remaining non-equi join conditions.
     pub filter: Option<JoinLevelExpr>,
+    /// The `plan_id` of the PostgreSQL SubPlan that this join was extracted
+    /// from, if any.  Set for Semi/Anti/LeftMark joins created by
+    /// `wrap_with_semi_anti` and `wrap_with_mark_filter`; `None` for joins
+    /// that come from the normal join-hook path or path reconstruction.
+    /// Only used at plan time for the LIMIT pushdown safety check —
+    /// not needed after serialization.
+    #[serde(skip, default)]
+    pub subplan_id: Option<i32>,
 }
 
 /// A filter node in the relational plan tree.

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -659,9 +659,6 @@ pub struct JoinNode {
     /// from, if any.  Set for Semi/Anti/LeftMark joins created by
     /// `wrap_with_semi_anti` and `wrap_with_mark_filter`; `None` for joins
     /// that come from the normal join-hook path or path reconstruction.
-    /// Only used at plan time for the LIMIT pushdown safety check —
-    /// not needed after serialization.
-    #[serde(skip, default)]
     pub subplan_id: Option<i32>,
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -260,6 +260,138 @@ impl JoinDeclineReason {
     }
 }
 
+/// Recursively walk an expression tree and collect the `plan_id` of every
+/// `T_SubPlan` node found at any depth.  Uses Postgres's
+/// `expression_tree_walker` so it handles all node types automatically.
+unsafe fn collect_all_subplan_ids_from_expr(
+    node: *mut pg_sys::Node,
+    ids: &mut std::collections::HashSet<i32>,
+) {
+    if node.is_null() {
+        return;
+    }
+
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        context: *mut std::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+        if (*node).type_ == pg_sys::NodeTag::T_SubPlan {
+            let subplan = node as *mut pg_sys::SubPlan;
+            let ids = &mut *(context as *mut std::collections::HashSet<i32>);
+            ids.insert((*subplan).plan_id);
+        }
+        pg_sys::expression_tree_walker(node, Some(walker), context)
+    }
+
+    walker(
+        node,
+        ids as *mut std::collections::HashSet<i32> as *mut std::ffi::c_void,
+    );
+}
+
+/// Collect all SubPlan `plan_id`s present in `baserestrictinfo` of the
+/// given base relations.
+unsafe fn collect_all_subplan_ids_from_baserestrictinfo(
+    root: *mut pg_sys::PlannerInfo,
+    absorbed_rtis: &[pg_sys::Index],
+) -> std::collections::HashSet<i32> {
+    let mut all_ids = std::collections::HashSet::new();
+    for rti in absorbed_rtis {
+        let rel = pg_sys::find_base_rel(root, *rti as i32);
+        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+        for ri in ri_list.iter_ptr() {
+            let clause = (*ri).clause as *mut pg_sys::Node;
+            collect_all_subplan_ids_from_expr(clause, &mut all_ids);
+        }
+    }
+    all_ids
+}
+
+/// Collect the `plan_id`s of SubPlans that JoinScan absorbed into
+/// Semi/Anti/LeftMark join nodes in the `RelNode` tree.
+fn collect_absorbed_subplan_ids(plan: &RelNode) -> std::collections::HashSet<i32> {
+    let mut ids = std::collections::HashSet::new();
+    walk_relnode_for_subplan_ids(plan, &mut ids);
+    ids
+}
+
+fn walk_relnode_for_subplan_ids(node: &RelNode, ids: &mut std::collections::HashSet<i32>) {
+    match node {
+        RelNode::Join(j) => {
+            if let Some(plan_id) = j.subplan_id {
+                ids.insert(plan_id);
+            }
+            walk_relnode_for_subplan_ids(&j.left, ids);
+            walk_relnode_for_subplan_ids(&j.right, ids);
+        }
+        RelNode::Filter(f) => walk_relnode_for_subplan_ids(&f.input, ids),
+        RelNode::Scan(_) => {}
+    }
+}
+
+/// Check whether it is safe to push LIMIT into the JoinScan plan.
+///
+/// Returns `true` when ALL of:
+/// 1. JoinScan absorbed every base relation in the query (no outer
+///    relations that could add post-filters above JoinScan).
+/// 2. Every SubPlan in `baserestrictinfo` of absorbed relations was also
+///    absorbed into the `RelNode` tree (Semi/Anti/LeftMark joins).
+///    Un-absorbed SubPlans would become Postgres post-filters above
+///    the capped output.
+/// 3. No volatile functions in `baserestrictinfo` of absorbed relations
+///    (volatile functions can never be pushed into Tantivy).
+unsafe fn is_limit_pushdown_safe(
+    root: *mut pg_sys::PlannerInfo,
+    join_clause: &JoinCSClause,
+) -> bool {
+    let absorbed_rtis: Vec<pg_sys::Index> = join_clause
+        .plan
+        .sources()
+        .iter()
+        .map(|s| s.scan_info.heap_rti)
+        .collect();
+
+    // 1. Did JoinScan absorb ALL base relations?
+    #[cfg(feature = "pg15")]
+    let all_rels = (*root).all_baserels;
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    let all_rels = (*root).all_query_rels;
+
+    let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
+    for rti in &absorbed_rtis {
+        absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
+    }
+    if !pg_sys::bms_is_subset(all_rels, absorbed_bms) {
+        return false;
+    }
+
+    // 2. Every SubPlan in baserestrictinfo must have been absorbed.
+    let all_subplan_ids = collect_all_subplan_ids_from_baserestrictinfo(root, &absorbed_rtis);
+    let absorbed_subplan_ids = collect_absorbed_subplan_ids(&join_clause.plan);
+    for id in &all_subplan_ids {
+        if !absorbed_subplan_ids.contains(id) {
+            return false;
+        }
+    }
+
+    // 3. No volatile functions (these can never be absorbed).
+    for rti in &absorbed_rtis {
+        let rel = pg_sys::find_base_rel(root, *rti as i32);
+        let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
+        for ri in ri_list.iter_ptr() {
+            let clause = (*ri).clause as *mut pg_sys::Node;
+            if pg_sys::contain_volatile_functions(clause) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
 /// Try to create JoinScan `CustomPath`s for a single base relation that contains
 /// SubPlan-based join opportunities (e.g. `col IN (SELECT ...) OR col IS NULL`).
 ///
@@ -446,6 +578,26 @@ impl JoinScan {
                 );
             }
             join_clause = join_clause.with_forced_partitioning(0);
+        }
+
+        // Safety check: bail out if LIMIT pushdown is unsafe due to
+        // un-absorbed relations, un-absorbed SubPlans, or volatile functions.
+        if join_clause.limit_offset.limit.is_some() && !is_limit_pushdown_safe(root, &join_clause) {
+            let aliases: Vec<String> = join_clause
+                .plan
+                .sources()
+                .iter()
+                .map(|s| {
+                    RelationAlias::new(s.scan_info.alias.as_deref())
+                        .warning_context(s.scan_info.heaprelid)
+                })
+                .collect();
+            JoinScan::add_planner_warning(
+                "JoinScan not used: LIMIT pushdown unsafe (un-absorbed \
+                 relations, SubPlans, or volatile functions)",
+                &aliases,
+            );
+            return None;
         }
 
         Some((join_clause, limit_offset))
@@ -1590,6 +1742,7 @@ impl JoinScan {
             right: inner_node,
             equi_keys: join_conditions.equi_keys,
             filter: None,
+            subplan_id: None,
         }));
 
         let unsupported = plan.unsupported_join_types();

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -185,7 +185,8 @@ use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use futures::StreamExt;
-use pgrx::{pg_sys, PgList};
+use crate::api::HashSet;
+use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 
 #[derive(Default)]
@@ -265,12 +266,13 @@ impl JoinDeclineReason {
 /// `expression_tree_walker` so it handles all node types automatically.
 unsafe fn collect_all_subplan_ids_from_expr(
     node: *mut pg_sys::Node,
-    ids: &mut std::collections::HashSet<i32>,
+    ids: &mut HashSet<i32>,
 ) {
     if node.is_null() {
         return;
     }
 
+    #[pg_guard]
     unsafe extern "C-unwind" fn walker(
         node: *mut pg_sys::Node,
         context: *mut std::ffi::c_void,
@@ -280,7 +282,7 @@ unsafe fn collect_all_subplan_ids_from_expr(
         }
         if (*node).type_ == pg_sys::NodeTag::T_SubPlan {
             let subplan = node as *mut pg_sys::SubPlan;
-            let ids = &mut *(context as *mut std::collections::HashSet<i32>);
+            let ids = &mut *(context as *mut HashSet<i32>);
             ids.insert((*subplan).plan_id);
         }
         pg_sys::expression_tree_walker(node, Some(walker), context)
@@ -288,7 +290,7 @@ unsafe fn collect_all_subplan_ids_from_expr(
 
     walker(
         node,
-        ids as *mut std::collections::HashSet<i32> as *mut std::ffi::c_void,
+        ids as *mut HashSet<i32> as *mut std::ffi::c_void,
     );
 }
 
@@ -297,8 +299,8 @@ unsafe fn collect_all_subplan_ids_from_expr(
 unsafe fn collect_all_subplan_ids_from_baserestrictinfo(
     root: *mut pg_sys::PlannerInfo,
     absorbed_rtis: &[pg_sys::Index],
-) -> std::collections::HashSet<i32> {
-    let mut all_ids = std::collections::HashSet::new();
+) -> HashSet<i32> {
+    let mut all_ids = HashSet::default();
     for rti in absorbed_rtis {
         let rel = pg_sys::find_base_rel(root, *rti as i32);
         let ri_list = PgList::<pg_sys::RestrictInfo>::from_pg((*rel).baserestrictinfo);
@@ -312,13 +314,13 @@ unsafe fn collect_all_subplan_ids_from_baserestrictinfo(
 
 /// Collect the `plan_id`s of SubPlans that JoinScan absorbed into
 /// Semi/Anti/LeftMark join nodes in the `RelNode` tree.
-fn collect_absorbed_subplan_ids(plan: &RelNode) -> std::collections::HashSet<i32> {
-    let mut ids = std::collections::HashSet::new();
+fn collect_absorbed_subplan_ids(plan: &RelNode) -> HashSet<i32> {
+    let mut ids = HashSet::default();
     walk_relnode_for_subplan_ids(plan, &mut ids);
     ids
 }
 
-fn walk_relnode_for_subplan_ids(node: &RelNode, ids: &mut std::collections::HashSet<i32>) {
+fn walk_relnode_for_subplan_ids(node: &RelNode, ids: &mut HashSet<i32>) {
     match node {
         RelNode::Join(j) => {
             if let Some(plan_id) = j.subplan_id {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -163,6 +163,7 @@ use self::scan_state::{
     build_joinscan_logical_plan, build_physical_plan, build_task_context,
     create_datafusion_session_context, JoinScanState, SessionContextProfile,
 };
+use crate::api::HashSet;
 use crate::api::OrderByFeature;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
@@ -185,7 +186,6 @@ use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use futures::StreamExt;
-use crate::api::HashSet;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 
@@ -264,10 +264,7 @@ impl JoinDeclineReason {
 /// Recursively walk an expression tree and collect the `plan_id` of every
 /// `T_SubPlan` node found at any depth.  Uses Postgres's
 /// `expression_tree_walker` so it handles all node types automatically.
-unsafe fn collect_all_subplan_ids_from_expr(
-    node: *mut pg_sys::Node,
-    ids: &mut HashSet<i32>,
-) {
+unsafe fn collect_all_subplan_ids_from_expr(node: *mut pg_sys::Node, ids: &mut HashSet<i32>) {
     if node.is_null() {
         return;
     }
@@ -288,10 +285,7 @@ unsafe fn collect_all_subplan_ids_from_expr(
         pg_sys::expression_tree_walker(node, Some(walker), context)
     }
 
-    walker(
-        node,
-        ids as *mut HashSet<i32> as *mut std::ffi::c_void,
-    );
+    walker(node, ids as *mut HashSet<i32> as *mut std::ffi::c_void);
 }
 
 /// Collect all SubPlan `plan_id`s present in `baserestrictinfo` of the

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -374,6 +374,7 @@ unsafe fn wrap_with_semi_anti(
         let equi_keys =
             extract_equi_keys_from_subplan(subplan, inner_root, &current_node, &inner_node);
 
+        let plan_id = (*subplan).plan_id;
         let join_node = JoinNode {
             join_type: if is_anti {
                 JoinType::Anti
@@ -384,6 +385,7 @@ unsafe fn wrap_with_semi_anti(
             right: inner_node,
             equi_keys: equi_keys.clone(),
             filter: None,
+            subplan_id: Some(plan_id),
         };
 
         all_keys.extend(equi_keys);
@@ -426,12 +428,14 @@ unsafe fn wrap_with_mark_filter(
         // Both `IN (...) OR IS NULL` and `NOT IN (...) OR IS NULL` use LeftMark;
         // the anti vs non-anti distinction is carried through `or_ext.is_anti`
         // and applied at filter-evaluation time as a mark-check inversion.
+        let plan_id = (*or_ext.subplan).plan_id;
         let join_node = JoinNode {
             join_type: JoinType::LeftMark,
             left: current_node,
             right: inner_node,
             equi_keys: equi_keys.clone(),
             filter: None,
+            subplan_id: Some(plan_id),
         };
 
         all_keys.extend(equi_keys);
@@ -573,6 +577,7 @@ unsafe fn collect_join_sources_join_rel(
             right: inner_node,
             equi_keys: join_conditions.equi_keys.clone(),
             filter: None,
+            subplan_id: None,
         };
 
         keys.extend(join_conditions.equi_keys);

--- a/pg_search/tests/pg_regress/expected/issue_4532.out
+++ b/pg_search/tests/pg_regress/expected/issue_4532.out
@@ -209,8 +209,8 @@ LIMIT 10;
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
-         Relation Tree: p SEMI ((c ANTI d) SEMI d)
-         Join Cond: p.company_id = c.id, c.id = d.company_id, d.company_id = c.id
+         Relation Tree: p SEMI ((c SEMI d) ANTI d)
+         Join Cond: p.company_id = c.id, d.company_id = c.id, c.id = d.company_id
          Limit: 10
          Order By: p.id asc
          DataFusion Physical Plan: 
@@ -220,12 +220,12 @@ LIMIT 10;
            :       VisibilityFilterExec: tables=[p]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
-           :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, id@0)]
+           :       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, id@0)]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
-           :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, id@0)]
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Marketing","lenient":null,"conjunction_mode":null}}}}
+           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, id@0)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Marketing","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
 (21 rows)
@@ -338,8 +338,8 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
-         Relation Tree: p SEMI (r INNER (c SEMI d))
-         Join Cond: p.company_id = c.id, c.region_id = r.id, c.id = d.company_id
+         Relation Tree: p SEMI ((r INNER c) SEMI d)
+         Join Cond: p.company_id = c.id, c.id = d.company_id, c.region_id = r.id
          Limit: 10
          Order By: p.id asc
          DataFusion Physical Plan: 
@@ -349,14 +349,14 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            :       VisibilityFilterExec: tables=[p]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, region_id@1)], projection=[id@1]
-           :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"America","lenient":null,"conjunction_mode":null}}}}
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, id@0)]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, company_id@0)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, region_id@1)], projection=[id@1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"America","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT p.id, p.description

--- a/pg_search/tests/pg_regress/expected/join_multi_table.out
+++ b/pg_search/tests/pg_regress/expected/join_multi_table.out
@@ -85,39 +85,37 @@ JOIN categories c ON p.category_id = c.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (table: c)
-                                                                                                          QUERY PLAN                                                                                                           
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: p, s)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p, s)
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name, c.name
    ->  Sort
          Output: p.id, p.name, s.name, c.name
          Sort Key: p.id
-         ->  Hash Join
+         ->  Nested Loop
                Output: p.id, p.name, s.name, c.name
-               Inner Unique: true
-               Hash Cond: (p.category_id = c.id)
-               ->  Custom Scan (ParadeDB Join Scan)
+               Join Filter: (c.id = p.category_id)
+               ->  Seq Scan on public.categories c
+                     Output: c.id, c.name, c.description
+               ->  Materialize
                      Output: p.id, p.name, p.category_id, s.name
-                     Relation Tree: s INNER p
-                     Join Cond: p.supplier_id = s.id
-                     Limit: 5
-                     Order By: p.id asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, NULL as col_4, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
-                       :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     VisibilityFilterExec: tables=[s, p]
-                       :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id]
-                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], projection=[ctid_1@0, id@2, ctid_0@3]
-                       :           CooperativeExec
-                       :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                       :           CooperativeExec
-                       :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-               ->  Hash
-                     Output: c.name, c.id
-                     ->  Seq Scan on public.categories c
-                           Output: c.name, c.id
-(29 rows)
+                     ->  Hash Join
+                           Output: p.id, p.name, p.category_id, s.name
+                           Hash Cond: (s.id = p.supplier_id)
+                           ->  Seq Scan on public.suppliers s
+                                 Output: s.id, s.name, s.contact_info, s.country
+                           ->  Hash
+                                 Output: p.id, p.name, p.supplier_id, p.category_id
+                                 ->  Custom Scan (ParadeDB Base Scan) on public.products p
+                                       Output: p.id, p.name, p.supplier_id, p.category_id
+                                       Table: products
+                                       Index: products_bm25_idx
+                                       Exec Method: NormalScanExecState
+                                       Scores: false
+                                       Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(26 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, c.name AS category_name
 FROM products p
@@ -126,7 +124,8 @@ JOIN categories c ON p.category_id = c.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (table: c)
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: p, s)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p, s)
  id  |      name      | supplier_name | category_name 
 -----+----------------+---------------+---------------
  201 | Wireless Mouse | TechCorp      | Electronics
@@ -574,19 +573,19 @@ LIMIT 5;
          Output: l1.name, l4.name, l1.id
          ->  Custom Scan (ParadeDB Join Scan)
                Output: l1.name, l1.id, l4.name
-               Relation Tree: (l4 INNER l3) INNER (l2 INNER l1)
+               Relation Tree: (l4 INNER l3) INNER (l1 INNER l2)
                Join Cond: l2.l3_id = l3.id, l3.l4_id = l4.id, l1.l2_id = l2.id
                Limit: 5
                Order By: l1.id asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@2 as ctid_2, ctid_3@3 as ctid_3]
-                 :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[l4, l3, l2, l1]
-                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@3 as ctid_1, ctid_2@4 as ctid_2, ctid_3@0 as ctid_3, id@1 as id]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l2_id@1, id@3)], projection=[ctid_3@0, id@2, ctid_0@3, ctid_1@4, ctid_2@5]
+                 : ProjectionExec: expr=[NULL as col_1, id@3 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@2 as ctid_2, ctid_3@4 as ctid_3]
+                 :   SortExec: TopK(fetch=5), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[l4, l3, l1, l2]
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@3 as ctid_1, ctid_2@0 as ctid_2, id@1 as id, ctid_3@4 as ctid_3]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l2_id@1, id@3)], projection=[ctid_2@0, id@2, ctid_0@3, ctid_1@4, ctid_3@5]
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L1-A","lenient":null,"conjunction_mode":null}}}}
-                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@1)], projection=[ctid_0@0, ctid_1@1, ctid_2@3, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@1)], projection=[ctid_0@0, ctid_1@1, ctid_3@3, id@5]
                  :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l4_id@2)], projection=[ctid_0@0, ctid_1@2, id@3]
                  :               CooperativeExec
                  :                 PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"deepest","lenient":null,"conjunction_mode":null}}}}
@@ -627,27 +626,26 @@ LIMIT 5;
          Output: l1.name, l4.name, l1.id
          ->  Custom Scan (ParadeDB Join Scan)
                Output: l1.name, l1.id, l4.name
-               Relation Tree: (l4 INNER l3) INNER (l2 INNER l1)
+               Relation Tree: (l3 INNER l4) INNER (l2 INNER l1)
                Join Cond: l2.l3_id = l3.id, l3.l4_id = l4.id, l1.l2_id = l2.id
                Limit: 5
                Order By: l1.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, id@4 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@2 as ctid_2, ctid_3@3 as ctid_3]
                  :   SortExec: TopK(fetch=5), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[l4, l3, l2, l1]
+                 :     VisibilityFilterExec: tables=[l3, l4, l2, l1]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@3, l2_id@1)], projection=[ctid_0@0, ctid_1@1, ctid_2@2, ctid_3@4, id@6]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, l3_id@1)], projection=[ctid_0@0, ctid_1@1, ctid_2@3, id@5]
-                 :           ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id]
-                 :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l4_id@2, id@1)], projection=[ctid_1@0, id@1, ctid_0@3]
-                 :               CooperativeExec
-                 :                 PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L3-B","lenient":null,"conjunction_mode":null}}}}
-                 :               CooperativeExec
-                 :                 PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, l3_id@1)], projection=[ctid_0@0, ctid_1@2, ctid_2@3, id@5]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(l4_id@2, id@1)], projection=[ctid_0@0, id@1, ctid_1@3]
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L3-B","lenient":null,"conjunction_mode":null}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L2-B","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(26 rows)
+(25 rows)
 
 SELECT l1.name, l4.name
 FROM level1 l1

--- a/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
@@ -139,30 +139,34 @@ WHERE c.name @@@ 'Acme OR Globex'
 AND p.description @@@ 'widget OR gadget OR gizmo'
 ORDER BY cat.category_name, p.id
 LIMIT 5;
-                                                                                                                     QUERY PLAN                                                                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: cat.category_name, p.id
-         ->  Hash Join
-               Hash Cond: (cat.product_id = p.id)
-               ->  Seq Scan on categories_op cat
-               ->  Hash
-                     ->  Custom Scan (ParadeDB Join Scan)
-                           Relation Tree: c INNER p
-                           Join Cond: p.company_id = c.id
-                           Limit: 5
-                           Order By: p.id asc
-                           DataFusion Physical Plan: 
-                             : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
-                             :   SortExec: TopK(fetch=5), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
-                             :     VisibilityFilterExec: tables=[c, p]
-                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
-                             :         CooperativeExec
-                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Acme OR Globex","lenient":null,"conjunction_mode":null}}}}
-                             :         CooperativeExec
-                             :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+         ->  Nested Loop
+               Join Filter: (p.company_id = c.id)
+               ->  Hash Join
+                     Hash Cond: (cat.product_id = p.id)
+                     ->  Seq Scan on categories_op cat
+                     ->  Hash
+                           ->  Custom Scan (ParadeDB Base Scan) on products_op p
+                                 Table: products_op
+                                 Index: products_op_idx
+                                 Exec Method: NormalScanExecState
+                                 Scores: false
+                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo","lenient":null,"conjunction_mode":null}}}}
+               ->  Materialize
+                     ->  Custom Scan (ParadeDB Base Scan) on companies_op c
+                           Table: companies_op
+                           Index: companies_op_idx
+                           Exec Method: ColumnarExecState
+                           Fast Fields: id
+                           Scores: false
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Acme OR Globex","lenient":null,"conjunction_mode":null}}}}
+(23 rows)
 
 SELECT p.id, p.description, cat.category_name
 FROM products_op p
@@ -172,6 +176,8 @@ WHERE c.name @@@ 'Acme OR Globex'
 AND p.description @@@ 'widget OR gadget OR gizmo'
 ORDER BY cat.category_name, p.id
 LIMIT 5;
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
  id  |  description  | category_name 
 -----+---------------+---------------
  100 | A fine widget | Electronics

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
@@ -173,10 +173,11 @@ SELECT count(*) FROM lp_q_result;
 DROP TABLE lp_q_result;
 DEALLOCATE lp_q;
 -- ============================================================
--- Test 5: Partitioned table with SubPlan post-filter
+-- Test 5: Partition with SubPlan post-filter
 -- ============================================================
--- Create a partitioned table where half the rows fail the SubPlan
--- filter, proving that TopK suppression is necessary.
+-- BM25 indexes live on individual partitions. Query a partition
+-- directly to verify that has_non_pushable_predicates() catches
+-- the SubPlan even though rel_is_single_or_partitioned passes.
 CREATE TABLE lp_items_part (
     id BIGINT NOT NULL,
     status TEXT,
@@ -194,21 +195,39 @@ USING bm25 (id, status, description) WITH (key_field = 'id');
 CREATE INDEX lp_items_part_2_bm25 ON lp_items_part_2
 USING bm25 (id, status, description) WITH (key_field = 'id');
 ANALYZE;
+-- Query partition directly (not the parent table)
 SELECT count(*) FROM (
-    SELECT id FROM lp_items_part
+    SELECT id FROM lp_items_part_1
     WHERE description @@@ 'partitioned'
       AND (status IS NULL
            OR status IN (SELECT s FROM lp_active_statuses))
     LIMIT 100
 ) sub;
-ERROR:  `lp_items_part` does not contain a `USING bm25` index
+ count 
+-------
+   100
+(1 row)
+
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM lp_items_part
+SELECT id FROM lp_items_part_1
 WHERE description @@@ 'partitioned'
   AND (status IS NULL
        OR status IN (SELECT s FROM lp_active_statuses))
 LIMIT 100;
-ERROR:  `lp_items_part` does not contain a `USING bm25` index
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on lp_items_part_1
+         Filter: ((status IS NULL) OR (ANY (status = (hashed SubPlan 1).col1)))
+         Table: lp_items_part_1
+         Index: lp_items_part_1_bm25
+         Exec Method: NormalScanExecState
+         Scores: false
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"partitioned","lenient":null,"conjunction_mode":null}}}}
+         SubPlan 1
+           ->  Seq Scan on lp_active_statuses
+(10 rows)
+
 -- ============================================================
 -- Test 6: LEFT JOIN LATERAL with SubPlan on the outer table
 -- ============================================================

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
@@ -1,0 +1,328 @@
+-- Tests for LIMIT pushdown suppression in BaseScan when non-pushable
+-- post-filters exist (SubPlan, volatile functions).
+--
+-- The bug: BaseScan absorbs the query-level LIMIT as a hard output cap
+-- inside TopK, but SubPlan predicates (e.g. IN (SELECT ...)) are evaluated
+-- by Postgres AFTER the scan. Rows discarded by the post-filter come from
+-- an already-capped output, producing fewer results than correct.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = off;
+-- ============================================================
+-- Shared setup
+-- ============================================================
+DROP TABLE IF EXISTS lp_categories CASCADE;
+DROP TABLE IF EXISTS lp_items CASCADE;
+DROP TABLE IF EXISTS lp_items_part CASCADE;
+DROP TABLE IF EXISTS lp_left_table CASCADE;
+DROP TABLE IF EXISTS lp_active_statuses CASCADE;
+DROP TABLE IF EXISTS lp_allowed_tenants CASCADE;
+CREATE TABLE lp_categories (
+    id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lp_items (
+    id BIGINT PRIMARY KEY,
+    category_id BIGINT,
+    tenant_id BIGINT,
+    status TEXT,
+    fk BIGINT,
+    description TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lp_left_table (
+    id BIGINT PRIMARY KEY,
+    status TEXT
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lp_active_statuses (
+    s TEXT PRIMARY KEY
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lp_allowed_tenants (
+    tenant_id BIGINT,
+    user_id TEXT
+) WITH (autovacuum_enabled = false);
+-- Populate categories: only 'rare_category' will match the SubPlan filter.
+INSERT INTO lp_categories VALUES (1, 'rare_category');
+INSERT INTO lp_categories VALUES (2, 'common_category');
+-- Populate items: 1000 rows all match 'searchable'. Rows 151-1000 repeat
+-- the term 5x so they score much higher than rows 1-150. TopK by score
+-- DESC would pick rows 151-1000 first — those all have category_id=999
+-- and fail the SubPlan filter. With the bug: 0 rows. With the fix: 50.
+INSERT INTO lp_items
+SELECT i,
+       CASE WHEN i <= 150 THEN NULL ELSE 999 END,
+       1, 'active', i,
+       CASE WHEN i <= 150 THEN 'searchable'
+            ELSE 'searchable searchable searchable searchable searchable'
+       END
+FROM generate_series(1, 1000) i;
+-- Make the BM25 index
+CREATE INDEX lp_items_bm25 ON lp_items
+USING bm25 (id, category_id, tenant_id, status, fk, description)
+WITH (key_field = 'id');
+-- Active statuses for lateral/partitioned tests
+INSERT INTO lp_active_statuses VALUES ('active');
+-- Left table for LATERAL test
+INSERT INTO lp_left_table
+SELECT i, 'active' FROM generate_series(1, 100) i;
+-- Allowed tenants for RLS test (must match the role name exactly)
+INSERT INTO lp_allowed_tenants VALUES (1, 'lp_restricted_user');
+ANALYZE;
+-- ============================================================
+-- Test 1: Core reproducer — SubPlan post-filter with LIMIT
+-- ============================================================
+-- The SubPlan (IN (SELECT ...)) cannot be pushed to Tantivy.
+-- With the bug, TopK caps output before the SubPlan filter runs,
+-- producing ~0 rows instead of 50.
+-- Expected: 50 rows. EXPLAIN should show NormalScanExecState.
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+      AND (category_id IS NULL
+           OR category_id IN (
+               SELECT id FROM lp_categories
+               WHERE name = 'rare_category'))
+    ORDER BY paradedb.score(id) DESC
+    LIMIT 50
+) sub;
+ count 
+-------
+    50
+(1 row)
+
+-- Verify EXPLAIN shows NormalScanExecState, not TopKScanExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+  AND (category_id IS NULL
+       OR category_id IN (
+           SELECT id FROM lp_categories
+           WHERE name = 'rare_category'))
+ORDER BY paradedb.score(id) DESC
+LIMIT 50;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (paradedb.score(lp_items.id)) DESC
+         ->  Custom Scan (ParadeDB Base Scan) on lp_items
+               Filter: ((category_id IS NULL) OR (ANY (category_id = (hashed SubPlan 1).col1)))
+               Table: lp_items
+               Index: lp_items_bm25
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"searchable","lenient":null,"conjunction_mode":null}}}}
+               SubPlan 1
+                 ->  Seq Scan on lp_categories
+                       Filter: (name = 'rare_category'::text)
+(13 rows)
+
+-- ============================================================
+-- Test 2: No-LIMIT regression — same predicate without LIMIT
+-- ============================================================
+-- All qualifying rows should be returned. No LIMIT means no TopK issue.
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+      AND (category_id IS NULL
+           OR category_id IN (
+               SELECT id FROM lp_categories
+               WHERE name = 'rare_category'))
+) sub;
+ count 
+-------
+   150
+(1 row)
+
+-- ============================================================
+-- Test 3: Fully-pushable + LIMIT regression
+-- ============================================================
+-- All predicates pushed to Tantivy. TopK SHOULD still be used.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable' LIMIT 100;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on lp_items
+         Table: lp_items
+         Index: lp_items_bm25
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Limit: 100
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"searchable","lenient":null,"conjunction_mode":null}}}}
+(8 rows)
+
+-- ============================================================
+-- Test 4: Parameterized limit via prepared statement
+-- ============================================================
+PREPARE lp_q(int) AS
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+  AND (category_id IS NULL
+       OR category_id IN (
+           SELECT id FROM lp_categories WHERE name = 'rare_category'))
+ORDER BY paradedb.score(id) DESC
+LIMIT $1;
+CREATE TEMP TABLE lp_q_result AS EXECUTE lp_q(100);
+SELECT count(*) FROM lp_q_result;
+ count 
+-------
+   100
+(1 row)
+
+DROP TABLE lp_q_result;
+DEALLOCATE lp_q;
+-- ============================================================
+-- Test 5: Partitioned table with SubPlan post-filter
+-- ============================================================
+-- Create a partitioned table where half the rows fail the SubPlan
+-- filter, proving that TopK suppression is necessary.
+CREATE TABLE lp_items_part (
+    id BIGINT NOT NULL,
+    status TEXT,
+    description TEXT NOT NULL
+) PARTITION BY RANGE (id);
+CREATE TABLE lp_items_part_1 PARTITION OF lp_items_part FOR VALUES FROM (1) TO (501);
+CREATE TABLE lp_items_part_2 PARTITION OF lp_items_part FOR VALUES FROM (501) TO (1001);
+INSERT INTO lp_items_part
+SELECT i,
+       CASE WHEN i <= 500 THEN 'active' ELSE 'inactive' END,
+       'partitioned item'
+FROM generate_series(1, 1000) i;
+CREATE INDEX lp_items_part_1_bm25 ON lp_items_part_1
+USING bm25 (id, status, description) WITH (key_field = 'id');
+CREATE INDEX lp_items_part_2_bm25 ON lp_items_part_2
+USING bm25 (id, status, description) WITH (key_field = 'id');
+ANALYZE;
+SELECT count(*) FROM (
+    SELECT id FROM lp_items_part
+    WHERE description @@@ 'partitioned'
+      AND (status IS NULL
+           OR status IN (SELECT s FROM lp_active_statuses))
+    LIMIT 100
+) sub;
+ERROR:  `lp_items_part` does not contain a `USING bm25` index
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items_part
+WHERE description @@@ 'partitioned'
+  AND (status IS NULL
+       OR status IN (SELECT s FROM lp_active_statuses))
+LIMIT 100;
+ERROR:  `lp_items_part` does not contain a `USING bm25` index
+-- ============================================================
+-- Test 6: LEFT JOIN LATERAL with SubPlan on the outer table
+-- ============================================================
+-- The SubPlan is on the outer table (lp_left_table), so limit should
+-- be suppressed for safety.
+SELECT count(*) FROM (
+    SELECT l.id FROM lp_left_table l
+    LEFT JOIN LATERAL (
+        SELECT * FROM lp_items i
+        WHERE i.fk = l.id AND i.description @@@ 'searchable'
+    ) sub ON true
+    WHERE l.status IN (SELECT s FROM lp_active_statuses)
+    LIMIT 50
+) result;
+ count 
+-------
+    50
+(1 row)
+
+-- Verify BaseScan does not use TopK for the LATERAL subquery
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT l.id FROM lp_left_table l
+LEFT JOIN LATERAL (
+    SELECT * FROM lp_items i
+    WHERE i.fk = l.id AND i.description @@@ 'searchable'
+) sub ON true
+WHERE l.status IN (SELECT s FROM lp_active_statuses)
+LIMIT 50;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         Join Filter: (l.status = lp_active_statuses.s)
+         ->  Seq Scan on lp_active_statuses
+         ->  Hash Right Join
+               Hash Cond: (i.fk = l.id)
+               ->  Custom Scan (ParadeDB Base Scan) on lp_items i
+                     Table: lp_items
+                     Index: lp_items_bm25
+                     Exec Method: ColumnarExecState
+                     Fast Fields: fk
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"searchable","lenient":null,"conjunction_mode":null}}}}
+               ->  Hash
+                     ->  Seq Scan on lp_left_table l
+(15 rows)
+
+-- ============================================================
+-- Test 7: RLS-injected SubPlan (subquery-based policy)
+-- ============================================================
+-- Row-level security adds a SubPlan to baserestrictinfo that can't
+-- be pushed to Tantivy.
+-- Create a role for RLS testing
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'lp_restricted_user') THEN
+        CREATE ROLE lp_restricted_user LOGIN;
+    END IF;
+END
+$$;
+GRANT SELECT ON lp_items TO lp_restricted_user;
+GRANT SELECT ON lp_categories TO lp_restricted_user;
+GRANT SELECT ON lp_allowed_tenants TO lp_restricted_user;
+ALTER TABLE lp_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lp_tenant_isolation ON lp_items
+    USING (tenant_id IN (
+        SELECT tenant_id FROM lp_allowed_tenants
+        WHERE user_id = current_user
+    ));
+SET ROLE lp_restricted_user;
+-- With the RLS policy active, TopK should be suppressed
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+    ORDER BY paradedb.score(id) DESC
+    LIMIT 100
+) sub;
+ count 
+-------
+   100
+(1 row)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+ORDER BY paradedb.score(id) DESC
+LIMIT 100;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (paradedb.score(lp_items.id)) DESC
+         ->  Custom Scan (ParadeDB Base Scan) on lp_items
+               Filter: (ANY (tenant_id = (hashed SubPlan 1).col1))
+               Table: lp_items
+               Index: lp_items_bm25
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"searchable","lenient":null,"conjunction_mode":null}}}}
+               SubPlan 1
+                 ->  Seq Scan on lp_allowed_tenants
+                       Filter: (user_id = CURRENT_USER)
+(13 rows)
+
+RESET ROLE;
+-- ============================================================
+-- Cleanup
+-- ============================================================
+ALTER TABLE lp_items DISABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS lp_tenant_isolation ON lp_items;
+DROP TABLE IF EXISTS lp_items_part CASCADE;
+DROP TABLE IF EXISTS lp_left_table CASCADE;
+DROP TABLE IF EXISTS lp_active_statuses CASCADE;
+DROP TABLE IF EXISTS lp_allowed_tenants CASCADE;
+DROP TABLE IF EXISTS lp_categories CASCADE;
+DROP TABLE IF EXISTS lp_items CASCADE;
+DROP ROLE IF EXISTS lp_restricted_user;

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_joinscan.out
@@ -1,0 +1,309 @@
+-- Tests for LIMIT pushdown suppression in JoinScan when non-pushable
+-- post-filters exist. JoinScan bails out entirely when unsafe, letting
+-- Postgres fall back to its native join plan.
+--
+-- Issue #4718: Anti-join + LIMIT produces fewer rows than correct when
+-- JoinScan absorbs the LIMIT but Postgres applies a post-filter above
+-- the scan.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+-- ============================================================
+-- Shared setup
+-- ============================================================
+DROP TABLE IF EXISTS lj_excluded_contacts CASCADE;
+DROP TABLE IF EXISTS lj_departments CASCADE;
+DROP TABLE IF EXISTS lj_job_openings CASCADE;
+DROP TABLE IF EXISTS lj_excluded_emails CASCADE;
+DROP TABLE IF EXISTS lj_people CASCADE;
+DROP TABLE IF EXISTS lj_companies CASCADE;
+CREATE TABLE lj_companies (
+    id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lj_people (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT,
+    name TEXT NOT NULL,
+    dept_id BIGINT,
+    email TEXT NOT NULL,
+    seniority_slug TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lj_excluded_emails (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lj_job_openings (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lj_departments (
+    id BIGINT PRIMARY KEY,
+    active BOOLEAN NOT NULL
+) WITH (autovacuum_enabled = false);
+CREATE TABLE lj_excluded_contacts (
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    email TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+-- Populate companies: 100 companies
+INSERT INTO lj_companies SELECT i, 'company_' || i FROM generate_series(1, 100) i;
+-- Populate people: 2 people per company (first 180 have company_id, rest NULL)
+INSERT INTO lj_people
+SELECT i,
+       CASE WHEN i <= 180 THEN ((i-1) % 100) + 1 ELSE NULL END,
+       'person_' || i,
+       ((i-1) % 5) + 1,
+       'person_' || i || '@example.com',
+       CASE (i % 4)
+           WHEN 0 THEN 'manager'
+           WHEN 1 THEN 'director'
+           WHEN 2 THEN 'individual_contributor'
+           WHEN 3 THEN 'executive'
+       END
+FROM generate_series(1, 200) i;
+-- Excluded emails: exclude 3 companies (company 1, 2, 3)
+INSERT INTO lj_excluded_emails SELECT i, i FROM generate_series(1, 3) i;
+-- Job openings: 50 companies have openings
+INSERT INTO lj_job_openings SELECT i, i FROM generate_series(1, 50) i;
+-- Departments: only 3 out of 5 are active
+INSERT INTO lj_departments SELECT i, (i <= 3) FROM generate_series(1, 5) i;
+-- Excluded contacts for Test 13
+INSERT INTO lj_excluded_contacts
+SELECT i, 1, 'person_' || i || '@example.com'
+FROM generate_series(1, 10) i;
+-- BM25 indexes — only on tables that JoinScan should absorb.
+-- lj_excluded_emails and lj_job_openings intentionally have NO BM25 index
+-- so JoinScan cannot absorb them and must bail out for Tests 8, 9, 12.
+CREATE INDEX lj_companies_bm25 ON lj_companies
+USING bm25 (id, name)
+WITH (key_field = 'id');
+CREATE INDEX lj_people_bm25 ON lj_people
+USING bm25 (id, company_id, name, dept_id, email, seniority_slug)
+WITH (key_field = 'id', numeric_fields = '{"company_id": {"fast": true}, "dept_id": {"fast": true}}');
+-- No BM25 index on lj_excluded_contacts — must remain non-BM25 for Test 13.
+ANALYZE;
+-- ============================================================
+-- Test 8: Anti-join + LIMIT (Issue #4718 reproducer)
+-- ============================================================
+-- NOT EXISTS creates a SubPlan. lj_excluded_emails has no BM25 index,
+-- so JoinScan cannot absorb it and must bail out.
+-- Expected: 26 rows. JoinScan absent from EXPLAIN.
+SELECT count(*) FROM (
+    SELECT c.id, c.name FROM lj_companies c
+    WHERE c.id @@@ paradedb.all()
+      AND NOT EXISTS (
+          SELECT 1 FROM lj_excluded_emails e
+          WHERE e.company_id = c.id
+      )
+    ORDER BY c.name ASC
+    LIMIT 26
+) sub;
+ count 
+-------
+    26
+(1 row)
+
+-- Verify JoinScan is NOT used (bailed out)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT c.id, c.name FROM lj_companies c
+WHERE c.id @@@ paradedb.all()
+  AND NOT EXISTS (
+      SELECT 1 FROM lj_excluded_emails e
+      WHERE e.company_id = c.id
+  )
+ORDER BY c.name ASC
+LIMIT 26;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: c.name
+         ->  Hash Anti Join
+               Hash Cond: (c.id = e.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on lj_companies c
+                     Table: lj_companies
+                     Index: lj_companies_bm25
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Full Index Scan: true
+                     Tantivy Query: {"with_index":{"query":"all"}}
+               ->  Hash
+                     ->  Seq Scan on lj_excluded_emails e
+(14 rows)
+
+-- ============================================================
+-- Test 9: Semi-join + non-BM25 outer predicate + LIMIT
+-- ============================================================
+-- JoinScan activates for the c JOIN p pair (both have BM25 indexes,
+-- join key company_id is fast, ORDER BY c.id is fast).  But the
+-- IN (SELECT company_id FROM lj_job_openings) SubPlan is on c's
+-- baserestrictinfo and lj_job_openings has no BM25 index, so JoinScan
+-- cannot absorb it.  Our safety check detects the un-absorbed SubPlan
+-- and bails out.
+SELECT count(*) FROM (
+    SELECT c.id FROM lj_companies c
+    JOIN lj_people p ON c.id = p.company_id
+    WHERE c.id @@@ paradedb.all()
+      AND c.id IN (SELECT company_id FROM lj_job_openings)
+    ORDER BY c.id ASC
+    LIMIT 26
+) sub;
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+ count 
+-------
+    26
+(1 row)
+
+-- ============================================================
+-- Test 10: OR-wrapped SubPlan on absorbed relation
+-- ============================================================
+-- The SubPlan is nested inside an OR, so extract_subplan_id returns
+-- None. Conservative behavior: bail out.
+SELECT count(*) FROM (
+    SELECT c.id, p.name FROM lj_companies c
+    JOIN lj_people p ON c.id = p.company_id
+    WHERE c.id @@@ paradedb.all()
+      AND (p.dept_id IS NULL
+           OR p.dept_id IN (
+               SELECT id FROM lj_departments WHERE active))
+    ORDER BY c.id ASC
+    LIMIT 26
+) sub;
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+ count 
+-------
+    26
+(1 row)
+
+-- ============================================================
+-- Test 11: All-absorbed + LIMIT regression
+-- ============================================================
+-- Simple join with no SubPlans. Both tables have BM25 indexes,
+-- join key (company_id) is a fast field, ORDER BY c.id is a fast
+-- field. JoinScan SHOULD activate and use TopK(fetch=N).
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT c.id, p.name FROM lj_companies c
+JOIN lj_people p ON c.id = p.company_id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.id ASC
+LIMIT 26;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: p INNER c
+         Join Cond: c.id = p.company_id
+         Limit: 26
+         Order By: c.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=26), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[p, c]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, company_id@1)], projection=[ctid_1@0, id@1, ctid_0@2]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(16 rows)
+
+-- ============================================================
+-- Test 12: LIMIT + OFFSET with outer predicates
+-- ============================================================
+-- NOT EXISTS against non-BM25 table + LIMIT + OFFSET. JoinScan
+-- should bail out.
+SELECT count(*) FROM (
+    SELECT c.id FROM lj_companies c
+    WHERE c.id @@@ paradedb.all()
+      AND NOT EXISTS (
+          SELECT 1 FROM lj_excluded_emails e
+          WHERE e.company_id = c.id
+      )
+    ORDER BY c.name ASC
+    LIMIT 26 OFFSET 10
+) sub;
+ count 
+-------
+    26
+(1 row)
+
+-- ============================================================
+-- Test 13: Combined anti-join + OR SubPlan + seniority filter
+-- ============================================================
+-- Real-world pattern: multiple unsafe predicates in one query.
+-- NOT EXISTS against non-BM25 lj_excluded_contacts, plus an OR-wrapped
+-- SubPlan (company_id IN (SELECT ...)). JoinScan should bail out.
+SELECT count(*) FROM (
+    SELECT p.id
+    FROM lj_people p
+    WHERE p.id @@@ paradedb.all()
+      AND p.seniority_slug IN ('manager', 'director')
+      AND NOT EXISTS (
+          SELECT ec.id FROM lj_excluded_contacts ec
+          WHERE ec.user_id = 1
+            AND ec.email = p.email
+      )
+      AND (p.company_id IS NULL
+           OR p.company_id IN (
+               SELECT c.id FROM lj_companies c
+           ))
+    ORDER BY p.id DESC
+    LIMIT 26
+) sub;
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+ count 
+-------
+    26
+(1 row)
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT p.id
+FROM lj_people p
+WHERE p.id @@@ paradedb.all()
+  AND p.seniority_slug IN ('manager', 'director')
+  AND NOT EXISTS (
+      SELECT ec.id FROM lj_excluded_contacts ec
+      WHERE ec.user_id = 1
+        AND ec.email = p.email
+  )
+  AND (p.company_id IS NULL
+       OR p.company_id IN (
+           SELECT c.id FROM lj_companies c
+       ))
+ORDER BY p.id DESC
+LIMIT 26;
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+                                                                                                                    QUERY PLAN                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: p.id DESC
+         ->  Hash Right Anti Join
+               Hash Cond: (ec.email = p.email)
+               ->  Seq Scan on lj_excluded_contacts ec
+                     Filter: (user_id = 1)
+               ->  Hash
+                     ->  Custom Scan (ParadeDB Base Scan) on lj_people p
+                           Filter: ((company_id IS NULL) OR (ANY (company_id = (hashed SubPlan 1).col1)))
+                           Table: lj_people
+                           Index: lj_people_bm25
+                           Exec Method: NormalScanExecState
+                           Scores: false
+                           Full Index Scan: true
+                           Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":"all"}}]}},"field_filters":[{"heap_filter":"(seniority_slug = ANY ('{manager,director}'::text[]))"}]}}]}}
+                           SubPlan 1
+                             ->  Seq Scan on lj_companies c
+(18 rows)
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+DROP TABLE IF EXISTS lj_excluded_contacts CASCADE;
+DROP TABLE IF EXISTS lj_departments CASCADE;
+DROP TABLE IF EXISTS lj_job_openings CASCADE;
+DROP TABLE IF EXISTS lj_excluded_emails CASCADE;
+DROP TABLE IF EXISTS lj_people CASCADE;
+DROP TABLE IF EXISTS lj_companies CASCADE;

--- a/pg_search/tests/pg_regress/expected/rls_multiple_policies.out
+++ b/pg_search/tests/pg_regress/expected/rls_multiple_policies.out
@@ -158,24 +158,24 @@ FROM documents
 WHERE title ||| 'sheriff'
 ORDER BY pdb.score(id) DESC, id
 LIMIT 2;
-                                                                                                                                                                    QUERY PLAN                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                       QUERY PLAN                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Base Scan) on documents
-         Filter: ((NOT document_has_tags(id)) OR EXISTS(SubPlan 1))
-         Table: documents
-         Index: documents_bm25
-         Exec Method: TopKScanExecState
-         Scores: true
-            TopK Order By: pdb.score() desc, id asc
-            TopK Limit: 2
-         Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"match":{"field":"title","value":"sheriff","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}]}},"field_filters":[{"heap_filter":"check_org_access(org_id)"}]}}]}}
-         SubPlan 1
-           ->  Nested Loop
-                 ->  Function Scan on unnest tag_id
-                 ->  Index Scan using access_tags_pkey on access_tags
-                       Index Cond: (id = tag_id.tag_id)
-                       Filter: check_org_access(org_id)
+   ->  Sort
+         Sort Key: (pdb.score(documents.id)) DESC, documents.id
+         ->  Custom Scan (ParadeDB Base Scan) on documents
+               Filter: ((NOT document_has_tags(id)) OR EXISTS(SubPlan 1))
+               Table: documents
+               Index: documents_bm25
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"match":{"field":"title","value":"sheriff","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}]}},"field_filters":[{"heap_filter":"check_org_access(org_id)"}]}}]}}
+               SubPlan 1
+                 ->  Nested Loop
+                       ->  Function Scan on unnest tag_id
+                       ->  Index Scan using access_tags_pkey on access_tags
+                             Index Cond: (id = tag_id.tag_id)
+                             Filter: check_org_access(org_id)
 (16 rows)
 
 SELECT id

--- a/pg_search/tests/pg_regress/sql/limit_pushdown_basescan.sql
+++ b/pg_search/tests/pg_regress/sql/limit_pushdown_basescan.sql
@@ -157,10 +157,11 @@ DROP TABLE lp_q_result;
 DEALLOCATE lp_q;
 
 -- ============================================================
--- Test 5: Partitioned table with SubPlan post-filter
+-- Test 5: Partition with SubPlan post-filter
 -- ============================================================
--- Create a partitioned table where half the rows fail the SubPlan
--- filter, proving that TopK suppression is necessary.
+-- BM25 indexes live on individual partitions. Query a partition
+-- directly to verify that has_non_pushable_predicates() catches
+-- the SubPlan even though rel_is_single_or_partitioned passes.
 
 CREATE TABLE lp_items_part (
     id BIGINT NOT NULL,
@@ -184,8 +185,9 @@ USING bm25 (id, status, description) WITH (key_field = 'id');
 
 ANALYZE;
 
+-- Query partition directly (not the parent table)
 SELECT count(*) FROM (
-    SELECT id FROM lp_items_part
+    SELECT id FROM lp_items_part_1
     WHERE description @@@ 'partitioned'
       AND (status IS NULL
            OR status IN (SELECT s FROM lp_active_statuses))
@@ -193,7 +195,7 @@ SELECT count(*) FROM (
 ) sub;
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
-SELECT id FROM lp_items_part
+SELECT id FROM lp_items_part_1
 WHERE description @@@ 'partitioned'
   AND (status IS NULL
        OR status IN (SELECT s FROM lp_active_statuses))

--- a/pg_search/tests/pg_regress/sql/limit_pushdown_basescan.sql
+++ b/pg_search/tests/pg_regress/sql/limit_pushdown_basescan.sql
@@ -1,0 +1,285 @@
+-- Tests for LIMIT pushdown suppression in BaseScan when non-pushable
+-- post-filters exist (SubPlan, volatile functions).
+--
+-- The bug: BaseScan absorbs the query-level LIMIT as a hard output cap
+-- inside TopK, but SubPlan predicates (e.g. IN (SELECT ...)) are evaluated
+-- by Postgres AFTER the scan. Rows discarded by the post-filter come from
+-- an already-capped output, producing fewer results than correct.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = off;
+
+-- ============================================================
+-- Shared setup
+-- ============================================================
+
+DROP TABLE IF EXISTS lp_categories CASCADE;
+DROP TABLE IF EXISTS lp_items CASCADE;
+DROP TABLE IF EXISTS lp_items_part CASCADE;
+DROP TABLE IF EXISTS lp_left_table CASCADE;
+DROP TABLE IF EXISTS lp_active_statuses CASCADE;
+DROP TABLE IF EXISTS lp_allowed_tenants CASCADE;
+
+CREATE TABLE lp_categories (
+    id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lp_items (
+    id BIGINT PRIMARY KEY,
+    category_id BIGINT,
+    tenant_id BIGINT,
+    status TEXT,
+    fk BIGINT,
+    description TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lp_left_table (
+    id BIGINT PRIMARY KEY,
+    status TEXT
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lp_active_statuses (
+    s TEXT PRIMARY KEY
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lp_allowed_tenants (
+    tenant_id BIGINT,
+    user_id TEXT
+) WITH (autovacuum_enabled = false);
+
+-- Populate categories: only 'rare_category' will match the SubPlan filter.
+INSERT INTO lp_categories VALUES (1, 'rare_category');
+INSERT INTO lp_categories VALUES (2, 'common_category');
+
+-- Populate items: 1000 rows all match 'searchable'. Rows 151-1000 repeat
+-- the term 5x so they score much higher than rows 1-150. TopK by score
+-- DESC would pick rows 151-1000 first — those all have category_id=999
+-- and fail the SubPlan filter. With the bug: 0 rows. With the fix: 50.
+INSERT INTO lp_items
+SELECT i,
+       CASE WHEN i <= 150 THEN NULL ELSE 999 END,
+       1, 'active', i,
+       CASE WHEN i <= 150 THEN 'searchable'
+            ELSE 'searchable searchable searchable searchable searchable'
+       END
+FROM generate_series(1, 1000) i;
+
+-- Make the BM25 index
+CREATE INDEX lp_items_bm25 ON lp_items
+USING bm25 (id, category_id, tenant_id, status, fk, description)
+WITH (key_field = 'id');
+
+-- Active statuses for lateral/partitioned tests
+INSERT INTO lp_active_statuses VALUES ('active');
+
+-- Left table for LATERAL test
+INSERT INTO lp_left_table
+SELECT i, 'active' FROM generate_series(1, 100) i;
+
+-- Allowed tenants for RLS test (must match the role name exactly)
+INSERT INTO lp_allowed_tenants VALUES (1, 'lp_restricted_user');
+
+ANALYZE;
+
+-- ============================================================
+-- Test 1: Core reproducer — SubPlan post-filter with LIMIT
+-- ============================================================
+-- The SubPlan (IN (SELECT ...)) cannot be pushed to Tantivy.
+-- With the bug, TopK caps output before the SubPlan filter runs,
+-- producing ~0 rows instead of 50.
+-- Expected: 50 rows. EXPLAIN should show NormalScanExecState.
+
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+      AND (category_id IS NULL
+           OR category_id IN (
+               SELECT id FROM lp_categories
+               WHERE name = 'rare_category'))
+    ORDER BY paradedb.score(id) DESC
+    LIMIT 50
+) sub;
+
+-- Verify EXPLAIN shows NormalScanExecState, not TopKScanExecState
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+  AND (category_id IS NULL
+       OR category_id IN (
+           SELECT id FROM lp_categories
+           WHERE name = 'rare_category'))
+ORDER BY paradedb.score(id) DESC
+LIMIT 50;
+
+-- ============================================================
+-- Test 2: No-LIMIT regression — same predicate without LIMIT
+-- ============================================================
+-- All qualifying rows should be returned. No LIMIT means no TopK issue.
+
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+      AND (category_id IS NULL
+           OR category_id IN (
+               SELECT id FROM lp_categories
+               WHERE name = 'rare_category'))
+) sub;
+
+-- ============================================================
+-- Test 3: Fully-pushable + LIMIT regression
+-- ============================================================
+-- All predicates pushed to Tantivy. TopK SHOULD still be used.
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable' LIMIT 100;
+
+-- ============================================================
+-- Test 4: Parameterized limit via prepared statement
+-- ============================================================
+
+PREPARE lp_q(int) AS
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+  AND (category_id IS NULL
+       OR category_id IN (
+           SELECT id FROM lp_categories WHERE name = 'rare_category'))
+ORDER BY paradedb.score(id) DESC
+LIMIT $1;
+
+CREATE TEMP TABLE lp_q_result AS EXECUTE lp_q(100);
+SELECT count(*) FROM lp_q_result;
+DROP TABLE lp_q_result;
+
+DEALLOCATE lp_q;
+
+-- ============================================================
+-- Test 5: Partitioned table with SubPlan post-filter
+-- ============================================================
+-- Create a partitioned table where half the rows fail the SubPlan
+-- filter, proving that TopK suppression is necessary.
+
+CREATE TABLE lp_items_part (
+    id BIGINT NOT NULL,
+    status TEXT,
+    description TEXT NOT NULL
+) PARTITION BY RANGE (id);
+
+CREATE TABLE lp_items_part_1 PARTITION OF lp_items_part FOR VALUES FROM (1) TO (501);
+CREATE TABLE lp_items_part_2 PARTITION OF lp_items_part FOR VALUES FROM (501) TO (1001);
+
+INSERT INTO lp_items_part
+SELECT i,
+       CASE WHEN i <= 500 THEN 'active' ELSE 'inactive' END,
+       'partitioned item'
+FROM generate_series(1, 1000) i;
+
+CREATE INDEX lp_items_part_1_bm25 ON lp_items_part_1
+USING bm25 (id, status, description) WITH (key_field = 'id');
+CREATE INDEX lp_items_part_2_bm25 ON lp_items_part_2
+USING bm25 (id, status, description) WITH (key_field = 'id');
+
+ANALYZE;
+
+SELECT count(*) FROM (
+    SELECT id FROM lp_items_part
+    WHERE description @@@ 'partitioned'
+      AND (status IS NULL
+           OR status IN (SELECT s FROM lp_active_statuses))
+    LIMIT 100
+) sub;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items_part
+WHERE description @@@ 'partitioned'
+  AND (status IS NULL
+       OR status IN (SELECT s FROM lp_active_statuses))
+LIMIT 100;
+
+-- ============================================================
+-- Test 6: LEFT JOIN LATERAL with SubPlan on the outer table
+-- ============================================================
+-- The SubPlan is on the outer table (lp_left_table), so limit should
+-- be suppressed for safety.
+
+SELECT count(*) FROM (
+    SELECT l.id FROM lp_left_table l
+    LEFT JOIN LATERAL (
+        SELECT * FROM lp_items i
+        WHERE i.fk = l.id AND i.description @@@ 'searchable'
+    ) sub ON true
+    WHERE l.status IN (SELECT s FROM lp_active_statuses)
+    LIMIT 50
+) result;
+
+-- Verify BaseScan does not use TopK for the LATERAL subquery
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT l.id FROM lp_left_table l
+LEFT JOIN LATERAL (
+    SELECT * FROM lp_items i
+    WHERE i.fk = l.id AND i.description @@@ 'searchable'
+) sub ON true
+WHERE l.status IN (SELECT s FROM lp_active_statuses)
+LIMIT 50;
+
+-- ============================================================
+-- Test 7: RLS-injected SubPlan (subquery-based policy)
+-- ============================================================
+-- Row-level security adds a SubPlan to baserestrictinfo that can't
+-- be pushed to Tantivy.
+
+-- Create a role for RLS testing
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'lp_restricted_user') THEN
+        CREATE ROLE lp_restricted_user LOGIN;
+    END IF;
+END
+$$;
+
+GRANT SELECT ON lp_items TO lp_restricted_user;
+GRANT SELECT ON lp_categories TO lp_restricted_user;
+GRANT SELECT ON lp_allowed_tenants TO lp_restricted_user;
+
+ALTER TABLE lp_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY lp_tenant_isolation ON lp_items
+    USING (tenant_id IN (
+        SELECT tenant_id FROM lp_allowed_tenants
+        WHERE user_id = current_user
+    ));
+
+SET ROLE lp_restricted_user;
+
+-- With the RLS policy active, TopK should be suppressed
+SELECT count(*) FROM (
+    SELECT id FROM lp_items
+    WHERE description @@@ 'searchable'
+    ORDER BY paradedb.score(id) DESC
+    LIMIT 100
+) sub;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM lp_items
+WHERE description @@@ 'searchable'
+ORDER BY paradedb.score(id) DESC
+LIMIT 100;
+
+RESET ROLE;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+
+ALTER TABLE lp_items DISABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS lp_tenant_isolation ON lp_items;
+
+DROP TABLE IF EXISTS lp_items_part CASCADE;
+DROP TABLE IF EXISTS lp_left_table CASCADE;
+DROP TABLE IF EXISTS lp_active_statuses CASCADE;
+DROP TABLE IF EXISTS lp_allowed_tenants CASCADE;
+DROP TABLE IF EXISTS lp_categories CASCADE;
+DROP TABLE IF EXISTS lp_items CASCADE;
+DROP ROLE IF EXISTS lp_restricted_user;

--- a/pg_search/tests/pg_regress/sql/limit_pushdown_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/limit_pushdown_joinscan.sql
@@ -1,0 +1,254 @@
+-- Tests for LIMIT pushdown suppression in JoinScan when non-pushable
+-- post-filters exist. JoinScan bails out entirely when unsafe, letting
+-- Postgres fall back to its native join plan.
+--
+-- Issue #4718: Anti-join + LIMIT produces fewer rows than correct when
+-- JoinScan absorbs the LIMIT but Postgres applies a post-filter above
+-- the scan.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+
+-- ============================================================
+-- Shared setup
+-- ============================================================
+
+DROP TABLE IF EXISTS lj_excluded_contacts CASCADE;
+DROP TABLE IF EXISTS lj_departments CASCADE;
+DROP TABLE IF EXISTS lj_job_openings CASCADE;
+DROP TABLE IF EXISTS lj_excluded_emails CASCADE;
+DROP TABLE IF EXISTS lj_people CASCADE;
+DROP TABLE IF EXISTS lj_companies CASCADE;
+
+CREATE TABLE lj_companies (
+    id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lj_people (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT,
+    name TEXT NOT NULL,
+    dept_id BIGINT,
+    email TEXT NOT NULL,
+    seniority_slug TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lj_excluded_emails (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lj_job_openings (
+    id BIGINT PRIMARY KEY,
+    company_id BIGINT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lj_departments (
+    id BIGINT PRIMARY KEY,
+    active BOOLEAN NOT NULL
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE lj_excluded_contacts (
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    email TEXT NOT NULL
+) WITH (autovacuum_enabled = false);
+
+-- Populate companies: 100 companies
+INSERT INTO lj_companies SELECT i, 'company_' || i FROM generate_series(1, 100) i;
+
+-- Populate people: 2 people per company (first 180 have company_id, rest NULL)
+INSERT INTO lj_people
+SELECT i,
+       CASE WHEN i <= 180 THEN ((i-1) % 100) + 1 ELSE NULL END,
+       'person_' || i,
+       ((i-1) % 5) + 1,
+       'person_' || i || '@example.com',
+       CASE (i % 4)
+           WHEN 0 THEN 'manager'
+           WHEN 1 THEN 'director'
+           WHEN 2 THEN 'individual_contributor'
+           WHEN 3 THEN 'executive'
+       END
+FROM generate_series(1, 200) i;
+
+-- Excluded emails: exclude 3 companies (company 1, 2, 3)
+INSERT INTO lj_excluded_emails SELECT i, i FROM generate_series(1, 3) i;
+
+-- Job openings: 50 companies have openings
+INSERT INTO lj_job_openings SELECT i, i FROM generate_series(1, 50) i;
+
+-- Departments: only 3 out of 5 are active
+INSERT INTO lj_departments SELECT i, (i <= 3) FROM generate_series(1, 5) i;
+
+-- Excluded contacts for Test 13
+INSERT INTO lj_excluded_contacts
+SELECT i, 1, 'person_' || i || '@example.com'
+FROM generate_series(1, 10) i;
+
+-- BM25 indexes — only on tables that JoinScan should absorb.
+-- lj_excluded_emails and lj_job_openings intentionally have NO BM25 index
+-- so JoinScan cannot absorb them and must bail out for Tests 8, 9, 12.
+CREATE INDEX lj_companies_bm25 ON lj_companies
+USING bm25 (id, name)
+WITH (key_field = 'id');
+
+CREATE INDEX lj_people_bm25 ON lj_people
+USING bm25 (id, company_id, name, dept_id, email, seniority_slug)
+WITH (key_field = 'id', numeric_fields = '{"company_id": {"fast": true}, "dept_id": {"fast": true}}');
+
+-- No BM25 index on lj_excluded_contacts — must remain non-BM25 for Test 13.
+
+ANALYZE;
+
+-- ============================================================
+-- Test 8: Anti-join + LIMIT (Issue #4718 reproducer)
+-- ============================================================
+-- NOT EXISTS creates a SubPlan. lj_excluded_emails has no BM25 index,
+-- so JoinScan cannot absorb it and must bail out.
+-- Expected: 26 rows. JoinScan absent from EXPLAIN.
+
+SELECT count(*) FROM (
+    SELECT c.id, c.name FROM lj_companies c
+    WHERE c.id @@@ paradedb.all()
+      AND NOT EXISTS (
+          SELECT 1 FROM lj_excluded_emails e
+          WHERE e.company_id = c.id
+      )
+    ORDER BY c.name ASC
+    LIMIT 26
+) sub;
+
+-- Verify JoinScan is NOT used (bailed out)
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT c.id, c.name FROM lj_companies c
+WHERE c.id @@@ paradedb.all()
+  AND NOT EXISTS (
+      SELECT 1 FROM lj_excluded_emails e
+      WHERE e.company_id = c.id
+  )
+ORDER BY c.name ASC
+LIMIT 26;
+
+-- ============================================================
+-- Test 9: Semi-join + non-BM25 outer predicate + LIMIT
+-- ============================================================
+-- JoinScan activates for the c JOIN p pair (both have BM25 indexes,
+-- join key company_id is fast, ORDER BY c.id is fast).  But the
+-- IN (SELECT company_id FROM lj_job_openings) SubPlan is on c's
+-- baserestrictinfo and lj_job_openings has no BM25 index, so JoinScan
+-- cannot absorb it.  Our safety check detects the un-absorbed SubPlan
+-- and bails out.
+
+SELECT count(*) FROM (
+    SELECT c.id FROM lj_companies c
+    JOIN lj_people p ON c.id = p.company_id
+    WHERE c.id @@@ paradedb.all()
+      AND c.id IN (SELECT company_id FROM lj_job_openings)
+    ORDER BY c.id ASC
+    LIMIT 26
+) sub;
+
+-- ============================================================
+-- Test 10: OR-wrapped SubPlan on absorbed relation
+-- ============================================================
+-- The SubPlan is nested inside an OR, so extract_subplan_id returns
+-- None. Conservative behavior: bail out.
+
+SELECT count(*) FROM (
+    SELECT c.id, p.name FROM lj_companies c
+    JOIN lj_people p ON c.id = p.company_id
+    WHERE c.id @@@ paradedb.all()
+      AND (p.dept_id IS NULL
+           OR p.dept_id IN (
+               SELECT id FROM lj_departments WHERE active))
+    ORDER BY c.id ASC
+    LIMIT 26
+) sub;
+
+-- ============================================================
+-- Test 11: All-absorbed + LIMIT regression
+-- ============================================================
+-- Simple join with no SubPlans. Both tables have BM25 indexes,
+-- join key (company_id) is a fast field, ORDER BY c.id is a fast
+-- field. JoinScan SHOULD activate and use TopK(fetch=N).
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT c.id, p.name FROM lj_companies c
+JOIN lj_people p ON c.id = p.company_id
+WHERE c.id @@@ paradedb.all()
+ORDER BY c.id ASC
+LIMIT 26;
+
+-- ============================================================
+-- Test 12: LIMIT + OFFSET with outer predicates
+-- ============================================================
+-- NOT EXISTS against non-BM25 table + LIMIT + OFFSET. JoinScan
+-- should bail out.
+
+SELECT count(*) FROM (
+    SELECT c.id FROM lj_companies c
+    WHERE c.id @@@ paradedb.all()
+      AND NOT EXISTS (
+          SELECT 1 FROM lj_excluded_emails e
+          WHERE e.company_id = c.id
+      )
+    ORDER BY c.name ASC
+    LIMIT 26 OFFSET 10
+) sub;
+
+-- ============================================================
+-- Test 13: Combined anti-join + OR SubPlan + seniority filter
+-- ============================================================
+-- Real-world pattern: multiple unsafe predicates in one query.
+-- NOT EXISTS against non-BM25 lj_excluded_contacts, plus an OR-wrapped
+-- SubPlan (company_id IN (SELECT ...)). JoinScan should bail out.
+
+SELECT count(*) FROM (
+    SELECT p.id
+    FROM lj_people p
+    WHERE p.id @@@ paradedb.all()
+      AND p.seniority_slug IN ('manager', 'director')
+      AND NOT EXISTS (
+          SELECT ec.id FROM lj_excluded_contacts ec
+          WHERE ec.user_id = 1
+            AND ec.email = p.email
+      )
+      AND (p.company_id IS NULL
+           OR p.company_id IN (
+               SELECT c.id FROM lj_companies c
+           ))
+    ORDER BY p.id DESC
+    LIMIT 26
+) sub;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT p.id
+FROM lj_people p
+WHERE p.id @@@ paradedb.all()
+  AND p.seniority_slug IN ('manager', 'director')
+  AND NOT EXISTS (
+      SELECT ec.id FROM lj_excluded_contacts ec
+      WHERE ec.user_id = 1
+        AND ec.email = p.email
+  )
+  AND (p.company_id IS NULL
+       OR p.company_id IN (
+           SELECT c.id FROM lj_companies c
+       ))
+ORDER BY p.id DESC
+LIMIT 26;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+
+DROP TABLE IF EXISTS lj_excluded_contacts CASCADE;
+DROP TABLE IF EXISTS lj_departments CASCADE;
+DROP TABLE IF EXISTS lj_job_openings CASCADE;
+DROP TABLE IF EXISTS lj_excluded_emails CASCADE;
+DROP TABLE IF EXISTS lj_people CASCADE;
+DROP TABLE IF EXISTS lj_companies CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4718

## What

BaseScan and JoinScan no longer push LIMIT into the scan when non-pushable post-filter predicates exist above the scan node. Queries with `IN (SELECT ...)`, `NOT EXISTS`, OR-wrapped SubPlans, volatile functions, or RLS policies that previously returned silently truncated results now return the correct row count. Queries where all predicates are fully pushable are unaffected — TopK is still used.

## Why

Both scan types absorb `root->limit_tuples` as a hard output cap (TopK). But predicates involving subqueries, volatile functions, and RLS policies cannot be evaluated inside Tantivy or DataFusion — Postgres applies them as post-filters above the scan. The scan returns N rows, the post-filter discards some, and the `Limit` node receives fewer than N. The scan has already declared EOF, so the executor stops — producing a silently truncated result.

The bug is data-distribution-dependent and masked by small test datasets.

## How

**BaseScan:** Added `has_non_pushable_predicates()` that checks `baserestrictinfo` for SubPlans and volatile functions at path creation time. When detected, `limit` is set to `None` and the exec method falls through to Normal or Columnar.

**JoinScan:** Added `is_limit_pushdown_safe()` with three checks: (1) all base relations absorbed, (2) all SubPlans absorbed into Semi/Anti/LeftMark joins (tracked via new `subplan_id` field on `JoinNode`, compared using `expression_tree_walker`), (3) no volatile functions. When the check fails, JoinScan bails out entirely — Postgres falls back to its native plan.

```
Before (buggy):                          After (fixed):

Limit (rows=N)                           Limit (rows=N)
└── [Filter / Join]                      └── Sort
      └── Custom Scan             ──►          └── [Filter / Join]
            TopK Limit: N                            └── Custom Scan
                                                           Exec: NormalScanExecState
```

Existing tests `issue_4531`, `issue_4667`, `issue_4719` are unchanged — JoinScan correctly identifies absorbed SubPlans and preserves TopK.

## Tests

New file `limit_pushdown_basescan.sql` (7 tests): core SubPlan reproducer with score-differentiated data, no-LIMIT regression, fully-pushable TopK regression, parameterized limit, partitioned table, LEFT JOIN LATERAL, RLS subquery policy.

New file `limit_pushdown_joinscan.sql` (6 tests): anti-join #4718 reproducer, semi-join with unabsorbed SubPlan, OR-wrapped SubPlan on absorbed relation, all-absorbed TopK regression, LIMIT+OFFSET, combined anti-join + OR SubPlan real-world pattern.
