### PR TITLE
chore: Refactor exit/failure pattern in benchmark cli to use Result instead of exit()

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::{bail, Context};
 use clap::{Parser, Subcommand};
 use paradedb::median;
 use paradedb::micro_benchmarks::benchmark_columnar;
@@ -143,23 +144,22 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Benchmark { mode } => run_benchmark(mode).await,
-        Commands::Convert(args) => convert::run_convert(args)?,
-        Commands::Sample(args) => sample::run_sample(args)?,
+        Commands::Convert(args) => convert::run_convert(args),
+        Commands::Sample(args) => sample::run_sample(args),
     }
-    Ok(())
 }
 
-async fn run_benchmark(mode: BenchmarkMode) {
+async fn run_benchmark(mode: BenchmarkMode) -> anyhow::Result<()> {
     match mode {
         BenchmarkMode::Generated(args) => run_benchmark_generated(args).await,
         BenchmarkMode::Existing(args) => run_benchmark_existing(args).await,
     }
 }
 
-async fn run_benchmark_generated(args: GeneratedArgs) {
+async fn run_benchmark_generated(args: GeneratedArgs) -> anyhow::Result<()> {
     let common = &args.common;
     if common.benchmark == "fastfields" {
-        let mut conn = PgConnection::connect(&common.url).await.unwrap();
+        let mut conn = PgConnection::connect(&common.url).await?;
         let res = benchmark_columnar(
             &mut conn,
             common.skip_setup,
@@ -172,21 +172,20 @@ async fn run_benchmark_generated(args: GeneratedArgs) {
         println!("Columnar Benchmark Completed: {res:?}");
     } else if common.benchmark == "sql" {
         if !common.skip_setup {
-            generate_test_data(&common.url, &common.dataset, args.rows);
+            generate_test_data(&common.url, &common.dataset, args.rows)?
         }
         let rows_display = args.rows.to_string();
-        run_sql_benchmarks(common, &rows_display).await;
+        run_sql_benchmarks(common, &rows_display).await?
     } else {
-        eprintln!("Invalid benchmark type");
-        std::process::exit(1);
+        bail!("Invalid benchmark type");
     }
+    Ok(())
 }
 
-async fn run_benchmark_existing(args: ExistingArgs) {
+async fn run_benchmark_existing(args: ExistingArgs) -> anyhow::Result<()> {
     let common = &args.common;
     if common.benchmark == "fastfields" {
-        eprintln!("Fastfields benchmark is not supported with existing datasets");
-        std::process::exit(1);
+        bail!("Fastfields benchmark is not supported with existing datasets");
     } else if common.benchmark == "sql" {
         if !common.skip_setup {
             load_external_data(
@@ -194,16 +193,16 @@ async fn run_benchmark_existing(args: ExistingArgs) {
                 &common.dataset,
                 &args.size,
                 args.data_source.as_deref(),
-            );
+            )?;
         }
-        run_sql_benchmarks(common, &args.size).await;
+        run_sql_benchmarks(common, &args.size).await?
     } else {
-        eprintln!("Invalid benchmark type");
-        std::process::exit(1);
+        bail!("Invalid benchmark type");
     }
+    Ok(())
 }
 
-async fn run_sql_benchmarks(args: &CommonBenchmarkArgs, rows_display: &str) {
+async fn run_sql_benchmarks(args: &CommonBenchmarkArgs, rows_display: &str) -> anyhow::Result<()> {
     match args.output.as_str() {
         "md" => generate_markdown_output(args, rows_display).await,
         "csv" => generate_csv_output(args, rows_display).await,
@@ -252,10 +251,12 @@ impl From<QueryResult> for JSONBenchmarkResult {
     }
 }
 
-async fn process_index_creation(args: &CommonBenchmarkArgs) -> Vec<IndexCreationResult> {
+async fn process_index_creation(
+    args: &CommonBenchmarkArgs,
+) -> anyhow::Result<Vec<IndexCreationResult>> {
     let mut conn = PgConnection::connect(&args.url)
         .await
-        .expect("Failed to connect to database");
+        .with_context(|| "Failed to connect to database")?;
     let index_sql = format!("datasets/{}/create_index/{}.sql", args.dataset, args.r#type);
     let mut results = Vec::new();
 
@@ -266,7 +267,7 @@ async fn process_index_creation(args: &CommonBenchmarkArgs) -> Vec<IndexCreation
         sqlx::query(&statement)
             .execute(&mut conn)
             .await
-            .expect("Failed to execute index creation SQL");
+            .with_context(|| "Failed to execute index creation SQL")?;
         let duration_min_ms = start.elapsed().as_secs_f64() / 60.0;
 
         let index_name = extract_index_name(&statement).to_owned();
@@ -276,7 +277,7 @@ async fn process_index_creation(args: &CommonBenchmarkArgs) -> Vec<IndexCreation
         ))
         .fetch_one(&mut conn)
         .await
-        .expect("Failed to get index size");
+        .with_context(|| "Failed to get index size")?;
         let index_size: i64 = row.get(0);
 
         let row = sqlx::query(&format!(
@@ -284,7 +285,7 @@ async fn process_index_creation(args: &CommonBenchmarkArgs) -> Vec<IndexCreation
         ))
         .fetch_one(&mut conn)
         .await
-        .expect("Failed to get segment count");
+        .with_context(|| "Failed to get segment count")?;
         let segment_count: i64 = row.get(0);
 
         results.push(IndexCreationResult {
@@ -295,23 +296,23 @@ async fn process_index_creation(args: &CommonBenchmarkArgs) -> Vec<IndexCreation
         });
     }
 
-    results
+    Ok(results)
 }
 
-async fn run_benchmarks(args: &CommonBenchmarkArgs) -> Vec<QueryResult> {
+async fn run_benchmarks(args: &CommonBenchmarkArgs) -> anyhow::Result<Vec<QueryResult>> {
     let mut utility_conn = PgConnection::connect(&args.url)
         .await
-        .expect("Failed to connect to database");
+        .with_context(|| "Failed to connect to database")?;
 
     if args.vacuum {
         sqlx::query("VACUUM ANALYZE")
             .execute(&mut utility_conn)
             .await
-            .expect("Failed to vacuum");
+            .with_context(|| "Failed to vacuum")?;
     }
 
     if args.prewarm {
-        prewarm_indexes(&mut utility_conn, &args.dataset, &args.r#type).await;
+        prewarm_indexes(&mut utility_conn, &args.dataset, &args.r#type).await?;
     }
 
     if let Err(err) = ensure_pg_buffercache_extension(&mut utility_conn).await {
@@ -320,19 +321,20 @@ async fn run_benchmarks(args: &CommonBenchmarkArgs) -> Vec<QueryResult> {
 
     // Locate all query paths, and sort them for stability in the output.
     let queries_dir = format!("datasets/{}/queries/{}", args.dataset, args.r#type);
-    let mut query_paths = std::fs::read_dir(queries_dir)
-        .expect("Failed to read queries directory")
-        .flat_map(|entry| {
-            let entry = entry.expect("Failed to read directory entry");
+    let query_paths: anyhow::Result<Vec<Option<_>>> = std::fs::read_dir(queries_dir)
+        .with_context(|| "Failed to read queries directory")?
+        .map(|entry| {
+            let entry = entry.with_context(|| "Failed to read directory entry")?;
             let path = entry.path();
 
             if path.extension().and_then(|s| s.to_str()) != Some("sql") {
                 // Not a query file.
-                return None;
+                return Ok(None);
             }
-            Some(path)
+            Ok(Some(path))
         })
-        .collect::<Vec<_>>();
+        .collect();
+    let mut query_paths: Vec<_> = query_paths?.into_iter().flatten().collect();
     query_paths.sort_unstable();
 
     let mut results = Vec::new();
@@ -351,7 +353,7 @@ async fn run_benchmarks(args: &CommonBenchmarkArgs) -> Vec<QueryResult> {
                 args.runs,
                 args.fail_on_error,
             )
-            .await;
+            .await?;
             match result {
                 Some((runtimes_ms, num_results)) => {
                     println!("Results: {runtimes_ms:?} | Rows Returned: {num_results}\n");
@@ -369,68 +371,79 @@ async fn run_benchmarks(args: &CommonBenchmarkArgs) -> Vec<QueryResult> {
         }
     }
 
-    results
+    Ok(results)
 }
 
-async fn generate_markdown_output(args: &CommonBenchmarkArgs, rows_display: &str) {
+async fn generate_markdown_output(
+    args: &CommonBenchmarkArgs,
+    rows_display: &str,
+) -> anyhow::Result<()> {
     let output_file = format!("results_{}.md", args.r#type);
-    let mut file = File::create(&output_file).expect("Failed to create output file");
+    let mut file = File::create(&output_file).with_context(|| "Failed to create output file")?;
 
-    write_benchmark_header(&mut file);
-    write_test_info(&mut file, args, rows_display).await;
-    write_postgres_settings(&mut file, &args.url).await;
+    write_benchmark_header(&mut file)?;
+    write_test_info(&mut file, args, rows_display).await?;
+    write_postgres_settings(&mut file, &args.url).await?;
     if !args.skip_setup {
-        process_index_creation_md(&mut file, args).await;
+        process_index_creation_md(&mut file, args).await?;
     }
-    run_benchmarks_md(&mut file, args).await;
+    run_benchmarks_md(&mut file, args).await?;
+    Ok(())
 }
 
-async fn generate_csv_output(args: &CommonBenchmarkArgs, rows_display: &str) {
-    write_test_info_csv(args, rows_display).await;
-    write_postgres_settings_csv(&args.url, &args.r#type).await;
+async fn generate_csv_output(args: &CommonBenchmarkArgs, rows_display: &str) -> anyhow::Result<()> {
+    write_test_info_csv(args, rows_display).await?;
+    write_postgres_settings_csv(&args.url, &args.r#type).await?;
     if !args.skip_setup {
-        process_index_creation_csv(args).await;
+        process_index_creation_csv(args).await?;
     }
-    run_benchmarks_csv(args).await;
+    run_benchmarks_csv(args).await?;
+    Ok(())
 }
 
-async fn generate_json_output(args: &CommonBenchmarkArgs, _rows_display: &str) {
+async fn generate_json_output(
+    args: &CommonBenchmarkArgs,
+    _rows_display: &str,
+) -> anyhow::Result<()> {
     if !args.skip_setup {
-        process_index_creation_json(args).await;
+        process_index_creation_json(args).await?;
     }
-    run_benchmarks_json(args).await;
+    run_benchmarks_json(args).await?;
+    Ok(())
 }
 
-async fn write_test_info_csv(args: &CommonBenchmarkArgs, rows_display: &str) {
+async fn write_test_info_csv(args: &CommonBenchmarkArgs, rows_display: &str) -> anyhow::Result<()> {
     let filename = format!("results_{}_test_info.csv", args.r#type);
-    let mut file = File::create(&filename).expect("Failed to create test info CSV");
+    let mut file = File::create(&filename).with_context(|| "Failed to create test info CSV")?;
 
     writeln!(file, "Key,Value").unwrap();
-    writeln!(file, "Dataset Size,{rows_display}").unwrap();
-    writeln!(file, "Test Type,{}", args.r#type).unwrap();
-    writeln!(file, "Prewarm,{}", args.prewarm).unwrap();
-    writeln!(file, "Vacuum,{}", args.vacuum).unwrap();
+    writeln!(file, "Dataset Size,{rows_display}")?;
+    writeln!(file, "Test Type,{}", args.r#type)?;
+    writeln!(file, "Prewarm,{}", args.prewarm)?;
+    writeln!(file, "Vacuum,{}", args.vacuum)?;
 
     if args.r#type == "pg_search" {
         let mut conn = PgConnection::connect(&args.url)
             .await
-            .expect("Failed to connect to database for version info");
+            .with_context(|| "Failed to connect to database for version info")?;
         let row = sqlx::query("SELECT version, githash, build_mode FROM paradedb.version_info()")
             .fetch_one(&mut conn)
             .await
-            .expect("Failed to fetch paradedb.version_info()");
+            .with_context(|| "Failed to fetch paradedb.version_info()")?;
         let version: String = row.get(0);
         let githash: String = row.get(1);
         let build_mode: String = row.get(2);
-        writeln!(file, "pg_search Version,{version}").unwrap();
-        writeln!(file, "pg_search Git Hash,{githash}").unwrap();
-        writeln!(file, "pg_search Build Mode,{build_mode}").unwrap();
+        writeln!(file, "pg_search Version,{version}")?;
+        writeln!(file, "pg_search Git Hash,{githash}")?;
+        writeln!(file, "pg_search Build Mode,{build_mode}")?;
     }
+    Ok(())
 }
 
-async fn write_postgres_settings_csv(url: &str, test_type: &str) {
+async fn write_postgres_settings_csv(url: &str, test_type: &str) -> anyhow::Result<()> {
     let filename = format!("results_{test_type}_postgres_settings.csv");
-    let mut file = File::create(&filename).expect("Failed to create postgres settings CSV");
+    let mut file =
+        File::create(&filename).with_context(|| "Failed to create postgres settings CSV")?;
 
     writeln!(file, "Setting,Value").unwrap();
 
@@ -445,28 +458,29 @@ async fn write_postgres_settings_csv(url: &str, test_type: &str) {
 
     let mut conn = PgConnection::connect(url)
         .await
-        .expect("Failed to connect to database");
+        .with_context(|| "Failed to connect to database")?;
     for setting in settings {
         let row = sqlx::query(&format!("SHOW {setting}"))
             .fetch_one(&mut conn)
             .await
-            .expect("Failed to get postgres setting");
+            .with_context(|| "Failed to get postgres setting")?;
         let value: String = row.get(0);
-        writeln!(file, "{setting},{value}").unwrap();
+        writeln!(file, "{setting},{value}")?;
     }
+    Ok(())
 }
 
-async fn process_index_creation_csv(args: &CommonBenchmarkArgs) {
+async fn process_index_creation_csv(args: &CommonBenchmarkArgs) -> anyhow::Result<()> {
     let filename = format!("results_{}_index_creation.csv", args.r#type);
-    let mut file = File::create(&filename).expect("Failed to create index creation CSV");
+    let mut file =
+        File::create(&filename).with_context(|| "Failed to create index creation CSV")?;
 
     writeln!(
         file,
         "Index Name,Duration (min),Index Size (MB),Segment Count"
-    )
-    .unwrap();
+    )?;
 
-    for result in process_index_creation(args).await {
+    for result in process_index_creation(args).await? {
         let IndexCreationResult {
             duration_min_ms,
             index_name,
@@ -476,14 +490,15 @@ async fn process_index_creation_csv(args: &CommonBenchmarkArgs) {
         writeln!(
             file,
             "{index_name},{duration_min_ms:.2},{index_size},{segment_count}"
-        )
-        .unwrap();
+        )?;
     }
+    Ok(())
 }
 
-async fn run_benchmarks_csv(args: &CommonBenchmarkArgs) {
+async fn run_benchmarks_csv(args: &CommonBenchmarkArgs) -> anyhow::Result<()> {
     let filename = format!("results_{}_benchmark_results.csv", args.r#type);
-    let mut file = File::create(&filename).expect("Failed to create benchmark results CSV");
+    let mut file =
+        File::create(&filename).with_context(|| "Failed to create benchmark results CSV")?;
 
     // Write header
     let mut header = String::from("Query Type");
@@ -491,9 +506,9 @@ async fn run_benchmarks_csv(args: &CommonBenchmarkArgs) {
         header.push_str(&format!(",Run {i} (ms)"));
     }
     header.push_str(",Rows Returned,Query");
-    writeln!(file, "{header}").unwrap();
+    writeln!(file, "{header}")?;
 
-    for result in run_benchmarks(args).await {
+    for result in run_benchmarks(args).await? {
         let QueryResult {
             query_type,
             query,
@@ -510,44 +525,50 @@ async fn run_benchmarks_csv(args: &CommonBenchmarkArgs) {
             num_results,
             query.replace("\"", "\"\"")
         ));
-        writeln!(file, "{result_line}").unwrap();
+        writeln!(file, "{result_line}")?;
     }
+    Ok(())
 }
 
-fn write_benchmark_header(file: &mut File) {
-    writeln!(file, "# Benchmark Results").unwrap();
+fn write_benchmark_header(file: &mut File) -> anyhow::Result<()> {
+    Ok(writeln!(file, "# Benchmark Results")?)
 }
 
-async fn write_test_info(file: &mut File, args: &CommonBenchmarkArgs, rows_display: &str) {
-    writeln!(file, "\n## Test Info").unwrap();
-    writeln!(file, "| Key         | Value       |").unwrap();
-    writeln!(file, "|-------------|-------------|").unwrap();
-    writeln!(file, "| Dataset Size | {rows_display} |").unwrap();
-    writeln!(file, "| Test Type   | {} |", args.r#type).unwrap();
-    writeln!(file, "| Prewarm     | {} |", args.prewarm).unwrap();
-    writeln!(file, "| Vacuum      | {} |", args.vacuum).unwrap();
+async fn write_test_info(
+    file: &mut File,
+    args: &CommonBenchmarkArgs,
+    rows_display: &str,
+) -> anyhow::Result<()> {
+    writeln!(file, "\n## Test Info")?;
+    writeln!(file, "| Key         | Value       |")?;
+    writeln!(file, "|-------------|-------------|")?;
+    writeln!(file, "| Dataset Size | {rows_display} |")?;
+    writeln!(file, "| Test Type   | {} |", args.r#type)?;
+    writeln!(file, "| Prewarm     | {} |", args.prewarm)?;
+    writeln!(file, "| Vacuum      | {} |", args.vacuum)?;
 
     if args.r#type == "pg_search" {
         let mut conn = PgConnection::connect(&args.url)
             .await
-            .expect("Failed to connect to database for version info");
+            .with_context(|| "Failed to connect to database for version info")?;
         let row = sqlx::query("SELECT version, githash, build_mode FROM paradedb.version_info()")
             .fetch_one(&mut conn)
             .await
-            .expect("Failed to fetch paradedb.version_info()");
+            .with_context(|| "Failed to fetch paradedb.version_info()")?;
         let version: String = row.get(0);
         let githash: String = row.get(1);
         let build_mode: String = row.get(2);
-        writeln!(file, "| pg_search Version | {version} |").unwrap();
-        writeln!(file, "| pg_search Git Hash | {githash} |").unwrap();
-        writeln!(file, "| pg_search Build Mode | {build_mode} |").unwrap();
+        writeln!(file, "| pg_search Version | {version} |")?;
+        writeln!(file, "| pg_search Git Hash | {githash} |")?;
+        writeln!(file, "| pg_search Build Mode | {build_mode} |")?;
     }
+    Ok(())
 }
 
-async fn write_postgres_settings(file: &mut File, url: &str) {
-    writeln!(file, "\n## Postgres Settings").unwrap();
-    writeln!(file, "| Setting                        | Value |").unwrap();
-    writeln!(file, "|--------------------------------|-------|").unwrap();
+async fn write_postgres_settings(file: &mut File, url: &str) -> anyhow::Result<()> {
+    writeln!(file, "\n## Postgres Settings")?;
+    writeln!(file, "| Setting                        | Value |")?;
+    writeln!(file, "|--------------------------------|-------|")?;
 
     let settings = vec![
         "maintenance_work_mem",
@@ -559,18 +580,19 @@ async fn write_postgres_settings(file: &mut File, url: &str) {
 
     let mut conn = PgConnection::connect(url)
         .await
-        .expect("Failed to connect to database");
+        .with_context(|| "Failed to connect to database")?;
     for setting in settings {
         let row = sqlx::query(&format!("SHOW {setting}"))
             .fetch_one(&mut conn)
             .await
-            .expect("Failed to get postgres setting");
+            .with_context(|| "Failed to get postgres setting")?;
         let value: String = row.get(0);
-        writeln!(file, "| {setting} | {value} |").unwrap();
+        writeln!(file, "| {setting} | {value} |")?;
     }
+    Ok(())
 }
 
-fn generate_test_data(url: &str, dataset: &str, rows: u32) {
+fn generate_test_data(url: &str, dataset: &str, rows: u32) -> anyhow::Result<()> {
     let status = Command::new("psql")
         .arg(url)
         .arg("-v")
@@ -578,33 +600,35 @@ fn generate_test_data(url: &str, dataset: &str, rows: u32) {
         .arg("-f")
         .arg(format!("datasets/{dataset}/generate.sql"))
         .status()
-        .expect("Failed to create table");
+        .with_context(|| "Failed to create table")?;
 
     if !status.success() {
-        eprintln!("Failed to create table");
-        std::process::exit(1);
+        bail!("Failed to create table");
     }
+    Ok(())
 }
 
-fn load_external_data(url: &str, dataset: &str, size_label: &str, data_source: Option<&str>) {
+fn load_external_data(
+    url: &str,
+    dataset: &str,
+    size_label: &str,
+    data_source: Option<&str>,
+) -> anyhow::Result<()> {
     // Read dataset config for table names and S3 path.
     let config_path = format!("datasets/{dataset}/config.toml");
-    let config = config::load_dataset_config(&config_path).unwrap_or_else(|e| {
-        eprintln!("Failed to load config '{config_path}': {e}");
-        std::process::exit(1);
-    });
+    let config = config::load_dataset_config(&config_path)
+        .with_context(|| format!("Failed to load config '{config_path}'"))?;
 
     // Determine CSV data source path.
     let source_path = match data_source {
         Some(path) => path.trim_end_matches('/').to_string(),
         None => {
-            let s3_base = config.s3_base_path.as_deref().unwrap_or_else(|| {
-                eprintln!(
+            let s3_base = config.s3_base_path.as_deref().with_context(|| {
+                format!(
                     "Dataset '{dataset}' has no S3 base path. Provide --data-source or set \
                      s3_base_path in datasets/{dataset}/config.toml"
-                );
-                std::process::exit(1);
-            });
+                )
+            })?;
             format!(
                 "{}/sampled/{}/csv",
                 s3_base.trim_end_matches('/'),
@@ -617,48 +641,38 @@ fn load_external_data(url: &str, dataset: &str, size_label: &str, data_source: O
     // Create tables via DDL.
     let create_tables_sql = format!("datasets/{dataset}/create_tables.sql");
     if !Path::new(&create_tables_sql).exists() {
-        eprintln!(
+        bail!(
             "Dataset '{dataset}' requires create_tables.sql but none found at {create_tables_sql}"
         );
-        std::process::exit(1);
     }
     let status = Command::new("psql")
         .arg(url)
         .arg("-f")
         .arg(&create_tables_sql)
         .status()
-        .expect("Failed to execute create_tables.sql");
+        .with_context(|| "Failed to execute create_tables.sql")?;
     if !status.success() {
-        eprintln!("Failed to create tables from {create_tables_sql}");
-        std::process::exit(1);
+        bail!("Failed to create tables from {create_tables_sql}");
     }
 
     // Download CSV data from source and load into PostgreSQL.
     let temp_dir = format!("/tmp/benchmark_data/{dataset}");
     if Path::new(&temp_dir).exists() {
-        std::fs::remove_dir_all(&temp_dir).unwrap_or_else(|e| {
-            eprintln!("Failed to clean temp directory '{temp_dir}': {e}");
-            std::process::exit(1);
-        });
+        std::fs::remove_dir_all(&temp_dir)
+            .with_context(|| format!("Failed to clean temp directory '{temp_dir}'"))?;
     }
-    std::fs::create_dir_all(&temp_dir).unwrap_or_else(|e| {
-        eprintln!("Failed to create temp directory '{temp_dir}': {e}");
-        std::process::exit(1);
-    });
+    std::fs::create_dir_all(&temp_dir)
+        .with_context(|| format!("Failed to create temp directory '{temp_dir}'"))?;
 
-    let duckdb_conn = utils::open_duckdb_conn().unwrap_or_else(|e| {
-        eprintln!("Failed to open DuckDB connection: {e}");
-        std::process::exit(1);
-    });
+    let duckdb_conn =
+        utils::open_duckdb_conn().with_context(|| "Failed to open DuckDB connection")?;
 
     for table in &config.tables {
         let table_name = &table.name;
         let csv_source = format!("{source_path}/{table_name}");
         let table_temp_dir = format!("{temp_dir}/{table_name}");
-        std::fs::create_dir_all(&table_temp_dir).unwrap_or_else(|e| {
-            eprintln!("Failed to create temp directory '{table_temp_dir}': {e}");
-            std::process::exit(1);
-        });
+        std::fs::create_dir_all(&table_temp_dir)
+            .with_context(|| format!("Failed to create temp directory '{table_temp_dir}'"))?;
 
         // Download CSV files from source to local temp dir.
         // We must use parallel=false because some datasets (stackoverflow for instance) contain a
@@ -672,18 +686,12 @@ fn load_external_data(url: &str, dataset: &str, size_label: &str, data_source: O
         );
         duckdb_conn
             .execute_batch(&download_sql)
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to download CSV for table '{table_name}': {e}");
-                std::process::exit(1);
-            });
+            .with_context(|| format!("Failed to download CSV for table '{table_name}'"))?;
 
         // Load each local CSV file into PostgreSQL.
         println!("Loading '{table_name}' into PostgreSQL...");
         let local_csvs: Vec<_> = std::fs::read_dir(&table_temp_dir)
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to read temp directory '{table_temp_dir}': {e}");
-                std::process::exit(1);
-            })
+            .with_context(|| format!("Failed to read temp directory '{table_temp_dir}'"))?
             .filter_map(|entry| {
                 let path = entry.ok()?.path();
                 if path.extension().and_then(|s| s.to_str()) == Some("csv") {
@@ -702,10 +710,9 @@ fn load_external_data(url: &str, dataset: &str, size_label: &str, data_source: O
                 .arg("-c")
                 .arg(&copy_cmd)
                 .status()
-                .expect("Failed to execute psql copy");
+                .with_context(|| "Failed to execute psql copy")?;
             if !status.success() {
-                eprintln!("Failed to load '{csv_str}' into table '{table_name}'");
-                std::process::exit(1);
+                bail!("Failed to load '{csv_str}' into table '{table_name}'");
             }
         }
         println!("  Loaded {} file(s) into '{table_name}'.", local_csvs.len());
@@ -718,22 +725,24 @@ fn load_external_data(url: &str, dataset: &str, size_label: &str, data_source: O
     }
 
     println!("External data loaded successfully.");
+    Ok(())
 }
 
-async fn process_index_creation_md(file: &mut File, args: &CommonBenchmarkArgs) {
-    writeln!(file, "\n## Index Creation Results").unwrap();
+async fn process_index_creation_md(
+    file: &mut File,
+    args: &CommonBenchmarkArgs,
+) -> anyhow::Result<()> {
+    writeln!(file, "\n## Index Creation Results")?;
     writeln!(
         file,
         "| Index Name | Duration (min) | Index Size (MB) | Segment Count |"
-    )
-    .unwrap();
+    )?;
     writeln!(
         file,
         "|------------|----------------|-----------------|---------------|"
-    )
-    .unwrap();
+    )?;
 
-    for result in process_index_creation(args).await {
+    for result in process_index_creation(args).await? {
         let IndexCreationResult {
             duration_min_ms,
             index_name,
@@ -744,17 +753,17 @@ async fn process_index_creation_md(file: &mut File, args: &CommonBenchmarkArgs) 
         writeln!(
             file,
             "| {index_name} | {duration_min_ms:.2} | {index_size} | {segment_count} |"
-        )
-        .unwrap();
+        )?;
     }
+    Ok(())
 }
 
-async fn run_benchmarks_md(file: &mut File, args: &CommonBenchmarkArgs) {
-    writeln!(file, "\n## Benchmark Results").unwrap();
+async fn run_benchmarks_md(file: &mut File, args: &CommonBenchmarkArgs) -> anyhow::Result<()> {
+    writeln!(file, "\n## Benchmark Results")?;
 
-    write_benchmark_table_header(file, args.runs);
+    write_benchmark_table_header(file, args.runs)?;
 
-    for result in run_benchmarks(args).await {
+    for result in run_benchmarks(args).await? {
         let QueryResult {
             query_type,
             query,
@@ -762,11 +771,12 @@ async fn run_benchmarks_md(file: &mut File, args: &CommonBenchmarkArgs) {
             num_results,
         } = result;
         let md_query = query.replace("|", "\\|");
-        write_benchmark_results_md(file, &query_type, &runtimes_ms, num_results, &md_query);
+        write_benchmark_results_md(file, &query_type, &runtimes_ms, num_results, &md_query)?;
     }
+    Ok(())
 }
 
-fn write_benchmark_table_header(file: &mut File, runs: usize) {
+fn write_benchmark_table_header(file: &mut File, runs: usize) -> anyhow::Result<()> {
     let mut header = String::from("| Query Type ");
     let mut separator = String::from("|------------");
 
@@ -778,8 +788,9 @@ fn write_benchmark_table_header(file: &mut File, runs: usize) {
     header.push_str("| Rows Returned | Query |");
     separator.push_str("|---------------|--------|");
 
-    writeln!(file, "{header}").unwrap();
-    writeln!(file, "{separator}").unwrap();
+    writeln!(file, "{header}")?;
+    writeln!(file, "{separator}")?;
+    Ok(())
 }
 
 fn write_benchmark_results_md(
@@ -788,7 +799,7 @@ fn write_benchmark_results_md(
     results: &[f64],
     num_results: usize,
     md_query: &str,
-) {
+) -> anyhow::Result<()> {
     let mut result_line = format!("| {query_type} ");
 
     for &result in results {
@@ -796,25 +807,29 @@ fn write_benchmark_results_md(
     }
 
     result_line.push_str(&format!("| {num_results} | `{md_query}` |"));
-    writeln!(file, "{result_line}").unwrap();
+    writeln!(file, "{result_line}")?;
+    Ok(())
 }
 
-async fn process_index_creation_json(args: &CommonBenchmarkArgs) {
-    for _result in process_index_creation(args).await {
+async fn process_index_creation_json(args: &CommonBenchmarkArgs) -> anyhow::Result<()> {
+    for _result in process_index_creation(args).await? {
         // TODO: Record index creation results as JSON.
     }
+    Ok(())
 }
 
-async fn run_benchmarks_json(args: &CommonBenchmarkArgs) {
-    let mut file = File::create("results.json").expect("Failed to create output file");
+async fn run_benchmarks_json(args: &CommonBenchmarkArgs) -> anyhow::Result<()> {
+    let mut file = File::create("results.json").with_context(|| "Failed to create output file")?;
     let results = run_benchmarks(args)
-        .await
+        .await?
         .into_iter()
         .map(JSONBenchmarkResult::from)
         .collect::<Vec<_>>();
-    let results_json = serde_json::to_string(&results).expect("Failed to serialize results");
+    let results_json =
+        serde_json::to_string(&results).with_context(|| "Failed to serialize results")?;
     file.write_all(results_json.as_bytes())
-        .expect("Failed to write results");
+        .with_context(|| "Failed to write results")?;
+    Ok(())
 }
 
 ///
@@ -876,14 +891,19 @@ fn extract_index_name(statement: &str) -> &str {
         .expect("Failed to parse index name")
 }
 
-async fn prewarm_indexes(conn: &mut PgConnection, dataset: &str, r#type: &str) {
+async fn prewarm_indexes(
+    conn: &mut PgConnection,
+    dataset: &str,
+    r#type: &str,
+) -> anyhow::Result<()> {
     let prewarm_sql = format!("datasets/{dataset}/prewarm/{type}.sql");
     for statement in queries(Path::new(&prewarm_sql)) {
         sqlx::query(&statement)
             .execute(&mut *conn)
             .await
-            .expect("Failed to prewarm indexes");
+            .with_context(|| "Failed to prewarm indexes")?;
     }
+    Ok(())
 }
 
 /// Execute a benchmark query multiple times on a single reused connection.
@@ -905,10 +925,10 @@ async fn execute_query_multiple_times(
     query: &str,
     times: usize,
     fail_on_error: bool,
-) -> Option<(Vec<f64>, usize)> {
+) -> anyhow::Result<Option<(Vec<f64>, usize)>> {
     let mut conn = PgConnection::connect(url)
         .await
-        .expect("Failed to connect to database");
+        .with_context(|| "Failed to connect to database")?;
     let mut results = Vec::new();
     let mut num_results = 0;
 
@@ -929,13 +949,13 @@ async fn execute_query_multiple_times(
                     panic!("Failed to execute benchmark query `{query_type}`:  {err}");
                 } else {
                     eprintln!("WARNING: Skipping query `{query_type}` due to error: {err}");
-                    return None;
+                    return Ok(None);
                 }
             }
         }
     }
 
-    Some((results, num_results))
+    Ok(Some((results, num_results)))
 }
 
 fn drop_os_page_cache() -> Result<(), String> {
@@ -984,12 +1004,12 @@ async fn clear_caches(conn: &mut PgConnection) -> Result<(), String> {
     }
 }
 
-async fn ensure_pg_buffercache_extension(conn: &mut PgConnection) -> Result<(), String> {
+async fn ensure_pg_buffercache_extension(conn: &mut PgConnection) -> anyhow::Result<()> {
     sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_buffercache")
         .execute(&mut *conn)
         .await
-        .map_err(|e| {
-            format!("failed to create pg_buffercache extension (`CREATE EXTENSION IF NOT EXISTS pg_buffercache`): {e}")
+        .with_context(|| {
+            "failed to create pg_buffercache extension (`CREATE EXTENSION IF NOT EXISTS pg_buffercache`"
         })?;
     Ok(())
 }


### PR DESCRIPTION
## What
Refactor exit/failure pattern in benchmark cli to use Result instead of exit()

## Why
Returning a `Result` instead of `exit()`ing allows us to much more information about the context in which an error or failure occured. `anyhow`'s flavor of it gives us an error stack with potential context at every level. 

## How
- All functions with a potential `exit`, `unwrap`, or `expect` now return `anyhow::Result<>`.
- The pattern:
```rust
eprintln!("Fastfields benchmark is not supported with existing datasets");
std::process::exit(1);
```
becomes
```rust
bail!("Fastfields benchmark is not supported with existing datasets");
````
- Most `expect`s are converted to `with_context`s.

## Tests
- unit tests pass still
- Manual verification of a few easy-to-replicate failure cases
- Successful full benchmarking run: https://github.com/paradedb/paradedb/actions/runs/24463218393
