### PR TITLE
fix: re-add meaningfull term filter

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -1,11 +1,11 @@
 -- string ff
-SELECT name, COUNT(*) FROM badges WHERE name === 'Question' GROUP BY name ORDER BY name;
+SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER BY name;
 
 -- aggregate custom scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE tag_based GROUP BY name;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}') FROM badges WHERE tag_based GROUP BY name;
+SELECT name, pdb.agg('{"value_count": {"field": "name"}}') FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE tag_based GROUP BY name;
+SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -1,5 +1,5 @@
 -- string ff
-SELECT name, COUNT(*) FROM badges WHERE tag_based GROUP BY name ORDER BY name;
+SELECT name, COUNT(*) FROM badges WHERE name === 'Question' GROUP BY name ORDER BY name;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE tag_based GROUP BY name;


### PR DESCRIPTION
# Ticket(s) Closed

## What
Re-adds a meaningful text filter to the stack overflow bucket-string-filter queries. Unfortunately, the only text field in badges is `name`, so doesn't test filtering on a different column like the other datasets. I did choose the token to maximize selectivity though, so hopefully this will provide similar insights

## Why
## How
## Tests
