### PR TITLE
docs: Scope pg_search/README.md to development only

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -17,6 +17,7 @@ on:
       - "docker/**"
       - "!docker/Dockerfile.stressgres"
       - "pg_search/**"
+      - "!pg_search/README.md"
       - "tokenizers/**"
   workflow_dispatch:
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - ".github/workflows/test-pg_search-upgrade.yml"
       - "pg_search/**"
+      - "!pg_search/README.md"
       - "tests/**"
       - "tokenizers/**"
       - "Cargo.toml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ ParadeDB's public-facing documentation is stored in the `docs` folder. If you ar
 
 ### Testing
 
-ParadeDB has three main categories of tests. For a full overview of how and when to use them, please see their respective documentation:
+ParadeDB has four main categories of tests. For a full overview of how and when to use them, please see their respective documentation:
 
 #### 1. pg regress tests
 
@@ -76,6 +76,14 @@ Located in the `pg_search/src` directory.
   - **Unit tests which run in Postgres as UDFs** if they are marked `#[pg_test]`. These use all of Postgres APIs via `pgrx`.
 - **Running:** Run them with `cargo test -p pg_search -- a_specific_method_to_run`. There is no need to pre-install the extension for `#[pg_test]` annotated tests (the annotation automatically handles it).
 - **Details:** See [`pg_search/README.md`](pg_search/README.md#testing) for more details.
+
+#### 4. Stress tests (Stressgres)
+
+Located in the `stressgres/` directory.
+
+- **Purpose:** Replicate representative customer workloads against ParadeDB (or vanilla Postgres) to surface concurrency, correctness, and performance regressions that don't show up in shorter-lived tests. Also the entry point for Antithesis deterministic simulation runs.
+- **Running:** Run a suite interactively with `cargo run -- ui suites/vanilla-postgres.toml`, or headlessly with `cargo run -- headless suites/vanilla-postgres.toml --runtime=300000`.
+- **Details:** See [`stressgres/README.md`](stressgres/README.md) for more details.
 
 ## Legal Info
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -3,74 +3,15 @@
 <br>
 </h1>
 
-## Overview
-
-`pg_search` is a Postgres extension that enables full text search over heap tables using the BM25 algorithm. It is built on top of Tantivy, the Rust-based alternative to Apache Lucene, using `pgrx`. Please refer to the [ParadeDB documentation](https://docs.paradedb.com/documentation/getting-started/install) to get started.
+This README covers **local development** of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://docs.paradedb.com).
 
 `pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at PostgreSQL 15.
 
-Benchmarks can be found in the [`/benchmarks` directory](../benchmarks/README.md).
+## Prerequisites
 
-## Installation
+### Rust
 
-### From ParadeDB
-
-The easiest way to use the extension is to run the ParadeDB Dockerfile:
-
-```bash
-docker run \
-  --name paradedb \
-  -e POSTGRES_USER=<user> \
-  -e POSTGRES_PASSWORD=<password> \
-  -e POSTGRES_DB=<dbname> \
-  -v paradedb_data:/var/lib/postgresql/ \
-  -p 5432:5432 \
-  -d \
-  paradedb/paradedb:latest
-```
-
-This will spin up a Postgres instance with `pg_search` preinstalled.
-
-### From Self-Hosted PostgreSQL
-
-If you are self-hosting Postgres and would like to use the extension within your existing Postgres, follow the steps below.
-
-It's **very important** to make the following change to your `postgresql.conf` configuration file. `pg_search` must be in the list of `shared_preload_libraries`:
-
-```c
-shared_preload_libraries = 'pg_search'
-```
-
-This enables the extension to spawn a background worker process that performs writes to the index. If this background process is not started because of an incorrect `postgresql.conf` configuration, your database connection will crash or hang when you attempt to create a `pg_search` index.
-
-#### Debian/Ubuntu
-
-We provide prebuilt binaries for Debian-based Linux for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
-
-#### RHEL/Rocky
-
-We provide prebuilt binaries for Red Hat-based Linux for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
-
-You can also install `pg_search` via [Pigsty](https://pigsty.io/ext/repo/). To install `pig` for `yum` / `dnf` compatible systems [follow these instructions](https://pigsty.io/ext/repo/yum/). Then:
-
-```bash
-dnf install pig
-pig install pg_search
-```
-
-#### macOS
-
-We provide prebuilt binaries for macOS for Postgres 15+. You can download the latest version for your architecture from the [releases page](https://github.com/paradedb/paradedb/releases).
-
-#### Windows
-
-Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
-
-## Development
-
-### Prerequisites
-
-To develop the extension, first install stable Rust using `rustup`:
+Install stable Rust using `rustup`:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -79,7 +20,9 @@ rustup install stable
 
 Note: While it is possible to install Rust via your package manager, we recommend using `rustup` as we've observed inconsistencies with Homebrew's Rust installation on macOS.
 
-Then, install the PostgreSQL version of your choice using your system package manager. Here we provide the commands for the default PostgreSQL version used by this project:
+### PostgreSQL
+
+Install the PostgreSQL version of your choice using your system package manager. Here we provide the commands for the default PostgreSQL version used by this project:
 
 ```bash
 # macOS
@@ -94,17 +37,19 @@ sudo apt-get update && sudo apt-get install -y postgresql-18 postgresql-server-d
 sudo pacman -S extra/postgresql
 ```
 
-If you are using Postgres.app to manage your macOS PostgreSQL, you'll need to add the `pg_config` binary to your path before continuing:
+If you are using Postgres.app to manage your macOS PostgreSQL, add the `pg_config` binary to your path before continuing:
 
 ```bash
 export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
 ```
 
-Then, install and initialize `pgrx`:
+### pgrx
+
+The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml). Install and initialize it for your Postgres version:
 
 ```bash
 # Note: Replace --pg18 with your version of Postgres, if different (i.e. --pg17, etc.)
-cargo install --locked cargo-pgrx --version 0.17.0
+cargo install --locked cargo-pgrx --version 0.18.0
 
 # macOS arm64
 cargo pgrx init --pg18=/opt/homebrew/opt/postgresql@18/bin/pg_config
@@ -119,11 +64,9 @@ cargo pgrx init --pg18=/usr/lib/postgresql/18/bin/pg_config
 cargo pgrx init --pg18=/usr/bin/pg_config
 ```
 
-If you prefer to use a different version of Postgres, update the `--pg` flag accordingly.
-
 Note: While it is possible to develop using pgrx's own Postgres installation(s), via `cargo pgrx init` without specifying a `pg_config` path, we recommend using your system package manager's Postgres as we've observed inconsistent behaviours when using pgrx's.
 
-`pgrx` requires `libclang`, which does not come by default on Linux. To install it:
+`pgrx` requires `libclang`, which does not come by default on Linux:
 
 ```bash
 # Ubuntu
@@ -133,9 +76,11 @@ sudo apt install libclang-dev
 sudo pacman -S extra/clang
 ```
 
-#### pgvector
+Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
 
-`pgvector` is needed for hybrid search integration tests.
+### pgvector
+
+`pgvector` is needed for hybrid search integration tests:
 
 ```bash
 # Note: Replace 18 with your version of Postgres
@@ -159,47 +104,53 @@ PG_CONFIG=/usr/bin/pg_config make
 sudo PG_CONFIG=/usr/bin/pg_config make install # may need sudo
 ```
 
-### Running the Extension
+## Running the Extension
 
-First, start pgrx:
+Start an interactive Postgres session with the extension built and loaded:
 
 ```bash
 cargo pgrx run
 ```
 
-This will launch an interactive connection to Postgres. Inside Postgres, create the extension by running:
+Inside Postgres, create the extension:
 
 ```sql
 CREATE EXTENSION pg_search;
 ```
 
-Now, you have access to all the extension functions.
+## Modifying the Extension
 
-### Modifying the Extension
+After making changes to the extension code:
 
-If you make changes to the extension code, follow these steps to update it:
+1. Recompile and start Postgres:
 
-1. Recompile the extension:
-
-```bash
-cargo pgrx run
-```
+   ```bash
+   cargo pgrx run
+   ```
 
 2. Recreate the extension to load the latest changes:
 
-```sql
-DROP EXTENSION pg_search;
-CREATE EXTENSION pg_search;
+   ```sql
+   DROP EXTENSION pg_search;
+   CREATE EXTENSION pg_search;
+   ```
+
+## Testing
+
+Unit tests live in `pg_search/src` and run with:
+
+```bash
+cargo test -p pg_search -- a_specific_method_to_run
 ```
 
-### Testing
+Tests marked `#[pg_test]` run inside the Postgres process and can use the full `pgrx` API. The annotation handles re-installing the extension automatically — no manual install needed.
 
-This section covers the **unit tests** located in the `pg_search/src` directory. For a complete overview of ParadeDB's testing infrastructure (which includes integration tests, client property tests, and pg regress tests), please see the [Testing section in `CONTRIBUTING.md`](../CONTRIBUTING.md#testing).
+For the other test categories (pg regress, integration tests, client property tests), see:
 
-Unit tests can be run using `cargo test -p pg_search -- a_specific_method_to_run`. These tests sometimes (if marked `#[pg_test]`) run inside the Postgres process, which allows them to use all of Postgres APIs via `pgrx`. There is no need to pre-install the extension for these: the `#[pg_test]` annotation on the test will re-install the extension automatically.
+- [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg regress tests
+- [`tests/README.md`](../tests/README.md) — integration tests and client property tests
+- [`CONTRIBUTING.md#testing`](../CONTRIBUTING.md#testing) — overview of all test categories and when to use which
 
-_Note: For **pg regress tests**, please refer to [pg_search/tests/pg_regress/README.md](tests/pg_regress/README.md). For **integration tests** and **client property tests**, please refer to [tests/README.md](../tests/README.md)._
+## Benchmarks
 
-## License
-
-`pg_search` is licensed under the [GNU Affero General Public License v3.0](../LICENSE) and as commercial software. For commercial licensing, please contact us at [sales@paradedb.com](mailto:sales@paradedb.com).
+See [`benchmarks/README.md`](../benchmarks/README.md).

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -3,7 +3,7 @@
 <br>
 </h1>
 
-This README covers **local development** of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://docs.paradedb.com).
+This README covers development of the `pg_search` extension. For installation, deployment, and usage, see the [top-level ParadeDB README](../README.md) or the [ParadeDB documentation](https://docs.paradedb.com).
 
 `pg_search` is supported on official PostgreSQL Global Development Group Postgres versions, starting at PostgreSQL 15.
 
@@ -96,7 +96,7 @@ For the other test categories (pg regress, integration tests, client property te
 
 - [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg_regress tests
 - [`tests/README.md`](../tests/README.md) — integration tests and client property tests
-- [`stressgres/README.md`](../stressgres/README.md) — Stressgres, the stress-testing tool used locally and in CI (including Antithesis deterministic simulation runs)
+- [`stressgres/README.md`](../stressgres/README.md) — Stressgres, the stress-testing tool used locally and in CI
 - [`CONTRIBUTING.md#testing`](../CONTRIBUTING.md#testing) — overview of all test categories and when to use which
 
 ## Benchmarks

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -11,14 +11,12 @@ This README covers **local development** of the `pg_search` extension. For insta
 
 ### Rust
 
-Install stable Rust using `rustup`:
+Install stable Rust:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup install stable
 ```
-
-Note: While it is possible to install Rust via your package manager, we recommend using `rustup` as we've observed inconsistencies with Homebrew's Rust installation on macOS.
 
 ### pgrx
 
@@ -41,11 +39,9 @@ cargo pgrx init
 
 `cargo pgrx init` builds every supported Postgres version this project targets (currently 15–18) into `~/.pgrx/<version>/pgrx-install/` and points future `cargo pgrx` commands at it — no system Postgres required. To target only a single version, pass e.g. `cargo pgrx init --pg18 download`.
 
-Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
-
 ### pgvector
 
-`pgvector` is needed for hybrid search integration tests. Build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
+`pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
 
 ```bash
 git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
@@ -94,11 +90,11 @@ Unit tests live in `pg_search/src` and run with:
 cargo test -p pg_search -- a_specific_method_to_run
 ```
 
-Tests marked `#[pg_test]` run inside the Postgres process and can use the full `pgrx` API. The annotation handles re-installing the extension automatically — no manual install needed.
+Tests marked `#[pg_test]` run inside the Postgres process and can use the full `pgrx` API. The annotation automatically reinstalls the extension — no manual install needed.
 
 For the other test categories (pg regress, integration tests, client property tests), see:
 
-- [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg regress tests
+- [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg_regress tests
 - [`tests/README.md`](../tests/README.md) — integration tests and client property tests
 - [`CONTRIBUTING.md#testing`](../CONTRIBUTING.md#testing) — overview of all test categories and when to use which
 

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -20,53 +20,9 @@ rustup install stable
 
 Note: While it is possible to install Rust via your package manager, we recommend using `rustup` as we've observed inconsistencies with Homebrew's Rust installation on macOS.
 
-### PostgreSQL
-
-Install the PostgreSQL version of your choice using your system package manager. Here we provide the commands for the default PostgreSQL version used by this project:
-
-```bash
-# macOS
-brew install postgresql@18
-
-# Ubuntu
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-sudo apt-get update && sudo apt-get install -y postgresql-18 postgresql-server-dev-18
-
-# Arch Linux
-sudo pacman -S extra/postgresql
-```
-
-If you are using Postgres.app to manage your macOS PostgreSQL, add the `pg_config` binary to your path before continuing:
-
-```bash
-export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
-```
-
 ### pgrx
 
-The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml). Install and initialize it for your Postgres version:
-
-```bash
-# Note: Replace --pg18 with your version of Postgres, if different (i.e. --pg17, etc.)
-cargo install --locked cargo-pgrx --version 0.18.0
-
-# macOS arm64
-cargo pgrx init --pg18=/opt/homebrew/opt/postgresql@18/bin/pg_config
-
-# macOS amd64
-cargo pgrx init --pg18=/usr/local/opt/postgresql@18/bin/pg_config
-
-# Ubuntu
-cargo pgrx init --pg18=/usr/lib/postgresql/18/bin/pg_config
-
-# Arch Linux
-cargo pgrx init --pg18=/usr/bin/pg_config
-```
-
-Note: While it is possible to develop using pgrx's own Postgres installation(s), via `cargo pgrx init` without specifying a `pg_config` path, we recommend using your system package manager's Postgres as we've observed inconsistent behaviours when using pgrx's.
-
-`pgrx` requires `libclang`, which does not come by default on Linux:
+The `cargo-pgrx` version must match the `pgrx` dependency declared in [`pg_search/Cargo.toml`](Cargo.toml). On Linux, `pgrx` also requires `libclang`:
 
 ```bash
 # Ubuntu
@@ -76,32 +32,27 @@ sudo apt install libclang-dev
 sudo pacman -S extra/clang
 ```
 
+Then install `cargo-pgrx` and let it bootstrap a managed PostgreSQL installation under `~/.pgrx/`:
+
+```bash
+cargo install --locked cargo-pgrx --version 0.18.0
+cargo pgrx init
+```
+
+`cargo pgrx init` builds every supported Postgres version this project targets (currently 15–18) into `~/.pgrx/<version>/pgrx-install/` and points future `cargo pgrx` commands at it — no system Postgres required. To target only a single version, pass e.g. `cargo pgrx init --pg18 download`.
+
 Windows is not supported. This restriction is [inherited from pgrx not supporting Windows](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#caveats--known-issues).
 
 ### pgvector
 
-`pgvector` is needed for hybrid search integration tests:
+`pgvector` is needed for hybrid search integration tests. Build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
 
 ```bash
-# Note: Replace 18 with your version of Postgres
 git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
-# macOS arm64
-PG_CONFIG=/opt/homebrew/opt/postgresql@18/bin/pg_config make
-sudo PG_CONFIG=/opt/homebrew/opt/postgresql@18/bin/pg_config make install # may need sudo
-
-# macOS amd64
-PG_CONFIG=/usr/local/opt/postgresql@18/bin/pg_config make
-sudo PG_CONFIG=/usr/local/opt/postgresql@18/bin/pg_config make install # may need sudo
-
-# Ubuntu
-PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config make
-sudo PG_CONFIG=/usr/lib/postgresql/18/bin/pg_config make install # may need sudo
-
-# Arch Linux
-PG_CONFIG=/usr/bin/pg_config make
-sudo PG_CONFIG=/usr/bin/pg_config make install # may need sudo
+PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make
+PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make install
 ```
 
 ## Running the Extension

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -92,10 +92,11 @@ cargo test -p pg_search -- a_specific_method_to_run
 
 Tests marked `#[pg_test]` run inside the Postgres process and can use the full `pgrx` API. The annotation automatically reinstalls the extension — no manual install needed.
 
-For the other test categories (pg regress, integration tests, client property tests), see:
+For the other test categories (pg regress, integration tests, client property tests, stress tests), see:
 
 - [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg_regress tests
 - [`tests/README.md`](../tests/README.md) — integration tests and client property tests
+- [`stressgres/README.md`](../stressgres/README.md) — Stressgres, the stress-testing tool used locally and in CI (including Antithesis deterministic simulation runs)
 - [`CONTRIBUTING.md#testing`](../CONTRIBUTING.md#testing) — overview of all test categories and when to use which
 
 ## Benchmarks


### PR DESCRIPTION
## Summary

The `pg_search` README had grown to duplicate the top-level README's overview, installation (Docker / Debian / RHEL / macOS), Windows-not-supported note, and license sections. All of that lives in the [top-level README](../README.md) and at [docs.paradedb.com](https://docs.paradedb.com), which left two sources of truth that drifted apart.

This PR strips `pg_search/README.md` down to development-only content and adds a one-line pointer at the top sending end users to the canonical sources.

## What's kept

- **Prerequisites** — Rust, PostgreSQL, pgrx, libclang, pgvector
- **Running the Extension** — `cargo pgrx run` + `CREATE EXTENSION`
- **Modifying the Extension** — recompile + drop/create cycle
- **Testing** — unit tests, with cross-references to `pg_regress`, integration tests, and `CONTRIBUTING.md#testing`
- **Benchmarks** — pointer to `benchmarks/README.md`

## What's removed

- Overview / hero copy (lives in top-level README + docs)
- Installation section: Docker, self-hosted Debian/RHEL/macOS, prebuilt-binary instructions (lives in top-level README + docs)
- Windows-not-supported notice (folded into the pgrx prerequisites section, since that's what causes the restriction)
- License section (lives in top-level README + `LICENSE`)

## Reorganization within Development

- Promoted `Prerequisites` subsections (Rust / PostgreSQL / pgrx / pgvector) from a flat list into named sub-headings so they can be linked individually.
- Moved the cargo-pgrx version note next to the install command so contributors don't miss it.

## Test plan

- [x] Verify all relative links in the new README resolve (`../README.md`, `../tests/README.md`, `tests/pg_regress/README.md`, `../CONTRIBUTING.md#testing`, `../benchmarks/README.md`, `Cargo.toml`)
- [x] Compare against top-level README to confirm no information is lost (everything dropped is documented elsewhere)