### PR TITLE
fix: improve error messages for pdb.score() and pdb.snippet() when used without WHERE clause

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -28,7 +28,7 @@ mod pdb {
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
     fn score_from_relation(relation_reference: AnyElement) -> f32 {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        panic!("pdb.score() requires a WHERE clause with a ParadeDB search operator (e.g. pdb.term, pdb.parse, pdb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     extension_sql!(
@@ -46,7 +46,7 @@ mod pdb {
 #[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    panic!("paradedb.score() requires a WHERE clause with a ParadeDB search operator (e.g. paradedb.term, paradedb.parse, paradedb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -271,7 +271,7 @@ pub mod pdb {
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> String {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        panic!("pdb.snippet() requires a WHERE clause with a ParadeDB search operator (e.g. pdb.term, pdb.parse, pdb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     #[allow(unused_variables)]
@@ -285,7 +285,7 @@ pub mod pdb {
         offset: default!(Option<i32>, "NULL"),
         sort_by: default!(String, "'score'"),
     ) -> Vec<String> {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        panic!("pdb.snippets() requires a WHERE clause with a ParadeDB search operator (e.g. pdb.term, pdb.parse, pdb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 
     #[allow(unused_variables)]
@@ -309,7 +309,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        panic!("pdb.snippet_positions() requires a WHERE clause with a ParadeDB search operator (e.g. pdb.term, pdb.parse, pdb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
     }
 }
 
@@ -326,7 +326,7 @@ fn paradedb_snippet_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> Option<String> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    panic!("paradedb.snippet() requires a WHERE clause with a ParadeDB search operator (e.g. paradedb.term, paradedb.parse, paradedb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 #[warn(deprecated)]
@@ -341,7 +341,7 @@ fn paradedb_snippets_from_relation(
     offset: default!(Option<i32>, "NULL"),
     sort_by: default!(String, "'score'"),
 ) -> Option<Vec<String>> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    panic!("paradedb.snippets() requires a WHERE clause with a ParadeDB search operator (e.g. paradedb.term, paradedb.parse, paradedb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 #[warn(deprecated)]
@@ -366,7 +366,7 @@ fn paradedb_snippet_positions_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    panic!("paradedb.snippet_positions() requires a WHERE clause with a ParadeDB search operator (e.g. paradedb.term, paradedb.parse, paradedb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose");
 }
 
 extension_sql!(


### PR DESCRIPTION
## Summary

Replaces the generic `"Unsupported query shape. Please report at ..."` panic messages in `pdb.score()`, `pdb.snippet()`, and related functions with actionable error messages that explain the requirement for a WHERE clause with a ParadeDB search operator.

## Problem

When using `pdb.score()`, `pdb.snippet()`, or related functions without a WHERE clause containing a ParadeDB search operator (e.g. `pdb.term`, `pdb.parse`, `pdb.fuzzy`), users see a generic error:

```
ERROR: Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
```

This is confusing because it suggests a bug rather than a usage error.

## Solution

Updated the panic messages to clearly explain the requirement:

```
ERROR: pdb.score() requires a WHERE clause with a ParadeDB search operator (e.g. pdb.term, pdb.parse, pdb.fuzzy). See https://docs.paradedb.com for details. If this query already has a search operator, please report at https://github.com/paradedb/paradedb/issues/new/choose
```

Each message is tailored to the specific function (`pdb.score`, `pdb.snippet`, `pdb.snippets`, `pdb.snippet_positions`, and their `paradedb.*` aliases).

Closes #4767

## Test Plan

- Run queries like `SELECT p.id, pdb.score(p.id) AS score FROM products AS p` and verify the new error message is displayed.