### PR TITLE
fix: report error for mismatched proximity operators

### DIFF
--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -38,14 +38,20 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
     match left {
         ProximityClause::Proximity {
             left,
-            distance,
+            distance: ProximityDistance::AnyOrder(distance),
             right: original_right,
         } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
             ProximityClause::Proximity {
                 left,
-                distance,
+                distance: ProximityDistance::AnyOrder(distance),
                 right: Box::new(right),
             }
+        }
+        ProximityClause::Proximity {
+            distance: ProximityDistance::InOrder(_),
+            right: original_right,
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
+            panic!("mismatched proximity operators: left side uses ##> (ordered) but right side uses ## (unordered). Use matching operators (## ... ## or ##> ... ##>) for consistency.");
         }
         _ => panic!("lhs of ## must be a ProximityClause with an uninitialized rhs"),
     }
@@ -71,14 +77,20 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
     match left {
         ProximityClause::Proximity {
             left,
-            distance,
+            distance: ProximityDistance::InOrder(distance),
             right: original_right,
         } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
             ProximityClause::Proximity {
                 left,
-                distance,
+                distance: ProximityDistance::InOrder(distance),
                 right: Box::new(right),
             }
+        }
+        ProximityClause::Proximity {
+            distance: ProximityDistance::AnyOrder(_),
+            right: original_right,
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
+            panic!("mismatched proximity operators: left side uses ## (unordered) but right side uses ##> (ordered). Use matching operators (## ... ## or ##> ... ##>) for consistency.");
         }
         _ => panic!("lhs of ## must be a ProximityClause with an uninitialized rhs"),
     }


### PR DESCRIPTION
## Summary

Reports a clear error when proximity queries use mismatched operators (e.g. `'history' ##> 1 ## 'book'`), instead of silently choosing ambiguous behavior based on whichever operator comes first.

## Problem

Proximity queries are expected to use matching pairs of operators:
- `## n ##` for unordered proximity
- `##> n ##>` for ordered proximity

But mismatched pairs like `##> 1 ##` or `## 1 ##>` were silently accepted, with the first operator's behavior winning. This was confusing for users.

## Changes

Updated `rhs_prox` and `rhs_prox_in_order` in `proximity.rs` to validate that the distance type of the left-hand `ProximityClause` matches the operator being applied. A mismatch now panics with a clear error message:

```
mismatched proximity operators: left side uses ##> (ordered) but right side uses ## (unordered). Use matching operators (## ... ## or ##> ... ##>) for consistency.
```

Closes #4398

## Test Plan

```sql
-- Should error with mismatched operators
SELECT * FROM mock_items WHERE description @@@ ('history' ##> 1 ## 'book');

-- Should error with mismatched operators (reverse)
SELECT * FROM mock_items WHERE description @@@ ('history' ## 1 ##> 'book');

-- Should work: matching unordered
SELECT * FROM mock_items WHERE description @@@ ('history' ## 1 ## 'book');

-- Should work: matching ordered
SELECT * FROM mock_items WHERE description @@@ ('history' ##> 1 ##> 'book');
```