### PR TITLE
test: Add high cardinality bucket query

### DIFF
--- a/benchmarks/datasets/stackoverflow/create_index/pg_search.sql
+++ b/benchmarks/datasets/stackoverflow/create_index/pg_search.sql
@@ -3,7 +3,7 @@ USING bm25 (
     id,
     title,
     body,
-    tags,
+    (tags::pdb.literal_normalized),
     post_type_id,
     score,
     creation_date,

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -17,9 +17,7 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackov
 SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
--- SELECT pdb.agg('{"value_count": {"field": "tags"}}'), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
-SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
+SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "tags"}}', false), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
-
+SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -12,3 +12,14 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}') FROM stackoverflow_
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
+
+-- high-cardinality aggregate scan
+SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+
+-- high-cardinality aggregate scan using pdb.agg
+-- SELECT pdb.agg('{"value_count": {"field": "tags"}}'), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
+SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
+
+-- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
+SELECT pdb.agg('{"value_count": {"field": "tags"}}', false), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' AND id @@@ pdb.all() GROUP BY tags;
+


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4285 

## What
Add's queries that match the shape: 
```sql
SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
``` 
that query against a high-cardinality field. (`tags` has 239,255 distinct values in the 1m dataset. The where clause drops that to ~10,300)

## Why
See #4284.

We need a high cardinality field in our term bucket queries that can exercise this query shape to make sure we don't regress.
## How

## Tests
Tested 100k version of this benchmark locally