### PR TITLE
fix: set citus.node_conninfo sslmode=prefer in CI

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -218,6 +218,7 @@ jobs:
         run: |
           sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_search'/" postgresql.conf
           sed -i "s/^max_connections = .*/max_connections = 300/" postgresql.conf
+          echo "citus.node_conninfo = 'sslmode=prefer'" >> postgresql.conf
 
       - name: Compile & install pg_search extension (system)
         if: matrix.pg_impl == 'system'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4792

## What

Adds `citus.node_conninfo = 'sslmode=prefer'` to the pgrx-managed `postgresql.conf` in CI.

## Why

Citus requires SSL for inter-node communication by default, but the pgrx-managed PostgreSQL instances in CI don't have SSL certificates configured. This causes Citus to fail with `server does not support SSL, but SSL was required` when it tries to connect to `localhost` for distributed operations like `create_distributed_table`.

## How

Appends the `citus.node_conninfo` GUC to `postgresql.conf` in the "Add extensions to shared_preload_libraries" CI step, setting `sslmode=prefer` so Citus falls back to plaintext when SSL isn't available.

## Tests

Existing Citus integration tests (`citus_distributed_tables_with_subquery_limit`, `citus_without_search_operators`, `citus_sharded_bm25_indexes`, `citus_catalog_queries_compatibility`) validate the fix — they exercise `create_distributed_table` and distributed queries that would fail without this setting.