### PR TITLE
chore: Update benchmark index creation sql to new syntax

### DIFF
--- a/benchmarks/datasets/docs/create_index/pg_search.sql
+++ b/benchmarks/datasets/docs/create_index/pg_search.sql
@@ -1,81 +1,42 @@
 CREATE INDEX pages_index ON pages
 USING bm25 (
     "id",
-    "content",
-    "title",
-    "parents",
-    "fileId",
+    ("content"::pdb.unicode_words('columnar=true')),
+    ("title"::pdb.unicode_words('columnar=true')),
+    ("parents"::pdb.unicode_words('columnar=true')),
+    ("fileId"::pdb.literal),
     "sizeInBytes",
     "createdAt"
 )
 WITH (
     key_field = 'id',
-    sort_by = 'fileId ASC NULLS FIRST',
-    text_fields = '{
-        "fileId": {
-            "tokenizer": {"type": "keyword"}, "fast": true
-        },
-        "content": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "title": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "parents": {
-            "tokenizer": {"type": "default"}, "fast": true
-        }
-    }'
+    sort_by = 'fileId ASC NULLS FIRST'
 );
 
 CREATE INDEX files_index ON files
 USING bm25 (
     "id",
-    "content",
-    "documentId",
-    "title",
-    "parents",
+    ("content"::pdb.unicode_words('columnar=true')),
+    ("documentId"::pdb.literal),
+    ("title"::pdb.unicode_words('columnar=true')),
+    ("parents"::pdb.unicode_words('columnar=true')),
     "sizeInBytes",
     "createdAt"
 )
 WITH (
     key_field = 'id',
-    sort_by = 'documentId ASC NULLS FIRST',
-    text_fields = '{
-        "documentId": {
-            "tokenizer": {"type": "keyword"}, "fast": true
-        },
-        "content": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "title": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "parents": {
-            "tokenizer": {"type": "default"}, "fast": true
-        }
-    }'
+    sort_by = 'documentId ASC NULLS FIRST'
 );
 
 CREATE INDEX documents_index ON documents
 USING bm25 (
     "id",
-    "content",
-    "title",
-    "parents",
+    ("content"::pdb.unicode_words('columnar=true')),
+    ("title"::pdb.unicode_words('columnar=true')),
+    ("parents"::pdb.unicode_words('columnar=true')),
     "createdAt"
 )
 WITH (
     key_field = 'id',
-    sort_by = 'id ASC NULLS FIRST',
-    text_fields = '{
-        "content": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "title": {
-            "tokenizer": {"type": "default"}, "fast": true
-        },
-        "parents": {
-            "tokenizer": {"type": "default"}, "fast": true
-        }
-    }'
+    sort_by = 'id ASC NULLS FIRST'
 );

--- a/benchmarks/datasets/logs/create_index/pg_search.sql
+++ b/benchmarks/datasets/logs/create_index/pg_search.sql
@@ -1,1 +1,11 @@
-CREATE INDEX benchmark_logs_idx ON benchmark_logs USING bm25 (id, message, country, severity, timestamp, metadata) WITH (key_field = 'id', text_fields = '{"country": {"fast": true, "tokenizer": {"type": "raw", "lowercase": true} }}', json_fields = '{"metadata": { "fast": true, "tokenizer": {"type": "raw", "lowercase": true}}}');
+CREATE INDEX benchmark_logs_idx ON benchmark_logs 
+USING bm25 (
+    id, 
+    message, 
+    (country::pdb.literal_normalized),
+    severity, 
+    timestamp, 
+    (metadata::pdb.literal_normalized)
+) WITH (
+    key_field = 'id'
+);

--- a/benchmarks/datasets/stackoverflow/create_index/pg_search.sql
+++ b/benchmarks/datasets/stackoverflow/create_index/pg_search.sql
@@ -1,2 +1,28 @@
-CREATE INDEX stackoverflow_posts_idx ON stackoverflow_posts USING bm25 (id, title, body, tags, post_type_id, score, creation_date, view_count, answer_count, comment_count, owner_display_name) WITH (key_field = 'id', text_fields = '{"owner_display_name": {"fast": true}}');
-CREATE INDEX badges_idx ON badges USING bm25 (id, name, date, user_id, class, tag_based) WITH (key_field = 'id', text_fields = '{"name": {"fast": true}}');
+CREATE INDEX stackoverflow_posts_idx ON stackoverflow_posts 
+USING bm25 (
+    id,
+    title,
+    body,
+    tags,
+    post_type_id,
+    score,
+    creation_date,
+    view_count,
+    answer_count,
+    comment_count,
+    (owner_display_name::pdb.unicode_words('columnar=true'))
+) WITH (
+    key_field = 'id'
+);
+
+CREATE INDEX badges_idx ON badges 
+USING bm25 (
+    id,
+    (name::pdb.unicode_words('columnar=true')),
+    date,
+    user_id,
+    class,
+    tag_based
+) WITH (
+    key_field = 'id'
+ );


### PR DESCRIPTION
## What
Updates the index creation statements to the new sql syntax

## Why
I should have done this as part of #4781 but I missed it.
## How
- Mostly straitfoward conversion of fast fields to `{field}::pdb.unicode_words('columnar=true')`
- Convert existing `keyword` tokenizer to `literal` and `raw` to `literal_normalized` since those appear to be functionally equivalent.

## Tests
Manually ran benchmarks for a small version of each dataset to verify valid syntax and that all queries still work.