### PR TITLE
fix: Scrub __PDB_NULL__ Sentinel from JSON Output of pdb.agg

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -549,6 +549,34 @@ pub fn execute_aggregate(
 pub const NULL_SENTINEL_MIN: &str = "\u{0000}\u{0000}\u{0000}\u{0000}__PDB_NULL__"; // Sorts BEFORE other strings
 pub const NULL_SENTINEL_MAX: &str = "\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}__PDB_NULL__"; // Sorts AFTER other strings (max Unicode codepoint)
 
+pub fn scrub_null_sentinels(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys_to_nullify = Vec::new();
+            for (k, v) in map.iter() {
+                if k.contains("__PDB_NULL__") {
+                    keys_to_nullify.push(k.to_string());
+                }
+                scrub_null_sentinels(v);
+            }
+            for k in keys_to_nullify {
+                map.insert(k, serde_json::Value::Null);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                scrub_null_sentinels(v);
+            }
+        }
+        serde_json::Value::String(s) => {
+            if s.contains("__PDB_NULL__") {
+                *value = serde_json::Value::Null;
+            }
+        }
+        _ => {}
+    }
+}
+
 // recursively set a `missing` bucket on all terms aggregations so NULL values produce a group
 fn set_missing_on_terms(
     aggs: &mut Aggregations,

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -553,7 +553,7 @@ pub fn scrub_null_sentinels(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
             let mut keys_to_nullify = Vec::new();
-            for (k, v) in map.iter() {
+            for (k, v) in map.iter_mut() {
                 if k.contains("__PDB_NULL__") {
                     keys_to_nullify.push(k.to_string());
                 }

--- a/pg_search/src/api/aggregate.rs
+++ b/pg_search/src/api/aggregate.rs
@@ -54,7 +54,7 @@ use std::error::Error;
 use pgrx::{default, pg_extern, Json, JsonB, PgRelation};
 use serde::{Deserialize, Serialize};
 
-use crate::aggregate::{execute_aggregate, AggregateRequest};
+use crate::aggregate::{execute_aggregate, scrub_null_sentinels, AggregateRequest};
 use crate::gucs;
 use crate::postgres::customscan::aggregatescan::aggregate_type::validate_agg_json_fields;
 use crate::postgres::rel::PgSearchRelation;
@@ -106,7 +106,9 @@ fn aggregate_impl(
     if aggregate.0.is_empty() {
         Ok(JsonB(serde_json::Value::Null))
     } else {
-        Ok(JsonB(serde_json::to_value(aggregate)?))
+        let mut val = serde_json::to_value(aggregate)?;
+        scrub_null_sentinels(&mut val);
+        Ok(JsonB(val))
     }
 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -17,7 +17,7 @@
 
 use crate::gucs;
 
-use crate::aggregate::{execute_aggregate, AggregateRequest};
+use crate::aggregate::{execute_aggregate, scrub_null_sentinels, AggregateRequest};
 use crate::api::HashMap;
 use crate::customscan::aggregatescan::build::{
     AggregationKey, DocCountKey, FilterSentinelKey, GroupedKey,
@@ -35,6 +35,13 @@ use tantivy::aggregation::agg_result::{
 use tantivy::aggregation::metric::SingleMetricResult as TantivySingleMetricResult;
 use tantivy::aggregation::Key;
 use tantivy::schema::OwnedValue;
+
+fn to_json_value_scrubbed<T: serde::Serialize + ?Sized>(val: &T) -> serde_json::Value {
+    let mut v = serde_json::to_value(val)
+        .unwrap_or_else(|e| pgrx::error!("Failed to serialize aggregate: {}", e));
+    scrub_null_sentinels(&mut v);
+    v
+}
 
 /// Unified result type for aggregates
 /// Can hold either a standard metric (f64) or a custom aggregate (JSON)
@@ -157,8 +164,7 @@ impl From<MetricResult> for AggregateResult {
             | TantivyMetricResult::Max(r) => AggregateResult::Metric(r),
             // Complex metrics (Stats, Percentiles, etc.) - serialize to JSON
             other => {
-                let json_value = serde_json::to_value(&other)
-                    .unwrap_or_else(|e| pgrx::error!("Failed to serialize metric: {}", e));
+                let json_value = to_json_value_scrubbed(&other);
                 AggregateResult::Json(json_value)
             }
         }
@@ -187,10 +193,7 @@ pub fn aggregate_result_to_datum(
             // If expected type is JSONB (for pdb.agg() custom aggregates),
             // serialize the entire metric result to match Tantivy's JSON format
             if expected_typoid == pg_sys::JSONBOID {
-                // Serialize the SingleMetricResult to JSON
-                let json_value = serde_json::to_value(&metric).unwrap_or_else(|e| {
-                    pgrx::error!("Failed to serialize metric result to JSON: {}", e)
-                });
+                let json_value = to_json_value_scrubbed(&metric);
                 JsonB(json_value).into_datum()
             } else if is_datetime_type(expected_typoid) {
                 // For date/time types, Tantivy stores DateTime values in fast fields as nanoseconds
@@ -366,9 +369,7 @@ impl AggregationResults {
                             .push(Some(MetricResult(metric.clone()).into()));
                     }
                     other => {
-                        let json_value = serde_json::to_value(other).unwrap_or_else(|e| {
-                            pgrx::error!("Failed to serialize aggregate: {}", e)
-                        });
+                        let json_value = to_json_value_scrubbed(other);
                         row.aggregates.push(Some(AggregateResult::Json(json_value)));
                     }
                 }
@@ -415,8 +416,7 @@ impl AggregationResults {
                 // For all other results (custom aggregates and other bucket types), serialize as JSON
                 // For custom aggregates (pdb.agg), this preserves all nested aggregations
                 other => {
-                    let json_value = serde_json::to_value(&other)
-                        .unwrap_or_else(|e| pgrx::error!("Failed to serialize aggregate: {}", e));
+                    let json_value = to_json_value_scrubbed(&other);
                     aggregates.push(Some(AggregateResult::Json(json_value)));
                 }
             }
@@ -527,10 +527,7 @@ impl AggregationResults {
                                     found_metrics.push(Some(MetricResult(metric.clone()).into()));
                                 }
                                 other => {
-                                    let json_value =
-                                        serde_json::to_value(other).unwrap_or_else(|e| {
-                                            pgrx::error!("Failed to serialize aggregate: {}", e)
-                                        });
+                                    let json_value = to_json_value_scrubbed(other);
                                     found_metrics.push(Some(AggregateResult::Json(json_value)));
                                 }
                             }

--- a/pg_search/tests/pg_regress/expected/agg-bool-terms.out
+++ b/pg_search/tests/pg_regress/expected/agg-bool-terms.out
@@ -114,7 +114,7 @@ FROM docs_nullable
 WHERE body @@@ pdb.all();
                                                                                                               agg                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": "__PDB_NULL__", "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+ {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
 (1 row)
 
 DROP TABLE docs_nullable CASCADE;


### PR DESCRIPTION
## Summary

Closes #4585

Follow-up to #4582 — the `__PDB_NULL__` sentinel strings used internally for grouping NULL values in Tantivy terms aggregations were leaking into user-visible JSON output from `pdb.agg()`.

## What

- Added `scrub_null_sentinels()` helper in `pg_search/src/aggregate/mod.rs` that recursively walks `serde_json::Value` and replaces any string (or object key) containing `__PDB_NULL__` with proper JSON `null`
- Applied scrubbing at the JSON serialization boundary in `pg_search/src/api/aggregate.rs` (direct `pdb.agg` API path)
- Applied scrubbing in `pg_search/src/postgres/customscan/aggregatescan/exec.rs` (custom scan `pdb.agg` path) via a `to_json_value_scrubbed` helper
- Updated expected test output: `"key": "__PDB_NULL__"` → `"key": null`

## Why

The internal `NULL_SENTINEL_MIN`/`NULL_SENTINEL_MAX` strings serve a valid purpose in Tantivy's terms aggregation (sorting NULL groups correctly), but they should not be exposed to users in JSON output. Users expect standard JSON `null`.

## How

The scrubbing happens post-serialization — the Tantivy aggregation internals remain unchanged, and only the final JSON output is cleaned before returning to PostgreSQL.

## Files Changed

- `pg_search/src/aggregate/mod.rs` — new `scrub_null_sentinels()` function
- `pg_search/src/api/aggregate.rs` — apply scrubbing in `aggregate_impl`
- `pg_search/src/postgres/customscan/aggregatescan/exec.rs` — apply scrubbing via `to_json_value_scrubbed` helper at all JSON serialization points
- `pg_search/tests/pg_regress/expected/agg-bool-terms.out` — updated expected output

## Tests

Updated existing regression test `agg-bool-terms` expected output to expect `null` instead of `"__PDB_NULL__"`.