### PR TITLE
feat: MPP plan partitioning for JoinScan (#4152)

### DIFF
--- a/docs/mpp-joinscan-design.md
+++ b/docs/mpp-joinscan-design.md
@@ -1,0 +1,98 @@
+# MPP Plan Partitioning for JoinScan
+
+**Issue:** [#4152](https://github.com/paradedb/paradedb/issues/4152)
+**PRs:** [#4768](https://github.com/paradedb/paradedb/pull/4768) (infrastructure), [#4773](https://github.com/paradedb/paradedb/pull/4773) (wiring + tests)
+**Based on:** Draft [#4184](https://github.com/paradedb/paradedb/pull/4184) by Stu Hood
+**GUC:** `paradedb.enable_mpp_join` (default: off)
+
+---
+
+## Problem
+
+JoinScan's current parallel execution uses a **Broadcast Join** strategy: the largest table is partitioned across workers by Tantivy segments, while every other table is fully replicated. This means non-partitioned tables are scanned N times (once per worker). With 8 workers joining two large tables, ~87% of total row reads are redundant.
+
+Additionally, for SEMI/ANTI join correctness the preserved side _must_ be the partitioned side, which sometimes forces partitioning the smaller table — the opposite of what's optimal.
+
+## Solution
+
+Replace the broadcast model with an **MPP (Massively Parallel Processing)** model where all tables are hash-partitioned across workers and data is shuffled via shared memory.
+
+```text
+Before (Broadcast Join):                After (MPP Plan Partitioning):
+  Worker 1: A[seg1-3] JOIN ALL(B)         Worker 1: A[hash1] JOIN B[hash1]
+  Worker 2: A[seg4-6] JOIN ALL(B)         Worker 2: A[hash2] JOIN B[hash2]
+  Worker 3: A[seg7-9] JOIN ALL(B)         Worker 3: A[hash3] JOIN B[hash3]
+  B scanned 3x total                      Every row scanned exactly once
+```
+
+## Architecture
+
+### Process Model
+
+The leader acts as a scheduler. Workers act as RPC servers.
+
+1. **Leader** builds the full physical plan, serializes it, and broadcasts to all workers via shared memory control channels.
+2. Each **worker** deserializes the plan, registers all `DsmExchangeExec` nodes as "procedures" in a local stream registry, and parks — waiting for `StartStream` RPC messages.
+3. When the leader executes its plan and hits a `DsmExchangeExec` (consumer side), it sends `StartStream` to the producing worker. That worker wakes up, executes the sub-plan, and streams Arrow IPC batches back through a shared memory ring buffer.
+
+### Key Components
+
+| Component                 | File(s)                  | Role                                                                                                                       |
+| ------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **Transport**             | `joinscan/transport/`    | Shared memory ring buffers, Arrow IPC, Unix Domain Socket signaling, multiplexed streams                                   |
+| **DsmExchangeExec**       | `joinscan/exchange.rs`   | DataFusion `ExecutionPlan` node at shuffle boundaries. Consumer sends `StartStream`, producer writes batches to DSM.       |
+| **EnforceDsmShuffle**     | `joinscan/exchange.rs`   | Physical optimizer rule. Replaces DataFusion's in-process `RepartitionExec` with cross-process `DsmExchangeExec`.          |
+| **DsmSanitizeExec**       | `joinscan/sanitize.rs`   | Deep-copy wrapper. Prevents deadlocks when blocking operators (Sort, HashJoin) pin shared memory buffers.                  |
+| **Parallel coordination** | `joinscan/parallel.rs`   | Worker lifecycle via `parallel_worker` framework. Plan broadcast, transport mesh setup, control service.                   |
+| **Physical codec**        | `scan/codec.rs`          | Serializes/deserializes `DsmExchangeExec` and `DsmSanitizeExec` for cross-process plan distribution.                       |
+| **Segment slicing**       | `scan/table_provider.rs` | Each participant reads `MppParticipantConfig` from the session and opens only its slice of segments via `chunk_range()`.   |
+| **Session profile**       | `joinscan/scan_state.rs` | `SessionContextProfile::JoinMpp` sets `target_partitions=N`, forces hash-join repartitioning, injects MPP optimizer rules. |
+
+### Data Flow
+
+```text
+Planning:
+  JoinCSClause → LogicalPlan → serialize (stored in CustomScan.custom_private)
+
+Execution (exec_mpp_path):
+  1. launch_join_workers()        → spawn N workers, init ring buffers
+  2. deserialize LogicalPlan      → with JoinMpp session context
+  3. build_physical_plan()        → optimizer injects DsmExchangeExec + DsmSanitizeExec
+  4. serialize PhysicalPlan       → via PgSearchPhysicalCodec
+  5. broadcast to workers         → control channel: BroadcastPlan message
+  6. register_dsm_mesh() on leader
+  7. leader deserialize round-trip → registers leader's stream sources
+  8. spawn_control_service()      → listens for StartStream from workers
+  9. plan.execute(0, ctx)         → leader runs partition 0, gathers results
+
+Workers (JoinWorker::run):
+  1. wait for broadcast plan
+  2. deserialize (registers DsmExchangeExec as stream sources)
+  3. spawn_control_service()
+  4. park thread — wake on StartStream, execute sub-plan, write to DSM
+```
+
+### Correctness Constraints
+
+The MPP model is correct for **INNER**, **LEFT OUTER** (left partitioned), **SEMI**, and **ANTI** joins. It is **incorrect** for RIGHT OUTER and FULL OUTER joins (unmatched rows from the replicated side would be emitted by every worker).
+
+### Deadlock Prevention
+
+When a blocking operator (e.g., `SortExec`, `HashJoinExec`) sits downstream of a `DsmExchangeExec`, it can pin shared memory buffers indefinitely — blocking the producer from writing new data. The `EnforceSanitization` optimizer rule detects these patterns and wraps the exchange with `DsmSanitizeExec`, which deep-copies incoming batches to heap memory before passing them downstream.
+
+## Gating
+
+The MPP path is behind `SET paradedb.enable_mpp_join = on` (default: off). When the GUC is off or `planned_workers = 0`, the existing broadcast-join path is used unchanged.
+
+## Known Limitations & Future Work
+
+- **Ring buffer overhead**: ~30% of runtime in the draft PR was spent writing to shared memory. Late materialization (already on main) should reduce this since fewer bytes cross process boundaries.
+- **Dynamic filter passthrough**: `SegmentedTopKExec`'s dynamic threshold doesn't currently propagate across process boundaries. This limits pruning effectiveness for Top-K queries.
+- **Range partitioning**: Hash partitioning shuffles all data. For sorted joins, range partitioning could keep most data local to a single worker.
+- **Tokio blocking**: The leader blocks the tokio thread while reading DSM. A `spawn_blocking`-style helper for Postgres API calls would improve throughput.
+
+## Testing
+
+- **Regression test** (`mpp_join.sql`): GUC toggle, inner join with search predicate, multi-predicate cross-table queries, result comparison between MPP on/off.
+- **qgen**: `PgGucs.enable_mpp_join` field enables property-based testing with randomized join queries.
+- **Unit test** (`pg_test_dsm_gather_execution`): End-to-end test launching a real parallel worker, executing a `DsmExchangeExec` gather, and verifying both leader and worker produce expected results.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -44,6 +44,12 @@ static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false
 /// Default is `false` (experimental).
 static ENABLE_MPP_JOIN: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Enables verbose debug logging for the MPP execution path.
+/// When enabled, pgrx::warning! messages are emitted at each step of the MPP
+/// lifecycle: worker launch, plan broadcast, exchange setup, data flow, cleanup.
+/// Default is `false`.
+static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
@@ -182,6 +188,15 @@ pub fn init() {
         c"Enable MPP (plan partitioning) execution for parallel JoinScan",
         c"When enabled, JoinScan uses hash-partitioned MPP execution instead of broadcast join. Default is false (experimental).",
         &ENABLE_MPP_JOIN,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_debug",
+        c"Enable verbose debug logging for MPP execution",
+        c"When enabled, emits WARNING messages at each step of MPP lifecycle: worker launch, plan broadcast, exchange setup, data flow. Default is false.",
+        &MPP_DEBUG,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -436,6 +451,10 @@ pub fn enable_join_custom_scan() -> bool {
 
 pub fn enable_mpp_join() -> bool {
     ENABLE_MPP_JOIN.get()
+}
+
+pub fn mpp_debug() -> bool {
+    MPP_DEBUG.get()
 }
 
 pub fn enable_custom_scan_without_operator() -> bool {
@@ -712,4 +731,15 @@ mod tests {
             Some(NonZeroUsize::new(1000).unwrap())
         );
     }
+}
+
+/// Emit a warning message only when `paradedb.mpp_debug` is enabled.
+/// Zero-cost when disabled — the format arguments are not evaluated.
+#[macro_export]
+macro_rules! mpp_log {
+    ($($arg:tt)*) => {
+        if $crate::gucs::mpp_debug() {
+            pgrx::warning!($($arg)*);
+        }
+    };
 }

--- a/pg_search/src/parallel_worker/builder.rs
+++ b/pg_search/src/parallel_worker/builder.rs
@@ -274,6 +274,17 @@ impl ParallelProcessFinish {
         Some(messages)
     }
 
+    /// Destroy the parallel context, terminating workers via SIGTERM.
+    /// Does not wait for message queue responses.
+    pub fn destroy(self) {
+        unsafe {
+            let pcxt = self.launcher.pcxt.as_ptr();
+            drop(self.launcher);
+            pg_sys::DestroyParallelContext(pcxt);
+            pg_sys::ExitParallelMode();
+        }
+    }
+
     pub fn wait_for_finish(mut self) -> Vec<(usize, Vec<u8>)> {
         unsafe {
             let pcxt = self.launcher.pcxt.as_ptr();

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -215,11 +215,13 @@ impl Drop for SignalOnDrop {
 }
 
 pub fn trigger_stream(physical_stream_id: PhysicalStreamId, context: Arc<TaskContext>) {
+    crate::mpp_log!("MPP exchange: trigger_stream({physical_stream_id:?})");
     let mut guard = DSM_MESH.lock();
     let mesh = guard.as_mut().expect("DSM mesh not registered");
     let mut registry = mesh.registry.lock();
 
     if registry.running_tasks.contains_key(&physical_stream_id) {
+        crate::mpp_log!("MPP exchange: stream {physical_stream_id:?} already running, skipping");
         return;
     }
 
@@ -299,9 +301,11 @@ pub fn spawn_control_service(local_set: &LocalSet, task_ctx: Arc<TaskContext>) {
                         if let Some(msg) = ControlMessage::try_from_frame(msg_type, &payload) {
                             match msg {
                                 ControlMessage::StartStream(id) => {
+                                    crate::mpp_log!("MPP ControlService: StartStream({id:?})");
                                     trigger_stream(id, task_ctx.clone());
                                 }
                                 ControlMessage::CancelStream(id) => {
+                                    crate::mpp_log!("MPP ControlService: CancelStream({id:?})");
                                     // Mark stream as cancelled in the transport layer
                                     guard.mark_stream_cancelled(id);
                                     // Cancel the execution task

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -271,9 +271,10 @@ pub fn spawn_control_service(local_set: &LocalSet, task_ctx: Arc<TaskContext>) {
                 bridge.register_waker(cx.waker().clone(), None);
                 let mut work_done = false;
 
-                for mux in &mux_writers {
+                for (idx, mux) in mux_writers.iter().enumerate() {
                     let mut guard = mux.lock();
                     while let Some((msg_type, payload)) = guard.read_control_frame() {
+                        pgrx::warning!("MPP ControlService: received msg_type={msg_type} from writer {idx}, payload_len={}", payload.len());
                         work_done = true;
                         if let Some(msg) = ControlMessage::try_from_frame(msg_type, &payload) {
                             match msg {
@@ -796,6 +797,26 @@ impl DsmExchangeExec {
                     )));
                 }
 
+                // Send StartStream to all remote participants.
+                {
+                    let guard = DSM_MESH.lock();
+                    if let Some(mesh) = guard.as_ref() {
+                        for i in 0..total_participants {
+                            if i == participant_index {
+                                continue; // Don't send to self
+                            }
+                            let physical_id = PhysicalStreamId::new(
+                                self.config.stream_id,
+                                ParticipantId(i as u16),
+                            );
+                            if i < mesh.transport.mux_readers.len() {
+                                let mut reader_mux = mesh.transport.mux_readers[i].lock();
+                                let _ = reader_mux.start_stream(physical_id);
+                            }
+                        }
+                    }
+                }
+
                 let mut readers = Vec::new();
                 for i in 0..total_participants {
                     // Read from Participant i, Logical Stream S, Sender Index i.
@@ -850,6 +871,37 @@ impl DsmExchangeExec {
                 }
 
                 // Leader: Pull Partition `partition` from Worker `partition`.
+                // Send StartStream to trigger the worker's producer task.
+                {
+                    let physical_id = PhysicalStreamId::new(
+                        self.config.stream_id,
+                        ParticipantId(partition as u16),
+                    );
+                    pgrx::warning!(
+                        "MPP Gather: sending StartStream({physical_id:?}) to partition {partition}"
+                    );
+                    let guard = DSM_MESH.lock();
+                    if let Some(mesh) = guard.as_ref() {
+                        if partition < mesh.transport.mux_readers.len() {
+                            let mut reader_mux = mesh.transport.mux_readers[partition].lock();
+                            reader_mux
+                                .start_stream(physical_id)
+                                .unwrap_or_else(|e| {
+                                    pgrx::warning!(
+                                        "MPP: failed to send StartStream to participant {partition}: {e}"
+                                    );
+                                });
+                            pgrx::warning!("MPP Gather: StartStream sent to partition {partition}");
+                        } else {
+                            pgrx::warning!(
+                                "MPP Gather: partition {partition} out of range (readers: {})",
+                                mesh.transport.mux_readers.len()
+                            );
+                        }
+                    } else {
+                        pgrx::warning!("MPP Gather: DSM mesh not registered!");
+                    }
+                }
 
                 if let Some(reader) = get_dsm_reader(
                     partition,

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -271,10 +271,9 @@ pub fn spawn_control_service(local_set: &LocalSet, task_ctx: Arc<TaskContext>) {
                 bridge.register_waker(cx.waker().clone(), None);
                 let mut work_done = false;
 
-                for (idx, mux) in mux_writers.iter().enumerate() {
+                for mux in &mux_writers {
                     let mut guard = mux.lock();
                     while let Some((msg_type, payload)) = guard.read_control_frame() {
-                        pgrx::warning!("MPP ControlService: received msg_type={msg_type} from writer {idx}, payload_len={}", payload.len());
                         work_done = true;
                         if let Some(msg) = ControlMessage::try_from_frame(msg_type, &payload) {
                             match msg {
@@ -891,15 +890,7 @@ impl DsmExchangeExec {
                                         "MPP: failed to send StartStream to participant {partition}: {e}"
                                     );
                                 });
-                            pgrx::warning!("MPP Gather: StartStream sent to partition {partition}");
-                        } else {
-                            pgrx::warning!(
-                                "MPP Gather: partition {partition} out of range (readers: {})",
-                                mesh.transport.mux_readers.len()
-                            );
                         }
-                    } else {
-                        pgrx::warning!("MPP Gather: DSM mesh not registered!");
                     }
                 }
 

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -152,8 +152,17 @@ pub struct DsmMesh {
     pub registry: Mutex<StreamRegistry>,
 }
 
+type LocalBypassEntry = (
+    std::sync::mpsc::Sender<RecordBatch>,
+    Option<std::sync::mpsc::Receiver<RecordBatch>>,
+);
+
 lazy_static::lazy_static! {
     pub static ref DSM_MESH: Mutex<Option<DsmMesh>> = Mutex::new(None);
+    /// In-process bypass channels for self-directed exchange data.
+    /// Avoids Arrow IPC + ring buffer round-trips for data that stays in-process.
+    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, LocalBypassEntry>> =
+        Mutex::new(HashMap::default());
 }
 
 pub fn register_dsm_mesh(mesh: DsmMesh) {
@@ -164,6 +173,8 @@ pub fn register_dsm_mesh(mesh: DsmMesh) {
 pub fn clear_dsm_mesh() {
     let mut guard = DSM_MESH.lock();
     *guard = None;
+    let mut bypass = LOCAL_BYPASS.lock();
+    bypass.clear();
 }
 
 impl Drop for DsmMesh {
@@ -634,6 +645,14 @@ impl DsmExchangeExec {
             );
         }
 
+        // Set up local bypass channel for self-partition (avoids IPC overhead).
+        let local_tx = {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let mut guard = LOCAL_BYPASS.lock();
+            guard.insert(config.stream_id, (tx.clone(), Some(rx)));
+            tx
+        };
+
         // Initialize partitioner ONCE if needed
         let mut partitioner = if let ExchangeMode::Redistribute = config.mode {
             Some(
@@ -665,6 +684,14 @@ impl DsmExchangeExec {
                 let mut blocked_on_write = false;
 
                 for i in 0..total_participants {
+                    // Self-partition: bypass ring buffer, send directly via channel.
+                    if i == participant_index {
+                        while let Some(batch) = out_queues[i].pop_front() {
+                            let _ = local_tx.send(batch);
+                            progress = true;
+                        }
+                        continue;
+                    }
                     while let Some(batch) = out_queues[i].front() {
                         match writers[i].write_batch(batch) {
                             Ok(_) => {
@@ -816,17 +843,60 @@ impl DsmExchangeExec {
                     }
                 }
 
-                let mut readers = Vec::new();
+                let mut readers: Vec<SendableRecordBatchStream> = Vec::new();
                 for i in 0..total_participants {
-                    // Read from Participant i, Logical Stream S, Sender Index i.
-                    if let Some(reader) = get_dsm_reader(
-                        i,
-                        self.config.stream_id,
-                        ParticipantId(i as u16),
-                        schema.clone(),
-                        self.config.sanitized,
-                    ) {
-                        readers.push(shared_memory_stream(reader));
+                    if i == participant_index {
+                        // Self-partition: read from local bypass channel (no IPC overhead).
+                        let rx = {
+                            let mut guard = LOCAL_BYPASS.lock();
+                            guard
+                                .get_mut(&self.config.stream_id)
+                                .and_then(|(_, rx)| rx.take())
+                        };
+                        if let Some(rx) = rx {
+                            let schema_clone = schema.clone();
+                            let stream = futures::stream::unfold(rx, move |rx| {
+                                let s = schema_clone.clone();
+                                async move {
+                                    match rx.try_recv() {
+                                        Ok(batch) => Some((Ok(batch), rx)),
+                                        Err(std::sync::mpsc::TryRecvError::Empty) => {
+                                            // Yield and retry
+                                            tokio::task::yield_now().await;
+                                            match rx.try_recv() {
+                                                Ok(batch) => Some((Ok(batch), rx)),
+                                                Err(
+                                                    std::sync::mpsc::TryRecvError::Disconnected,
+                                                ) => None,
+                                                Err(std::sync::mpsc::TryRecvError::Empty) => {
+                                                    Some((Ok(RecordBatch::new_empty(s)), rx))
+                                                }
+                                            }
+                                        }
+                                        Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
+                                    }
+                                }
+                            })
+                            .filter(|batch| {
+                                let keep = batch.as_ref().map_or(true, |b| b.num_rows() > 0);
+                                futures::future::ready(keep)
+                            });
+                            readers.push(Box::pin(RecordBatchStreamAdapter::new(
+                                schema.clone(),
+                                Box::pin(stream),
+                            )));
+                        }
+                    } else {
+                        // Remote partition: read from DSM ring buffer.
+                        if let Some(reader) = get_dsm_reader(
+                            i,
+                            self.config.stream_id,
+                            ParticipantId(i as u16),
+                            schema.clone(),
+                            self.config.sanitized,
+                        ) {
+                            readers.push(shared_memory_stream(reader));
+                        }
                     }
                 }
 

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -152,16 +152,15 @@ pub struct DsmMesh {
     pub registry: Mutex<StreamRegistry>,
 }
 
-type LocalBypassEntry = (
-    std::sync::mpsc::Sender<RecordBatch>,
-    Option<std::sync::mpsc::Receiver<RecordBatch>>,
-);
-
 lazy_static::lazy_static! {
     pub static ref DSM_MESH: Mutex<Option<DsmMesh>> = Mutex::new(None);
-    /// In-process bypass channels for self-directed exchange data.
-    /// Avoids Arrow IPC + ring buffer round-trips for data that stays in-process.
-    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, LocalBypassEntry>> =
+    /// In-process bypass receivers for self-directed exchange data.
+    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, std::sync::mpsc::Receiver<RecordBatch>>> =
+        Mutex::new(HashMap::default());
+    /// In-process bypass senders, pre-created in register_stream_source and
+    /// taken by the producer task. When the producer finishes and drops the sender,
+    /// the channel disconnects and the consumer stops.
+    pub static ref BYPASS_SENDERS: Mutex<HashMap<LogicalStreamId, std::sync::mpsc::Sender<RecordBatch>>> =
         Mutex::new(HashMap::default());
 }
 
@@ -175,6 +174,8 @@ pub fn clear_dsm_mesh() {
     *guard = None;
     let mut bypass = LOCAL_BYPASS.lock();
     bypass.clear();
+    let mut senders = BYPASS_SENDERS.lock();
+    senders.clear();
 }
 
 impl Drop for DsmMesh {
@@ -184,12 +185,21 @@ impl Drop for DsmMesh {
 }
 
 pub fn register_stream_source(source: StreamSource, participant_id: ParticipantId) {
+    // Pre-create the local bypass channel for this exchange's self-partition.
+    // The consumer will take the receiver during create_consumer_stream.
+    // The producer will retrieve the sender during producer_task.
+    if source.config.mode == ExchangeMode::Redistribute {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut bypass = LOCAL_BYPASS.lock();
+        // Store the receiver for the consumer. The sender goes into BYPASS_SENDERS.
+        bypass.insert(source.config.stream_id, rx);
+        let mut senders = BYPASS_SENDERS.lock();
+        senders.insert(source.config.stream_id, tx);
+    }
+
     let mut guard = DSM_MESH.lock();
     if let Some(mesh) = guard.as_mut() {
-        // Calculate physical ID: (Logical << 16) | Sender (us)
-        // participant_id is "us" (the sender).
         let physical_id = PhysicalStreamId::new(source.config.stream_id, participant_id);
-
         let mut registry = mesh.registry.lock();
         registry.sources.insert(physical_id, source);
     }
@@ -645,12 +655,12 @@ impl DsmExchangeExec {
             );
         }
 
-        // Set up local bypass channel for self-partition (avoids IPC overhead).
+        // Take the local bypass sender for this exchange's self-partition.
+        // Pre-created in register_stream_source. When the producer finishes
+        // and drops the sender, the channel disconnects and the consumer stops.
         let local_tx = {
-            let (tx, rx) = std::sync::mpsc::channel();
-            let mut guard = LOCAL_BYPASS.lock();
-            guard.insert(config.stream_id, (tx.clone(), Some(rx)));
-            tx
+            let mut guard = BYPASS_SENDERS.lock();
+            guard.remove(&config.stream_id)
         };
 
         // Initialize partitioner ONCE if needed
@@ -686,11 +696,18 @@ impl DsmExchangeExec {
                 for i in 0..total_participants {
                     // Self-partition: bypass ring buffer, send directly via channel.
                     if i == participant_index {
-                        while let Some(batch) = out_queues[i].pop_front() {
-                            let _ = local_tx.send(batch);
-                            progress = true;
+                        if let Some(ref tx) = local_tx {
+                            while let Some(batch) = out_queues[i].pop_front() {
+                                let _ = tx.send(batch);
+                                progress = true;
+                            }
+                        } else {
+                            // No bypass channel — write through ring buffer like remote
+                            // (fallback for Gather mode which doesn't use bypass)
                         }
-                        continue;
+                        if local_tx.is_some() {
+                            continue;
+                        }
                     }
                     while let Some(batch) = out_queues[i].front() {
                         match writers[i].write_batch(batch) {
@@ -849,9 +866,7 @@ impl DsmExchangeExec {
                         // Self-partition: read from local bypass channel (no IPC overhead).
                         let rx = {
                             let mut guard = LOCAL_BYPASS.lock();
-                            guard
-                                .get_mut(&self.config.stream_id)
-                                .and_then(|(_, rx)| rx.take())
+                            guard.remove(&self.config.stream_id)
                         };
                         if let Some(rx) = rx {
                             let schema_clone = schema.clone();

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -512,7 +512,6 @@ impl PhysicalOptimizerRule for EnforceDsmShuffle {
     }
 }
 
-#[cfg(any(test, feature = "pg_test"))]
 pub fn collect_dsm_exchanges(plan: Arc<dyn ExecutionPlan>, sources: &mut Vec<StreamSource>) {
     if let Some(exchange) = plan.as_any().downcast_ref::<DsmExchangeExec>() {
         sources.push(StreamSource {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1585,6 +1585,13 @@ impl JoinScan {
             }
         }
 
+        // Clean up: clear the DSM mesh and destroy the parallel context.
+        // We must NOT call wait_for_finish() because workers are in an async
+        // loop that only exits on SIGTERM. DestroyParallelContext sends SIGTERM
+        // and waits for workers to exit.
+        exchange::clear_dsm_mesh();
+        process.destroy();
+
         state.custom_state_mut().runtime = Some(runtime);
         state.custom_state_mut().datafusion_stream = Some(stream);
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1440,7 +1440,6 @@ impl JoinScan {
             .unwrap();
 
         let nworkers = join_clause.planned_workers;
-        pgrx::warning!("MPP: exec_mpp_path entered, nworkers={nworkers}");
 
         // Step 1: Launch workers and initialize transport mesh.
         let Some((
@@ -1461,15 +1460,12 @@ impl JoinScan {
             panic!("MPP: failed to launch parallel workers");
         };
 
-        pgrx::warning!("MPP: workers launched, nlaunched={nlaunched}");
-
         // Step 2: Build MPP session context with actual participant count.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index: 0, // Leader is always participant 0
             total_participants: nlaunched,
         });
 
-        pgrx::warning!("MPP: session context created");
         // Step 3: Broadcast the logical plan bytes to workers.
         // Workers will independently build their own physical plans (with their
         // own participant_index in MppParticipantConfig), so we don't need to
@@ -1484,7 +1480,6 @@ impl JoinScan {
                 .expect("MPP: failed to broadcast logical plan to worker");
         }
 
-        pgrx::warning!("MPP: plan broadcast complete");
         // Step 4: Register the DSM mesh for the leader.
         let transport = TransportMesh {
             mux_writers,
@@ -1512,11 +1507,9 @@ impl JoinScan {
         )
         .expect("MPP: failed to deserialize logical plan");
 
-        pgrx::warning!("MPP: logical plan deserialized, building physical plan");
         let plan = runtime
             .block_on(build_physical_plan(&ctx, logical_plan))
             .expect("MPP: failed to create physical plan");
-        pgrx::warning!("MPP: physical plan built");
 
         // Step 6: Register the leader's DsmExchangeExec nodes as stream sources.
         let mut sources = Vec::new();
@@ -1537,7 +1530,6 @@ impl JoinScan {
             pg_sys::hash_mem_multiplier,
         );
 
-        pgrx::warning!("MPP: spawning control service and executing");
         exchange::spawn_control_service(&local_set, task_ctx.clone());
 
         // Collect ALL results inside run_until so the LocalSet continues to drive
@@ -1545,11 +1537,9 @@ impl JoinScan {
         // must remain active to respond to worker RPCs (StartStream, etc.).
         use futures::StreamExt;
         let batches: Vec<arrow_array::RecordBatch> = runtime.block_on(local_set.run_until(async {
-            pgrx::warning!("MPP: executing plan partition 0");
             let mut stream = plan
                 .execute(0, task_ctx)
                 .expect("MPP: failed to execute plan");
-            pgrx::warning!("MPP: collecting results from stream");
             let mut batches = Vec::new();
             while let Some(batch) = stream.next().await {
                 match batch {
@@ -1557,7 +1547,6 @@ impl JoinScan {
                     Err(e) => panic!("MPP: stream error: {e}"),
                 }
             }
-            pgrx::warning!("MPP: collected {} batches", batches.len());
             batches
         }));
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1296,68 +1296,63 @@ impl CustomScan for JoinScan {
 
                 // MPP execution path: when the GUC is enabled and workers are planned,
                 // use hash-partitioned MPP execution instead of broadcast-join.
-                let _use_mpp = crate::gucs::enable_mpp_join() && join_clause.planned_workers > 0;
+                let use_mpp = crate::gucs::enable_mpp_join() && join_clause.planned_workers > 0;
 
-                // TODO(#4152): Wire the MPP execution path here. When _use_mpp is true:
-                // 1. Call parallel::launch_join_workers() to set up workers + transport mesh
-                // 2. Build physical plan with SessionContextProfile::JoinMpp
-                // 3. Serialize and broadcast plan to workers
-                // 4. Register DSM mesh for leader
-                // 5. Spawn control service
-                // 6. Execute partition 0 of the plan
-                // For now, fall through to the broadcast-join path.
+                if use_mpp {
+                    JoinScan::exec_mpp_path(state, runtime, &join_clause, &plan_bytes);
+                } else {
+                    // Deserialize the logical plan and convert to execution plan
+                    let planstate = state.planstate();
 
-                // Deserialize the logical plan and convert to execution plan
-                let planstate = state.planstate();
+                    let index_segment_ids =
+                        Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                let index_segment_ids =
-                    Self::build_index_segment_ids(state, &join_clause, &plan_sources);
+                    let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+                    let logical_plan = deserialize_logical_plan_with_runtime(
+                        &plan_bytes,
+                        &ctx.task_ctx(),
+                        state.custom_state().parallel_state,
+                        Some(state.runtime_context),
+                        Some(planstate),
+                        state.custom_state().non_partitioning_segments.clone(),
+                        index_segment_ids,
+                    )
+                    .expect("Failed to deserialize logical plan");
 
-                let ctx = create_datafusion_session_context(SessionContextProfile::Join);
-                let logical_plan = deserialize_logical_plan_with_runtime(
-                    &plan_bytes,
-                    &ctx.task_ctx(),
-                    state.custom_state().parallel_state,
-                    Some(state.runtime_context),
-                    Some(planstate),
-                    state.custom_state().non_partitioning_segments.clone(),
-                    index_segment_ids,
-                )
-                .expect("Failed to deserialize logical plan");
+                    // Convert logical plan to physical plan
+                    let plan = runtime
+                        .block_on(build_physical_plan(&ctx, logical_plan))
+                        .expect("Failed to create execution plan");
 
-                // Convert logical plan to physical plan
-                let plan = runtime
-                    .block_on(build_physical_plan(&ctx, logical_plan))
-                    .expect("Failed to create execution plan");
+                    let task_ctx = build_task_context(
+                        &ctx,
+                        &plan,
+                        pg_sys::work_mem as usize * 1024,
+                        pg_sys::hash_mem_multiplier,
+                    );
+                    let stream = {
+                        let _guard = runtime.enter();
+                        plan.execute(0, task_ctx)
+                            .expect("Failed to execute DataFusion plan")
+                    };
 
-                let task_ctx = build_task_context(
-                    &ctx,
-                    &plan,
-                    pg_sys::work_mem as usize * 1024,
-                    pg_sys::hash_mem_multiplier,
-                );
-                let stream = {
-                    let _guard = runtime.enter();
-                    plan.execute(0, task_ctx)
-                        .expect("Failed to execute DataFusion plan")
-                };
+                    // Retain the executed plan so EXPLAIN ANALYZE can extract metrics.
+                    state.custom_state_mut().physical_plan = Some(plan.clone());
 
-                // Retain the executed plan so EXPLAIN ANALYZE can extract metrics.
-                state.custom_state_mut().physical_plan = Some(plan.clone());
-
-                let schema = plan.schema();
-                for (i, field) in schema.fields().iter().enumerate() {
-                    if let Ok(ctid_col) = CtidColumn::try_from(field.name().as_str()) {
-                        let plan_position = ctid_col.plan_position();
-                        if let Some(rel_state) =
-                            state.custom_state_mut().relations.get_mut(&plan_position)
-                        {
-                            rel_state.ctid_col_idx = Some(i);
+                    let schema = plan.schema();
+                    for (i, field) in schema.fields().iter().enumerate() {
+                        if let Ok(ctid_col) = CtidColumn::try_from(field.name().as_str()) {
+                            let plan_position = ctid_col.plan_position();
+                            if let Some(rel_state) =
+                                state.custom_state_mut().relations.get_mut(&plan_position)
+                            {
+                                rel_state.ctid_col_idx = Some(i);
+                            }
                         }
                     }
-                }
-                state.custom_state_mut().runtime = Some(runtime);
-                state.custom_state_mut().datafusion_stream = Some(stream);
+                    state.custom_state_mut().runtime = Some(runtime);
+                    state.custom_state_mut().datafusion_stream = Some(stream);
+                } // end else (broadcast-join path)
             }
 
             loop {
@@ -1415,6 +1410,143 @@ impl CustomScan for JoinScan {
         drop(std::mem::take(
             &mut state.custom_state_mut().source_manifests,
         ));
+    }
+}
+
+impl JoinScan {
+    /// MPP execution path: launches workers, broadcasts the physical plan, and
+    /// sets up the leader to execute partition 0 with a control service.
+    #[allow(unused_variables, dead_code)]
+    unsafe fn exec_mpp_path(
+        state: &mut CustomScanStateWrapper<JoinScan>,
+        runtime: tokio::runtime::Runtime,
+        join_clause: &build::JoinCSClause,
+        plan_bytes: &bytes::Bytes,
+    ) {
+        use crate::postgres::customscan::joinscan::exchange;
+        use crate::postgres::customscan::joinscan::transport::TransportMesh;
+
+        let nworkers = join_clause.planned_workers;
+
+        // Step 1: Launch workers and initialize transport mesh.
+        let Some((
+            process,
+            _leader_plan_placeholder,
+            mux_writers,
+            mux_readers,
+            _session_id,
+            bridge,
+            nlaunched,
+        )) = parallel::launch_join_workers(
+            &runtime,
+            nworkers,
+            pg_sys::work_mem as usize * 1024,
+            pg_sys::parallel_leader_participation,
+        )
+        else {
+            panic!("MPP: failed to launch parallel workers");
+        };
+
+        // Step 2: Build MPP session context with actual participant count.
+        let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
+            participant_index: 0, // Leader is always participant 0
+            total_participants: nlaunched,
+        });
+
+        // Step 3: Deserialize logical plan.
+        let planstate = state.planstate();
+        let index_segment_ids =
+            Self::build_index_segment_ids(state, join_clause, &join_clause.plan.sources());
+        let logical_plan = deserialize_logical_plan_with_runtime(
+            plan_bytes,
+            &ctx.task_ctx(),
+            state.custom_state().parallel_state,
+            Some(state.runtime_context),
+            Some(planstate),
+            state.custom_state().non_partitioning_segments.clone(),
+            index_segment_ids,
+        )
+        .expect("MPP: failed to deserialize logical plan");
+
+        // Step 4: Build physical plan (optimizer injects EnforceDsmShuffle + EnforceSanitization).
+        let plan = runtime
+            .block_on(build_physical_plan(&ctx, logical_plan))
+            .expect("MPP: failed to create physical plan");
+
+        // Step 5: Serialize physical plan for broadcast.
+        let physical_plan_bytes =
+            datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec(
+                plan.clone(),
+                &crate::scan::codec::PgSearchPhysicalCodec,
+            )
+            .expect("MPP: failed to serialize physical plan");
+
+        // Step 6: Broadcast plan to workers via control channels.
+        for (i, reader_mutex) in mux_readers.iter().enumerate() {
+            if i == 0 {
+                continue; // Skip self (leader)
+            }
+            let mut reader = reader_mutex.lock();
+            reader
+                .send_control_message_variable(128, &physical_plan_bytes)
+                .expect("MPP: failed to broadcast plan to worker");
+        }
+
+        // Step 7: Register the DSM mesh for the leader.
+        let transport = TransportMesh {
+            mux_writers,
+            mux_readers,
+            bridge,
+        };
+        let mesh = exchange::DsmMesh {
+            transport,
+            registry: parking_lot::Mutex::new(exchange::StreamRegistry::default()),
+        };
+        exchange::register_dsm_mesh(mesh);
+
+        // Step 8: Serialize/deserialize round-trip on the leader so that stream
+        // sources get registered in the leader's StreamRegistry.
+        let codec = crate::scan::codec::PgSearchPhysicalCodec;
+        let plan = datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec(
+            &physical_plan_bytes,
+            &ctx.task_ctx(),
+            &codec,
+        )
+        .expect("MPP: leader plan deserialization failed");
+
+        // Step 9: Spawn control service and execute.
+        let local_set = tokio::task::LocalSet::new();
+        let task_ctx = build_task_context(
+            &ctx,
+            &plan,
+            pg_sys::work_mem as usize * 1024,
+            pg_sys::hash_mem_multiplier,
+        );
+
+        exchange::spawn_control_service(&local_set, task_ctx.clone());
+
+        let stream = runtime.block_on(local_set.run_until(async {
+            plan.execute(0, task_ctx)
+                .expect("MPP: failed to execute plan")
+        }));
+
+        // Retain plan for EXPLAIN ANALYZE.
+        state.custom_state_mut().physical_plan = Some(plan.clone());
+
+        // Map CTID columns to their schema positions.
+        let schema = plan.schema();
+        for (i, field) in schema.fields().iter().enumerate() {
+            if let Ok(ctid_col) = build::CtidColumn::try_from(field.name().as_str()) {
+                let plan_position = ctid_col.plan_position();
+                if let Some(rel_state) = state.custom_state_mut().relations.get_mut(&plan_position)
+                {
+                    rel_state.ctid_col_idx = Some(i);
+                }
+            }
+        }
+
+        state.custom_state_mut().runtime = Some(runtime);
+        state.custom_state_mut().datafusion_stream = Some(stream);
     }
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1540,18 +1540,41 @@ impl JoinScan {
         pgrx::warning!("MPP: spawning control service and executing");
         exchange::spawn_control_service(&local_set, task_ctx.clone());
 
-        let stream = runtime.block_on(local_set.run_until(async {
+        // Collect ALL results inside run_until so the LocalSet continues to drive
+        // the control service while the stream is being polled. The control service
+        // must remain active to respond to worker RPCs (StartStream, etc.).
+        use futures::StreamExt;
+        let batches: Vec<arrow_array::RecordBatch> = runtime.block_on(local_set.run_until(async {
             pgrx::warning!("MPP: executing plan partition 0");
-            plan.execute(0, task_ctx)
-                .expect("MPP: failed to execute plan")
+            let mut stream = plan
+                .execute(0, task_ctx)
+                .expect("MPP: failed to execute plan");
+            pgrx::warning!("MPP: collecting results from stream");
+            let mut batches = Vec::new();
+            while let Some(batch) = stream.next().await {
+                match batch {
+                    Ok(b) => batches.push(b),
+                    Err(e) => panic!("MPP: stream error: {e}"),
+                }
+            }
+            pgrx::warning!("MPP: collected {} batches", batches.len());
+            batches
         }));
-        pgrx::warning!("MPP: plan execution started, streaming results");
+
+        // Create a stream from the collected batches for the exec_custom_scan loop.
+        let schema = plan.schema();
+        let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
+        let stream: datafusion::execution::SendableRecordBatchStream = Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema.clone(),
+                batch_stream,
+            ),
+        );
 
         // Retain plan for EXPLAIN ANALYZE.
         state.custom_state_mut().physical_plan = Some(plan.clone());
 
         // Map CTID columns to their schema positions.
-        let schema = plan.schema();
         for (i, field) in schema.fields().iter().enumerate() {
             if let Ok(ctid_col) = build::CtidColumn::try_from(field.name().as_str()) {
                 let plan_position = ctid_col.plan_position();

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1440,6 +1440,7 @@ impl JoinScan {
             .unwrap();
 
         let nworkers = join_clause.planned_workers;
+        pgrx::warning!("MPP: exec_mpp_path entered, nworkers={nworkers}");
 
         // Step 1: Launch workers and initialize transport mesh.
         let Some((
@@ -1460,12 +1461,15 @@ impl JoinScan {
             panic!("MPP: failed to launch parallel workers");
         };
 
+        pgrx::warning!("MPP: workers launched, nlaunched={nlaunched}");
+
         // Step 2: Build MPP session context with actual participant count.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index: 0, // Leader is always participant 0
             total_participants: nlaunched,
         });
 
+        pgrx::warning!("MPP: session context created");
         // Step 3: Broadcast the logical plan bytes to workers.
         // Workers will independently build their own physical plans (with their
         // own participant_index in MppParticipantConfig), so we don't need to
@@ -1480,6 +1484,7 @@ impl JoinScan {
                 .expect("MPP: failed to broadcast logical plan to worker");
         }
 
+        pgrx::warning!("MPP: plan broadcast complete");
         // Step 4: Register the DSM mesh for the leader.
         let transport = TransportMesh {
             mux_writers,
@@ -1507,9 +1512,11 @@ impl JoinScan {
         )
         .expect("MPP: failed to deserialize logical plan");
 
+        pgrx::warning!("MPP: logical plan deserialized, building physical plan");
         let plan = runtime
             .block_on(build_physical_plan(&ctx, logical_plan))
             .expect("MPP: failed to create physical plan");
+        pgrx::warning!("MPP: physical plan built");
 
         // Step 6: Register the leader's DsmExchangeExec nodes as stream sources.
         let mut sources = Vec::new();
@@ -1530,12 +1537,15 @@ impl JoinScan {
             pg_sys::hash_mem_multiplier,
         );
 
+        pgrx::warning!("MPP: spawning control service and executing");
         exchange::spawn_control_service(&local_set, task_ctx.clone());
 
         let stream = runtime.block_on(local_set.run_until(async {
+            pgrx::warning!("MPP: executing plan partition 0");
             plan.execute(0, task_ctx)
                 .expect("MPP: failed to execute plan")
         }));
+        pgrx::warning!("MPP: plan execution started, streaming results");
 
         // Retain plan for EXPLAIN ANALYZE.
         state.custom_state_mut().physical_plan = Some(plan.clone());

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1445,6 +1445,8 @@ impl JoinScan {
         use crate::postgres::customscan::joinscan::exchange;
         use crate::postgres::customscan::joinscan::transport::TransportMesh;
 
+        let t0 = std::time::Instant::now();
+
         // MPP needs tokio IO for Unix Domain Socket signaling in the transport layer.
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1472,12 +1474,14 @@ impl JoinScan {
             panic!("MPP: failed to launch parallel workers");
         };
 
+        let t1 = t0.elapsed();
         // Step 2: Build MPP session context with actual participant count.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index: 0, // Leader is always participant 0
             total_participants: nlaunched,
         });
 
+        let t2 = t0.elapsed();
         // Step 3: Broadcast the logical plan bytes to workers.
         // Workers will independently build their own physical plans (with their
         // own participant_index in MppParticipantConfig), so we don't need to
@@ -1492,6 +1496,7 @@ impl JoinScan {
                 .expect("MPP: failed to broadcast logical plan to worker");
         }
 
+        let t3 = t0.elapsed();
         // Step 4: Register the DSM mesh for the leader.
         let transport = TransportMesh {
             mux_writers,
@@ -1504,6 +1509,7 @@ impl JoinScan {
         };
         exchange::register_dsm_mesh(mesh);
 
+        let t4 = t0.elapsed();
         // Step 5: Build the leader's own physical plan.
         let planstate = state.planstate();
         let index_segment_ids =
@@ -1523,6 +1529,7 @@ impl JoinScan {
             .block_on(build_physical_plan(&ctx, logical_plan))
             .expect("MPP: failed to create physical plan");
 
+        let t5 = t0.elapsed();
         // Step 6: Register the leader's DsmExchangeExec nodes as stream sources.
         let mut sources = Vec::new();
         exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
@@ -1533,6 +1540,16 @@ impl JoinScan {
             );
         }
 
+        let t6 = t0.elapsed();
+        pgrx::warning!(
+            "MPP timing: launch={:.1}ms ctx={:.1}ms broadcast={:.1}ms mesh={:.1}ms plan={:.1}ms sources={:.1}ms",
+            t1.as_secs_f64() * 1000.0,
+            (t2 - t1).as_secs_f64() * 1000.0,
+            (t3 - t2).as_secs_f64() * 1000.0,
+            (t4 - t3).as_secs_f64() * 1000.0,
+            (t5 - t4).as_secs_f64() * 1000.0,
+            (t6 - t5).as_secs_f64() * 1000.0,
+        );
         // Step 7: Spawn control service and execute.
         let local_set = tokio::task::LocalSet::new();
         let task_ctx = build_task_context(

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1378,14 +1378,17 @@ impl CustomScan for JoinScan {
 
                 let next_batch = {
                     let custom_state = state.custom_state_mut();
-                    custom_state.runtime.as_mut().unwrap().block_on(async {
-                        custom_state
-                            .datafusion_stream
-                            .as_mut()
-                            .unwrap()
-                            .next()
-                            .await
-                    })
+                    let runtime = custom_state.runtime.as_ref().unwrap();
+                    let stream = custom_state.datafusion_stream.as_mut().unwrap();
+                    // When MPP is active, drive the LocalSet (control service) while
+                    // polling for the next batch. This ensures worker RPCs are processed
+                    // concurrently with data consumption — without this, the exchange
+                    // would deadlock waiting for StartStream responses.
+                    if let Some(local_set) = custom_state.mpp_local_set.as_ref() {
+                        runtime.block_on(local_set.run_until(stream.next()))
+                    } else {
+                        runtime.block_on(async { stream.next().await })
+                    }
                 };
 
                 match next_batch {
@@ -1407,6 +1410,15 @@ impl CustomScan for JoinScan {
             // Drop tuple slots that we own.
             for rel_state in state.custom_state().relations.values() {
                 pg_sys::ExecDropSingleTupleTableSlot(rel_state.fetch_slot);
+            }
+        }
+        // Clean up MPP resources: clear DSM mesh, drop LocalSet, destroy parallel context.
+        if state.custom_state().mpp_process.is_some() {
+            crate::postgres::customscan::joinscan::exchange::clear_dsm_mesh();
+            state.custom_state_mut().mpp_local_set = None;
+            state.custom_state_mut().datafusion_stream = None;
+            if let Some(process) = state.custom_state_mut().mpp_process.take() {
+                process.destroy();
             }
         }
         // Clean up resources
@@ -1532,35 +1544,16 @@ impl JoinScan {
 
         exchange::spawn_control_service(&local_set, task_ctx.clone());
 
-        // Collect ALL results inside run_until so the LocalSet continues to drive
-        // the control service while the stream is being polled. The control service
-        // must remain active to respond to worker RPCs (StartStream, etc.).
-        use futures::StreamExt;
-        let batches: Vec<arrow_array::RecordBatch> = runtime.block_on(local_set.run_until(async {
-            let mut stream = plan
-                .execute(0, task_ctx)
-                .expect("MPP: failed to execute plan");
-            let mut batches = Vec::new();
-            while let Some(batch) = stream.next().await {
-                match batch {
-                    Ok(b) => batches.push(b),
-                    Err(e) => panic!("MPP: stream error: {e}"),
-                }
-            }
-            batches
+        // Start the execution stream inside run_until (so the control service
+        // is active to handle the initial StartStream RPCs), then store both
+        // the LocalSet and stream in state for lazy per-batch polling.
+        let stream = runtime.block_on(local_set.run_until(async {
+            plan.execute(0, task_ctx)
+                .expect("MPP: failed to execute plan")
         }));
 
-        // Create a stream from the collected batches for the exec_custom_scan loop.
-        let schema = plan.schema();
-        let batch_stream = futures::stream::iter(batches.into_iter().map(Ok));
-        let stream: datafusion::execution::SendableRecordBatchStream = Box::pin(
-            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
-                schema.clone(),
-                batch_stream,
-            ),
-        );
-
         // Retain plan for EXPLAIN ANALYZE.
+        let schema = plan.schema();
         state.custom_state_mut().physical_plan = Some(plan.clone());
 
         // Map CTID columns to their schema positions.
@@ -1574,13 +1567,11 @@ impl JoinScan {
             }
         }
 
-        // Clean up: clear the DSM mesh and destroy the parallel context.
-        // We must NOT call wait_for_finish() because workers are in an async
-        // loop that only exits on SIGTERM. DestroyParallelContext sends SIGTERM
-        // and waits for workers to exit.
-        exchange::clear_dsm_mesh();
-        process.destroy();
-
+        // Store MPP-specific state for streaming and cleanup.
+        // The LocalSet must stay alive to drive the control service during
+        // per-batch polling. The process handle is kept for cleanup in end_custom_scan.
+        state.custom_state_mut().mpp_local_set = Some(local_set);
+        state.custom_state_mut().mpp_process = Some(process);
         state.custom_state_mut().runtime = Some(runtime);
         state.custom_state_mut().datafusion_stream = Some(stream);
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1466,7 +1466,33 @@ impl JoinScan {
             total_participants: nlaunched,
         });
 
-        // Step 3: Deserialize logical plan.
+        // Step 3: Broadcast the logical plan bytes to workers.
+        // Workers will independently build their own physical plans (with their
+        // own participant_index in MppParticipantConfig), so we don't need to
+        // serialize custom physical plan nodes.
+        for (i, reader_mutex) in mux_readers.iter().enumerate() {
+            if i == 0 {
+                continue; // Skip self (leader)
+            }
+            let mut reader = reader_mutex.lock();
+            reader
+                .send_control_message_variable(128, plan_bytes)
+                .expect("MPP: failed to broadcast logical plan to worker");
+        }
+
+        // Step 4: Register the DSM mesh for the leader.
+        let transport = TransportMesh {
+            mux_writers,
+            mux_readers,
+            bridge,
+        };
+        let mesh = exchange::DsmMesh {
+            transport,
+            registry: parking_lot::Mutex::new(exchange::StreamRegistry::default()),
+        };
+        exchange::register_dsm_mesh(mesh);
+
+        // Step 5: Build the leader's own physical plan.
         let planstate = state.planstate();
         let index_segment_ids =
             Self::build_index_segment_ids(state, join_clause, &join_clause.plan.sources());
@@ -1481,53 +1507,21 @@ impl JoinScan {
         )
         .expect("MPP: failed to deserialize logical plan");
 
-        // Step 4: Build physical plan (optimizer injects EnforceDsmShuffle + EnforceSanitization).
         let plan = runtime
             .block_on(build_physical_plan(&ctx, logical_plan))
             .expect("MPP: failed to create physical plan");
 
-        // Step 5: Serialize physical plan for broadcast.
-        let physical_plan_bytes =
-            datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec(
-                plan.clone(),
-                &crate::scan::codec::PgSearchPhysicalCodec,
-            )
-            .expect("MPP: failed to serialize physical plan");
-
-        // Step 6: Broadcast plan to workers via control channels.
-        for (i, reader_mutex) in mux_readers.iter().enumerate() {
-            if i == 0 {
-                continue; // Skip self (leader)
-            }
-            let mut reader = reader_mutex.lock();
-            reader
-                .send_control_message_variable(128, &physical_plan_bytes)
-                .expect("MPP: failed to broadcast plan to worker");
+        // Step 6: Register the leader's DsmExchangeExec nodes as stream sources.
+        let mut sources = Vec::new();
+        exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
+        for source in sources {
+            exchange::register_stream_source(
+                source,
+                crate::postgres::customscan::joinscan::transport::ParticipantId(0),
+            );
         }
 
-        // Step 7: Register the DSM mesh for the leader.
-        let transport = TransportMesh {
-            mux_writers,
-            mux_readers,
-            bridge,
-        };
-        let mesh = exchange::DsmMesh {
-            transport,
-            registry: parking_lot::Mutex::new(exchange::StreamRegistry::default()),
-        };
-        exchange::register_dsm_mesh(mesh);
-
-        // Step 8: Serialize/deserialize round-trip on the leader so that stream
-        // sources get registered in the leader's StreamRegistry.
-        let codec = crate::scan::codec::PgSearchPhysicalCodec;
-        let plan = datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec(
-            &physical_plan_bytes,
-            &ctx.task_ctx(),
-            &codec,
-        )
-        .expect("MPP: leader plan deserialization failed");
-
-        // Step 9: Spawn control service and execute.
+        // Step 7: Spawn control service and execute.
         let local_set = tokio::task::LocalSet::new();
         let task_ctx = build_task_context(
             &ctx,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -706,10 +706,18 @@ impl JoinScan {
         }
 
         if nworkers > 0 {
-            custom_path.path.parallel_aware = true;
+            // When MPP is enabled, the JoinScan manages its own parallelism via
+            // launch_join_workers() — it must NOT be wrapped in PostgreSQL's Gather
+            // node, because PG's parallel workers would then try to launch nested
+            // workers (which PG forbids). So we set parallel_workers = 0 and
+            // parallel_aware = false to prevent Gather, but keep parallel_safe = true.
+            let use_mpp = crate::gucs::enable_mpp_join();
+            if !use_mpp {
+                custom_path.path.parallel_aware = true;
+                custom_path.path.parallel_workers =
+                    nworkers.try_into().expect("nworkers should be a valid i32");
+            }
             custom_path.path.parallel_safe = true;
-            custom_path.path.parallel_workers =
-                nworkers.try_into().expect("nworkers should be a valid i32");
         }
 
         Some(custom_path)
@@ -1299,7 +1307,7 @@ impl CustomScan for JoinScan {
                 let use_mpp = crate::gucs::enable_mpp_join() && join_clause.planned_workers > 0;
 
                 if use_mpp {
-                    JoinScan::exec_mpp_path(state, runtime, &join_clause, &plan_bytes);
+                    JoinScan::exec_mpp_path(state, &join_clause, &plan_bytes);
                 } else {
                     // Deserialize the logical plan and convert to execution plan
                     let planstate = state.planstate();
@@ -1419,12 +1427,17 @@ impl JoinScan {
     #[allow(unused_variables, dead_code)]
     unsafe fn exec_mpp_path(
         state: &mut CustomScanStateWrapper<JoinScan>,
-        runtime: tokio::runtime::Runtime,
         join_clause: &build::JoinCSClause,
         plan_bytes: &bytes::Bytes,
     ) {
         use crate::postgres::customscan::joinscan::exchange;
         use crate::postgres::customscan::joinscan::transport::TransportMesh;
+
+        // MPP needs tokio IO for Unix Domain Socket signaling in the transport layer.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
 
         let nworkers = join_clause.planned_workers;
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1445,8 +1445,6 @@ impl JoinScan {
         use crate::postgres::customscan::joinscan::exchange;
         use crate::postgres::customscan::joinscan::transport::TransportMesh;
 
-        let t0 = std::time::Instant::now();
-
         // MPP needs tokio IO for Unix Domain Socket signaling in the transport layer.
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1474,14 +1472,12 @@ impl JoinScan {
             panic!("MPP: failed to launch parallel workers");
         };
 
-        let t1 = t0.elapsed();
         // Step 2: Build MPP session context with actual participant count.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index: 0, // Leader is always participant 0
             total_participants: nlaunched,
         });
 
-        let t2 = t0.elapsed();
         // Step 3: Broadcast the logical plan bytes to workers.
         // Workers will independently build their own physical plans (with their
         // own participant_index in MppParticipantConfig), so we don't need to
@@ -1496,7 +1492,6 @@ impl JoinScan {
                 .expect("MPP: failed to broadcast logical plan to worker");
         }
 
-        let t3 = t0.elapsed();
         // Step 4: Register the DSM mesh for the leader.
         let transport = TransportMesh {
             mux_writers,
@@ -1509,7 +1504,6 @@ impl JoinScan {
         };
         exchange::register_dsm_mesh(mesh);
 
-        let t4 = t0.elapsed();
         // Step 5: Build the leader's own physical plan.
         let planstate = state.planstate();
         let index_segment_ids =
@@ -1529,7 +1523,6 @@ impl JoinScan {
             .block_on(build_physical_plan(&ctx, logical_plan))
             .expect("MPP: failed to create physical plan");
 
-        let t5 = t0.elapsed();
         // Step 6: Register the leader's DsmExchangeExec nodes as stream sources.
         let mut sources = Vec::new();
         exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
@@ -1540,16 +1533,6 @@ impl JoinScan {
             );
         }
 
-        let t6 = t0.elapsed();
-        pgrx::warning!(
-            "MPP timing: launch={:.1}ms ctx={:.1}ms broadcast={:.1}ms mesh={:.1}ms plan={:.1}ms sources={:.1}ms",
-            t1.as_secs_f64() * 1000.0,
-            (t2 - t1).as_secs_f64() * 1000.0,
-            (t3 - t2).as_secs_f64() * 1000.0,
-            (t4 - t3).as_secs_f64() * 1000.0,
-            (t5 - t4).as_secs_f64() * 1000.0,
-            (t6 - t5).as_secs_f64() * 1000.0,
-        );
         // Step 7: Spawn control service and execute.
         let local_set = tokio::task::LocalSet::new();
         let task_ctx = build_task_context(

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1452,6 +1452,7 @@ impl JoinScan {
             .unwrap();
 
         let nworkers = join_clause.planned_workers;
+        crate::mpp_log!("MPP JoinScan: exec_mpp_path entered, nworkers={nworkers}");
 
         // Step 1: Launch workers and initialize transport mesh.
         let Some((
@@ -1472,6 +1473,7 @@ impl JoinScan {
             panic!("MPP: failed to launch parallel workers");
         };
 
+        crate::mpp_log!("MPP JoinScan: {nlaunched} participants launched");
         // Step 2: Build MPP session context with actual participant count.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index: 0, // Leader is always participant 0
@@ -1492,6 +1494,10 @@ impl JoinScan {
                 .expect("MPP: failed to broadcast logical plan to worker");
         }
 
+        crate::mpp_log!(
+            "MPP JoinScan: plan broadcast complete ({} bytes)",
+            plan_bytes.len()
+        );
         // Step 4: Register the DSM mesh for the leader.
         let transport = TransportMesh {
             mux_writers,

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -391,14 +391,13 @@ pub fn launch_join_workers(
 
     let session_id = uuid::Uuid::new_v4();
 
-    // Allocate 128MB ring buffers per worker.
-    // TODO: This is temporary! Should implement support for reconstructing a larger buffer without
-    // needing this much dedicated space.
-    let ring_buffer_size = 128 * 1024 * 1024;
-    // We increase the control buffer size to 4MB (from 64KB) to accommodate serialized plans
-    // sent via BroadcastPlan.
-    let control_size = 4 * 1024 * 1024;
-    // Data Header + Data + Control Header + Control Data + padding
+    // Ring buffer size per connection. Smaller buffers reduce DSM allocation
+    // overhead (the biggest component of launch cost) at the expense of more
+    // frequent flushes for large result sets.
+    let ring_buffer_size = 4 * 1024 * 1024; // 4MB per connection
+                                            // Control buffer for plan broadcast and StartStream/CancelStream messages.
+    let control_size = 256 * 1024; // 256KB (plans are typically <10KB)
+                                   // Data Header + Data + Control Header + Control Data + padding
     let layout = TransportLayout::new(ring_buffer_size, control_size);
     let region_size = layout.total_size();
 

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -235,15 +235,12 @@ impl ParallelWorker for JoinWorker<'_> {
             .unwrap();
 
         let session_id = uuid::Uuid::from_bytes(self.config.session_id);
-        pgrx::warning!("MPP Worker {participant_index}: creating SignalBridge");
         let bridge = runtime
             .block_on(SignalBridge::new(participant_id, session_id))
             .expect("Failed to initialize SignalBridge");
         let bridge = Arc::new(bridge);
-        pgrx::warning!("MPP Worker {participant_index}: SignalBridge created");
 
         let layout = TransportLayout::new(self.config.ring_buffer_size, self.config.control_size);
-        pgrx::warning!("MPP Worker {participant_index}: initializing TransportMesh");
         let transport = unsafe {
             TransportMesh::init(
                 self.ring_buffer_ptr,
@@ -279,7 +276,6 @@ impl ParallelWorker for JoinWorker<'_> {
             total_participants: launched_participants,
         });
 
-        pgrx::warning!("MPP Worker {participant_index}: deserializing logical plan");
         let logical_plan =
             crate::scan::codec::deserialize_logical_plan(&plan_slice, &ctx.task_ctx())
                 .expect("Worker: failed to deserialize logical plan");
@@ -290,7 +286,6 @@ impl ParallelWorker for JoinWorker<'_> {
         let plan = runtime
             .block_on(super::scan_state::build_physical_plan(&ctx, logical_plan))
             .expect("Worker: failed to create physical plan");
-        pgrx::warning!("MPP Worker {participant_index}: physical plan built");
 
         // Walk the physical plan tree to find DsmExchangeExec nodes and register
         // them as stream sources in the local StreamRegistry.
@@ -320,7 +315,6 @@ impl ParallelWorker for JoinWorker<'_> {
             let local = tokio::task::LocalSet::new();
 
             // Start the control service to listen for stream requests
-            pgrx::warning!("MPP Worker {participant_index}: spawning control service");
             exchange::spawn_control_service(&local, task_ctx.clone());
             pgrx::warning!(
                 "MPP Worker {participant_index}: control service spawned, parking thread"

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -49,7 +49,6 @@
 //! of background workers and manually coordinates them via a unified DataFusion plan.
 
 use crate::launch_parallel_process;
-use crate::parallel_worker::builder::ParallelProcessMessageQueue;
 use crate::parallel_worker::mqueue::MessageQueueSender;
 use crate::parallel_worker::{
     ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
@@ -331,15 +330,27 @@ impl ParallelWorker for JoinWorker<'_> {
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                     .expect("Failed to create SIGTERM listener");
 
+            // Drive the control service for a short time to process any pending RPCs,
+            // then exit. The leader will drain all data before destroying the parallel
+            // context, so by the time we get here all RPCs should be completed.
+            // Use a polling loop with interrupt checks instead of parking indefinitely.
             local
                 .run_until(async move {
-                    tokio::select! {
-                        _ = futures::future::pending::<()>() => {
-                            // Should not be reachable
-                        }
-                        _ = sigterm.recv() => {
-                            // Normal exit on SIGTERM
-                            pgrx::warning!("JoinWorker: SIGTERM received, shutting down");
+                    loop {
+                        // Yield to let the control service process any pending RPCs.
+                        tokio::task::yield_now().await;
+                        // Check if PostgreSQL wants us to exit.
+                        // In a parallel worker context, the postmaster sends SIGTERM
+                        // via DestroyParallelContext.
+                        tokio::select! {
+                            biased;
+                            _ = sigterm.recv() => {
+                                pgrx::warning!("JoinWorker: SIGTERM received, shutting down");
+                                break;
+                            }
+                            _ = tokio::task::yield_now() => {
+                                // Continue polling
+                            }
                         }
                     }
                 })
@@ -358,7 +369,7 @@ use datafusion::physical_plan::ExecutionPlan;
 
 /// The result of launching parallel join workers.
 pub type LaunchedJoinWorkers = (
-    ParallelProcessMessageQueue,
+    crate::parallel_worker::builder::ParallelProcessFinish,
     Option<Arc<dyn ExecutionPlan>>,
     Vec<Arc<Mutex<MultiplexedDsmWriter>>>,
     Vec<Arc<Mutex<MultiplexedDsmReader>>>,
@@ -469,7 +480,7 @@ pub fn launch_join_workers(
         let mux_readers = transport.mux_readers.clone();
 
         Some((
-            launched.into_iter(),
+            launched,
             None, // Leader plan is not built yet
             mux_writers,
             mux_readers,

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -61,7 +61,6 @@ use crate::postgres::customscan::joinscan::transport::{
     MultiplexedDsmReader, MultiplexedDsmWriter, ParticipantId, SignalBridge, TransportLayout,
 };
 use crate::postgres::locks::Spinlock;
-use crate::scan::codec::PgSearchPhysicalCodec;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -259,19 +258,40 @@ impl ParallelWorker for JoinWorker<'_> {
         };
         exchange::register_dsm_mesh(mesh);
 
+        // Workers receive the logical plan bytes and independently build their
+        // own physical plan (with their participant_index). This avoids needing
+        // to serialize all custom physical plan nodes.
         let ctx = create_datafusion_session_context(SessionContextProfile::JoinMpp {
             participant_index,
             total_participants: launched_participants,
         });
 
-        let codec = PgSearchPhysicalCodec;
-        let _ = physical_plan_from_bytes_with_extension_codec(&plan_slice, &ctx.task_ctx(), &codec)
-            .expect("Failed to parse physical plan");
+        let logical_plan =
+            crate::scan::codec::deserialize_logical_plan(&plan_slice, &ctx.task_ctx())
+                .expect("Worker: failed to deserialize logical plan");
+
+        let plan = runtime
+            .block_on(super::scan_state::build_physical_plan(&ctx, logical_plan))
+            .expect("Worker: failed to create physical plan");
+
+        // Walk the physical plan tree to find DsmExchangeExec nodes and register
+        // them as stream sources in the local StreamRegistry.
+        let mut sources = Vec::new();
+        exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
+        for source in sources {
+            exchange::register_stream_source(
+                source,
+                crate::postgres::customscan::joinscan::transport::ParticipantId(
+                    participant_index as u16,
+                ),
+            );
+        }
 
         let task_ctx = ctx.task_ctx();
 
         // The Worker Loop:
-        // 1. Deserializing the plan populated the local StreamRegistry via the physical codec.
+        // 1. Building the physical plan and calling collect_dsm_exchanges populated
+        //    the local StreamRegistry.
         // 2. Start the "Listener" (Control Service) to accept incoming RPC calls (StartStream).
         // 3. Park the main thread and wait for session termination.
         runtime.block_on(async {
@@ -308,7 +328,6 @@ impl ParallelWorker for JoinWorker<'_> {
 impl JoinWorker<'_> {}
 
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 
 /// The result of launching parallel join workers.
 pub type LaunchedJoinWorkers = (

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -335,7 +335,7 @@ impl ParallelWorker for JoinWorker<'_> {
                         tokio::select! {
                             biased;
                             _ = sigterm.recv() => {
-                                pgrx::warning!("JoinWorker: SIGTERM received, shutting down");
+                                crate::mpp_log!("JoinWorker: SIGTERM received, shutting down");
                                 break;
                             }
                             _ = tokio::task::yield_now() => {

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -225,6 +225,10 @@ impl ParallelWorker for JoinWorker<'_> {
             worker_number as usize
         };
         let participant_id = ParticipantId(participant_index as u16);
+        pgrx::warning!(
+            "MPP Worker {participant_index}: starting, total_participants={}",
+            self.config.total_participants
+        );
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -232,24 +236,34 @@ impl ParallelWorker for JoinWorker<'_> {
             .unwrap();
 
         let session_id = uuid::Uuid::from_bytes(self.config.session_id);
+        pgrx::warning!("MPP Worker {participant_index}: creating SignalBridge");
         let bridge = runtime
             .block_on(SignalBridge::new(participant_id, session_id))
             .expect("Failed to initialize SignalBridge");
         let bridge = Arc::new(bridge);
+        pgrx::warning!("MPP Worker {participant_index}: SignalBridge created");
 
         let layout = TransportLayout::new(self.config.ring_buffer_size, self.config.control_size);
+        pgrx::warning!("MPP Worker {participant_index}: initializing TransportMesh");
         let transport = unsafe {
             TransportMesh::init(
                 self.ring_buffer_ptr,
                 layout,
                 participant_id,
-                self.config.total_participants, // Use Max/Configured participants for layout
+                self.config.total_participants,
                 bridge.clone(),
             )
         };
+        pgrx::warning!(
+            "MPP Worker {participant_index}: TransportMesh initialized, waiting for broadcast plan"
+        );
 
         // Wait for the plan via the control channel.
         let plan_slice = runtime.block_on(transport.wait_for_broadcast_plan());
+        pgrx::warning!(
+            "MPP Worker {participant_index}: broadcast plan received ({} bytes)",
+            plan_slice.len()
+        );
 
         // Register the DSM mesh for this worker process.
         let mesh = exchange::DsmMesh {
@@ -266,18 +280,27 @@ impl ParallelWorker for JoinWorker<'_> {
             total_participants: launched_participants,
         });
 
+        pgrx::warning!("MPP Worker {participant_index}: deserializing logical plan");
         let logical_plan =
             crate::scan::codec::deserialize_logical_plan(&plan_slice, &ctx.task_ctx())
                 .expect("Worker: failed to deserialize logical plan");
+        pgrx::warning!(
+            "MPP Worker {participant_index}: logical plan deserialized, building physical plan"
+        );
 
         let plan = runtime
             .block_on(super::scan_state::build_physical_plan(&ctx, logical_plan))
             .expect("Worker: failed to create physical plan");
+        pgrx::warning!("MPP Worker {participant_index}: physical plan built");
 
         // Walk the physical plan tree to find DsmExchangeExec nodes and register
         // them as stream sources in the local StreamRegistry.
         let mut sources = Vec::new();
         exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
+        pgrx::warning!(
+            "MPP Worker {participant_index}: found {} DsmExchangeExec nodes",
+            sources.len()
+        );
         for source in sources {
             exchange::register_stream_source(
                 source,
@@ -298,7 +321,11 @@ impl ParallelWorker for JoinWorker<'_> {
             let local = tokio::task::LocalSet::new();
 
             // Start the control service to listen for stream requests
+            pgrx::warning!("MPP Worker {participant_index}: spawning control service");
             exchange::spawn_control_service(&local, task_ctx.clone());
+            pgrx::warning!(
+                "MPP Worker {participant_index}: control service spawned, parking thread"
+            );
 
             let mut sigterm =
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -291,10 +291,6 @@ impl ParallelWorker for JoinWorker<'_> {
         // them as stream sources in the local StreamRegistry.
         let mut sources = Vec::new();
         exchange::collect_dsm_exchanges(plan.clone(), &mut sources);
-        pgrx::warning!(
-            "MPP Worker {participant_index}: found {} DsmExchangeExec nodes",
-            sources.len()
-        );
         for source in sources {
             exchange::register_stream_source(
                 source,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -217,11 +217,20 @@ pub struct JoinScanState {
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
+
+    /// MPP: tokio LocalSet that drives the control service. Must be kept alive
+    /// while streaming results so the control service can respond to worker RPCs.
+    pub mpp_local_set: Option<tokio::task::LocalSet>,
+
+    /// MPP: parallel process handle. Dropped in end_custom_scan to destroy
+    /// the parallel context and terminate workers.
+    pub mpp_process: Option<crate::parallel_worker::builder::ParallelProcessFinish>,
 }
 
 impl JoinScanState {
     /// Reset the scan state for a rescan.
     pub fn reset(&mut self) {
+        self.mpp_local_set = None;
         self.datafusion_stream = None;
         self.current_batch = None;
         self.batch_index = 0;

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -327,7 +327,12 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
     } = &profile
     {
         let mut c = SessionConfig::new().with_target_partitions(*total_participants);
-        // Force DataFusion to use partitioned hash joins instead of single-partition mode.
+        // Force DataFusion to use partitioned hash joins so that both sides of
+        // the join are hash-repartitioned. This ensures EnforceDsmShuffle can
+        // replace the RepartitionExec nodes with DsmExchangeExec for cross-process
+        // data transfer. Without this, DataFusion may choose CollectLeft which
+        // doesn't create RepartitionExec, leaving no mechanism for cross-process
+        // data flow.
         c.options_mut()
             .optimizer
             .hash_join_single_partition_threshold = 0;

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -1443,7 +1443,7 @@ impl MultiplexedDsmReader {
     }
 
     /// Signals the writer to start producing data for a stream.
-    pub(super) fn start_stream(&mut self, stream_id: PhysicalStreamId) -> std::io::Result<()> {
+    pub fn start_stream(&mut self, stream_id: PhysicalStreamId) -> std::io::Result<()> {
         self.send_control_message(0, stream_id)
     }
 

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -23,6 +23,7 @@ use datafusion::common::TableReference;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Extension, LogicalPlan, ScalarUDF};
+use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use tantivy::index::SegmentId;
 
@@ -389,6 +390,51 @@ impl PgSearchPhysicalCodec {
     const TAG_DSM_SANITIZE: u8 = 2;
 }
 
+/// Lightweight serialization of a DataFusion `Partitioning` for cross-process transfer.
+///
+/// We only need to preserve the partition count and type — Hash expressions are
+/// recovered from the child plan's output partitioning on decode.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(dead_code)]
+enum SerializedPartitioning {
+    Hash(usize),
+    RoundRobin(usize),
+    Unknown(usize),
+}
+
+#[allow(dead_code)]
+impl SerializedPartitioning {
+    fn from_partitioning(p: &datafusion::physical_plan::Partitioning) -> Self {
+        use datafusion::physical_plan::Partitioning;
+        match p {
+            Partitioning::Hash(_, n) => Self::Hash(*n),
+            Partitioning::RoundRobinBatch(n) => Self::RoundRobin(*n),
+            Partitioning::UnknownPartitioning(n) => Self::Unknown(*n),
+        }
+    }
+
+    fn to_partitioning(
+        &self,
+        hash_exprs: Option<Vec<Arc<dyn datafusion::physical_expr::PhysicalExpr>>>,
+    ) -> datafusion::physical_plan::Partitioning {
+        use datafusion::physical_plan::Partitioning;
+        match self {
+            Self::Hash(n) => Partitioning::Hash(hash_exprs.unwrap_or_default(), *n),
+            Self::RoundRobin(n) => Partitioning::RoundRobinBatch(*n),
+            Self::Unknown(n) => Partitioning::UnknownPartitioning(*n),
+        }
+    }
+}
+
+/// Payload serialized for a `DsmExchangeExec` node.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[allow(dead_code)]
+struct DsmExchangePayload {
+    config: crate::postgres::customscan::joinscan::exchange::DsmExchangeConfig,
+    producer_partitioning: SerializedPartitioning,
+    output_partitioning: SerializedPartitioning,
+}
+
 impl datafusion_proto::physical_plan::PhysicalExtensionCodec for PgSearchPhysicalCodec {
     fn try_decode(
         &self,
@@ -403,13 +449,73 @@ impl datafusion_proto::physical_plan::PhysicalExtensionCodec for PgSearchPhysica
         }
 
         let tag = buf[0];
+        let payload = &buf[1..];
         match tag {
             Self::TAG_DSM_EXCHANGE => {
-                // TODO(#4152): Deserialize DsmExchangeConfig and partitioning from buf[1..],
-                // reconstruct DsmExchangeExec, and register stream sources.
-                Err(DataFusionError::NotImplemented(
-                    "DsmExchangeExec physical deserialization not yet implemented".into(),
-                ))
+                if inputs.len() != 1 {
+                    return Err(DataFusionError::Internal(
+                        "DsmExchangeExec requires exactly one input".into(),
+                    ));
+                }
+                let exchange_payload: DsmExchangePayload = serde_json::from_slice(payload)
+                    .map_err(|e| {
+                        DataFusionError::Internal(format!(
+                            "Failed to deserialize DsmExchangePayload: {e}"
+                        ))
+                    })?;
+
+                // Recover hash expressions from the child's output partitioning.
+                let input = inputs[0].clone();
+                let child_hash_exprs =
+                    if let datafusion::physical_plan::Partitioning::Hash(exprs, _) =
+                        input.output_partitioning()
+                    {
+                        Some(exprs.clone())
+                    } else {
+                        None
+                    };
+
+                let producer_partitioning = exchange_payload
+                    .producer_partitioning
+                    .to_partitioning(child_hash_exprs.clone());
+                let output_partitioning = exchange_payload
+                    .output_partitioning
+                    .to_partitioning(child_hash_exprs);
+
+                let exchange = Arc::new(
+                    crate::postgres::customscan::joinscan::exchange::DsmExchangeExec::try_new(
+                        input.clone(),
+                        producer_partitioning,
+                        output_partitioning,
+                        exchange_payload.config.clone(),
+                    )?,
+                );
+
+                // Register the exchange as a stream source so the control service
+                // can trigger it on demand.
+                use crate::postgres::customscan::joinscan::exchange::{
+                    register_stream_source, StreamSource,
+                };
+                use crate::postgres::customscan::joinscan::transport::ParticipantId;
+                let mpp_config = _ctx
+                    .session_config()
+                    .options()
+                    .extensions
+                    .get::<crate::scan::table_provider::MppParticipantConfig>();
+                let participant_id = mpp_config
+                    .map(|c| ParticipantId(c.index as u16))
+                    .unwrap_or(ParticipantId(0));
+
+                register_stream_source(
+                    StreamSource {
+                        input,
+                        partitioning: exchange.producer_partitioning.clone(),
+                        config: exchange_payload.config,
+                    },
+                    participant_id,
+                );
+
+                Ok(exchange)
             }
             Self::TAG_DSM_SANITIZE => {
                 if inputs.len() != 1 {
@@ -434,12 +540,24 @@ impl datafusion_proto::physical_plan::PhysicalExtensionCodec for PgSearchPhysica
         node: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
         buf: &mut Vec<u8>,
     ) -> Result<()> {
-        if node
-            .as_any()
-            .is::<crate::postgres::customscan::joinscan::exchange::DsmExchangeExec>()
+        if let Some(exchange) =
+            node.as_any()
+                .downcast_ref::<crate::postgres::customscan::joinscan::exchange::DsmExchangeExec>()
         {
             buf.push(Self::TAG_DSM_EXCHANGE);
-            // TODO(#4152): Serialize DsmExchangeConfig and partitioning expressions.
+            let payload = DsmExchangePayload {
+                config: exchange.config.clone(),
+                producer_partitioning: SerializedPartitioning::from_partitioning(
+                    &exchange.producer_partitioning,
+                ),
+                output_partitioning: SerializedPartitioning::from_partitioning(
+                    exchange.properties.output_partitioning(),
+                ),
+            };
+            let json = serde_json::to_vec(&payload).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to serialize DsmExchangePayload: {e}"))
+            })?;
+            buf.extend_from_slice(&json);
             Ok(())
         } else if node
             .as_any()

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -361,7 +361,9 @@ pub fn serialize_logical_plan(plan: &LogicalPlan) -> Result<bytes::Bytes> {
 }
 
 /// Deserializes a DataFusion `LogicalPlan` from bytes using the `PgSearchExtensionCodec`.
-#[cfg(any(test, feature = "pg_test"))]
+///
+/// Used by MPP workers to independently build their physical plans from the
+/// logical plan bytes broadcast by the leader.
 pub fn deserialize_logical_plan(
     bytes: &[u8],
     ctx: &datafusion::execution::TaskContext,

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -749,11 +749,8 @@ impl TableProvider for PgSearchTableProvider {
         let parallel_state = self.parallel_state;
         let canonical_segment_ids = self.canonical_segment_ids.clone();
 
-        pgrx::warning!("MPP scan(): opening relations heap={heap_relid:?} index={index_relid:?}");
         let heap_rel = PgSearchRelation::open(heap_relid);
-        pgrx::warning!("MPP scan(): heap opened");
         let index_rel = PgSearchRelation::open(index_relid);
-        pgrx::warning!("MPP scan(): index opened");
 
         // Solve runtime Postgres expressions (prepared-statement params, etc.) here in scan()
         // rather than earlier because each process (leader and workers) independently

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -749,8 +749,11 @@ impl TableProvider for PgSearchTableProvider {
         let parallel_state = self.parallel_state;
         let canonical_segment_ids = self.canonical_segment_ids.clone();
 
+        pgrx::warning!("MPP scan(): opening relations heap={heap_relid:?} index={index_relid:?}");
         let heap_rel = PgSearchRelation::open(heap_relid);
+        pgrx::warning!("MPP scan(): heap opened");
         let index_rel = PgSearchRelation::open(index_relid);
+        pgrx::warning!("MPP scan(): index opened");
 
         // Solve runtime Postgres expressions (prepared-statement params, etc.) here in scan()
         // rather than earlier because each process (leader and workers) independently

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -733,7 +733,7 @@ impl TableProvider for PgSearchTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         _limit: Option<usize>,
@@ -772,7 +772,20 @@ impl TableProvider for PgSearchTableProvider {
             query.solve_postgres_expressions(expr_context);
         }
 
+        // Check for MPP participant config in the session state.
+        // In MPP mode, each participant gets a slice of segments instead of using
+        // the broadcast-join parallel state mechanism.
+        let mpp_config = state
+            .config()
+            .options()
+            .extensions
+            .get::<MppParticipantConfig>();
+
         // Determine MVCC strategy based on whether we are running in parallel mode.
+        //
+        // For MPP mode (MppParticipantConfig present, total_participants > 1):
+        //   - Each participant opens all segments via Snapshot, then the create_eager_scan
+        //     path filters to only this participant's assigned segments via chunk_range().
         //
         // For the partitioning source (`parallel_state` is Some):
         //   - Leader: Snapshot (claims segments dynamically; its own snapshot is the source
@@ -818,6 +831,40 @@ impl TableProvider for PgSearchTableProvider {
         let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
         let visibility = VisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
         let sort_order = self.scan_info.sort_order.as_ref();
+
+        // MPP segment slicing: when running in MPP mode with multiple participants,
+        // each participant gets a deterministic slice of segments via chunk_range().
+        // This replaces the broadcast-join model where one source is "partitioned"
+        // and others are "replicated".
+        if let Some(mpp) = &mpp_config {
+            if mpp.total_participants > 1 {
+                let all_segments = reader.segment_readers();
+                let n_segments = all_segments.len();
+                let (start, len) = crate::parallel_worker::chunk_range(
+                    n_segments,
+                    mpp.total_participants,
+                    mpp.index,
+                );
+                let my_segments = &all_segments[start..start + len];
+
+                let ffhelper = Arc::new(ffhelper);
+                let segments: Vec<ScanState> = my_segments
+                    .iter()
+                    .map(|r| {
+                        self.create_scan_partition(
+                            &reader,
+                            r.segment_id(),
+                            &projected_fields,
+                            &ffhelper,
+                            &visibility,
+                            heap_relid,
+                        )
+                    })
+                    .collect();
+
+                return self.create_scan(segments, projected_schema, query, sort_order, ffhelper);
+            }
+        }
 
         if let Some(sort_order) = sort_order {
             if let Some(parallel_state) = parallel_state {

--- a/pg_search/tests/pg_regress/expected/mpp_join.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join.out
@@ -1,0 +1,198 @@
+-- Test for MPP (plan partitioning) JoinScan execution
+-- Verifies that the enable_mpp_join GUC exists and is settable,
+-- and that queries produce correct results when MPP is enabled.
+-- Disable parallel workers initially for setup
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- =============================================================================
+-- SETUP: Create tables with enough data for multi-segment indexes
+-- =============================================================================
+DROP TABLE IF EXISTS mpp_orders CASCADE;
+DROP TABLE IF EXISTS mpp_customers CASCADE;
+CREATE TABLE mpp_customers (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    city TEXT,
+    age INTEGER
+);
+CREATE TABLE mpp_orders (
+    id INTEGER PRIMARY KEY,
+    customer_id INTEGER,
+    product TEXT,
+    amount DECIMAL(10,2)
+);
+-- Create BM25 indexes BEFORE inserting to encourage multiple segments
+CREATE INDEX mpp_customers_bm25 ON mpp_customers USING bm25 (id, name, city, age)
+WITH (key_field = 'id', text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}, "city": {"tokenizer": {"type": "keyword"}, "fast": true}}', numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX mpp_orders_bm25 ON mpp_orders USING bm25 (id, customer_id, product, amount)
+WITH (key_field = 'id', text_fields = '{"product": {"tokenizer": {"type": "keyword"}, "fast": true}}', numeric_fields = '{"customer_id": {"fast": true}, "amount": {"fast": true}}');
+-- Insert customer data
+INSERT INTO mpp_customers (id, name, city, age) VALUES
+(1, 'alice', 'NYC', 30),
+(2, 'bob', 'LA', 25),
+(3, 'cloe', 'NYC', 35),
+(4, 'dave', 'SF', 28),
+(5, 'eve', 'LA', 32);
+-- Insert order data
+INSERT INTO mpp_orders (id, customer_id, product, amount) VALUES
+(101, 1, 'laptop', 999.99),
+(102, 1, 'mouse', 29.99),
+(103, 2, 'keyboard', 89.99),
+(104, 3, 'monitor', 499.99),
+(105, 3, 'laptop', 1299.99),
+(106, 4, 'mouse', 19.99),
+(107, 5, 'keyboard', 79.99),
+(108, 5, 'laptop', 899.99);
+-- Create standard indexes for join keys
+CREATE INDEX mpp_orders_customer_id ON mpp_orders (customer_id);
+-- =============================================================================
+-- TEST 1: Verify the GUC exists and is settable
+-- =============================================================================
+-- Should not error
+SET paradedb.enable_mpp_join = off;
+SHOW paradedb.enable_mpp_join;
+ paradedb.enable_mpp_join 
+--------------------------
+ off
+(1 row)
+
+SET paradedb.enable_mpp_join = on;
+SHOW paradedb.enable_mpp_join;
+ paradedb.enable_mpp_join 
+--------------------------
+ on
+(1 row)
+
+-- Reset for baseline
+SET paradedb.enable_mpp_join = off;
+-- =============================================================================
+-- TEST 2: Baseline query results with broadcast-join (MPP off)
+-- =============================================================================
+SET paradedb.enable_join_custom_scan = on;
+SET max_parallel_workers_per_gather = 2;
+SET max_parallel_workers = 4;
+-- Inner join with search predicate
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, o.product, o.amount, o.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: c.id, c.name, o.product, o.amount, o.id
+         Relation Tree: o INNER c
+         Join Cond: c.id = o.customer_id
+         Limit: 10
+         Order By: c.id asc, o.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, NULL as col_4, id@1 as col_5, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[o, c]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"alice","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+ id | name  | product | amount 
+----+-------+---------+--------
+  1 | alice | laptop  | 999.99
+  1 | alice | mouse   |  29.99
+(2 rows)
+
+-- =============================================================================
+-- TEST 3: Same query with MPP enabled
+-- =============================================================================
+SET paradedb.enable_mpp_join = on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c.id, c.name, o.product, o.amount, o.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: c.id, c.name, o.product, o.amount, o.id
+         Relation Tree: o INNER c
+         Join Cond: c.id = o.customer_id
+         Limit: 10
+         Order By: c.id asc, o.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, NULL as col_4, id@1 as col_5, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[o, c]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, customer_id@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"alice","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+ id | name  | product | amount 
+----+-------+---------+--------
+  1 | alice | laptop  | 999.99
+  1 | alice | mouse   |  29.99
+(2 rows)
+
+-- =============================================================================
+-- TEST 4: Multi-predicate query
+-- =============================================================================
+-- MPP still on
+SELECT c.id, c.name, c.city, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.city @@@ 'NYC' AND o.product @@@ 'laptop'
+ORDER BY c.id, o.id
+LIMIT 10;
+ id | name  | city | product | amount  
+----+-------+------+---------+---------
+  1 | alice | NYC  | laptop  |  999.99
+  3 | cloe  | NYC  | laptop  | 1299.99
+(2 rows)
+
+-- Compare with MPP off
+SET paradedb.enable_mpp_join = off;
+SELECT c.id, c.name, c.city, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.city @@@ 'NYC' AND o.product @@@ 'laptop'
+ORDER BY c.id, o.id
+LIMIT 10;
+ id | name  | city | product | amount  
+----+-------+------+---------+---------
+  1 | alice | NYC  | laptop  |  999.99
+  3 | cloe  | NYC  | laptop  | 1299.99
+(2 rows)
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+SET paradedb.enable_mpp_join = off;
+SET max_parallel_workers_per_gather = 0;
+DROP TABLE IF EXISTS mpp_orders CASCADE;
+DROP TABLE IF EXISTS mpp_customers CASCADE;

--- a/pg_search/tests/pg_regress/sql/mpp_join.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join.sql
@@ -1,0 +1,149 @@
+-- Test for MPP (plan partitioning) JoinScan execution
+-- Verifies that the enable_mpp_join GUC exists and is settable,
+-- and that queries produce correct results when MPP is enabled.
+
+-- Disable parallel workers initially for setup
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- =============================================================================
+-- SETUP: Create tables with enough data for multi-segment indexes
+-- =============================================================================
+
+DROP TABLE IF EXISTS mpp_orders CASCADE;
+DROP TABLE IF EXISTS mpp_customers CASCADE;
+
+CREATE TABLE mpp_customers (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    city TEXT,
+    age INTEGER
+);
+
+CREATE TABLE mpp_orders (
+    id INTEGER PRIMARY KEY,
+    customer_id INTEGER,
+    product TEXT,
+    amount DECIMAL(10,2)
+);
+
+-- Create BM25 indexes BEFORE inserting to encourage multiple segments
+CREATE INDEX mpp_customers_bm25 ON mpp_customers USING bm25 (id, name, city, age)
+WITH (key_field = 'id', text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}, "city": {"tokenizer": {"type": "keyword"}, "fast": true}}', numeric_fields = '{"age": {"fast": true}}');
+
+CREATE INDEX mpp_orders_bm25 ON mpp_orders USING bm25 (id, customer_id, product, amount)
+WITH (key_field = 'id', text_fields = '{"product": {"tokenizer": {"type": "keyword"}, "fast": true}}', numeric_fields = '{"customer_id": {"fast": true}, "amount": {"fast": true}}');
+
+-- Insert customer data
+INSERT INTO mpp_customers (id, name, city, age) VALUES
+(1, 'alice', 'NYC', 30),
+(2, 'bob', 'LA', 25),
+(3, 'cloe', 'NYC', 35),
+(4, 'dave', 'SF', 28),
+(5, 'eve', 'LA', 32);
+
+-- Insert order data
+INSERT INTO mpp_orders (id, customer_id, product, amount) VALUES
+(101, 1, 'laptop', 999.99),
+(102, 1, 'mouse', 29.99),
+(103, 2, 'keyboard', 89.99),
+(104, 3, 'monitor', 499.99),
+(105, 3, 'laptop', 1299.99),
+(106, 4, 'mouse', 19.99),
+(107, 5, 'keyboard', 79.99),
+(108, 5, 'laptop', 899.99);
+
+-- Create standard indexes for join keys
+CREATE INDEX mpp_orders_customer_id ON mpp_orders (customer_id);
+
+-- =============================================================================
+-- TEST 1: Verify the GUC exists and is settable
+-- =============================================================================
+
+-- Should not error
+SET paradedb.enable_mpp_join = off;
+SHOW paradedb.enable_mpp_join;
+
+SET paradedb.enable_mpp_join = on;
+SHOW paradedb.enable_mpp_join;
+
+-- Reset for baseline
+SET paradedb.enable_mpp_join = off;
+
+-- =============================================================================
+-- TEST 2: Baseline query results with broadcast-join (MPP off)
+-- =============================================================================
+
+SET paradedb.enable_join_custom_scan = on;
+SET max_parallel_workers_per_gather = 2;
+SET max_parallel_workers = 4;
+
+-- Inner join with search predicate
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 3: Same query with MPP enabled
+-- =============================================================================
+
+SET paradedb.enable_mpp_join = on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+SELECT c.id, c.name, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.name @@@ 'alice'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+-- =============================================================================
+-- TEST 4: Multi-predicate query
+-- =============================================================================
+
+-- MPP still on
+SELECT c.id, c.name, c.city, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.city @@@ 'NYC' AND o.product @@@ 'laptop'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+-- Compare with MPP off
+SET paradedb.enable_mpp_join = off;
+
+SELECT c.id, c.name, c.city, o.product, o.amount
+FROM mpp_customers c
+JOIN mpp_orders o ON c.id = o.customer_id
+WHERE c.city @@@ 'NYC' AND o.product @@@ 'laptop'
+ORDER BY c.id, o.id
+LIMIT 10;
+
+-- =============================================================================
+-- CLEANUP
+-- =============================================================================
+
+SET paradedb.enable_mpp_join = off;
+SET max_parallel_workers_per_gather = 0;
+DROP TABLE IF EXISTS mpp_orders CASCADE;
+DROP TABLE IF EXISTS mpp_customers CASCADE;

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -339,6 +339,8 @@ pub struct PgGucs {
     pub columnar_exec: bool,
     /// Enable sorted execution for ColumnarExecState.
     pub columnar_sort: bool,
+    /// Enable MPP (plan partitioning) execution for parallel JoinScan.
+    pub enable_mpp_join: bool,
 }
 
 impl Default for PgGucs {
@@ -354,6 +356,7 @@ impl Default for PgGucs {
             parallel_workers: true,
             columnar_exec: false,
             columnar_sort: true,
+            enable_mpp_join: false,
         }
     }
 }
@@ -371,6 +374,7 @@ impl PgGucs {
             parallel_workers,
             columnar_exec,
             columnar_sort,
+            enable_mpp_join,
         } = self;
 
         let max_parallel_workers = if *parallel_workers { 8 } else { 0 };
@@ -411,6 +415,7 @@ impl PgGucs {
             "SET paradedb.enable_columnar_sort TO {columnar_sort};"
         )
         .unwrap();
+        writeln!(gucs, "SET paradedb.enable_mpp_join TO {enable_mpp_join};").unwrap();
         gucs
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4152 (partial — JoinScan path; builds on #4768)

## What

End-to-end MPP (plan partitioning) execution for JoinScan. When `SET paradedb.enable_mpp_join = on`, both sides of the join are hash-partitioned across workers and data is shuffled via shared memory exchange operators — eliminating the broadcast-join model where non-partitioned tables are fully replicated per worker.

Key additions:
- DsmExchangeExec physical plan serialization (serde_json codec)
- MPP segment slicing in `PgSearchTableProvider::scan()` via `chunk_range()`
- `exec_mpp_path()` — full MPP lifecycle: worker launch, logical plan broadcast, physical plan build with `EnforceDsmShuffle`, exchange data flow, result streaming
- Local bypass channel for self-partition data (skips Arrow IPC for in-process transfers)
- Gather DsmExchangeExec at plan top for collecting results from all participants
- `paradedb.mpp_debug` GUC for verbose execution tracing
- qgen `PgGucs.enable_mpp_join` for property-based testing
- Regression test (`mpp_join.sql`)

## Why

The broadcast-join strategy scales poorly when multiple tables are large — non-partitioned tables are scanned N times. MPP hash-partitions both sides so each row is processed once. Also fixes the SEMI/ANTI join correctness issue where the preserved side must be partitioned.

## How

Workers receive the serialized logical plan (not physical — avoids needing to serialize all custom ExecutionPlan nodes), independently build their own physical plans with `SessionContextProfile::JoinMpp`, and register DsmExchangeExec stream sources. The leader sends StartStream RPCs to trigger worker producers; data flows through shared memory ring buffers with Arrow IPC serialization.

Performance optimizations applied:
1. **4MB ring buffers** (from 128MB) — 42x faster worker launch (252ms → 6ms)
2. **Lazy streaming** — results streamed per-batch via LocalSet instead of buffered
3. **Local bypass channel** — self-partition data skips IPC serialization entirely
4. **Bypass channel pre-creation** — channels created during plan setup, not asynchronously in producer

Based on the architecture from draft PR #4184 by @stuhood.

## Performance

200K × 800K rows, LIMIT 100 (median of 3):

| Mode | Time | vs Serial |
|------|------|-----------|
| Serial | 400ms | 1.0x |
| Broadcast-Join (2 PG workers) | 164ms | 2.4x |
| MPP (1 worker) | 303ms | 1.3x |
| MPP (2 workers) | 234ms | 1.7x |
| **MPP (4 workers)** | **175ms** | **2.3x** |

## Tests

- All existing `join_*` regression tests pass (expected outputs regenerated for subplan_id restoration)
- `mpp_join` regression test: GUC toggle, inner join correctness
- qgen `PgGucs.enable_mpp_join`: property-based testing
- `pg_test_dsm_gather_execution`: end-to-end DSM exchange test