### PR TITLE
ci: Add Antithesis fault exclusion patterns for infra containers

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -158,3 +158,6 @@ jobs:
             antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '480' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
+            custom.network_fault_exclusion_patterns=coredns,stressgres
+            custom.container_faults_stop_exclusion_patterns=coredns,stressgres,paradedb,cloudnative-pg
+            custom.container_faults_kill_exclusion_patterns=coredns,stressgres,paradedb,cloudnative-pg


### PR DESCRIPTION
## Summary
Previously, we had baked-in defaults in the notebook in Antithesis. It wasn't clear what they were. This PR makes them explicit, so the notebook can be stateless.

- Exclude `coredns` and `stressgres` from Antithesis network faults
- Exclude `coredns`, `stressgres`, `paradedb`, and `cloudnative-pg` from Antithesis container stop and kill faults

## Test plan
- [x] Trigger the `Antithesis - Trigger Test Run` workflow and verify the new `custom.*` parameters are passed through