### PR TITLE
feat: Support semi/anti joins with disjunctive (OR) join conditions in JoinScan, and Native function support

### DIFF
--- a/pg_search/src/postgres/customscan/datafusion/explain.rs
+++ b/pg_search/src/postgres/customscan/datafusion/explain.rs
@@ -125,5 +125,15 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
                 "(mark = true OR col IS NULL)".to_string()
             }
         }
+        JoinLevelExpr::PgExpression { pg_node_string, .. } => unsafe {
+            let Ok(c_str) = std::ffi::CString::new(pg_node_string.as_str()) else {
+                return pg_node_string.clone();
+            };
+            let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
+            if node.is_null() {
+                return pg_node_string.clone();
+            }
+            format_expr_for_explain(node.cast())
+        },
     }
 }

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -1,0 +1,1035 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Extended PostgreSQL → DataFusion expression translation.
+//!
+//! This file augments `PredicateTranslator` (defined in `translator.rs`) with
+//! additional node-type handlers via a split `impl` block. The methods here
+//! cover expression shapes beyond the simple binary-operator / Var / Const
+//! core — FuncExpr, NullTest, BooleanTest, CaseExpr, CoalesceExpr, NullIfExpr,
+//! MinMaxExpr, ScalarArrayOpExpr, and CoerceViaIO — plus a UDF fallback hook
+//! (`try_wrap_as_udf`) for opaque expressions.
+
+use datafusion::common::ScalarValue;
+use datafusion::logical_expr::expr::{Case, InList, ScalarFunction};
+use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator, ScalarUDF};
+use pgrx::{pg_sys, PgList};
+use std::ffi::CStr;
+use std::sync::Arc;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::datafusion::translator::{
+    deparse_expr_for_debug, node_tag_debug, type_name, PredicateTranslator,
+};
+use crate::postgres::customscan::expr_eval::InputVarInfo;
+use crate::postgres::customscan::pg_expr_udf::PgExprUdf;
+
+const PVC_RECURSE_ALL: i32 = (pg_sys::PVC_RECURSE_AGGREGATES
+    | pg_sys::PVC_RECURSE_WINDOWFUNCS
+    | pg_sys::PVC_RECURSE_PLACEHOLDERS) as i32;
+
+/// Short, `&'static str` label for the subset of PG node tags that reach
+/// `try_wrap_as_udf`. Used only for building human-readable UDF names — a
+/// rename in `pg_sys::NodeTag` won't silently shift the emitted label.
+fn node_tag_label(tag: pg_sys::NodeTag) -> &'static str {
+    match tag {
+        pg_sys::NodeTag::T_OpExpr => "opexpr",
+        pg_sys::NodeTag::T_FuncExpr => "funcexpr",
+        pg_sys::NodeTag::T_BoolExpr => "boolexpr",
+        pg_sys::NodeTag::T_NullTest => "nulltest",
+        pg_sys::NodeTag::T_BooleanTest => "booleantest",
+        pg_sys::NodeTag::T_CaseExpr => "caseexpr",
+        pg_sys::NodeTag::T_CoalesceExpr => "coalesceexpr",
+        pg_sys::NodeTag::T_NullIfExpr => "nullifexpr",
+        pg_sys::NodeTag::T_MinMaxExpr => "minmaxexpr",
+        pg_sys::NodeTag::T_ScalarArrayOpExpr => "scalararrayopexpr",
+        pg_sys::NodeTag::T_CoerceViaIO => "coerceviaio",
+        pg_sys::NodeTag::T_RelabelType => "relabeltype",
+        _ => "expr",
+    }
+}
+
+impl<'a> PredicateTranslator<'a> {
+    /// Translate a `FuncExpr` node.
+    ///
+    /// Looks up the function's `(schema, name)` identity via the Postgres
+    /// catalog, translates each argument recursively, and dispatches to
+    /// [`Self::translate_known_func`]. Returns `None` when any argument
+    /// fails to translate or the function isn't in the known-func map.
+    pub(crate) unsafe fn translate_func_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let func = node as *mut pg_sys::FuncExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*func).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+
+        let funcid = (*func).funcid;
+        let namespace_oid = pg_sys::get_func_namespace(funcid);
+        let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
+        let func_name_ptr = pg_sys::get_func_name(funcid);
+        if namespace_ptr.is_null() || func_name_ptr.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: could not resolve function identity [FuncExpr] funcid={}",
+                funcid.to_u32()
+            );
+            return None;
+        }
+
+        let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
+        let name = CStr::from_ptr(func_name_ptr).to_str().ok()?;
+
+        let arity = df_args.len();
+        let result = Self::translate_known_func(schema, name, df_args);
+        if result.is_none() {
+            pgrx::debug1!(
+                "PredicateTranslator: no native mapping [FuncExpr] func={}.{}, arity={} | {}",
+                schema,
+                name,
+                arity,
+                deparse_expr_for_debug(node, self.sources)
+            );
+        }
+        result
+    }
+
+    /// Map a `(schema, name, args)` triple to a native DataFusion `Expr`.
+    ///
+    /// Returns `None` for unrecognized functions — the caller can fall back
+    /// to UDF wrapping.
+    fn translate_known_func(schema: &str, name: &str, args: Vec<Expr>) -> Option<Expr> {
+        // Scoped imports: these expr_fn modules contain very short names
+        // (`abs`, `upper`, `round`, etc.) that could easily shadow or collide
+        // if pulled in at file scope. Keep them local to this function.
+        // Core items aren't glob-re-exported, so list them explicitly.
+        use datafusion::functions::core::expr_fn::{coalesce, greatest, least, nullif};
+        use datafusion::functions::math::expr_fn::*;
+        use datafusion::functions::string::expr_fn::*;
+        use datafusion::functions::unicode::expr_fn::*;
+
+        let arity = args.len();
+        let mut it = args.into_iter();
+        match schema {
+            "pg_catalog" => {
+                match (name, arity) {
+                    // string module
+                    ("upper", 1) => Some(upper(it.next()?)),
+                    ("lower", 1) => Some(lower(it.next()?)),
+                    ("btrim" | "trim", _) => Some(btrim(it.collect())),
+                    ("ltrim", _) => Some(ltrim(it.collect())),
+                    ("rtrim", _) => Some(rtrim(it.collect())),
+                    ("concat", _) => Some(concat(it.collect())),
+                    ("ascii", 1) => Some(ascii(it.next()?)),
+                    ("repeat", 2) => Some(repeat(it.next()?, it.next()?)),
+                    ("starts_with", 2) => Some(starts_with(it.next()?, it.next()?)),
+                    ("ends_with", 2) => Some(ends_with(it.next()?, it.next()?)),
+                    ("replace", 3) => Some(replace(it.next()?, it.next()?, it.next()?)),
+
+                    // unicode module
+                    ("length" | "char_length" | "character_length", 1) => {
+                        Some(character_length(it.next()?))
+                    }
+                    ("substr" | "substring", _) => match arity {
+                        2 => Some(substr(it.next()?, it.next()?)),
+                        3 => Some(substring(it.next()?, it.next()?, it.next()?)),
+                        _ => None,
+                    },
+                    ("reverse", 1) => Some(reverse(it.next()?)),
+
+                    // math module
+                    ("abs", 1) => Some(abs(it.next()?)),
+                    ("ceil" | "ceiling", 1) => Some(ceil(it.next()?)),
+                    ("floor", 1) => Some(floor(it.next()?)),
+                    ("round", _) => Some(round(it.collect())),
+                    ("sqrt", 1) => Some(sqrt(it.next()?)),
+                    ("power" | "pow", 2) => Some(power(it.next()?, it.next()?)),
+                    ("sign", 1) => Some(signum(it.next()?)),
+                    ("ln", 1) => Some(ln(it.next()?)),
+                    ("log" | "log10", 1) => Some(log10(it.next()?)),
+
+                    // core module
+                    ("coalesce", _) => Some(coalesce(it.collect())),
+                    ("nullif", 2) => Some(nullif(it.next()?, it.next()?)),
+                    ("greatest", _) => Some(greatest(it.collect())),
+                    ("least", _) => Some(least(it.collect())),
+
+                    _ => None,
+                }
+            }
+
+            _ => None,
+        }
+    }
+
+    /// Translate a `NullTest` (x IS NULL / IS NOT NULL).
+    pub(crate) unsafe fn translate_null_test(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let nt = node as *mut pg_sys::NullTest;
+        let arg = self.translate((*nt).arg.cast())?;
+        match (*nt).nulltesttype {
+            pg_sys::NullTestType::IS_NULL => Some(Expr::IsNull(Box::new(arg))),
+            pg_sys::NullTestType::IS_NOT_NULL => Some(Expr::IsNotNull(Box::new(arg))),
+            _ => None,
+        }
+    }
+
+    /// Translate a `BooleanTest` (x IS TRUE / IS NOT TRUE / …).
+    pub(crate) unsafe fn translate_boolean_test(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let bt = node as *mut pg_sys::BooleanTest;
+        let arg = self.translate((*bt).arg.cast())?;
+        match (*bt).booltesttype {
+            pg_sys::BoolTestType::IS_TRUE => Some(Expr::IsTrue(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_TRUE => Some(Expr::IsNotTrue(Box::new(arg))),
+            pg_sys::BoolTestType::IS_FALSE => Some(Expr::IsFalse(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_FALSE => Some(Expr::IsNotFalse(Box::new(arg))),
+            pg_sys::BoolTestType::IS_UNKNOWN => Some(Expr::IsUnknown(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_UNKNOWN => Some(Expr::IsNotUnknown(Box::new(arg))),
+            _ => None,
+        }
+    }
+
+    /// Translate a `CaseExpr` (CASE [operand] WHEN … THEN … ELSE … END).
+    pub(crate) unsafe fn translate_case_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let case = node as *mut pg_sys::CaseExpr;
+
+        let operand = if !(*case).arg.is_null() {
+            Some(Box::new(self.translate((*case).arg.cast())?))
+        } else {
+            None
+        };
+
+        let when_list = PgList::<pg_sys::Node>::from_pg((*case).args);
+        let mut when_then_expr: Vec<(Box<Expr>, Box<Expr>)> = Vec::with_capacity(when_list.len());
+        for w in when_list.iter_ptr() {
+            let cw = w as *mut pg_sys::CaseWhen;
+            let when = self.translate((*cw).expr.cast())?;
+            let then = self.translate((*cw).result.cast())?;
+            when_then_expr.push((Box::new(when), Box::new(then)));
+        }
+        if when_then_expr.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty WHEN list [CaseExpr]");
+            return None;
+        }
+
+        let else_expr = if !(*case).defresult.is_null() {
+            Some(Box::new(self.translate((*case).defresult.cast())?))
+        } else {
+            None
+        };
+
+        Some(Expr::Case(Case {
+            expr: operand,
+            when_then_expr,
+            else_expr,
+        }))
+    }
+
+    /// Translate a `CoalesceExpr` to DataFusion's `coalesce(args)`.
+    pub(crate) unsafe fn translate_coalesce_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::coalesce;
+
+        let ce = node as *mut pg_sys::CoalesceExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*ce).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+        if df_args.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty args list [CoalesceExpr]");
+            return None;
+        }
+
+        Some(coalesce(df_args))
+    }
+
+    /// Translate a `NullIfExpr`. Postgres shares the `OpExpr` layout for this
+    /// node, so we cast to `OpExpr` and read its two-argument list.
+    pub(crate) unsafe fn translate_nullif_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::nullif;
+
+        debug_assert_eq!(
+            (*node).type_,
+            pg_sys::NodeTag::T_NullIfExpr,
+            "translate_nullif_expr called with wrong NodeTag"
+        );
+        let op = node as *mut pg_sys::OpExpr;
+        let args = PgList::<pg_sys::Node>::from_pg((*op).args);
+        if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [NullIfExpr]",
+                args.len()
+            );
+            return None;
+        }
+        let left = self.translate(args.get_ptr(0)?)?;
+        let right = self.translate(args.get_ptr(1)?)?;
+        Some(nullif(left, right))
+    }
+
+    /// Translate a `MinMaxExpr` (GREATEST / LEAST).
+    pub(crate) unsafe fn translate_min_max_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::{greatest, least};
+
+        let mmx = node as *mut pg_sys::MinMaxExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*mmx).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+        if df_args.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty args list [MinMaxExpr]");
+            return None;
+        }
+
+        let is_greatest = matches!((*mmx).op, pg_sys::MinMaxOp::IS_GREATEST);
+        Some(if is_greatest {
+            greatest(df_args)
+        } else {
+            least(df_args)
+        })
+    }
+
+    /// Translate a `ScalarArrayOpExpr` (`scalar = ANY(ARRAY[...])` /
+    /// `scalar <> ALL(ARRAY[...])`) to `Expr::InList`.
+    ///
+    /// Only supports the ArrayExpr form of the RHS (literal array); other
+    /// shapes (subqueries, runtime-constructed arrays) return `None`.
+    pub(crate) unsafe fn translate_scalar_array_op_expr(
+        &self,
+        node: *mut pg_sys::Node,
+    ) -> Option<Expr> {
+        let saop = node as *mut pg_sys::ScalarArrayOpExpr;
+        let args = PgList::<pg_sys::Node>::from_pg((*saop).args);
+        if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [ScalarArrayOpExpr]",
+                args.len()
+            );
+            return None;
+        }
+
+        let scalar = self.translate(args.get_ptr(0)?)?;
+
+        let rhs = args.get_ptr(1)?;
+        if (*rhs).type_ != pg_sys::NodeTag::T_ArrayExpr {
+            pgrx::debug1!(
+                "PredicateTranslator: RHS is not ArrayExpr [ScalarArrayOpExpr] rhs_tag={} | {}",
+                node_tag_debug(rhs),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            return None;
+        }
+        let array_expr = rhs as *mut pg_sys::ArrayExpr;
+        let elements = PgList::<pg_sys::Node>::from_pg((*array_expr).elements);
+        let list: Option<Vec<Expr>> = elements.iter_ptr().map(|el| self.translate(el)).collect();
+        let list = list?;
+
+        let negated = !(*saop).useOr;
+
+        Some(Expr::InList(InList {
+            expr: Box::new(scalar),
+            list,
+            negated,
+        }))
+    }
+
+    /// Translate a `CoerceViaIO`. Only transparent text-family coercions are
+    /// accepted (TEXT ↔ VARCHAR ↔ NAME); everything else may change value
+    /// semantics and is rejected.
+    pub(crate) unsafe fn translate_coerce_via_io(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let coerce = node as *mut pg_sys::CoerceViaIO;
+        let arg_node: *mut pg_sys::Node = (*coerce).arg.cast();
+        if arg_node.is_null() {
+            return None;
+        }
+
+        let source = pg_sys::exprType(arg_node);
+        let target = (*coerce).resulttype;
+
+        const TEXT_FAMILY: &[pg_sys::Oid] = &[pg_sys::TEXTOID, pg_sys::VARCHAROID, pg_sys::NAMEOID];
+        let in_text = |oid: pg_sys::Oid| TEXT_FAMILY.contains(&oid);
+
+        if in_text(source) && in_text(target) {
+            self.translate(arg_node)
+        } else {
+            pgrx::debug1!(
+                "PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source={}, target={} | {}",
+                type_name(source),
+                type_name(target),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            None
+        }
+    }
+
+    /// Wrap an otherwise-untranslatable PostgreSQL expression subtree as a
+    /// [`PgExprUdf`] scalar function. At execution time the UDF rehydrates the
+    /// serialized node, populates a virtual tuple slot from its Arrow input
+    /// columns, and delegates to `ExecEvalExpr`.
+    ///
+    /// Returns `None` when the expression can't be wrapped:
+    ///   - result type is outside the supported set,
+    ///   - some input Var can't be resolved against `self.sources` / mapper,
+    ///   - `nodeToString` returns null.
+    ///
+    /// Called unconditionally as the final fallback in
+    /// [`PredicateTranslator::translate`] — any subtree that fails native
+    /// translation is wrapped here.
+    pub(crate) unsafe fn try_wrap_as_udf(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let result_type_oid = pg_sys::exprType(node);
+        if PgExprUdf::get_result_type_to_arrow(result_type_oid).is_none() {
+            pgrx::debug1!(
+                "PredicateTranslator: unsupported result type for UDF wrap [{}] type={} | {}",
+                node_tag_debug(node),
+                type_name(result_type_oid),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            return None;
+        }
+
+        let var_list = pg_sys::pull_var_clause(node, PVC_RECURSE_ALL);
+        let vars = PgList::<pg_sys::Var>::from_pg(var_list);
+
+        let mut seen: HashSet<(pg_sys::Index, pg_sys::AttrNumber)> = HashSet::default();
+        let mut input_exprs: Vec<Expr> = Vec::new();
+        let mut input_vars: Vec<InputVarInfo> = Vec::new();
+
+        for var_ptr in vars.iter_ptr() {
+            if var_ptr.is_null() {
+                continue;
+            }
+            let varno = (*var_ptr).varno as pg_sys::Index;
+            let varattno = (*var_ptr).varattno;
+
+            if varno == 0 || varattno <= 0 {
+                continue;
+            }
+            // Skip internal join sentinels (INNER_VAR, OUTER_VAR) but allow
+            // INDEX_VAR — it references the custom scan's own output tlist
+            // and translate_var handles it via the mapper.
+            if varno >= pg_sys::INNER_VAR as pg_sys::Index
+                && varno != pg_sys::INDEX_VAR as pg_sys::Index
+            {
+                continue;
+            }
+            if !seen.insert((varno, varattno)) {
+                continue;
+            }
+
+            let col_expr = match self.translate_var(var_ptr) {
+                Some(expr) => expr,
+                None => {
+                    pgrx::debug1!(
+                        "PredicateTranslator: UDF wrap failed — could not resolve Var [{}] varno={}, varattno={} | {}",
+                        node_tag_debug(node),
+                        varno,
+                        varattno,
+                        deparse_expr_for_debug(node, self.sources)
+                    );
+                    return None;
+                }
+            };
+            input_exprs.push(col_expr);
+            input_vars.push(InputVarInfo {
+                rti: varno,
+                attno: varattno,
+                type_oid: (*var_ptr).vartype,
+                typmod: (*var_ptr).vartypmod,
+                collation: (*var_ptr).varcollid,
+            });
+        }
+
+        let node_str = pg_sys::nodeToString(node.cast());
+        if node_str.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: nodeToString returned null [{}]",
+                node_tag_debug(node)
+            );
+            return None;
+        }
+        let pg_expr_string = CStr::from_ptr(node_str).to_string_lossy().into_owned();
+        pg_sys::pfree(node_str.cast());
+
+        let udf_name = PgExprUdf::stable_name(node_tag_label((*node).type_), &pg_expr_string);
+        let udf = PgExprUdf::new(udf_name, pg_expr_string, input_vars, result_type_oid);
+
+        Some(Expr::ScalarFunction(ScalarFunction::new_udf(
+            Arc::new(ScalarUDF::new_from_impl(udf)),
+            input_exprs,
+        )))
+    }
+
+    // -----------------------------------------------------------------
+    // Core node-type translators. These are the arms dispatched from
+    // `translate()` in `translator.rs` — `pub(crate)` so the split impl
+    // block in `translator.rs` can call them as methods on `&self`.
+    // -----------------------------------------------------------------
+
+    pub(crate) unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
+        let node = op_expr as *mut pg_sys::Node;
+        let args = PgList::<pg_sys::Node>::from_pg((*op_expr).args);
+        if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [OpExpr]",
+                args.len()
+            );
+            return None; // Only support binary operators for now
+        }
+
+        // Capture raw arg types before translation for diagnostic logging.
+        let left_arg = args.get_ptr(0)?;
+        let right_arg = args.get_ptr(1)?;
+        let left_type = pg_sys::exprType(left_arg);
+        let right_type = pg_sys::exprType(right_arg);
+
+        let left = self.translate(left_arg)?;
+        let right = self.translate(right_arg)?;
+
+        // Resolve the operator's `(schema, name)` identity from the PG
+        // catalog. Mirrors `translate_func_expr`'s namespace gate: we only
+        // natively translate operators that live in `pg_catalog`, so a
+        // user-defined operator in another schema that happens to share a
+        // symbol (e.g. `=`) with a pg_catalog operator isn't silently
+        // mistranslated. The operator's namespace is the namespace of its
+        // implementing function (`get_opcode` → `get_func_namespace`).
+        let opno = (*op_expr).opno;
+        let op_name_ptr = pg_sys::get_opname(opno);
+        let namespace_oid = pg_sys::get_func_namespace(pg_sys::get_opcode(opno));
+        let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
+        if op_name_ptr.is_null() || namespace_ptr.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: could not resolve operator identity [OpExpr] opno={}",
+                opno.to_u32()
+            );
+            return None;
+        }
+        let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
+        let op_str = CStr::from_ptr(op_name_ptr).to_str().ok()?;
+
+        if schema != "pg_catalog" {
+            pgrx::debug1!(
+                "PredicateTranslator: non-pg_catalog operator [OpExpr] op={}.{}, types=({}, {}) | {}",
+                schema,
+                op_str,
+                type_name(left_type),
+                type_name(right_type),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            return None;
+        }
+
+        let op = match op_str {
+            "=" => Operator::Eq,
+            "<>" | "!=" => Operator::NotEq,
+            "<" => Operator::Lt,
+            "<=" => Operator::LtEq,
+            ">" => Operator::Gt,
+            ">=" => Operator::GtEq,
+            "+" => Operator::Plus,
+            "-" => Operator::Minus,
+            "*" => Operator::Multiply,
+            "/" => Operator::Divide,
+            "%" => Operator::Modulo,
+            _ => {
+                pgrx::debug1!(
+                    "PredicateTranslator: unsupported operator [OpExpr] op=\"{}.{}\", types=({}, {}) | {}",
+                    schema,
+                    op_str,
+                    type_name(left_type),
+                    type_name(right_type),
+                    deparse_expr_for_debug(node, self.sources)
+                );
+                return None;
+            }
+        };
+
+        Some(Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left),
+            op,
+            Box::new(right),
+        )))
+    }
+
+    pub(crate) unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
+        let varno = (*var).varno as pg_sys::Index;
+        let varattno = (*var).varattno;
+
+        // INDEX_VAR is allowed because it represents a reference to the custom scan's output
+        if varno != pg_sys::INDEX_VAR as pg_sys::Index
+            && !self.sources.iter().any(|s| s.contains_rti(varno))
+        {
+            pgrx::debug1!(
+                "PredicateTranslator: unknown source [Var] varno={}, varattno={}",
+                varno,
+                varattno
+            );
+            return None;
+        }
+
+        if let Some(ref mapper) = self.mapper {
+            if let Some(expr) = mapper.map_var(varno, varattno) {
+                return Some(expr);
+            }
+            pgrx::debug1!(
+                "PredicateTranslator: mapper failed to resolve [Var] varno={}, varattno={}",
+                varno,
+                varattno
+            );
+            return None;
+        }
+
+        Some(col("placeholder"))
+    }
+
+    pub(crate) unsafe fn translate_const(&self, c: *mut pg_sys::Const) -> Option<Expr> {
+        if (*c).constisnull {
+            return Some(lit(ScalarValue::Null));
+        }
+
+        let type_oid = (*c).consttype;
+        let datum = (*c).constvalue;
+
+        // Simple mapping for common types
+        let scalar_value = match type_oid {
+            pg_sys::INT2OID => {
+                let val = datum.value() as i16;
+                ScalarValue::Int16(Some(val))
+            }
+            pg_sys::INT4OID => {
+                let val = datum.value() as i32;
+                ScalarValue::Int32(Some(val))
+            }
+            pg_sys::INT8OID => {
+                let val = datum.value() as i64;
+                ScalarValue::Int64(Some(val))
+            }
+            pg_sys::FLOAT4OID => {
+                let val = f32::from_bits(datum.value() as u32);
+                ScalarValue::Float32(Some(val))
+            }
+            pg_sys::FLOAT8OID => {
+                let val = f64::from_bits(datum.value() as u64);
+                ScalarValue::Float64(Some(val))
+            }
+            pg_sys::BOOLOID => {
+                let val = datum.value() != 0;
+                ScalarValue::Boolean(Some(val))
+            }
+            _ => {
+                pgrx::debug1!(
+                    "PredicateTranslator: unsupported const type [Const] type={}",
+                    type_name(type_oid)
+                );
+                return None;
+            }
+        };
+
+        Some(lit(scalar_value))
+    }
+
+    pub(crate) unsafe fn translate_bool_expr(
+        &self,
+        bool_expr: *mut pg_sys::BoolExpr,
+    ) -> Option<Expr> {
+        let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
+
+        match (*bool_expr).boolop {
+            pg_sys::BoolExprType::AND_EXPR => {
+                if args.len() < 2 {
+                    return None;
+                }
+                let mut expr = self.translate(args.get_ptr(0)?)?;
+                for i in 1..args.len() {
+                    let right = self.translate(args.get_ptr(i)?)?;
+                    expr = Expr::BinaryExpr(BinaryExpr::new(
+                        Box::new(expr),
+                        Operator::And,
+                        Box::new(right),
+                    ));
+                }
+                Some(expr)
+            }
+            pg_sys::BoolExprType::OR_EXPR => {
+                if args.len() < 2 {
+                    return None;
+                }
+                let mut expr = self.translate(args.get_ptr(0)?)?;
+                for i in 1..args.len() {
+                    let right = self.translate(args.get_ptr(i)?)?;
+                    expr = Expr::BinaryExpr(BinaryExpr::new(
+                        Box::new(expr),
+                        Operator::Or,
+                        Box::new(right),
+                    ));
+                }
+                Some(expr)
+            }
+            pg_sys::BoolExprType::NOT_EXPR => {
+                if args.len() != 1 {
+                    return None;
+                }
+                let child = self.translate(args.get_ptr(0)?)?;
+                Some(Expr::Not(Box::new(child)))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::col;
+    use pgrx::prelude::*;
+    use proptest::prelude::*;
+
+    /// All `(name, arity)` pairs that `translate_known_func` must accept
+    /// under `pg_catalog`. Keep in sync with the match arms in
+    /// `PredicateTranslator::translate_known_func`.
+    #[allow(dead_code)]
+    const KNOWN_FUNCS: &[(&str, usize)] = &[
+        // string module (fixed arity)
+        ("upper", 1),
+        ("lower", 1),
+        ("ascii", 1),
+        ("repeat", 2),
+        ("starts_with", 2),
+        ("ends_with", 2),
+        ("replace", 3),
+        // string module (variadic; always match)
+        ("btrim", 0),
+        ("btrim", 1),
+        ("btrim", 2),
+        ("trim", 0),
+        ("trim", 1),
+        ("trim", 2),
+        ("ltrim", 0),
+        ("ltrim", 1),
+        ("ltrim", 2),
+        ("rtrim", 0),
+        ("rtrim", 1),
+        ("rtrim", 2),
+        ("concat", 0),
+        ("concat", 1),
+        ("concat", 2),
+        ("concat", 3),
+        // unicode module
+        ("length", 1),
+        ("char_length", 1),
+        ("character_length", 1),
+        ("substr", 2),
+        ("substr", 3),
+        ("substring", 2),
+        ("substring", 3),
+        ("reverse", 1),
+        // math module
+        ("abs", 1),
+        ("ceil", 1),
+        ("ceiling", 1),
+        ("floor", 1),
+        ("round", 0),
+        ("round", 1),
+        ("round", 2),
+        ("sqrt", 1),
+        ("power", 2),
+        ("pow", 2),
+        ("sign", 1),
+        ("ln", 1),
+        ("log", 1),
+        ("log10", 1),
+        // core module
+        ("coalesce", 0),
+        ("coalesce", 1),
+        ("coalesce", 2),
+        ("coalesce", 3),
+        ("nullif", 2),
+        ("greatest", 0),
+        ("greatest", 1),
+        ("greatest", 2),
+        ("greatest", 3),
+        ("least", 0),
+        ("least", 1),
+        ("least", 2),
+        ("least", 3),
+    ];
+
+    #[allow(dead_code)]
+    fn placeholder_args(arity: usize) -> Vec<Expr> {
+        (0..arity).map(|i| col(format!("c{i}"))).collect()
+    }
+
+    // ---------- Test 1: translate_known_func coverage (pure Rust) ----------
+
+    #[test]
+    fn known_funcs_all_return_some() {
+        for &(name, arity) in KNOWN_FUNCS {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", name, args);
+            assert!(
+                out.is_some(),
+                "expected Some for pg_catalog.{name}/{arity}, got None",
+            );
+        }
+    }
+
+    #[test]
+    fn non_pg_catalog_schema_returns_none() {
+        for &(name, arity) in KNOWN_FUNCS {
+            for schema in ["public", "my_schema", "information_schema", ""] {
+                let args = placeholder_args(arity);
+                let out = PredicateTranslator::translate_known_func(schema, name, args);
+                assert!(
+                    out.is_none(),
+                    "expected None for {schema}.{name}/{arity}, got Some",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wrong_arity_returns_none() {
+        // Fixed-arity functions rejected when called with the wrong count.
+        let cases: &[(&str, usize)] = &[
+            ("upper", 0),
+            ("upper", 2),
+            ("lower", 2),
+            ("replace", 1),
+            ("replace", 2),
+            ("replace", 4),
+            ("ascii", 0),
+            ("ascii", 2),
+            ("repeat", 1),
+            ("repeat", 3),
+            ("starts_with", 1),
+            ("starts_with", 3),
+            ("nullif", 1),
+            ("nullif", 3),
+            ("power", 1),
+            ("power", 3),
+            ("abs", 0),
+            ("abs", 2),
+            ("length", 0),
+            ("length", 2),
+            ("substr", 0),
+            ("substr", 1),
+            ("substr", 4),
+        ];
+        for &(name, arity) in cases {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", name, args);
+            assert!(
+                out.is_none(),
+                "expected None for pg_catalog.{name}/{arity}, got Some",
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn unknown_func_name_returns_none(
+            name in "[a-z_]{3,15}".prop_filter("not a known func", |n| {
+                !KNOWN_FUNCS.iter().any(|(k, _)| *k == n)
+            }),
+            arity in 0usize..5,
+        ) {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", &name, args);
+            prop_assert!(
+                out.is_none(),
+                "expected None for pg_catalog.{name}/{arity}, got Some",
+            );
+        }
+    }
+
+    // ---------- SQL-level tests (need live Postgres) ----------
+
+    fn setup_test_tables() {
+        pgrx::Spi::run(
+            r#"
+            DROP TABLE IF EXISTS prop_exclusions CASCADE;
+            DROP TABLE IF EXISTS prop_items CASCADE;
+            CREATE TABLE prop_items (
+                id SERIAL PRIMARY KEY,
+                name TEXT NOT NULL,
+                value INT NOT NULL
+            );
+            CREATE TABLE prop_exclusions (
+                id SERIAL PRIMARY KEY,
+                pattern TEXT,
+                threshold INT NOT NULL
+            );
+            INSERT INTO prop_items (name, value) VALUES
+                ('alpha', 10), ('beta', 20), ('gamma', 30),
+                ('', 0), ('UPPER', 100), ('  trimme  ', 50);
+            INSERT INTO prop_exclusions (pattern, threshold) VALUES
+                ('alpha', 5), (NULL, 10), ('', 15),
+                ('BETA', 20), ('gamma', 25), ('  trimme  ', 30);
+            CREATE INDEX prop_items_idx ON prop_items
+                USING bm25 (id, name, value)
+                WITH (
+                    key_field='id',
+                    text_fields='{"name": {"fast": true}}',
+                    numeric_fields='{"value": {"fast": true}}'
+                );
+            CREATE INDEX prop_exclusions_idx ON prop_exclusions
+                USING bm25 (id, pattern, threshold)
+                WITH (
+                    key_field='id',
+                    text_fields='{"pattern": {"fast": true}}',
+                    numeric_fields='{"threshold": {"fast": true}}'
+                );
+            "#,
+        )
+        .expect("setup_test_tables failed");
+    }
+
+    fn run_ids(query: &str) -> Vec<i32> {
+        pgrx::Spi::connect(|client| {
+            let args: [pgrx::datum::DatumWithOid; 0] = [];
+            let result = client.select(query, None, &args)?;
+            let mut ids = Vec::new();
+            for row in result {
+                if let Some(id) = row.get_by_name::<i32, _>("id")? {
+                    ids.push(id);
+                }
+            }
+            Ok::<_, pgrx::spi::Error>(ids)
+        })
+        .expect("run_ids failed")
+    }
+
+    fn explain_plan(query: &str) -> String {
+        pgrx::Spi::connect(|client| {
+            let args: [pgrx::datum::DatumWithOid; 0] = [];
+            let result = client.select(query, None, &args)?;
+            let mut out = String::new();
+            for row in result {
+                if let Some(line) = row.get::<String>(1)? {
+                    out.push_str(&line);
+                    out.push('\n');
+                }
+            }
+            Ok::<_, pgrx::spi::Error>(out)
+        })
+        .expect("explain_plan failed")
+    }
+
+    fn arb_bool_expr() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("e.pattern IS NULL".to_string()),
+            Just("e.pattern IS NOT NULL".to_string()),
+            Just("length(e.pattern) > 3".to_string()),
+            Just("upper(e.pattern) = upper(i.name)".to_string()),
+            Just("COALESCE(e.pattern, '') = i.name".to_string()),
+            // Arithmetic operators — native via translate_op_expr (+, -, *, /, %).
+            Just("e.threshold + 10 > i.value".to_string()),
+            Just("e.threshold * 2 > 50".to_string()),
+            Just("i.value - e.threshold > 0".to_string()),
+        ]
+    }
+
+    fn anti_join_query(expr: &str) -> String {
+        // LIMIT is required for JoinScan to absorb a Semi/Anti subquery.
+        format!(
+            "SELECT i.id FROM prop_items i \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM prop_exclusions e \
+                 WHERE e.id @@@ paradedb.all() AND ({expr}) \
+             ) \
+             AND i.id @@@ paradedb.all() \
+             ORDER BY i.id LIMIT 10"
+        )
+    }
+
+    // ---------- Test 2: JoinScan results match native PG ----------
+
+    #[pg_test]
+    fn joinscan_matches_native() {
+        setup_test_tables();
+        let cfg = ProptestConfig::with_cases(5);
+        proptest!(cfg, |(expr in arb_bool_expr())| {
+            let query = anti_join_query(&expr);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+            let joinscan = run_ids(&query);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = off").unwrap();
+            let native = run_ids(&query);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+
+            prop_assert_eq!(joinscan, native, "mismatch for expression: {}", expr);
+        });
+    }
+
+    // ---------- Test 3: EXPLAIN shows JoinScan absorbed the expression ----------
+
+    /// Only cross-table expressions — JoinScan's Semi/Anti absorption
+    /// requires the predicate to reference Vars from both sides of the
+    /// EXISTS/NOT EXISTS subquery. Single-table filters (e.g.
+    /// `length(e.pattern) > 3`) get pushed down as heap filters on the
+    /// inner scan and bypass JoinScan entirely.
+    fn arb_absorbable_expr() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("upper(e.pattern) = i.name".to_string()),
+            Just("lower(e.pattern) = lower(i.name)".to_string()),
+            Just("abs(e.threshold) > i.value".to_string()),
+            Just("COALESCE(e.pattern, '') = i.name".to_string()),
+            Just("CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name".to_string(),),
+            Just("e.pattern = i.name OR length(e.pattern) > 100".to_string()),
+            Just("e.pattern = i.name OR e.pattern IS NULL".to_string()),
+            Just("upper(e.pattern) = i.name OR e.threshold > i.value".to_string()),
+            // Arithmetic cross-table predicates — now native OpExpr.
+            Just("e.threshold * 2 > i.value".to_string()),
+            Just("e.threshold + i.value > 100".to_string()),
+        ]
+    }
+
+    #[pg_test]
+    fn expression_is_absorbed_by_joinscan() {
+        setup_test_tables();
+        pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+        let cfg = ProptestConfig::with_cases(5);
+        proptest!(cfg, |(expr in arb_absorbable_expr())| {
+            let explain_query = format!("EXPLAIN (COSTS OFF) {}", anti_join_query(&expr));
+            let plan = explain_plan(&explain_query);
+
+            prop_assert!(
+                plan.contains("ParadeDB Join Scan"),
+                "expression '{}' was not absorbed by JoinScan. Plan:\n{}",
+                expr,
+                plan
+            );
+            prop_assert!(
+                !plan.contains("JoinScan not used"),
+                "expression '{}' triggered JoinScan decline. Plan:\n{}",
+                expr,
+                plan
+            );
+        });
+    }
+
+    // DISTINCT native-function coverage is already exercised
+    // thoroughly by `tests/pg_regress/sql/join_distinct_expr.sql`, whose
+    // expected output pins `upper(...)`, `character_length(...)`, `IS NULL`,
+    // etc. in the physical plan. Repeating that via a proptest on the
+    // minimal in-test schema triggers an unrelated JoinScan DISTINCT+PK-join
+    // schema bug (column-name="" in apply_distinct_group_by), so the SQL
+    // regression remains the authoritative coverage for that path.
+}

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -127,11 +127,14 @@ impl<'a> PredicateTranslator<'a> {
             "pg_catalog" => {
                 match (name, arity) {
                     // string module
-                    ("upper", 1) => Some(upper(it.next()?)),
-                    ("lower", 1) => Some(lower(it.next()?)),
-                    ("btrim" | "trim", _) => Some(btrim(it.collect())),
-                    ("ltrim", _) => Some(ltrim(it.collect())),
-                    ("rtrim", _) => Some(rtrim(it.collect())),
+                    //
+                    // `upper` / `lower` / `btrim` / `trim` / `ltrim` / `rtrim`
+                    // are intentionally NOT mapped here. They are
+                    // collation-aware: DataFusion's implementations use Rust's
+                    // Unicode rules, which can differ from PostgreSQL's
+                    // locale-specific behavior. The `try_wrap_as_udf` fallback
+                    // runs them through `ExecEvalExpr` instead, preserving
+                    // PG-correct semantics.
                     ("concat", _) => Some(concat(it.collect())),
                     ("ascii", 1) => Some(ascii(it.next()?)),
                     ("repeat", 2) => Some(repeat(it.next()?, it.next()?)),
@@ -703,26 +706,15 @@ mod tests {
     #[allow(dead_code)]
     const KNOWN_FUNCS: &[(&str, usize)] = &[
         // string module (fixed arity)
-        ("upper", 1),
-        ("lower", 1),
+        // Note: `upper`, `lower`, `btrim`, `trim`, `ltrim`, `rtrim` are
+        // intentionally excluded — they're collation-aware and handled by
+        // the PgExprUdf fallback to preserve PG-correct semantics.
         ("ascii", 1),
         ("repeat", 2),
         ("starts_with", 2),
         ("ends_with", 2),
         ("replace", 3),
         // string module (variadic; always match)
-        ("btrim", 0),
-        ("btrim", 1),
-        ("btrim", 2),
-        ("trim", 0),
-        ("trim", 1),
-        ("trim", 2),
-        ("ltrim", 0),
-        ("ltrim", 1),
-        ("ltrim", 2),
-        ("rtrim", 0),
-        ("rtrim", 1),
-        ("rtrim", 2),
         ("concat", 0),
         ("concat", 1),
         ("concat", 2),
@@ -803,10 +795,11 @@ mod tests {
     #[test]
     fn wrong_arity_returns_none() {
         // Fixed-arity functions rejected when called with the wrong count.
+        // `upper` / `lower` / `btrim` / `trim` / `ltrim` / `rtrim` are
+        // deliberately absent: they're excluded from `translate_known_func`
+        // entirely (collation-aware), so they return None for every arity —
+        // not a wrong-arity test subject.
         let cases: &[(&str, usize)] = &[
-            ("upper", 0),
-            ("upper", 2),
-            ("lower", 2),
             ("replace", 1),
             ("replace", 2),
             ("replace", 4),

--- a/pg_search/src/postgres/customscan/datafusion/mod.rs
+++ b/pg_search/src/postgres/customscan/datafusion/mod.rs
@@ -27,5 +27,6 @@
 //! and the `RelNode` family of relation-tree types into this module as well.
 
 pub mod explain;
+mod expr_translators;
 pub mod memory;
 pub mod translator;

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -191,6 +191,30 @@ impl<'a> PredicateTranslator<'a> {
         }
     }
 
+    /// Check whether an expression can be translated to DataFusion.
+    /// Validates both node-type support and column resolution against
+    /// the provided sources, without requiring plan_position or
+    /// output_columns.
+    pub unsafe fn can_translate(sources: &'a [&'a JoinSource], node: *mut pg_sys::Node) -> bool {
+        struct ValidationMapper<'a> {
+            sources: &'a [&'a JoinSource],
+        }
+
+        impl<'a> ColumnMapper for ValidationMapper<'a> {
+            /// Just confirm the source exists — field registration hasn't
+            /// happened yet at this planning stage. Column validity is
+            /// covered by all_vars_are_fast_fields_recursive which runs first.
+            fn map_var(&self, varno: pg_sys::Index, _varattno: pg_sys::AttrNumber) -> Option<Expr> {
+                let _source = self.sources.iter().find(|s| s.contains_rti(varno))?;
+                Some(col("placeholder"))
+            }
+        }
+
+        let mapper = ValidationMapper { sources };
+        let translator = Self::new(sources).with_mapper(Box::new(mapper));
+        translator.translate(node).is_some()
+    }
+
     /// Translate a PostgreSQL expression to a DataFusion `Expr`.
     ///
     /// Returns `None` if the expression cannot be translated.

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -15,11 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use datafusion::common::{Column, JoinType, Result, ScalarValue, TableReference};
+use datafusion::common::{Column, JoinType, Result, TableReference};
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator};
 use datafusion::prelude::DataFrame;
-use pgrx::{pg_sys, PgList};
+use pgrx::pg_sys;
 
 use crate::api::{HashMap, HashSet};
 use crate::postgres::customscan::joinscan::build::{
@@ -27,7 +27,6 @@ use crate::postgres::customscan::joinscan::build::{
     RelationAlias,
 };
 use crate::postgres::customscan::joinscan::privdat::{OutputColumnInfo, SCORE_COL_NAME};
-use crate::postgres::customscan::opexpr::lookup_operator;
 use crate::scan::SearchPredicateUDF;
 
 pub trait ColumnMapper {
@@ -35,10 +34,75 @@ pub trait ColumnMapper {
     fn map_var(&self, varno: pg_sys::Index, varattno: pg_sys::AttrNumber) -> Option<Expr>;
 }
 
+/// Human-readable PG type name (e.g. `"integer"`, `"jsonb"`) for debug
+/// logging. Falls back to `"OID {n}"` if the OID can't be resolved.
+pub(crate) unsafe fn type_name(oid: pg_sys::Oid) -> String {
+    let c_str = pg_sys::format_type_be(oid);
+    if c_str.is_null() {
+        return format!("OID {}", oid);
+    }
+    std::ffi::CStr::from_ptr(c_str)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Deparse a PG expression into readable SQL for debug logs. Builds a
+/// deparse context that covers every join source so Var nodes resolve to
+/// qualified column names (e.g. `e.pattern`). Wrapped in
+/// [`pgrx::PgTryBuilder`] so a PG error inside `deparse_expression` (which
+/// doesn't handle every possible node shape) degrades to a short tag
+/// fallback instead of unwinding the caller.
+pub(crate) unsafe fn deparse_expr_for_debug(
+    node: *mut pg_sys::Node,
+    sources: &[&JoinSource],
+) -> String {
+    use std::panic::AssertUnwindSafe;
+    if node.is_null() {
+        return "<null>".to_string();
+    }
+
+    let tag_fallback = || format!("{:?}", (*node).type_);
+
+    pgrx::PgTryBuilder::new(AssertUnwindSafe(|| {
+        let mut context: *mut pg_sys::List = std::ptr::null_mut();
+        for source in sources {
+            let alias = source.scan_info.alias.as_deref().unwrap_or("?");
+            let relname = match std::ffi::CString::new(alias) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let rel_context =
+                pg_sys::deparse_context_for(relname.as_ptr(), source.scan_info.heaprelid);
+            context = pg_sys::list_concat(context, rel_context);
+        }
+        let deparsed = pg_sys::deparse_expression(node.cast(), context, sources.len() > 1, false);
+        if deparsed.is_null() {
+            return tag_fallback();
+        }
+        std::ffi::CStr::from_ptr(deparsed)
+            .to_string_lossy()
+            .into_owned()
+    }))
+    .catch_others(|_| tag_fallback())
+    .execute()
+}
+
+/// Short label for a node tag (strips the `T_` prefix). Used in debug
+/// logs so the offending node type is immediately scannable. Separate from
+/// `expr_translators::node_tag_label`, which covers only the subset of
+/// tags that reach the UDF-naming path.
+pub(crate) unsafe fn node_tag_debug(node: *mut pg_sys::Node) -> String {
+    if node.is_null() {
+        return "null".to_string();
+    }
+    let dbg = format!("{:?}", (*node).type_);
+    dbg.strip_prefix("T_").unwrap_or(&dbg).to_string()
+}
+
 /// Helper struct for translating PostgreSQL expression trees into DataFusion `Expr`s.
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
-    mapper: Option<Box<dyn ColumnMapper + 'a>>,
+    pub(crate) mapper: Option<Box<dyn ColumnMapper + 'a>>,
 }
 
 impl<'a> PredicateTranslator<'a> {
@@ -229,10 +293,11 @@ impl<'a> PredicateTranslator<'a> {
     /// cannot be evaluated purely in DataFusion and must fall back to PostgreSQL evaluation.
     pub unsafe fn translate(&self, node: *mut pg_sys::Node) -> Option<Expr> {
         if node.is_null() {
+            pgrx::debug1!("PredicateTranslator: null node pointer");
             return None;
         }
 
-        match (*node).type_ {
+        let native = match (*node).type_ {
             pg_sys::NodeTag::T_OpExpr => self.translate_op_expr(node as *mut pg_sys::OpExpr),
             pg_sys::NodeTag::T_Var => self.translate_var(node as *mut pg_sys::Var),
             pg_sys::NodeTag::T_Const => self.translate_const(node as *mut pg_sys::Const),
@@ -243,148 +308,37 @@ impl<'a> PredicateTranslator<'a> {
                 let relabel = node as *mut pg_sys::RelabelType;
                 self.translate((*relabel).arg.cast())
             }
-            // Type casts (CoerceViaIO, FuncExpr) are not supported because
-            // they may change value semantics. Cross-type comparisons like INT < NUMERIC
-            // require proper type coercion that DataFusion cannot perform correctly when
-            // the underlying fast field storage uses different scales/representations.
+            pg_sys::NodeTag::T_FuncExpr => self.translate_func_expr(node),
+            pg_sys::NodeTag::T_NullTest => self.translate_null_test(node),
+            pg_sys::NodeTag::T_BooleanTest => self.translate_boolean_test(node),
+            pg_sys::NodeTag::T_CaseExpr => self.translate_case_expr(node),
+            pg_sys::NodeTag::T_CoalesceExpr => self.translate_coalesce_expr(node),
+            pg_sys::NodeTag::T_NullIfExpr => self.translate_nullif_expr(node),
+            pg_sys::NodeTag::T_MinMaxExpr => self.translate_min_max_expr(node),
+            pg_sys::NodeTag::T_ScalarArrayOpExpr => self.translate_scalar_array_op_expr(node),
+            pg_sys::NodeTag::T_CoerceViaIO => self.translate_coerce_via_io(node),
             _ => None,
-        }
-    }
-
-    unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
-        let args = PgList::<pg_sys::Node>::from_pg((*op_expr).args);
-        if args.len() != 2 {
-            return None; // Only support binary operators for now
-        }
-
-        let left = self.translate(args.get_ptr(0)?)?;
-        let right = self.translate(args.get_ptr(1)?)?;
-
-        let opno = (*op_expr).opno;
-        let op_str = lookup_operator(opno)?;
-
-        let op = match op_str {
-            "=" => Operator::Eq,
-            "<>" => Operator::NotEq,
-            "<" => Operator::Lt,
-            "<=" => Operator::LtEq,
-            ">" => Operator::Gt,
-            ">=" => Operator::GtEq,
-            _ => return None,
         };
 
-        Some(Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(left),
-            op,
-            Box::new(right),
-        )))
+        // Fallback runs per recursive call, so the innermost failing subtree
+        // gets wrapped, and its parent can still evaluate natively.
+        native.or_else(|| {
+            let wrapped = self.try_wrap_as_udf(node);
+            if wrapped.is_none() {
+                pgrx::debug1!(
+                    "PredicateTranslator: UDF fallback failed [{}] | {}",
+                    node_tag_debug(node),
+                    deparse_expr_for_debug(node, self.sources)
+                );
+            }
+            wrapped
+        })
     }
 
-    unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
-        let varno = (*var).varno as pg_sys::Index;
-        let varattno = (*var).varattno;
-
-        // INDEX_VAR is allowed because it represents a reference to the custom scan's output
-        if varno != pg_sys::INDEX_VAR as pg_sys::Index
-            && !self.sources.iter().any(|s| s.contains_rti(varno))
-        {
-            return None;
-        }
-
-        if let Some(ref mapper) = self.mapper {
-            if let Some(expr) = mapper.map_var(varno, varattno) {
-                return Some(expr);
-            }
-            return None;
-        }
-
-        Some(col("placeholder"))
-    }
-
-    unsafe fn translate_const(&self, c: *mut pg_sys::Const) -> Option<Expr> {
-        if (*c).constisnull {
-            return Some(lit(ScalarValue::Null));
-        }
-
-        let type_oid = (*c).consttype;
-        let datum = (*c).constvalue;
-
-        // Simple mapping for common types
-        let scalar_value = match type_oid {
-            pg_sys::INT2OID => {
-                let val = datum.value() as i16;
-                ScalarValue::Int16(Some(val))
-            }
-            pg_sys::INT4OID => {
-                let val = datum.value() as i32;
-                ScalarValue::Int32(Some(val))
-            }
-            pg_sys::INT8OID => {
-                let val = datum.value() as i64;
-                ScalarValue::Int64(Some(val))
-            }
-            pg_sys::FLOAT4OID => {
-                let val = f32::from_bits(datum.value() as u32);
-                ScalarValue::Float32(Some(val))
-            }
-            pg_sys::FLOAT8OID => {
-                let val = f64::from_bits(datum.value() as u64);
-                ScalarValue::Float64(Some(val))
-            }
-            pg_sys::BOOLOID => {
-                let val = datum.value() != 0;
-                ScalarValue::Boolean(Some(val))
-            }
-            _ => return None,
-        };
-
-        Some(lit(scalar_value))
-    }
-
-    unsafe fn translate_bool_expr(&self, bool_expr: *mut pg_sys::BoolExpr) -> Option<Expr> {
-        let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
-
-        match (*bool_expr).boolop {
-            pg_sys::BoolExprType::AND_EXPR => {
-                if args.len() < 2 {
-                    return None;
-                }
-                let mut expr = self.translate(args.get_ptr(0)?)?;
-                for i in 1..args.len() {
-                    let right = self.translate(args.get_ptr(i)?)?;
-                    expr = Expr::BinaryExpr(BinaryExpr::new(
-                        Box::new(expr),
-                        Operator::And,
-                        Box::new(right),
-                    ));
-                }
-                Some(expr)
-            }
-            pg_sys::BoolExprType::OR_EXPR => {
-                if args.len() < 2 {
-                    return None;
-                }
-                let mut expr = self.translate(args.get_ptr(0)?)?;
-                for i in 1..args.len() {
-                    let right = self.translate(args.get_ptr(i)?)?;
-                    expr = Expr::BinaryExpr(BinaryExpr::new(
-                        Box::new(expr),
-                        Operator::Or,
-                        Box::new(right),
-                    ));
-                }
-                Some(expr)
-            }
-            pg_sys::BoolExprType::NOT_EXPR => {
-                if args.len() != 1 {
-                    return None;
-                }
-                let child = self.translate(args.get_ptr(0)?)?;
-                Some(Expr::Not(Box::new(child)))
-            }
-            _ => None,
-        }
-    }
+    // `translate_op_expr`, `translate_var`, `translate_const`,
+    // `translate_bool_expr` — plus the extended node-type translators and
+    // the UDF fallback — are defined in `expr_translators.rs` on a split
+    // `impl PredicateTranslator` block.
 }
 
 /// Translate a `JoinLevelExpr` predicate into a DataFusion filter expression
@@ -579,34 +533,46 @@ pub fn build_join_df_with_filter(
 }
 
 /// Deserialize a PostgreSQL expression from its `nodeToString` representation
-/// and translate it to a DataFusion `Expr` against `sources`. The translator
-/// is seeded with a [`CombinedMapper`] so Var nodes (carrying their original
-/// `(varno, varattno)`) resolve to qualified DataFusion columns.
+/// and translate it to a DataFusion `Expr` against `sources`, using the
+/// caller-supplied `mapper` to resolve Var nodes. `context` is used only in
+/// error messages to disambiguate call sites.
+pub unsafe fn translate_pg_node_string<'a>(
+    pg_node_string: &str,
+    sources: &'a [&'a JoinSource],
+    mapper: Box<dyn ColumnMapper + 'a>,
+    context: &'static str,
+) -> Result<Expr> {
+    let c_str = std::ffi::CString::new(pg_node_string).map_err(|e| {
+        DataFusionError::Internal(format!("CString conversion failed for {context}: {e}"))
+    })?;
+    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
+    if node.is_null() {
+        return Err(DataFusionError::Internal(format!(
+            "stringToNode returned null for {context}"
+        )));
+    }
+
+    let translator = PredicateTranslator::new(sources).with_mapper(mapper);
+    translator.translate(node.cast()).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "PredicateTranslator failed to translate deserialized {context}"
+        ))
+    })
+}
+
+/// Translate a `PgExpression` join filter using a [`CombinedMapper`] so Var
+/// nodes (carrying their original `(varno, varattno)`) resolve to qualified
+/// DataFusion columns.
 unsafe fn translate_pg_expression_filter(
     pg_node_string: &str,
     sources: &[&JoinSource],
     output_columns: &[OutputColumnInfo],
 ) -> Result<Expr> {
-    let c_str = std::ffi::CString::new(pg_node_string).map_err(|e| {
-        DataFusionError::Internal(format!("CString conversion failed for PgExpression: {e}"))
-    })?;
-    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
-    if node.is_null() {
-        return Err(DataFusionError::Internal(
-            "stringToNode returned null for PgExpression".into(),
-        ));
-    }
-
     let mapper = CombinedMapper {
         sources,
         output_columns,
     };
-    let translator = PredicateTranslator::new(sources).with_mapper(Box::new(mapper));
-    translator.translate(node.cast()).ok_or_else(|| {
-        DataFusionError::Internal(
-            "PredicateTranslator failed to translate deserialized PgExpression".into(),
-        )
-    })
+    translate_pg_node_string(pg_node_string, sources, Box::new(mapper), "PgExpression")
 }
 
 /// Build equi-join filter expressions from a [`JoinNode`]'s key pairs.

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -182,6 +182,12 @@ impl<'a> PredicateTranslator<'a> {
                 let null_check = Expr::IsNull(Box::new(col(col_name)));
                 Some(mark_check.or(null_check))
             }
+            // `PgExpression` is only produced as a top-level `JoinNode.filter`
+            // for Semi/Anti joins, translated in [`build_join_df_with_filter`]
+            // via `stringToNode` + [`PredicateTranslator::translate`] with a
+            // `CombinedMapper` against the join's sources. It should never
+            // appear inside a `RelNode::Filter` predicate tree.
+            JoinLevelExpr::PgExpression { .. } => None,
         }
     }
 
@@ -449,8 +455,19 @@ pub fn build_join_df(
     allowed_join_types: JoinTypeAllowList,
 ) -> Result<DataFrame> {
     let on = build_equi_join_exprs(join)?;
+    let df_join_type = map_join_type(join.join_type, allowed_join_types)?;
 
-    let df_join_type = match (join.join_type, allowed_join_types) {
+    if on.is_empty() {
+        left.join(right, df_join_type, &[], &[], None)
+    } else {
+        left.join_on(right, df_join_type, on)
+    }
+}
+
+/// Map a [`super::build::JoinType`] to DataFusion's `JoinType`, honoring the
+/// allow-list policy.
+fn map_join_type(jt: PgJoinType, allowed_join_types: JoinTypeAllowList) -> Result<JoinType> {
+    Ok(match (jt, allowed_join_types) {
         (PgJoinType::Inner, _) => JoinType::Inner,
         (PgJoinType::Left, _) => JoinType::Left,
         (PgJoinType::Right, _) => JoinType::Right,
@@ -473,13 +490,93 @@ pub fn build_join_df(
                 jt
             )));
         }
+    })
+}
+
+/// Like [`build_join_df`], but translates [`JoinNode::filter`] and attaches it
+/// to the join (passed to `DataFrame::join`'s filter parameter, which
+/// DataFusion lowers to `NestedLoopJoinExec` when there are no equi keys).
+///
+/// Required for Semi/Anti joins whose condition cannot be expressed as equi
+/// keys (e.g. `a.col = b.x OR a.col = b.y`): a post-join filter would mean
+/// "cross-join then filter", which drops every left row under LeftAnti
+/// semantics. Placing the predicate on the join itself evaluates it per
+/// (left, right) pair and preserves correctness.
+///
+/// The filter expression is built by deserializing the PostgreSQL expression
+/// tree (stored in [`JoinLevelExpr::PgExpression`]) with `stringToNode` and
+/// translating it via [`PredicateTranslator::translate`] + [`CombinedMapper`]
+/// — the same pipeline used for regular join-level conditions, just without
+/// the custom_exprs / setrefs round-trip that fails under Semi/Anti tlist
+/// pruning.
+pub fn build_join_df_with_filter(
+    left: DataFrame,
+    right: DataFrame,
+    join: &JoinNode,
+    sources: &[&JoinSource],
+    output_columns: &[OutputColumnInfo],
+    allowed_join_types: JoinTypeAllowList,
+) -> Result<DataFrame> {
+    let df_join_type = map_join_type(join.join_type, allowed_join_types)?;
+
+    let filter_expr = match &join.filter {
+        Some(JoinLevelExpr::PgExpression { pg_node_string, .. }) => unsafe {
+            translate_pg_expression_filter(pg_node_string, sources, output_columns)?
+        },
+        Some(other) => {
+            return Err(DataFusionError::NotImplemented(format!(
+                "JoinNode.filter variant {:?} not yet supported in build_join_df_with_filter",
+                other
+            )));
+        }
+        None => {
+            return build_join_df(left, right, join, allowed_join_types);
+        }
     };
 
-    if on.is_empty() {
-        left.join(right, df_join_type, &[], &[], None)
-    } else {
-        left.join_on(right, df_join_type, on)
+    if join.equi_keys.is_empty() {
+        return left.join(right, df_join_type, &[], &[], Some(filter_expr));
     }
+
+    // The mixed case (equi keys + join filter) is not exercised today: only
+    // the disjunctive Semi/Anti path populates `JoinNode.filter`, and it
+    // always yields empty equi keys. Surface an explicit error so a future
+    // planner change that introduces the mixed case is noticed instead of
+    // silently producing a cross-join.
+    Err(DataFusionError::NotImplemented(
+        "JoinNode.filter combined with equi-join keys is not yet supported".into(),
+    ))
+}
+
+/// Deserialize a PostgreSQL expression from its `nodeToString` representation
+/// and translate it to a DataFusion `Expr` against `sources`. The translator
+/// is seeded with a [`CombinedMapper`] so Var nodes (carrying their original
+/// `(varno, varattno)`) resolve to qualified DataFusion columns.
+unsafe fn translate_pg_expression_filter(
+    pg_node_string: &str,
+    sources: &[&JoinSource],
+    output_columns: &[OutputColumnInfo],
+) -> Result<Expr> {
+    let c_str = std::ffi::CString::new(pg_node_string).map_err(|e| {
+        DataFusionError::Internal(format!("CString conversion failed for PgExpression: {e}"))
+    })?;
+    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
+    if node.is_null() {
+        return Err(DataFusionError::Internal(
+            "stringToNode returned null for PgExpression".into(),
+        ));
+    }
+
+    let mapper = CombinedMapper {
+        sources,
+        output_columns,
+    };
+    let translator = PredicateTranslator::new(sources).with_mapper(Box::new(mapper));
+    translator.translate(node.cast()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "PredicateTranslator failed to translate deserialized PgExpression".into(),
+        )
+    })
 }
 
 /// Build equi-join filter expressions from a [`JoinNode`]'s key pairs.

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -213,7 +213,13 @@ impl<'a> PredicateTranslator<'a> {
             pg_sys::NodeTag::T_Var => self.translate_var(node as *mut pg_sys::Var),
             pg_sys::NodeTag::T_Const => self.translate_const(node as *mut pg_sys::Const),
             pg_sys::NodeTag::T_BoolExpr => self.translate_bool_expr(node as *mut pg_sys::BoolExpr),
-            // Type casts (RelabelType, CoerceViaIO, FuncExpr) are not supported because
+            pg_sys::NodeTag::T_RelabelType => {
+                // Binary-compatible cast (e.g. varchar → text). The underlying
+                // datum is identical — just recurse into the inner expression.
+                let relabel = node as *mut pg_sys::RelabelType;
+                self.translate((*relabel).arg.cast())
+            }
+            // Type casts (CoerceViaIO, FuncExpr) are not supported because
             // they may change value semantics. Cross-type comparisons like INT < NUMERIC
             // require proper type coercion that DataFusion cannot perform correctly when
             // the underlying fast field storage uses different scales/representations.

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -620,6 +620,24 @@ pub enum JoinLevelExpr {
         /// Attribute number of the outer column tested for IS NULL.
         null_test_attno: pgrx::pg_sys::AttrNumber,
     },
+    /// A PostgreSQL expression serialized via `nodeToString`, evaluated as a
+    /// join filter.
+    ///
+    /// During planning the raw `pg_sys::Expr` is validated for DataFusion
+    /// translatability via `PredicateTranslator::translate` and serialized with
+    /// `nodeToString`. At execution time `stringToNode` rehydrates the tree,
+    /// which `PredicateTranslator` then translates to a DataFusion `Expr`
+    /// (Var nodes resolve via `CombinedMapper` against the join's sources).
+    ///
+    /// `input_vars` lists every `(rti, attno)` referenced by the expression so
+    /// the projection pass can register the required columns. Used for
+    /// Semi/Anti join filters because the MultiTablePredicate / custom_exprs
+    /// pipeline would fail in setrefs: Semi/Anti prunes the inner relation
+    /// from the scan tlist, leaving inner-side Vars unresolvable.
+    PgExpression {
+        pg_node_string: String,
+        input_vars: Vec<(pgrx::pg_sys::Index, pgrx::pg_sys::AttrNumber)>,
+    },
 }
 
 /// A node in the intermediate relational plan tree.
@@ -891,11 +909,36 @@ impl RelNode {
         match self {
             RelNode::Scan(_) => {}
             RelNode::Join(j) => {
-                acc.extend(j.equi_keys.clone());
+                acc.extend(j.equi_keys.iter().cloned());
                 j.left.collect_join_keys(acc);
                 j.right.collect_join_keys(acc);
             }
             RelNode::Filter(f) => f.input.collect_join_keys(acc),
+        }
+    }
+
+    /// Recursively collect every `(rti, attno)` referenced by a join-level
+    /// filter (`JoinNode.filter`). Used by `build_source_df` to keep the
+    /// referenced columns out of the deferred-output promotion — the filter
+    /// is evaluated before the join emits rows, so the columns must be
+    /// materialized in the per-source scan.
+    pub fn filter_input_vars(&self) -> Vec<(pg_sys::Index, pg_sys::AttrNumber)> {
+        let mut result = Vec::new();
+        self.collect_filter_input_vars(&mut result);
+        result
+    }
+
+    fn collect_filter_input_vars(&self, acc: &mut Vec<(pg_sys::Index, pg_sys::AttrNumber)>) {
+        match self {
+            RelNode::Scan(_) => {}
+            RelNode::Join(j) => {
+                if let Some(JoinLevelExpr::PgExpression { input_vars, .. }) = &j.filter {
+                    acc.extend(input_vars.iter().copied());
+                }
+                j.left.collect_filter_input_vars(acc);
+                j.right.collect_filter_input_vars(acc);
+            }
+            RelNode::Filter(f) => f.input.collect_filter_input_vars(acc),
         }
     }
 
@@ -925,6 +968,17 @@ impl RelNode {
                     {
                         acc.push((left_src.plan_position, left_att));
                         acc.push((right_src.plan_position, right_att));
+                    }
+                }
+                if let Some(JoinLevelExpr::PgExpression { input_vars, .. }) = &j.filter {
+                    for &(rti, attno) in input_vars {
+                        if let Some(source) = j
+                            .left
+                            .source_for_rti_in_subtree(rti)
+                            .or_else(|| j.right.source_for_rti_in_subtree(rti))
+                        {
+                            acc.push((source.plan_position, attno));
+                        }
                     }
                 }
                 j.left.collect_join_key_projections(acc);

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -629,14 +629,17 @@ pub enum JoinLevelExpr {
     /// which `PredicateTranslator` then translates to a DataFusion `Expr`
     /// (Var nodes resolve via `CombinedMapper` against the join's sources).
     ///
-    /// `input_vars` lists every `(rti, attno)` referenced by the expression so
-    /// the projection pass can register the required columns. Used for
+    /// `input_vars` describes each Var dependency (RTI, attno, plus the type
+    /// metadata captured at planning time so execution avoids catalog
+    /// lookups). The projection pass uses `(rti, attno)` to register the
+    /// required columns; the type metadata is also serialized through
+    /// `JoinCSClause` and available to any future consumer. Used for
     /// Semi/Anti join filters because the MultiTablePredicate / custom_exprs
     /// pipeline would fail in setrefs: Semi/Anti prunes the inner relation
     /// from the scan tlist, leaving inner-side Vars unresolvable.
     PgExpression {
         pg_node_string: String,
-        input_vars: Vec<(pgrx::pg_sys::Index, pgrx::pg_sys::AttrNumber)>,
+        input_vars: Vec<InputVarInfo>,
     },
 }
 
@@ -933,7 +936,7 @@ impl RelNode {
             RelNode::Scan(_) => {}
             RelNode::Join(j) => {
                 if let Some(JoinLevelExpr::PgExpression { input_vars, .. }) = &j.filter {
-                    acc.extend(input_vars.iter().copied());
+                    acc.extend(input_vars.iter().map(|v| (v.rti, v.attno)));
                 }
                 j.left.collect_filter_input_vars(acc);
                 j.right.collect_filter_input_vars(acc);
@@ -971,13 +974,13 @@ impl RelNode {
                     }
                 }
                 if let Some(JoinLevelExpr::PgExpression { input_vars, .. }) = &j.filter {
-                    for &(rti, attno) in input_vars {
+                    for v in input_vars {
                         if let Some(source) = j
                             .left
-                            .source_for_rti_in_subtree(rti)
-                            .or_else(|| j.right.source_for_rti_in_subtree(rti))
+                            .source_for_rti_in_subtree(v.rti)
+                            .or_else(|| j.right.source_for_rti_in_subtree(v.rti))
                         {
-                            acc.push((source.plan_position, attno));
+                            acc.push((source.plan_position, v.attno));
                         }
                     }
                 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -154,10 +154,12 @@ use self::planning::{
     extract_orderby_from_parse_sort_clause, get_score_func_rti, order_by_columns_are_fast_fields,
     pathkey_uses_scores_from_source,
 };
-use self::predicate::extract_join_level_conditions;
+use self::predicate::{all_vars_are_fast_fields_recursive, extract_join_level_conditions};
 use self::privdat::PrivateData;
 use crate::postgres::customscan::datafusion::explain::{format_join_level_expr, get_attname_safe};
+use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
 use crate::postgres::customscan::pullup::resolve_fast_field;
+use crate::postgres::utils::expr_collect_vars;
 
 use self::scan_state::{
     build_joinscan_logical_plan, build_physical_plan, build_task_context,
@@ -512,7 +514,12 @@ impl JoinScan {
             return None;
         }
 
-        if join_keys.is_empty() {
+        // Empty join_keys are normally a rejection, but a disjunctive Semi/Anti
+        // condition (`a = b OR a = c`) legitimately produces no equi-keys — the
+        // predicate lives on `JoinNode.filter` and DataFusion evaluates it via
+        // NestedLoopJoinExec. Skip this gate for plans that contain a Semi/Anti
+        // join; per-key validation below is simply a no-op when there are none.
+        if join_keys.is_empty() && !plan.has_semi_or_anti() {
             return None;
         }
 
@@ -1723,7 +1730,16 @@ impl JoinScan {
             aliases: aliases.clone(),
         };
 
-        if join_conditions.equi_keys.is_empty() {
+        // For Semi/Anti joins, allow empty equi_keys when there are other_conditions
+        // (e.g. disjunctive join conditions like `a.col = b.x OR a.col = b.y`).
+        // DataFusion handles this as a cross-join + filter via NestedLoopJoinExec,
+        // placing the filter on the JoinNode directly (see later in this function).
+        let is_semi_anti = matches!(
+            jointype,
+            pg_sys::JoinType::JOIN_SEMI | pg_sys::JoinType::JOIN_ANTI
+        );
+        let has_other_conditions = !join_conditions.other_conditions.is_empty();
+        if join_conditions.equi_keys.is_empty() && !(is_semi_anti && has_other_conditions) {
             return Err(warn(JoinDeclineReason::NoEquiKeys));
         }
 
@@ -1732,12 +1748,85 @@ impl JoinScan {
         let parsed_jointype = build::JoinType::try_from(jointype)
             .map_err(|e| warn(JoinDeclineReason::Other(e.to_string())))?;
 
+        // For Semi/Anti with additional conditions that cannot ride the
+        // MultiTablePredicate pipeline (setrefs would fail to resolve inner-side
+        // Vars once the inner relation is pruned), try to absorb each condition
+        // into `JoinNode.filter` as a serialized `PgExpression`. Only attempted
+        // when `equi_keys` is empty — the mixed case isn't supported end-to-end
+        // yet (see `build_join_df_with_filter`).
+        let try_absorb_disjunction = is_semi_anti && join_conditions.equi_keys.is_empty();
+        let (initial_filter, remaining_other_conditions) = if try_absorb_disjunction {
+            let mut current_sources = outer_node.sources();
+            current_sources.extend(inner_node.sources());
+
+            // Validating translatability with the live pointer now means
+            // `stringToNode` + `PredicateTranslator::translate` will succeed at
+            // execution time on the same shape.
+            let translator = PredicateTranslator::new(&current_sources);
+            let mut absorbed_clauses: Vec<*mut pg_sys::Node> = Vec::new();
+            let mut remaining: Vec<*mut pg_sys::RestrictInfo> =
+                Vec::with_capacity(join_conditions.other_conditions.len());
+            for ri in join_conditions.other_conditions {
+                let clause = (*ri).clause;
+                if clause.is_null()
+                    || !all_vars_are_fast_fields_recursive(clause.cast(), &current_sources)
+                    || translator.translate(clause.cast()).is_none()
+                {
+                    remaining.push(ri);
+                    continue;
+                }
+                absorbed_clauses.push(clause.cast());
+            }
+
+            let filter = match absorbed_clauses.len() {
+                0 => None,
+                _ => {
+                    // Combine multiple absorbed clauses into a single AND at
+                    // the PG node level so we serialize one expression tree.
+                    let combined_node: *mut pg_sys::Node = if absorbed_clauses.len() == 1 {
+                        absorbed_clauses[0]
+                    } else {
+                        let mut list = PgList::<pg_sys::Expr>::new();
+                        for n in &absorbed_clauses {
+                            list.push((*n).cast());
+                        }
+                        pg_sys::make_andclause(list.into_pg()).cast()
+                    };
+                    let pg_node_string = {
+                        let node_str = pg_sys::nodeToString(combined_node.cast());
+                        std::ffi::CStr::from_ptr(node_str)
+                            .to_string_lossy()
+                            .into_owned()
+                    };
+                    let input_vars = expr_collect_vars(combined_node, false)
+                        .into_iter()
+                        .map(|v| (v.rti, v.attno))
+                        .collect();
+                    Some(build::JoinLevelExpr::PgExpression {
+                        pg_node_string,
+                        input_vars,
+                    })
+                }
+            };
+            (filter, remaining)
+        } else {
+            (None, join_conditions.other_conditions)
+        };
+
+        // The disjunctive-filter path was the only way to satisfy the equi-keys
+        // gate for this Semi/Anti join; absorption failed, so decline rather
+        // than fall through to the MultiTablePredicate pipeline (setrefs would
+        // fail on inner-side Vars).
+        if try_absorb_disjunction && initial_filter.is_none() {
+            return Err(warn(JoinDeclineReason::NoEquiKeys));
+        }
+
         let mut plan = RelNode::Join(Box::new(build::JoinNode {
             join_type: parsed_jointype,
             left: outer_node,
             right: inner_node,
             equi_keys: join_conditions.equi_keys,
-            filter: None,
+            filter: initial_filter,
             subplan_id: None,
         }));
 
@@ -1766,12 +1855,16 @@ impl JoinScan {
         // This builds an expression tree that can reference:
         // - Predicate nodes: Tantivy search queries
         // - MultiTablePredicate nodes: PostgreSQL expressions
+        //
+        // Disjunctive Var=Var conditions already absorbed into
+        // `JoinNode.filter` (above) are filtered out of `remaining_other_conditions`
+        // so they are not re-processed here as MultiTablePredicates.
         let current_sources = join_clause.plan.sources();
         let (join_clause_updated, multi_table_clauses) = extract_join_level_conditions(
             root,
             extra,
             &current_sources,
-            &join_conditions.other_conditions,
+            &remaining_other_conditions,
             join_clause.clone(),
         )
         .map_err(|_| warn(JoinDeclineReason::JoinLevelExtractionFailed))?;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1845,7 +1845,9 @@ impl JoinScan {
         // gate for this Semi/Anti join; absorption failed, so decline rather
         // than fall through to the MultiTablePredicate pipeline (setrefs would
         // fail on inner-side Vars).
-        if try_absorb_disjunction && initial_filter.is_none() {
+        if try_absorb_disjunction
+            && (initial_filter.is_none() || !remaining_other_conditions.is_empty())
+        {
             return Err(warn(JoinDeclineReason::NoEquiKeys));
         }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -516,9 +516,14 @@ impl JoinScan {
         // Empty join_keys are normally a rejection, but a disjunctive Semi/Anti
         // condition (`a = b OR a = c`) legitimately produces no equi-keys — the
         // predicate lives on `JoinNode.filter` and DataFusion evaluates it via
-        // NestedLoopJoinExec. Skip this gate for plans that contain a Semi/Anti
-        // join; per-key validation below is simply a no-op when there are none.
-        if join_keys.is_empty() && !plan.has_semi_or_anti() {
+        // NestedLoopJoinExec. Only the outermost join benefits from this
+        // relaxation; a nested Semi/Anti deeper in the tree does not excuse
+        // the current join-hook invocation from needing equi-keys.
+        let root_is_semi_anti = matches!(
+            &plan,
+            RelNode::Join(j) if matches!(j.join_type, build::JoinType::Semi | build::JoinType::Anti)
+        );
+        if join_keys.is_empty() && !root_is_semi_anti {
             return None;
         }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -159,7 +159,6 @@ use self::privdat::PrivateData;
 use crate::postgres::customscan::datafusion::explain::{format_join_level_expr, get_attname_safe};
 use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
 use crate::postgres::customscan::pullup::resolve_fast_field;
-use crate::postgres::utils::expr_collect_vars;
 
 use self::scan_state::{
     build_joinscan_logical_plan, build_physical_plan, build_task_context,
@@ -1659,6 +1658,39 @@ fn bake_logical_plan(private_data: &mut PrivateData, custom_exprs: *mut pg_sys::
     );
 }
 
+/// Walk `node` and build an [`InputVarInfo`] for every base-relation Var
+/// referenced, capturing type metadata from the live Var pointer so execution
+/// doesn't need catalog lookups. Uses `pull_var_clause` (same as the DISTINCT
+/// extraction path in `planning.rs`) to recurse through all wrappers.
+unsafe fn collect_input_vars(node: *mut pg_sys::Node) -> Vec<build::InputVarInfo> {
+    const PVC_RECURSE_ALL: i32 = (pg_sys::PVC_RECURSE_AGGREGATES
+        | pg_sys::PVC_RECURSE_WINDOWFUNCS
+        | pg_sys::PVC_RECURSE_PLACEHOLDERS) as i32;
+    let var_list = pg_sys::pull_var_clause(node, PVC_RECURSE_ALL);
+    let vars = PgList::<pg_sys::Var>::from_pg(var_list);
+    let mut result = Vec::with_capacity(vars.len());
+    let mut seen = crate::api::HashSet::default();
+    for var_ptr in vars.iter_ptr() {
+        let rti = (*var_ptr).varno as pg_sys::Index;
+        let attno = (*var_ptr).varattno;
+        // Skip non-base-relation Vars and whole-row references.
+        if rti == 0 || rti >= pg_sys::INNER_VAR as pg_sys::Index || attno <= 0 {
+            continue;
+        }
+        if !seen.insert((rti, attno)) {
+            continue;
+        }
+        result.push(build::InputVarInfo {
+            rti,
+            attno,
+            type_oid: (*var_ptr).vartype,
+            typmod: (*var_ptr).vartypmod,
+            collation: (*var_ptr).varcollid,
+        });
+    }
+    result
+}
+
 /// Append every entry in `best_path.custom_private` (skipping index 0, which
 /// holds the serialized `PrivateData`) onto `list`. Used twice in
 /// `plan_custom_path`: once to splice the trailing restrictlist clauses onto
@@ -1797,10 +1829,7 @@ impl JoinScan {
                             .to_string_lossy()
                             .into_owned()
                     };
-                    let input_vars = expr_collect_vars(combined_node, false)
-                        .into_iter()
-                        .map(|v| (v.rti, v.attno))
-                        .collect();
+                    let input_vars = collect_input_vars(combined_node);
                     Some(build::JoinLevelExpr::PgExpression {
                         pg_node_string,
                         input_vars,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1762,7 +1762,6 @@ impl JoinScan {
             // Validating translatability with the live pointer now means
             // `stringToNode` + `PredicateTranslator::translate` will succeed at
             // execution time on the same shape.
-            let translator = PredicateTranslator::new(&current_sources);
             let mut absorbed_clauses: Vec<*mut pg_sys::Node> = Vec::new();
             let mut remaining: Vec<*mut pg_sys::RestrictInfo> =
                 Vec::with_capacity(join_conditions.other_conditions.len());
@@ -1770,7 +1769,7 @@ impl JoinScan {
                 let clause = (*ri).clause;
                 if clause.is_null()
                     || !all_vars_are_fast_fields_recursive(clause.cast(), &current_sources)
-                    || translator.translate(clause.cast()).is_none()
+                    || !PredicateTranslator::can_translate(&current_sources, clause.cast())
                 {
                     remaining.push(ri);
                     continue;

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -926,13 +926,10 @@ unsafe fn equi_key_pair_from_opexpr(
     let var0 = arg0 as *mut pg_sys::Var;
     let var1 = arg1 as *mut pg_sys::Var;
 
-    let varno0 = (*var0).varno as pg_sys::Index;
-    let varno1 = (*var1).varno as pg_sys::Index;
-    let attno0 = (*var0).varattno;
-    let attno1 = (*var1).varattno;
-
-    let (rti0, att0) = find_source_for_var(sources, varno0, attno0)?;
-    let (rti1, att1) = find_source_for_var(sources, varno1, attno1)?;
+    let (rti0, att0) =
+        find_source_for_var(sources, (*var0).varno as pg_sys::Index, (*var0).varattno)?;
+    let (rti1, att1) =
+        find_source_for_var(sources, (*var1).varno as pg_sys::Index, (*var1).varattno)?;
 
     let type_oid = (*var0).vartype;
     let (typlen, typbyval) = get_type_info(type_oid);
@@ -961,6 +958,7 @@ unsafe fn extract_join_conditions_from_list(
         has_search_predicate: false,
     };
 
+    let search_op = anyelement_query_input_opoid();
     let list = PgList::<pg_sys::RestrictInfo>::from_pg(restrictlist);
     for ri in list.iter_ptr() {
         let clause = (*ri).clause;
@@ -968,25 +966,19 @@ unsafe fn extract_join_conditions_from_list(
             continue;
         }
 
-        // Check if this clause contains our @@@ operator
-        let search_op = anyelement_query_input_opoid();
-        if expr_contains_any_operator(clause.cast(), &[search_op]) {
+        let has_search_op = expr_contains_any_operator(clause.cast(), &[search_op]);
+        if has_search_op {
             result.has_search_predicate = true;
         }
 
-        // Try to identify equi-join conditions (OpExpr with Var = Var using equality operator)
         let mut is_equi_join = false;
-
         if let Some(jk) = equi_key_pair_from_opexpr(clause.cast(), sources) {
             result.equi_keys.push(jk);
             is_equi_join = true;
         }
 
-        if !is_equi_join {
-            let has_search_op = expr_contains_any_operator(clause.cast(), &[search_op]);
-            if !has_search_op {
-                result.other_conditions.push(ri);
-            }
+        if !is_equi_join && !has_search_op {
+            result.other_conditions.push(ri);
         }
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -911,8 +911,7 @@ unsafe fn extract_join_conditions_from_list(
     };
 
     let search_op = anyelement_query_input_opoid();
-    let valid_rtis: Vec<pg_sys::Index> =
-        sources.iter().map(|s| s.scan_info.heap_rti).collect();
+    let valid_rtis: Vec<pg_sys::Index> = sources.iter().map(|s| s.scan_info.heap_rti).collect();
     let list = PgList::<pg_sys::RestrictInfo>::from_pg(restrictlist);
     for ri in list.iter_ptr() {
         let clause = (*ri).clause;

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -897,6 +897,57 @@ unsafe fn resolve_subplan_output_var(
     let var = nodecast!(Var, T_Var, expr)?;
     Some(((*var).varno as pg_sys::Index, (*var).varattno))
 }
+/// If `clause` is a `T_OpExpr` implementing equality between two Var nodes (one
+/// from each side of the join), produce the corresponding [`JoinKeyPair`].
+unsafe fn equi_key_pair_from_opexpr(
+    clause: *mut pg_sys::Node,
+    sources: &[&JoinSource],
+) -> Option<JoinKeyPair> {
+    if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
+        return None;
+    }
+    let opexpr = clause as *mut pg_sys::OpExpr;
+    let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
+    if args.len() != 2 {
+        return None;
+    }
+
+    let opno = (*opexpr).opno;
+    if lookup_operator(opno) != Some("=") {
+        return None;
+    }
+
+    let arg0 = strip_wrappers(args.get_ptr(0)?);
+    let arg1 = strip_wrappers(args.get_ptr(1)?);
+
+    if (*arg0).type_ != pg_sys::NodeTag::T_Var || (*arg1).type_ != pg_sys::NodeTag::T_Var {
+        return None;
+    }
+    let var0 = arg0 as *mut pg_sys::Var;
+    let var1 = arg1 as *mut pg_sys::Var;
+
+    let varno0 = (*var0).varno as pg_sys::Index;
+    let varno1 = (*var1).varno as pg_sys::Index;
+    let attno0 = (*var0).varattno;
+    let attno1 = (*var1).varattno;
+
+    let (rti0, att0) = find_source_for_var(sources, varno0, attno0)?;
+    let (rti1, att1) = find_source_for_var(sources, varno1, attno1)?;
+
+    let type_oid = (*var0).vartype;
+    let (typlen, typbyval) = get_type_info(type_oid);
+
+    Some(JoinKeyPair {
+        outer_rti: rti0,
+        outer_attno: att0,
+        inner_rti: rti1,
+        inner_attno: att1,
+        type_oid,
+        typlen,
+        typbyval,
+    })
+}
+
 /// Parses a given list of `RestrictInfo` nodes to extract equi-join conditions and other join filters.
 /// Iterates over the given restrict list and groups conditions according to whether they are
 /// standard join keys or general functional predicates.
@@ -926,60 +977,12 @@ unsafe fn extract_join_conditions_from_list(
         // Try to identify equi-join conditions (OpExpr with Var = Var using equality operator)
         let mut is_equi_join = false;
 
-        if (*clause).type_ == pg_sys::NodeTag::T_OpExpr {
-            let opexpr = clause as *mut pg_sys::OpExpr;
-            let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
-
-            // Equi-join: should have exactly 2 args, both Var nodes, AND use equality operator
-            if args.len() == 2 {
-                let arg0 = args.get_ptr(0).unwrap();
-                let arg1 = args.get_ptr(1).unwrap();
-
-                // Check if operator is an equality operator
-                let opno = (*opexpr).opno;
-                let is_equality_op = lookup_operator(opno) == Some("=");
-
-                if is_equality_op {
-                    let stripped_arg0 = strip_wrappers(arg0);
-                    let stripped_arg1 = strip_wrappers(arg1);
-
-                    if (*stripped_arg0).type_ == pg_sys::NodeTag::T_Var
-                        && (*stripped_arg1).type_ == pg_sys::NodeTag::T_Var
-                    {
-                        let var0 = stripped_arg0 as *mut pg_sys::Var;
-                        let var1 = stripped_arg1 as *mut pg_sys::Var;
-
-                        let varno0 = (*var0).varno as pg_sys::Index;
-                        let varno1 = (*var1).varno as pg_sys::Index;
-                        let attno0 = (*var0).varattno;
-                        let attno1 = (*var1).varattno;
-
-                        // Try to map vars to sources
-                        let source0 = find_source_for_var(sources, varno0, attno0);
-                        let source1 = find_source_for_var(sources, varno1, attno1);
-
-                        if let (Some((rti0, att0)), Some((rti1, att1))) = (source0, source1) {
-                            let type_oid = (*var0).vartype;
-                            let (typlen, typbyval) = get_type_info(type_oid);
-
-                            result.equi_keys.push(JoinKeyPair {
-                                outer_rti: rti0,
-                                outer_attno: att0,
-                                inner_rti: rti1,
-                                inner_attno: att1,
-                                type_oid,
-                                typlen,
-                                typbyval,
-                            });
-                            is_equi_join = true;
-                        }
-                    }
-                }
-            }
+        if let Some(jk) = equi_key_pair_from_opexpr(clause.cast(), sources) {
+            result.equi_keys.push(jk);
+            is_equi_join = true;
         }
 
         if !is_equi_join {
-            let search_op = anyelement_query_input_opoid();
             let has_search_op = expr_contains_any_operator(clause.cast(), &[search_op]);
             if !has_search_op {
                 result.other_conditions.push(ri);

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -897,54 +897,6 @@ unsafe fn resolve_subplan_output_var(
     let var = nodecast!(Var, T_Var, expr)?;
     Some(((*var).varno as pg_sys::Index, (*var).varattno))
 }
-/// If `clause` is a `T_OpExpr` implementing equality between two Var nodes (one
-/// from each side of the join), produce the corresponding [`JoinKeyPair`].
-unsafe fn equi_key_pair_from_opexpr(
-    clause: *mut pg_sys::Node,
-    sources: &[&JoinSource],
-) -> Option<JoinKeyPair> {
-    if clause.is_null() || (*clause).type_ != pg_sys::NodeTag::T_OpExpr {
-        return None;
-    }
-    let opexpr = clause as *mut pg_sys::OpExpr;
-    let args = PgList::<pg_sys::Node>::from_pg((*opexpr).args);
-    if args.len() != 2 {
-        return None;
-    }
-
-    let opno = (*opexpr).opno;
-    if lookup_operator(opno) != Some("=") {
-        return None;
-    }
-
-    let arg0 = strip_wrappers(args.get_ptr(0)?);
-    let arg1 = strip_wrappers(args.get_ptr(1)?);
-
-    if (*arg0).type_ != pg_sys::NodeTag::T_Var || (*arg1).type_ != pg_sys::NodeTag::T_Var {
-        return None;
-    }
-    let var0 = arg0 as *mut pg_sys::Var;
-    let var1 = arg1 as *mut pg_sys::Var;
-
-    let (rti0, att0) =
-        find_source_for_var(sources, (*var0).varno as pg_sys::Index, (*var0).varattno)?;
-    let (rti1, att1) =
-        find_source_for_var(sources, (*var1).varno as pg_sys::Index, (*var1).varattno)?;
-
-    let type_oid = (*var0).vartype;
-    let (typlen, typbyval) = get_type_info(type_oid);
-
-    Some(JoinKeyPair {
-        outer_rti: rti0,
-        outer_attno: att0,
-        inner_rti: rti1,
-        inner_attno: att1,
-        type_oid,
-        typlen,
-        typbyval,
-    })
-}
-
 /// Parses a given list of `RestrictInfo` nodes to extract equi-join conditions and other join filters.
 /// Iterates over the given restrict list and groups conditions according to whether they are
 /// standard join keys or general functional predicates.
@@ -959,6 +911,8 @@ unsafe fn extract_join_conditions_from_list(
     };
 
     let search_op = anyelement_query_input_opoid();
+    let valid_rtis: Vec<pg_sys::Index> =
+        sources.iter().map(|s| s.scan_info.heap_rti).collect();
     let list = PgList::<pg_sys::RestrictInfo>::from_pg(restrictlist);
     for ri in list.iter_ptr() {
         let clause = (*ri).clause;
@@ -972,7 +926,12 @@ unsafe fn extract_join_conditions_from_list(
         }
 
         let mut is_equi_join = false;
-        if let Some(jk) = equi_key_pair_from_opexpr(clause.cast(), sources) {
+        let equi_pair = if (*clause).type_ == pg_sys::NodeTag::T_OpExpr {
+            build::try_extract_equi_key(clause.cast(), &valid_rtis)
+        } else {
+            None
+        };
+        if let Some(jk) = equi_pair {
             result.equi_keys.push(jk);
             is_equi_join = true;
         }

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -113,9 +113,7 @@ pub unsafe fn extract_join_level_conditions(
             }
 
             // Check if the predicate can be translated to DataFusion
-            let translator = PredicateTranslator::new(sources);
-
-            if translator.translate(clause.cast()).is_none() {
+            if !PredicateTranslator::can_translate(sources, clause.cast()) {
                 return Err(format!(
                     "Multi-table predicate '{}' cannot be executed by DataFusion (unsupported operator or type)",
                     format_expr_for_explain(clause.cast())

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -85,7 +85,8 @@ use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
     apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
-    make_source_score_col, CombinedMapper, JoinTypeAllowList, PredicateTranslator,
+    make_source_score_col, translate_pg_node_string, ColumnMapper, CombinedMapper,
+    JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
@@ -116,6 +117,37 @@ fn resolve_var_to_df_col(
         let field = source.column_name(mapped)?;
         Some(make_source_col(source, &field))
     })
+}
+
+/// Adapter that lets `PredicateTranslator` resolve Vars against a
+/// `JoinCSClause` by delegating to [`resolve_var_to_df_col`].
+struct JoinClauseMapper<'a> {
+    join_clause: &'a JoinCSClause,
+}
+
+impl<'a> ColumnMapper for JoinClauseMapper<'a> {
+    fn map_var(&self, varno: pg_sys::Index, varattno: pg_sys::AttrNumber) -> Option<Expr> {
+        resolve_var_to_df_col(self.join_clause, varno, varattno)
+    }
+}
+
+/// Translate a `ChildProjection::Expression` via `PredicateTranslator`.
+///
+/// Known `pg_catalog` functions (length, upper, abs, etc.) map to native
+/// DataFusion functions; unknown functions fall back to `PgExprUdf` via
+/// `try_wrap_as_udf`.
+unsafe fn translate_child_projection_expr(
+    pg_expr_string: &str,
+    join_clause: &JoinCSClause,
+) -> Result<Expr> {
+    let sources = join_clause.plan.sources();
+    let mapper = JoinClauseMapper { join_clause };
+    translate_pg_node_string(
+        pg_expr_string,
+        &sources,
+        Box::new(mapper),
+        "ChildProjection::Expression",
+    )
 }
 
 /// Query planner that lowers JoinScan's custom logical nodes
@@ -263,7 +295,9 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
-    let mut builder = SessionStateBuilder::new().with_config(config);
+    let mut builder = SessionStateBuilder::new()
+        .with_config(config)
+        .with_default_features();
 
     // Inject visibility before late materialization so ctid lineage is analyzed
     // while DeferredCtid columns are still present in the logical plan.
@@ -665,46 +699,8 @@ fn apply_distinct_group_by(
         let col_alias = format!("col_{}", i + 1);
 
         let (expr, map_key) = match proj {
-            build::ChildProjection::Expression {
-                pg_expr_string,
-                input_vars,
-                result_type_oid,
-                ..
-            } => {
-                let udf_name = format!(
-                    "{}{}",
-                    crate::postgres::customscan::pg_expr_udf::PG_EXPR_UDF_PREFIX,
-                    i
-                );
-
-                let input_exprs: Vec<Expr> = input_vars
-                    .iter()
-                    .filter_map(|var_info| {
-                        resolve_var_to_df_col(join_clause, var_info.rti, var_info.attno)
-                    })
-                    .collect();
-
-                if input_exprs.len() != input_vars.len() {
-                    return Err(DataFusionError::Internal(format!(
-                        "PgExprUdf: could not resolve all input columns \
-                         (resolved {} of {})",
-                        input_exprs.len(),
-                        input_vars.len()
-                    )));
-                }
-
-                let udf = crate::postgres::customscan::pg_expr_udf::PgExprUdf::new(
-                    udf_name,
-                    pg_expr_string.clone(),
-                    input_vars.clone(),
-                    *result_type_oid,
-                );
-
-                let e =
-                    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
-                        Arc::new(datafusion::logical_expr::ScalarUDF::new_from_impl(udf)),
-                        input_exprs,
-                    ));
+            build::ChildProjection::Expression { pg_expr_string, .. } => {
+                let e = unsafe { translate_child_projection_expr(pg_expr_string, join_clause)? };
                 // Expressions don't participate in sort-step column mapping
                 (e, None)
             }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -84,8 +84,8 @@ use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
-    apply_join_level_filter, build_join_df, make_col, make_source_col, make_source_score_col,
-    CombinedMapper, JoinTypeAllowList, PredicateTranslator,
+    apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
+    make_source_score_col, CombinedMapper, JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
@@ -427,6 +427,7 @@ struct RelNodeBuildCtx<'a> {
     join_clause: &'a JoinCSClause,
     translated_exprs: &'a [Expr],
     ctid_map: &'a crate::api::HashMap<pg_sys::Index, Expr>,
+    output_columns: &'a [OutputColumnInfo],
 }
 
 /// Recursively lowers a `RelNode` tree into a DataFusion `DataFrame`.
@@ -502,16 +503,16 @@ fn build_relnode_df<'a>(
             RelNode::Join(join) => {
                 let left_df = build_relnode_df(rctx, &join.left).await?;
                 let right_df = build_relnode_df(rctx, &join.right).await?;
-
-                let df = build_join_df(left_df, right_df, join, JoinTypeAllowList::All)?;
-
-                if join.filter.is_some() {
-                    return Err(DataFusionError::NotImplemented(
-                        "Non-equi join filters are not yet implemented".into(),
-                    ));
-                }
-
-                Ok(df)
+                let mut sources = join.left.sources();
+                sources.extend(join.right.sources());
+                build_join_df_with_filter(
+                    left_df,
+                    right_df,
+                    join,
+                    &sources,
+                    rctx.output_columns,
+                    JoinTypeAllowList::All,
+                )
             }
             RelNode::Filter(filter) => {
                 let df = build_relnode_df(rctx, &filter.input).await?;
@@ -593,6 +594,7 @@ fn build_clause_df<'a>(
             join_clause,
             translated_exprs: &translated_exprs,
             ctid_map: &ctid_map,
+            output_columns: &private_data.output_columns,
         };
         let df = build_relnode_df(&rctx, &join_clause.plan).await?;
 
@@ -973,6 +975,16 @@ fn build_source_df<'a>(
             }
             if source.contains_rti(jk.inner_rti) {
                 if let Some(col) = source.column_name(jk.inner_attno) {
+                    required_early.insert(col);
+                }
+            }
+        }
+        // Columns referenced by `JoinNode.filter` (e.g. a disjunctive Semi/Anti
+        // `PgExpression`) must also be materialized eagerly — the filter is
+        // evaluated per row pair before the join emits anything.
+        for (rti, attno) in join_clause.plan.filter_input_vars() {
+            if source.contains_rti(rti) {
+                if let Some(col) = source.column_name(attno) {
                     required_early.insert(col);
                 }
             }

--- a/pg_search/src/postgres/customscan/pg_expr_udf.rs
+++ b/pg_search/src/postgres/customscan/pg_expr_udf.rs
@@ -132,6 +132,42 @@ impl PgExprUdf {
         Signature::variadic_any(Volatility::Immutable)
     }
 
+    /// Returns the Arrow `DataType` for a PG result type OID if `PgExprUdf`
+    /// can evaluate it, or `None` if unsupported. This is the single gate for
+    /// whether an expression can be UDF-wrapped.
+    ///
+    /// KEEP IN SYNC with the `eval_expr_to_arrow!` arms in
+    /// [`Self::invoke_with_args`] — every OID accepted here must have a
+    /// matching match arm there, and vice versa.
+    pub fn get_result_type_to_arrow(oid: pg_sys::Oid) -> Option<DataType> {
+        match oid {
+            pg_sys::BOOLOID => Some(DataType::Boolean),
+            pg_sys::INT2OID => Some(DataType::Int16),
+            pg_sys::INT4OID => Some(DataType::Int32),
+            pg_sys::INT8OID => Some(DataType::Int64),
+            pg_sys::FLOAT4OID => Some(DataType::Float32),
+            pg_sys::FLOAT8OID => Some(DataType::Float64),
+            pg_sys::TEXTOID | pg_sys::VARCHAROID | pg_sys::NAMEOID => Some(DataType::Utf8),
+            _ => None,
+        }
+    }
+
+    /// Build a deterministic, EXPLAIN-stable UDF name from a short node-tag
+    /// label and the serialized expression. Two subtrees with the same
+    /// serialized form collide on the same name — semantically correct,
+    /// since they're the same expression.
+    ///
+    /// Uses `FxHasher` (from `rustc-hash`) rather than `std`'s
+    /// `DefaultHasher`: the FxHash algorithm is documented and stable across
+    /// Rust releases, whereas `DefaultHasher`'s output is explicitly not.
+    pub fn stable_name(tag: &str, pg_expr_string: &str) -> String {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = rustc_hash::FxHasher::default();
+        pg_expr_string.hash(&mut hasher);
+        let short_hash = hasher.finish() as u32;
+        format!("{PG_EXPR_UDF_PREFIX}{tag}_{short_hash:08x}")
+    }
+
     /// Rebuild derived fields after deserialization.
     pub fn fixup_after_deserialize(&mut self) {
         self.return_type = types_arrow::pg_type_to_arrow(self.result_type_oid);
@@ -225,6 +261,9 @@ unsafe fn populate_slot(
 /// and append the result directly to an Arrow builder. No intermediate Vec<Datum>.
 ///
 /// Follows the `fetch_ff_column!` pattern from `fast_fields_helper.rs`.
+///
+/// KEEP IN SYNC with [`PgExprUdf::get_result_type_to_arrow`] — every PG type
+/// accepted by that gate must have a matching arm here, and vice versa.
 macro_rules! eval_expr_to_arrow {
     (
         $self_:expr, $num_rows:expr, $pg_state:expr, $args:expr, $input_vars:expr,
@@ -253,10 +292,17 @@ macro_rules! eval_expr_to_arrow {
                     std::sync::Arc::new(builder.finish()) as std::sync::Arc<dyn Array>
                 }
             )*
-            other => panic!(
-                "PgExprUdf: unsupported result type OID {other} — \
-                 add a branch to eval_expr_to_arrow!"
-            ),
+            other => {
+                debug_assert!(
+                    Self::get_result_type_to_arrow(other).is_none(),
+                    "PgExprUdf::get_result_type_to_arrow accepts OID {other} but \
+                     eval_expr_to_arrow! has no branch for it — keep the two in sync"
+                );
+                return Err(DataFusionError::Internal(format!(
+                    "PgExprUdf: unsupported result type OID {other} — \
+                     PgExprUdf::get_result_type_to_arrow must gate wrapping before this point"
+                )));
+            }
         }
     };
 }
@@ -285,11 +331,8 @@ impl ScalarUDFImpl for PgExprUdf {
         // SAFETY: single-threaded access guaranteed by target_partitions=1.
         let pg_state = unsafe { self.get_or_init_state() };
 
-        debug_assert!(
-            !self.input_vars.is_empty(),
-            "PgExprUdf '{}' has no input_vars — expression must have Var dependencies",
-            self.name
-        );
+        // A UDF over only constants has no input Vars — that's valid.
+        // ExecEvalExpr evaluates it with an empty slot.
 
         let n = args.number_rows;
         let arg_values = &args.args;

--- a/pg_search/tests/pg_regress/expected/expr_translator_debug.out
+++ b/pg_search/tests/pg_regress/expected/expr_translator_debug.out
@@ -1,0 +1,158 @@
+-- Regression test for `PredicateTranslator` debug1 logging.
+--
+-- Every failed translation path emits a structured `pgrx::debug1!` line of
+-- the form:
+--
+--     DEBUG: PredicateTranslator: <reason> [<NodeTag>] <key=value pairs> | <deparsed SQL>
+--
+-- This test raises `client_min_messages` to `debug1` and runs EXPLAIN on
+-- queries crafted to trip specific translator rejection points, verifying
+-- the expected log lines appear in order.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS et_items CASCADE;
+DROP TABLE IF EXISTS et_exclusions CASCADE;
+CREATE TABLE et_items (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    value INT NOT NULL
+);
+CREATE TABLE et_exclusions (
+    id SERIAL PRIMARY KEY,
+    pattern TEXT
+);
+INSERT INTO et_items (name, value) VALUES
+    ('alpha', 10), ('beta', 20);
+INSERT INTO et_exclusions (pattern) VALUES
+    ('alpha'), ('beta');
+CREATE INDEX et_items_idx ON et_items
+    USING bm25 (id, name, value)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"name":{"fast":true}}',
+        numeric_fields = '{"value":{"fast":true}}'
+    );
+CREATE INDEX et_exclusions_idx ON et_exclusions
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"pattern":{"fast":true}}'
+    );
+SET paradedb.enable_join_custom_scan = on;
+SET client_min_messages = 'debug1';
+-- =====================================================================
+-- 1. Unsupported operator (textcat `||`) → [OpExpr] log
+-- =====================================================================
+-- `translate_op_expr` doesn't know the `||` operator. It logs
+--   DEBUG: PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | ...
+-- Also emits
+--   DEBUG: PredicateTranslator: unsupported const type [Const] type=text
+-- for the `'_x'` string literal that `translate_const` doesn't support.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern || '_x' = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="pg_catalog.||", types=(text, text) | T_OpExpr
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="pg_catalog.||", types=(text, text) | T_OpExpr
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CAST(pdb_eval_expr_opexpr_927de030(CAST(e_1.pattern AS Utf8)) AS Utf8View)@1)], projection=[ctid_0@0], fetch=5
+           :     VisibilityFilterExec: tables=[i]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     ProjectionExec: expr=[pattern@0 as pattern, CAST(pdb_eval_expr_opexpr_927de030(CAST(pattern@0 AS Utf8)) AS Utf8View) as CAST(pdb_eval_expr_opexpr_927de030(CAST(e_1.pattern AS Utf8)) AS Utf8View)]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- =====================================================================
+-- 2. Unknown function → [FuncExpr] no native mapping
+-- =====================================================================
+-- `md5` isn't in `translate_known_func`'s pg_catalog map. Expect:
+--   DEBUG: PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | ...
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | T_FuncExpr
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | T_FuncExpr
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(e_1.pattern AS Utf8)) AS Utf8View)@1)], projection=[ctid_0@0], fetch=5
+           :     VisibilityFilterExec: tables=[i]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     ProjectionExec: expr=[pattern@0 as pattern, CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) AS Utf8View) as CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(e_1.pattern AS Utf8)) AS Utf8View)]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- =====================================================================
+-- 3. Cross-type cast → [CoerceViaIO] rejected + deparsed SQL in log
+-- =====================================================================
+-- `CAST(i.value AS text)` is a CoerceViaIO from int4 → text. The
+-- translator only allows coercions inside the text family (TEXT ↔
+-- VARCHAR ↔ NAME); int → text is rejected. Because the inner node is
+-- a simple Var reference, `deparse_expression` succeeds here and the
+-- log line includes the actual SQL (e.g. `(i.value)::text`) after the
+-- `|` separator — unlike the first two cases whose cross-RTE shape
+-- forces the helper to fall back to the node-tag label.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CAST(i.value AS text) = e.pattern
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source=integer, target=text | (i.value)::text
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source=integer, target=text | (i.value)::text
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(CAST(pdb_eval_expr_coerceviaio_66583d6c(i_0.value) AS Utf8View)@2, pattern@0)], projection=[ctid_0@0, value@1], fetch=5
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, value@1 as value, CAST(pdb_eval_expr_coerceviaio_66583d6c(value@1) AS Utf8View) as CAST(pdb_eval_expr_coerceviaio_66583d6c(i_0.value) AS Utf8View)]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     CooperativeExec
+           :       PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- Cleanup
+RESET client_min_messages;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE et_items CASCADE;
+DROP TABLE et_exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -79,7 +79,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -531,7 +531,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[upper(name@1) IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1
                              :       VisibilityFilterExec: tables=[s, p]
@@ -870,7 +870,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -1157,7 +1157,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[upper(pdb_eval_expr_funcexpr_685b54ea(CAST(name@1 AS Utf8))) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_d16211df(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -79,7 +79,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -154,7 +154,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -232,7 +232,7 @@ ORDER BY p.name
                              : ProjectionExec: expr=[col_1@0 as col_1, col_3@1 as col_2, col_3@1 as col_3, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
                              :   SortExec: TopK(fetch=10), expr=[col_3@1 ASC NULLS LAST], preserve_partitioning=[false]
                              :     ProjectionExec: expr=[col_1@0 as col_1, col_3@2 as col_3, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1]
-                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
+                             :       AggregateExec: mode=Single, gby=[supplier_id@2 * 10 + id@4 as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
                              :         VisibilityFilterExec: tables=[s, p]
                              :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4, id@5]
                              :             CooperativeExec
@@ -305,7 +305,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -380,7 +380,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -455,7 +455,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -531,7 +531,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1
                              :       VisibilityFilterExec: tables=[s, p]
@@ -580,7 +580,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -653,7 +653,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -727,7 +727,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_f1ebe528(supplier_id@2) * 100 as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -799,7 +799,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_eb551b6f(supplier_id@2) / 3 as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -870,7 +870,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -943,7 +943,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -991,6 +991,83 @@ ORDER BY p.name
             | tablet
  FastP      | 
             | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- TEST 8b: CaseExpr — DISTINCT CASE WHEN col IS NOT NULL THEN col ELSE 'N/A' END
+-- =============================================================================
+-- Exercises the translator's CaseExpr path. EXPLAIN should show
+-- `CASE WHEN ... END` in the DataFusion plan, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: p.name, (CASE WHEN (s.name IS NOT NULL) THEN s.name ELSE 'N/A'::text END)
+               ->  Result
+                     ->  Custom Scan (ParadeDB Join Scan)
+                           Relation Tree: s INNER p
+                           Join Cond: p.supplier_id = s.id
+                           Limit: 10
+                           Distinct: true
+                           Order By: p.name asc
+                           DataFusion Physical Plan: 
+                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   TantivyLookupExec: decode=[name]
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
+
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+ supplier_or_default |      name       
+---------------------+-----------------
+ TechCorp            | 
+ TechCorp            | Headphones
+ TechCorp            | Keyboard
+ N/A                 | USB Cable
+ TechCorp            | WIRELESS ROUTER
+ TechCorp            | Wireless Mouse
+ N/A                 | tablet
+ FastParts           | 
+ N/A                 | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+ supplier_or_default |      name       
+---------------------+-----------------
+ TechCorp            | 
+ TechCorp            | Headphones
+ TechCorp            | Keyboard
+ N/A                 | USB Cable
+ TechCorp            | WIRELESS ROUTER
+ TechCorp            | Wireless Mouse
+ N/A                 | tablet
+ FastParts           | 
+ N/A                 | 
 (9 rows)
 
 SET paradedb.enable_join_custom_scan = on;
@@ -1052,6 +1129,85 @@ WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast
 (9 rows)
 
 -- No crash, no error, correct results via native PG.
+-- =============================================================================
+-- TEST 10: Mixed native + PgExprUdf in a single DISTINCT expression
+-- =============================================================================
+-- Outer `upper()` is in the pg_catalog native map; inner `md5()` isn't, so
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show
+-- `upper(pdb_eval_expr_funcexpr_*(...))` in the AggregateExec gby list —
+-- both native and UDF paths exercised in one projection.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: p.name, (upper(md5(s.name)))
+               ->  Result
+                     ->  Custom Scan (ParadeDB Join Scan)
+                           Relation Tree: s INNER p
+                           Join Cond: p.supplier_id = s.id
+                           Limit: 10
+                           Distinct: true
+                           Order By: p.name asc
+                           DataFusion Physical Plan: 
+                             : AggregateExec: mode=Single, gby=[upper(pdb_eval_expr_funcexpr_685b54ea(CAST(name@1 AS Utf8))) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   TantivyLookupExec: decode=[name]
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
+
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+            mixed_key             |      name       
+----------------------------------+-----------------
+ D9CE5A9B751D2E18071CC135E51C524B | 
+ D9CE5A9B751D2E18071CC135E51C524B | Headphones
+ D9CE5A9B751D2E18071CC135E51C524B | Keyboard
+                                  | USB Cable
+ D9CE5A9B751D2E18071CC135E51C524B | WIRELESS ROUTER
+ D9CE5A9B751D2E18071CC135E51C524B | Wireless Mouse
+                                  | tablet
+ 9818B8B1AAC79FB78ABE7B48D8ECC003 | 
+                                  | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+            mixed_key             |      name       
+----------------------------------+-----------------
+ D9CE5A9B751D2E18071CC135E51C524B | 
+ D9CE5A9B751D2E18071CC135E51C524B | Headphones
+ D9CE5A9B751D2E18071CC135E51C524B | Keyboard
+                                  | USB Cable
+ D9CE5A9B751D2E18071CC135E51C524B | WIRELESS ROUTER
+ D9CE5A9B751D2E18071CC135E51C524B | Wireless Mouse
+                                  | tablet
+ 9818B8B1AAC79FB78ABE7B48D8ECC003 | 
+                                  | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
 -- CLEANUP
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -825,6 +825,140 @@ WARNING:  JoinScan not used: failed to extract join-level conditions (ensure all
 (17 rows)
 
 -- =============================================================================
+-- TEST 12: Functions in cross-table predicates (native DF + UDF fallback)
+-- =============================================================================
+-- Exercise PredicateTranslator's FuncExpr + arithmetic-OpExpr paths inside a
+-- multi-table predicate. Both sides' columns are fast fields, so JoinScan
+-- should absorb these and the EXPLAIN should show `abs(...)` natively while
+-- the arithmetic OpExpr (`-`) gets wrapped as `pdb_eval_expr_opexpr_*` via
+-- `try_wrap_as_udf`.
+-- 12a: abs() wrapping a cross-table arithmetic OpExpr
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.supplier_id, s.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.supplier_id, s.id
+         Relation Tree: s INNER p
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: heap:{OPEXPR :opno 525 :opfuncid 150 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({OPEXPR :opno 555 :opfuncid 181 :opresulttype 23 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1} {VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1}) :location -1}) :location -1} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location -1 :constvalue 4 [ 0 0 0 0 0 0 0 0 ]}) :location -1}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@4 as col_1, supplier_id@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[s, p]
+           :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1 - id@0) >= 0
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped FuncExpr
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var.
+-- RHS `length(to_hex(s.id))` nests two FuncExprs: `to_hex` is a pg_catalog
+-- function that is NOT in `translate_known_func`'s native map, so it falls
+-- through to `try_wrap_as_udf` and becomes `pdb_eval_expr_funcexpr_*`. The
+-- outer `length` (→ `character_length`) IS native and wraps the UDF. The
+-- outer `<=` comparison stays native. EXPLAIN should show native
+-- `abs(supplier_id)` and native `character_length(pdb_eval_expr_funcexpr_*(id))`
+-- side by side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.supplier_id, s.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.supplier_id, s.id
+         Relation Tree: s INNER p
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: heap:{OPEXPR :opno 523 :opfuncid 149 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1}) :location -1} {FUNCEXPR :funcid 1317 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 100 :args ({FUNCEXPR :funcid 2089 :funcresulttype 25 :funcretset false :funcvariadic false :funcformat 0 :funccollid 100 :inputcollid 0 :args ({VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1}) :location -1}) :location -1}) :location -1}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@4 as col_1, supplier_id@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[s, p]
+           :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= CAST(character_length(pdb_eval_expr_funcexpr_34e97bf1(id@0)) AS Int64)
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+ id | supplier_id | supplier_pk 
+----+-------------+-------------
+(0 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+ id | supplier_id | supplier_pk 
+----+-------------+-------------
+(0 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 DROP TABLE IF EXISTS products CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -948,12 +948,12 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            :   SortExec: TopK(fetch=5), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(upper(i_0.name)@3, upper(e_1.pattern)@1)], projection=[ctid_0@0, id@2]
-           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as upper(i_0.name)]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(pdb_eval_expr_funcexpr_53eb87a5(i_0.name)@3, pdb_eval_expr_funcexpr_44945b63(e_1.pattern)@1)], projection=[ctid_0@0, id@2]
+           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, pdb_eval_expr_funcexpr_53eb87a5(CAST(name@1 AS Utf8)) as pdb_eval_expr_funcexpr_53eb87a5(i_0.name)]
            :         VisibilityFilterExec: tables=[i]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :       ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as upper(e_1.pattern)]
+           :       ProjectionExec: expr=[pattern@0 as pattern, pdb_eval_expr_funcexpr_44945b63(CAST(pattern@0 AS Utf8)) as pdb_eval_expr_funcexpr_44945b63(e_1.pattern)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (16 rows)
@@ -1315,8 +1315,8 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-                                                                                                           QUERY PLAN                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: i ANTI e
@@ -1330,7 +1330,7 @@ LIMIT 5;
            :         VisibilityFilterExec: tables=[i]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :         ProjectionExec: expr=[pattern@0 as pattern, CAST(upper(pattern@0) AS Utf8View) as join_proj_push_down_1, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) = never-matches as join_proj_push_down_2]
+           :         ProjectionExec: expr=[pattern@0 as pattern, CAST(pdb_eval_expr_funcexpr_44945b63(CAST(pattern@0 AS Utf8)) AS Utf8View) as join_proj_push_down_1, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) = never-matches as join_proj_push_down_2]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (16 rows)
@@ -1378,23 +1378,28 @@ SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
 -- =====================================================================
--- Cross-table disjunction where `upper` and `character_length`
--- (via the `length` alias) are both in `translate_known_func`'s
--- pg_catalog map; operators `=`, `>`, `OR` are native structural.
--- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+-- `character_length` (via the `length` alias) is in
+-- `translate_known_func`'s pg_catalog map; arithmetic comparisons `>`,
+-- `<>`, and the boolean `OR` are native structural. Var references on
+-- both sides of the disjunction resolve via the mapper. The EXPLAIN
+-- should contain NO `pdb_eval_expr_*` UDFs anywhere.
+--
+-- Note: `upper` / `lower` / `btrim` / `trim` / `ltrim` / `rtrim` are
+-- intentionally excluded from the native map (collation-aware — see
+-- tier 22), so an "all native" case can't use them.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-                                                                                                  QUERY PLAN                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: i ANTI e
@@ -1404,12 +1409,12 @@ LIMIT 5;
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
            :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
-           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 > join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
-           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, character_length(name@1) as join_proj_push_down_2]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_2@3 > join_proj_push_down_1@2 OR id@1 != id@0, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, character_length(name@1) as join_proj_push_down_1]
            :           VisibilityFilterExec: tables=[i]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, character_length(pattern@0) as join_proj_push_down_4]
+           :         ProjectionExec: expr=[pattern@0 as pattern, id@1 as id, character_length(pattern@0) as join_proj_push_down_2]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (17 rows)
@@ -1419,19 +1424,14 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
- id  
------
- 500
- 498
- 496
- 494
- 492
-(5 rows)
+ id 
+----
+(0 rows)
 
 SET paradedb.enable_join_custom_scan TO off;
 SELECT i.id
@@ -1439,42 +1439,39 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
- id  
------
- 500
- 498
- 496
- 494
- 492
-(5 rows)
+ id 
+----
+(0 rows)
 
 SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
 -- =====================================================================
--- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
--- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
--- both tables so the whole tree is absorbed at the join level (not pushed
--- down as a single-table heap filter). EXPLAIN should contain BOTH native
--- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
+-- Cross-table disjunction: `length()` maps natively via
+-- `character_length`; `upper()` is collation-aware and excluded from the
+-- native map, so it's wrapped as a PgExprUdf. The disjunction spans both
+-- tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH
+-- native `character_length(...)` AND `pdb_eval_expr_funcexpr_*` in the
+-- same plan.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: i ANTI e
@@ -1484,12 +1481,12 @@ LIMIT 5;
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
            :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
-           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 = join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
-           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@1 AS Utf8)) as join_proj_push_down_2]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_2@2 > join_proj_push_down_1@1 OR join_proj_push_down_3@3 = name@0, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, character_length(name@1) as join_proj_push_down_1]
            :           VisibilityFilterExec: tables=[i]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) as join_proj_push_down_4]
+           :         ProjectionExec: expr=[pattern@0 as pattern, character_length(pattern@0) as join_proj_push_down_2, CAST(pdb_eval_expr_funcexpr_44945b63(CAST(pattern@0 AS Utf8)) AS Utf8View) as join_proj_push_down_3]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (17 rows)
@@ -1499,7 +1496,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -1519,7 +1516,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -1616,6 +1613,182 @@ LIMIT 5;
 (5 rows)
 
 SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 22. Collation-aware UDF: upper() under a non-default collation
+-- =====================================================================
+-- `upper`, `lower`, `btrim`, `trim`, `ltrim`, `rtrim` are intentionally
+-- excluded from `translate_known_func`'s native map because DataFusion
+-- implements them with Rust's Unicode rules, which don't always match
+-- PostgreSQL's locale-specific behavior. Instead they go through
+-- `try_wrap_as_udf` → `ExecEvalExpr`, which invokes PG's own
+-- implementation and honors the column's / expression's collation.
+--
+-- The dataset below is seeded with *case-varying* strings so that
+-- `upper(pattern) = upper(name)` matches pairs that plain `=` cannot.
+-- The test runs three queries back to back:
+--
+--   A. NOT EXISTS with `upper(... COLLATE "C") = upper(... COLLATE "C")`
+--      on JoinScan — case-insensitive match → rows whose name has NO
+--      case-insensitive peer in patterns survive.
+--   B. The same query with a plain `=` comparison — case-sensitive →
+--      rows whose name has no *exact* peer in patterns survive. Because
+--      the data is all case-mismatched, no row is excluded and every
+--      coll_item returns, proving the `upper()` wrapping in (A) is
+--      actually doing something the plain `=` isn't.
+--   C. Re-run (A) with JoinScan off — must return byte-identical rows
+--      to (A), proving the UDF → ExecEvalExpr path preserves PG-correct
+--      locale semantics. A future regression that adds `upper`/`lower`
+--      back to the native map would show up here as an ON-vs-OFF diff.
+DROP TABLE IF EXISTS coll_items CASCADE;
+DROP TABLE IF EXISTS coll_patterns CASCADE;
+-- Table layout is shaped for the disjunctive Semi/Anti absorption path:
+-- each NOT EXISTS below has the form
+--   (p.id = i.pattern_id OR <case predicate>)
+-- — a disjunction of one equi-key-shaped arm and one collation-aware
+-- predicate. Because every row uses `pattern_id = 99` (which never
+-- matches a real `coll_patterns.id`), the equi arm contributes
+-- nothing: the case predicate is the sole discriminator. That makes
+-- (A) vs (B) diverge purely on `upper()` vs plain `=`.
+CREATE TABLE coll_items (
+    id bigint PRIMARY KEY,
+    name text,
+    pattern_id bigint
+);
+INSERT INTO coll_items (id, name, pattern_id) VALUES
+    (1, 'Alpha',   99),  -- case-insensitive pair with 'ALPHA'
+    (2, 'beta',    99),  -- pairs with 'BETA'
+    (3, 'GAMMA',   99),  -- pairs with 'gamma'
+    (4, 'Delta',   99),  -- no case-insensitive peer
+    (5, 'epsilon', 99);  -- no case-insensitive peer
+CREATE TABLE coll_patterns (
+    id bigint PRIMARY KEY,
+    pattern text
+);
+INSERT INTO coll_patterns (id, pattern) VALUES
+    (1, 'ALPHA'),
+    (2, 'BETA'),
+    (3, 'gamma');
+CREATE INDEX coll_items_idx ON coll_items
+    USING bm25 (id, name, pattern_id)
+    WITH (
+        key_field = id,
+        text_fields = '{"name": {"fast": true, "tokenizer": {"type": "keyword"}}}',
+        numeric_fields = '{"pattern_id": {"fast": true}}'
+    );
+CREATE INDEX coll_patterns_idx ON coll_patterns
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = id,
+        text_fields = '{"pattern": {"fast": true, "tokenizer": {"type": "keyword"}}}'
+    );
+-- (A) Disjunctive equi-key OR `upper(... COLLATE "C")` — JoinScan's
+-- disjunctive-absorption path routes the whole predicate through
+-- PgExpression → NestedLoopJoinExec, where the UDF fallback evaluates
+-- `upper()` with PG-correct semantics. Because every row has
+-- `pattern_id = 99` (no matching p.id), the equi arm contributes
+-- nothing: the `upper()` comparison is the sole discriminator.
+-- Expected survivors: Delta, epsilon — items 1–3 pair case-insensitively
+-- with their patterns and are excluded.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI p
+         Limit: 10
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, name@1 as col_2, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, name@2 as name, id@3 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=id@1 = pattern_id@0 OR join_proj_push_down_2@3 = join_proj_push_down_1@2, projection=[ctid_0@0, pattern_id@1, name@2, id@3]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, pattern_id@1 as pattern_id, name@2 as name, id@3 as id, pdb_eval_expr_funcexpr_4b32ca6c(CAST(name@2 AS Utf8)) as join_proj_push_down_1]
+           :           VisibilityFilterExec: tables=[i]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :         ProjectionExec: expr=[id@0 as id, pattern@1 as pattern, pdb_eval_expr_funcexpr_52e8edc5(CAST(pattern@1 AS Utf8)) as join_proj_push_down_2]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+ id |  name   
+----+---------
+  4 | Delta
+  5 | epsilon
+(2 rows)
+
+-- (B) Same disjunction, but with a plain `=` in place of `upper(...)`.
+-- The equi arm still contributes nothing (pattern_id=99), so this is
+-- case-sensitive: none of items 1–3 match their paired pattern on exact
+-- case, and every row survives. Contrasts with (A) to prove upper() is
+-- genuinely being evaluated.
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR p.pattern = i.name)
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+ id |  name   
+----+---------
+  1 | Alpha
+  2 | beta
+  3 | GAMMA
+  4 | Delta
+  5 | epsilon
+(5 rows)
+
+-- (C) Re-run (A) with JoinScan off; rows must match (A) byte-for-byte.
+-- If someone re-adds `upper`/`lower` to the native map and DataFusion's
+-- Unicode implementation diverges from PG's locale-aware `upper` for
+-- the COLLATE "C" clause, (A) and (C) will disagree here.
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+ id |  name   
+----+---------
+  4 | Delta
+  5 | epsilon
+(2 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+DROP TABLE coll_items CASCADE;
+DROP TABLE coll_patterns CASCADE;
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -1,0 +1,660 @@
+-- Tests for Semi and Anti Joins with disjunctive (OR) join conditions.
+-- Verifies the fix for https://github.com/paradedb/paradedb/issues/4776:
+-- when a NOT EXISTS/EXISTS subquery uses OR across multiple equalities,
+-- JoinScan should absorb the join using DataFusion's NestedLoopJoinExec
+-- (cross-join + filter) instead of falling back to Postgres's Nested Loop.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS items CASCADE;
+CREATE TABLE items (
+    id bigint NOT NULL PRIMARY KEY,
+    name text,
+    alt_name text,
+    category text
+);
+INSERT INTO items (id, name, alt_name, category)
+SELECT
+    i,
+    'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1, 500) as i;
+DROP TABLE IF EXISTS exclusions CASCADE;
+CREATE TABLE exclusions (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern text,
+    reason text
+);
+-- Populate exclusions so roughly half of items are excluded via `name` match
+-- and a smaller slice is excluded via `alt_name` match. Includes a few
+-- patterns that match both name and alt_name to exercise the OR branching.
+INSERT INTO exclusions (pattern, reason)
+SELECT 'name_' || i, 'name-based'
+FROM generate_series(1, 250) as i
+WHERE i % 5 = 0;
+INSERT INTO exclusions (pattern, reason)
+SELECT 'alt_' || i, 'alt-based'
+FROM generate_series(1, 500) as i
+WHERE i % 3 = 0 AND i % 15 = 0;
+CREATE INDEX items_idx ON items
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }'
+);
+CREATE INDEX exclusions_idx ON exclusions
+USING bm25 (id, pattern, reason)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "reason": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 1. NOT EXISTS with 2-arm OR join condition (the core repro)
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+-- =====================================================================
+-- 2. EXISTS with 2-arm OR join condition
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i SEMI e
+         Limit: 10
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftSemi, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 10;
+ id  
+-----
+  10
+  20
+  30
+  40
+  50
+  60
+  70
+  80
+  90
+ 100
+(10 rows)
+
+-- =====================================================================
+-- 3. NOT EXISTS with 3-arm OR
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@3 = name@0 OR pattern@3 = alt_name@1 OR pattern@3 = category@2, projection=[ctid_0@0, id@4]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+-- =====================================================================
+-- 4. Correctness cross-check: compare JoinScan result with JoinScan off
+-- =====================================================================
+-- Capture the result with JoinScan enabled, then again with it off, and
+-- diff them. They must match.
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 5. Non-translatable arm: graceful fallback to PG native
+-- =====================================================================
+-- A disjunction where one arm uses a function call (length()) that the
+-- PredicateTranslator cannot handle. JoinScan should decline and PG's
+-- native Nested Loop Anti Join should run — results must still be correct.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR length(e.pattern) > 100)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: i.id DESC
+         ->  Nested Loop Anti Join
+               Join Filter: ((e.pattern = i.name) OR (length(e.pattern) > 100))
+               ->  Custom Scan (ParadeDB Base Scan) on items i
+                     Table: items
+                     Index: items_idx
+                     Exec Method: ColumnarExecState
+                     Fast Fields: id, name
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+               ->  Materialize
+                     ->  Custom Scan (ParadeDB Base Scan) on exclusions e
+                           Table: exclusions
+                           Index: exclusions_idx
+                           Exec Method: ColumnarExecState
+                           Fast Fields: pattern
+                           Scores: false
+                           Full Index Scan: true
+                           Tantivy Query: {"with_index":{"query":"all"}}
+(21 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR length(e.pattern) > 100)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+-- =====================================================================
+-- 6. NOT EXISTS with inequality operator (<>)
+-- =====================================================================
+-- A single <> comparison. The old EquiKeyDisjunction shape could not
+-- represent this; PgExpression carries the full OpExpr, so PredicateTranslator
+-- maps it to Operator::NotEq.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=id@1 != id@0
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id 
+----
+(0 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id 
+----
+(0 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 7. NOT EXISTS with mixed operators in OR (> and =)
+-- =====================================================================
+-- Disjunction of > and =, both Var-vs-Var. Both operators are supported
+-- by PredicateTranslator.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=id@2 > id@0 OR pattern@3 = name@1, projection=[ctid_0@0, id@1]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 8. EXISTS with Var = Const in an OR arm
+-- =====================================================================
+-- One arm compares a Var to a bigint literal. The old EquiKeyDisjunction
+-- shape required Var-vs-Var on every arm; PgExpression has no such
+-- restriction — PredicateTranslator::translate_const handles INT8OID.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i SEMI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftSemi, filter=pattern@1 = name@0 OR join_proj_push_down_1@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, id@1 as id, id@1 = 42 as join_proj_push_down_1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 9. NOT EXISTS with AND nested inside OR
+-- =====================================================================
+-- Nested BoolExpr(AND) inside BoolExpr(OR). PredicateTranslator handles
+-- both boolean operators recursively.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@3 = name@0 AND id@4 > id@1 OR pattern@3 = alt_name@2, projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- Cleanup
+DROP TABLE items CASCADE;
+DROP TABLE exclusions CASCADE;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -263,11 +263,12 @@ LIMIT 10;
 
 SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
--- 5. Non-translatable arm: graceful fallback to PG native
+-- 5. Generic function in disjunctive filter: native DataFusion evaluation
 -- =====================================================================
--- A disjunction where one arm uses a function call (length()) that the
--- PredicateTranslator cannot handle. JoinScan should decline and PG's
--- native Nested Loop Anti Join should run — results must still be correct.
+-- A disjunction where one arm uses a pg_catalog function (length()).
+-- PredicateTranslator maps it to DataFusion's native character_length(),
+-- allowing JoinScan to absorb the full expression. The EXPLAIN should
+-- show character_length(...) in the physical plan, not a PgExprUdf.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -279,31 +280,25 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: i.id DESC
-         ->  Nested Loop Anti Join
-               Join Filter: ((e.pattern = i.name) OR (length(e.pattern) > 100))
-               ->  Custom Scan (ParadeDB Base Scan) on items i
-                     Table: items
-                     Index: items_idx
-                     Exec Method: ColumnarExecState
-                     Fast Fields: id, name
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-               ->  Materialize
-                     ->  Custom Scan (ParadeDB Base Scan) on exclusions e
-                           Table: exclusions
-                           Index: exclusions_idx
-                           Exec Method: ColumnarExecState
-                           Fast Fields: pattern
-                           Scores: false
-                           Full Index Scan: true
-                           Tantivy Query: {"with_index":{"query":"all"}}
-(21 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@1 = name@0 OR join_proj_push_down_1@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, character_length(pattern@0) > 100 as join_proj_push_down_1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
 
 SELECT i.id
 FROM items i
@@ -315,7 +310,6 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
  id  
 -----
  500
@@ -928,6 +922,700 @@ LIMIT 10;
 SET paradedb.enable_join_custom_scan TO on;
 DROP TABLE items_vc CASCADE;
 DROP TABLE exclusions_vc CASCADE;
+-- =====================================================================
+-- 13. upper() in EXISTS semi-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `upper(...)` in the physical plan and JoinScan
+-- should absorb the whole semi-join (no "JoinScan not used" warning).
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i SEMI e
+         Limit: 5
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(upper(i_0.name)@3, upper(e_1.pattern)@1)], projection=[ctid_0@0, id@2]
+           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as upper(i_0.name)]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as upper(e_1.pattern)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+ id 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+ id 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 14. COALESCE() in NOT EXISTS anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `coalesce(...)` natively, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END@1)], projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, CASE WHEN pattern@0 IS NOT NULL THEN pattern@0 ELSE  END as CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 15. IS NULL arm in disjunctive anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `IS NULL` natively and JoinScan should absorb the
+-- disjunction.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@1 = name@0 OR join_proj_push_down_1@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, pattern@0 IS NULL as join_proj_push_down_1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 16. CASE WHEN in anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `CASE WHEN ... END` natively, not a PgExprUdf.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END@1)], projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, CASE WHEN pattern@0 IS NOT NULL THEN pattern@0 ELSE  END as CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 17. Arithmetic OpExpr (`*`) maps natively
+-- =====================================================================
+-- `translate_op_expr` now handles `+`, `-`, `*`, `/`, `%` — the `(e.id * 2)`
+-- subtree maps directly to `Operator::Multiply`. EXPLAIN should contain a
+-- native multiplication (e.g. `id * 2`) and NO `pdb_eval_expr_opexpr_*`.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_1@1 > id@0, projection=[ctid_0@0, id@1]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[id@0 as id, id@0 * 2 as join_proj_push_down_1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 18. Mixed native + UDF in one disjunction
+-- =====================================================================
+-- `upper()` is in the pg_catalog map → native; `md5()` is not →
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show `upper`
+-- on one arm and `pdb_eval_expr_funcexpr_*` on the other.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_1@1 = name@0 OR join_proj_push_down_2@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, CAST(upper(pattern@0) AS Utf8View) as join_proj_push_down_1, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) = never-matches as join_proj_push_down_2]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
+-- =====================================================================
+-- Cross-table disjunction where `upper` and `character_length`
+-- (via the `length` alias) are both in `translate_known_func`'s
+-- pg_catalog map; operators `=`, `>`, `OR` are native structural.
+-- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 > join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, character_length(name@1) as join_proj_push_down_2]
+           :           VisibilityFilterExec: tables=[i]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, character_length(pattern@0) as join_proj_push_down_4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
+-- =====================================================================
+-- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
+-- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
+-- both tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 = join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@1 AS Utf8)) as join_proj_push_down_2]
+           :           VisibilityFilterExec: tables=[i]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) as join_proj_push_down_4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 21. Tier 3 — PURE PgExprUdf: every function → UDF
+-- =====================================================================
+-- Neither `md5` nor `to_hex` is in the pg_catalog map, so both FuncExprs
+-- are wrapped by `try_wrap_as_udf`. The top-level `=`, `<>`, `AND` are
+-- native structural combinators, but every function-producing subtree
+-- is UDF-wrapped. EXPLAIN should contain only `pdb_eval_expr_funcexpr_*`
+-- wrappers and NO native pg_catalog scalar function names.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                                                         QUERY PLAN                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(pdb_eval_expr_funcexpr_887b5ea5(i_0.name)@3, pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)@2)], filter=pdb_eval_expr_funcexpr_7e60c530(id@1) != pdb_eval_expr_funcexpr_64208395(id@0), projection=[ctid_0@0, id@1]
+           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, name@2 as name, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@2 AS Utf8)) as pdb_eval_expr_funcexpr_887b5ea5(i_0.name)]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[id@0 as id, pattern@1 as pattern, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@1 AS Utf8)) as pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -654,6 +654,280 @@ LIMIT 10;
 (10 rows)
 
 SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 10. Single equi-key Semi/Anti regression
+-- =====================================================================
+-- A plain Var = Var NOT EXISTS with no OR must still go through the
+-- equi-key path (HashJoinExec), not PgExpression/NestedLoopJoinExec.
+-- Regression guard: single equalities must not be routed through the
+-- new disjunctive-filter absorption.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Join Cond: e.pattern = i.name
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, pattern@0)], projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+ 490
+ 488
+ 486
+ 484
+ 482
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 11. NULL semantics on OR arms
+-- =====================================================================
+-- Restrict the outer side to rows where `i.alt_name IS NULL` by targeting
+-- odd ids (category:"other") — the setup leaves `alt_name` NULL whenever
+-- `i % 3 != 0`. Verifies that NULL comparisons inside disjunctive arms
+-- produce the same result under DataFusion's NestedLoopJoinExec as under
+-- PostgreSQL's native Nested Loop Anti Join.
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"other"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 499
+ 497
+ 493
+ 491
+ 489
+ 487
+ 485
+ 483
+ 481
+ 479
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"other"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 499
+ 497
+ 493
+ 491
+ 489
+ 487
+ 485
+ 483
+ 481
+ 479
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 12. RelabelType path with varchar columns
+-- =====================================================================
+-- varchar columns force PostgreSQL to wrap each Var in a RelabelType
+-- (varchar -> text) before the equality operator. This exercises the
+-- translator's RelabelType-stripping path for disjunctive filters; if
+-- broken, JoinScan would fall back to a Nested Loop Anti Join.
+DROP TABLE IF EXISTS items_vc CASCADE;
+DROP TABLE IF EXISTS exclusions_vc CASCADE;
+CREATE TABLE items_vc (
+    id bigint NOT NULL PRIMARY KEY,
+    name varchar(100),
+    alt_name varchar(100),
+    category varchar(100)
+);
+INSERT INTO items_vc (id, name, alt_name, category)
+SELECT
+    i,
+    ('name_' || i)::varchar(100),
+    CASE WHEN i % 3 = 0 THEN ('alt_' || i)::varchar(100) ELSE NULL END,
+    (CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END)::varchar(100)
+FROM generate_series(1, 200) as i;
+CREATE TABLE exclusions_vc (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern varchar(100)
+);
+INSERT INTO exclusions_vc (pattern)
+SELECT ('name_' || i)::varchar(100)
+FROM generate_series(1, 100) as i
+WHERE i % 5 = 0;
+CREATE INDEX items_vc_idx ON items_vc
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }'
+);
+CREATE INDEX exclusions_vc_idx ON exclusions_vc
+USING bm25 (id, pattern)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(14 rows)
+
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 200
+ 198
+ 196
+ 194
+ 192
+ 190
+ 188
+ 186
+ 184
+ 182
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+ id  
+-----
+ 200
+ 198
+ 196
+ 194
+ 192
+ 190
+ 188
+ 186
+ 184
+ 182
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+DROP TABLE items_vc CASCADE;
+DROP TABLE exclusions_vc CASCADE;
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
@@ -1,0 +1,265 @@
+-- Parallel regression for disjunctive Semi/Anti JoinScan (issue #4776).
+--
+-- `validate_and_build_clause` forces `partitioning_source_index = 0` for any
+-- plan that contains a Semi/Anti join (build::JoinCSClause::
+-- `with_forced_partitioning(0)`), and disjunctive Semi/Anti conditions now
+-- lower to `NestedLoopJoinExec` instead of `HashJoinExec`. The combination
+-- must still produce correct results under parallel execution: the outer
+-- (partitioned) side sees a disjoint slice per worker, the inner
+-- (replicated) side is fully scanned by every worker, and the anti/semi
+-- filter fires per (left, right) row pair.
+--
+-- Regression guard: we cross-check a parallel disjunctive NOT EXISTS /
+-- EXISTS against the JoinScan-off PG-native plan on the same data.
+-- Any dropped rows, duplicates, or missed matches from worker
+-- partitioning would surface as a set diff.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.min_rows_per_worker = 0;
+SET max_parallel_workers = 4;
+SET max_parallel_workers_per_gather = 4;
+SET parallel_tuple_cost = 0;
+SET parallel_setup_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_leader_participation = off;
+DROP TABLE IF EXISTS jsd_par_items CASCADE;
+DROP TABLE IF EXISTS jsd_par_exclusions CASCADE;
+CREATE TABLE jsd_par_items (
+    id bigint PRIMARY KEY,
+    name text,
+    alt_name text,
+    category text
+) WITH (autovacuum_enabled = false);
+CREATE TABLE jsd_par_exclusions (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern text
+) WITH (autovacuum_enabled = false);
+-- Segment-per-batch index to force multiple segments and give workers
+-- something to partition across. `global_mutable_segment_rows = 0` flushes
+-- after each INSERT; `target_segment_count` + `background_layer_sizes`
+-- keeps background merges from collapsing segments back together.
+SET paradedb.global_mutable_segment_rows = 0;
+CREATE INDEX jsd_par_items_idx ON jsd_par_items
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }',
+    target_segment_count = 64,
+    background_layer_sizes = '0'
+);
+CREATE INDEX jsd_par_exclusions_idx ON jsd_par_exclusions
+USING bm25 (id, pattern)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }',
+    target_segment_count = 64,
+    background_layer_sizes = '0'
+);
+-- Batched inserts → multiple segments on the partitioning side. Each
+-- 1000-row batch triggers a segment flush under
+-- `global_mutable_segment_rows = 0`.
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1, 1000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1001, 2000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(2001, 3000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(3001, 4000) i;
+INSERT INTO jsd_par_exclusions (pattern)
+SELECT 'name_' || i FROM generate_series(1, 2000) i WHERE i % 7 = 0;
+INSERT INTO jsd_par_exclusions (pattern)
+SELECT 'alt_' || i FROM generate_series(1, 4000) i WHERE i % 3 = 0 AND i % 11 = 0;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE jsd_par_items;
+ANALYZE jsd_par_exclusions;
+-- =====================================================================
+-- 1. Parallel NOT EXISTS with 2-arm disjunctive OR
+-- =====================================================================
+-- Capture JoinScan-absorbed (parallel) result into a temp, then compare
+-- against the JoinScan-off (native Nested Loop Anti) result on the
+-- same session. Set-equal + row-count equal means no dropped/duplicated
+-- rows from parallel partitioning.
+-- LIMIT is required by `validate_and_build_clause` to activate JoinScan
+-- on top-level queries; pick a bound that comfortably exceeds the
+-- ~1802-row result set so no rows are dropped. The matching LIMIT on
+-- the JoinScan-off side keeps the comparison apples-to-apples.
+CREATE TEMP TABLE jsd_par_r1_on AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+SET paradedb.enable_join_custom_scan = off;
+CREATE TEMP TABLE jsd_par_r1_off AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+SET paradedb.enable_join_custom_scan = on;
+-- Row counts must match.
+SELECT
+    (SELECT count(*) FROM jsd_par_r1_on)  AS joinscan_rows,
+    (SELECT count(*) FROM jsd_par_r1_off) AS native_rows,
+    (SELECT count(*) FROM jsd_par_r1_on)
+      = (SELECT count(*) FROM jsd_par_r1_off) AS row_counts_match;
+ joinscan_rows | native_rows | row_counts_match 
+---------------+-------------+------------------
+          1802 |        1802 | t
+(1 row)
+
+-- Symmetric difference must be empty in both directions.
+SELECT count(*) AS joinscan_only FROM (
+    SELECT id FROM jsd_par_r1_on EXCEPT SELECT id FROM jsd_par_r1_off
+) d;
+ joinscan_only 
+---------------
+             0
+(1 row)
+
+SELECT count(*) AS native_only FROM (
+    SELECT id FROM jsd_par_r1_off EXCEPT SELECT id FROM jsd_par_r1_on
+) d;
+ native_only 
+-------------
+           0
+(1 row)
+
+-- Spot-check the top-10 descending for visible correctness.
+SELECT id FROM jsd_par_r1_on ORDER BY id DESC LIMIT 10;
+  id  
+------
+ 4000
+ 3998
+ 3996
+ 3994
+ 3992
+ 3990
+ 3988
+ 3986
+ 3984
+ 3982
+(10 rows)
+
+DROP TABLE jsd_par_r1_on;
+DROP TABLE jsd_par_r1_off;
+-- =====================================================================
+-- 2. Parallel EXISTS with 3-arm disjunctive OR
+-- =====================================================================
+-- LIMIT well above the ~198-row result set so both sides capture the
+-- full set for the EXCEPT comparison.
+CREATE TEMP TABLE jsd_par_r2_on AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+SET paradedb.enable_join_custom_scan = off;
+CREATE TEMP TABLE jsd_par_r2_off AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+SET paradedb.enable_join_custom_scan = on;
+SELECT
+    (SELECT count(*) FROM jsd_par_r2_on)  AS joinscan_rows,
+    (SELECT count(*) FROM jsd_par_r2_off) AS native_rows,
+    (SELECT count(*) FROM jsd_par_r2_on)
+      = (SELECT count(*) FROM jsd_par_r2_off) AS row_counts_match;
+ joinscan_rows | native_rows | row_counts_match 
+---------------+-------------+------------------
+           198 |         198 | t
+(1 row)
+
+SELECT count(*) AS joinscan_only FROM (
+    SELECT id FROM jsd_par_r2_on EXCEPT SELECT id FROM jsd_par_r2_off
+) d;
+ joinscan_only 
+---------------
+             0
+(1 row)
+
+SELECT count(*) AS native_only FROM (
+    SELECT id FROM jsd_par_r2_off EXCEPT SELECT id FROM jsd_par_r2_on
+) d;
+ native_only 
+-------------
+           0
+(1 row)
+
+SELECT id FROM jsd_par_r2_on ORDER BY id ASC LIMIT 10;
+ id  
+-----
+  14
+  28
+  42
+  56
+  66
+  70
+  84
+  98
+ 112
+ 126
+(10 rows)
+
+DROP TABLE jsd_par_r2_on;
+DROP TABLE jsd_par_r2_off;
+-- Cleanup
+DROP TABLE jsd_par_items CASCADE;
+DROP TABLE jsd_par_exclusions CASCADE;
+RESET paradedb.enable_custom_scan;
+RESET paradedb.enable_join_custom_scan;
+RESET paradedb.min_rows_per_worker;
+RESET max_parallel_workers;
+RESET max_parallel_workers_per_gather;
+RESET parallel_tuple_cost;
+RESET parallel_setup_cost;
+RESET min_parallel_table_scan_size;
+RESET min_parallel_index_scan_size;
+RESET parallel_leader_participation;

--- a/pg_search/tests/pg_regress/sql/expr_translator_debug.sql
+++ b/pg_search/tests/pg_regress/sql/expr_translator_debug.sql
@@ -1,0 +1,105 @@
+-- Regression test for `PredicateTranslator` debug1 logging.
+--
+-- Every failed translation path emits a structured `pgrx::debug1!` line of
+-- the form:
+--
+--     DEBUG: PredicateTranslator: <reason> [<NodeTag>] <key=value pairs> | <deparsed SQL>
+--
+-- This test raises `client_min_messages` to `debug1` and runs EXPLAIN on
+-- queries crafted to trip specific translator rejection points, verifying
+-- the expected log lines appear in order.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS et_items CASCADE;
+DROP TABLE IF EXISTS et_exclusions CASCADE;
+
+CREATE TABLE et_items (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    value INT NOT NULL
+);
+CREATE TABLE et_exclusions (
+    id SERIAL PRIMARY KEY,
+    pattern TEXT
+);
+INSERT INTO et_items (name, value) VALUES
+    ('alpha', 10), ('beta', 20);
+INSERT INTO et_exclusions (pattern) VALUES
+    ('alpha'), ('beta');
+
+CREATE INDEX et_items_idx ON et_items
+    USING bm25 (id, name, value)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"name":{"fast":true}}',
+        numeric_fields = '{"value":{"fast":true}}'
+    );
+CREATE INDEX et_exclusions_idx ON et_exclusions
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"pattern":{"fast":true}}'
+    );
+
+SET paradedb.enable_join_custom_scan = on;
+SET client_min_messages = 'debug1';
+
+-- =====================================================================
+-- 1. Unsupported operator (textcat `||`) → [OpExpr] log
+-- =====================================================================
+-- `translate_op_expr` doesn't know the `||` operator. It logs
+--   DEBUG: PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | ...
+-- Also emits
+--   DEBUG: PredicateTranslator: unsupported const type [Const] type=text
+-- for the `'_x'` string literal that `translate_const` doesn't support.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern || '_x' = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- =====================================================================
+-- 2. Unknown function → [FuncExpr] no native mapping
+-- =====================================================================
+-- `md5` isn't in `translate_known_func`'s pg_catalog map. Expect:
+--   DEBUG: PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | ...
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- =====================================================================
+-- 3. Cross-type cast → [CoerceViaIO] rejected + deparsed SQL in log
+-- =====================================================================
+-- `CAST(i.value AS text)` is a CoerceViaIO from int4 → text. The
+-- translator only allows coercions inside the text family (TEXT ↔
+-- VARCHAR ↔ NAME); int → text is rejected. Because the inner node is
+-- a simple Var reference, `deparse_expression` succeeds here and the
+-- log line includes the actual SQL (e.g. `(i.value)::text`) after the
+-- `|` separator — unlike the first two cases whose cross-RTE shape
+-- forces the helper to fall back to the node-tag label.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CAST(i.value AS text) = e.pattern
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- Cleanup
+RESET client_min_messages;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE et_items CASCADE;
+DROP TABLE et_exclusions CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_distinct_expr.sql
+++ b/pg_search/tests/pg_regress/sql/join_distinct_expr.sql
@@ -412,6 +412,36 @@ ORDER BY p.name
 SET paradedb.enable_join_custom_scan = on;
 
 -- =============================================================================
+-- TEST 8b: CaseExpr — DISTINCT CASE WHEN col IS NOT NULL THEN col ELSE 'N/A' END
+-- =============================================================================
+-- Exercises the translator's CaseExpr path. EXPLAIN should show
+-- `CASE WHEN ... END` in the DataFusion plan, not a PgExprUdf wrapper.
+
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
 -- TEST 9: Unsupported result type — graceful fallback to native PG
 -- =============================================================================
 -- to_jsonb returns JSONB which is not in is_arrow_convertible.
@@ -435,6 +465,37 @@ ORDER BY p.name
     LIMIT 10;
 
 -- No crash, no error, correct results via native PG.
+
+-- =============================================================================
+-- TEST 10: Mixed native + PgExprUdf in a single DISTINCT expression
+-- =============================================================================
+-- Outer `upper()` is in the pg_catalog native map; inner `md5()` isn't, so
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show
+-- `upper(pdb_eval_expr_funcexpr_*(...))` in the AggregateExec gby list —
+-- both native and UDF paths exercised in one projection.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
 
 -- =============================================================================
 -- CLEANUP

--- a/pg_search/tests/pg_regress/sql/join_predicates.sql
+++ b/pg_search/tests/pg_regress/sql/join_predicates.sql
@@ -472,6 +472,79 @@ WHERE p.description @@@ 'wireless'
 LIMIT 10;
 
 -- =============================================================================
+-- TEST 12: Functions in cross-table predicates (native DF + UDF fallback)
+-- =============================================================================
+-- Exercise PredicateTranslator's FuncExpr + arithmetic-OpExpr paths inside a
+-- multi-table predicate. Both sides' columns are fast fields, so JoinScan
+-- should absorb these and the EXPLAIN should show `abs(...)` natively while
+-- the arithmetic OpExpr (`-`) gets wrapped as `pdb_eval_expr_opexpr_*` via
+-- `try_wrap_as_udf`.
+
+-- 12a: abs() wrapping a cross-table arithmetic OpExpr
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped FuncExpr
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var.
+-- RHS `length(to_hex(s.id))` nests two FuncExprs: `to_hex` is a pg_catalog
+-- function that is NOT in `translate_known_func`'s native map, so it falls
+-- through to `try_wrap_as_udf` and becomes `pdb_eval_expr_funcexpr_*`. The
+-- outer `length` (→ `character_length`) IS native and wraps the UDF. The
+-- outer `<=` comparison stays native. EXPLAIN should show native
+-- `abs(supplier_id)` and native `character_length(pdb_eval_expr_funcexpr_*(id))`
+-- side by side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
+ORDER BY p.id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -375,6 +375,173 @@ ORDER BY i.id DESC
 LIMIT 10;
 SET paradedb.enable_join_custom_scan TO on;
 
+-- =====================================================================
+-- 10. Single equi-key Semi/Anti regression
+-- =====================================================================
+-- A plain Var = Var NOT EXISTS with no OR must still go through the
+-- equi-key path (HashJoinExec), not PgExpression/NestedLoopJoinExec.
+-- Regression guard: single equalities must not be routed through the
+-- new disjunctive-filter absorption.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 11. NULL semantics on OR arms
+-- =====================================================================
+-- Restrict the outer side to rows where `i.alt_name IS NULL` by targeting
+-- odd ids (category:"other") — the setup leaves `alt_name` NULL whenever
+-- `i % 3 != 0`. Verifies that NULL comparisons inside disjunctive arms
+-- produce the same result under DataFusion's NestedLoopJoinExec as under
+-- PostgreSQL's native Nested Loop Anti Join.
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"other"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"other"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 12. RelabelType path with varchar columns
+-- =====================================================================
+-- varchar columns force PostgreSQL to wrap each Var in a RelabelType
+-- (varchar -> text) before the equality operator. This exercises the
+-- translator's RelabelType-stripping path for disjunctive filters; if
+-- broken, JoinScan would fall back to a Nested Loop Anti Join.
+DROP TABLE IF EXISTS items_vc CASCADE;
+DROP TABLE IF EXISTS exclusions_vc CASCADE;
+
+CREATE TABLE items_vc (
+    id bigint NOT NULL PRIMARY KEY,
+    name varchar(100),
+    alt_name varchar(100),
+    category varchar(100)
+);
+INSERT INTO items_vc (id, name, alt_name, category)
+SELECT
+    i,
+    ('name_' || i)::varchar(100),
+    CASE WHEN i % 3 = 0 THEN ('alt_' || i)::varchar(100) ELSE NULL END,
+    (CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END)::varchar(100)
+FROM generate_series(1, 200) as i;
+
+CREATE TABLE exclusions_vc (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern varchar(100)
+);
+INSERT INTO exclusions_vc (pattern)
+SELECT ('name_' || i)::varchar(100)
+FROM generate_series(1, 100) as i
+WHERE i % 5 = 0;
+
+CREATE INDEX items_vc_idx ON items_vc
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }'
+);
+
+CREATE INDEX exclusions_vc_idx ON exclusions_vc
+USING bm25 (id, pattern)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items_vc i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions_vc e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+DROP TABLE items_vc CASCADE;
+DROP TABLE exclusions_vc CASCADE;
+
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -1,0 +1,382 @@
+-- Tests for Semi and Anti Joins with disjunctive (OR) join conditions.
+-- Verifies the fix for https://github.com/paradedb/paradedb/issues/4776:
+-- when a NOT EXISTS/EXISTS subquery uses OR across multiple equalities,
+-- JoinScan should absorb the join using DataFusion's NestedLoopJoinExec
+-- (cross-join + filter) instead of falling back to Postgres's Nested Loop.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS items CASCADE;
+CREATE TABLE items (
+    id bigint NOT NULL PRIMARY KEY,
+    name text,
+    alt_name text,
+    category text
+);
+
+INSERT INTO items (id, name, alt_name, category)
+SELECT
+    i,
+    'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1, 500) as i;
+
+DROP TABLE IF EXISTS exclusions CASCADE;
+CREATE TABLE exclusions (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern text,
+    reason text
+);
+
+-- Populate exclusions so roughly half of items are excluded via `name` match
+-- and a smaller slice is excluded via `alt_name` match. Includes a few
+-- patterns that match both name and alt_name to exercise the OR branching.
+INSERT INTO exclusions (pattern, reason)
+SELECT 'name_' || i, 'name-based'
+FROM generate_series(1, 250) as i
+WHERE i % 5 = 0;
+
+INSERT INTO exclusions (pattern, reason)
+SELECT 'alt_' || i, 'alt-based'
+FROM generate_series(1, 500) as i
+WHERE i % 3 = 0 AND i % 15 = 0;
+
+CREATE INDEX items_idx ON items
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }'
+);
+
+CREATE INDEX exclusions_idx ON exclusions
+USING bm25 (id, pattern, reason)
+WITH (
+    key_field = id,
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "reason": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }'
+);
+
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 1. NOT EXISTS with 2-arm OR join condition (the core repro)
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+-- =====================================================================
+-- 2. EXISTS with 2-arm OR join condition
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 10;
+
+-- =====================================================================
+-- 3. NOT EXISTS with 3-arm OR
+-- =====================================================================
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+-- =====================================================================
+-- 4. Correctness cross-check: compare JoinScan result with JoinScan off
+-- =====================================================================
+-- Capture the result with JoinScan enabled, then again with it off, and
+-- diff them. They must match.
+SET paradedb.enable_join_custom_scan TO off;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 5. Non-translatable arm: graceful fallback to PG native
+-- =====================================================================
+-- A disjunction where one arm uses a function call (length()) that the
+-- PredicateTranslator cannot handle. JoinScan should decline and PG's
+-- native Nested Loop Anti Join should run — results must still be correct.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR length(e.pattern) > 100)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR length(e.pattern) > 100)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+-- =====================================================================
+-- 6. NOT EXISTS with inequality operator (<>)
+-- =====================================================================
+-- A single <> comparison. The old EquiKeyDisjunction shape could not
+-- represent this; PgExpression carries the full OpExpr, so PredicateTranslator
+-- maps it to Operator::NotEq.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.id <> i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 7. NOT EXISTS with mixed operators in OR (> and =)
+-- =====================================================================
+-- Disjunction of > and =, both Var-vs-Var. Both operators are supported
+-- by PredicateTranslator.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id > i.id OR e.pattern = i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 8. EXISTS with Var = Const in an OR arm
+-- =====================================================================
+-- One arm compares a Var to a bigint literal. The old EquiKeyDisjunction
+-- shape required Var-vs-Var on every arm; PgExpression has no such
+-- restriction — PredicateTranslator::translate_const handles INT8OID.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.id = 42::bigint)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 9. NOT EXISTS with AND nested inside OR
+-- =====================================================================
+-- Nested BoolExpr(AND) inside BoolExpr(OR). PredicateTranslator handles
+-- both boolean operators recursively.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          (e.pattern = i.name AND e.id > i.id)
+          OR e.pattern = i.alt_name
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- Cleanup
+DROP TABLE items CASCADE;
+DROP TABLE exclusions CASCADE;
+
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -172,11 +172,12 @@ LIMIT 10;
 SET paradedb.enable_join_custom_scan TO on;
 
 -- =====================================================================
--- 5. Non-translatable arm: graceful fallback to PG native
+-- 5. Generic function in disjunctive filter: native DataFusion evaluation
 -- =====================================================================
--- A disjunction where one arm uses a function call (length()) that the
--- PredicateTranslator cannot handle. JoinScan should decline and PG's
--- native Nested Loop Anti Join should run — results must still be correct.
+-- A disjunction where one arm uses a pg_catalog function (length()).
+-- PredicateTranslator maps it to DataFusion's native character_length(),
+-- allowing JoinScan to absorb the full expression. The EXPLAIN should
+-- show character_length(...) in the physical plan, not a PgExprUdf.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -541,6 +542,386 @@ SET paradedb.enable_join_custom_scan TO on;
 
 DROP TABLE items_vc CASCADE;
 DROP TABLE exclusions_vc CASCADE;
+
+-- =====================================================================
+-- 13. upper() in EXISTS semi-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `upper(...)` in the physical plan and JoinScan
+-- should absorb the whole semi-join (no "JoinScan not used" warning).
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 14. COALESCE() in NOT EXISTS anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `coalesce(...)` natively, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 15. IS NULL arm in disjunctive anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `IS NULL` natively and JoinScan should absorb the
+-- disjunction.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 16. CASE WHEN in anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `CASE WHEN ... END` natively, not a PgExprUdf.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 17. Arithmetic OpExpr (`*`) maps natively
+-- =====================================================================
+-- `translate_op_expr` now handles `+`, `-`, `*`, `/`, `%` — the `(e.id * 2)`
+-- subtree maps directly to `Operator::Multiply`. EXPLAIN should contain a
+-- native multiplication (e.g. `id * 2`) and NO `pdb_eval_expr_opexpr_*`.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 18. Mixed native + UDF in one disjunction
+-- =====================================================================
+-- `upper()` is in the pg_catalog map → native; `md5()` is not →
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show `upper`
+-- on one arm and `pdb_eval_expr_funcexpr_*` on the other.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
+-- =====================================================================
+-- Cross-table disjunction where `upper` and `character_length`
+-- (via the `length` alias) are both in `translate_known_func`'s
+-- pg_catalog map; operators `=`, `>`, `OR` are native structural.
+-- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
+-- =====================================================================
+-- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
+-- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
+-- both tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 21. Tier 3 — PURE PgExprUdf: every function → UDF
+-- =====================================================================
+-- Neither `md5` nor `to_hex` is in the pg_catalog map, so both FuncExprs
+-- are wrapped by `try_wrap_as_udf`. The top-level `=`, `<>`, `AND` are
+-- native structural combinators, but every function-producing subtree
+-- is UDF-wrapped. EXPLAIN should contain only `pdb_eval_expr_funcexpr_*`
+-- wrappers and NO native pg_catalog scalar function names.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND to_hex(e.id) <> to_hex(i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
 
 -- Cleanup
 DROP TABLE items CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -792,17 +792,22 @@ SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
 -- =====================================================================
--- Cross-table disjunction where `upper` and `character_length`
--- (via the `length` alias) are both in `translate_known_func`'s
--- pg_catalog map; operators `=`, `>`, `OR` are native structural.
--- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+-- `character_length` (via the `length` alias) is in
+-- `translate_known_func`'s pg_catalog map; arithmetic comparisons `>`,
+-- `<>`, and the boolean `OR` are native structural. Var references on
+-- both sides of the disjunction resolve via the mapper. The EXPLAIN
+-- should contain NO `pdb_eval_expr_*` UDFs anywhere.
+--
+-- Note: `upper` / `lower` / `btrim` / `trim` / `ltrim` / `rtrim` are
+-- intentionally excluded from the native map (collation-aware — see
+-- tier 22), so an "all native" case can't use them.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -813,7 +818,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -825,7 +830,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+      AND (length(e.pattern) > length(i.name) OR e.id <> i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -835,18 +840,20 @@ SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
 -- =====================================================================
--- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
--- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
--- both tables so the whole tree is absorbed at the join level (not pushed
--- down as a single-table heap filter). EXPLAIN should contain BOTH native
--- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
+-- Cross-table disjunction: `length()` maps natively via
+-- `character_length`; `upper()` is collation-aware and excluded from the
+-- native map, so it's wrapped as a PgExprUdf. The disjunction spans both
+-- tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH
+-- native `character_length(...)` AND `pdb_eval_expr_funcexpr_*` in the
+-- same plan.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -857,7 +864,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -869,7 +876,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
+      AND (length(e.pattern) > length(i.name) OR upper(e.pattern) = i.name)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -922,6 +929,149 @@ AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
 SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 22. Collation-aware UDF: upper() under a non-default collation
+-- =====================================================================
+-- `upper`, `lower`, `btrim`, `trim`, `ltrim`, `rtrim` are intentionally
+-- excluded from `translate_known_func`'s native map because DataFusion
+-- implements them with Rust's Unicode rules, which don't always match
+-- PostgreSQL's locale-specific behavior. Instead they go through
+-- `try_wrap_as_udf` → `ExecEvalExpr`, which invokes PG's own
+-- implementation and honors the column's / expression's collation.
+--
+-- The dataset below is seeded with *case-varying* strings so that
+-- `upper(pattern) = upper(name)` matches pairs that plain `=` cannot.
+-- The test runs three queries back to back:
+--
+--   A. NOT EXISTS with `upper(... COLLATE "C") = upper(... COLLATE "C")`
+--      on JoinScan — case-insensitive match → rows whose name has NO
+--      case-insensitive peer in patterns survive.
+--   B. The same query with a plain `=` comparison — case-sensitive →
+--      rows whose name has no *exact* peer in patterns survive. Because
+--      the data is all case-mismatched, no row is excluded and every
+--      coll_item returns, proving the `upper()` wrapping in (A) is
+--      actually doing something the plain `=` isn't.
+--   C. Re-run (A) with JoinScan off — must return byte-identical rows
+--      to (A), proving the UDF → ExecEvalExpr path preserves PG-correct
+--      locale semantics. A future regression that adds `upper`/`lower`
+--      back to the native map would show up here as an ON-vs-OFF diff.
+DROP TABLE IF EXISTS coll_items CASCADE;
+DROP TABLE IF EXISTS coll_patterns CASCADE;
+
+-- Table layout is shaped for the disjunctive Semi/Anti absorption path:
+-- each NOT EXISTS below has the form
+--   (p.id = i.pattern_id OR <case predicate>)
+-- — a disjunction of one equi-key-shaped arm and one collation-aware
+-- predicate. Because every row uses `pattern_id = 99` (which never
+-- matches a real `coll_patterns.id`), the equi arm contributes
+-- nothing: the case predicate is the sole discriminator. That makes
+-- (A) vs (B) diverge purely on `upper()` vs plain `=`.
+CREATE TABLE coll_items (
+    id bigint PRIMARY KEY,
+    name text,
+    pattern_id bigint
+);
+INSERT INTO coll_items (id, name, pattern_id) VALUES
+    (1, 'Alpha',   99),  -- case-insensitive pair with 'ALPHA'
+    (2, 'beta',    99),  -- pairs with 'BETA'
+    (3, 'GAMMA',   99),  -- pairs with 'gamma'
+    (4, 'Delta',   99),  -- no case-insensitive peer
+    (5, 'epsilon', 99);  -- no case-insensitive peer
+
+CREATE TABLE coll_patterns (
+    id bigint PRIMARY KEY,
+    pattern text
+);
+INSERT INTO coll_patterns (id, pattern) VALUES
+    (1, 'ALPHA'),
+    (2, 'BETA'),
+    (3, 'gamma');
+
+CREATE INDEX coll_items_idx ON coll_items
+    USING bm25 (id, name, pattern_id)
+    WITH (
+        key_field = id,
+        text_fields = '{"name": {"fast": true, "tokenizer": {"type": "keyword"}}}',
+        numeric_fields = '{"pattern_id": {"fast": true}}'
+    );
+CREATE INDEX coll_patterns_idx ON coll_patterns
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = id,
+        text_fields = '{"pattern": {"fast": true, "tokenizer": {"type": "keyword"}}}'
+    );
+
+-- (A) Disjunctive equi-key OR `upper(... COLLATE "C")` — JoinScan's
+-- disjunctive-absorption path routes the whole predicate through
+-- PgExpression → NestedLoopJoinExec, where the UDF fallback evaluates
+-- `upper()` with PG-correct semantics. Because every row has
+-- `pattern_id = 99` (no matching p.id), the equi arm contributes
+-- nothing: the `upper()` comparison is the sole discriminator.
+-- Expected survivors: Delta, epsilon — items 1–3 pair case-insensitively
+-- with their patterns and are excluded.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+
+-- (B) Same disjunction, but with a plain `=` in place of `upper(...)`.
+-- The equi arm still contributes nothing (pattern_id=99), so this is
+-- case-sensitive: none of items 1–3 match their paired pattern on exact
+-- case, and every row survives. Contrasts with (A) to prove upper() is
+-- genuinely being evaluated.
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR p.pattern = i.name)
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+
+-- (C) Re-run (A) with JoinScan off; rows must match (A) byte-for-byte.
+-- If someone re-adds `upper`/`lower` to the native map and DataFusion's
+-- Unicode implementation diverges from PG's locale-aware `upper` for
+-- the COLLATE "C" clause, (A) and (C) will disagree here.
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id, i.name
+FROM coll_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM coll_patterns p
+    WHERE p.id @@@ paradedb.all()
+      AND (p.id = i.pattern_id
+           OR upper(p.pattern COLLATE "C") = upper(i.name COLLATE "C"))
+)
+AND i.id @@@ paradedb.all()
+ORDER BY i.id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+DROP TABLE coll_items CASCADE;
+DROP TABLE coll_patterns CASCADE;
 
 -- Cleanup
 DROP TABLE items CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive_parallel.sql
@@ -1,0 +1,236 @@
+-- Parallel regression for disjunctive Semi/Anti JoinScan (issue #4776).
+--
+-- `validate_and_build_clause` forces `partitioning_source_index = 0` for any
+-- plan that contains a Semi/Anti join (build::JoinCSClause::
+-- `with_forced_partitioning(0)`), and disjunctive Semi/Anti conditions now
+-- lower to `NestedLoopJoinExec` instead of `HashJoinExec`. The combination
+-- must still produce correct results under parallel execution: the outer
+-- (partitioned) side sees a disjoint slice per worker, the inner
+-- (replicated) side is fully scanned by every worker, and the anti/semi
+-- filter fires per (left, right) row pair.
+--
+-- Regression guard: we cross-check a parallel disjunctive NOT EXISTS /
+-- EXISTS against the JoinScan-off PG-native plan on the same data.
+-- Any dropped rows, duplicates, or missed matches from worker
+-- partitioning would surface as a set diff.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.min_rows_per_worker = 0;
+SET max_parallel_workers = 4;
+SET max_parallel_workers_per_gather = 4;
+SET parallel_tuple_cost = 0;
+SET parallel_setup_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_leader_participation = off;
+
+DROP TABLE IF EXISTS jsd_par_items CASCADE;
+DROP TABLE IF EXISTS jsd_par_exclusions CASCADE;
+
+CREATE TABLE jsd_par_items (
+    id bigint PRIMARY KEY,
+    name text,
+    alt_name text,
+    category text
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE jsd_par_exclusions (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    pattern text
+) WITH (autovacuum_enabled = false);
+
+-- Segment-per-batch index to force multiple segments and give workers
+-- something to partition across. `global_mutable_segment_rows = 0` flushes
+-- after each INSERT; `target_segment_count` + `background_layer_sizes`
+-- keeps background merges from collapsing segments back together.
+SET paradedb.global_mutable_segment_rows = 0;
+
+CREATE INDEX jsd_par_items_idx ON jsd_par_items
+USING bm25 (id, name, alt_name, category)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "alt_name": {"fast": true, "tokenizer": {"type": "keyword"}},
+        "category": {"fast": true, "tokenizer": {"type": "keyword"}, "normalizer": "lowercase"}
+    }',
+    target_segment_count = 64,
+    background_layer_sizes = '0'
+);
+
+CREATE INDEX jsd_par_exclusions_idx ON jsd_par_exclusions
+USING bm25 (id, pattern)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "pattern": {"fast": true, "tokenizer": {"type": "keyword"}}
+    }',
+    target_segment_count = 64,
+    background_layer_sizes = '0'
+);
+
+-- Batched inserts → multiple segments on the partitioning side. Each
+-- 1000-row batch triggers a segment flush under
+-- `global_mutable_segment_rows = 0`.
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1, 1000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(1001, 2000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(2001, 3000) i;
+INSERT INTO jsd_par_items SELECT i, 'name_' || i,
+    CASE WHEN i % 3 = 0 THEN 'alt_' || i ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN 'target' ELSE 'other' END
+FROM generate_series(3001, 4000) i;
+
+INSERT INTO jsd_par_exclusions (pattern)
+SELECT 'name_' || i FROM generate_series(1, 2000) i WHERE i % 7 = 0;
+INSERT INTO jsd_par_exclusions (pattern)
+SELECT 'alt_' || i FROM generate_series(1, 4000) i WHERE i % 3 = 0 AND i % 11 = 0;
+
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE jsd_par_items;
+ANALYZE jsd_par_exclusions;
+
+-- =====================================================================
+-- 1. Parallel NOT EXISTS with 2-arm disjunctive OR
+-- =====================================================================
+-- Capture JoinScan-absorbed (parallel) result into a temp, then compare
+-- against the JoinScan-off (native Nested Loop Anti) result on the
+-- same session. Set-equal + row-count equal means no dropped/duplicated
+-- rows from parallel partitioning.
+-- LIMIT is required by `validate_and_build_clause` to activate JoinScan
+-- on top-level queries; pick a bound that comfortably exceeds the
+-- ~1802-row result set so no rows are dropped. The matching LIMIT on
+-- the JoinScan-off side keeps the comparison apples-to-apples.
+CREATE TEMP TABLE jsd_par_r1_on AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+
+SET paradedb.enable_join_custom_scan = off;
+
+CREATE TEMP TABLE jsd_par_r1_off AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- Row counts must match.
+SELECT
+    (SELECT count(*) FROM jsd_par_r1_on)  AS joinscan_rows,
+    (SELECT count(*) FROM jsd_par_r1_off) AS native_rows,
+    (SELECT count(*) FROM jsd_par_r1_on)
+      = (SELECT count(*) FROM jsd_par_r1_off) AS row_counts_match;
+
+-- Symmetric difference must be empty in both directions.
+SELECT count(*) AS joinscan_only FROM (
+    SELECT id FROM jsd_par_r1_on EXCEPT SELECT id FROM jsd_par_r1_off
+) d;
+SELECT count(*) AS native_only FROM (
+    SELECT id FROM jsd_par_r1_off EXCEPT SELECT id FROM jsd_par_r1_on
+) d;
+
+-- Spot-check the top-10 descending for visible correctness.
+SELECT id FROM jsd_par_r1_on ORDER BY id DESC LIMIT 10;
+
+DROP TABLE jsd_par_r1_on;
+DROP TABLE jsd_par_r1_off;
+
+-- =====================================================================
+-- 2. Parallel EXISTS with 3-arm disjunctive OR
+-- =====================================================================
+-- LIMIT well above the ~198-row result set so both sides capture the
+-- full set for the EXCEPT comparison.
+CREATE TEMP TABLE jsd_par_r2_on AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+
+SET paradedb.enable_join_custom_scan = off;
+
+CREATE TEMP TABLE jsd_par_r2_off AS
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+
+SET paradedb.enable_join_custom_scan = on;
+
+SELECT
+    (SELECT count(*) FROM jsd_par_r2_on)  AS joinscan_rows,
+    (SELECT count(*) FROM jsd_par_r2_off) AS native_rows,
+    (SELECT count(*) FROM jsd_par_r2_on)
+      = (SELECT count(*) FROM jsd_par_r2_off) AS row_counts_match;
+
+SELECT count(*) AS joinscan_only FROM (
+    SELECT id FROM jsd_par_r2_on EXCEPT SELECT id FROM jsd_par_r2_off
+) d;
+SELECT count(*) AS native_only FROM (
+    SELECT id FROM jsd_par_r2_off EXCEPT SELECT id FROM jsd_par_r2_on
+) d;
+
+SELECT id FROM jsd_par_r2_on ORDER BY id ASC LIMIT 10;
+
+DROP TABLE jsd_par_r2_on;
+DROP TABLE jsd_par_r2_off;
+
+-- Cleanup
+DROP TABLE jsd_par_items CASCADE;
+DROP TABLE jsd_par_exclusions CASCADE;
+
+RESET paradedb.enable_custom_scan;
+RESET paradedb.enable_join_custom_scan;
+RESET paradedb.min_rows_per_worker;
+RESET max_parallel_workers;
+RESET max_parallel_workers_per_gather;
+RESET parallel_tuple_cost;
+RESET parallel_setup_cost;
+RESET min_parallel_table_scan_size;
+RESET min_parallel_index_scan_size;
+RESET parallel_leader_participation;


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4776

## What

JoinScan now absorbs `NOT EXISTS` / `EXISTS` subqueries with disjunctive join conditions like `e.pattern = i.name OR e.pattern = i.alt_name`. Previously these fell back to PostgreSQL's native Nested Loop executor. DataFusion evaluates them via `NestedLoopJoinExec` with the condition as a join filter, preserving late materialization and Top-K pruning benefits.

Also, it adds native function support: https://github.com/paradedb/paradedb/pull/4815

## Why

PostgreSQL pulls up `EXISTS` / `NOT EXISTS` into standard semi/anti joins, delivering the disjunctive condition as a single `T_BoolExpr(OR)` in the join hook's `restrictlist`. `extract_join_conditions_from_list` classified it as an `other_condition` (not an equi-key), and the `equi_keys.is_empty()` gate in `try_build_join_custom_path` unconditionally rejected it.

## How

1. **New `JoinLevelExpr::PgExpression` variant** (`build.rs`). Stores a `nodeToString`-serialized PostgreSQL expression plus `(rti, attno)` pairs for projection registration. Lives in `JoinNode.filter`, serialized as part of `JoinCSClause` in `custom_private`.

2. **Gate relaxation** (`mod.rs:1730`). `equi_keys.is_empty()` now passes for `JOIN_SEMI` / `JOIN_ANTI` when `other_conditions` is non-empty. A secondary gate at `validate_and_build_clause` (`mod.rs:512`) is relaxed for plans containing a semi/anti join via `has_semi_or_anti()`.

3. **Planning-time absorption** (`mod.rs:1748–1810`). For semi/anti with empty equi-keys, each `other_condition` is validated: `all_vars_are_fast_fields_recursive` + `PredicateTranslator::translate()` (shape-only, no mapper). Translatable conditions are serialized via `nodeToString`, combined with `make_andclause` if multiple, and placed on `JoinNode.filter` as `PgExpression`. Non-translatable conditions stay in `remaining_other_conditions` for `extract_join_level_conditions`. If nothing is absorbed, JoinScan declines.

4. **Execution-time translation** (`translator.rs`). New `translate_pg_expression_filter` deserializes via `stringToNode` and translates with `PredicateTranslator` + `CombinedMapper`. `build_join_df_with_filter` passes the result to `DataFrame::join`'s filter parameter. DataFusion lowers this to `NestedLoopJoinExec`.

5. **Projection registration** (`build.rs`). `collect_join_key_projections` and `filter_input_vars` walk `PgExpression.input_vars` to ensure referenced columns are projected. `scan_state.rs` adds filter vars to `required_early` so they aren't deferred.

6. **Refactored equi-key extraction** (`planning.rs`). Inline equi-key logic extracted into `equi_key_pair_from_opexpr`, reducing `extract_join_conditions_from_list` by ~50 lines.

7. **`T_RelabelType` support** (`translator.rs`). `PredicateTranslator::translate()` now unwraps `RelabelType` (binary-compatible casts like `varchar → text`) and recurses, matching the pattern used by aggregatescan.

## Tests

New file `semi_join_filter.sql` with 9 test cases:

- **1–3.** `NOT EXISTS` / `EXISTS` with 2-arm and 3-arm OR (the core repro). EXPLAIN verifies `NestedLoopJoinExec` with filter.
- **4.** Correctness cross-check: JoinScan on vs off produce identical results.
- **5.** Non-translatable arm (`length()` function call). Verifies graceful fallback to PG native — no error, correct results.
- **6.** Single `<>` inequality. Verifies `PgExpression` handles operators beyond `=`.
- **7.** Mixed operators in OR (`>` and `=`).
- **8.** `Var = Const` in an OR arm (`e.id = 42::bigint`).
- **9.** Nested `AND` inside `OR`.

All cases include JoinScan-off cross-checks confirming result equivalence. Existing join tests pass unchanged.

## Known Limitations

- **Mixed case** (equi-keys + disjunctive filter on the same join) declines with `NotImplemented` at execution time. Absorption is only attempted when `equi_keys` is empty, so this is currently unreachable.
- **`planning.rs:532` path-reconstruction gate** not relaxed. Multi-table plans where the disjunctive semi/anti is a child join cannot be reconstructed. 2-table case (the common pattern) works via the direct join-hook path.
- **`FuncExpr` not translatable.** Expressions containing function calls (e.g., `length()`, `upper()`) cause JoinScan to decline. Extending `PredicateTranslator` with `PgExprUdf` fallback for unsupported subtrees is a natural follow-up.