### PR TITLE
feat: add edge_ngram tokenizer for search-as-you-type

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -19,3 +19,7 @@ notin
 NotIn
 fillter
 AtLeast
+fo
+Fo
+caf
+worl

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
+skip = tokenizers/src/edge_ngram.rs
 ignore-multiline-regex = \{\s*/\*\s*\*\s*codespell:ignore-begin\s*\*\s*\*/\s*\}.*?\{\s*/\*\s*\*\s*codespell:ignore-end\s*\*\s*\*/\s*\}

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,2 @@
 [codespell]
-skip = tokenizers/src/edge_ngram.rs
 ignore-multiline-regex = \{\s*/\*\s*\*\s*codespell:ignore-begin\s*\*\s*\*/\s*\}.*?\{\s*/\*\s*\*\s*codespell:ignore-end\s*\*\s*\*/\s*\}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6155,7 +6155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8179,6 +8179,7 @@ version = "0.22.6"
 dependencies = [
  "anyhow",
  "emoji",
+ "icu_properties",
  "icu_segmenter",
  "lindera",
  "once_cell",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,7 @@
                               "documentation/tokenizers/available-tokenizers/literal-normalized",
                               "documentation/tokenizers/available-tokenizers/whitespace",
                               "documentation/tokenizers/available-tokenizers/ngrams",
+                              "documentation/tokenizers/available-tokenizers/edge-ngrams",
                               "documentation/tokenizers/available-tokenizers/simple",
                               "documentation/tokenizers/available-tokenizers/regex",
                               "documentation/tokenizers/available-tokenizers/chinese-compatible",

--- a/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
@@ -1,0 +1,70 @@
+---
+title: Edge Ngram
+description: Generates prefix n-grams per word, ideal for search-as-you-type
+canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/edge-ngrams
+---
+
+The edge ngram tokenizer first splits text into words at character-class boundaries, then generates n-grams anchored
+to the **beginning** of each word. This makes it ideal for "search-as-you-type" functionality, where users find matches
+as they type partial words.
+
+The tokenizer takes two required arguments: the minimum and maximum gram length. For each word, it emits prefix tokens
+from `min_gram` to `max_gram` characters long (clamped to the word length). Words shorter than `min_gram` are skipped.
+
+```sql
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, (description::pdb.edge_ngram(2,5)))
+WITH (key_field='id');
+```
+
+To get a feel for this tokenizer, run the following command and replace the text with your own:
+
+```sql
+SELECT 'Quick Fox'::pdb.edge_ngram(2,5)::text[];
+```
+
+```ini Expected Response
+            text
+-----------------------------
+ {qu,qui,quic,quick,fo,fox}
+(1 row)
+```
+
+## Token Chars
+
+By default, the edge ngram tokenizer treats letters and digits as token content and everything else (spaces,
+punctuation, symbols) as word delimiters. You can customize this with `token_chars`, which accepts a comma-separated
+list of character classes: `letter`, `digit`, `whitespace`, `punctuation`, `symbol`.
+
+For example, including `punctuation` keeps hyphens as part of words:
+
+```sql
+SELECT 'Quick-Fox'::pdb.edge_ngram(2,5,'token_chars=letter,digit,punctuation')::text[];
+```
+
+```ini Expected Response
+          text
+-------------------------
+ {qu,qui,quic,quick}
+(1 row)
+```
+
+## Search-as-you-Type
+
+A common pattern is to use edge ngrams at index time for autocomplete, combined with a different tokenizer at
+[search time](/documentation/tokenizers/search-tokenizer) so that the query string is not itself split into edge
+ngrams:
+
+```sql
+CREATE TABLE products (id SERIAL PRIMARY KEY, name TEXT);
+INSERT INTO products (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
+
+CREATE INDEX ON products
+USING bm25 (id, (name::pdb.edge_ngram(2,10,'alias=edge')))
+WITH (key_field='id');
+
+-- Matches "ParadeDB" and "Paragraph" using the edge ngram index
+SELECT * FROM products WHERE (name::pdb.unicode_words('alias=edge')) @@@ 'Par';
+
+DROP TABLE products;
+```

--- a/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
@@ -34,10 +34,8 @@ SELECT 'Quick Fox'::pdb.edge_ngram(2,5)::text[];
 
 By default, the edge ngram tokenizer treats letters and digits as token content and everything else (spaces,
 punctuation, symbols) as word delimiters. You can customize this with `token_chars`, which accepts a comma-separated
-list of character classes: `letter`, `digit`, `whitespace`, `punctuation`, `symbol`.
-
-Note that `punctuation` only matches ASCII punctuation characters. Unicode punctuation (em-dash, guillemets, etc.)
-is not included and will act as a word delimiter. This differs from Elasticsearch, which uses Unicode categories.
+list of character classes: `letter`, `digit`, `whitespace`, `punctuation`, `symbol`. Character classification uses
+Unicode general categories, matching Elasticsearch's behavior.
 
 For example, including `punctuation` keeps hyphens as part of words:
 

--- a/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
@@ -48,23 +48,3 @@ SELECT 'Quick-Fox'::pdb.edge_ngram(2,5,'token_chars=letter,digit,punctuation')::
  {qu,qui,quic,quick}
 (1 row)
 ```
-
-## Search-as-you-Type
-
-A common pattern is to use edge ngrams at index time for autocomplete, combined with a different tokenizer at
-[search time](/documentation/tokenizers/search-tokenizer) so that the query string is not itself split into edge
-ngrams:
-
-```sql
-CREATE TABLE products (id SERIAL PRIMARY KEY, name TEXT);
-INSERT INTO products (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
-
-CREATE INDEX ON products
-USING bm25 (id, (name::pdb.edge_ngram(2,10,'alias=edge')))
-WITH (key_field='id');
-
--- Matches "ParadeDB" and "Paragraph" using the edge ngram index
-SELECT * FROM products WHERE (name::pdb.unicode_words('alias=edge')) @@@ 'Par';
-
-DROP TABLE products;
-```

--- a/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/edge-ngrams.mdx
@@ -36,6 +36,9 @@ By default, the edge ngram tokenizer treats letters and digits as token content 
 punctuation, symbols) as word delimiters. You can customize this with `token_chars`, which accepts a comma-separated
 list of character classes: `letter`, `digit`, `whitespace`, `punctuation`, `symbol`.
 
+Note that `punctuation` only matches ASCII punctuation characters. Unicode punctuation (em-dash, guillemets, etc.)
+is not included and will act as a word delimiter. This differs from Elasticsearch, which uses Unicode categories.
+
 For example, including `punctuation` keeps hyphens as part of words:
 
 ```sql

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-GUT3PK9wc0Qh1UZoiNN1uA6GPbjmpZqTvEPMsCYQ7g0=";
+  cargoHash = "sha256-XHHE53KCQeU/u2ZSQdIQp/O5YpXc96OJraFdDXrmcd4=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.22.5--0.22.6.sql
+++ b/pg_search/sql/pg_search--0.22.5--0.22.6.sql
@@ -29,3 +29,77 @@ BEGIN
 	END IF;
 END
 $$;
+
+-- Add edge_ngram tokenizer type
+CREATE TYPE pdb.edge_ngram;
+CREATE OR REPLACE FUNCTION pdb.edge_ngram_in(cstring) RETURNS pdb.edge_ngram AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.edge_ngram_out(pdb.edge_ngram) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.edge_ngram_send(pdb.edge_ngram) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION pdb.edge_ngram_recv(internal) RETURNS pdb.edge_ngram AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
+CREATE TYPE pdb.edge_ngram (
+    INPUT = pdb.edge_ngram_in,
+    OUTPUT = pdb.edge_ngram_out,
+    SEND = pdb.edge_ngram_send,
+    RECEIVE = pdb.edge_ngram_recv,
+    COLLATABLE = true,
+    CATEGORY = 't',
+    PREFERRED = false,
+    LIKE = text
+);
+
+ALTER TYPE pdb.edge_ngram SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
+
+CREATE CAST (text AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+CREATE CAST (varchar AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+
+CREATE FUNCTION pdb."tokenize_edge_ngram"(
+    "s" pdb.edge_ngram
+) RETURNS TEXT[]
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'tokenize_edge_ngram_wrapper';
+
+CREATE CAST (pdb.edge_ngram AS TEXT[]) WITH FUNCTION pdb.tokenize_edge_ngram AS IMPLICIT;
+
+CREATE FUNCTION pdb."json_to_edge_ngram"(
+    "json" json
+) RETURNS pdb.edge_ngram
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'json_to_edge_ngram_wrapper';
+
+CREATE FUNCTION pdb."jsonb_to_edge_ngram"(
+    "jsonb" jsonb
+) RETURNS pdb.edge_ngram
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'jsonb_to_edge_ngram_wrapper';
+
+CREATE CAST (json AS pdb.edge_ngram) WITH FUNCTION pdb.json_to_edge_ngram AS ASSIGNMENT;
+CREATE CAST (jsonb AS pdb.edge_ngram) WITH FUNCTION pdb.jsonb_to_edge_ngram AS ASSIGNMENT;
+
+CREATE FUNCTION pdb."uuid_to_edge_ngram"(
+    "uuid" uuid
+) RETURNS pdb.edge_ngram
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'uuid_to_edge_ngram_wrapper';
+
+CREATE CAST (uuid AS pdb.edge_ngram) WITH FUNCTION pdb.uuid_to_edge_ngram AS ASSIGNMENT;
+
+CREATE FUNCTION pdb."text_array_to_edge_ngram"(
+    "arr" text[]
+) RETURNS pdb.edge_ngram
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'text_array_to_edge_ngram_wrapper';
+
+CREATE FUNCTION pdb."varchar_array_to_edge_ngram"(
+    "arr" varchar[]
+) RETURNS pdb.edge_ngram
+    IMMUTABLE STRICT PARALLEL SAFE
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'varchar_array_to_edge_ngram_wrapper';
+
+CREATE CAST (text[] AS pdb.edge_ngram) WITH FUNCTION pdb.text_array_to_edge_ngram AS ASSIGNMENT;
+CREATE CAST (varchar[] AS pdb.edge_ngram) WITH FUNCTION pdb.varchar_array_to_edge_ngram AS ASSIGNMENT;

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -566,6 +566,25 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        EdgeNgram,
+        SearchTokenizer::EdgeNgram {
+            min_gram: 1,
+            max_gram: 2,
+            token_chars: vec!["letter".to_string(), "digit".to_string()],
+            filters: SearchTokenizerFilters::default(),
+        },
+        tokenize_edge_ngram,
+        json_to_edge_ngram,
+        jsonb_to_edge_ngram,
+        uuid_to_edge_ngram,
+        text_array_to_edge_ngram,
+        varchar_array_to_edge_ngram,
+        "edge_ngram",
+        preferred = false,
+        custom_typmod = false
+    );
+
+    define_tokenizer_type!(
         Regex,
         SearchTokenizer::RegexTokenizer {
             pattern: ".*".to_string(),

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -37,8 +37,8 @@ mod typmod;
 use crate::schema::{IndexRecordOption, SearchFieldConfig};
 
 pub use crate::api::tokenizers::typmod::{
-    AliasTypmod, GenericTypmod, JiebaTypmod, LinderaTypmod, NgramTypmod, RegexTypmod, Typmod,
-    UncheckedTypmod, UnicodeWordsTypmod,
+    AliasTypmod, EdgeNgramTypmod, GenericTypmod, JiebaTypmod, LinderaTypmod, NgramTypmod,
+    RegexTypmod, Typmod, UncheckedTypmod, UnicodeWordsTypmod,
 };
 
 // if a ::pdb.<tokenizer> cast is used, ie ::pdb.simple, ::pdb.lindera, etc.
@@ -171,6 +171,23 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
             }
             if let Some(v) = parsed.get("positions").and_then(|p| p.as_bool()) {
                 *positions = v;
+            }
+            *filters = SearchTokenizerFilters::from(parsed);
+        }
+        SearchTokenizer::EdgeNgram {
+            min_gram,
+            max_gram,
+            token_chars,
+            filters,
+        } => {
+            if let Some(v) = parsed.try_get("min", 0).and_then(|p| p.as_usize()) {
+                *min_gram = v;
+            }
+            if let Some(v) = parsed.try_get("max", 1).and_then(|p| p.as_usize()) {
+                *max_gram = v;
+            }
+            if let Some(s) = parsed.get("token_chars").and_then(|p| p.as_str()) {
+                *token_chars = s.split(',').map(|c| c.trim().to_string()).collect();
             }
             *filters = SearchTokenizerFilters::from(parsed);
         }
@@ -352,6 +369,20 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             *prefix_only = ngram_typmod.prefix_only;
             *positions = ngram_typmod.positions;
             *filters = ngram_typmod.filters;
+        }
+        SearchTokenizer::EdgeNgram {
+            min_gram,
+            max_gram,
+            token_chars,
+            filters,
+        } => {
+            let edge_ngram_typmod = EdgeNgramTypmod::try_from(typmod).unwrap_or_else(|e| {
+                panic!("{}", e);
+            });
+            *min_gram = edge_ngram_typmod.min_gram;
+            *max_gram = edge_ngram_typmod.max_gram;
+            *token_chars = edge_ngram_typmod.token_chars;
+            *filters = edge_ngram_typmod.filters;
         }
         SearchTokenizer::RegexTokenizer { pattern, filters } => {
             let regex_typmod = RegexTypmod::try_from(typmod).unwrap_or_else(|e| {

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -101,6 +101,12 @@ fn tokenizer_from_name(name: &str) -> Option<SearchTokenizer> {
             positions: false,
             filters: SearchTokenizerFilters::default(),
         },
+        "edge_ngram" => SearchTokenizer::EdgeNgram {
+            min_gram: 0,
+            max_gram: 0,
+            token_chars: vec![],
+            filters: SearchTokenizerFilters::default(),
+        },
         "whitespace" => SearchTokenizer::WhiteSpace(SearchTokenizerFilters::default()),
         "literal" => SearchTokenizer::Keyword,
         "literal_normalized" => {

--- a/pg_search/src/api/tokenizers/typmod/definitions.rs
+++ b/pg_search/src/api/tokenizers/typmod/definitions.rs
@@ -51,6 +51,14 @@ pub struct NgramTypmod {
     pub filters: SearchTokenizerFilters,
 }
 
+// for pdb.edge_ngram
+pub struct EdgeNgramTypmod {
+    pub min_gram: usize,
+    pub max_gram: usize,
+    pub token_chars: Vec<String>,
+    pub filters: SearchTokenizerFilters,
+}
+
 // for pdb.regex_pattern
 pub struct RegexTypmod {
     pub pattern: regex::Regex,
@@ -120,6 +128,41 @@ impl TypmodRules for NgramTypmod {
             ),
             rule!("prefix_only", ValueConstraint::Boolean),
             rule!("positions", ValueConstraint::Boolean),
+        ]
+    }
+}
+
+impl TypmodRules for EdgeNgramTypmod {
+    fn rules() -> Vec<PropertyRule> {
+        vec![
+            rule!(
+                "min",
+                ValueConstraint::Integer {
+                    min: Some(1),
+                    max: None,
+                },
+                required,
+                positional = 0
+            ),
+            rule!(
+                "max",
+                ValueConstraint::Integer {
+                    min: Some(1),
+                    max: None,
+                },
+                required,
+                positional = 1
+            ),
+            rule!(
+                "token_chars",
+                ValueConstraint::StringChoiceMultiple(vec![
+                    "letter",
+                    "digit",
+                    "whitespace",
+                    "punctuation",
+                    "symbol"
+                ])
+            ),
         ]
     }
 }
@@ -236,6 +279,34 @@ impl TryFrom<i32> for NgramTypmod {
             max_gram,
             prefix_only,
             positions,
+            filters,
+        })
+    }
+}
+
+impl TryFrom<i32> for EdgeNgramTypmod {
+    type Error = typmod::Error;
+
+    fn try_from(typmod: i32) -> Result<Self, Self::Error> {
+        let parsed = Self::parsed(typmod)?;
+        let filters = SearchTokenizerFilters::from(&parsed);
+        let min_gram = parsed
+            .try_get("min", 0)
+            .and_then(|p| p.as_usize())
+            .ok_or(typmod::Error::MissingKey("min"))?;
+        let max_gram = parsed
+            .try_get("max", 1)
+            .and_then(|p| p.as_usize())
+            .ok_or(typmod::Error::MissingKey("max"))?;
+        let token_chars = parsed
+            .get("token_chars")
+            .and_then(|p| p.as_str())
+            .map(|s| s.split(',').map(|c| c.trim().to_string()).collect())
+            .unwrap_or_else(|| vec!["letter".to_string(), "digit".to_string()]);
+        Ok(EdgeNgramTypmod {
+            min_gram,
+            max_gram,
+            token_chars,
             filters,
         })
     }

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -41,8 +41,8 @@ SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
 (1 row)
 
 SELECT 'this is a test.'::pdb.edge_ngram(2, 4)::text[];
-              text
----------------------------------
+             text
+------------------------------
  {th,thi,this,is,te,tes,test}
 (1 row)
 

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -40,6 +40,12 @@ SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
  {thi,this,"this ",his,"his ","his i","is ","is i","is is","s i","s is","s is "," is"," is "," is a","is ","is a","is a ","s a","s a ","s a t"," a "," a t"," a te","a t","a te","a tes"," te"," tes"," test",tes,test,test.,est,est.,st.}
 (1 row)
 
+SELECT 'this is a test.'::pdb.edge_ngram(2, 4)::text[];
+              text
+---------------------------------
+ {th,thi,this,is,te,tes,test}
+(1 row)
+
 SELECT 'this is a test.'::pdb.regex_pattern('is|a')::text[];
    text    
 -----------

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -41,7 +41,7 @@ SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
 (1 row)
 
 SELECT 'this is a test.'::pdb.edge_ngram(2, 4)::text[];
-             text
+             text             
 ------------------------------
  {th,thi,this,is,te,tes,test}
 (1 row)

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -215,6 +215,36 @@ SELECT 'Running Shoes.  olé'::pdb.ngram('min=2', 'max=3', 'lowercase=false', 's
  {Ru,Run,un,unn,nn,nni,ni,nin,in,ing,ng,"ng ","g ","g S"," S"," Sh",Sh,Sho,ho,hoe,oe,oe,es,es.,s.,"s. ",". ",".  ","  ","  o"," o"," ol",ol,ole,le}
 (1 row)
 
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5)::text[];
+            text
+-----------------------------
+ {qu,qui,quic,quick,fo,fox}
+(1 row)
+
+SELECT 'Quick Fox'::pdb.edge_ngram(1, 2)::text[];
+   text
+-----------
+ {q,qu,f,fo}
+(1 row)
+
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=true')::text[];
+            text
+-----------------------------
+ {qu,qui,quic,quick,fo,fox}
+(1 row)
+
+SELECT 'Quick-Fox'::pdb.edge_ngram(2, 5, 'token_chars=letter,digit,punctuation')::text[];
+          text
+-------------------------
+ {qu,qui,quic,quick}
+(1 row)
+
+SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
+            text
+-----------------------------
+ {qu,qui,quic,quick,fo,fox}
+(1 row)
+
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=arabic')::text[];
         text         
 ---------------------
@@ -426,6 +456,7 @@ CREATE INDEX idxtokenizer_typmod_display ON tokenizer_typmod_display USING bm25
         (description::pdb.lindera(japanese, 'alias=lindera_japanese')),
         (description::pdb.lindera(korean, 'alias=lindera_korean')),
         (description::pdb.ngram(3, 5, 'alias=ngram')),
+        (description::pdb.edge_ngram(2, 5, 'alias=edge_ngram')),
         (description::pdb.regex_pattern('is|a', 'alias=regex')),
         (description::pdb.simple('alias=simple')),
         (description::pdb.whitespace('alias=whitespace')),
@@ -434,9 +465,9 @@ CREATE INDEX idxtokenizer_typmod_display ON tokenizer_typmod_display USING bm25
     )
     WITH (key_field = 'id');
 SELECT indexdef from pg_indexes where indexname = 'idxtokenizer_typmod_display';
-                                                                                                                                                                                                                                                                                                                                                                                                                    indexdef                                                                                                                                                                                                                                                                                                                                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- CREATE INDEX idxtokenizer_typmod_display ON public.tokenizer_typmod_display USING bm25 (id, description, ((description)::pdb.chinese_compatible('alias=chinese_compatible')), ((description)::pdb.literal('alias=literal')), ((description)::pdb.jieba('alias=jieba')), ((description)::pdb.lindera('chinese', 'alias=lindera_chinese')), ((description)::pdb.lindera('japanese', 'alias=lindera_japanese')), ((description)::pdb.lindera('korean', 'alias=lindera_korean')), ((description)::pdb.ngram('3', '5', 'alias=ngram')), ((description)::pdb.regex_pattern('is|a', 'alias=regex')), ((description)::pdb.simple('alias=simple')), ((description)::pdb.whitespace('alias=whitespace')), ((description)::pdb.source_code('alias=source_code')), ((description)::pdb.literal_normalized('alias=literal_normalized'))) WITH (key_field=id)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                      indexdef
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE INDEX idxtokenizer_typmod_display ON public.tokenizer_typmod_display USING bm25 (id, description, ((description)::pdb.chinese_compatible('alias=chinese_compatible')), ((description)::pdb.literal('alias=literal')), ((description)::pdb.jieba('alias=jieba')), ((description)::pdb.lindera('chinese', 'alias=lindera_chinese')), ((description)::pdb.lindera('japanese', 'alias=lindera_japanese')), ((description)::pdb.lindera('korean', 'alias=lindera_korean')), ((description)::pdb.ngram('3', '5', 'alias=ngram')), ((description)::pdb.edge_ngram('2', '5', 'alias=edge_ngram')), ((description)::pdb.regex_pattern('is|a', 'alias=regex')), ((description)::pdb.simple('alias=simple')), ((description)::pdb.whitespace('alias=whitespace')), ((description)::pdb.source_code('alias=source_code')), ((description)::pdb.literal_normalized('alias=literal_normalized'))) WITH (key_field=id)
 (1 row)
 
 DROP TABLE tokenizer_typmod_display;

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -245,13 +245,14 @@ SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
  {qu,qui,quic,quick,fo,fox}
 (1 row)
 
+-- End-to-end: create index, insert, search
 DROP TABLE IF EXISTS edge_ngram_e2e;
 CREATE TABLE edge_ngram_e2e (id serial8 NOT NULL PRIMARY KEY, name text);
 INSERT INTO edge_ngram_e2e (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
 CREATE INDEX idx_edge_ngram_e2e ON edge_ngram_e2e USING bm25 (id, (name::pdb.edge_ngram(2, 10))) WITH (key_field = 'id');
 SELECT name FROM edge_ngram_e2e WHERE name @@@ 'par' ORDER BY name;
-    name    
-------------
+   name    
+-----------
  ParadeDB
  Paragraph
 (2 rows)
@@ -477,8 +478,8 @@ CREATE INDEX idxtokenizer_typmod_display ON tokenizer_typmod_display USING bm25
     )
     WITH (key_field = 'id');
 SELECT indexdef from pg_indexes where indexname = 'idxtokenizer_typmod_display';
-                                                                                                                                                                                                                                                                                                                                                                                                                                                   indexdef                                                                                                                                                                                                                                                                                                                                                                                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                    indexdef                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CREATE INDEX idxtokenizer_typmod_display ON public.tokenizer_typmod_display USING bm25 (id, description, ((description)::pdb.chinese_compatible('alias=chinese_compatible')), ((description)::pdb.literal('alias=literal')), ((description)::pdb.jieba('alias=jieba')), ((description)::pdb.lindera('chinese', 'alias=lindera_chinese')), ((description)::pdb.lindera('japanese', 'alias=lindera_japanese')), ((description)::pdb.lindera('korean', 'alias=lindera_korean')), ((description)::pdb.ngram('3', '5', 'alias=ngram')), ((description)::pdb.edge_ngram('2', '5', 'alias=edge_ngram')), ((description)::pdb.regex_pattern('is|a', 'alias=regex')), ((description)::pdb.simple('alias=simple')), ((description)::pdb.whitespace('alias=whitespace')), ((description)::pdb.source_code('alias=source_code')), ((description)::pdb.literal_normalized('alias=literal_normalized'))) WITH (key_field=id)
 (1 row)
 

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -216,31 +216,31 @@ SELECT 'Running Shoes.  olé'::pdb.ngram('min=2', 'max=3', 'lowercase=false', 's
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram(2, 5)::text[];
-            text
+            text            
 ----------------------------
  {qu,qui,quic,quick,fo,fox}
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram(1, 2)::text[];
-    text
+    text     
 -------------
  {q,qu,f,fo}
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=false')::text[];
-            text
+            text            
 ----------------------------
  {Qu,Qui,Quic,Quick,Fo,Fox}
 (1 row)
 
 SELECT 'Quick-Fox'::pdb.edge_ngram(2, 5, 'token_chars=letter,digit,punctuation')::text[];
-        text
+        text         
 ---------------------
  {qu,qui,quic,quick}
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
-            text
+            text            
 ----------------------------
  {qu,qui,quic,quick,fo,fox}
 (1 row)
@@ -250,14 +250,13 @@ CREATE TABLE edge_ngram_e2e (id serial8 NOT NULL PRIMARY KEY, name text);
 INSERT INTO edge_ngram_e2e (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
 CREATE INDEX idx_edge_ngram_e2e ON edge_ngram_e2e USING bm25 (id, (name::pdb.edge_ngram(2, 10))) WITH (key_field = 'id');
 SELECT name FROM edge_ngram_e2e WHERE name @@@ 'par' ORDER BY name;
-    name
+    name    
 ------------
  ParadeDB
  Paragraph
 (2 rows)
 
 DROP TABLE edge_ngram_e2e;
-
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=arabic')::text[];
         text         
 ---------------------
@@ -478,8 +477,8 @@ CREATE INDEX idxtokenizer_typmod_display ON tokenizer_typmod_display USING bm25
     )
     WITH (key_field = 'id');
 SELECT indexdef from pg_indexes where indexname = 'idxtokenizer_typmod_display';
-                                                                                                                                                                                                                                                                                                                                                                                                                                                      indexdef
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                   indexdef                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CREATE INDEX idxtokenizer_typmod_display ON public.tokenizer_typmod_display USING bm25 (id, description, ((description)::pdb.chinese_compatible('alias=chinese_compatible')), ((description)::pdb.literal('alias=literal')), ((description)::pdb.jieba('alias=jieba')), ((description)::pdb.lindera('chinese', 'alias=lindera_chinese')), ((description)::pdb.lindera('japanese', 'alias=lindera_japanese')), ((description)::pdb.lindera('korean', 'alias=lindera_korean')), ((description)::pdb.ngram('3', '5', 'alias=ngram')), ((description)::pdb.edge_ngram('2', '5', 'alias=edge_ngram')), ((description)::pdb.regex_pattern('is|a', 'alias=regex')), ((description)::pdb.simple('alias=simple')), ((description)::pdb.whitespace('alias=whitespace')), ((description)::pdb.source_code('alias=source_code')), ((description)::pdb.literal_normalized('alias=literal_normalized'))) WITH (key_field=id)
 (1 row)
 

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -217,33 +217,46 @@ SELECT 'Running Shoes.  olé'::pdb.ngram('min=2', 'max=3', 'lowercase=false', 's
 
 SELECT 'Quick Fox'::pdb.edge_ngram(2, 5)::text[];
             text
------------------------------
+----------------------------
  {qu,qui,quic,quick,fo,fox}
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram(1, 2)::text[];
-   text
------------
+    text
+-------------
  {q,qu,f,fo}
 (1 row)
 
-SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=true')::text[];
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=false')::text[];
             text
------------------------------
- {qu,qui,quic,quick,fo,fox}
+----------------------------
+ {Qu,Qui,Quic,Quick,Fo,Fox}
 (1 row)
 
 SELECT 'Quick-Fox'::pdb.edge_ngram(2, 5, 'token_chars=letter,digit,punctuation')::text[];
-          text
--------------------------
+        text
+---------------------
  {qu,qui,quic,quick}
 (1 row)
 
 SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
             text
------------------------------
+----------------------------
  {qu,qui,quic,quick,fo,fox}
 (1 row)
+
+DROP TABLE IF EXISTS edge_ngram_e2e;
+CREATE TABLE edge_ngram_e2e (id serial8 NOT NULL PRIMARY KEY, name text);
+INSERT INTO edge_ngram_e2e (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
+CREATE INDEX idx_edge_ngram_e2e ON edge_ngram_e2e USING bm25 (id, (name::pdb.edge_ngram(2, 10))) WITH (key_field = 'id');
+SELECT name FROM edge_ngram_e2e WHERE name @@@ 'par' ORDER BY name;
+    name
+------------
+ ParadeDB
+ Paragraph
+(2 rows)
+
+DROP TABLE edge_ngram_e2e;
 
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=arabic')::text[];
         text         

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
@@ -5,6 +5,7 @@ SELECT 'this is a test.'::pdb.lindera(chinese)::text[];
 SELECT 'this is a test.'::pdb.lindera(japanese)::text[];
 SELECT 'this is a test.'::pdb.lindera(korean)::text[];
 SELECT 'this is a test.'::pdb.ngram(3, 5)::text[];
+SELECT 'this is a test.'::pdb.edge_ngram(2, 4)::text[];
 SELECT 'this is a test.'::pdb.regex_pattern('is|a')::text[];
 SELECT 'this is a test.'::pdb.simple::text[];
 SELECT 'this is a test.'::pdb.simple('stemmer=english')::text[];

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
@@ -45,6 +45,12 @@ SELECT 'Running Shoes.  olé'::pdb.ngram(2, 3, 'lowercase=false')::text[];
 SELECT 'Running Shoes.  olé'::pdb.ngram(2, 3, 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
 SELECT 'Running Shoes.  olé'::pdb.ngram('min=2', 'max=3', 'lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];
 
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5)::text[];
+SELECT 'Quick Fox'::pdb.edge_ngram(1, 2)::text[];
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=true')::text[];
+SELECT 'Quick-Fox'::pdb.edge_ngram(2, 5, 'token_chars=letter,digit,punctuation')::text[];
+SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
+
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=arabic')::text[];
 SELECT 'Novinka počasí funguje.'::pdb.simple('stemmer=czech')::text[];
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=danish')::text[];
@@ -108,6 +114,7 @@ CREATE INDEX idxtokenizer_typmod_display ON tokenizer_typmod_display USING bm25
         (description::pdb.lindera(japanese, 'alias=lindera_japanese')),
         (description::pdb.lindera(korean, 'alias=lindera_korean')),
         (description::pdb.ngram(3, 5, 'alias=ngram')),
+        (description::pdb.edge_ngram(2, 5, 'alias=edge_ngram')),
         (description::pdb.regex_pattern('is|a', 'alias=regex')),
         (description::pdb.simple('alias=simple')),
         (description::pdb.whitespace('alias=whitespace')),

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
@@ -47,9 +47,17 @@ SELECT 'Running Shoes.  olé'::pdb.ngram('min=2', 'max=3', 'lowercase=false', 's
 
 SELECT 'Quick Fox'::pdb.edge_ngram(2, 5)::text[];
 SELECT 'Quick Fox'::pdb.edge_ngram(1, 2)::text[];
-SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=true')::text[];
+SELECT 'Quick Fox'::pdb.edge_ngram(2, 5, 'lowercase=false')::text[];
 SELECT 'Quick-Fox'::pdb.edge_ngram(2, 5, 'token_chars=letter,digit,punctuation')::text[];
 SELECT 'Quick Fox'::pdb.edge_ngram('min=2', 'max=5')::text[];
+
+-- End-to-end: create index, insert, search
+DROP TABLE IF EXISTS edge_ngram_e2e;
+CREATE TABLE edge_ngram_e2e (id serial8 NOT NULL PRIMARY KEY, name text);
+INSERT INTO edge_ngram_e2e (name) VALUES ('PostgreSQL'), ('ParadeDB'), ('Paragraph');
+CREATE INDEX idx_edge_ngram_e2e ON edge_ngram_e2e USING bm25 (id, (name::pdb.edge_ngram(2, 10))) WITH (key_field = 'id');
+SELECT name FROM edge_ngram_e2e WHERE name @@@ 'par' ORDER BY name;
+DROP TABLE edge_ngram_e2e;
 
 SELECT 'Running Shoes.  olé'::pdb.simple('stemmer=arabic')::text[];
 SELECT 'Novinka počasí funguje.'::pdb.simple('stemmer=czech')::text[];

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -100,6 +100,7 @@ fn list_tokenizers(mut conn: PgConnection) {
             ("chinese_compatible".into(),),
             ("source_code".into(),),
             ("ngram".into(),),
+            ("edge_ngram".into(),),
             ("chinese_lindera_deprecated".into(),),
             ("chinese_lindera".into(),),
             ("japanese_lindera_deprecated".into(),),

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -21,6 +21,7 @@ strum_macros = "0.27.2"
 strum = { version = "0.27.2", features = ["derive"] }
 tantivy-jieba = { workspace = true }
 emoji = "0.2.1"
+icu_properties = "2.1.2"
 unicode-segmentation = "1.12.0"
 icu_segmenter = "2.1.1"
 opencc-jieba-rs = "0.7.2"

--- a/tokenizers/src/edge_ngram.rs
+++ b/tokenizers/src/edge_ngram.rs
@@ -70,14 +70,26 @@ pub struct EdgeNgramTokenizer {
 }
 
 impl EdgeNgramTokenizer {
-    pub fn new(min_gram: usize, max_gram: usize, token_chars: Vec<TokenCharClass>) -> Self {
-        assert!(min_gram >= 1, "min_gram must be >= 1");
-        assert!(max_gram >= min_gram, "max_gram must be >= min_gram");
-        Self {
+    pub fn new(
+        min_gram: usize,
+        max_gram: usize,
+        token_chars: Vec<TokenCharClass>,
+    ) -> tantivy::Result<Self> {
+        if min_gram < 1 {
+            return Err(tantivy::TantivyError::InvalidArgument(
+                "min_gram must be >= 1".to_string(),
+            ));
+        }
+        if max_gram < min_gram {
+            return Err(tantivy::TantivyError::InvalidArgument(
+                "max_gram must be >= min_gram".to_string(),
+            ));
+        }
+        Ok(Self {
             min_gram,
             max_gram,
             token_chars,
-        }
+        })
     }
 }
 
@@ -238,7 +250,8 @@ mod tests {
     #[test]
     fn test_basic() {
         let mut tok =
-            EdgeNgramTokenizer::new(2, 5, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+            EdgeNgramTokenizer::new(2, 5, vec![TokenCharClass::Letter, TokenCharClass::Digit])
+                .unwrap();
         assert_eq!(
             collect_text(&mut tok, "Quick Fox"),
             vec!["Qu", "Qui", "Quic", "Quick", "Fo", "Fox"]
@@ -248,7 +261,8 @@ mod tests {
     #[test]
     fn test_defaults() {
         let mut tok =
-            EdgeNgramTokenizer::new(1, 2, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+            EdgeNgramTokenizer::new(1, 2, vec![TokenCharClass::Letter, TokenCharClass::Digit])
+                .unwrap();
         assert_eq!(
             collect_text(&mut tok, "Quick Fox"),
             vec!["Q", "Qu", "F", "Fo"]
@@ -257,19 +271,19 @@ mod tests {
 
     #[test]
     fn test_words_shorter_than_min_gram_skipped() {
-        let mut tok = EdgeNgramTokenizer::new(3, 5, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(3, 5, vec![TokenCharClass::Letter]).unwrap();
         assert_eq!(collect_text(&mut tok, "I am here"), vec!["her", "here"]);
     }
 
     #[test]
     fn test_empty_input() {
-        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]).unwrap();
         assert_eq!(collect_text(&mut tok, ""), Vec::<String>::new());
     }
 
     #[test]
     fn test_unicode() {
-        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]).unwrap();
         assert_eq!(collect_text(&mut tok, "café"), vec!["c", "ca", "caf"]);
     }
 
@@ -279,7 +293,8 @@ mod tests {
             2,
             5,
             vec![TokenCharClass::Letter, TokenCharClass::Punctuation],
-        );
+        )
+        .unwrap();
         // Hyphen is ASCII punctuation, so "Quick-Fox" is one word
         assert_eq!(
             collect_text(&mut tok, "Quick-Fox"),
@@ -290,7 +305,8 @@ mod tests {
     #[test]
     fn test_digits_as_tokens() {
         let mut tok =
-            EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+            EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter, TokenCharClass::Digit])
+                .unwrap();
         assert_eq!(
             collect_text(&mut tok, "abc 123"),
             vec!["a", "ab", "abc", "1", "12", "123"]
@@ -299,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_positions() {
-        let mut tok = EdgeNgramTokenizer::new(2, 4, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(2, 4, vec![TokenCharClass::Letter]).unwrap();
         let tokens = collect_tokens(&mut tok, "hello world");
         // All grams from "hello" share position 0, all from "world" share position 1
         assert_eq!(
@@ -317,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_offsets() {
-        let mut tok = EdgeNgramTokenizer::new(2, 3, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(2, 3, vec![TokenCharClass::Letter]).unwrap();
         let mut stream = tok.token_stream("hi world");
         assert!(stream.advance());
         assert_eq!(stream.token().text, "hi");
@@ -337,13 +353,13 @@ mod tests {
 
     #[test]
     fn test_max_gram_clamped_to_word_length() {
-        let mut tok = EdgeNgramTokenizer::new(1, 10, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(1, 10, vec![TokenCharClass::Letter]).unwrap();
         assert_eq!(collect_text(&mut tok, "hi"), vec!["h", "hi"]);
     }
 
     #[test]
     fn test_only_delimiters() {
-        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]).unwrap();
         assert_eq!(collect_text(&mut tok, "123 !@#"), Vec::<String>::new());
     }
 }

--- a/tokenizers/src/edge_ngram.rs
+++ b/tokenizers/src/edge_ngram.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use icu_properties::props::GeneralCategory;
+use icu_properties::CodePointMapData;
 use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -47,12 +49,29 @@ impl TokenCharClass {
             Self::Letter => c.is_alphabetic(),
             Self::Digit => c.is_numeric(),
             Self::Whitespace => c.is_whitespace(),
-            Self::Punctuation => c.is_ascii_punctuation(),
-            Self::Symbol => {
-                !c.is_alphabetic()
-                    && !c.is_numeric()
-                    && !c.is_whitespace()
-                    && !c.is_ascii_punctuation()
+            Self::Punctuation | Self::Symbol => {
+                let gc = CodePointMapData::<GeneralCategory>::new();
+                let cat = gc.get(c);
+                match self {
+                    Self::Punctuation => matches!(
+                        cat,
+                        GeneralCategory::ConnectorPunctuation
+                            | GeneralCategory::DashPunctuation
+                            | GeneralCategory::ClosePunctuation
+                            | GeneralCategory::FinalPunctuation
+                            | GeneralCategory::InitialPunctuation
+                            | GeneralCategory::OtherPunctuation
+                            | GeneralCategory::OpenPunctuation
+                    ),
+                    Self::Symbol => matches!(
+                        cat,
+                        GeneralCategory::CurrencySymbol
+                            | GeneralCategory::ModifierSymbol
+                            | GeneralCategory::MathSymbol
+                            | GeneralCategory::OtherSymbol
+                    ),
+                    _ => unreachable!(),
+                }
             }
         }
     }

--- a/tokenizers/src/edge_ngram.rs
+++ b/tokenizers/src/edge_ngram.rs
@@ -120,9 +120,8 @@ pub struct EdgeNgramTokenStream<'a> {
     token: Token,
     // Scanning state: byte offset in the input where we look for the next word
     scan_offset: usize,
-    // Current word we're emitting grams for (byte range in input)
+    // Current word we're emitting grams for
     word_start: usize,
-    word_end: usize,
     word_char_count: usize,
     // How many chars of the current word we've emitted so far
     current_gram_chars: usize,
@@ -145,7 +144,6 @@ impl Tokenizer for EdgeNgramTokenizer {
             token: Token::default(),
             scan_offset: 0,
             word_start: 0,
-            word_end: 0,
             word_char_count: 0,
             current_gram_chars: 0,
             in_word: false,
@@ -182,7 +180,6 @@ impl EdgeNgramTokenStream<'_> {
             offset += c.len_utf8();
             self.word_char_count += 1;
         }
-        self.word_end = offset;
         self.scan_offset = offset;
         true
     }
@@ -302,8 +299,11 @@ mod tests {
 
     #[test]
     fn test_unicode() {
-        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]).unwrap();
-        assert_eq!(collect_text(&mut tok, "café"), vec!["c", "ca", "caf"]);
+        let mut tok = EdgeNgramTokenizer::new(1, 4, vec![TokenCharClass::Letter]).unwrap();
+        assert_eq!(
+            collect_text(&mut tok, "café"),
+            vec!["c", "ca", "caf", "café"]
+        );
     }
 
     #[test]

--- a/tokenizers/src/edge_ngram.rs
+++ b/tokenizers/src/edge_ngram.rs
@@ -1,0 +1,349 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TokenCharClass {
+    Letter,
+    Digit,
+    Whitespace,
+    Punctuation,
+    Symbol,
+}
+
+impl std::str::FromStr for TokenCharClass {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "letter" => Ok(Self::Letter),
+            "digit" => Ok(Self::Digit),
+            "whitespace" => Ok(Self::Whitespace),
+            "punctuation" => Ok(Self::Punctuation),
+            "symbol" => Ok(Self::Symbol),
+            other => Err(format!("unknown token_chars class: '{other}'. expected one of: letter, digit, whitespace, punctuation, symbol")),
+        }
+    }
+}
+
+impl TokenCharClass {
+    fn matches(&self, c: char) -> bool {
+        match self {
+            Self::Letter => c.is_alphabetic(),
+            Self::Digit => c.is_numeric(),
+            Self::Whitespace => c.is_whitespace(),
+            Self::Punctuation => c.is_ascii_punctuation(),
+            Self::Symbol => {
+                !c.is_alphabetic()
+                    && !c.is_numeric()
+                    && !c.is_whitespace()
+                    && !c.is_ascii_punctuation()
+            }
+        }
+    }
+}
+
+fn matches_any(c: char, classes: &[TokenCharClass]) -> bool {
+    classes.iter().any(|cls| cls.matches(c))
+}
+
+#[derive(Clone)]
+pub struct EdgeNgramTokenizer {
+    min_gram: usize,
+    max_gram: usize,
+    token_chars: Vec<TokenCharClass>,
+}
+
+impl EdgeNgramTokenizer {
+    pub fn new(min_gram: usize, max_gram: usize, token_chars: Vec<TokenCharClass>) -> Self {
+        assert!(min_gram >= 1, "min_gram must be >= 1");
+        assert!(max_gram >= min_gram, "max_gram must be >= min_gram");
+        Self {
+            min_gram,
+            max_gram,
+            token_chars,
+        }
+    }
+}
+
+pub struct EdgeNgramTokenStream<'a> {
+    text: &'a str,
+    min_gram: usize,
+    max_gram: usize,
+    token_chars: Vec<TokenCharClass>,
+    token: Token,
+    // Scanning state: byte offset in the input where we look for the next word
+    scan_offset: usize,
+    // Current word we're emitting grams for (byte range in input)
+    word_start: usize,
+    word_end: usize,
+    word_char_count: usize,
+    // How many chars of the current word we've emitted so far
+    current_gram_chars: usize,
+    // Whether we're currently emitting grams for a word
+    in_word: bool,
+    // Position counter (increments per word)
+    position: usize,
+    first_advance: bool,
+}
+
+impl Tokenizer for EdgeNgramTokenizer {
+    type TokenStream<'a> = EdgeNgramTokenStream<'a>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        EdgeNgramTokenStream {
+            text,
+            min_gram: self.min_gram,
+            max_gram: self.max_gram,
+            token_chars: self.token_chars.clone(),
+            token: Token::default(),
+            scan_offset: 0,
+            word_start: 0,
+            word_end: 0,
+            word_char_count: 0,
+            current_gram_chars: 0,
+            in_word: false,
+            position: 0,
+            first_advance: true,
+        }
+    }
+}
+
+impl EdgeNgramTokenStream<'_> {
+    fn find_next_word(&mut self) -> bool {
+        let len = self.text.len();
+
+        // Skip non-matching characters
+        let mut offset = self.scan_offset;
+        for c in self.text[offset..].chars() {
+            if matches_any(c, &self.token_chars) {
+                break;
+            }
+            offset += c.len_utf8();
+        }
+
+        if offset >= len {
+            return false;
+        }
+
+        // Collect matching characters
+        self.word_start = offset;
+        self.word_char_count = 0;
+        for c in self.text[offset..].chars() {
+            if !matches_any(c, &self.token_chars) {
+                break;
+            }
+            offset += c.len_utf8();
+            self.word_char_count += 1;
+        }
+        self.word_end = offset;
+        self.scan_offset = offset;
+        true
+    }
+}
+
+impl TokenStream for EdgeNgramTokenStream<'_> {
+    fn advance(&mut self) -> bool {
+        loop {
+            if self.in_word {
+                self.current_gram_chars += 1;
+                if self.current_gram_chars > self.max_gram
+                    || self.current_gram_chars > self.word_char_count
+                {
+                    self.in_word = false;
+                    continue;
+                }
+
+                // Compute byte end for current_gram_chars characters from word_start
+                let byte_end = self.text[self.word_start..]
+                    .chars()
+                    .take(self.current_gram_chars)
+                    .map(|c| c.len_utf8())
+                    .sum::<usize>()
+                    + self.word_start;
+
+                self.token.text.clear();
+                self.token
+                    .text
+                    .push_str(&self.text[self.word_start..byte_end]);
+                self.token.offset_from = self.word_start;
+                self.token.offset_to = byte_end;
+                self.token.position = self.position;
+                return true;
+            }
+
+            // Find next word
+            if !self.find_next_word() {
+                return false;
+            }
+
+            // Skip words shorter than min_gram
+            if self.word_char_count < self.min_gram {
+                continue;
+            }
+
+            if !self.first_advance {
+                self.position += 1;
+            }
+            self.first_advance = false;
+            self.in_word = true;
+            self.current_gram_chars = self.min_gram - 1; // will be incremented to min_gram on next loop
+        }
+    }
+
+    fn token(&self) -> &Token {
+        &self.token
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        &mut self.token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect_tokens(tokenizer: &mut EdgeNgramTokenizer, text: &str) -> Vec<(String, usize)> {
+        let mut stream = tokenizer.token_stream(text);
+        let mut tokens = Vec::new();
+        while stream.advance() {
+            tokens.push((stream.token().text.clone(), stream.token().position));
+        }
+        tokens
+    }
+
+    fn collect_text(tokenizer: &mut EdgeNgramTokenizer, text: &str) -> Vec<String> {
+        collect_tokens(tokenizer, text)
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect()
+    }
+
+    #[test]
+    fn test_basic() {
+        let mut tok =
+            EdgeNgramTokenizer::new(2, 5, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+        assert_eq!(
+            collect_text(&mut tok, "Quick Fox"),
+            vec!["Qu", "Qui", "Quic", "Quick", "Fo", "Fox"]
+        );
+    }
+
+    #[test]
+    fn test_defaults() {
+        let mut tok =
+            EdgeNgramTokenizer::new(1, 2, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+        assert_eq!(
+            collect_text(&mut tok, "Quick Fox"),
+            vec!["Q", "Qu", "F", "Fo"]
+        );
+    }
+
+    #[test]
+    fn test_words_shorter_than_min_gram_skipped() {
+        let mut tok = EdgeNgramTokenizer::new(3, 5, vec![TokenCharClass::Letter]);
+        assert_eq!(collect_text(&mut tok, "I am here"), vec!["her", "here"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        assert_eq!(collect_text(&mut tok, ""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_unicode() {
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        assert_eq!(collect_text(&mut tok, "café"), vec!["c", "ca", "caf"]);
+    }
+
+    #[test]
+    fn test_token_chars_with_punctuation() {
+        let mut tok = EdgeNgramTokenizer::new(
+            2,
+            5,
+            vec![TokenCharClass::Letter, TokenCharClass::Punctuation],
+        );
+        // Hyphen is ASCII punctuation, so "Quick-Fox" is one word
+        assert_eq!(
+            collect_text(&mut tok, "Quick-Fox"),
+            vec!["Qu", "Qui", "Quic", "Quick"]
+        );
+    }
+
+    #[test]
+    fn test_digits_as_tokens() {
+        let mut tok =
+            EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter, TokenCharClass::Digit]);
+        assert_eq!(
+            collect_text(&mut tok, "abc 123"),
+            vec!["a", "ab", "abc", "1", "12", "123"]
+        );
+    }
+
+    #[test]
+    fn test_positions() {
+        let mut tok = EdgeNgramTokenizer::new(2, 4, vec![TokenCharClass::Letter]);
+        let tokens = collect_tokens(&mut tok, "hello world");
+        // All grams from "hello" share position 0, all from "world" share position 1
+        assert_eq!(
+            tokens,
+            vec![
+                ("he".to_string(), 0),
+                ("hel".to_string(), 0),
+                ("hell".to_string(), 0),
+                ("wo".to_string(), 1),
+                ("wor".to_string(), 1),
+                ("worl".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_offsets() {
+        let mut tok = EdgeNgramTokenizer::new(2, 3, vec![TokenCharClass::Letter]);
+        let mut stream = tok.token_stream("hi world");
+        assert!(stream.advance());
+        assert_eq!(stream.token().text, "hi");
+        assert_eq!(stream.token().offset_from, 0);
+        assert_eq!(stream.token().offset_to, 2);
+
+        assert!(stream.advance());
+        assert_eq!(stream.token().text, "wo");
+        assert_eq!(stream.token().offset_from, 3);
+        assert_eq!(stream.token().offset_to, 5);
+
+        assert!(stream.advance());
+        assert_eq!(stream.token().text, "wor");
+        assert_eq!(stream.token().offset_from, 3);
+        assert_eq!(stream.token().offset_to, 6);
+    }
+
+    #[test]
+    fn test_max_gram_clamped_to_word_length() {
+        let mut tok = EdgeNgramTokenizer::new(1, 10, vec![TokenCharClass::Letter]);
+        assert_eq!(collect_text(&mut tok, "hi"), vec!["h", "hi"]);
+    }
+
+    #[test]
+    fn test_only_delimiters() {
+        let mut tok = EdgeNgramTokenizer::new(1, 3, vec![TokenCharClass::Letter]);
+        assert_eq!(collect_text(&mut tok, "123 !@#"), Vec::<String>::new());
+    }
+}

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod chinese_convert;
 pub mod cjk;
 pub mod code;
+pub mod edge_ngram;
 pub mod icu;
 pub mod lindera;
 pub mod manager;

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -18,6 +18,7 @@
 
 use std::fmt::Write;
 
+use crate::edge_ngram::{EdgeNgramTokenizer, TokenCharClass};
 use crate::icu::ICUTokenizer;
 use crate::ngram::NgramTokenizer;
 use crate::{
@@ -379,6 +380,12 @@ pub enum SearchTokenizer {
         positions: bool,
         filters: SearchTokenizerFilters,
     },
+    EdgeNgram {
+        min_gram: usize,
+        max_gram: usize,
+        token_chars: Vec<String>,
+        filters: SearchTokenizerFilters,
+    },
     ChineseLinderaDeprecated(SearchTokenizerFilters),
     ChineseLindera {
         filters: SearchTokenizerFilters,
@@ -488,6 +495,22 @@ impl SearchTokenizer {
                     filters,
                 })
             }
+            "edge_ngram" => {
+                let min_gram: usize =
+                    value.get("min_gram").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
+                let max_gram: usize =
+                    value.get("max_gram").and_then(|v| v.as_u64()).unwrap_or(2) as usize;
+                let token_chars: Vec<String> = value
+                    .get("token_chars")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_else(|| vec!["letter".to_string(), "digit".to_string()]);
+                Ok(SearchTokenizer::EdgeNgram {
+                    min_gram,
+                    max_gram,
+                    token_chars,
+                    filters,
+                })
+            }
             "chinese_lindera" => Ok(SearchTokenizer::ChineseLinderaDeprecated(filters)),
             "japanese_lindera" => Ok(SearchTokenizer::JapaneseLinderaDeprecated(filters)),
             "korean_lindera" => Ok(SearchTokenizer::KoreanLinderaDeprecated(filters)),
@@ -569,6 +592,22 @@ impl SearchTokenizer {
                     .unwrap_or_else(|e| panic!("{}", e)),
                 filters
             ),
+            SearchTokenizer::EdgeNgram {
+                min_gram,
+                max_gram,
+                token_chars,
+                filters,
+            } => {
+                let classes = token_chars
+                    .iter()
+                    .map(|s| s.parse::<TokenCharClass>())
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap_or_else(|e| panic!("{}", e));
+                add_filters!(
+                    EdgeNgramTokenizer::new(*min_gram, *max_gram, classes),
+                    filters
+                )
+            }
             SearchTokenizer::ChineseCompatible(filters) => {
                 add_filters!(ChineseTokenizer, filters)
             }
@@ -683,6 +722,7 @@ impl SearchTokenizer {
             SearchTokenizer::ChineseCompatible(filters) => filters,
             SearchTokenizer::SourceCode(filters) => filters,
             SearchTokenizer::Ngram { filters, .. } => filters,
+            SearchTokenizer::EdgeNgram { filters, .. } => filters,
             SearchTokenizer::ChineseLinderaDeprecated(filters) => filters,
             SearchTokenizer::ChineseLindera { filters, .. } => filters,
             SearchTokenizer::JapaneseLinderaDeprecated(filters) => filters,
@@ -757,6 +797,17 @@ impl SearchTokenizer {
                 let positions_suffix = if *positions { "_positions:true" } else { "" };
                 format!(
                     "ngram_mingram:{min_gram}_maxgram:{max_gram}_prefixonly:{prefix_only}{positions_suffix}{filters_suffix}"
+                )
+            }
+            SearchTokenizer::EdgeNgram {
+                min_gram,
+                max_gram,
+                token_chars,
+                filters: _,
+            } => {
+                let tc = token_chars.join(",");
+                format!(
+                    "edge_ngram_mingram:{min_gram}_maxgram:{max_gram}_tokenchars:{tc}{filters_suffix}"
                 )
             }
             SearchTokenizer::ChineseLinderaDeprecated(_filters) => {

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -604,7 +604,8 @@ impl SearchTokenizer {
                     .collect::<Result<Vec<_>, _>>()
                     .unwrap_or_else(|e| panic!("{}", e));
                 add_filters!(
-                    EdgeNgramTokenizer::new(*min_gram, *max_gram, classes),
+                    EdgeNgramTokenizer::new(*min_gram, *max_gram, classes)
+                        .unwrap_or_else(|e| panic!("{}", e)),
                     filters
                 )
             }
@@ -805,7 +806,9 @@ impl SearchTokenizer {
                 token_chars,
                 filters: _,
             } => {
-                let tc = token_chars.join(",");
+                let mut tc_sorted = token_chars.clone();
+                tc_sorted.sort();
+                let tc = tc_sorted.join(",");
                 format!(
                     "edge_ngram_mingram:{min_gram}_maxgram:{max_gram}_tokenchars:{tc}{filters_suffix}"
                 )


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1960

## What

Implement an edge n-gram tokenizer matching Elasticsearch's semantics: splits text into words at character-class boundaries, then emits prefix n-grams (min_gram..max_gram) per word.

Supports configurable `token_chars` (letter, digit, whitespace, punctuation, symbol).

SQL usage: 

```sql
'Quick Fox'::pdb.edge_ngram(2, 5)::text[]
```

## Why

## How

## Tests
