### PR TITLE
fix: Recognize `id + 0` and similar identity expressions in JoinScan ORDER BY matching

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -46,7 +46,7 @@ use crate::postgres::customscan::CustomScan;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_collect_vars, expr_contains_any_operator};
-use crate::postgres::var::fieldname_from_var;
+use crate::postgres::var::{fieldname_from_var, unwrap_order_preserving};
 use crate::query::SearchQueryInput;
 
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
@@ -1802,6 +1802,11 @@ impl JoinSortExprKind {
         output_rtis: &[pg_sys::Index],
         pathkey_equivalence_member: bool,
     ) -> Self {
+        // Strip order-preserving wrappers (e.g. `id + 0`, RelabelType, CoerceToDomain)
+        // so that the expression reaches the pattern-matching below in canonical form.
+        let check_expr =
+            unwrap_order_preserving(check_expr as *mut pg_sys::Node) as *mut pg_sys::Expr;
+
         if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {
             let inner_expr = strip_wrappers((*nt).arg.cast()).cast::<pg_sys::Expr>();
             let nulltesttype = if (*nt).nulltesttype == pg_sys::NullTestType::IS_NULL {

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1308,7 +1308,9 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
 
         for member in members.iter_ptr() {
             let expr = (*member).em_expr;
-            let mut check_expr = strip_wrappers(expr.cast());
+            // Chain strip_wrappers (for PlaceHolderVar/RelabelType) then
+            // unwrap_order_preserving (for identity OpExpr like `id + 0`).
+            let mut check_expr = unwrap_order_preserving(strip_wrappers(expr.cast()));
 
             // Unwrap NullTest to inspect the inner expression
             if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -46,7 +46,7 @@ use crate::postgres::customscan::CustomScan;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_collect_vars, expr_contains_any_operator};
-use crate::postgres::var::{fieldname_from_var, unwrap_order_preserving};
+use crate::postgres::var::{fieldname_from_var, strip_identity_wrappers};
 use crate::query::SearchQueryInput;
 
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
@@ -1310,11 +1310,11 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
             let expr = (*member).em_expr;
             // Chain strip_wrappers (for PlaceHolderVar/RelabelType) then
             // unwrap_order_preserving (for identity OpExpr like `id + 0`).
-            let mut expr = unwrap_order_preserving(strip_wrappers(expr.cast()));
+            let mut expr = strip_identity_wrappers(strip_wrappers(expr.cast()));
 
             // Unwrap NullTest to inspect the inner expression
             if let Some(nt) = nodecast!(NullTest, T_NullTest, expr) {
-                expr = unwrap_order_preserving(strip_wrappers((*nt).arg.cast()));
+                expr = strip_identity_wrappers(strip_wrappers((*nt).arg.cast()));
             }
 
             if sources
@@ -1807,7 +1807,7 @@ impl JoinSortExprKind {
         // Strip order-preserving wrappers (e.g. `id + 0`, RelabelType, CoerceToDomain)
         // so that the expression reaches the pattern-matching below in canonical form.
         let check_expr =
-            unwrap_order_preserving(check_expr as *mut pg_sys::Node) as *mut pg_sys::Expr;
+            strip_identity_wrappers(check_expr as *mut pg_sys::Node) as *mut pg_sys::Expr;
 
         if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {
             let inner_expr = strip_wrappers((*nt).arg.cast()).cast::<pg_sys::Expr>();

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1310,21 +1310,21 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
             let expr = (*member).em_expr;
             // Chain strip_wrappers (for PlaceHolderVar/RelabelType) then
             // unwrap_order_preserving (for identity OpExpr like `id + 0`).
-            let mut check_expr = unwrap_order_preserving(strip_wrappers(expr.cast()));
+            let mut expr = unwrap_order_preserving(strip_wrappers(expr.cast()));
 
             // Unwrap NullTest to inspect the inner expression
-            if let Some(nt) = nodecast!(NullTest, T_NullTest, check_expr) {
-                check_expr = strip_wrappers((*nt).arg.cast());
+            if let Some(nt) = nodecast!(NullTest, T_NullTest, expr) {
+                expr = unwrap_order_preserving(strip_wrappers((*nt).arg.cast()));
             }
 
             if sources
                 .iter()
-                .any(|s| is_score_func_recursive(check_expr.cast(), s))
+                .any(|s| is_score_func_recursive(expr.cast(), s))
             {
                 continue 'pathkey;
             }
 
-            if let Some(var) = nodecast!(Var, T_Var, check_expr) {
+            if let Some(var) = nodecast!(Var, T_Var, expr) {
                 let varno = (*var).varno as pg_sys::Index;
                 let varattno = (*var).varattno;
 
@@ -1350,7 +1350,7 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
                         continue;
                     };
                     if find_matching_fast_field(
-                        expr as *mut pg_sys::Node,
+                        expr,
                         &index_rel.index_expressions(),
                         schema,
                         source.scan_info.heap_rti,

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1309,7 +1309,7 @@ pub(super) unsafe fn order_by_columns_are_fast_fields(
         for member in members.iter_ptr() {
             let expr = (*member).em_expr;
             // Chain strip_wrappers (for PlaceHolderVar/RelabelType) then
-            // unwrap_order_preserving (for identity OpExpr like `id + 0`).
+            // strip_identity_wrappers (for identity OpExpr like `id + 0`).
             let mut expr = strip_identity_wrappers(strip_wrappers(expr.cast()));
 
             // Unwrap NullTest to inspect the inner expression

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -33,7 +33,9 @@ use crate::postgres::customscan::score_funcoids;
 use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
-use crate::postgres::var::{fieldname_from_var, find_one_var_and_fieldname, VarContext};
+use crate::postgres::var::{
+    fieldname_from_var, find_one_var_and_fieldname, unwrap_order_preserving, VarContext,
+};
 use crate::schema::{SearchField, SearchIndexSchema};
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
 
@@ -192,6 +194,10 @@ pub unsafe fn analyze_sort_expression(
     context: VarContext,
     index_info: Option<&IndexExpressionInfo>,
 ) -> Option<(SortExpressionType, *mut pg_sys::Var, Option<FieldName>)> {
+    // Strip order-preserving wrappers (e.g. `id + 0`, RelabelType, CoerceToDomain)
+    // so that the expression reaches the pattern-matching below in canonical form.
+    let node = unsafe { unwrap_order_preserving(node) };
+
     if let Some(var) = extract_score_var(node) {
         return Some((SortExpressionType::Score, var, None));
     }

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -196,7 +196,7 @@ pub unsafe fn analyze_sort_expression(
 ) -> Option<(SortExpressionType, *mut pg_sys::Var, Option<FieldName>)> {
     // Strip order-preserving wrappers (e.g. `id + 0`, RelabelType, CoerceToDomain)
     // so that the expression reaches the pattern-matching below in canonical form.
-    let node = unsafe { unwrap_order_preserving(node) };
+    let node = unwrap_order_preserving(node);
 
     if let Some(var) = extract_score_var(node) {
         return Some((SortExpressionType::Score, var, None));

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -34,7 +34,7 @@ use crate::postgres::options::{SortByDirection, SortByField};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::var::{
-    fieldname_from_var, find_one_var_and_fieldname, unwrap_order_preserving, VarContext,
+    fieldname_from_var, find_one_var_and_fieldname, strip_identity_wrappers, VarContext,
 };
 use crate::schema::{SearchField, SearchIndexSchema};
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
@@ -196,7 +196,7 @@ pub unsafe fn analyze_sort_expression(
 ) -> Option<(SortExpressionType, *mut pg_sys::Var, Option<FieldName>)> {
     // Strip order-preserving wrappers (e.g. `id + 0`, RelabelType, CoerceToDomain)
     // so that the expression reaches the pattern-matching below in canonical form.
-    let node = unwrap_order_preserving(node);
+    let node = strip_identity_wrappers(node);
 
     if let Some(var) = extract_score_var(node) {
         return Some((SortExpressionType::Score, var, None));

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -22,8 +22,8 @@ use crate::nodecast;
 use crate::postgres::var::identity_ops::IdentityOp;
 use pgrx::pg_sys::NodeTag::{T_CoerceViaIO, T_Const, T_OpExpr, T_RelabelType, T_Var};
 use pgrx::pg_sys::{expression_tree_walker, CoerceViaIO, Const, OpExpr, RelabelType, Var};
-use pgrx::PgOid;
 use pgrx::{is_a, pg_guard, pg_sys, FromDatum, PgList, PgRelation};
+use pgrx::{AnyNumeric, PgOid};
 use std::ffi::CStr;
 use std::ptr::addr_of_mut;
 use std::sync::OnceLock;
@@ -183,6 +183,9 @@ unsafe fn is_identity_operation(
             pg_sys::INT8OID => i64::from_datum(datum, false) == Some(expected),
             pg_sys::FLOAT4OID => f32::from_datum(datum, false) == Some(expected as f32),
             pg_sys::FLOAT8OID => f64::from_datum(datum, false) == Some(expected as f64),
+            pg_sys::NUMERICOID => {
+                AnyNumeric::from_datum(datum, false) == Some(AnyNumeric::from(expected))
+            }
             _ => false,
         }
     };

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -19,6 +19,7 @@ use crate::api::FieldName;
 use crate::api::HashSet;
 use crate::customscan::operator_oid;
 use crate::nodecast;
+use crate::postgres::var::identity_ops::IdentityOp;
 use pgrx::pg_sys::NodeTag::{T_CoerceViaIO, T_Const, T_OpExpr, T_RelabelType, T_Var};
 use pgrx::pg_sys::{expression_tree_walker, CoerceViaIO, Const, OpExpr, RelabelType, Var};
 use pgrx::PgOid;
@@ -27,20 +28,75 @@ use std::ffi::CStr;
 use std::ptr::addr_of_mut;
 use std::sync::OnceLock;
 
-/// Operator OIDs from pg_catalog, stable across PG14–PG18.
-/// Source: `SELECT oid, oprcode FROM pg_operator WHERE …`
-mod op_oids {
+/// Operator OIDs
+mod identity_ops {
+    use crate::api::HashMap;
+    use crate::postgres::customscan::operator_oid;
     use pgrx::pg_sys::Oid;
-    pub const INT4PL: Oid = Oid::from_u32(551);
-    pub const INT8PL: Oid = Oid::from_u32(684);
-    pub const FLOAT4PL: Oid = Oid::from_u32(586);
-    pub const FLOAT8PL: Oid = Oid::from_u32(591);
-    pub const NUMERIC_ADD: Oid = Oid::from_u32(1758);
-    pub const INT4MI: Oid = Oid::from_u32(555);
-    pub const INT8MI: Oid = Oid::from_u32(688);
-    pub const INT4MUL: Oid = Oid::from_u32(514);
-    pub const INT8MUL: Oid = Oid::from_u32(686);
-    pub const INT4DIV: Oid = Oid::from_u32(528);
+    use std::sync::OnceLock;
+    use strum::Display;
+
+    #[derive(Copy, Clone, Debug, Display)]
+    pub enum IdentityOp {
+        Add,
+        Sub,
+        Mul,
+        Div,
+    }
+
+    static IDENTITY_OPS: OnceLock<HashMap<Oid, IdentityOp>> = OnceLock::new();
+
+    pub unsafe fn lookup() -> &'static HashMap<Oid, IdentityOp> {
+        IDENTITY_OPS.get_or_init(|| {
+            let mut map = HashMap::default();
+
+            // +(T, T) → Add (identity: 0, either side)
+            for sig in [
+                "+(int4,int4)",
+                "+(int8,int8)",
+                "+(float4,float4)",
+                "+(float8,float8)",
+                "+(numeric,numeric)",
+            ] {
+                map.insert(operator_oid(sig), IdentityOp::Add);
+            }
+
+            // -(T, T) → Sub (identity: 0, right side only)
+            for sig in [
+                "-(int4,int4)",
+                "-(int8,int8)",
+                "-(float4,float4)",
+                "-(float8,float8)",
+                "-(numeric,numeric)",
+            ] {
+                map.insert(operator_oid(sig), IdentityOp::Sub);
+            }
+
+            // *(T, T) → Mul (identity: 1, either side)
+            for sig in [
+                "*(int4,int4)",
+                "*(int8,int8)",
+                "*(float4,float4)",
+                "*(float8,float8)",
+                "*(numeric,numeric)",
+            ] {
+                map.insert(operator_oid(sig), IdentityOp::Mul);
+            }
+
+            // /(T, T) → Div (identity: 1, right side only)
+            for sig in [
+                "/(int4,int4)",
+                "/(int8,int8)",
+                "/(float4,float4)",
+                "/(float8,float8)",
+                "/(numeric,numeric)",
+            ] {
+                map.insert(operator_oid(sig), IdentityOp::Div);
+            }
+
+            map
+        })
+    }
 }
 
 /// Strip wrappers from `expr` that do not affect row ordering.
@@ -51,10 +107,10 @@ mod op_oids {
 ///
 /// Safe to call with a null pointer; returns null in that case.
 pub(crate) unsafe fn unwrap_order_preserving(mut expr: *mut pg_sys::Node) -> *mut pg_sys::Node {
-    if expr.is_null() {
-        return expr;
-    }
     loop {
+        if expr.is_null() {
+            return expr;
+        }
         match (*expr).type_ {
             pg_sys::NodeTag::T_RelabelType => {
                 expr = (*(expr as *mut pg_sys::RelabelType)).arg as *mut pg_sys::Node;
@@ -88,6 +144,7 @@ unsafe fn try_unwrap_identity_opexpr(op: *mut pg_sys::OpExpr) -> Option<*mut pg_
     // Match "Var-side <op> Const" or "Const <op> Var-side".
     // The "var side" is the non-Const operand — it may itself be a wrapped Var.
     let (var_side, const_side, const_on_right) = match ((*left).type_, (*right).type_) {
+        (pg_sys::NodeTag::T_Const, pg_sys::NodeTag::T_Const) => return None,
         (pg_sys::NodeTag::T_Const, _) => (right, left as *mut pg_sys::Const, false),
         (_, pg_sys::NodeTag::T_Const) => (left, right as *mut pg_sys::Const, true),
         _ => return None,
@@ -114,41 +171,29 @@ unsafe fn is_identity_operation(
         return false;
     }
 
-    match opno {
-        // Addition: identity element is 0, commutative (either side)
-        op_oids::INT4PL => i32::from_datum((*konst).constvalue, false) == Some(0),
-        op_oids::INT8PL => i64::from_datum((*konst).constvalue, false) == Some(0),
-        op_oids::FLOAT4PL => f32::from_datum((*konst).constvalue, false) == Some(0.0),
-        op_oids::FLOAT8PL => f64::from_datum((*konst).constvalue, false) == Some(0.0),
-        op_oids::NUMERIC_ADD => {
-            // For numeric, extract as string and check for zero
-            numeric_const_is_zero(konst)
+    let Some(&op) = identity_ops::lookup().get(&opno) else {
+        return false;
+    };
+
+    let const_is = |expected: i64| -> bool {
+        let datum = (*konst).constvalue;
+        let typoid = (*konst).consttype;
+        match typoid {
+            pg_sys::INT4OID => i32::from_datum(datum, false) == Some(expected as i32),
+            pg_sys::INT8OID => i64::from_datum(datum, false) == Some(expected),
+            pg_sys::FLOAT4OID => f32::from_datum(datum, false) == Some(expected as f32),
+            pg_sys::FLOAT8OID => f64::from_datum(datum, false) == Some(expected as f64),
+            _ => false,
         }
+    };
 
-        // Subtraction: identity element is 0, but only when const is on the right
-        // (0 - id inverts ordering)
-        op_oids::INT4MI => const_on_right && i32::from_datum((*konst).constvalue, false) == Some(0),
-        op_oids::INT8MI => const_on_right && i64::from_datum((*konst).constvalue, false) == Some(0),
-
-        // Multiplication: identity element is 1, commutative (either side)
-        op_oids::INT4MUL => i32::from_datum((*konst).constvalue, false) == Some(1),
-        op_oids::INT8MUL => i64::from_datum((*konst).constvalue, false) == Some(1),
-
-        // Division: identity element is 1, only when const is on the right
-        op_oids::INT4DIV => {
-            const_on_right && i32::from_datum((*konst).constvalue, false) == Some(1)
-        }
-
-        _ => false,
-    }
-}
-
-/// Check if a numeric `Const` node represents zero.
-unsafe fn numeric_const_is_zero(konst: *mut pg_sys::Const) -> bool {
-    let numeric: Option<pgrx::AnyNumeric> = FromDatum::from_datum((*konst).constvalue, false);
-    match numeric {
-        Some(n) => n == pgrx::AnyNumeric::from(0i32),
-        None => false,
+    // Note: -0.0 == 0.0 in IEEE 754, so float_col + (-0.0) also gets
+    // unwrapped. This is correct — adding -0.0 is an identity operation.
+    match op {
+        IdentityOp::Add => const_is(0),
+        IdentityOp::Sub => const_on_right && const_is(0),
+        IdentityOp::Mul => const_is(1),
+        IdentityOp::Div => const_on_right && const_is(1),
     }
 }
 

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -98,15 +98,15 @@ mod identity_ops {
         })
     }
 }
-
-/// Strip wrappers from `expr` that do not affect row ordering.
+/// Strip identity wrappers from `expr`: `RelabelType`, `CoerceToDomain`,
+/// and `OpExpr` where the operator is a known identity operation
+/// (e.g. `+ 0`, `- 0`, `* 1`, `/ 1` against pg_catalog numeric types).
 ///
-/// Returns a pointer to the first inner node whose shape the rest of
-/// the planner recognizes (typically a `Var`). If no wrapper can be
-/// safely removed, returns `expr` unchanged.
+/// Returns the innermost non-identity node (typically a `Var`).
+/// If nothing can be safely stripped, returns `expr` unchanged.
 ///
 /// Safe to call with a null pointer; returns null in that case.
-pub(crate) unsafe fn unwrap_order_preserving(mut expr: *mut pg_sys::Node) -> *mut pg_sys::Node {
+pub(crate) unsafe fn strip_identity_wrappers(mut expr: *mut pg_sys::Node) -> *mut pg_sys::Node {
     loop {
         if expr.is_null() {
             return expr;

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -82,8 +82,8 @@ unsafe fn try_unwrap_identity_opexpr(op: *mut pg_sys::OpExpr) -> Option<*mut pg_
     if args_list.len() != 2 {
         return None;
     }
-    let left = args_list.get_ptr(0)? as *mut pg_sys::Node;
-    let right = args_list.get_ptr(1)? as *mut pg_sys::Node;
+    let left = args_list.get_ptr(0)?;
+    let right = args_list.get_ptr(1)?;
 
     // Match "Var-side <op> Const" or "Const <op> Var-side".
     // The "var side" is the non-Const operand — it may itself be a wrapped Var.

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -27,6 +27,145 @@ use std::ffi::CStr;
 use std::ptr::addr_of_mut;
 use std::sync::OnceLock;
 
+/// Operator OIDs from pg_catalog, stable across PG14–PG18.
+/// Source: `SELECT oid, oprcode FROM pg_operator WHERE …`
+mod op_oids {
+    use pgrx::pg_sys::Oid;
+    pub const INT4PL: Oid = Oid::from_u32(551);
+    pub const INT8PL: Oid = Oid::from_u32(684);
+    pub const FLOAT4PL: Oid = Oid::from_u32(586);
+    pub const FLOAT8PL: Oid = Oid::from_u32(591);
+    pub const NUMERIC_ADD: Oid = Oid::from_u32(1758);
+    pub const INT4MI: Oid = Oid::from_u32(555);
+    pub const INT8MI: Oid = Oid::from_u32(688);
+    pub const INT4MUL: Oid = Oid::from_u32(514);
+    pub const INT8MUL: Oid = Oid::from_u32(686);
+    pub const INT4DIV: Oid = Oid::from_u32(528);
+}
+
+/// Strip wrappers from `expr` that do not affect row ordering.
+///
+/// Returns a pointer to the first inner node whose shape the rest of
+/// the planner recognizes (typically a `Var`). If no wrapper can be
+/// safely removed, returns `expr` unchanged.
+///
+/// Safe to call with a null pointer; returns null in that case.
+pub(crate) unsafe fn unwrap_order_preserving(mut expr: *mut pg_sys::Node) -> *mut pg_sys::Node {
+    if expr.is_null() {
+        return expr;
+    }
+    loop {
+        match (*expr).type_ {
+            pg_sys::NodeTag::T_RelabelType => {
+                expr = (*(expr as *mut pg_sys::RelabelType)).arg as *mut pg_sys::Node;
+            }
+            pg_sys::NodeTag::T_CoerceToDomain => {
+                expr = (*(expr as *mut pg_sys::CoerceToDomain)).arg as *mut pg_sys::Node;
+            }
+            pg_sys::NodeTag::T_OpExpr => match try_unwrap_identity_opexpr(expr as *mut pg_sys::OpExpr) {
+                Some(inner) => expr = inner,
+                None => return expr,
+            },
+            _ => return expr,
+        }
+    }
+}
+
+/// Attempt to unwrap an `OpExpr` of the shape `Var <op> Const` or `Const <op> Var`
+/// where the operator is a known identity operation (e.g. `+ 0`, `* 1`).
+unsafe fn try_unwrap_identity_opexpr(op: *mut pg_sys::OpExpr) -> Option<*mut pg_sys::Node> {
+    // Must have exactly two args.
+    let args = (*op).args;
+    let args_list = PgList::<pg_sys::Node>::from_pg(args);
+    if args_list.len() != 2 {
+        return None;
+    }
+    let left = args_list.get_ptr(0)? as *mut pg_sys::Node;
+    let right = args_list.get_ptr(1)? as *mut pg_sys::Node;
+
+    // Match "Var-side <op> Const" or "Const <op> Var-side".
+    // The "var side" is the non-Const operand — it may itself be a wrapped Var.
+    let (var_side, const_side, const_on_right) = match ((*left).type_, (*right).type_) {
+        (pg_sys::NodeTag::T_Const, _) => (right, left as *mut pg_sys::Const, false),
+        (_, pg_sys::NodeTag::T_Const) => (left, right as *mut pg_sys::Const, true),
+        _ => return None,
+    };
+
+    // Operator OID + identity-value check.
+    if !is_identity_operation((*op).opno, const_side, const_on_right) {
+        return None;
+    }
+    Some(var_side)
+}
+
+/// Check whether the given operator OID combined with the constant value
+/// forms an identity operation that preserves row ordering.
+///
+/// `const_on_right` indicates whether the constant is the right operand.
+/// For non-commutative operators like `-` and `/`, the constant must be on the right.
+unsafe fn is_identity_operation(
+    opno: pg_sys::Oid,
+    konst: *mut pg_sys::Const,
+    const_on_right: bool,
+) -> bool {
+    if konst.is_null() || (*konst).constisnull {
+        return false;
+    }
+
+    match opno {
+        // Addition: identity element is 0, commutative (either side)
+        op_oids::INT4PL => {
+            i32::from_datum((*konst).constvalue, false) == Some(0)
+        }
+        op_oids::INT8PL => {
+            i64::from_datum((*konst).constvalue, false) == Some(0)
+        }
+        op_oids::FLOAT4PL => {
+            f32::from_datum((*konst).constvalue, false) == Some(0.0)
+        }
+        op_oids::FLOAT8PL => {
+            f64::from_datum((*konst).constvalue, false) == Some(0.0)
+        }
+        op_oids::NUMERIC_ADD => {
+            // For numeric, extract as string and check for zero
+            numeric_const_is_zero(konst)
+        }
+
+        // Subtraction: identity element is 0, but only when const is on the right
+        // (0 - id inverts ordering)
+        op_oids::INT4MI => {
+            const_on_right && i32::from_datum((*konst).constvalue, false) == Some(0)
+        }
+        op_oids::INT8MI => {
+            const_on_right && i64::from_datum((*konst).constvalue, false) == Some(0)
+        }
+
+        // Multiplication: identity element is 1, commutative (either side)
+        op_oids::INT4MUL => {
+            i32::from_datum((*konst).constvalue, false) == Some(1)
+        }
+        op_oids::INT8MUL => {
+            i64::from_datum((*konst).constvalue, false) == Some(1)
+        }
+
+        // Division: identity element is 1, only when const is on the right
+        op_oids::INT4DIV => {
+            const_on_right && i32::from_datum((*konst).constvalue, false) == Some(1)
+        }
+
+        _ => false,
+    }
+}
+
+/// Check if a numeric `Const` node represents zero.
+unsafe fn numeric_const_is_zero(konst: *mut pg_sys::Const) -> bool {
+    let numeric: Option<pgrx::AnyNumeric> = FromDatum::from_datum((*konst).constvalue, false);
+    match numeric {
+        Some(n) => n == pgrx::AnyNumeric::from(0i32),
+        None => false,
+    }
+}
+
 #[derive(Clone, Copy)]
 pub enum VarContext {
     Planner(*mut pg_sys::PlannerInfo),

--- a/pg_search/src/postgres/var.rs
+++ b/pg_search/src/postgres/var.rs
@@ -62,10 +62,12 @@ pub(crate) unsafe fn unwrap_order_preserving(mut expr: *mut pg_sys::Node) -> *mu
             pg_sys::NodeTag::T_CoerceToDomain => {
                 expr = (*(expr as *mut pg_sys::CoerceToDomain)).arg as *mut pg_sys::Node;
             }
-            pg_sys::NodeTag::T_OpExpr => match try_unwrap_identity_opexpr(expr as *mut pg_sys::OpExpr) {
-                Some(inner) => expr = inner,
-                None => return expr,
-            },
+            pg_sys::NodeTag::T_OpExpr => {
+                match try_unwrap_identity_opexpr(expr as *mut pg_sys::OpExpr) {
+                    Some(inner) => expr = inner,
+                    None => return expr,
+                }
+            }
             _ => return expr,
         }
     }
@@ -114,18 +116,10 @@ unsafe fn is_identity_operation(
 
     match opno {
         // Addition: identity element is 0, commutative (either side)
-        op_oids::INT4PL => {
-            i32::from_datum((*konst).constvalue, false) == Some(0)
-        }
-        op_oids::INT8PL => {
-            i64::from_datum((*konst).constvalue, false) == Some(0)
-        }
-        op_oids::FLOAT4PL => {
-            f32::from_datum((*konst).constvalue, false) == Some(0.0)
-        }
-        op_oids::FLOAT8PL => {
-            f64::from_datum((*konst).constvalue, false) == Some(0.0)
-        }
+        op_oids::INT4PL => i32::from_datum((*konst).constvalue, false) == Some(0),
+        op_oids::INT8PL => i64::from_datum((*konst).constvalue, false) == Some(0),
+        op_oids::FLOAT4PL => f32::from_datum((*konst).constvalue, false) == Some(0.0),
+        op_oids::FLOAT8PL => f64::from_datum((*konst).constvalue, false) == Some(0.0),
         op_oids::NUMERIC_ADD => {
             // For numeric, extract as string and check for zero
             numeric_const_is_zero(konst)
@@ -133,20 +127,12 @@ unsafe fn is_identity_operation(
 
         // Subtraction: identity element is 0, but only when const is on the right
         // (0 - id inverts ordering)
-        op_oids::INT4MI => {
-            const_on_right && i32::from_datum((*konst).constvalue, false) == Some(0)
-        }
-        op_oids::INT8MI => {
-            const_on_right && i64::from_datum((*konst).constvalue, false) == Some(0)
-        }
+        op_oids::INT4MI => const_on_right && i32::from_datum((*konst).constvalue, false) == Some(0),
+        op_oids::INT8MI => const_on_right && i64::from_datum((*konst).constvalue, false) == Some(0),
 
         // Multiplication: identity element is 1, commutative (either side)
-        op_oids::INT4MUL => {
-            i32::from_datum((*konst).constvalue, false) == Some(1)
-        }
-        op_oids::INT8MUL => {
-            i64::from_datum((*konst).constvalue, false) == Some(1)
-        }
+        op_oids::INT4MUL => i32::from_datum((*konst).constvalue, false) == Some(1),
+        op_oids::INT8MUL => i64::from_datum((*konst).constvalue, false) == Some(1),
 
         // Division: identity element is 1, only when const is on the right
         op_oids::INT4DIV => {

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -1,0 +1,623 @@
+-- Tests for JoinScan with ORDER BY expressions that are order-preserving
+-- wrappers around bare columns (e.g. id + 0, id - 0, id * 1, id / 1).
+-- Regression test for https://github.com/paradedb/paradedb/issues/4754
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+DROP TABLE IF EXISTS companies CASCADE;
+DROP TABLE IF EXISTS funding_rounds CASCADE;
+CREATE TABLE companies (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+CREATE TABLE funding_rounds (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER,
+    amount INTEGER,
+    round_type TEXT
+);
+INSERT INTO companies (id, name, description) VALUES
+(1, 'TechStartup', 'A technology startup building innovative solutions'),
+(2, 'DataCorp', 'Data analytics and machine learning company'),
+(3, 'CloudNet', 'Cloud networking and infrastructure provider'),
+(4, 'AIVentures', 'Artificial intelligence research and development'),
+(5, 'WebScale', 'Web-scale distributed systems company');
+INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
+(101, 1, 1000000, 'seed'),
+(102, 1, 5000000, 'series_a'),
+(103, 2, 2000000, 'seed'),
+(104, 3, 10000000, 'series_b'),
+(105, 4, 500000, 'seed'),
+(106, 5, 3000000, 'series_a');
+CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
+WITH (key_field = 'id');
+CREATE INDEX funding_rounds_bm25_idx ON funding_rounds USING bm25 (id, company_id, amount, round_type)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"company_id": {"fast": true}, "amount": {"fast": true}}'
+);
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- TEST 1: Baseline — JoinScan activates with bare ORDER BY c.id DESC
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: c.id, c.name
+         Relation Tree: c SEMI fr
+         Join Cond: c.id = fr.company_id
+         Limit: 10
+         Order By: c.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+           :       VisibilityFilterExec: tables=[c]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- =============================================================================
+-- TEST 2: JoinScan should activate with ORDER BY c.id + 0 DESC
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + 0))
+   ->  Sort
+         Output: c.id, c.name, ((c.id + 0))
+         Sort Key: ((c.id + 0)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id + 0)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- =============================================================================
+-- TEST 3: Results must match between bare column and expression form
+-- =============================================================================
+-- Bare column form
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- Expression form (id + 0) — must return identical rows
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- =============================================================================
+-- TEST 4: ORDER BY c.id - 0 DESC (subtraction with zero on right)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id - 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id - 0))
+   ->  Sort
+         Output: c.id, c.name, ((c.id - 0))
+         Sort Key: ((c.id - 0)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id - 0)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 5: ORDER BY c.id * 1 DESC (multiplication by one)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id * 1))
+   ->  Sort
+         Output: c.id, c.name, ((c.id * 1))
+         Sort Key: ((c.id * 1)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id * 1)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 6: ORDER BY c.id / 1 DESC (division by one)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id / 1 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id / 1))
+   ->  Sort
+         Output: c.id, c.name, ((c.id / 1))
+         Sort Key: ((c.id / 1)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id / 1)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 7: Nested wrappers — (c.id + 0)::int4 should still unwrap
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY (c.id + 0)::int4 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + 0))
+   ->  Sort
+         Output: c.id, c.name, ((c.id + 0))
+         Sort Key: ((c.id + 0)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id + 0)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 8: Non-identity expression should NOT activate JoinScan
+-- ORDER BY c.id + 1 DESC — this is NOT order-preserving identity
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 1 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + 1))
+   ->  Sort
+         Output: c.id, c.name, ((c.id + 1))
+         Sort Key: ((c.id + 1)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id + 1)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 9: 0 - c.id should NOT unwrap (inverts ordering)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 0 - c.id DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((0 - c.id))
+   ->  Sort
+         Output: c.id, c.name, ((0 - c.id))
+         Sort Key: ((0 - c.id)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (0 - c.id)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 10: Var + Var should NOT unwrap (not a Const)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + c.id DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + c.id))
+   ->  Sort
+         Output: c.id, c.name, ((c.id + c.id))
+         Sort Key: ((c.id + c.id)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id + c.id)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(22 rows)
+
+-- =============================================================================
+-- TEST 11: Using === operator alongside @@@
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + 0))
+   ->  Sort
+         Output: c.id, c.name, ((c.id + 0))
+         Sort Key: ((c.id + 0)) DESC
+         ->  Nested Loop Semi Join
+               Output: c.id, c.name, (c.id + 0)
+               Join Filter: (c.id = fr.company_id)
+               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+                     Output: c.id, c.name
+                     Table: companies
+                     Index: companies_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
+                     Output: fr.company_id
+                     Table: funding_rounds
+                     Index: funding_rounds_bm25_idx
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"term":{"field":"round_type","value":"seed","is_datetime":false}}}}
+(22 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- =============================================================================
+-- TEST 12: Production-shape query — multiple IN subqueries with NOT EXISTS
+-- =============================================================================
+DROP TABLE IF EXISTS orders CASCADE;
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER,
+    status TEXT,
+    total INTEGER
+);
+INSERT INTO orders (id, company_id, status, total) VALUES
+(201, 1, 'completed', 5000),
+(202, 2, 'pending', 3000),
+(203, 1, 'cancelled', 1000),
+(204, 3, 'completed', 8000),
+(205, 4, 'completed', 2000);
+CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, status, total)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"company_id": {"fast": true}, "total": {"fast": true}}'
+);
+-- Complex query with multiple IN subqueries and NOT EXISTS
+-- Result correctness: bare column vs expression form must match.
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+    AND NOT EXISTS (
+        SELECT 1 FROM orders o
+        WHERE o.company_id = fr.company_id
+        AND o.status @@@ 'cancelled'
+    )
+)
+AND c.description @@@ 'technology OR intelligence'
+ORDER BY c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name    
+----+------------
+  4 | AIVentures
+(1 row)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+    AND NOT EXISTS (
+        SELECT 1 FROM orders o
+        WHERE o.company_id = fr.company_id
+        AND o.status @@@ 'cancelled'
+    )
+)
+AND c.description @@@ 'technology OR intelligence'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr, o)
+WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: fr, o)
+WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr, o)
+ id |    name    
+----+------------
+  4 | AIVentures
+(1 row)
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS funding_rounds CASCADE;
+DROP TABLE IF EXISTS companies CASCADE;
+RESET paradedb.enable_join_custom_scan;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -36,7 +36,8 @@ INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
 (106, 5, 3000000, 'series_a');
 CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
 WITH (key_field = 'id');
-CREATE INDEX funding_rounds_bm25_idx ON funding_rounds USING bm25 (id, company_id, amount, round_type)
+CREATE INDEX funding_rounds_bm25_idx ON funding_rounds
+USING bm25 (id, company_id, amount, (round_type::pdb.literal))
 WITH (
     key_field = 'id',
     numeric_fields = '{"company_id": {"fast": true}, "amount": {"fast": true}}'
@@ -108,33 +109,29 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, c.name, ((c.id + 0))
-   ->  Sort
-         Output: c.id, c.name, ((c.id + 0))
-         Sort Key: ((c.id + 0)) DESC
-         ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id + 0)
-               Join Filter: (c.id = fr.company_id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
-                     Output: c.id, c.name
-                     Table: companies
-                     Index: companies_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
-                     Output: fr.company_id
-                     Table: funding_rounds
-                     Index: funding_rounds_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+   ->  Result
+         Output: c.id, c.name, (c.id + 0)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
 
 SELECT c.id, c.name
 FROM companies c
@@ -146,8 +143,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
  id |    name     
 ----+-------------
   1 | TechStartup
@@ -184,8 +180,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
  id |    name     
 ----+-------------
   1 | TechStartup
@@ -205,33 +200,45 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id - 0 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, c.name, ((c.id - 0))
-   ->  Sort
-         Output: c.id, c.name, ((c.id - 0))
-         Sort Key: ((c.id - 0)) DESC
-         ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id - 0)
-               Join Filter: (c.id = fr.company_id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
-                     Output: c.id, c.name
-                     Table: companies
-                     Index: companies_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
-                     Output: fr.company_id
-                     Table: funding_rounds
-                     Index: funding_rounds_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+   ->  Result
+         Output: c.id, c.name, (c.id - 0)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id - 0 DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
 
 -- =============================================================================
 -- TEST 5: ORDER BY c.id * 1 DESC (multiplication by one)
@@ -247,33 +254,45 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id * 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, c.name, ((c.id * 1))
-   ->  Sort
-         Output: c.id, c.name, ((c.id * 1))
-         Sort Key: ((c.id * 1)) DESC
-         ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id * 1)
-               Join Filter: (c.id = fr.company_id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
-                     Output: c.id, c.name
-                     Table: companies
-                     Index: companies_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
-                     Output: fr.company_id
-                     Table: funding_rounds
-                     Index: funding_rounds_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+   ->  Result
+         Output: c.id, c.name, (c.id * 1)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
 
 -- =============================================================================
 -- TEST 6: ORDER BY c.id / 1 DESC (division by one)
@@ -289,33 +308,45 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id / 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, c.name, ((c.id / 1))
-   ->  Sort
-         Output: c.id, c.name, ((c.id / 1))
-         Sort Key: ((c.id / 1)) DESC
-         ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id / 1)
-               Join Filter: (c.id = fr.company_id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
-                     Output: c.id, c.name
-                     Table: companies
-                     Index: companies_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
-                     Output: fr.company_id
-                     Table: funding_rounds
-                     Index: funding_rounds_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+   ->  Result
+         Output: c.id, c.name, (c.id / 1)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id / 1 DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
 
 -- =============================================================================
 -- TEST 7: Nested wrappers — (c.id + 0)::int4 should still unwrap
@@ -331,33 +362,45 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY (c.id + 0)::int4 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, c.name, ((c.id + 0))
-   ->  Sort
-         Output: c.id, c.name, ((c.id + 0))
-         Sort Key: ((c.id + 0)) DESC
-         ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id + 0)
-               Join Filter: (c.id = fr.company_id)
-               ->  Custom Scan (ParadeDB Base Scan) on public.companies c
-                     Output: c.id, c.name
-                     Table: companies
-                     Index: companies_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
-               ->  Custom Scan (ParadeDB Base Scan) on public.funding_rounds fr
-                     Output: fr.company_id
-                     Table: funding_rounds
-                     Index: funding_rounds_bm25_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
-(22 rows)
+   ->  Result
+         Output: c.id, c.name, (c.id + 0)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY (c.id + 0)::int4 DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
 
 -- =============================================================================
 -- TEST 8: Non-identity expression should NOT activate JoinScan
@@ -500,17 +543,72 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0 DESC
 LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.id + 0))
+   ->  Result
+         Output: c.id, c.name, (c.id + 0)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"term":{"field":"round_type","value":"seed","is_datetime":false}}}}
+(19 rows)
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id |    name     
+----+-------------
+  1 | TechStartup
+(1 row)
+
+-- =============================================================================
+-- TEST 12: Cross-type expression should NOT unwrap (different operator OID)
+-- c.id is int4, 0::bigint makes this int48pl (OID not in whitelist)
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0::bigint DESC
+LIMIT 10;
 WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: c.id, c.name, ((c.id + 0))
+   Output: c.id, c.name, ((c.id + '0'::bigint))
    ->  Sort
-         Output: c.id, c.name, ((c.id + 0))
-         Sort Key: ((c.id + 0)) DESC
+         Output: c.id, c.name, ((c.id + '0'::bigint))
+         Sort Key: ((c.id + '0'::bigint)) DESC
          ->  Nested Loop Semi Join
-               Output: c.id, c.name, (c.id + 0)
+               Output: c.id, c.name, (c.id + '0'::bigint)
                Join Filter: (c.id = fr.company_id)
                ->  Custom Scan (ParadeDB Base Scan) on public.companies c
                      Output: c.id, c.name
@@ -528,25 +626,8 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
                      Tantivy Query: {"with_index":{"query":{"term":{"field":"round_type","value":"seed","is_datetime":false}}}}
 (22 rows)
 
-SELECT c.id, c.name
-FROM companies c
-WHERE c.id IN (
-    SELECT fr.company_id
-    FROM funding_rounds fr
-    WHERE fr.round_type === 'seed'
-)
-AND c.description @@@ 'technology'
-ORDER BY c.id + 0 DESC
-LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
- id |    name     
-----+-------------
-  1 | TechStartup
-(1 row)
-
 -- =============================================================================
--- TEST 12: Production-shape query — multiple IN subqueries with NOT EXISTS
+-- TEST 13: Production-shape query — multiple IN subqueries with NOT EXISTS
 -- =============================================================================
 DROP TABLE IF EXISTS orders CASCADE;
 CREATE TABLE orders (
@@ -561,7 +642,7 @@ INSERT INTO orders (id, company_id, status, total) VALUES
 (203, 1, 'cancelled', 1000),
 (204, 3, 'completed', 8000),
 (205, 4, 'completed', 2000);
-CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, status, total)
+CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, (status::pdb.literal), total)
 WITH (
     key_field = 'id',
     numeric_fields = '{"company_id": {"fast": true}, "total": {"fast": true}}'
@@ -604,9 +685,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology OR intelligence'
 ORDER BY c.id + 0 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr, o)
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: fr, o)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr, o)
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
  id |    name    
 ----+------------
   4 | AIVentures

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -34,8 +34,14 @@ INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
 (104, 3, 10000000, 'series_b'),
 (105, 4, 500000, 'seed'),
 (106, 5, 3000000, 'series_a');
-CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
-WITH (key_field = 'id');
+-- Add a BIGINT column for int8 operator coverage
+ALTER TABLE companies ADD COLUMN big_id BIGINT;
+UPDATE companies SET big_id = id;
+CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description, big_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"big_id": {"fast": true}}'
+);
 CREATE INDEX funding_rounds_bm25_idx ON funding_rounds
 USING bm25 (id, company_id, amount, (round_type::pdb.literal))
 WITH (
@@ -401,6 +407,244 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
 ----+-------------
   1 | TechStartup
 (1 row)
+
+-- =============================================================================
+-- Type coverage — JoinScan
+-- =============================================================================
+-- int8: big_id + 0::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.big_id + 0::bigint DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.big_id + '0'::bigint))
+   ->  Result
+         Output: c.id, c.name, (c.big_id + '0'::bigint)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name, c.big_id
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.big_id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, big_id@2 as col_3, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[big_id@2 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+-- int8: big_id * 1::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.big_id * 1::bigint DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((c.big_id * '1'::bigint))
+   ->  Result
+         Output: c.id, c.name, (c.big_id * '1'::bigint)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name, c.big_id
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.big_id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, big_id@2 as col_3, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[big_id@2 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+-- const-on-left: 0 + id (commutative, should unwrap)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 0 + c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((0 + c.id))
+   ->  Result
+         Output: c.id, c.name, (0 + c.id)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+-- const-on-left: 1 * id (commutative, should unwrap)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 1 * c.id DESC
+LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, ((1 * c.id))
+   ->  Result
+         Output: c.id, c.name, (1 * c.id)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: c.id, c.name
+               Relation Tree: c SEMI fr
+               Join Cond: c.id = fr.company_id
+               Limit: 10
+               Order By: c.id desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, ctid_0@0 as ctid_0]
+                 :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+                 :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+                 :       VisibilityFilterExec: tables=[c]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+                 :       CooperativeExec
+                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"round_type","query_string":"seed","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+-- =============================================================================
+-- Type coverage — BaseScan (single-table, no join)
+-- =============================================================================
+-- int4: id + 0
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, name, ((id + 0))
+   ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+         Output: id, name, (id + 0)
+         Table: companies
+         Index: companies_bm25_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id desc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+-- int4: id * 1
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, name, ((id * 1))
+   ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+         Output: id, name, (id * 1)
+         Table: companies
+         Index: companies_bm25_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id desc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+-- int8: big_id + 0::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.big_id + 0::bigint DESC
+LIMIT 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, name, ((big_id + '0'::bigint))
+   ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+         Output: id, name, (big_id + '0'::bigint)
+         Table: companies
+         Index: companies_bm25_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: big_id desc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
+
+-- const-on-left: 0 + id (commutative)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY 0 + c.id DESC
+LIMIT 10;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, name, ((0 + id))
+   ->  Custom Scan (ParadeDB Base Scan) on public.companies c
+         Output: id, name, (0 + id)
+         Table: companies
+         Index: companies_bm25_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: id desc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
+(11 rows)
 
 -- =============================================================================
 -- TEST 8: Non-identity expression should NOT activate JoinScan

--- a/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
+++ b/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
@@ -43,8 +43,15 @@ INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
 (105, 4, 500000, 'seed'),
 (106, 5, 3000000, 'series_a');
 
-CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
-WITH (key_field = 'id');
+-- Add a BIGINT column for int8 operator coverage
+ALTER TABLE companies ADD COLUMN big_id BIGINT;
+UPDATE companies SET big_id = id;
+
+CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description, big_id)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"big_id": {"fast": true}}'
+);
 
 CREATE INDEX funding_rounds_bm25_idx ON funding_rounds
 USING bm25 (id, company_id, amount, (round_type::pdb.literal))
@@ -243,6 +250,98 @@ WHERE c.id IN (
 )
 AND c.description @@@ 'technology'
 ORDER BY (c.id + 0)::int4 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- Type coverage — JoinScan
+-- =============================================================================
+
+-- int8: big_id + 0::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.big_id + 0::bigint DESC
+LIMIT 10;
+
+-- int8: big_id * 1::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.big_id * 1::bigint DESC
+LIMIT 10;
+
+-- const-on-left: 0 + id (commutative, should unwrap)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 0 + c.id DESC
+LIMIT 10;
+
+-- const-on-left: 1 * id (commutative, should unwrap)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 1 * c.id DESC
+LIMIT 10;
+
+-- =============================================================================
+-- Type coverage — BaseScan (single-table, no join)
+-- =============================================================================
+
+-- int4: id + 0
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+-- int4: id * 1
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+
+-- int8: big_id + 0::bigint
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY c.big_id + 0::bigint DESC
+LIMIT 10;
+
+-- const-on-left: 0 + id (commutative)
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.description @@@ 'technology'
+ORDER BY 0 + c.id DESC
 LIMIT 10;
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
+++ b/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
@@ -46,7 +46,8 @@ INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
 CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
 WITH (key_field = 'id');
 
-CREATE INDEX funding_rounds_bm25_idx ON funding_rounds USING bm25 (id, company_id, amount, round_type)
+CREATE INDEX funding_rounds_bm25_idx ON funding_rounds
+USING bm25 (id, company_id, amount, (round_type::pdb.literal))
 WITH (
     key_field = 'id',
     numeric_fields = '{"company_id": {"fast": true}, "amount": {"fast": true}}'
@@ -152,11 +153,33 @@ AND c.description @@@ 'technology'
 ORDER BY c.id - 0 DESC
 LIMIT 10;
 
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id - 0 DESC
+LIMIT 10;
+
 -- =============================================================================
 -- TEST 5: ORDER BY c.id * 1 DESC (multiplication by one)
 -- =============================================================================
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+
 SELECT c.id, c.name
 FROM companies c
 WHERE c.id IN (
@@ -184,11 +207,33 @@ AND c.description @@@ 'technology'
 ORDER BY c.id / 1 DESC
 LIMIT 10;
 
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id / 1 DESC
+LIMIT 10;
+
 -- =============================================================================
 -- TEST 7: Nested wrappers — (c.id + 0)::int4 should still unwrap
 -- =============================================================================
 
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY (c.id + 0)::int4 DESC
+LIMIT 10;
+
 SELECT c.id, c.name
 FROM companies c
 WHERE c.id IN (
@@ -277,7 +322,24 @@ ORDER BY c.id + 0 DESC
 LIMIT 10;
 
 -- =============================================================================
--- TEST 12: Production-shape query — multiple IN subqueries with NOT EXISTS
+-- TEST 12: Cross-type expression should NOT unwrap (different operator OID)
+-- c.id is int4, 0::bigint makes this int48pl (OID not in whitelist)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0::bigint DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 13: Production-shape query — multiple IN subqueries with NOT EXISTS
 -- =============================================================================
 
 DROP TABLE IF EXISTS orders CASCADE;
@@ -296,7 +358,7 @@ INSERT INTO orders (id, company_id, status, total) VALUES
 (204, 3, 'completed', 8000),
 (205, 4, 'completed', 2000);
 
-CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, status, total)
+CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, (status::pdb.literal), total)
 WITH (
     key_field = 'id',
     numeric_fields = '{"company_id": {"fast": true}, "total": {"fast": true}}'

--- a/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
+++ b/pg_search/tests/pg_regress/sql/join_orderby_expression.sql
@@ -1,0 +1,350 @@
+-- Tests for JoinScan with ORDER BY expressions that are order-preserving
+-- wrappers around bare columns (e.g. id + 0, id - 0, id * 1, id / 1).
+-- Regression test for https://github.com/paradedb/paradedb/issues/4754
+
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS companies CASCADE;
+DROP TABLE IF EXISTS funding_rounds CASCADE;
+
+CREATE TABLE companies (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+
+CREATE TABLE funding_rounds (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER,
+    amount INTEGER,
+    round_type TEXT
+);
+
+INSERT INTO companies (id, name, description) VALUES
+(1, 'TechStartup', 'A technology startup building innovative solutions'),
+(2, 'DataCorp', 'Data analytics and machine learning company'),
+(3, 'CloudNet', 'Cloud networking and infrastructure provider'),
+(4, 'AIVentures', 'Artificial intelligence research and development'),
+(5, 'WebScale', 'Web-scale distributed systems company');
+
+INSERT INTO funding_rounds (id, company_id, amount, round_type) VALUES
+(101, 1, 1000000, 'seed'),
+(102, 1, 5000000, 'series_a'),
+(103, 2, 2000000, 'seed'),
+(104, 3, 10000000, 'series_b'),
+(105, 4, 500000, 'seed'),
+(106, 5, 3000000, 'series_a');
+
+CREATE INDEX companies_bm25_idx ON companies USING bm25 (id, name, description)
+WITH (key_field = 'id');
+
+CREATE INDEX funding_rounds_bm25_idx ON funding_rounds USING bm25 (id, company_id, amount, round_type)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"company_id": {"fast": true}, "amount": {"fast": true}}'
+);
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- TEST 1: Baseline — JoinScan activates with bare ORDER BY c.id DESC
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 2: JoinScan should activate with ORDER BY c.id + 0 DESC
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 3: Results must match between bare column and expression form
+-- =============================================================================
+
+-- Bare column form
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id DESC
+LIMIT 10;
+
+-- Expression form (id + 0) — must return identical rows
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 4: ORDER BY c.id - 0 DESC (subtraction with zero on right)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id - 0 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 5: ORDER BY c.id * 1 DESC (multiplication by one)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id * 1 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 6: ORDER BY c.id / 1 DESC (division by one)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id / 1 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 7: Nested wrappers — (c.id + 0)::int4 should still unwrap
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY (c.id + 0)::int4 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 8: Non-identity expression should NOT activate JoinScan
+-- ORDER BY c.id + 1 DESC — this is NOT order-preserving identity
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 1 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 9: 0 - c.id should NOT unwrap (inverts ordering)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY 0 - c.id DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 10: Var + Var should NOT unwrap (not a Const)
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + c.id DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 11: Using === operator alongside @@@
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type === 'seed'
+)
+AND c.description @@@ 'technology'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 12: Production-shape query — multiple IN subqueries with NOT EXISTS
+-- =============================================================================
+
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    company_id INTEGER,
+    status TEXT,
+    total INTEGER
+);
+
+INSERT INTO orders (id, company_id, status, total) VALUES
+(201, 1, 'completed', 5000),
+(202, 2, 'pending', 3000),
+(203, 1, 'cancelled', 1000),
+(204, 3, 'completed', 8000),
+(205, 4, 'completed', 2000);
+
+CREATE INDEX orders_bm25_idx ON orders USING bm25 (id, company_id, status, total)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"company_id": {"fast": true}, "total": {"fast": true}}'
+);
+
+-- Complex query with multiple IN subqueries and NOT EXISTS
+-- Result correctness: bare column vs expression form must match.
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+    AND NOT EXISTS (
+        SELECT 1 FROM orders o
+        WHERE o.company_id = fr.company_id
+        AND o.status @@@ 'cancelled'
+    )
+)
+AND c.description @@@ 'technology OR intelligence'
+ORDER BY c.id DESC
+LIMIT 10;
+
+SELECT c.id, c.name
+FROM companies c
+WHERE c.id IN (
+    SELECT fr.company_id
+    FROM funding_rounds fr
+    WHERE fr.round_type @@@ 'seed'
+    AND NOT EXISTS (
+        SELECT 1 FROM orders o
+        WHERE o.company_id = fr.company_id
+        AND o.status @@@ 'cancelled'
+    )
+)
+AND c.description @@@ 'technology OR intelligence'
+ORDER BY c.id + 0 DESC
+LIMIT 10;
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS funding_rounds CASCADE;
+DROP TABLE IF EXISTS companies CASCADE;
+
+RESET paradedb.enable_join_custom_scan;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4754

## What

JoinScan now activates when `ORDER BY` wraps an indexed column in an identity operation (`+ 0`, `- 0`, `* 1`, `/ 1`). Previously these expressions fell through to `NoMatch`, bypassing JoinScan.

## Why

ORMs emit expressions like `id + 0` in `ORDER BY` clauses. Postgres doesn't fold these in pathkey equivalence members, so the `OpExpr` reaches `classify()` intact and gets rejected.

## How

1. **`unwrap_order_preserving` helper** in `var.rs`. Loops over an expression peeling `RelabelType`, `CoerceToDomain`, and `OpExpr` wrappers where the operator is a known identity. Returns expression unchanged if nothing can be safely removed.
2. **Closed operator OID whitelist** (10 `pg_catalog` OIDs for int4/int8/float4/float8/numeric arithmetic). Hardcoded constants — pgrx doesn't export operator OIDs. Float `*`/`/` excluded due to `NaN`.
3. **One-liner added** at the top of `JoinSortExprKind::classify()` and `analyze_sort_expression()`. Strictly additive — only peels node types that currently map to `NoMatch`.

## Tests

- `orderby_expression_uses_joinscan`: repro from #4754, asserts JoinScan in EXPLAIN for `id + 0`, verifies identical results to bare column.
- Negative cases: `id + 1`, `0 - id`, `id + id`, `id + 0::bigint` all correctly rejected.
- Production-shape smoke test with multiple `IN`/`NOT EXISTS` subqueries.