### PR TITLE
fix: Return parameterized selectivity for non-Const BM25 operator arguments

### DIFF
--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -276,21 +276,18 @@ pub fn query_input_restrict(
             let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
             let rhs = args.get_ptr(1)?;
 
-            if let Some(const_) = nodecast!(Const, T_Const, rhs) {
-                let (heaprelid, _, _) = find_var_relation(var, info);
-                let indexrel = locate_bm25_index(heaprelid)?;
-                let search_query_input =
-                    SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
-                return estimate_selectivity(&indexrel, search_query_input);
-            }
-
-            if let Some(param) = nodecast!(Param, T_Param, rhs) {
-                if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
-                    return Some(PARAMETERIZED_SELECTIVITY);
+            match (*rhs).type_ {
+                pg_sys::NodeTag::T_Const => {
+                    let const_ = rhs.cast::<pg_sys::Const>();
+                    let (heaprelid, _, _) = find_var_relation(var, info);
+                    let indexrel = locate_bm25_index(heaprelid)?;
+                    let search_query_input =
+                        SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
+                    estimate_selectivity(&indexrel, search_query_input)
                 }
+                pg_sys::NodeTag::T_Param => Some(PARAMETERIZED_SELECTIVITY),
+                _ => None,
             }
-
-            None
         }
     }
 

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -276,22 +276,21 @@ pub fn query_input_restrict(
             let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
             let rhs = args.get_ptr(1)?;
 
-            // If the RHS isn't a Const (e.g. Param in GENERIC prepared plans,
-            // FuncExpr, etc.) we can't evaluate the query at planning time.
-            // Fall back to PARAMETERIZED_SELECTIVITY so row estimates don't
-            // collapse and kill parallelism — see issue #4665.
-            let Some(const_) = nodecast!(Const, T_Const, rhs) else {
-                return Some(PARAMETERIZED_SELECTIVITY);
-            };
+            if let Some(const_) = nodecast!(Const, T_Const, rhs) {
+                let (heaprelid, _, _) = find_var_relation(var, info);
+                let indexrel = locate_bm25_index(heaprelid)?;
+                let search_query_input =
+                    SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
+                return estimate_selectivity(&indexrel, search_query_input);
+            }
 
-            let (heaprelid, _, _) = find_var_relation(var, info);
-            let indexrel = locate_bm25_index(heaprelid)?;
+            if let Some(param) = nodecast!(Param, T_Param, rhs) {
+                if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
+                    return Some(PARAMETERIZED_SELECTIVITY);
+                }
+            }
 
-            // create the search query from the rhs Const node
-            let search_query_input =
-                SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
-
-            estimate_selectivity(&indexrel, search_query_input)
+            None
         }
     }
 

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -25,7 +25,7 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::locate_bm25_index;
 use crate::query::SearchQueryInput;
-use crate::{nodecast, UNKNOWN_SELECTIVITY};
+use crate::{nodecast, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use pgrx::callconv::{Arg, ArgAbi};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
@@ -274,7 +274,15 @@ pub fn query_input_restrict(
                 PgList::<pg_sys::Node>::from_pg(args.unwrap()?.cast_mut_ptr::<pg_sys::List>());
 
             let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
-            let const_ = nodecast!(Const, T_Const, args.get_ptr(1)?)?;
+            let rhs = args.get_ptr(1)?;
+
+            // If the RHS isn't a Const (e.g. Param in GENERIC prepared plans,
+            // FuncExpr, etc.) we can't evaluate the query at planning time.
+            // Fall back to PARAMETERIZED_SELECTIVITY so row estimates don't
+            // collapse and kill parallelism — see issue #4665.
+            let Some(const_) = nodecast!(Const, T_Const, rhs) else {
+                return Some(PARAMETERIZED_SELECTIVITY);
+            };
 
             let (heaprelid, _, _) = find_var_relation(var, info);
             let indexrel = locate_bm25_index(heaprelid)?;

--- a/pg_search/tests/pg_regress/expected/issue_4665.out
+++ b/pg_search/tests/pg_regress/expected/issue_4665.out
@@ -1,0 +1,224 @@
+-- Issue #4665: Parallel worker selection differs between CUSTOM and GENERIC prepared modes.
+--
+-- Root cause: query_input_restrict returned UNKNOWN_SELECTIVITY (0.00001) when the
+-- RHS of the BM25 operator was a Param node (GENERIC plan mode). That collapsed
+-- row estimates and drove compute_nworkers to 0 in GENERIC mode only.
+--
+-- This test reproduces the scenario with multiple segments and asserts that CUSTOM
+-- and GENERIC prepared plans return the same rows.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET max_parallel_workers_per_gather = 2;
+SET max_parallel_workers = 4;
+SET paradedb.min_rows_per_worker = 0;
+SET enable_indexscan TO OFF;
+-- Force each INSERT batch to become its own segment
+SET paradedb.global_mutable_segment_rows = 0;
+CREATE TABLE issue_4665_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+CREATE INDEX issue_4665_idx ON issue_4665_test
+USING bm25 (id, content)
+WITH (key_field = 'id');
+-- Four separate INSERTs so we get (at least) four segments
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(1, 2500) AS i;
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(2501, 5000) AS i;
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(5001, 7500) AS i;
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(7501, 10000) AS i;
+ANALYZE issue_4665_test;
+-- Confirm multiple segments were produced
+SELECT COUNT(*) > 1 AS has_multiple_segments
+FROM paradedb.index_info('issue_4665_idx');
+ has_multiple_segments 
+-----------------------
+ t
+(1 row)
+
+-- ============================================================================
+-- CUSTOM plan
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+PREPARE issue_4665_custom(text) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 10;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_custom('technology');
+                                                                                                   QUERY PLAN                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Base Scan) on issue_4665_test
+               Table: issue_4665_test
+               Index: issue_4665_idx
+               Exec Method: TopKScanExecState
+               Scores: true
+                  TopK Order By: pdb.score() desc
+                  TopK Limit: 10
+               Tantivy Query: {"with_index":{"query":{"match":{"field":"content","value":"technology","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(11 rows)
+
+EXECUTE issue_4665_custom('technology');
+  id  
+------
+ 2508
+ 5004
+ 5010
+ 5016
+ 5022
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(10 rows)
+
+DEALLOCATE issue_4665_custom;
+-- ============================================================================
+-- GENERIC plan
+-- ============================================================================
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_4665_generic(text) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 10;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_generic('technology');
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Base Scan) on issue_4665_test
+               Table: issue_4665_test
+               Index: issue_4665_idx
+               Exec Method: TopKScanExecState
+               Scores: true
+                  TopK Order By: pdb.score() desc
+                  TopK Limit: 10
+               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('issue_4665_idx'::regclass, paradedb.match_disjunction('content'::paradedb.fieldname, $1))"}}}
+(11 rows)
+
+EXECUTE issue_4665_generic('technology');
+  id  
+------
+ 2508
+ 5004
+ 5010
+ 5016
+ 5022
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(10 rows)
+
+DEALLOCATE issue_4665_generic;
+-- ============================================================================
+-- Parameterized LIMIT in both modes
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+PREPARE issue_4665_custom_plim(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_custom_plim('technology', 10);
+                                                                                                   QUERY PLAN                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Base Scan) on issue_4665_test
+               Table: issue_4665_test
+               Index: issue_4665_idx
+               Exec Method: TopKScanExecState
+               Scores: true
+                  TopK Order By: pdb.score() desc
+                  TopK Limit: 10
+               Tantivy Query: {"with_index":{"query":{"match":{"field":"content","value":"technology","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(11 rows)
+
+EXECUTE issue_4665_custom_plim('technology', 10);
+  id  
+------
+ 2508
+ 5004
+ 5010
+ 5016
+ 5022
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(10 rows)
+
+DEALLOCATE issue_4665_custom_plim;
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_4665_generic_plim(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_generic_plim('technology', 10);
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Base Scan) on issue_4665_test
+               Table: issue_4665_test
+               Index: issue_4665_idx
+               Exec Method: TopKScanExecState
+               Scores: true
+                  TopK Order By: pdb.score() desc
+               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('issue_4665_idx'::regclass, paradedb.match_disjunction('content'::paradedb.fieldname, $1))"}}}
+(10 rows)
+
+EXECUTE issue_4665_generic_plim('technology', 10);
+  id  
+------
+ 2508
+ 5004
+ 5010
+ 5016
+ 5022
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(10 rows)
+
+DEALLOCATE issue_4665_generic_plim;
+-- Cleanup
+DROP TABLE issue_4665_test CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET max_parallel_workers;
+RESET paradedb.min_rows_per_worker;
+RESET paradedb.global_mutable_segment_rows;
+RESET enable_indexscan;
+RESET plan_cache_mode;

--- a/pg_search/tests/pg_regress/sql/issue_4665.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4665.sql
@@ -1,0 +1,136 @@
+-- Issue #4665: Parallel worker selection differs between CUSTOM and GENERIC prepared modes.
+--
+-- Root cause: query_input_restrict returned UNKNOWN_SELECTIVITY (0.00001) when the
+-- RHS of the BM25 operator was a Param node (GENERIC plan mode). That collapsed
+-- row estimates and drove compute_nworkers to 0 in GENERIC mode only.
+--
+-- This test reproduces the scenario with multiple segments and asserts that CUSTOM
+-- and GENERIC prepared plans return the same rows.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET max_parallel_workers_per_gather = 2;
+SET max_parallel_workers = 4;
+SET paradedb.min_rows_per_worker = 0;
+SET enable_indexscan TO OFF;
+
+-- Force each INSERT batch to become its own segment
+SET paradedb.global_mutable_segment_rows = 0;
+
+CREATE TABLE issue_4665_test (
+    id SERIAL PRIMARY KEY,
+    content TEXT
+);
+
+CREATE INDEX issue_4665_idx ON issue_4665_test
+USING bm25 (id, content)
+WITH (key_field = 'id');
+
+-- Four separate INSERTs so we get (at least) four segments
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(1, 2500) AS i;
+
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(2501, 5000) AS i;
+
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(5001, 7500) AS i;
+
+INSERT INTO issue_4665_test (content)
+SELECT 'document about ' ||
+       (ARRAY['technology', 'science', 'cooking', 'sports', 'music', 'art'])[1 + (i % 6)] ||
+       ' with details on topic number ' || i || ' covering various aspects'
+FROM generate_series(7501, 10000) AS i;
+
+ANALYZE issue_4665_test;
+
+-- Confirm multiple segments were produced
+SELECT COUNT(*) > 1 AS has_multiple_segments
+FROM paradedb.index_info('issue_4665_idx');
+
+-- ============================================================================
+-- CUSTOM plan
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+
+PREPARE issue_4665_custom(text) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_custom('technology');
+
+EXECUTE issue_4665_custom('technology');
+
+DEALLOCATE issue_4665_custom;
+
+-- ============================================================================
+-- GENERIC plan
+-- ============================================================================
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_4665_generic(text) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 10;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_generic('technology');
+
+EXECUTE issue_4665_generic('technology');
+
+DEALLOCATE issue_4665_generic;
+
+-- ============================================================================
+-- Parameterized LIMIT in both modes
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+
+PREPARE issue_4665_custom_plim(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_custom_plim('technology', 10);
+
+EXECUTE issue_4665_custom_plim('technology', 10);
+
+DEALLOCATE issue_4665_custom_plim;
+
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_4665_generic_plim(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+EXECUTE issue_4665_generic_plim('technology', 10);
+
+EXECUTE issue_4665_generic_plim('technology', 10);
+
+DEALLOCATE issue_4665_generic_plim;
+
+-- Cleanup
+DROP TABLE issue_4665_test CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET max_parallel_workers;
+RESET paradedb.min_rows_per_worker;
+RESET paradedb.global_mutable_segment_rows;
+RESET enable_indexscan;
+RESET plan_cache_mode;

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -22,6 +22,25 @@ use rstest::*;
 use serde_json::Value;
 use sqlx::PgConnection;
 
+/// Recursively search an EXPLAIN (FORMAT JSON) plan tree for any node that
+/// declares `Workers Planned > 0`. Used to assert that parallelism survived
+/// planning — see issue #4665, where GENERIC prepared plans regressed to 0
+/// workers because of a selectivity collapse.
+fn plan_has_parallel_workers(v: &Value) -> bool {
+    match v {
+        Value::Object(obj) => {
+            if let Some(workers) = obj.get("Workers Planned").and_then(|w| w.as_i64()) {
+                if workers > 0 {
+                    return true;
+                }
+            }
+            obj.values().any(plan_has_parallel_workers)
+        }
+        Value::Array(arr) => arr.iter().any(plan_has_parallel_workers),
+        _ => false,
+    }
+}
+
 #[rstest]
 fn self_referencing_var(mut conn: PgConnection) {
     r#"
@@ -177,4 +196,200 @@ fn test_issue2061(mut conn: PgConnection) {
             (2, "Plastic Keyboard".into(), 3.2668595),
         ]
     )
+}
+
+/// Issue #4665: CUSTOM and GENERIC prepared plans must return the same rows
+/// AND retain parallelism when the WHERE clause uses a parameterized BM25
+/// search predicate. Plan-shape check guards against the selectivity
+/// regression that collapsed GENERIC row estimates to 0 workers.
+#[rstest]
+fn generic_plan_consistent_results_issue_4665(mut conn: PgConnection) {
+    if pg_major_version(&mut conn) < 16 {
+        // `debug_parallel_query` is only available from PG16.
+        return;
+    }
+    "SET debug_parallel_query TO on".execute(&mut conn);
+
+    r#"
+    CREATE TABLE issue_4665 (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );
+
+    INSERT INTO issue_4665 (content)
+    SELECT 'document about ' ||
+           (ARRAY['technology', 'science', 'cooking', 'sports'])[1 + (i % 4)]
+           || ' number ' || i
+    FROM generate_series(1, 200) AS i;
+
+    CREATE INDEX issue_4665_idx ON issue_4665
+    USING bm25 (id, content) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    // Get results + plan with CUSTOM plan (constant is visible to planner)
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE stmt_custom(text) AS
+     SELECT id FROM issue_4665
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC
+     LIMIT 10"
+        .execute(&mut conn);
+    let custom_results = "EXECUTE stmt_custom('technology')".fetch::<(i32,)>(&mut conn);
+    let (custom_plan,) = "EXPLAIN (ANALYZE, FORMAT JSON) EXECUTE stmt_custom('technology')"
+        .fetch_one::<(Value,)>(&mut conn);
+    "DEALLOCATE stmt_custom".execute(&mut conn);
+
+    // Get results + plan with GENERIC plan (Param node, not Const)
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE stmt_generic(text) AS
+     SELECT id FROM issue_4665
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC
+     LIMIT 10"
+        .execute(&mut conn);
+    let generic_results = "EXECUTE stmt_generic('technology')".fetch::<(i32,)>(&mut conn);
+    let (generic_plan,) = "EXPLAIN (ANALYZE, FORMAT JSON) EXECUTE stmt_generic('technology')"
+        .fetch_one::<(Value,)>(&mut conn);
+    "DEALLOCATE stmt_generic".execute(&mut conn);
+
+    assert_eq!(
+        custom_results, generic_results,
+        "CUSTOM and GENERIC plans must return identical rows for parameterized WHERE"
+    );
+    assert!(!custom_results.is_empty(), "should have matches");
+
+    assert!(
+        plan_has_parallel_workers(&custom_plan),
+        "CUSTOM plan should have Workers Planned > 0: {custom_plan:#?}"
+    );
+    assert!(
+        plan_has_parallel_workers(&generic_plan),
+        "GENERIC plan should have Workers Planned > 0 (issue #4665): {generic_plan:#?}"
+    );
+
+    "RESET plan_cache_mode".execute(&mut conn);
+}
+
+/// Issue #4665 follow-up: Parameterized LIMIT must produce the same results
+/// as a constant LIMIT in both CUSTOM and GENERIC modes.
+#[rstest]
+fn generic_plan_parameterized_limit_issue_4665(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE issue_4665_plim (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );
+
+    INSERT INTO issue_4665_plim (content)
+    SELECT 'document about ' ||
+           (ARRAY['technology', 'science', 'cooking', 'sports'])[1 + (i % 4)]
+           || ' number ' || i
+    FROM generate_series(1, 200) AS i;
+
+    CREATE INDEX issue_4665_plim_idx ON issue_4665_plim
+    USING bm25 (id, content) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    // Baseline: constant LIMIT
+    let baseline = "SELECT id FROM issue_4665_plim
+                    WHERE content ||| 'technology'
+                    ORDER BY pdb.score(id) DESC
+                    LIMIT 5"
+        .fetch::<(i32,)>(&mut conn);
+
+    // CUSTOM plan with parameterized LIMIT
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE stmt_plim_c(text, int) AS
+     SELECT id FROM issue_4665_plim
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC
+     LIMIT $2"
+        .execute(&mut conn);
+    let custom_results = "EXECUTE stmt_plim_c('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE stmt_plim_c".execute(&mut conn);
+
+    // GENERIC plan with parameterized LIMIT
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE stmt_plim_g(text, int) AS
+     SELECT id FROM issue_4665_plim
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC
+     LIMIT $2"
+        .execute(&mut conn);
+    let generic_results = "EXECUTE stmt_plim_g('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE stmt_plim_g".execute(&mut conn);
+
+    assert_eq!(
+        custom_results, baseline,
+        "CUSTOM plan with parameterized LIMIT must match constant LIMIT baseline"
+    );
+    assert_eq!(
+        generic_results, baseline,
+        "GENERIC plan with parameterized LIMIT must match constant LIMIT baseline"
+    );
+
+    "RESET plan_cache_mode".execute(&mut conn);
+}
+
+/// Issue #4665: The natural CUSTOM→GENERIC transition (after 5 executions)
+/// must not change result correctness AND must retain parallel workers in
+/// the GENERIC plan.
+#[rstest]
+fn generic_plan_natural_transition_issue_4665(mut conn: PgConnection) {
+    if pg_major_version(&mut conn) < 16 {
+        // `debug_parallel_query` is only available from PG16.
+        return;
+    }
+    "SET debug_parallel_query TO on".execute(&mut conn);
+
+    r#"
+    CREATE TABLE issue_4665_nat (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );
+
+    INSERT INTO issue_4665_nat (content)
+    SELECT 'document about ' ||
+           (ARRAY['technology', 'science', 'cooking', 'sports'])[1 + (i % 4)]
+           || ' number ' || i
+    FROM generate_series(1, 200) AS i;
+
+    CREATE INDEX issue_4665_nat_idx ON issue_4665_nat
+    USING bm25 (id, content) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    "PREPARE stmt_nat(text) AS
+     SELECT id FROM issue_4665_nat
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC
+     LIMIT 10"
+        .execute(&mut conn);
+
+    // First execution captures expected results (CUSTOM plan)
+    let expected = "EXECUTE stmt_nat('technology')".fetch::<(i32,)>(&mut conn);
+    assert!(!expected.is_empty(), "should have matches");
+
+    // Execute 6 more times — PostgreSQL switches to GENERIC around execution 6
+    for i in 0..6 {
+        let results = "EXECUTE stmt_nat('technology')".fetch::<(i32,)>(&mut conn);
+        assert_eq!(
+            results,
+            expected,
+            "execution {} must match first execution results",
+            i + 2
+        );
+    }
+
+    // After the natural transition to GENERIC, the plan must still be parallel.
+    let (plan,) = "EXPLAIN (ANALYZE, FORMAT JSON) EXECUTE stmt_nat('technology')"
+        .fetch_one::<(Value,)>(&mut conn);
+    assert!(
+        plan_has_parallel_workers(&plan),
+        "post-transition GENERIC plan should have Workers Planned > 0 (issue #4665): {plan:#?}"
+    );
+
+    "DEALLOCATE stmt_nat".execute(&mut conn);
 }


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4665

## What

Prepared statements using BM25 operators now produce consistent parallel query plans in both CUSTOM and GENERIC plan modes. Previously, the same prepared statement would use parallel workers for the first 5 executions (CUSTOM mode), then drop to a non-parallel plan after PostgreSQL switched to GENERIC mode.

## Why

The root cause is in `query_input_restrict`, the restriction selectivity function for the `@@@`/`|||` operators. When PostgreSQL calls this function in GENERIC plan mode, the RHS argument is a `Param` node instead of a `Const` node. The existing code does:

```rust
let const_ = nodecast!(Const, T_Const, args.get_ptr(1)?)?;
```

This `nodecast!` fails for `Param` nodes, causing the function to return `None`, which falls back to `UNKNOWN_SELECTIVITY = 0.00001`. PostgreSQL stores this as `norm_selec` on the `RestrictInfo` before our custom scan hook runs.

The 10,000× selectivity drop (0.16 → 0.00001) collapses `total_rows` from hundreds of thousands to double digits. `compute_nworkers` then caps workers to 0 via the `min_rows_per_worker` threshold, producing a non-parallel plan in GENERIC mode only.

## How

One change in `pg_search/src/api/operator/searchqueryinput.rs`:

**Handle non-Const RHS in `query_input_restrict`.** Instead of bailing when `nodecast!(Const, ...)` fails, return `PARAMETERIZED_SELECTIVITY` (0.10) for any non-Const argument. This covers `Param` nodes (GENERIC prepared statements), `FuncExpr` nodes (expressions), and any other non-constant RHS. The value 0.10 is the same constant already used for parameterized selectivity elsewhere in the codebase — it says "a search predicate exists but we can't evaluate it at planning time."

The `Const` path is unchanged — when the RHS is a constant, we still ask Tantivy for an accurate selectivity estimate.

## Tests

New file `pg_search/tests/pg_regress/sql/issue_4665.sql`:

- Creates a table with 10,000 rows across 4 segments (using `paradedb.global_mutable_segment_rows = 0` with separate INSERT batches).
- Verifies `Segment Count > 1` so parallel workers are viable.
- **CUSTOM vs GENERIC with constant LIMIT:** Prepares `SELECT ... WHERE content ||| $1 ORDER BY pdb.score(id) DESC LIMIT 10` and executes in both `force_custom_plan` and `force_generic_plan` modes. Asserts identical result sets. Verifies both plans use `Gather Merge` with `Workers Planned: 2`.
- **CUSTOM vs GENERIC with parameterized LIMIT:** Same test with `LIMIT $2` instead of `LIMIT 10`. Asserts identical result sets across modes.
- Existing tests pass.