### PR TITLE
chore: Prepare 0.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ CLAUDE.local.md
 
 .github/scripts/verify
 __pycache__
+profile.trace
+*.trace
+*.trace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,6 +4740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6155,7 +6165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6440,6 +6450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6515,6 +6535,12 @@ dependencies = [
  "rayon",
  "rgb",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7787,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7811,10 +7837,13 @@ dependencies = [
  "log",
  "lru",
  "lz4_flex 0.12.1",
+ "matrixmultiply",
  "measure_time",
  "once_cell",
  "oneshot",
  "parking_lot",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
  "rayon",
  "regex",
  "rust-stemmers",
@@ -7842,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "bitpacking",
 ]
@@ -7850,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7865,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7898,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7910,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7923,13 +7952,13 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
  "once_cell",
  "parking_lot",
- "rand_distr",
+ "rand_distr 0.4.3",
  "tantivy-common",
 ]
 
@@ -7960,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=d5ee26759e6fed0fa14987d450a16ab862c3a32c#d5ee26759e6fed0fa14987d450a16ab862c3a32c"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1786,7 +1786,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -5218,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7813,7 +7812,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7871,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "bitpacking",
 ]
@@ -7879,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7894,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7927,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7939,7 +7938,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7952,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7989,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#206c474cd6f8f1a1bb2c941770f9815bea76acd9"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -378,7 +378,7 @@ version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "serde_core",
  "serde_json",
 ]
@@ -464,7 +464,7 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -709,7 +709,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -754,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -795,9 +795,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -813,11 +813,11 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -879,7 +879,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1173,7 +1173,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -1344,10 +1344,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -1488,15 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,7 +1588,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1663,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -1763,6 +1755,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1792,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1822,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1833,8 +1859,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1868,7 +1894,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "tempfile",
  "tokio",
@@ -1878,8 +1904,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1902,8 +1928,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1924,8 +1950,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -1945,8 +1971,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "futures",
  "log",
@@ -1955,8 +1981,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1976,15 +2002,15 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2006,8 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2028,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2051,13 +2077,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2071,15 +2097,15 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2098,8 +2124,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2110,8 +2136,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2129,7 +2155,7 @@ dependencies = [
  "log",
  "memchr",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -2137,8 +2163,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2158,8 +2184,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2170,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2185,8 +2211,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2202,8 +2228,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2211,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2221,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "chrono",
@@ -2239,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2261,8 +2287,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2275,8 +2301,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2291,8 +2317,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2308,8 +2334,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2339,8 +2365,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "chrono",
@@ -2360,13 +2386,13 @@ dependencies = [
  "datafusion-proto-common",
  "object_store",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "datafusion-proto-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2375,8 +2401,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2391,8 +2417,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=branch-53#d24faa0134b75ea3a17fff94c2a271d858ef88e2"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion.git?branch=branch-53#eae7bf4fa1c037c0a065d1f36d0669f5bb97a9cf"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2589,12 +2615,13 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2970,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -3032,7 +3059,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -3088,7 +3115,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -3261,7 +3288,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -3389,7 +3416,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3406,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -3420,7 +3447,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3499,6 +3526,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -3628,9 +3661,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -3657,15 +3690,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3730,12 +3762,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3743,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3758,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3772,15 +3805,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3792,15 +3825,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3812,15 +3845,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3835,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a807a7488f3f758629ae86d99d9d30dce24da2fb2945d74c80a4f4a62c71db73"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
 dependencies = [
  "core_maths",
  "icu_collections",
@@ -3851,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebbb7321d9e21d25f5660366cb6c08201d0175898a3a6f7a41ee9685af21c80"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -3912,7 +3945,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif 0.14.1",
+ "gif 0.14.2",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -3973,21 +4006,21 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indextree"
-version = "4.8.0"
+version = "4.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f80a9409db2176ff13877276660f5149fee32592698d2100afe8b52043d4405"
+checksum = "5cee462cd93b03891663339b59a21246cc5fc2cc95060d0bb5059e25cd50edc4"
 dependencies = [
  "indextree-macros",
 ]
@@ -4254,9 +4287,9 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
-version = "0.3.93"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4379,15 +4412,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "cc",
  "flate2",
@@ -4402,25 +4435,25 @@ dependencies = [
 
 [[package]]
 name = "libflate"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -4464,14 +4497,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4486,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -4563,7 +4596,7 @@ dependencies = [
  "memmap2",
  "num_cpus",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest 0.13.2",
  "rkyv 0.8.15",
@@ -4661,9 +4694,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -4700,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4730,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4886,6 +4919,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -5052,7 +5094,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5120,13 +5162,12 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "opencc-jieba-rs"
-version = "0.7.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b45e7c99dfa9f7e1306db1db67d7745c0f011158f1c2994227e4ee9bc03418b"
+checksum = "1374548d1a5832b9a25a69aef815a5ec9128051f7f583ed0452cdfeafcb427d0"
 dependencies = [
  "include-flate",
  "jieba-rs 0.7.4",
- "libflate",
  "once_cell",
  "rayon",
  "rayon-core",
@@ -5138,11 +5179,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -5170,9 +5211,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -5380,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5414,7 +5455,7 @@ dependencies = [
  "postcard",
  "proptest",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rstest",
  "rustc-hash",
@@ -5442,7 +5483,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd42eed31a68e3e6d7cec284cdaacd8ffa9b2b3ebb3f1df9ec2fd3558834c6e7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bitvec",
  "enum-map",
  "libc",
@@ -5572,7 +5613,7 @@ dependencies = [
  "pgrx-pg-config 0.17.0",
  "postgres",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -5678,7 +5719,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "phf_shared 0.13.1",
 ]
 
@@ -5751,7 +5792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-io",
 ]
 
@@ -5778,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5853,7 +5894,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5956,7 +5997,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -5974,9 +6015,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
  "writeable",
@@ -6058,7 +6099,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -6125,9 +6166,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6164,7 +6205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6267,7 +6308,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6356,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6366,13 +6407,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6434,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -6455,7 +6496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -6512,7 +6553,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -6567,16 +6608,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6922,7 +6963,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6935,7 +6976,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6944,9 +6985,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -7008,9 +7049,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7078,7 +7119,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7097,9 +7138,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -7181,9 +7222,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -7515,7 +7556,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7561,7 +7602,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -7635,7 +7676,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7841,7 +7882,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr 0.5.1",
  "rayon",
  "regex",
@@ -8016,7 +8057,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
@@ -8034,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -8053,7 +8094,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rstest",
  "rustc-hash",
  "serde",
@@ -8177,9 +8218,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -8203,7 +8244,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "emoji",
@@ -8225,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -8242,9 +8283,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8281,7 +8322,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2 0.6.3",
  "tokio",
  "tokio-util",
@@ -8343,7 +8384,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -8370,9 +8411,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -8393,21 +8434,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -8420,9 +8461,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -8445,7 +8486,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -8861,9 +8902,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8875,9 +8916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.66"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8885,9 +8926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8895,9 +8936,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8908,9 +8949,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -8943,7 +8984,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -8951,9 +8992,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.93"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9630,7 +9671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -9662,9 +9703,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -9722,9 +9763,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9733,9 +9774,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9765,18 +9806,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9792,20 +9833,21 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -9815,9 +9857,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "bitpacking",
 ]
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7952,7 +7952,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#1e0c9c9e4fc62f82ebc85bec8f1e937431588258"
+source = "git+https://github.com/paradedb/tantivy.git?branch=vector-search#d9697ebeb3f95b58fc3ad9968ceee6e4dd05c40e"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.6"
+version = "0.23.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "d5ee26759e6fed0fa14987d450a16ab862c3a32c", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "vector-search", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.17.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "d5ee26759e6fed0fa14987d450a16ab862c3a32c" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "vector-search" }

--- a/docs/changelog/0.23.0.mdx
+++ b/docs/changelog/0.23.0.mdx
@@ -1,0 +1,48 @@
+---
+title: 0.23.0
+noindex: true
+---
+
+## New Features 🎉
+
+- Aggregate-on-JOIN support: a full pipeline for running aggregates over join results, including:
+  - 3+ table join support and `DISTINCT` aggregates in AggregateScan.
+  - `LEFT`/`RIGHT`/`FULL JOIN` and `COUNT(DISTINCT)`.
+  - `HAVING` clause and per-aggregate `FILTER` clause.
+  - `ORDER BY` within `STRING_AGG` and `ARRAY_AGG`.
+  - JSON sub-field `GROUP BY` in the DataFusion aggregate path.
+  - Date/Timestamp projection and `STDDEV`/`VARIANCE` aggregates.
+  - Extended aggregate TopK detection to `GROUP BY` column and `MIN`/`MAX` ordering.
+  - TopK optimization for aggregate queries via Tantivy and DataFusion.
+- New `edge_ngram` tokenizer for search-as-you-type use cases.
+- Support for `IS NULL`/`IS NOT NULL` predicates in Top-K JoinScan.
+- Per-field tunable BM25 `k1` and `b` parameters via typmod.
+- Explicit control of prefix behavior for fuzzy queries.
+- `keep_whitespace` option for Lindera tokenizers.
+- Support for the `citext` Postgres type.
+
+## Performance Improvements 🚀
+
+- Lazily set up tokenizers, avoiding unnecessary initialization overhead.
+- Conditionally enable scoring in row estimation for faster planning.
+- Cache `anyelement_search_opoids` to reduce repeated catalog lookups.
+- Cache `score`/`snippet` function OIDs.
+- Cache `segment_id` to `segment_ordinal` mapping during `SearchIndexReader` construction.
+
+## Stability Improvements 💪
+
+- Suppress LIMIT pushdown when non-pushable post-filters are present.
+- Resolve equi-key projections structurally in `collect_required_fields`.
+- Restore `PVC_RECURSE_PLACEHOLDERS` in JoinScan planning.
+- Fix Top K for prepared statements.
+- Recognize identity expressions (e.g. `id + 0`) in JoinScan `ORDER BY` matching.
+- Swallow benign `SHM_MQ_DETACHED` on parallel worker shutdown.
+- Re-add meaningful term filter.
+- Fix boolean `===` boolean comparison.
+- Use `plan_position` instead of `heap_rti` for JoinScan partitioning.
+- Allow unaliased, tokenized index fields to be selected by name when the same column is indexed multiple times.
+- Support `varchar`, `text[]`, and `citext` parameters in operators with generic plans.
+- Bump `vergen-git2` to 9.x to match `vergen` 9.x.
+- Fix Nix workflow to fail after auto-fixing `cargoHash`.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.0).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -39,7 +39,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.22.6-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.23.0-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -42,7 +42,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.22.6` with the `pg_search` version you wish to install and
+  You can replace `0.23.0` with the `pg_search` version you wish to install and
   `17` with the version of Postgres you are using.
 </Note>
 
@@ -50,49 +50,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/postgresql-17-pg-search_0.22.6-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/postgresql-17-pg-search_0.22.6-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/postgresql-17-pg-search_0.22.6-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/postgresql-17-pg-search_0.22.6-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/pg_search_17-0.22.6-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search_17-0.23.0-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/pg_search_17-0.22.6-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search_17-0.23.0-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/pg_search@17--0.22.6.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search@17--0.23.0.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.22.6/pg_search@17--0.22.6.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search@17--0.23.0.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.22.6`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.23.0`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.22.6
+docker pull paradedb/paradedb:0.23.0
 ```
 
-The latest version of the Docker image should be `0.22.6`.
+The latest version of the Docker image should be `0.23.0`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.22.6';
+ALTER EXTENSION pg_search UPDATE TO '0.23.0';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.22.6",
+        "version": "v0.23.0",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -345,6 +345,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.23.0",
                   "changelog/0.22.6",
                   "changelog/0.22.5",
                   "changelog/0.22.4",

--- a/pg_search/sql/pg_search--0.22.6--0.23.0.sql
+++ b/pg_search/sql/pg_search--0.22.6--0.23.0.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.0'" to load this file. \quit

--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -385,6 +385,11 @@ pub enum OrderByFeature {
         inner: Box<OrderByFeature>,
         nulltesttype: NullTestKind,
     },
+    VectorDistance {
+        name: FieldName,
+        rti: u32,
+        query_vector: Vec<f32>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -409,6 +414,7 @@ impl std::fmt::Display for OrderByFeature {
                 };
                 write!(f, "{inner} {test}")
             }
+            Self::VectorDistance { name, .. } => write!(f, "{name} <-> vector"),
         }
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -370,6 +370,7 @@ impl SearchIndexReader {
 
         let directory = mvcc_style.directory(index_relation);
         let mut index = Index::open(directory.clone())?;
+        crate::vector::register_vector_plugins(&mut index);
         let total_segment_count = directory
             .total_segment_count()
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -914,6 +915,35 @@ impl SearchIndexReader {
                 feature: OrderByFeature::NullTest { .. },
                 ..
             } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
+            OrderByInfo {
+                feature:
+                    OrderByFeature::VectorDistance {
+                        name, query_vector, ..
+                    },
+                direction,
+            } => {
+                let field = self
+                    .schema
+                    .search_field(name)
+                    .expect("vector field should exist in index schema");
+                let tantivy_field = field.field();
+                let order: ComparatorEnum = (*direction).into();
+                let sort_computer = tantivy::collector::sort_key::SortByVectorDistance::new(
+                    query_vector.clone(),
+                    tantivy_field,
+                );
+                TopKSearchResults::new_for_discarded_field(
+                    &self.searcher,
+                    self.top_in_segments(
+                        segment_ids,
+                        (sort_computer, order),
+                        erased_features,
+                        n,
+                        offset,
+                        aux_collector,
+                    ),
+                )
+            }
         }
     }
 
@@ -1394,6 +1424,13 @@ impl SearchIndexReader {
                     feature: OrderByFeature::NullTest { .. },
                     ..
                 } => unreachable!("NullTest ORDER BY is only used in JoinScan"),
+                OrderByInfo {
+                    feature: OrderByFeature::VectorDistance { .. },
+                    ..
+                } => {
+                    // Vector distance cannot be a secondary sort key
+                    unimplemented!("Vector distance ORDER BY can only be the primary sort key")
+                }
             }
         }
 

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -363,6 +363,19 @@ impl SearchIndexMerger {
         })
     }
 
+    pub fn open_for_merge(
+        directory: MVCCDirectory,
+        indexrel: &crate::postgres::rel::PgSearchRelation,
+    ) -> Result<SearchIndexMerger> {
+        let mut index = Index::open(directory.clone())?;
+        crate::vector::register_vector_plugins_for_merge(&mut index, indexrel);
+        Ok(Self {
+            index,
+            merged_segment_ids: Default::default(),
+            directory,
+        })
+    }
+
     pub fn all_entries(&self) -> HashMap<SegmentId, SegmentMetaEntry> {
         self.directory.all_entries()
     }

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -140,6 +140,7 @@ impl SerialIndexWriter {
 
         let directory = mvcc_satisfies.directory(index_relation);
         let mut index = Index::open(directory)?;
+        crate::vector::register_vector_plugins(&mut index);
         let schema = index_relation.schema()?;
         setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();
@@ -353,7 +354,8 @@ pub struct SearchIndexMerger {
 
 impl SearchIndexMerger {
     pub fn open(directory: MVCCDirectory) -> Result<SearchIndexMerger> {
-        let index = Index::open(directory.clone())?;
+        let mut index = Index::open(directory.clone())?;
+        crate::vector::register_vector_plugins(&mut index);
         Ok(Self {
             index,
             merged_segment_ids: Default::default(),

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -140,7 +140,7 @@ impl SerialIndexWriter {
 
         let directory = mvcc_satisfies.directory(index_relation);
         let mut index = Index::open(directory)?;
-        crate::vector::register_vector_plugins(&mut index);
+        crate::vector::register_vector_plugins_for_merge(&mut index, index_relation);
         let schema = index_relation.schema()?;
         setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -24,6 +24,7 @@ mod postgres;
 mod query;
 pub(crate) mod scan;
 mod schema;
+pub(crate) mod vector;
 
 pub mod gucs;
 pub mod parallel_worker;

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -312,7 +312,7 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
     };
 
     let mut index = Index::create(directory, schema.clone(), settings)?;
-    crate::vector::register_vector_plugins(&mut index);
+    crate::vector::register_vector_plugins_for_merge(&mut index, index_relation);
 
     Ok(())
 }

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -281,6 +281,7 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
             SearchFieldType::NumericBytes(..) => {
                 builder.add_bytes_field(name.as_ref(), config.clone())
             }
+            SearchFieldType::Vector(_, dims) => builder.add_vector_field(name.as_ref(), dims),
         };
     }
 
@@ -309,7 +310,71 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
         docstore_compress_dedicated_thread: false,
         ..IndexSettings::default()
     };
-    let _ = Index::create(directory, schema, settings)?;
+
+    // Collect vector fields for plugin registration
+    let vector_fields: Vec<_> = unsafe { extract_field_attributes(index_relation.as_ptr()) }
+        .into_iter()
+        .filter_map(|(name, attr)| {
+            if let SearchFieldType::Vector(_, dims) = attr.tantivy_type {
+                let field = schema.get_field(name.as_ref()).ok()?;
+                Some((field, dims))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if vector_fields.is_empty() {
+        let _ = Index::create(directory, schema.clone(), settings)?;
+    } else {
+        use std::sync::Arc;
+        use tantivy::vector::bqvec::BqVecPlugin;
+        use tantivy::vector::cluster::kmeans::KMeansConfig;
+        use tantivy::vector::cluster::plugin::{ClusterConfig, ClusterFieldConfig, ClusterPlugin};
+        use tantivy::vector::rabitq::rotation::{DynamicRotator, RotatorType};
+        use tantivy::vector::rabitq::Metric;
+        use tantivy::IndexBuilder;
+
+        let field_configs: Vec<ClusterFieldConfig> = vector_fields
+            .iter()
+            .map(|&(field, dims)| {
+                let rotator = Arc::new(DynamicRotator::new(dims, RotatorType::FhtKacRotator, 42));
+                let padded_dims = rotator.padded_dim();
+                let ex_bits = 2; // default: 1-bit binary + 2-bit extended
+                ClusterFieldConfig {
+                    field,
+                    dims,
+                    padded_dims,
+                    ex_bits,
+                    metric: Metric::L2,
+                    rotator,
+                    rotator_seed: 42,
+                }
+            })
+            .collect();
+
+        let cluster_config = ClusterConfig {
+            fields: field_configs,
+            clustering_threshold: 1000,
+            num_clusters_fn: Arc::new(|n| (n as f64 / 250.0).ceil() as usize),
+            kmeans: KMeansConfig::default(),
+            sample_ratio: 0.1,
+            sample_cap: 65536,
+            sampler_factory: Arc::new(crate::vector::NoopSamplerFactory),
+        };
+
+        let bqvec_plugin = BqVecPlugin::builder().build();
+
+        let index_builder = IndexBuilder::new()
+            .schema(schema.clone())
+            .settings(settings)
+            .plugin(Arc::new(ClusterPlugin::new(cluster_config)))
+            .plugin(Arc::new(bqvec_plugin));
+
+        let dir: Box<dyn tantivy::directory::Directory> = directory.into();
+        let _ = index_builder.create(dir)?;
+    }
+
     Ok(())
 }
 

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -311,69 +311,8 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
         ..IndexSettings::default()
     };
 
-    // Collect vector fields for plugin registration
-    let vector_fields: Vec<_> = unsafe { extract_field_attributes(index_relation.as_ptr()) }
-        .into_iter()
-        .filter_map(|(name, attr)| {
-            if let SearchFieldType::Vector(_, dims) = attr.tantivy_type {
-                let field = schema.get_field(name.as_ref()).ok()?;
-                Some((field, dims))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if vector_fields.is_empty() {
-        let _ = Index::create(directory, schema.clone(), settings)?;
-    } else {
-        use std::sync::Arc;
-        use tantivy::vector::bqvec::BqVecPlugin;
-        use tantivy::vector::cluster::kmeans::KMeansConfig;
-        use tantivy::vector::cluster::plugin::{ClusterConfig, ClusterFieldConfig, ClusterPlugin};
-        use tantivy::vector::rabitq::rotation::{DynamicRotator, RotatorType};
-        use tantivy::vector::rabitq::Metric;
-        use tantivy::IndexBuilder;
-
-        let field_configs: Vec<ClusterFieldConfig> = vector_fields
-            .iter()
-            .map(|&(field, dims)| {
-                let rotator = Arc::new(DynamicRotator::new(dims, RotatorType::FhtKacRotator, 42));
-                let padded_dims = rotator.padded_dim();
-                let ex_bits = 2; // default: 1-bit binary + 2-bit extended
-                ClusterFieldConfig {
-                    field,
-                    dims,
-                    padded_dims,
-                    ex_bits,
-                    metric: Metric::L2,
-                    rotator,
-                    rotator_seed: 42,
-                }
-            })
-            .collect();
-
-        let cluster_config = ClusterConfig {
-            fields: field_configs,
-            clustering_threshold: 1000,
-            num_clusters_fn: Arc::new(|n| (n as f64 / 250.0).ceil() as usize),
-            kmeans: KMeansConfig::default(),
-            sample_ratio: 0.1,
-            sample_cap: 65536,
-            sampler_factory: Arc::new(crate::vector::NoopSamplerFactory),
-        };
-
-        let bqvec_plugin = BqVecPlugin::builder().build();
-
-        let index_builder = IndexBuilder::new()
-            .schema(schema.clone())
-            .settings(settings)
-            .plugin(Arc::new(ClusterPlugin::new(cluster_config)))
-            .plugin(Arc::new(bqvec_plugin));
-
-        let dir: Box<dyn tantivy::directory::Directory> = directory.into();
-        let _ = index_builder.create(dir)?;
-    }
+    let mut index = Index::create(directory, schema.clone(), settings)?;
+    crate::vector::register_vector_plugins(&mut index);
 
     Ok(())
 }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -446,7 +446,7 @@ impl WorkerBuildState {
             segment_ids_to_merge
         );
         let directory = MvccSatisfies::Mergeable.directory(&self.indexrel);
-        let mut merger = SearchIndexMerger::open(directory)?;
+        let mut merger = SearchIndexMerger::open_for_merge(directory, &self.indexrel)?;
         unsafe { set_ps_display_suffix(MERGING.as_ptr()) };
         merger.merge_segments(&segment_ids_to_merge)?;
 

--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -99,6 +99,13 @@ pub fn is_citext_oid(oid: pg_sys::Oid) -> bool {
     cid != pg_sys::Oid::INVALID && oid == cid
 }
 
+pub fn is_pgvector_oid(oid: pg_sys::Oid) -> bool {
+    static VECTOR_OID: OnceLock<pg_sys::Oid> = OnceLock::new();
+    let vid = *VECTOR_OID
+        .get_or_init(|| lookup_typoid(c"public", c"vector").unwrap_or(pg_sys::Oid::INVALID));
+    vid != pg_sys::Oid::INVALID && oid == vid
+}
+
 /// Helper function to lookup a function's [`pg_sys::Oid`] by name, argument types, and namespace
 pub fn lookup_procoid(
     namespace: &CStr,

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -363,7 +363,8 @@ impl AggregateCSClause {
                 OrderByFeature::Field { name, .. } => Some(name.to_string()),
                 OrderByFeature::Score { .. }
                 | OrderByFeature::Var { .. }
-                | OrderByFeature::NullTest { .. } => None,
+                | OrderByFeature::NullTest { .. }
+                | OrderByFeature::VectorDistance { .. } => None,
             })
             .collect()
     }

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -35,6 +35,12 @@ pub enum OrderByStyle {
         name: FieldName,
         rti: u32,
     },
+    VectorDistance {
+        pathkey: *mut pg_sys::PathKey,
+        name: FieldName,
+        rti: u32,
+        query_vector: Vec<f32>,
+    },
 }
 
 impl OrderByStyle {
@@ -42,6 +48,7 @@ impl OrderByStyle {
         match self {
             OrderByStyle::Score { pathkey, .. } => *pathkey,
             OrderByStyle::Field { pathkey, .. } => *pathkey,
+            OrderByStyle::VectorDistance { pathkey, .. } => *pathkey,
         }
     }
 
@@ -92,6 +99,16 @@ impl From<&OrderByStyle> for OrderByInfo {
                 rti: *rti,
             },
             OrderByStyle::Score { rti, .. } => OrderByFeature::Score { rti: *rti },
+            OrderByStyle::VectorDistance {
+                name,
+                rti,
+                query_vector,
+                ..
+            } => OrderByFeature::VectorDistance {
+                name: name.to_owned(),
+                rti: *rti,
+                query_vector: query_vector.clone(),
+            },
         };
         OrderByInfo {
             feature,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -807,6 +807,9 @@ fn resolve_orderby_feature(
         OrderByFeature::NullTest { .. } => {
             unreachable!("NullTest is handled by apply_sort directly")
         }
+        OrderByFeature::VectorDistance { .. } => {
+            unimplemented!("Vector distance ORDER BY is not supported in JoinScan")
+        }
     }
 }
 
@@ -1009,7 +1012,7 @@ fn build_source_df<'a>(
                             }
                         }
                     }
-                    OrderByFeature::Score { .. } => {}
+                    OrderByFeature::Score { .. } | OrderByFeature::VectorDistance { .. } => {}
                     OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
                         OrderByFeature::Field { name, rti } => {
                             if source.contains_rti(*rti) {

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -40,7 +40,7 @@ use crate::schema::{SearchField, SearchIndexSchema};
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
 
 /// The type of sort expression found in an ORDER BY clause.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SortExpressionType {
     /// Sorting by search score: `ORDER BY pdb.score(...)`
     Score,
@@ -50,6 +50,8 @@ pub enum SortExpressionType {
     Raw,
     /// Sorting by an expression that matched an indexed expression in `pg_index.indexprs`.
     IndexedExpression,
+    /// Sorting by vector distance: `ORDER BY col <-> '[...]'`
+    VectorDistance(Vec<f32>),
 }
 
 /// Reason why pathkeys cannot be used for Top K execution
@@ -221,6 +223,16 @@ pub unsafe fn analyze_sort_expression(
         }
     }
 
+    if let Some((var, query_vector)) = extract_vector_distance(node, context) {
+        let (relid, attno) = context.var_relation(var);
+        let field_name = fieldname_from_var(relid, var, attno);
+        return Some((
+            SortExpressionType::VectorDistance(query_vector),
+            var,
+            field_name,
+        ));
+    }
+
     if let Some(var) = extract_lower_var(node) {
         let (relid, attno) = context.var_relation(var);
         let field_name = fieldname_from_var(relid, var, attno);
@@ -232,6 +244,60 @@ pub unsafe fn analyze_sort_expression(
     }
 
     None
+}
+
+/// Check if an operator OID is pgvector's L2 distance operator (<->).
+fn is_vector_distance_opoid(opoid: pg_sys::Oid) -> bool {
+    use std::sync::OnceLock;
+    static L2_DIST_OPOID: OnceLock<pg_sys::Oid> = OnceLock::new();
+    let cached = *L2_DIST_OPOID.get_or_init(|| unsafe {
+        direct_function_call::<pg_sys::Oid>(
+            pg_sys::regoperatorin,
+            &[c"<->(vector,vector)".into_datum()],
+        )
+        .unwrap_or(pg_sys::Oid::INVALID)
+    });
+    cached != pg_sys::Oid::INVALID && opoid == cached
+}
+
+/// Detect `col <-> '[...]'` vector distance expression.
+/// Returns (column Var, query vector as Vec<f32>) if matched.
+unsafe fn extract_vector_distance(
+    node: *mut pg_sys::Node,
+    _context: VarContext,
+) -> Option<(*mut pg_sys::Var, Vec<f32>)> {
+    let opexpr = nodecast!(OpExpr, T_OpExpr, node)?;
+    if !is_vector_distance_opoid((*opexpr).opno) {
+        return None;
+    }
+
+    let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
+    if args.len() != 2 {
+        return None;
+    }
+
+    let left = args.get_ptr(0)?;
+    let right = args.get_ptr(1)?;
+
+    // left should be a Var (column reference), right should be a Const (query vector)
+    let (var_node, const_node) = if !left.is_null() && (*left).type_ == pg_sys::NodeTag::T_Var {
+        (left as *mut pg_sys::Var, right)
+    } else if !right.is_null() && (*right).type_ == pg_sys::NodeTag::T_Var {
+        (right as *mut pg_sys::Var, left)
+    } else {
+        return None;
+    };
+
+    // Extract the constant vector value
+    let const_node = nodecast!(Const, T_Const, const_node)?;
+    if (*const_node).constisnull {
+        return None;
+    }
+
+    let datum = (*const_node).constvalue;
+    let query_vector = crate::postgres::types::extract_pgvector_floats_from_datum(datum);
+
+    Some((var_node, query_vector))
 }
 
 /// Extract FuncExpr from PlaceHolderVar node
@@ -400,6 +466,18 @@ where
                             }
                         }
                     }
+                    SortExpressionType::VectorDistance(ref query_vector) => {
+                        if let Some(field_name) = field_name_opt {
+                            pathkey_styles.push(OrderByStyle::VectorDistance {
+                                pathkey,
+                                name: field_name,
+                                rti,
+                                query_vector: query_vector.clone(),
+                            });
+                            found_valid_member = true;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -550,6 +628,10 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 if !search_field.is_fast() {
                     return false;
                 }
+            }
+            SortExpressionType::VectorDistance(_) => {
+                // Vector distance is always valid if the field exists in the index
+                continue;
             }
         }
     }

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -414,8 +414,9 @@ unsafe fn merge_index(
     // before it decides to find the segments it should vacuum.  The reason is that it needs to see
     // the final merged segment, not the original segments that will be deleted
     let metadata = MetaPage::open(indexrel);
-    let merger = SearchIndexMerger::open(MvccSatisfies::Mergeable.directory(indexrel))
-        .expect("should be able to open merger");
+    let merger =
+        SearchIndexMerger::open_for_merge(MvccSatisfies::Mergeable.directory(indexrel), indexrel)
+            .expect("should be able to open merger");
 
     // further reduce the set of segments that the LayeredMergePolicy will operate on by internally
     // simulating the process, allowing concurrent merges to consider segments we're not, only retaining

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -254,19 +254,21 @@ pub unsafe fn do_merge(
     let merge_lock = metadata.acquire_merge_lock();
     let foreground_layer_sizes = layer_sizes.foreground_layer_sizes.clone();
 
-    let (needs_background_merge, largest_layer_size) =
-        if layer_sizes.user_configured_background_layers() {
-            let combined_layers = layer_sizes.combined();
-            let merger = SearchIndexMerger::open(MvccSatisfies::Mergeable.directory(index))?;
-            let mut background_merge_policy = LayeredMergePolicy::new(combined_layers);
+    let (needs_background_merge, largest_layer_size) = if layer_sizes
+        .user_configured_background_layers()
+    {
+        let combined_layers = layer_sizes.combined();
+        let merger =
+            SearchIndexMerger::open_for_merge(MvccSatisfies::Mergeable.directory(index), index)?;
+        let mut background_merge_policy = LayeredMergePolicy::new(combined_layers);
 
-            background_merge_policy.set_mergeable_segment_entries(&metadata, &merge_lock, &merger);
-            let (merge_candidates, largest_layer_size) = background_merge_policy.simulate();
+        background_merge_policy.set_mergeable_segment_entries(&metadata, &merge_lock, &merger);
+        let (merge_candidates, largest_layer_size) = background_merge_policy.simulate();
 
-            (!merge_candidates.is_empty(), largest_layer_size)
-        } else {
-            (false, 0)
-        };
+        (!merge_candidates.is_empty(), largest_layer_size)
+    } else {
+        (false, 0)
+    };
 
     if needs_background_merge && !need_backpressure {
         // if we need (and think we can do) a background merge then we prefer to do that

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -1174,6 +1174,9 @@ fn key_field_config(field_type: SearchFieldType) -> SearchFieldConfig {
             indexed: true,
             fast: true,
         },
+        SearchFieldType::Vector(_, _) => {
+            panic!("vector fields cannot be used as key fields")
+        }
     }
 }
 

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -17,7 +17,7 @@
 
 use crate::api::tokenizers::type_is_tokenizer;
 use crate::nodecast;
-use crate::postgres::catalog::is_citext_oid;
+use crate::postgres::catalog::{is_citext_oid, is_pgvector_oid};
 use crate::postgres::datetime::{datetime_components_to_tantivy_date, MICROSECONDS_IN_SECOND};
 use crate::postgres::jsonb_support::jsonb_datum_to_serde_json_value;
 use crate::postgres::range::RangeToTantivyValue;
@@ -330,6 +330,12 @@ impl TantivyValue {
                 String::from_datum(datum, false).ok_or(TantivyValueError::DatumDeref)?,
             ),
 
+            PgOid::Custom(custom) if is_pgvector_oid(*custom) => {
+                let floats = extract_pgvector_floats_from_datum(datum);
+                let bytes: Vec<u8> = floats.iter().flat_map(|f| f.to_le_bytes()).collect();
+                Ok(TantivyValue(OwnedValue::Bytes(bytes)))
+            }
+
             PgOid::Custom(custom) => {
                 if is_citext_oid(*custom) {
                     return TantivyValue::try_from(
@@ -348,6 +354,24 @@ impl TantivyValue {
     ) -> Result<Self, TantivyValueError> {
         Self::try_from_datum(any_element.datum(), PgOid::from_untagged(any_element.oid()))
     }
+}
+
+/// Extract f32 values from a pgvector datum.
+/// pgvector's internal layout: varlena header, then int16 dim, int16 unused, then float4[dim].
+/// Extract f32 values from a pgvector datum.
+/// pgvector's internal layout after varlena header: int16 dim, int16 unused, float4[dim].
+pub unsafe fn extract_pgvector_floats_from_datum(datum: Datum) -> Vec<f32> {
+    let ptr = datum.cast_mut_ptr::<pg_sys::varlena>();
+    let detoasted = pg_sys::pg_detoast_datum(ptr);
+    let data = pgrx::varlena::vardata_any(detoasted);
+    let dim = *(data as *const i16) as usize;
+    let floats_ptr = (data as *const u8).add(4) as *const f32;
+    let slice = std::slice::from_raw_parts(floats_ptr, dim);
+    let result = slice.to_vec();
+    if detoasted != ptr {
+        pg_sys::pfree(detoasted as *mut std::ffi::c_void);
+    }
+    result
 }
 
 impl fmt::Display for TantivyValue {

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -832,8 +832,14 @@ pub unsafe fn row_to_search_document<'a>(
             {
                 document.add_field_value(search_field.field(), &OwnedValue::from(value));
             }
+        } else if matches!(search_field.field_type(), SearchFieldType::Vector(..)) {
+            let vec =
+                unsafe { crate::postgres::types::extract_pgvector_floats_from_datum(actual_datum) };
+            document.add_leaf_field_value(
+                search_field.field(),
+                tantivy::schema::document::ReferenceValueLeaf::Vector(&vec),
+            );
         } else {
-            // Check for NUMERIC field types that need special handling
             let tv = match search_field.field_type() {
                 SearchFieldType::Numeric64(_, scale) => {
                     TantivyValue::try_from_numeric_i64(actual_datum, scale)

--- a/pg_search/src/schema/config.rs
+++ b/pg_search/src/schema/config.rs
@@ -99,6 +99,15 @@ pub enum SearchFieldConfig {
         #[serde(default = "default_as_true")]
         fast: bool,
     },
+    Vector {
+        dims: usize,
+        #[serde(default = "default_vector_metric")]
+        metric: String,
+    },
+}
+
+fn default_vector_metric() -> String {
+    "l2".to_string()
 }
 
 impl SearchFieldConfig {
@@ -289,6 +298,13 @@ impl SearchFieldConfig {
 
     pub fn default_range() -> Self {
         Self::from_json(json!({"Json": {"fast": true}}))
+    }
+
+    pub fn default_vector(dims: usize) -> Self {
+        Self::Vector {
+            dims,
+            metric: default_vector_metric(),
+        }
     }
 }
 

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -21,7 +21,7 @@ pub mod range;
 
 use crate::api::FieldName;
 use crate::api::HashMap;
-use crate::postgres::catalog::is_citext_oid;
+use crate::postgres::catalog::{is_citext_oid, is_pgvector_oid};
 use crate::postgres::options::{BM25IndexOptions, SortByDirection, SortByField};
 pub use crate::postgres::utils::{convert_pg_date_string, FieldSource};
 use crate::postgres::utils::{resolve_base_type, ExtractedFieldAttribute};
@@ -70,6 +70,8 @@ pub enum SearchFieldType {
     /// NUMERIC with precision > 18 or unlimited: stored as lexicographically sortable bytes.
     /// The Option<i16> is the scale (number of decimal places), or None for unlimited precision.
     NumericBytes(pg_sys::Oid, Option<i16>),
+    /// Dense vector field (pgvector type). The usize is the number of dimensions.
+    Vector(pg_sys::Oid, usize),
 }
 
 impl SearchFieldType {
@@ -101,6 +103,7 @@ impl SearchFieldType {
             SearchFieldType::Json(_) => SearchFieldConfig::default_json(),
             SearchFieldType::Date(_) => SearchFieldConfig::default_date(),
             SearchFieldType::Range(_) => SearchFieldConfig::default_range(),
+            SearchFieldType::Vector(_, dims) => SearchFieldConfig::default_vector(*dims),
         }
     }
 
@@ -119,6 +122,7 @@ impl SearchFieldType {
             SearchFieldType::Range(oid) => *oid,
             SearchFieldType::Numeric64(oid, _) => *oid,
             SearchFieldType::NumericBytes(oid, _) => *oid,
+            SearchFieldType::Vector(oid, _) => *oid,
         }
         .into()
     }
@@ -181,6 +185,9 @@ impl SearchFieldType {
 
             // NumericBytes is stored as BinaryView
             SearchFieldType::NumericBytes(..) => arrow_schema::DataType::BinaryView,
+
+            // Vector is not stored in Arrow columnar format
+            SearchFieldType::Vector(..) => arrow_schema::DataType::BinaryView,
         }
     }
 }
@@ -316,6 +323,11 @@ impl TryFrom<(PgOid, Typmod, pg_sys::Oid)> for SearchFieldType {
             PgOid::Custom(tokenizer_oid) if type_is_tokenizer(*tokenizer_oid) => Ok(
                 SearchFieldType::Tokenized(*tokenizer_oid, typmod, inner_typoid),
             ),
+
+            PgOid::Custom(custom) if is_pgvector_oid(*custom) => {
+                let dims = if typmod > 0 { typmod as usize } else { 0 };
+                Ok(SearchFieldType::Vector(*custom, dims))
+            }
 
             PgOid::Custom(custom) => {
                 if is_citext_oid(*custom) {

--- a/pg_search/src/vector/mod.rs
+++ b/pg_search/src/vector/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use pgrx::pg_sys;
 use tantivy::index::SegmentReader;
 use tantivy::indexer::doc_id_mapping::SegmentDocIdMapping;
 use tantivy::schema::{Field, FieldType};
@@ -9,34 +10,200 @@ use tantivy::vector::cluster::plugin::{ClusterConfig, ClusterFieldConfig, Cluste
 use tantivy::vector::cluster::sampler::{VectorSampler, VectorSamplerFactory};
 use tantivy::vector::rabitq::rotation::{DynamicRotator, RotatorType};
 use tantivy::vector::rabitq::Metric;
-use tantivy::DocId;
+use tantivy::{DocAddress, DocId};
 
-pub struct NoopSamplerFactory;
+use crate::postgres::rel::PgSearchRelation;
 
-impl VectorSamplerFactory for NoopSamplerFactory {
-    fn create_sampler(
-        &self,
-        _readers: &[SegmentReader],
-        _doc_id_mapping: &SegmentDocIdMapping,
-    ) -> tantivy::Result<Box<dyn VectorSampler>> {
-        Ok(Box::new(NoopSampler))
+use std::collections::HashMap;
+
+pub struct VectorFieldInfo {
+    pub attno: pg_sys::AttrNumber,
+    pub dims: usize,
+}
+
+pub struct PgHeapVectorSamplerFactory {
+    heap_oid: pg_sys::Oid,
+    field_info: HashMap<Field, VectorFieldInfo>,
+}
+
+impl PgHeapVectorSamplerFactory {
+    pub fn new(heap_oid: pg_sys::Oid, field_info: HashMap<Field, VectorFieldInfo>) -> Self {
+        Self {
+            heap_oid,
+            field_info,
+        }
     }
 }
 
-struct NoopSampler;
+impl VectorSamplerFactory for PgHeapVectorSamplerFactory {
+    fn create_sampler(
+        &self,
+        readers: &[SegmentReader],
+        doc_id_mapping: &SegmentDocIdMapping,
+    ) -> tantivy::Result<Box<dyn VectorSampler>> {
+        let mapping: Vec<DocAddress> = doc_id_mapping.iter_old_doc_addrs().collect();
 
-impl VectorSampler for NoopSampler {
+        let mut ctid_columns = Vec::with_capacity(readers.len());
+        for reader in readers {
+            let col = reader.fast_fields().u64("ctid").map_err(|e| {
+                tantivy::TantivyError::InternalError(format!("ctid fast field: {e}"))
+            })?;
+            ctid_columns.push(col);
+        }
+
+        let field_attno: HashMap<Field, pg_sys::AttrNumber> = self
+            .field_info
+            .iter()
+            .map(|(&f, info)| (f, info.attno))
+            .collect();
+        let field_dims: HashMap<Field, usize> = self
+            .field_info
+            .iter()
+            .map(|(&f, info)| (f, info.dims))
+            .collect();
+
+        Ok(Box::new(PgHeapVectorSampler {
+            mapping,
+            ctid_columns,
+            heap_oid: self.heap_oid,
+            field_attno,
+            field_dims,
+        }))
+    }
+}
+
+struct PgHeapVectorSampler {
+    mapping: Vec<DocAddress>,
+    ctid_columns: Vec<tantivy::columnar::Column<u64>>,
+    heap_oid: pg_sys::Oid,
+    field_attno: HashMap<Field, pg_sys::AttrNumber>,
+    field_dims: HashMap<Field, usize>,
+}
+
+unsafe impl Send for PgHeapVectorSampler {}
+unsafe impl Sync for PgHeapVectorSampler {}
+
+impl VectorSampler for PgHeapVectorSampler {
     fn sample_vectors(
         &self,
-        _field: Field,
+        field: Field,
         doc_ids: &[DocId],
     ) -> tantivy::Result<Vec<Option<Vec<f32>>>> {
-        Ok(vec![None; doc_ids.len()])
+        let attno = *self.field_attno.get(&field).ok_or_else(|| {
+            tantivy::TantivyError::InternalError(format!(
+                "no heap attno mapping for vector field {field:?}"
+            ))
+        })?;
+
+        let mut results = Vec::with_capacity(doc_ids.len());
+
+        unsafe {
+            let heaprel = PgSearchRelation::open(self.heap_oid);
+            let snapshot = pg_sys::GetActiveSnapshot();
+            let slot = pg_sys::MakeSingleTupleTableSlot(
+                heaprel.tuple_desc().as_ptr(),
+                &pg_sys::TTSOpsBufferHeapTuple,
+            );
+
+            for &new_doc_id in doc_ids {
+                let addr = self.mapping[new_doc_id as usize];
+                let ctid_col = &self.ctid_columns[addr.segment_ord as usize];
+                let ctid_val = ctid_col.first(addr.doc_id);
+
+                let vec = if let Some(ctid) = ctid_val {
+                    let mut tid = pg_sys::ItemPointerData::default();
+                    crate::postgres::utils::u64_to_item_pointer(ctid, &mut tid);
+
+                    let found = pg_sys::table_tuple_fetch_row_version(
+                        heaprel.as_ptr(),
+                        &mut tid,
+                        snapshot,
+                        slot,
+                    );
+
+                    if found {
+                        let mut is_null = false;
+                        let datum = pg_sys::slot_getattr(slot, attno as i32, &mut is_null);
+                        if !is_null {
+                            let floats =
+                                crate::postgres::types::extract_pgvector_floats_from_datum(datum);
+                            Some(floats)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                results.push(vec);
+            }
+
+            pg_sys::ExecDropSingleTupleTableSlot(slot);
+        }
+
+        Ok(results)
     }
 
-    fn dims(&self, _field: Field) -> usize {
-        0
+    fn dims(&self, field: Field) -> usize {
+        self.field_dims.get(&field).copied().unwrap_or(0)
     }
+}
+
+/// Detect all vector columns' heap attribute info from an index relation.
+/// Returns (heap_oid, map of field_name → VectorFieldInfo) if vector columns are found.
+pub unsafe fn find_vector_heap_info(
+    indexrel: &PgSearchRelation,
+) -> Option<(pg_sys::Oid, Vec<(String, VectorFieldInfo)>)> {
+    let heap_rel = indexrel.heap_relation()?;
+    let heap_oid = heap_rel.oid();
+    let tupdesc = heap_rel.tuple_desc();
+
+    let mut fields = Vec::new();
+    for i in 0..tupdesc.len() {
+        let attr = tupdesc.get(i)?;
+        let type_oid = attr.type_oid().value();
+        if crate::postgres::catalog::is_pgvector_oid(type_oid) {
+            let attno = (i + 1) as pg_sys::AttrNumber;
+            let typmod = attr.atttypmod;
+            let dims = if typmod > 0 { typmod as usize } else { 0 };
+            let name = attr.name().to_string();
+            fields.push((name, VectorFieldInfo { attno, dims }));
+        }
+    }
+
+    if fields.is_empty() {
+        None
+    } else {
+        Some((heap_oid, fields))
+    }
+}
+
+pub fn register_vector_plugins_for_merge(index: &mut tantivy::Index, indexrel: &PgSearchRelation) {
+    let schema = index.schema();
+    let has_vector = schema
+        .fields()
+        .any(|(_, entry)| matches!(entry.field_type(), FieldType::Vector(_)));
+
+    if !has_vector {
+        return;
+    }
+
+    if let Some((heap_oid, heap_fields)) = unsafe { find_vector_heap_info(indexrel) } {
+        let mut field_info = HashMap::new();
+        for (name, info) in heap_fields {
+            if let Ok(field) = schema.get_field(&name) {
+                field_info.insert(field, info);
+            }
+        }
+        if !field_info.is_empty() {
+            register_vector_plugins_with_sampler(index, heap_oid, field_info);
+            return;
+        }
+    }
+
+    register_vector_plugins(index);
 }
 
 pub fn register_vector_plugins(index: &mut tantivy::Index) {
@@ -87,4 +254,88 @@ pub fn register_vector_plugins(index: &mut tantivy::Index) {
 
     index.register_plugin(Arc::new(ClusterPlugin::new(cluster_config)));
     index.register_plugin(Arc::new(bqvec_plugin));
+}
+
+fn register_vector_plugins_with_sampler(
+    index: &mut tantivy::Index,
+    heap_oid: pg_sys::Oid,
+    field_info: HashMap<Field, VectorFieldInfo>,
+) {
+    let schema = index.schema();
+    let vector_fields: Vec<(Field, usize)> = schema
+        .fields()
+        .filter_map(|(field, entry)| {
+            if let FieldType::Vector(opts) = entry.field_type() {
+                Some((field, opts.dimensions))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if vector_fields.is_empty() {
+        return;
+    }
+
+    let field_configs: Vec<ClusterFieldConfig> = vector_fields
+        .iter()
+        .map(|&(field, dims)| {
+            let rotator = Arc::new(DynamicRotator::new(dims, RotatorType::FhtKacRotator, 42));
+            let padded_dims = rotator.padded_dim();
+            ClusterFieldConfig {
+                field,
+                dims,
+                padded_dims,
+                ex_bits: 2,
+                metric: Metric::L2,
+                rotator,
+                rotator_seed: 42,
+            }
+        })
+        .collect();
+
+    let sampler_factory = Arc::new(PgHeapVectorSamplerFactory::new(heap_oid, field_info));
+
+    let cluster_config = ClusterConfig {
+        fields: field_configs,
+        clustering_threshold: 1000,
+        num_clusters_fn: Arc::new(|n| (n as f64 / 250.0).ceil() as usize),
+        kmeans: KMeansConfig::default(),
+        sample_ratio: 0.1,
+        sample_cap: 65536,
+        sampler_factory,
+    };
+
+    let bqvec_plugin = BqVecPlugin::builder().build();
+
+    index.register_plugin(Arc::new(ClusterPlugin::new(cluster_config)));
+    index.register_plugin(Arc::new(bqvec_plugin));
+}
+
+struct NoopSamplerFactory;
+
+impl VectorSamplerFactory for NoopSamplerFactory {
+    fn create_sampler(
+        &self,
+        _readers: &[SegmentReader],
+        _doc_id_mapping: &SegmentDocIdMapping,
+    ) -> tantivy::Result<Box<dyn VectorSampler>> {
+        Ok(Box::new(NoopSampler))
+    }
+}
+
+struct NoopSampler;
+
+impl VectorSampler for NoopSampler {
+    fn sample_vectors(
+        &self,
+        _field: Field,
+        doc_ids: &[DocId],
+    ) -> tantivy::Result<Vec<Option<Vec<f32>>>> {
+        Ok(vec![None; doc_ids.len()])
+    }
+
+    fn dims(&self, _field: Field) -> usize {
+        0
+    }
 }

--- a/pg_search/src/vector/mod.rs
+++ b/pg_search/src/vector/mod.rs
@@ -1,0 +1,33 @@
+use tantivy::index::SegmentReader;
+use tantivy::indexer::doc_id_mapping::SegmentDocIdMapping;
+use tantivy::schema::Field;
+use tantivy::vector::cluster::sampler::{VectorSampler, VectorSamplerFactory};
+use tantivy::DocId;
+
+pub struct NoopSamplerFactory;
+
+impl VectorSamplerFactory for NoopSamplerFactory {
+    fn create_sampler(
+        &self,
+        _readers: &[SegmentReader],
+        _doc_id_mapping: &SegmentDocIdMapping,
+    ) -> tantivy::Result<Box<dyn VectorSampler>> {
+        Ok(Box::new(NoopSampler))
+    }
+}
+
+struct NoopSampler;
+
+impl VectorSampler for NoopSampler {
+    fn sample_vectors(
+        &self,
+        _field: Field,
+        doc_ids: &[DocId],
+    ) -> tantivy::Result<Vec<Option<Vec<f32>>>> {
+        Ok(vec![None; doc_ids.len()])
+    }
+
+    fn dims(&self, _field: Field) -> usize {
+        0
+    }
+}

--- a/pg_search/src/vector/mod.rs
+++ b/pg_search/src/vector/mod.rs
@@ -1,7 +1,14 @@
+use std::sync::Arc;
+
 use tantivy::index::SegmentReader;
 use tantivy::indexer::doc_id_mapping::SegmentDocIdMapping;
-use tantivy::schema::Field;
+use tantivy::schema::{Field, FieldType};
+use tantivy::vector::bqvec::BqVecPlugin;
+use tantivy::vector::cluster::kmeans::KMeansConfig;
+use tantivy::vector::cluster::plugin::{ClusterConfig, ClusterFieldConfig, ClusterPlugin};
 use tantivy::vector::cluster::sampler::{VectorSampler, VectorSamplerFactory};
+use tantivy::vector::rabitq::rotation::{DynamicRotator, RotatorType};
+use tantivy::vector::rabitq::Metric;
 use tantivy::DocId;
 
 pub struct NoopSamplerFactory;
@@ -30,4 +37,54 @@ impl VectorSampler for NoopSampler {
     fn dims(&self, _field: Field) -> usize {
         0
     }
+}
+
+pub fn register_vector_plugins(index: &mut tantivy::Index) {
+    let schema = index.schema();
+    let vector_fields: Vec<(Field, usize)> = schema
+        .fields()
+        .filter_map(|(field, entry)| {
+            if let FieldType::Vector(opts) = entry.field_type() {
+                Some((field, opts.dimensions))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if vector_fields.is_empty() {
+        return;
+    }
+
+    let field_configs: Vec<ClusterFieldConfig> = vector_fields
+        .iter()
+        .map(|&(field, dims)| {
+            let rotator = Arc::new(DynamicRotator::new(dims, RotatorType::FhtKacRotator, 42));
+            let padded_dims = rotator.padded_dim();
+            ClusterFieldConfig {
+                field,
+                dims,
+                padded_dims,
+                ex_bits: 2,
+                metric: Metric::L2,
+                rotator,
+                rotator_seed: 42,
+            }
+        })
+        .collect();
+
+    let cluster_config = ClusterConfig {
+        fields: field_configs,
+        clustering_threshold: 1000,
+        num_clusters_fn: Arc::new(|n| (n as f64 / 250.0).ceil() as usize),
+        kmeans: KMeansConfig::default(),
+        sample_ratio: 0.1,
+        sample_cap: 65536,
+        sampler_factory: Arc::new(NoopSamplerFactory),
+    };
+
+    let bqvec_plugin = BqVecPlugin::builder().build();
+
+    index.register_plugin(Arc::new(ClusterPlugin::new(cluster_config)));
+    index.register_plugin(Arc::new(bqvec_plugin));
 }

--- a/pg_search/tests/pg_regress/expected/vector-search.out
+++ b/pg_search/tests/pg_regress/expected/vector-search.out
@@ -1,0 +1,42 @@
+-- Test vector search with pgvector integration
+CREATE EXTENSION IF NOT EXISTS vector;
+-- Create table with vector column
+CREATE TABLE test_vectors (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    embedding vector(3)
+);
+-- Insert test data
+INSERT INTO test_vectors (description, embedding) VALUES
+    ('red apple', '[1, 0, 0]'),
+    ('green apple', '[0, 1, 0]'),
+    ('blue sky', '[0, 0, 1]'),
+    ('red sky', '[0.9, 0, 0.1]'),
+    ('green grass', '[0.1, 0.9, 0]');
+-- Create BM25 index that includes the vector column
+CREATE INDEX idx_test_vectors ON test_vectors USING bm25 (id, description, embedding);
+-- Hybrid search: text filter + vector distance ordering
+SELECT id, description FROM test_vectors
+WHERE description @@@ 'apple'
+ORDER BY embedding <-> '[1, 0, 0]'
+LIMIT 3;
+ id | description
+----+-------------
+  1 | red apple
+  2 | green apple
+(2 rows)
+
+-- Hybrid search: different query
+SELECT id, description FROM test_vectors
+WHERE description @@@ 'sky'
+ORDER BY embedding <-> '[0, 0, 1]'
+LIMIT 3;
+ id | description
+----+-------------
+  3 | blue sky
+  4 | red sky
+(2 rows)
+
+-- Clean up
+DROP INDEX idx_test_vectors;
+DROP TABLE test_vectors;

--- a/pg_search/tests/pg_regress/sql/vector-search.sql
+++ b/pg_search/tests/pg_regress/sql/vector-search.sql
@@ -1,0 +1,38 @@
+-- Test vector search with pgvector integration
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Create table with vector column
+CREATE TABLE test_vectors (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    embedding vector(3)
+);
+
+-- Insert test data
+INSERT INTO test_vectors (description, embedding) VALUES
+    ('red apple', '[1, 0, 0]'),
+    ('green apple', '[0, 1, 0]'),
+    ('blue sky', '[0, 0, 1]'),
+    ('red sky', '[0.9, 0, 0.1]'),
+    ('green grass', '[0.1, 0.9, 0]');
+
+-- Create BM25 index that includes the vector column
+CREATE INDEX idx_test_vectors ON test_vectors USING bm25 (id, description, embedding)
+WITH (key_field = 'id');
+
+-- Hybrid search: text filter + vector distance ordering
+SELECT id, description FROM test_vectors
+WHERE description @@@ 'apple'
+ORDER BY embedding <-> '[1, 0, 0]'
+LIMIT 3;
+
+-- Hybrid search: different query
+SELECT id, description FROM test_vectors
+WHERE description @@@ 'sky'
+ORDER BY embedding <-> '[0, 0, 1]'
+LIMIT 3;
+
+-- Clean up
+DROP INDEX idx_test_vectors;
+DROP TABLE test_vectors;


### PR DESCRIPTION
## Summary

- Bump version from 0.22.6 to 0.23.0 across Cargo.toml, docs, and upgrade scripts
- Add SQL migration script `pg_search--0.22.6--0.23.0.sql`
- Add changelog for 0.23.0 covering PRs on main not cherry-picked into 0.22.x releases

### Changelog highlights

**New Features:** Aggregate-on-JOIN full pipeline (3+ table joins, HAVING, FILTER, LEFT/RIGHT/FULL JOIN, COUNT(DISTINCT), STRING_AGG/ARRAY_AGG ORDER BY, JSON sub-field GROUP BY, TopK for aggregates), edge_ngram tokenizer, IS NULL/IS NOT NULL in Top-K JoinScan, per-field BM25 k1/b tuning, citext support, fuzzy prefix control, Lindera keep_whitespace.

**Performance:** Lazy tokenizer setup, conditional scoring in row estimation, cached opoids/funcoids/segment mappings.

**Stability:** JoinScan and aggregate scan fixes, LIMIT pushdown suppression, identity expression recognition, generic plan parameter support.

## Test plan

- [ ] CI passes (pre-commit hooks passed locally)
- [ ] Verify Cargo.lock is consistent
- [ ] Review changelog for completeness against merged PRs