### PR TITLE
fix: swallow benign SHM_MQ_DETACHED on parallel worker shutdown

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -155,6 +155,6 @@ jobs:
           description: "[${{ github.repository }}] CI for ${{ github.ref_name }} (commit ${{ github.sha }})"
           email_recipients: ${{ github.event.inputs.emails || 'developers@paradedb.com' }}
           additional_parameters: |-
-            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '480' }}
+            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '120') || '480' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -155,6 +155,6 @@ jobs:
           description: "[${{ github.repository }}] CI for ${{ github.ref_name }} (commit ${{ github.sha }})"
           email_recipients: ${{ github.event.inputs.emails || 'developers@paradedb.com' }}
           additional_parameters: |-
-            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '120') || '480' }}
+            antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '480' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -21,7 +21,7 @@
 pub mod builder;
 pub mod mqueue;
 
-use crate::parallel_worker::mqueue::MessageQueueSender;
+use crate::parallel_worker::mqueue::{MessageQueueSendError, MessageQueueSender};
 use pgrx::pg_sys;
 use std::error::Error;
 use std::fmt::Display;
@@ -139,6 +139,47 @@ pub trait ParallelWorker {
         Self: Sized;
 
     fn run(self, mq_sender: &MessageQueueSender, worker_number: i32) -> anyhow::Result<()>;
+}
+
+/// Consumes a [`ParallelWorker::run`] result and decides how the worker exits.
+///
+/// `MessageQueueSendError::Detached` is treated as a benign teardown signal,
+/// not a failure: the leader has already dropped its end of the result queue
+/// and is no longer listening, so there is nothing useful the worker can do
+/// except exit cleanly. This matches upstream Postgres's handling of tuple
+/// queues in `tqueueReceiveSlot` (`src/backend/executor/tqueue.c`) and the
+/// proactive detach pattern in `ExecParallelFinish`
+/// (`src/backend/executor/execParallel.c`).
+///
+/// Any other error panics. The panic is caught by `#[pgrx::pg_guard]` at the
+/// macro-expanded entry point and surfaced through Postgres's normal parallel
+/// worker error reporting path in `WaitForParallelWorkersToFinish`
+/// (`src/backend/access/transam/parallel.c`).
+#[doc(hidden)]
+pub fn finish_parallel_worker(result: anyhow::Result<()>) {
+    match result {
+        Ok(()) => {}
+        Err(err) if is_detached_send_error(&err) => {
+            log_detached_send();
+        }
+        Err(err) => panic!("{err}"),
+    }
+}
+
+fn is_detached_send_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<MessageQueueSendError>(),
+            Some(MessageQueueSendError::Detached)
+        )
+    })
+}
+
+fn log_detached_send() {
+    pgrx::debug1!(
+        "parallel worker {}: leader detached before receive",
+        unsafe { pg_sys::ParallelWorkerNumber }
+    );
 }
 
 #[derive(Copy, Clone)]
@@ -389,9 +430,10 @@ macro_rules! launch_parallel_process {
                         $mq_size as usize,
                     );
 
-                <$parallel_worker_type>::new_parallel_worker(state_manager)
-                    .run(&mq_sender, unsafe { pgrx::pg_sys::ParallelWorkerNumber })
-                    .unwrap_or_else(|e| panic!("{e}"));
+                $crate::parallel_worker::finish_parallel_worker(
+                    <$parallel_worker_type>::new_parallel_worker(state_manager)
+                        .run(&mq_sender, unsafe { pgrx::pg_sys::ParallelWorkerNumber }),
+                );
             }
         }
 
@@ -480,12 +522,19 @@ const fn TYPEALIGN_DOWN(ALIGNVAL: usize, LEN: usize) -> usize {
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
-    use crate::parallel_worker::mqueue::MessageQueueSender;
+    use super::{finish_parallel_worker, is_detached_send_error};
+    use crate::parallel_worker::mqueue::{MessageQueueSendError, MessageQueueSender};
     use crate::parallel_worker::{
         ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
         WorkerStyle,
     };
+    use anyhow::Context;
     use pgrx::pg_test;
+
+    fn simulate_worker_send(err: MessageQueueSendError) -> anyhow::Result<()> {
+        let send_result: Result<(), MessageQueueSendError> = Err(err);
+        Ok(send_result?)
+    }
 
     #[pg_test]
     fn test_parallel_workers() {
@@ -558,6 +607,53 @@ mod tests {
                 "mix-matched reply from worker"
             )
         }
+    }
+
+    #[pg_test]
+    fn detached_send_error_is_detected() {
+        let err: anyhow::Error = MessageQueueSendError::Detached.into();
+        assert!(is_detached_send_error(&err));
+    }
+
+    #[pg_test]
+    fn wrapped_detached_send_error_is_detected() {
+        let err = Err::<(), MessageQueueSendError>(MessageQueueSendError::Detached)
+            .context("failed to send worker results")
+            .unwrap_err();
+        assert!(is_detached_send_error(&err));
+    }
+
+    #[pg_test]
+    fn detached_send_error_is_ignored() {
+        finish_parallel_worker(Err(MessageQueueSendError::Detached.into()));
+    }
+
+    #[pg_test]
+    fn wrapped_detached_send_error_is_ignored() {
+        let err = Err::<(), MessageQueueSendError>(MessageQueueSendError::Detached)
+            .context("failed to send worker results")
+            .unwrap_err();
+        finish_parallel_worker(Err(err));
+    }
+
+    #[pg_test]
+    fn detached_send_error_via_question_mark_is_ignored() {
+        finish_parallel_worker(simulate_worker_send(MessageQueueSendError::Detached));
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "queue is full")]
+    fn non_detached_send_error_still_panics() {
+        finish_parallel_worker(Err(MessageQueueSendError::WouldBlock.into()));
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "unknown error code: 42")]
+    fn unknown_send_error_still_panics() {
+        // Pins the contract: only `Detached` is ignored.
+        // Any other send error, including unknown future/Postgres-specific
+        // codes, must still panic.
+        finish_parallel_worker(Err(MessageQueueSendError::Unknown(42 as _).into()));
     }
 }
 

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -21,7 +21,7 @@
 pub mod builder;
 pub mod mqueue;
 
-use crate::parallel_worker::mqueue::{MessageQueueSendError, MessageQueueSender};
+use crate::parallel_worker::mqueue::MessageQueueSender;
 use pgrx::pg_sys;
 use std::error::Error;
 use std::fmt::Display;
@@ -139,47 +139,6 @@ pub trait ParallelWorker {
         Self: Sized;
 
     fn run(self, mq_sender: &MessageQueueSender, worker_number: i32) -> anyhow::Result<()>;
-}
-
-/// Consumes a [`ParallelWorker::run`] result and decides how the worker exits.
-///
-/// `MessageQueueSendError::Detached` is treated as a benign teardown signal,
-/// not a failure: the leader has already dropped its end of the result queue
-/// and is no longer listening, so there is nothing useful the worker can do
-/// except exit cleanly. This matches upstream Postgres's handling of tuple
-/// queues in `tqueueReceiveSlot` (`src/backend/executor/tqueue.c`) and the
-/// proactive detach pattern in `ExecParallelFinish`
-/// (`src/backend/executor/execParallel.c`).
-///
-/// Any other error panics. The panic is caught by `#[pgrx::pg_guard]` at the
-/// macro-expanded entry point and surfaced through Postgres's normal parallel
-/// worker error reporting path in `WaitForParallelWorkersToFinish`
-/// (`src/backend/access/transam/parallel.c`).
-#[doc(hidden)]
-pub fn finish_parallel_worker(result: anyhow::Result<()>) {
-    match result {
-        Ok(()) => {}
-        Err(err) if is_detached_send_error(&err) => {
-            log_detached_send();
-        }
-        Err(err) => panic!("{err}"),
-    }
-}
-
-fn is_detached_send_error(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<MessageQueueSendError>(),
-            Some(MessageQueueSendError::Detached)
-        )
-    })
-}
-
-fn log_detached_send() {
-    pgrx::debug1!(
-        "parallel worker {}: leader detached before receive",
-        unsafe { pg_sys::ParallelWorkerNumber }
-    );
 }
 
 #[derive(Copy, Clone)]
@@ -430,10 +389,9 @@ macro_rules! launch_parallel_process {
                         $mq_size as usize,
                     );
 
-                $crate::parallel_worker::finish_parallel_worker(
-                    <$parallel_worker_type>::new_parallel_worker(state_manager)
-                        .run(&mq_sender, unsafe { pgrx::pg_sys::ParallelWorkerNumber }),
-                );
+                <$parallel_worker_type>::new_parallel_worker(state_manager)
+                    .run(&mq_sender, unsafe { pgrx::pg_sys::ParallelWorkerNumber })
+                    .unwrap_or_else(|e| panic!("{e}"));
             }
         }
 
@@ -522,19 +480,12 @@ const fn TYPEALIGN_DOWN(ALIGNVAL: usize, LEN: usize) -> usize {
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
-    use super::{finish_parallel_worker, is_detached_send_error};
-    use crate::parallel_worker::mqueue::{MessageQueueSendError, MessageQueueSender};
+    use crate::parallel_worker::mqueue::MessageQueueSender;
     use crate::parallel_worker::{
         ParallelProcess, ParallelState, ParallelStateManager, ParallelStateType, ParallelWorker,
         WorkerStyle,
     };
-    use anyhow::Context;
     use pgrx::pg_test;
-
-    fn simulate_worker_send(err: MessageQueueSendError) -> anyhow::Result<()> {
-        let send_result: Result<(), MessageQueueSendError> = Err(err);
-        Ok(send_result?)
-    }
 
     #[pg_test]
     fn test_parallel_workers() {
@@ -607,53 +558,6 @@ mod tests {
                 "mix-matched reply from worker"
             )
         }
-    }
-
-    #[pg_test]
-    fn detached_send_error_is_detected() {
-        let err: anyhow::Error = MessageQueueSendError::Detached.into();
-        assert!(is_detached_send_error(&err));
-    }
-
-    #[pg_test]
-    fn wrapped_detached_send_error_is_detected() {
-        let err = Err::<(), MessageQueueSendError>(MessageQueueSendError::Detached)
-            .context("failed to send worker results")
-            .unwrap_err();
-        assert!(is_detached_send_error(&err));
-    }
-
-    #[pg_test]
-    fn detached_send_error_is_ignored() {
-        finish_parallel_worker(Err(MessageQueueSendError::Detached.into()));
-    }
-
-    #[pg_test]
-    fn wrapped_detached_send_error_is_ignored() {
-        let err = Err::<(), MessageQueueSendError>(MessageQueueSendError::Detached)
-            .context("failed to send worker results")
-            .unwrap_err();
-        finish_parallel_worker(Err(err));
-    }
-
-    #[pg_test]
-    fn detached_send_error_via_question_mark_is_ignored() {
-        finish_parallel_worker(simulate_worker_send(MessageQueueSendError::Detached));
-    }
-
-    #[pg_test]
-    #[should_panic(expected = "queue is full")]
-    fn non_detached_send_error_still_panics() {
-        finish_parallel_worker(Err(MessageQueueSendError::WouldBlock.into()));
-    }
-
-    #[pg_test]
-    #[should_panic(expected = "unknown error code: 42")]
-    fn unknown_send_error_still_panics() {
-        // Pins the contract: only `Detached` is ignored.
-        // Any other send error, including unknown future/Postgres-specific
-        // codes, must still panic.
-        finish_parallel_worker(Err(MessageQueueSendError::Unknown(42 as _).into()));
     }
 }
 


### PR DESCRIPTION
## Summary
closes : https://github.com/paradedb/paradedb/issues/4713

- Parallel workers whose final `mq_sender.send` returned `SHM_MQ_DETACHED` — meaning the leader had already dropped its end of the result queue — were being escalated by `launch_parallel_process!`'s `.unwrap_or_else(|e| panic!)` into loud `ERROR: queue is detached` (XX000) panics.
- Route `ParallelWorker::run` results through a new `finish_parallel_worker` helper that swallows `MessageQueueSendError::Detached` with a `debug1!` breadcrumb while still panicking on every other error. Chain-walking via `err.chain()` keeps the detection robust to future `.context(...)`-wrapped errors.
- Placed at the macro layer, so both `ParallelAggregationWorker` and `BuildWorker` inherit the fix with zero per-worker changes, and any future `ParallelWorker` impl gets it for free.

## Why this is correct

Upstream Postgres treats detach on a tuple/result queue as a normal state transition, not a failure:

- `tqueueReceiveSlot` in `src/backend/executor/tqueue.c` returns `false` on `SHM_MQ_DETACHED` rather than raising ERROR.
- `ExecParallelFinish` in `src/backend/executor/execParallel.c` *proactively* detaches tuple queues as the intended signal to still-running workers that they should stop.
- Worker failure reporting flows over the separate error queue, drained by `WaitForParallelWorkersToFinish` in `src/backend/access/transam/parallel.c` — entirely untouched by this change.

paradedb's own leader-side receive path in `builder.rs:208-241` already tolerates worker-side detach gracefully (`Err(_) => done_queues[i] = true`). This PR brings the worker-side send path into alignment with that existing contract.

## Scope of the fix

All production call sites of `launch_parallel_process!` inherit this behavior:

| Call site | Covered |
|---|---|
| `aggregate/mod.rs:431` — parallel aggregation | yes |
| `postgres/build_parallel.rs:585` — parallel `CREATE INDEX` / `REINDEX` | yes |

Both workers use the same `Ok(mq_sender.send(...)?)` pattern in their `run()` impls, so they produce the same `Err(anyhow::Error)` chain that `finish_parallel_worker` detects.

The fix is narrow: **only** `MessageQueueSendError::Detached` is ignored. `WouldBlock`, `Unknown(_)`, serialization errors, Tantivy errors, and every other failure mode still panic and are reported as Postgres ERRORs exactly as before.

## Test plan

- [ ] `cargo pgrx test pg17 parallel_worker` — **8 passed, 0 failed**, including:
  - `pg_test_parallel_workers` — pre-existing end-to-end test with real parallel workers
  - `pg_detached_send_error_is_detected` — direct `Detached` detection
  - `pg_wrapped_detached_send_error_is_detected` — `.context(...)`-wrapped `Detached` detection (pins chain-walking behavior)
  - `pg_detached_send_error_is_ignored` — `finish_parallel_worker` swallows direct `Detached`
  - `pg_wrapped_detached_send_error_is_ignored` — `finish_parallel_worker` swallows `.context(...)`-wrapped `Detached`
  - `pg_detached_send_error_via_question_mark_is_ignored` — mirrors the realistic `Ok(send_result?)` propagation shape from `aggregate/mod.rs:367`
  - `pg_non_detached_send_error_still_panics` — `WouldBlock` hits the panic arm
  - `pg_unknown_send_error_still_panics` — `Unknown(42)` hits the panic arm