### PR TITLE
feat: MPP plan partitioning for AggregateScan (#4152)

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -17,7 +17,7 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
 
 -- MPP aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*)
+SET statement_timeout TO '120s'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
@@ -19,3 +19,11 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section'
 GROUP BY f.title
 ORDER BY f.title;
+
+-- MPP aggregate scan
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section'
+GROUP BY f.title
+ORDER BY f.title;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
@@ -21,7 +21,7 @@ GROUP BY f.title
 ORDER BY f.title;
 
 -- MPP aggregate scan
-SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section'

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(p."sizeInB
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -17,7 +17,7 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
 
 -- MPP aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+SET statement_timeout TO '120s'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
@@ -31,3 +31,17 @@ GROUP BY
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
+
+-- MPP TopK aggregate scan
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+    f.title,
+    COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'
+GROUP BY
+    f.title
+ORDER BY
+    COUNT(*) DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
@@ -33,7 +33,7 @@ ORDER BY
 LIMIT 10;
 
 -- MPP TopK aggregate scan
-SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
     f.title,
     COUNT(*)
 FROM files f

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -29,18 +29,3 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
-
--- MPP join scan
-SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-    f.id,
-    f.title,
-    MAX(p."createdAt") as last_activity
-FROM files f
-JOIN pages p ON f.id = p."fileId"
-WHERE
-    f.content ||| 'Section'       -- Search Term
-GROUP BY
-    f.id, f.title
-ORDER BY
-    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
-LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -31,7 +31,7 @@ ORDER BY
 LIMIT 10;
 
 -- MPP join scan
-SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
     f.id,
     f.title,
     MAX(p."createdAt") as last_activity

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -29,3 +29,18 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
+
+-- MPP join scan
+SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
@@ -29,3 +29,18 @@ WHERE
 ORDER BY
     d.title ASC                     -- Single Feature Sort (Parent Field)
 LIMIT 50;
+
+-- MPP join scan
+SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT DISTINCT
+    d.id,
+    d.title,
+    d.parents
+FROM documents d
+JOIN files f ON d.id = f."documentId"
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    p."sizeInBytes" > 5000            -- Filter on the "Many" side
+    AND d.parents ||| 'parent group'
+ORDER BY
+    d.title ASC                     -- Single Feature Sort (Parent Field)
+LIMIT 50;

--- a/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
@@ -29,18 +29,3 @@ WHERE
 ORDER BY
     d.title ASC                     -- Single Feature Sort (Parent Field)
 LIMIT 50;
-
--- MPP join scan
-SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT DISTINCT
-    d.id,
-    d.title,
-    d.parents
-FROM documents d
-JOIN files f ON d.id = f."documentId"
-JOIN pages p ON f.id = p."fileId"
-WHERE
-    p."sizeInBytes" > 5000            -- Filter on the "Many" side
-    AND d.parents ||| 'parent group'
-ORDER BY
-    d.title ASC                     -- Single Feature Sort (Parent Field)
-LIMIT 50;

--- a/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
@@ -31,7 +31,7 @@ ORDER BY
 LIMIT 50;
 
 -- MPP join scan
-SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT DISTINCT
+SET statement_timeout TO '120s'; SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT DISTINCT
     d.id,
     d.title,
     d.parents

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -31,3 +31,19 @@ WHERE
 ORDER BY
     f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title,
+    d.parents as document_parents
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents ||| 'parent group'
+    AND f.title ||| 'collab12'
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -31,19 +31,3 @@ WHERE
 ORDER BY
     f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-    f.id,
-    f.title,
-    f."createdAt",
-    d.title as document_title,
-    d.parents as document_parents
-FROM files f
-JOIN documents d ON f."documentId" = d.id
-WHERE
-    d.parents ||| 'parent group'
-    AND f.title ||| 'collab12'
-ORDER BY
-    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
-LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -33,7 +33,7 @@ ORDER BY
 LIMIT 20;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
     f.id,
     f.title,
     f."createdAt",

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
@@ -15,12 +15,3 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-  *
-FROM
-  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
-WHERE
-  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
-LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
@@ -17,7 +17,7 @@ WHERE
 LIMIT 5;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
   *
 FROM
   documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
@@ -15,3 +15,12 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+  *
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
@@ -19,3 +19,14 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+  documents.id,
+  files.id,
+  pages.id
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
@@ -19,14 +19,3 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-  documents.id,
-  files.id,
-  pages.id
-FROM
-  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
-WHERE
-  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
-LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
@@ -21,7 +21,7 @@ WHERE
 LIMIT 5;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
   documents.id,
   files.id,
   pages.id

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
@@ -55,3 +55,14 @@ WHERE
   documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+  *,
+  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
@@ -57,7 +57,7 @@ ORDER BY score DESC
 LIMIT 1000;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
   *,
   pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
 FROM

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
@@ -55,14 +55,3 @@ WHERE
   documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-  *,
-  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
-FROM
-  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
-WHERE
-  documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
-ORDER BY score DESC
-LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
@@ -23,16 +23,3 @@ WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-  documents.id,
-  files.id,
-  pages.id,
-  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
-FROM
-  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
-WHERE
-  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
-ORDER BY score DESC
-LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
@@ -23,3 +23,16 @@ WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+  documents.id,
+  files.id,
+  pages.id,
+  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
@@ -25,7 +25,7 @@ ORDER BY score DESC
 LIMIT 1000;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
   documents.id,
   files.id,
   pages.id,

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -27,3 +27,17 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+    f.id,
+    f.title,
+    pdb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title ||| 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents ||| 'parent group'
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -27,17 +27,3 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-    f.id,
-    f.title,
-    pdb.score(f.id) as relevance
-FROM files f
-JOIN documents d ON f."documentId" = d.id
-WHERE
-    f.title ||| 'File'              -- Driving the Sort (Single Feature)
-    AND d.parents ||| 'parent group'
-ORDER BY
-    relevance DESC
-LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -29,7 +29,7 @@ ORDER BY
 LIMIT 10;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
     f.id,
     f.title,
     pdb.score(f.id) as relevance

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -82,3 +82,20 @@ WHERE
 ORDER BY
     f.title ASC
 LIMIT 25;
+
+-- MPP join scan
+SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents ||| 'PROJECT_ALPHA'
+        AND title ||| 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC
+LIMIT 25;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -82,20 +82,3 @@ WHERE
 ORDER BY
     f.title ASC
 LIMIT 25;
-
--- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
-    f.id,
-    f.title,
-    f."createdAt"
-FROM files f
-WHERE
-    f."documentId" IN (
-        SELECT id
-        FROM documents
-        WHERE parents ||| 'PROJECT_ALPHA'
-        AND title ||| 'Document Title 1'
-    )
-ORDER BY
-    f.title ASC
-LIMIT 25;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -84,7 +84,7 @@ ORDER BY
 LIMIT 25;
 
 -- MPP join scan
-SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
+SET statement_timeout TO '120s'; SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp_join TO on; SELECT
     f.id,
     f.title,
     f."createdAt"

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -67,6 +67,18 @@ pub fn create_aggregate_session_context() -> SessionContext {
     create_datafusion_session_context(SessionContextProfile::Aggregate)
 }
 
+/// Create an MPP-aware aggregate session context for parallel execution.
+#[allow(dead_code)]
+pub fn create_mpp_aggregate_session_context(
+    participant_index: usize,
+    total_participants: usize,
+) -> SessionContext {
+    create_datafusion_session_context(SessionContextProfile::JoinMpp {
+        participant_index,
+        total_participants,
+    })
+}
+
 /// Build the complete DataFusion logical plan for an aggregate-on-join query:
 /// scan(s) → join → aggregate [→ sort → limit].
 #[allow(clippy::too_many_arguments)]

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -68,7 +68,6 @@ pub fn create_aggregate_session_context() -> SessionContext {
 }
 
 /// Create an MPP-aware aggregate session context for parallel execution.
-#[allow(dead_code)]
 pub fn create_mpp_aggregate_session_context(
     participant_index: usize,
     total_participants: usize,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1209,21 +1209,7 @@ impl AggregateScan {
             let next = {
                 use futures::StreamExt;
                 if let Some(local_set) = df_state.mpp_local_set.as_ref() {
-                    runtime.block_on(local_set.run_until(async {
-                        // Periodically yield to the runtime so the IO driver can
-                        // process cross-process UDS signals from workers, and also
-                        // check for PostgreSQL cancel/timeout signals.
-                        loop {
-                            pgrx::check_for_interrupts!();
-                            tokio::select! {
-                                biased;
-                                result = stream.next() => break result,
-                                _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
-                                    // Timeout: yield to IO driver and retry
-                                }
-                            }
-                        }
-                    }))
+                    runtime.block_on(local_set.run_until(stream.next()))
                 } else {
                     runtime.block_on(async { stream.next().await })
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1040,25 +1040,26 @@ impl AggregateScan {
                 Err(e) => pgrx::error!("Failed to build DataFusion aggregate logical plan: {}", e),
             };
 
-            if use_mpp {
-                // MPP path: launch workers, broadcast plan, execute with exchanges
-                use crate::postgres::customscan::joinscan::{
-                    exchange, parallel, transport::TransportMesh,
-                };
+            // Attempt MPP launch. If it fails (e.g. parallel workers
+            // unavailable), fall back to the standard serial path.
+            let launched = if use_mpp {
+                use crate::postgres::customscan::joinscan::parallel;
+                parallel::launch_join_workers(
+                    &runtime,
+                    mpp_workers,
+                    unsafe { pg_sys::work_mem as usize * 1024 },
+                    unsafe { pg_sys::parallel_leader_participation },
+                )
+            } else {
+                None
+            };
+
+            if let Some((process, _, mux_writers, mux_readers, _session_id, bridge, nlaunched)) =
+                launched
+            {
+                // MPP path: broadcast plan, execute with exchanges
+                use crate::postgres::customscan::joinscan::{exchange, transport::TransportMesh};
                 use crate::scan::codec::serialize_logical_plan;
-
-                let nworkers = mpp_workers;
-
-                let Some((process, _, mux_writers, mux_readers, _session_id, bridge, nlaunched)) =
-                    parallel::launch_join_workers(
-                        &runtime,
-                        nworkers,
-                        unsafe { pg_sys::work_mem as usize * 1024 },
-                        unsafe { pg_sys::parallel_leader_participation },
-                    )
-                else {
-                    pgrx::error!("MPP AggregateScan: failed to launch workers");
-                };
 
                 // Serialize logical plan for broadcast
                 let plan_bytes = serialize_logical_plan(&logical_plan).unwrap_or_else(|e| {
@@ -1129,6 +1130,12 @@ impl AggregateScan {
                 df_state.runtime = Some(runtime);
                 df_state.stream = Some(stream);
             } else {
+                if use_mpp {
+                    crate::mpp_log!(
+                        "MPP AggregateScan: could not launch workers, falling back to serial"
+                    );
+                }
+
                 // Standard single-threaded path
                 let physical_plan = runtime
                     .block_on(build_physical_plan(&ctx, logical_plan))

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1066,10 +1066,16 @@ impl AggregateScan {
                 use crate::postgres::customscan::joinscan::{exchange, transport::TransportMesh};
                 use crate::scan::codec::serialize_logical_plan;
 
+                pgrx::warning!("MPP AggregateScan: {} participants launched", nlaunched);
+
                 // Serialize logical plan for broadcast
                 let plan_bytes = serialize_logical_plan(&logical_plan).unwrap_or_else(|e| {
                     pgrx::error!("MPP AggregateScan: failed to serialize plan: {e}")
                 });
+                pgrx::warning!(
+                    "MPP AggregateScan: plan serialized ({} bytes), broadcasting",
+                    plan_bytes.len()
+                );
 
                 // Broadcast to workers
                 for (i, reader_mutex) in mux_readers.iter().enumerate() {
@@ -1104,9 +1110,15 @@ impl AggregateScan {
                         pgrx::error!("MPP AggregateScan: physical plan failed: {e}")
                     });
 
+                pgrx::warning!("MPP AggregateScan: physical plan built");
+
                 // Register leader's stream sources
                 let mut sources = Vec::new();
                 exchange::collect_dsm_exchanges(physical_plan.clone(), &mut sources);
+                pgrx::warning!(
+                    "MPP AggregateScan: {} DsmExchangeExec nodes found",
+                    sources.len()
+                );
                 for source in sources {
                     exchange::register_stream_source(
                         source,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -998,7 +998,12 @@ impl AggregateScan {
             // rather than planning time. This avoids needing to serialize planned_workers
             // in the private data.
             let mpp_workers = if crate::gucs::enable_mpp_join() {
-                let max_workers = unsafe { pg_sys::max_parallel_workers_per_gather as usize };
+                // Both GUCs must allow parallelism. max_parallel_workers_per_gather
+                // caps workers for this query; max_parallel_workers is a global cap
+                // that ParallelProcessBuilder also checks — if it's 0, DSM init will
+                // fail, so we skip MPP upfront.
+                let max_workers = (unsafe { pg_sys::max_parallel_workers_per_gather as usize })
+                    .min(unsafe { pg_sys::max_parallel_workers as usize });
                 max_workers.min(4) // Cap at 4 for now
             } else {
                 0

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -346,7 +346,6 @@ impl CustomScan for AggregateScan {
                     batch_row_idx: 0,
                     mpp_local_set: None,
                     mpp_process: None,
-                    planned_workers: 0, // TODO: set from planner
                 });
                 builder.build()
             }
@@ -995,7 +994,16 @@ impl AggregateScan {
 
         // First call: build and execute the DataFusion plan
         if df_state.runtime.is_none() {
-            let use_mpp = crate::gucs::enable_mpp_join() && df_state.planned_workers > 0;
+            // For AggregateScan, compute worker count at execution time from GUCs
+            // rather than planning time. This avoids needing to serialize planned_workers
+            // in the private data.
+            let mpp_workers = if crate::gucs::enable_mpp_join() {
+                let max_workers = unsafe { pg_sys::max_parallel_workers_per_gather as usize };
+                max_workers.min(4) // Cap at 4 for now
+            } else {
+                0
+            };
+            let use_mpp = mpp_workers > 0;
 
             let runtime = if use_mpp {
                 tokio::runtime::Builder::new_current_thread()
@@ -1009,7 +1017,7 @@ impl AggregateScan {
             };
 
             let ctx = if use_mpp {
-                let nworkers = df_state.planned_workers;
+                let nworkers = mpp_workers;
                 let total =
                     crate::postgres::customscan::joinscan::scan_state::compute_total_participants(
                         nworkers,
@@ -1048,7 +1056,7 @@ impl AggregateScan {
                 };
                 use crate::scan::codec::serialize_logical_plan;
 
-                let nworkers = df_state.planned_workers;
+                let nworkers = mpp_workers;
 
                 let Some((process, _, mux_writers, mux_readers, _session_id, bridge, nlaunched)) =
                     parallel::launch_join_workers(

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -344,6 +344,9 @@ impl CustomScan for AggregateScan {
                     stream: None,
                     current_batch: None,
                     batch_row_idx: 0,
+                    mpp_local_set: None,
+                    mpp_process: None,
+                    planned_workers: 0, // TODO: set from planner
                 });
                 builder.build()
             }
@@ -529,6 +532,15 @@ impl CustomScan for AggregateScan {
         // intended lifecycle boundary rather than relying on Postgres to drop the
         // state wrapper later. Mirrors JoinScan::end_custom_scan.
         if let Some(mut df_state) = state.custom_state_mut().datafusion_state.take() {
+            // Clean up MPP resources before dropping DataFusion state.
+            if df_state.mpp_process.is_some() {
+                crate::postgres::customscan::joinscan::exchange::clear_dsm_mesh();
+                df_state.mpp_local_set = None;
+                df_state.stream = None;
+                if let Some(process) = df_state.mpp_process.take() {
+                    process.destroy();
+                }
+            }
             df_state.stream = None;
             df_state.current_batch = None;
             df_state.runtime = None;
@@ -983,17 +995,36 @@ impl AggregateScan {
 
         // First call: build and execute the DataFusion plan
         if df_state.runtime.is_none() {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
+            let use_mpp = crate::gucs::enable_mpp_join() && df_state.planned_workers > 0;
 
-            let ctx = create_aggregate_session_context();
+            let runtime = if use_mpp {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e))
+            } else {
+                tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e))
+            };
+
+            let ctx = if use_mpp {
+                let nworkers = df_state.planned_workers;
+                let total =
+                    crate::postgres::customscan::joinscan::scan_state::compute_total_participants(
+                        nworkers,
+                    );
+                datafusion_exec::create_mpp_aggregate_session_context(0, total)
+            } else {
+                create_aggregate_session_context()
+            };
 
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
-            let physical_plan = runtime.block_on(async {
-                let logical = build_join_aggregate_plan(
+
+            // Build logical plan
+            let logical_plan = runtime.block_on(async {
+                build_join_aggregate_plan(
                     &df_state.plan,
                     &df_state.targetlist,
                     df_state.topk.as_ref(),
@@ -1003,31 +1034,128 @@ impl AggregateScan {
                     df_state.having_filter.as_ref(),
                     &ctx,
                 )
-                .await?;
-                build_physical_plan(&ctx, logical).await
+                .await
             });
-
-            let physical_plan = match physical_plan {
+            let logical_plan = match logical_plan {
                 Ok(p) => p,
-                Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+                Err(e) => pgrx::error!("Failed to build DataFusion aggregate logical plan: {}", e),
             };
 
-            let task_ctx = build_task_context(
-                &ctx,
-                &physical_plan,
-                unsafe { pg_sys::work_mem as usize * 1024 },
-                unsafe { pg_sys::hash_mem_multiplier },
-            );
-            let stream = {
-                let _guard = runtime.enter();
-                match physical_plan.execute(0, task_ctx) {
-                    Ok(s) => s,
-                    Err(e) => pgrx::error!("Failed to execute DataFusion aggregate plan: {}", e),
+            if use_mpp {
+                // MPP path: launch workers, broadcast plan, execute with exchanges
+                use crate::postgres::customscan::joinscan::{
+                    exchange, parallel, transport::TransportMesh,
+                };
+                use crate::scan::codec::serialize_logical_plan;
+
+                let nworkers = df_state.planned_workers;
+
+                let Some((process, _, mux_writers, mux_readers, _session_id, bridge, nlaunched)) =
+                    parallel::launch_join_workers(
+                        &runtime,
+                        nworkers,
+                        unsafe { pg_sys::work_mem as usize * 1024 },
+                        unsafe { pg_sys::parallel_leader_participation },
+                    )
+                else {
+                    pgrx::error!("MPP AggregateScan: failed to launch workers");
+                };
+
+                // Serialize logical plan for broadcast
+                let plan_bytes = serialize_logical_plan(&logical_plan).unwrap_or_else(|e| {
+                    pgrx::error!("MPP AggregateScan: failed to serialize plan: {e}")
+                });
+
+                // Broadcast to workers
+                for (i, reader_mutex) in mux_readers.iter().enumerate() {
+                    if i == 0 {
+                        continue;
+                    }
+                    let mut reader = reader_mutex.lock();
+                    reader
+                        .send_control_message_variable(128, &plan_bytes)
+                        .unwrap_or_else(|e| {
+                            pgrx::error!("MPP AggregateScan: broadcast failed: {e}")
+                        });
                 }
-            };
 
-            df_state.runtime = Some(runtime);
-            df_state.stream = Some(stream);
+                // Register DSM mesh
+                let transport = TransportMesh {
+                    mux_writers,
+                    mux_readers,
+                    bridge,
+                };
+                let mesh = exchange::DsmMesh {
+                    transport,
+                    registry: parking_lot::Mutex::new(exchange::StreamRegistry::default()),
+                };
+                exchange::register_dsm_mesh(mesh);
+
+                // Rebuild context with actual participant count, build physical plan
+                let ctx = datafusion_exec::create_mpp_aggregate_session_context(0, nlaunched);
+                let physical_plan = runtime
+                    .block_on(build_physical_plan(&ctx, logical_plan))
+                    .unwrap_or_else(|e| {
+                        pgrx::error!("MPP AggregateScan: physical plan failed: {e}")
+                    });
+
+                // Register leader's stream sources
+                let mut sources = Vec::new();
+                exchange::collect_dsm_exchanges(physical_plan.clone(), &mut sources);
+                for source in sources {
+                    exchange::register_stream_source(
+                        source,
+                        crate::postgres::customscan::joinscan::transport::ParticipantId(0),
+                    );
+                }
+
+                // Spawn control service and execute with LocalSet
+                let local_set = tokio::task::LocalSet::new();
+                let task_ctx = build_task_context(
+                    &ctx,
+                    &physical_plan,
+                    unsafe { pg_sys::work_mem as usize * 1024 },
+                    unsafe { pg_sys::hash_mem_multiplier },
+                );
+                exchange::spawn_control_service(&local_set, task_ctx.clone());
+
+                let stream = runtime.block_on(local_set.run_until(async {
+                    physical_plan
+                        .execute(0, task_ctx)
+                        .unwrap_or_else(|e| panic!("MPP AggregateScan: execution failed: {e}"))
+                }));
+
+                df_state.mpp_local_set = Some(local_set);
+                df_state.mpp_process = Some(process);
+                df_state.runtime = Some(runtime);
+                df_state.stream = Some(stream);
+            } else {
+                // Standard single-threaded path
+                let physical_plan = runtime
+                    .block_on(build_physical_plan(&ctx, logical_plan))
+                    .unwrap_or_else(|e| {
+                        pgrx::error!("Failed to build aggregate physical plan: {e}")
+                    });
+
+                let task_ctx = build_task_context(
+                    &ctx,
+                    &physical_plan,
+                    unsafe { pg_sys::work_mem as usize * 1024 },
+                    unsafe { pg_sys::hash_mem_multiplier },
+                );
+                let stream = {
+                    let _guard = runtime.enter();
+                    match physical_plan.execute(0, task_ctx) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            pgrx::error!("Failed to execute DataFusion aggregate plan: {}", e)
+                        }
+                    }
+                };
+
+                df_state.runtime = Some(runtime);
+                df_state.stream = Some(stream);
+            }
         }
 
         // Consume batches row-by-row
@@ -1050,14 +1178,19 @@ impl AggregateScan {
                 df_state.current_batch = None;
             }
 
-            // Fetch next batch from stream
+            // Fetch next batch from stream. When MPP is active, drive the
+            // LocalSet (control service) so worker RPCs are processed.
             let runtime = df_state.runtime.as_ref().unwrap();
             let stream = df_state.stream.as_mut().unwrap();
 
-            let next = runtime.block_on(async {
+            let next = {
                 use futures::StreamExt;
-                stream.next().await
-            });
+                if let Some(local_set) = df_state.mpp_local_set.as_ref() {
+                    runtime.block_on(local_set.run_until(stream.next()))
+                } else {
+                    runtime.block_on(async { stream.next().await })
+                }
+            };
 
             match next {
                 Some(Ok(batch)) => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1197,7 +1197,21 @@ impl AggregateScan {
             let next = {
                 use futures::StreamExt;
                 if let Some(local_set) = df_state.mpp_local_set.as_ref() {
-                    runtime.block_on(local_set.run_until(stream.next()))
+                    runtime.block_on(local_set.run_until(async {
+                        // Periodically yield to the runtime so the IO driver can
+                        // process cross-process UDS signals from workers, and also
+                        // check for PostgreSQL cancel/timeout signals.
+                        loop {
+                            pgrx::check_for_interrupts!();
+                            tokio::select! {
+                                biased;
+                                result = stream.next() => break result,
+                                _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                                    // Timeout: yield to IO driver and retry
+                                }
+                            }
+                        }
+                    }))
                 } else {
                     runtime.block_on(async { stream.next().await })
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1209,7 +1209,23 @@ impl AggregateScan {
             let next = {
                 use futures::StreamExt;
                 if let Some(local_set) = df_state.mpp_local_set.as_ref() {
-                    runtime.block_on(local_set.run_until(stream.next()))
+                    runtime.block_on(local_set.run_until(async {
+                        loop {
+                            // Check for PostgreSQL cancel/timeout signals.
+                            // This runs inside the async context so it executes
+                            // even when block_on would otherwise park forever.
+                            pgrx::check_for_interrupts!();
+                            // Poll stream with a short timeout so we can
+                            // re-check interrupts periodically.
+                            tokio::select! {
+                                biased;
+                                result = stream.next() => break result,
+                                _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                                    continue;
+                                }
+                            }
+                        }
+                    }))
                 } else {
                     runtime.block_on(async { stream.next().await })
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1016,16 +1016,7 @@ impl AggregateScan {
                     .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e))
             };
 
-            let ctx = if use_mpp {
-                let nworkers = mpp_workers;
-                let total =
-                    crate::postgres::customscan::joinscan::scan_state::compute_total_participants(
-                        nworkers,
-                    );
-                datafusion_exec::create_mpp_aggregate_session_context(0, total)
-            } else {
-                create_aggregate_session_context()
-            };
+            let ctx = create_aggregate_session_context();
 
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -73,8 +73,6 @@ pub struct DataFusionAggState {
     pub mpp_local_set: Option<tokio::task::LocalSet>,
     /// MPP: parallel process handle for cleanup.
     pub mpp_process: Option<crate::parallel_worker::builder::ParallelProcessFinish>,
-    /// MPP: number of planned workers (from planner, 0 = no MPP).
-    pub planned_workers: usize,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -68,6 +68,13 @@ pub struct DataFusionAggState {
     pub current_batch: Option<RecordBatch>,
     /// Row index within current_batch.
     pub batch_row_idx: usize,
+
+    /// MPP: tokio LocalSet that drives the control service during streaming.
+    pub mpp_local_set: Option<tokio::task::LocalSet>,
+    /// MPP: parallel process handle for cleanup.
+    pub mpp_process: Option<crate::parallel_worker::builder::ParallelProcessFinish>,
+    /// MPP: number of planned workers (from planner, 0 = no MPP).
+    pub planned_workers: usize,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -154,17 +154,6 @@ pub struct DsmMesh {
 
 lazy_static::lazy_static! {
     pub static ref DSM_MESH: Mutex<Option<DsmMesh>> = Mutex::new(None);
-    /// In-process bypass receivers for self-directed exchange data.
-    /// Uses tokio::sync::mpsc so the consumer properly returns Pending (instead of
-    /// spin-waiting) when the channel is empty, allowing the LocalSet to schedule
-    /// other tasks (control service, producers) efficiently.
-    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, tokio::sync::mpsc::UnboundedReceiver<RecordBatch>>> =
-        Mutex::new(HashMap::default());
-    /// In-process bypass senders, pre-created in register_stream_source and
-    /// taken by the producer task. When the producer finishes and drops the sender,
-    /// the channel disconnects and the consumer stops.
-    pub static ref BYPASS_SENDERS: Mutex<HashMap<LogicalStreamId, tokio::sync::mpsc::UnboundedSender<RecordBatch>>> =
-        Mutex::new(HashMap::default());
 }
 
 pub fn register_dsm_mesh(mesh: DsmMesh) {
@@ -175,10 +164,6 @@ pub fn register_dsm_mesh(mesh: DsmMesh) {
 pub fn clear_dsm_mesh() {
     let mut guard = DSM_MESH.lock();
     *guard = None;
-    let mut bypass = LOCAL_BYPASS.lock();
-    bypass.clear();
-    let mut senders = BYPASS_SENDERS.lock();
-    senders.clear();
 }
 
 impl Drop for DsmMesh {
@@ -188,22 +173,14 @@ impl Drop for DsmMesh {
 }
 
 pub fn register_stream_source(source: StreamSource, participant_id: ParticipantId) {
-    // Pre-create the local bypass channel for this exchange's self-partition.
-    // The consumer will take the receiver during create_consumer_stream.
-    // The producer will retrieve the sender during producer_task.
-    // Both Redistribute and Gather modes use bypass channels to avoid ring-buffer
-    // IPC for self-directed data. Without this, Gather mode routes self-partition
-    // data through shared memory, which adds serialization overhead and can cause
-    // deadlocks when the ring buffer fills faster than the single-threaded LocalSet
-    // can drain it.
-    {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut bypass = LOCAL_BYPASS.lock();
-        bypass.insert(source.config.stream_id, rx);
-        let mut senders = BYPASS_SENDERS.lock();
-        senders.insert(source.config.stream_id, tx);
-    }
-
+    // All data (including self-partition) flows through ring buffers. This is
+    // critical for correct IO driver polling: in-process bypass channels
+    // (tokio::sync::mpsc) keep LocalSet tasks cycling via internal notifications,
+    // preventing the tokio IO driver from ever polling. This starves the
+    // SignalBridge UDS listener, so DSM readers for remote participants never
+    // wake — causing a deadlock. Ring buffers use SignalBridge.signal(self) for
+    // same-process waking, which directly calls wakers without IO, while still
+    // allowing the LocalSet to yield when the ring buffer is empty.
     let mut guard = DSM_MESH.lock();
     if let Some(mesh) = guard.as_mut() {
         let physical_id = PhysicalStreamId::new(source.config.stream_id, participant_id);
@@ -666,14 +643,6 @@ impl DsmExchangeExec {
             );
         }
 
-        // Take the local bypass sender for this exchange's self-partition.
-        // Pre-created in register_stream_source. When the producer finishes
-        // and drops the sender, the channel disconnects and the consumer stops.
-        let local_tx = {
-            let mut guard = BYPASS_SENDERS.lock();
-            guard.remove(&config.stream_id)
-        };
-
         // Initialize partitioner ONCE if needed
         let mut partitioner = if let ExchangeMode::Redistribute = config.mode {
             Some(
@@ -705,17 +674,6 @@ impl DsmExchangeExec {
                 let mut blocked_on_write = false;
 
                 for i in 0..total_participants {
-                    // Self-partition: bypass ring buffer, send directly via channel.
-                    // Both Redistribute and Gather modes use bypass channels.
-                    if i == participant_index {
-                        if let Some(ref tx) = local_tx {
-                            while let Some(batch) = out_queues[i].pop_front() {
-                                let _ = tx.send(batch);
-                                progress = true;
-                            }
-                            continue;
-                        }
-                    }
                     while let Some(batch) = out_queues[i].front() {
                         match writers[i].write_batch(batch) {
                             Ok(_) => {
@@ -867,37 +825,21 @@ impl DsmExchangeExec {
                     }
                 }
 
+                // All participants (including self) read from DSM ring buffers.
+                // Self-partition data goes through the same ring buffer path;
+                // SignalBridge.signal(self) wakes the reader directly without IO,
+                // ensuring the LocalSet can yield and the IO driver polls for
+                // remote UDS signals.
                 let mut readers: Vec<SendableRecordBatchStream> = Vec::new();
                 for i in 0..total_participants {
-                    if i == participant_index {
-                        // Self-partition: read from local bypass channel (no IPC overhead).
-                        // Uses tokio::sync::mpsc so recv() properly returns Pending when
-                        // empty, allowing the LocalSet to schedule other tasks instead of
-                        // spin-waiting.
-                        let rx = {
-                            let mut guard = LOCAL_BYPASS.lock();
-                            guard.remove(&self.config.stream_id)
-                        };
-                        if let Some(rx) = rx {
-                            let stream = futures::stream::unfold(rx, |mut rx| async move {
-                                rx.recv().await.map(|batch| (Ok(batch), rx))
-                            });
-                            readers.push(Box::pin(RecordBatchStreamAdapter::new(
-                                schema.clone(),
-                                Box::pin(stream),
-                            )));
-                        }
-                    } else {
-                        // Remote partition: read from DSM ring buffer.
-                        if let Some(reader) = get_dsm_reader(
-                            i,
-                            self.config.stream_id,
-                            ParticipantId(i as u16),
-                            schema.clone(),
-                            self.config.sanitized,
-                        ) {
-                            readers.push(shared_memory_stream(reader));
-                        }
+                    if let Some(reader) = get_dsm_reader(
+                        i,
+                        self.config.stream_id,
+                        ParticipantId(i as u16),
+                        schema.clone(),
+                        self.config.sanitized,
+                    ) {
+                        readers.push(shared_memory_stream(reader));
                     }
                 }
 
@@ -940,46 +882,10 @@ impl DsmExchangeExec {
                     }
                 }
 
-                // Leader: Pull Partition `partition`.
-                if partition == participant_index {
-                    // Self-partition: use bypass channel instead of ring buffer.
-                    // This avoids serialization overhead and prevents deadlocks
-                    // when the producer and consumer share the same LocalSet.
-                    let rx = {
-                        let mut guard = LOCAL_BYPASS.lock();
-                        guard.remove(&self.config.stream_id)
-                    };
-                    if let Some(rx) = rx {
-                        // We still need to send StartStream to trigger the producer.
-                        let physical_id = PhysicalStreamId::new(
-                            self.config.stream_id,
-                            ParticipantId(partition as u16),
-                        );
-                        crate::mpp_log!(
-                            "MPP Gather: sending StartStream({physical_id:?}) to self (bypass)"
-                        );
-                        let guard = DSM_MESH.lock();
-                        if let Some(mesh) = guard.as_ref() {
-                            if partition < mesh.transport.mux_readers.len() {
-                                let mut reader_mux = mesh.transport.mux_readers[partition].lock();
-                                let _ = reader_mux.start_stream(physical_id);
-                            }
-                        }
-                        drop(guard);
-
-                        let stream = futures::stream::unfold(rx, |mut rx| async move {
-                            rx.recv().await.map(|batch| (Ok(batch), rx))
-                        });
-                        return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                            schema,
-                            Box::pin(stream),
-                        )));
-                    }
-                    // Fallback: no bypass channel, use ring buffer path below
-                }
-
-                // Remote partition (or fallback): send StartStream to trigger
-                // the worker's producer task.
+                // Leader: Send StartStream and read from ring buffer.
+                // All partitions (including self) use ring buffers. For
+                // self-partition, SignalBridge.signal(self) wakes the reader
+                // directly without IO.
                 {
                     let physical_id = PhysicalStreamId::new(
                         self.config.stream_id,

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -680,14 +680,13 @@ impl DsmExchangeExec {
         let mut yield_counter: u64 = 0;
         poll_fn(|cx| {
             loop {
-                // Cooperative yielding: every 16 iterations, re-queue this task
-                // and return Pending. This gives the LocalSet a chance to run
-                // other tasks (e.g. Gather producer / consumer tasks) AND lets
-                // the tokio IO driver poll for UDS signals from remote
-                // participants. Without this, self-signal direct waking can
-                // cause this task to loop indefinitely, starving IO.
+                // Cooperative yielding: re-queue this task and return Pending
+                // on every other iteration. This gives the LocalSet a chance
+                // to run other tasks (Gather producer / consumer tasks that
+                // need to drain ring buffers) AND lets the tokio IO driver
+                // poll for UDS signals from remote participants.
                 yield_counter += 1;
-                if yield_counter.is_multiple_of(16) {
+                if yield_counter.is_multiple_of(2) {
                     cx.waker().wake_by_ref();
                     return Poll::Pending;
                 }

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -746,8 +746,14 @@ impl DsmExchangeExec {
                     }
                 }
 
-                // 2. Poll input stream if not done
-                if !input_done {
+                // 2. Poll input stream if not done AND all queues are drained.
+                // This creates backpressure: the producer stops reading from the
+                // scan until all previously partitioned data is flushed to ring
+                // buffers. Without this, the producer reads the entire input
+                // (~5M rows per participant) into unbounded out_queues, then
+                // tries to drain — causing circular ring buffer deadlocks when
+                // all participants are simultaneously blocked.
+                if !input_done && all_queues_empty {
                     match input_stream.as_mut().poll_next(cx) {
                         Poll::Ready(Some(Ok(batch))) => {
                             total_rows += batch.num_rows() as u64;

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -102,7 +102,8 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
-use futures::{future::poll_fn, Stream, StreamExt};
+use futures::future::poll_fn;
+use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use tokio::sync::watch;
 
@@ -224,9 +225,30 @@ pub fn trigger_stream(physical_stream_id: PhysicalStreamId, context: Arc<TaskCon
             })
             .clone();
 
-        let task = tokio::task::spawn_local(async move {
+        // Spawn the producer on a dedicated OS thread instead of spawn_local.
+        //
+        // This is the critical fix for the exchange deadlock: when all ring
+        // buffers fill simultaneously, producers blocked on writes prevent
+        // consumers from draining data because they all share a single-threaded
+        // LocalSet. By moving producers to their own OS threads, each producer
+        // can independently block (with a short sleep) on ring buffer writes
+        // while the LocalSet thread remains free to run consumer tasks and the
+        // tokio IO driver (for processing UDS signals from remote participants).
+        let join_handle = std::thread::spawn(move || {
             let _guard = SignalOnDrop(Some(tx));
-            DsmExchangeExec::producer_task(input, partitioning, config, context).await;
+            DsmExchangeExec::producer_task_blocking(input, partitioning, config, context);
+        });
+
+        // Wrap std::thread::JoinHandle in a tokio JoinHandle by spawning a
+        // local task that awaits the thread. This preserves the existing
+        // abort/cleanup interface (StreamRegistry expects JoinHandle<()>).
+        let task = tokio::task::spawn_local(async move {
+            // Park this lightweight task until the OS thread finishes.
+            // Use spawn_blocking to wait without blocking the LocalSet.
+            let _ = tokio::task::spawn_blocking(move || {
+                let _ = join_handle.join();
+            })
+            .await;
         });
 
         registry
@@ -614,12 +636,27 @@ impl DsmExchangeExec {
         })
     }
 
-    pub(crate) async fn producer_task(
+    /// Synchronous producer that runs on a dedicated OS thread.
+    ///
+    /// This is the key to breaking the exchange deadlock: instead of running as
+    /// a `spawn_local` task on the single-threaded `LocalSet` (where it competes
+    /// with consumer tasks and the IO driver), each producer gets its own OS
+    /// thread. When a ring buffer is full, the producer simply sleeps briefly
+    /// and retries, while the `LocalSet` thread is free to run consumer tasks
+    /// that drain ring buffers and process UDS signals from remote participants.
+    pub(crate) fn producer_task_blocking(
         input: Arc<dyn ExecutionPlan>,
         partitioning: Partitioning,
         config: DsmExchangeConfig,
         context: Arc<TaskContext>,
     ) {
+        // Each producer thread gets its own lightweight tokio runtime to drive
+        // the DataFusion input stream (which is async). This runtime only needs
+        // to poll the input — all ring buffer writes are synchronous.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Failed to create producer thread runtime");
+
         let (participant_index, total_participants) = get_mpp_config(&context);
         let participant_id = ParticipantId(participant_index as u16);
         let num_partitions = input.output_partitioning().partition_count();
@@ -631,7 +668,7 @@ impl DsmExchangeExec {
                     .expect("Failed to execute input"),
             );
         }
-        let input_stream = futures::stream::select_all(streams).fuse();
+        let input_stream = futures::stream::select_all(streams);
         let mut input_stream = Box::pin(input_stream);
         let schema = input.schema();
 
@@ -663,13 +700,12 @@ impl DsmExchangeExec {
             vec![std::collections::VecDeque::new(); total_participants];
 
         let mut input_done = false;
-        let bridge = get_dsm_bridge();
         let mut total_batches: u64 = 0;
         let mut total_rows: u64 = 0;
         let mut blocked_count: u64 = 0;
 
         pgrx::warning!(
-            "MPP producer_task: stream_id={}, mode={:?}, participant={}/{}, input_partitions={}",
+            "MPP producer_task_blocking: stream_id={}, mode={:?}, participant={}/{}, input_partitions={}",
             config.stream_id.0,
             config.mode,
             participant_index,
@@ -677,151 +713,115 @@ impl DsmExchangeExec {
             num_partitions,
         );
 
-        let mut yield_counter: u64 = 0;
-        poll_fn(|cx| {
-            loop {
-                // Cooperative yielding: re-queue this task and return Pending
-                // on every other iteration. This gives the LocalSet a chance
-                // to run other tasks (Gather producer / consumer tasks that
-                // need to drain ring buffers) AND lets the tokio IO driver
-                // poll for UDS signals from remote participants.
-                yield_counter += 1;
-                if yield_counter.is_multiple_of(2) {
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
-                }
+        // The backpressure threshold: only poll input when total queued batches
+        // across all output queues is below this limit. This prevents unbounded
+        // memory growth while still allowing enough buffering to keep the
+        // pipeline busy.
+        const MAX_QUEUED_BATCHES: usize = 4;
 
-                // Allow PostgreSQL to process statement_timeout / cancel signals.
-                pgrx::check_for_interrupts!();
+        loop {
+            // 1. Try to drain all output queues to ring buffers.
+            let mut all_queues_empty = true;
+            let mut any_blocked = false;
 
-                let mut progress = false;
-
-                // 1. Try to drain all queues
-                let mut all_queues_empty = true;
-                let mut blocked_on_write = false;
-
-                for i in 0..total_participants {
-                    while let Some(batch) = out_queues[i].front() {
-                        match writers[i].write_batch(batch) {
-                            Ok(_) => {
-                                out_queues[i].pop_front();
-                                progress = true;
-                            }
-                            Err(datafusion::error::DataFusionError::IoError(ref msg))
-                                if msg.kind() == ErrorKind::WouldBlock =>
-                            {
-                                // Check-Register-Check pattern
-                                bridge.register_waker(cx.waker().clone(), None);
-
-                                // Retry immediately to avoid race condition where space became available
-                                // after the first check but before we registered the waker.
-                                match writers[i].write_batch(batch) {
-                                    Ok(_) => {
-                                        out_queues[i].pop_front();
-                                        progress = true;
-                                    }
-                                    Err(datafusion::error::DataFusionError::IoError(ref msg))
-                                        if msg.kind() == ErrorKind::WouldBlock =>
-                                    {
-                                        blocked_on_write = true;
-                                        all_queues_empty = false;
-                                        break;
-                                    }
-                                    Err(e) => panic!("Producer failed on retry: {}", e),
-                                }
-                                break;
-                            }
-                            Err(datafusion::error::DataFusionError::IoError(ref msg))
-                                if msg.kind() == ErrorKind::BrokenPipe =>
-                            {
-                                // Receiver closed
-                                out_queues[i].clear();
-                                break;
-                            }
-                            Err(e) => panic!("Producer failed: {}", e),
+            for i in 0..total_participants {
+                while let Some(batch) = out_queues[i].front() {
+                    match writers[i].write_batch(batch) {
+                        Ok(_) => {
+                            out_queues[i].pop_front();
                         }
-                    }
-                    if !out_queues[i].is_empty() {
-                        all_queues_empty = false;
+                        Err(datafusion::error::DataFusionError::IoError(ref msg))
+                            if msg.kind() == ErrorKind::WouldBlock =>
+                        {
+                            any_blocked = true;
+                            all_queues_empty = false;
+                            break;
+                        }
+                        Err(datafusion::error::DataFusionError::IoError(ref msg))
+                            if msg.kind() == ErrorKind::BrokenPipe =>
+                        {
+                            // Receiver closed — drop all pending data for this target
+                            out_queues[i].clear();
+                            break;
+                        }
+                        Err(e) => panic!("Producer write failed: {}", e),
                     }
                 }
-
-                // 2. Poll input stream if not done AND all queues are drained.
-                // This creates backpressure: the producer stops reading from the
-                // scan until all previously partitioned data is flushed to ring
-                // buffers. Without this, the producer reads the entire input
-                // (~5M rows per participant) into unbounded out_queues, then
-                // tries to drain — causing circular ring buffer deadlocks when
-                // all participants are simultaneously blocked.
-                if !input_done && all_queues_empty {
-                    match input_stream.as_mut().poll_next(cx) {
-                        Poll::Ready(Some(Ok(batch))) => {
-                            total_rows += batch.num_rows() as u64;
-                            total_batches += 1;
-                            match config.mode {
-                                ExchangeMode::Redistribute => {
-                                    partitioner
-                                        .as_mut()
-                                        .unwrap()
-                                        .partition(batch, |dest_idx, partitioned_batch| {
-                                            if dest_idx < out_queues.len() {
-                                                out_queues[dest_idx].push_back(partitioned_batch);
-                                            }
-                                            Ok(())
-                                        })
-                                        .expect("Partitioning failed");
-                                }
-                                ExchangeMode::Gather => {
-                                    out_queues[0].push_back(batch);
-                                }
-                            }
-                            progress = true;
-                        }
-                        Poll::Ready(Some(Err(e))) => panic!("Input stream failed: {}", e),
-                        Poll::Ready(None) => {
-                            input_done = true;
-                            progress = true; // State change counts as progress
-                            pgrx::warning!(
-                                "MPP producer_task: stream_id={} input done, {} batches, {} rows, {} blocked",
-                                config.stream_id.0, total_batches, total_rows, blocked_count,
-                            );
-                        }
-                        Poll::Pending => {
-                            // Input not ready
-                        }
-                    }
+                if !out_queues[i].is_empty() {
+                    all_queues_empty = false;
                 }
-
-                if input_done && all_queues_empty {
-                    return Poll::Ready(());
-                }
-
-                // If blocked on any ring buffer write, yield immediately. This is critical: without yielding,
-                // the producer can cycle indefinitely writing to self-partition
-                // ring buffers (which the local consumer drains), starving the
-                // tokio IO driver. Remote participants signal space-available via
-                // UDS, which only fires when the IO driver polls — and that only
-                // happens when ALL LocalSet tasks return Pending.
-                if blocked_on_write {
-                    blocked_count += 1;
-                    bridge.register_waker(cx.waker().clone(), None);
-                    return Poll::Pending;
-                }
-
-                // If we made progress (and not blocked), try again immediately
-                if progress {
-                    continue;
-                }
-
-                // If input is pending, it already registered waker.
-
-                return Poll::Pending;
             }
-        })
-        .await;
+
+            // 2. Check completion.
+            if input_done && all_queues_empty {
+                break;
+            }
+
+            // 3. Apply backpressure: only poll input when queues are small enough.
+            let total_queued: usize = out_queues.iter().map(|q| q.len()).sum();
+            if !input_done && total_queued < MAX_QUEUED_BATCHES {
+                // Use the thread-local runtime to poll the async input stream.
+                let next = rt.block_on(async {
+                    // Try to get the next batch without blocking indefinitely.
+                    // Use poll_fn to do a single poll attempt.
+                    poll_fn(|cx| match input_stream.as_mut().poll_next(cx) {
+                        Poll::Ready(item) => Poll::Ready(Some(item)),
+                        Poll::Pending => Poll::Ready(None),
+                    })
+                    .await
+                });
+
+                match next {
+                    Some(Some(Ok(batch))) => {
+                        total_rows += batch.num_rows() as u64;
+                        total_batches += 1;
+                        match config.mode {
+                            ExchangeMode::Redistribute => {
+                                partitioner
+                                    .as_mut()
+                                    .unwrap()
+                                    .partition(batch, |dest_idx, partitioned_batch| {
+                                        if dest_idx < out_queues.len() {
+                                            out_queues[dest_idx].push_back(partitioned_batch);
+                                        }
+                                        Ok(())
+                                    })
+                                    .expect("Partitioning failed");
+                            }
+                            ExchangeMode::Gather => {
+                                out_queues[0].push_back(batch);
+                            }
+                        }
+                        continue; // Made progress — loop immediately
+                    }
+                    Some(Some(Err(e))) => panic!("Input stream failed: {}", e),
+                    Some(None) => {
+                        input_done = true;
+                        pgrx::warning!(
+                            "MPP producer_task_blocking: stream_id={} input done, {} batches, {} rows, {} blocked",
+                            config.stream_id.0, total_batches, total_rows, blocked_count,
+                        );
+                        continue; // State changed — try draining again
+                    }
+                    None => {
+                        // Input not ready (Pending). If queues also blocked,
+                        // we need to wait for space to free up.
+                    }
+                }
+            }
+
+            // 4. If blocked on writes or input pending, sleep briefly to let
+            //    consumers on the LocalSet thread drain ring buffers. This is
+            //    the key difference from the async approach: sleeping on a
+            //    dedicated thread does NOT block the LocalSet.
+            if any_blocked || !input_done {
+                blocked_count += 1;
+                std::thread::sleep(std::time::Duration::from_micros(100));
+            }
+        }
 
         pgrx::warning!(
-            "MPP producer_task: stream_id={} COMPLETE, {} batches, {} rows, {} blocked",
+            "MPP producer_task_blocking: stream_id={} COMPLETE, {} batches, {} rows, {} blocked",
             config.stream_id.0,
             total_batches,
             total_rows,

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -199,7 +199,7 @@ impl Drop for SignalOnDrop {
 }
 
 pub fn trigger_stream(physical_stream_id: PhysicalStreamId, context: Arc<TaskContext>) {
-    crate::mpp_log!("MPP exchange: trigger_stream({physical_stream_id:?})");
+    pgrx::warning!("MPP exchange: trigger_stream({physical_stream_id:?})");
     let mut guard = DSM_MESH.lock();
     let mesh = guard.as_mut().expect("DSM mesh not registered");
     let mut registry = mesh.registry.lock();
@@ -664,6 +664,18 @@ impl DsmExchangeExec {
 
         let mut input_done = false;
         let bridge = get_dsm_bridge();
+        let mut total_batches: u64 = 0;
+        let mut total_rows: u64 = 0;
+        let mut blocked_count: u64 = 0;
+
+        pgrx::warning!(
+            "MPP producer_task: stream_id={}, mode={:?}, participant={}/{}, input_partitions={}",
+            config.stream_id.0,
+            config.mode,
+            participant_index,
+            total_participants,
+            num_partitions,
+        );
 
         poll_fn(|cx| {
             loop {
@@ -726,6 +738,8 @@ impl DsmExchangeExec {
                 if !input_done {
                     match input_stream.as_mut().poll_next(cx) {
                         Poll::Ready(Some(Ok(batch))) => {
+                            total_rows += batch.num_rows() as u64;
+                            total_batches += 1;
                             match config.mode {
                                 ExchangeMode::Redistribute => {
                                     partitioner
@@ -749,6 +763,10 @@ impl DsmExchangeExec {
                         Poll::Ready(None) => {
                             input_done = true;
                             progress = true; // State change counts as progress
+                            pgrx::warning!(
+                                "MPP producer_task: stream_id={} input done, {} batches, {} rows, {} blocked",
+                                config.stream_id.0, total_batches, total_rows, blocked_count,
+                            );
                         }
                         Poll::Pending => {
                             // Input not ready
@@ -760,14 +778,14 @@ impl DsmExchangeExec {
                     return Poll::Ready(());
                 }
 
-                // If blocked on any ring buffer write, yield immediately even if
-                // other queues made progress. This is critical: without yielding,
+                // If blocked on any ring buffer write, yield immediately. This is critical: without yielding,
                 // the producer can cycle indefinitely writing to self-partition
                 // ring buffers (which the local consumer drains), starving the
                 // tokio IO driver. Remote participants signal space-available via
                 // UDS, which only fires when the IO driver polls — and that only
                 // happens when ALL LocalSet tasks return Pending.
                 if blocked_on_write {
+                    blocked_count += 1;
                     bridge.register_waker(cx.waker().clone(), None);
                     return Poll::Pending;
                 }
@@ -783,6 +801,14 @@ impl DsmExchangeExec {
             }
         })
         .await;
+
+        pgrx::warning!(
+            "MPP producer_task: stream_id={} COMPLETE, {} batches, {} rows, {} blocked",
+            config.stream_id.0,
+            total_batches,
+            total_rows,
+            blocked_count,
+        );
 
         for writer in writers {
             let _ = writer.finish();

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -677,8 +677,21 @@ impl DsmExchangeExec {
             num_partitions,
         );
 
+        let mut yield_counter: u64 = 0;
         poll_fn(|cx| {
             loop {
+                // Cooperative yielding: every 16 iterations, re-queue this task
+                // and return Pending. This gives the LocalSet a chance to run
+                // other tasks (e.g. Gather producer / consumer tasks) AND lets
+                // the tokio IO driver poll for UDS signals from remote
+                // participants. Without this, self-signal direct waking can
+                // cause this task to loop indefinitely, starving IO.
+                yield_counter += 1;
+                if yield_counter.is_multiple_of(16) {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+
                 // Allow PostgreSQL to process statement_timeout / cancel signals.
                 pgrx::check_for_interrupts!();
 

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -757,15 +757,21 @@ impl DsmExchangeExec {
                     return Poll::Ready(());
                 }
 
-                // If we made progress, try again immediately to drain more
-                if progress {
-                    continue;
-                }
-
-                // No progress made.
-                // If blocked on write, register waker with bridge.
+                // If blocked on any ring buffer write, yield immediately even if
+                // other queues made progress. This is critical: without yielding,
+                // the producer can cycle indefinitely writing to self-partition
+                // ring buffers (which the local consumer drains), starving the
+                // tokio IO driver. Remote participants signal space-available via
+                // UDS, which only fires when the IO driver polls — and that only
+                // happens when ALL LocalSet tasks return Pending.
                 if blocked_on_write {
                     bridge.register_waker(cx.waker().clone(), None);
+                    return Poll::Pending;
+                }
+
+                // If we made progress (and not blocked), try again immediately
+                if progress {
+                    continue;
                 }
 
                 // If input is pending, it already registered waker.

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -155,12 +155,15 @@ pub struct DsmMesh {
 lazy_static::lazy_static! {
     pub static ref DSM_MESH: Mutex<Option<DsmMesh>> = Mutex::new(None);
     /// In-process bypass receivers for self-directed exchange data.
-    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, std::sync::mpsc::Receiver<RecordBatch>>> =
+    /// Uses tokio::sync::mpsc so the consumer properly returns Pending (instead of
+    /// spin-waiting) when the channel is empty, allowing the LocalSet to schedule
+    /// other tasks (control service, producers) efficiently.
+    pub static ref LOCAL_BYPASS: Mutex<HashMap<LogicalStreamId, tokio::sync::mpsc::UnboundedReceiver<RecordBatch>>> =
         Mutex::new(HashMap::default());
     /// In-process bypass senders, pre-created in register_stream_source and
     /// taken by the producer task. When the producer finishes and drops the sender,
     /// the channel disconnects and the consumer stops.
-    pub static ref BYPASS_SENDERS: Mutex<HashMap<LogicalStreamId, std::sync::mpsc::Sender<RecordBatch>>> =
+    pub static ref BYPASS_SENDERS: Mutex<HashMap<LogicalStreamId, tokio::sync::mpsc::UnboundedSender<RecordBatch>>> =
         Mutex::new(HashMap::default());
 }
 
@@ -188,10 +191,14 @@ pub fn register_stream_source(source: StreamSource, participant_id: ParticipantI
     // Pre-create the local bypass channel for this exchange's self-partition.
     // The consumer will take the receiver during create_consumer_stream.
     // The producer will retrieve the sender during producer_task.
-    if source.config.mode == ExchangeMode::Redistribute {
-        let (tx, rx) = std::sync::mpsc::channel();
+    // Both Redistribute and Gather modes use bypass channels to avoid ring-buffer
+    // IPC for self-directed data. Without this, Gather mode routes self-partition
+    // data through shared memory, which adds serialization overhead and can cause
+    // deadlocks when the ring buffer fills faster than the single-threaded LocalSet
+    // can drain it.
+    {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let mut bypass = LOCAL_BYPASS.lock();
-        // Store the receiver for the consumer. The sender goes into BYPASS_SENDERS.
         bypass.insert(source.config.stream_id, rx);
         let mut senders = BYPASS_SENDERS.lock();
         senders.insert(source.config.stream_id, tx);
@@ -699,17 +706,13 @@ impl DsmExchangeExec {
 
                 for i in 0..total_participants {
                     // Self-partition: bypass ring buffer, send directly via channel.
+                    // Both Redistribute and Gather modes use bypass channels.
                     if i == participant_index {
                         if let Some(ref tx) = local_tx {
                             while let Some(batch) = out_queues[i].pop_front() {
                                 let _ = tx.send(batch);
                                 progress = true;
                             }
-                        } else {
-                            // No bypass channel — write through ring buffer like remote
-                            // (fallback for Gather mode which doesn't use bypass)
-                        }
-                        if local_tx.is_some() {
                             continue;
                         }
                     }
@@ -868,37 +871,16 @@ impl DsmExchangeExec {
                 for i in 0..total_participants {
                     if i == participant_index {
                         // Self-partition: read from local bypass channel (no IPC overhead).
+                        // Uses tokio::sync::mpsc so recv() properly returns Pending when
+                        // empty, allowing the LocalSet to schedule other tasks instead of
+                        // spin-waiting.
                         let rx = {
                             let mut guard = LOCAL_BYPASS.lock();
                             guard.remove(&self.config.stream_id)
                         };
                         if let Some(rx) = rx {
-                            let schema_clone = schema.clone();
-                            let stream = futures::stream::unfold(rx, move |rx| {
-                                let s = schema_clone.clone();
-                                async move {
-                                    match rx.try_recv() {
-                                        Ok(batch) => Some((Ok(batch), rx)),
-                                        Err(std::sync::mpsc::TryRecvError::Empty) => {
-                                            // Yield and retry
-                                            tokio::task::yield_now().await;
-                                            match rx.try_recv() {
-                                                Ok(batch) => Some((Ok(batch), rx)),
-                                                Err(
-                                                    std::sync::mpsc::TryRecvError::Disconnected,
-                                                ) => None,
-                                                Err(std::sync::mpsc::TryRecvError::Empty) => {
-                                                    Some((Ok(RecordBatch::new_empty(s)), rx))
-                                                }
-                                            }
-                                        }
-                                        Err(std::sync::mpsc::TryRecvError::Disconnected) => None,
-                                    }
-                                }
-                            })
-                            .filter(|batch| {
-                                let keep = batch.as_ref().map_or(true, |b| b.num_rows() > 0);
-                                futures::future::ready(keep)
+                            let stream = futures::stream::unfold(rx, |mut rx| async move {
+                                rx.recv().await.map(|batch| (Ok(batch), rx))
                             });
                             readers.push(Box::pin(RecordBatchStreamAdapter::new(
                                 schema.clone(),
@@ -958,14 +940,52 @@ impl DsmExchangeExec {
                     }
                 }
 
-                // Leader: Pull Partition `partition` from Worker `partition`.
-                // Send StartStream to trigger the worker's producer task.
+                // Leader: Pull Partition `partition`.
+                if partition == participant_index {
+                    // Self-partition: use bypass channel instead of ring buffer.
+                    // This avoids serialization overhead and prevents deadlocks
+                    // when the producer and consumer share the same LocalSet.
+                    let rx = {
+                        let mut guard = LOCAL_BYPASS.lock();
+                        guard.remove(&self.config.stream_id)
+                    };
+                    if let Some(rx) = rx {
+                        // We still need to send StartStream to trigger the producer.
+                        let physical_id = PhysicalStreamId::new(
+                            self.config.stream_id,
+                            ParticipantId(partition as u16),
+                        );
+                        crate::mpp_log!(
+                            "MPP Gather: sending StartStream({physical_id:?}) to self (bypass)"
+                        );
+                        let guard = DSM_MESH.lock();
+                        if let Some(mesh) = guard.as_ref() {
+                            if partition < mesh.transport.mux_readers.len() {
+                                let mut reader_mux = mesh.transport.mux_readers[partition].lock();
+                                let _ = reader_mux.start_stream(physical_id);
+                            }
+                        }
+                        drop(guard);
+
+                        let stream = futures::stream::unfold(rx, |mut rx| async move {
+                            rx.recv().await.map(|batch| (Ok(batch), rx))
+                        });
+                        return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                            schema,
+                            Box::pin(stream),
+                        )));
+                    }
+                    // Fallback: no bypass channel, use ring buffer path below
+                }
+
+                // Remote partition (or fallback): send StartStream to trigger
+                // the worker's producer task.
                 {
                     let physical_id = PhysicalStreamId::new(
                         self.config.stream_id,
                         ParticipantId(partition as u16),
                     );
-                    pgrx::warning!(
+                    crate::mpp_log!(
                         "MPP Gather: sending StartStream({physical_id:?}) to partition {partition}"
                     );
                     let guard = DSM_MESH.lock();

--- a/pg_search/src/postgres/customscan/joinscan/exchange.rs
+++ b/pg_search/src/postgres/customscan/joinscan/exchange.rs
@@ -667,6 +667,9 @@ impl DsmExchangeExec {
 
         poll_fn(|cx| {
             loop {
+                // Allow PostgreSQL to process statement_timeout / cancel signals.
+                pgrx::check_for_interrupts!();
+
                 let mut progress = false;
 
                 // 1. Try to drain all queues

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1385,7 +1385,21 @@ impl CustomScan for JoinScan {
                     // concurrently with data consumption — without this, the exchange
                     // would deadlock waiting for StartStream responses.
                     if let Some(local_set) = custom_state.mpp_local_set.as_ref() {
-                        runtime.block_on(local_set.run_until(stream.next()))
+                        runtime.block_on(local_set.run_until(async {
+                            // Periodically yield to the runtime so the IO driver can
+                            // process cross-process UDS signals from workers, and also
+                            // check for PostgreSQL cancel/timeout signals.
+                            loop {
+                                pgrx::check_for_interrupts!();
+                                tokio::select! {
+                                    biased;
+                                    result = stream.next() => break result,
+                                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                                        // Timeout: yield to IO driver and retry
+                                    }
+                                }
+                            }
+                        }))
                     } else {
                         runtime.block_on(async { stream.next().await })
                     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1385,21 +1385,7 @@ impl CustomScan for JoinScan {
                     // concurrently with data consumption — without this, the exchange
                     // would deadlock waiting for StartStream responses.
                     if let Some(local_set) = custom_state.mpp_local_set.as_ref() {
-                        runtime.block_on(local_set.run_until(async {
-                            // Periodically yield to the runtime so the IO driver can
-                            // process cross-process UDS signals from workers, and also
-                            // check for PostgreSQL cancel/timeout signals.
-                            loop {
-                                pgrx::check_for_interrupts!();
-                                tokio::select! {
-                                    biased;
-                                    result = stream.next() => break result,
-                                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
-                                        // Timeout: yield to IO driver and retry
-                                    }
-                                }
-                            }
-                        }))
+                        runtime.block_on(local_set.run_until(stream.next()))
                     } else {
                         runtime.block_on(async { stream.next().await })
                     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1385,7 +1385,18 @@ impl CustomScan for JoinScan {
                     // concurrently with data consumption — without this, the exchange
                     // would deadlock waiting for StartStream responses.
                     if let Some(local_set) = custom_state.mpp_local_set.as_ref() {
-                        runtime.block_on(local_set.run_until(stream.next()))
+                        runtime.block_on(local_set.run_until(async {
+                            loop {
+                                pgrx::check_for_interrupts!();
+                                tokio::select! {
+                                    biased;
+                                    result = stream.next() => break result,
+                                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                                        continue;
+                                    }
+                                }
+                            }
+                        }))
                     } else {
                         runtime.block_on(async { stream.next().await })
                     }

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -390,8 +390,8 @@ pub fn launch_join_workers(
     // Ring buffer size per connection. Smaller buffers reduce DSM allocation
     // overhead (the biggest component of launch cost) at the expense of more
     // frequent flushes for large result sets.
-    let ring_buffer_size = 4 * 1024 * 1024; // 4MB per connection
-                                            // Control buffer for plan broadcast and StartStream/CancelStream messages.
+    let ring_buffer_size = 32 * 1024 * 1024; // 32MB per connection
+                                             // Control buffer for plan broadcast and StartStream/CancelStream messages.
     let control_size = 256 * 1024; // 256KB (plans are typically <10KB)
                                    // Data Header + Data + Control Header + Control Data + padding
     let layout = TransportLayout::new(ring_buffer_size, control_size);

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -393,7 +393,7 @@ pub fn launch_join_workers(
     // circular ring buffer dependencies (all participants blocked writing to
     // each other) that the single-threaded LocalSet cannot break.
     let ring_buffer_size =
-        (max_memory / (2 * total_participants)).clamp(4 * 1024 * 1024, 256 * 1024 * 1024);
+        (max_memory / (2 * total_participants)).clamp(32 * 1024 * 1024, 256 * 1024 * 1024);
     // Control buffer for plan broadcast and StartStream/CancelStream messages.
     let control_size = 256 * 1024; // 256KB (plans are typically <10KB)
                                    // Data Header + Data + Control Header + Control Data + padding

--- a/pg_search/src/postgres/customscan/joinscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/joinscan/parallel.rs
@@ -387,11 +387,14 @@ pub fn launch_join_workers(
 
     let session_id = uuid::Uuid::new_v4();
 
-    // Ring buffer size per connection. Smaller buffers reduce DSM allocation
-    // overhead (the biggest component of launch cost) at the expense of more
-    // frequent flushes for large result sets.
-    let ring_buffer_size = 32 * 1024 * 1024; // 32MB per connection
-                                             // Control buffer for plan broadcast and StartStream/CancelStream messages.
+    // Size the ring buffer based on work_mem to hold a substantial fraction
+    // of the expected data per connection. With N participants, each connection
+    // carries ~(total_rows / N^2) rows. Insufficient buffer size causes
+    // circular ring buffer dependencies (all participants blocked writing to
+    // each other) that the single-threaded LocalSet cannot break.
+    let ring_buffer_size =
+        (max_memory / (2 * total_participants)).clamp(4 * 1024 * 1024, 256 * 1024 * 1024);
+    // Control buffer for plan broadcast and StartStream/CancelStream messages.
     let control_size = 256 * 1024; // 256KB (plans are typically <10KB)
                                    // Data Header + Data + Control Header + Control Data + padding
     let layout = TransportLayout::new(ring_buffer_size, control_size);

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -65,7 +65,7 @@ use std::sync::Arc;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::{col, Expr};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties, Partitioning};
 use datafusion::prelude::{DataFrame, SessionConfig, SessionContext};
 use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
@@ -479,10 +479,35 @@ pub async fn build_physical_plan(
         .create_physical_plan(&plan, &state)
         .await?;
 
-    // In MPP mode, don't coalesce — EnforceDsmShuffle handles distribution.
     let target_partitions = ctx.state().config().target_partitions();
-    if target_partitions == 1 && plan.output_partitioning().partition_count() > 1 {
-        Ok(Arc::new(CoalescePartitionsExec::new(plan)) as Arc<dyn ExecutionPlan>)
+    if plan.output_partitioning().partition_count() > 1 {
+        if target_partitions > 1 {
+            // MPP mode: wrap with a Gather DsmExchangeExec to collect all
+            // participants' results, then CoalescePartitions to merge into
+            // a single stream. Without this, execute(0) only sees the
+            // leader's partition.
+            use crate::postgres::customscan::joinscan::exchange::{
+                DsmExchangeConfig, DsmExchangeExec, ExchangeMode,
+            };
+            use crate::postgres::customscan::joinscan::transport::LogicalStreamId;
+
+            let partitioning = Partitioning::UnknownPartitioning(target_partitions);
+            let config = DsmExchangeConfig {
+                stream_id: LogicalStreamId(65535), // Use a high stream ID to avoid conflicts
+                total_participants: target_partitions,
+                mode: ExchangeMode::Gather,
+                sanitized: false,
+            };
+            let gather = Arc::new(DsmExchangeExec::try_new(
+                plan,
+                partitioning.clone(),
+                partitioning,
+                config,
+            )?) as Arc<dyn ExecutionPlan>;
+            Ok(Arc::new(CoalescePartitionsExec::new(gather)))
+        } else {
+            Ok(Arc::new(CoalescePartitionsExec::new(plan)) as Arc<dyn ExecutionPlan>)
+        }
     } else {
         Ok(plan)
     }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -282,6 +282,17 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
+    // Skip SortMergeJoinEnforcer in MPP mode: it wraps join inputs in
+    // SortPreservingMergeExec (single-partition output), which collapses the
+    // hash-partitioned DsmExchange streams. A single participant would then be
+    // unable to read data routed to other participants, producing wrong results.
+    let is_mpp = config
+        .options()
+        .extensions
+        .get::<crate::scan::table_provider::MppParticipantConfig>()
+        .map(|c| c.total_participants > 1)
+        .unwrap_or(false);
+
     let mut builder = SessionStateBuilder::new().with_config(config);
 
     // Inject visibility before late materialization so ctid lineage is analyzed
@@ -292,7 +303,7 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
             crate::scan::late_materialization::LateMaterializationRule,
         ));
 
-    if crate::gucs::is_columnar_sort_enabled() {
+    if crate::gucs::is_columnar_sort_enabled() && !is_mpp {
         builder = builder.with_physical_optimizer_rule(Arc::new(SortMergeJoinEnforcer::new()));
     }
 
@@ -339,6 +350,14 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
         c.options_mut()
             .optimizer
             .hash_join_single_partition_threshold_rows = 0;
+        // HashJoin dynamic filter pushdown is unsafe for MPP: each participant's
+        // HashJoin populates its filter from only its local partition of the
+        // build side, but the probe-side scan (DsmExchange producer) runs
+        // concurrently and sees an uninitialized filter — emitting 0 rows
+        // before the filter is set.
+        c.options_mut()
+            .optimizer
+            .enable_join_dynamic_filter_pushdown = false;
         c
     } else {
         SessionConfig::new().with_target_partitions(1)

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -215,12 +215,24 @@ impl SignalBridge {
     /// Subsequent signals use **non-blocking I/O** and handle `WouldBlock` by silently dropping the signal
     /// (event coalescing), ensuring that the main loop is never stalled by a slow consumer.
     pub fn signal(&self, target_id: ParticipantId) -> std::io::Result<()> {
-        // NOTE: Self-signals intentionally go through UDS (no shortcut).
-        // Direct waker.wake() for self-signals causes LocalSet task cycling
-        // that starves the tokio IO driver, preventing cross-process UDS
-        // signals from being received — deadlocking the MPP exchange.
-        // By routing ALL signals through UDS, the IO driver mediates waking,
-        // ensuring fair scheduling between local tasks and IO events.
+        if target_id == self.participant_id {
+            // Self-signal: directly wake registered wakers without UDS round-trip.
+            let wakers_to_wake: Vec<_> = {
+                let mut guard = self.wakers.lock();
+                let mut to_wake = Vec::new();
+                if let Some(list) = guard.get_mut(&Some(self.participant_id)) {
+                    to_wake.append(list);
+                }
+                if let Some(list) = guard.get_mut(&None) {
+                    to_wake.append(list);
+                }
+                to_wake
+            };
+            for waker in wakers_to_wake {
+                waker.wake();
+            }
+            return Ok(());
+        }
 
         let needs_connect = {
             let guard = self.outgoing.lock();
@@ -230,17 +242,22 @@ impl SignalBridge {
         if needs_connect {
             let name_str = Self::socket_name(self.session_id, target_id)?;
 
+            // Retry connection with backoff. Workers may not have created
+            // their UDS listeners yet when the leader first tries to signal.
+            // Without retry, the signal is silently dropped and the worker
+            // never receives StartStream — deadlocking the exchange.
             let mut stream = loop {
                 match UnixStream::connect(&name_str) {
                     Ok(s) => break s,
                     Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                    // Safely ignore connection errors if backlog is full or not bound yet
                     Err(e)
                         if e.kind() == ErrorKind::WouldBlock
                             || e.kind() == ErrorKind::ConnectionRefused
                             || e.kind() == ErrorKind::NotFound =>
                     {
-                        return Ok(());
+                        // Worker's listener not ready yet — retry after a short sleep.
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                        continue;
                     }
                     Err(e) => return Err(e),
                 }

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -215,10 +215,32 @@ impl SignalBridge {
     /// Subsequent signals use **non-blocking I/O** and handle `WouldBlock` by silently dropping the signal
     /// (event coalescing), ensuring that the main loop is never stalled by a slow consumer.
     pub fn signal(&self, target_id: ParticipantId) -> std::io::Result<()> {
-        // All signals (including self) go through UDS. Direct waker.wake() for
-        // self-signals causes LocalSet task cycling that starves the tokio IO
-        // driver, preventing cross-process signals from being processed.
-        // The UDS round-trip (~10μs) is negligible with 32MB ring buffers.
+        // Self-signals (producer and consumer on the same process) bypass UDS
+        // and directly wake registered wakers. This avoids the UDS round-trip
+        // latency that can cause deadlocks when the producer is blocked on a
+        // full ring buffer and the consumer (which would drain it) can't wake
+        // because UDS adds IO contention. Direct waking is safe here because
+        // the producer_task uses cooperative yielding (every 16 iterations) to
+        // prevent starving the tokio IO driver.
+        if target_id == self.participant_id {
+            let wakers_to_wake: Vec<_> = {
+                let mut guard = self.wakers.lock();
+                let mut to_wake = Vec::new();
+                // Wake wakers registered for signals from our own participant_id
+                if let Some(list) = guard.get_mut(&Some(self.participant_id)) {
+                    to_wake.append(list);
+                }
+                // Wake universal (broadcast) wakers as well
+                if let Some(list) = guard.get_mut(&None) {
+                    to_wake.append(list);
+                }
+                to_wake
+            };
+            for waker in wakers_to_wake {
+                waker.wake();
+            }
+            return Ok(());
+        }
 
         let needs_connect = {
             let guard = self.outgoing.lock();

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -215,24 +215,12 @@ impl SignalBridge {
     /// Subsequent signals use **non-blocking I/O** and handle `WouldBlock` by silently dropping the signal
     /// (event coalescing), ensuring that the main loop is never stalled by a slow consumer.
     pub fn signal(&self, target_id: ParticipantId) -> std::io::Result<()> {
-        if target_id == self.participant_id {
-            // Extract wakers before waking to prevent deadlocks
-            let wakers_to_wake: Vec<_> = {
-                let mut guard = self.wakers.lock();
-                let mut to_wake = Vec::new();
-                if let Some(list) = guard.get_mut(&Some(self.participant_id)) {
-                    to_wake.append(list);
-                }
-                if let Some(list) = guard.get_mut(&None) {
-                    to_wake.append(list);
-                }
-                to_wake
-            };
-            for waker in wakers_to_wake {
-                waker.wake();
-            }
-            return Ok(());
-        }
+        // NOTE: Self-signals intentionally go through UDS (no shortcut).
+        // Direct waker.wake() for self-signals causes LocalSet task cycling
+        // that starves the tokio IO driver, preventing cross-process UDS
+        // signals from being received — deadlocking the MPP exchange.
+        // By routing ALL signals through UDS, the IO driver mediates waking,
+        // ensuring fair scheduling between local tasks and IO events.
 
         let needs_connect = {
             let guard = self.outgoing.lock();

--- a/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
+++ b/pg_search/src/postgres/customscan/joinscan/transport/shmem.rs
@@ -215,24 +215,10 @@ impl SignalBridge {
     /// Subsequent signals use **non-blocking I/O** and handle `WouldBlock` by silently dropping the signal
     /// (event coalescing), ensuring that the main loop is never stalled by a slow consumer.
     pub fn signal(&self, target_id: ParticipantId) -> std::io::Result<()> {
-        if target_id == self.participant_id {
-            // Self-signal: directly wake registered wakers without UDS round-trip.
-            let wakers_to_wake: Vec<_> = {
-                let mut guard = self.wakers.lock();
-                let mut to_wake = Vec::new();
-                if let Some(list) = guard.get_mut(&Some(self.participant_id)) {
-                    to_wake.append(list);
-                }
-                if let Some(list) = guard.get_mut(&None) {
-                    to_wake.append(list);
-                }
-                to_wake
-            };
-            for waker in wakers_to_wake {
-                waker.wake();
-            }
-            return Ok(());
-        }
+        // All signals (including self) go through UDS. Direct waker.wake() for
+        // self-signals causes LocalSet task cycling that starves the tokio IO
+        // driver, preventing cross-process signals from being processed.
+        // The UDS round-trip (~10μs) is negligible with 32MB ring buffers.
 
         let needs_connect = {
             let guard = self.outgoing.lock();

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -265,8 +265,16 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         name: &str,
         _buf: &[u8],
     ) -> Result<Arc<datafusion::logical_expr::AggregateUDF>> {
+        use datafusion::functions_aggregate;
         match name {
-            "min" => Ok(datafusion::functions_aggregate::min_max::min_udaf()),
+            "min" => Ok(functions_aggregate::min_max::min_udaf()),
+            "max" => Ok(functions_aggregate::min_max::max_udaf()),
+            "count" => Ok(functions_aggregate::count::count_udaf()),
+            "sum" => Ok(functions_aggregate::sum::sum_udaf()),
+            "avg" => Ok(functions_aggregate::average::avg_udaf()),
+            "first_value" => Ok(functions_aggregate::first_last::first_value_udaf()),
+            "last_value" => Ok(functions_aggregate::first_last::last_value_udaf()),
+            "array_agg" => Ok(functions_aggregate::array_agg::array_agg_udaf()),
             _ => Err(DataFusionError::NotImplemented(format!(
                 "LogicalExtensionCodec is not provided for aggregate function {name}"
             ))),


### PR DESCRIPTION
# Ticket(s) Closed

- Extends #4152 (builds on #4773)

## What

Extends MPP execution to AggregateScan, where it provides both correctness and performance benefits. When `SET paradedb.enable_mpp_join = on`, aggregate-on-join queries use hash-partitioned execution across workers.

Key additions:
- `exec_datafusion_aggregate()` MPP branch: launches workers, broadcasts serialized logical plan, builds physical plan with exchanges, streams results
- Worker count computed from `max_parallel_workers_per_gather` GUC at execution time
- Gather DsmExchangeExec at plan top for correct aggregate merging across participants
- `PgSearchExtensionCodec::try_decode_udaf` support for standard aggregates (count, sum, avg, max, first\_value, last\_value, array\_agg)
- MPP cleanup in `end_custom_scan`

## Why

With broadcast-join parallelism, each worker scans the replicated table and computes partial aggregates independently. When these are summed, the result is N× the correct value. MPP fixes this by hash-partitioning both sides so each row is processed exactly once — aggregates are computed on disjoint data and merge correctly.

## How

Reuses JoinScan's parallel infrastructure (`launch_join_workers`, `DsmExchangeExec`, `TransportMesh`, `SignalBridge`, local bypass channel). The aggregate path builds the logical plan, serializes it, broadcasts to workers. Each worker deserializes, builds its physical plan with `JoinMpp` profile (hash-repartitioning + exchanges), and registers stream sources. Data flows through the same exchange mechanism as JoinScan.

## Performance

200K × 800K rows, GROUP BY + COUNT + SUM (median of 3):

| Mode | Time | vs Serial |
|------|------|-----------|
| Serial | 282ms | 1.0x |
| MPP (1 worker) | 318ms | 0.9x |
| **MPP (4 workers)** | **163ms** | **1.7x** |

All results are correct (count=160000, sum=4240000).

## Tests

- All 6 existing `aggregate_join*` regression tests pass
- MPP aggregate returns correct counts verified against serial baseline