### PR TITLE
refactor: Remove pgrx_embed workaround in FilterQuery

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -104,7 +104,7 @@ Then, install and initialize `pgrx`:
 
 ```bash
 # Note: Replace --pg18 with your version of Postgres, if different (i.e. --pg17, etc.)
-cargo install --locked cargo-pgrx --version 0.17.0
+cargo install --locked cargo-pgrx --version 0.18.0
 
 # macOS arm64
 cargo pgrx init --pg18=/opt/homebrew/opt/postgresql@18/bin/pg_config

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -124,9 +124,6 @@ pub unsafe extern "C-unwind" fn _PG_init() {
 
     // Register global planner hook for window function support
     customscan::register_window_aggregate_hook();
-
-    // Initialize the filter query builder
-    customscan::aggregatescan::filterquery::init_filter_query_builder();
 }
 
 #[pg_extern]

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -262,7 +262,7 @@ impl CollectAggregations for AggregateCSClause {
                 aggs.insert(
                     FilterSentinelKey::NAME.to_string(),
                     Aggregation {
-                        agg: new_filter_query(self.quals.query().clone(), self.indexrelid)?.into(),
+                        agg: new_filter_query(self.quals.query().clone(), self.indexrelid).into(),
                         sub_aggregation: term_aggs,
                     },
                 );
@@ -710,7 +710,7 @@ impl CollectFlat<Option<FilterQuery>, FiltersWithoutGroupBy> for AggregateCSClau
         Ok(self.targetlist.aggregates().map(|agg| {
             agg.filter_expr()
                 .as_ref()
-                .map(|q| new_filter_query(q.clone(), agg.indexrelid()).expect("filter query"))
+                .map(|q| new_filter_query(q.clone(), agg.indexrelid()))
         }))
     }
 }
@@ -722,7 +722,7 @@ impl CollectFlat<FilterQuery, FiltersWithGroupBy> for AggregateCSClause {
                 Some(q) => q.clone(),
                 None => SearchQueryInput::All,
             };
-            new_filter_query(query, agg.indexrelid()).expect("filter query")
+            new_filter_query(query, agg.indexrelid())
         }))
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/filterquery.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/filterquery.rs
@@ -16,9 +16,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! FilterQuery - a tantivy QueryBuilder for PostgreSQL filter aggregations.
-//!
-//! Uses a function pointer to defer PostgreSQL-dependent query building to runtime,
-//! which is required to avoid linker errors in pgrx_embed.
 
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
@@ -37,40 +34,18 @@ use tantivy::schema::Schema;
 use tantivy::tokenizer::TokenizerManager;
 use tantivy::TantivyError;
 
-/// Type alias for the filter query builder function.
-/// This function is set at runtime to avoid pulling PostgreSQL symbols into pgrx_embed.
-/// Takes the JSON-serialized query and indexrelid.
-type BuildFilterQueryFn = fn(serde_json::Value, u32) -> anyhow::Result<Box<dyn Query>>;
-
-/// Global function pointer for building filter queries.
-/// This is initialized at extension load time via `init_filter_query_builder()`.
-/// Using a function pointer breaks the link-time dependency on PostgreSQL symbols,
-/// allowing the pgrx_embed binary to be built without them.
-static BUILD_FILTER_QUERY_FN: std::sync::OnceLock<BuildFilterQueryFn> = std::sync::OnceLock::new();
-
-/// Initialize the query builder. Call from `_PG_init`.
-pub fn init_filter_query_builder() {
-    BUILD_FILTER_QUERY_FN.get_or_init(|| build_query);
-}
-
 /// Create a FilterQuery from SearchQueryInput.
-pub fn new_filter_query(
-    query: SearchQueryInput,
-    indexrelid: pg_sys::Oid,
-) -> anyhow::Result<FilterQuery> {
-    Ok(FilterQuery {
-        query: serde_json::to_value(&query)?,
+pub fn new_filter_query(query: SearchQueryInput, indexrelid: pg_sys::Oid) -> FilterQuery {
+    FilterQuery {
+        query,
         indexrelid: indexrelid.to_u32(),
-    })
+    }
 }
 
-/// A QueryBuilder wrapping SearchQueryInput as JSON to avoid link-time PostgreSQL dependencies.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FilterQuery {
-    /// The SearchQueryInput serialized as JSON.
-    /// We store it as JSON to avoid importing SearchQueryInput which has PostgreSQL dependencies.
-    query: serde_json::Value,
-    /// Index OID stored as u32 to avoid pg_sys::Oid which would pull in PostgreSQL symbols.
+    query: SearchQueryInput,
+    /// Index OID stored as u32 because `pg_sys::Oid` is not `Serialize`.
     indexrelid: u32,
 }
 
@@ -83,57 +58,51 @@ impl From<FilterQuery> for AggregationVariants {
 #[typetag::serde]
 impl QueryBuilder for FilterQuery {
     fn build_query(&self, _: &Schema, _: &TokenizerManager) -> tantivy::Result<Box<dyn Query>> {
-        // Get the builder function that was initialized at extension load time.
-        // This indirection via function pointer avoids pulling PostgreSQL symbols
-        // into the pgrx_embed binary at link time.
-        let build_fn = BUILD_FILTER_QUERY_FN
-            .get()
-            .expect("call init_filter_query_builder() in _PG_init");
-        build_fn(self.query.clone(), self.indexrelid)
-            .map_err(|e| TantivyError::InvalidArgument(e.to_string()))
+        let indexrelid = pg_sys::Oid::from(self.indexrelid);
+        let context = ExprContextGuard::new();
+        let index = PgSearchRelation::with_lock(indexrelid, pg_sys::AccessShareLock as _);
+        let schema = index
+            .schema()
+            .map_err(|e| TantivyError::InvalidArgument(e.to_string()))?;
+        let reader = SearchIndexReader::open_with_context(
+            &index,
+            self.query.clone(),
+            false,
+            MvccSatisfies::Snapshot,
+            NonNull::new(context.as_ptr()),
+            None,
+            self.query.needs_tokenizer(),
+        )
+        .map_err(|e| TantivyError::InvalidArgument(e.to_string()))?;
+
+        let tantivy_query = self
+            .query
+            .clone()
+            .into_tantivy_query(
+                &schema,
+                &|| {
+                    QueryParser::for_index(
+                        reader.searcher().index(),
+                        schema.fields().map(|(f, _)| f).collect(),
+                    )
+                },
+                reader.searcher(),
+                index.oid(),
+                index.heap_relation().map(|r| r.oid()),
+                NonNull::new(context.as_ptr()),
+                None,
+            )
+            .map_err(|e| TantivyError::InvalidArgument(e.to_string()))?;
+
+        Ok(Box::new(QueryWithContext {
+            query: Box::new(tantivy_query),
+            _context: Arc::new(context),
+        }))
     }
 
     fn box_clone(&self) -> Box<dyn QueryBuilder> {
         Box::new(self.clone())
     }
-}
-
-fn build_query(query_json: serde_json::Value, indexrelid: u32) -> anyhow::Result<Box<dyn Query>> {
-    let query: SearchQueryInput = serde_json::from_value(query_json)?;
-    let indexrelid = pg_sys::Oid::from(indexrelid);
-    let context = ExprContextGuard::new();
-
-    let index = PgSearchRelation::with_lock(indexrelid, pg_sys::AccessShareLock as _);
-    let schema = index.schema()?;
-    let reader = SearchIndexReader::open_with_context(
-        &index,
-        query.clone(),
-        false,
-        MvccSatisfies::Snapshot,
-        NonNull::new(context.as_ptr()),
-        None,
-        query.needs_tokenizer(),
-    )?;
-
-    let tantivy_query = query.into_tantivy_query(
-        &schema,
-        &|| {
-            QueryParser::for_index(
-                reader.searcher().index(),
-                schema.fields().map(|(f, _)| f).collect(),
-            )
-        },
-        reader.searcher(),
-        index.oid(),
-        index.heap_relation().map(|r| r.oid()),
-        NonNull::new(context.as_ptr()),
-        None,
-    )?;
-
-    Ok(Box::new(QueryWithContext {
-        query: Box::new(tantivy_query),
-        _context: Arc::new(context),
-    }))
 }
 
 /// Wraps a Query with its ExprContextGuard to extend the context's lifetime.


### PR DESCRIPTION
## Summary

Stacked on top of #4805. pgrx 0.18.0 removes the `pgrx_embed` binary entirely, so the runtime function-pointer indirection that existed in `filterquery.rs` solely to keep PostgreSQL symbols out of pgrx_embed at link time is no longer necessary.

- Drop `BUILD_FILTER_QUERY_FN` `OnceLock` and `init_filter_query_builder()` (plus its call site in `_PG_init`)
- Store `SearchQueryInput` directly on `FilterQuery` instead of a `serde_json::Value` round-trip on every build; `indexrelid` stays a `u32` because `pg_sys::Oid` is not `Serialize`
- Inline the build logic into `QueryBuilder::build_query` and make `new_filter_query` infallible (nothing in the fast path could actually fail)

Net: `-49 / +83` → ~60 fewer lines in the hot path and one less global initialization step at extension load.

Closes #3715

## Notes for reviewer

Rebase this onto `main` once #4805 merges, then retarget the base to `main`. I left it stacked so the diff is reviewable against the 0.18 upgrade without noise from the API migration.

## Test plan

- [x] `cargo check --workspace --features pg_search/pg18` passes locally (clean, no warnings)
- [x] CI: existing `test-pg_search` aggregate / filter-aggregation regress cases stay green on pg15–pg18 (these exercise `FilterQuery::build_query` end-to-end, so any serde-wire-format regression would surface)
- [x] Manual smoke: run an aggregation with a `FILTER (WHERE ...)` clause against a BM25 index to confirm the serialized plan round-trips through typetag correctly