### PR TITLE
feat: Native DataFusion evaluation for pg_catalog functions in JoinScan expressions

### DIFF
--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -649,6 +649,10 @@ mod tests {
             Just("length(e.pattern) > 3".to_string()),
             Just("upper(e.pattern) = upper(i.name)".to_string()),
             Just("COALESCE(e.pattern, '') = i.name".to_string()),
+            // Arithmetic operators — native via translate_op_expr (+, -, *, /, %).
+            Just("e.threshold + 10 > i.value".to_string()),
+            Just("e.threshold * 2 > 50".to_string()),
+            Just("i.value - e.threshold > 0".to_string()),
         ]
     }
 
@@ -703,6 +707,9 @@ mod tests {
             Just("e.pattern = i.name OR length(e.pattern) > 100".to_string()),
             Just("e.pattern = i.name OR e.pattern IS NULL".to_string()),
             Just("upper(e.pattern) = i.name OR e.threshold > i.value".to_string()),
+            // Arithmetic cross-table predicates — now native OpExpr.
+            Just("e.threshold * 2 > i.value".to_string()),
+            Just("e.threshold + i.value > 100".to_string()),
         ]
     }
 

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -498,20 +498,39 @@ impl<'a> PredicateTranslator<'a> {
         let left = self.translate(left_arg)?;
         let right = self.translate(right_arg)?;
 
-        // Resolve the operator name straight from PG's catalog. The shared
-        // `lookup_operator` table in `opexpr.rs` is scoped to the Tantivy
-        // pushdown set and excludes arithmetic; DataFusion's translator has
-        // its own set of native operators, so we go around it here.
+        // Resolve the operator's `(schema, name)` identity from the PG
+        // catalog. Mirrors `translate_func_expr`'s namespace gate: we only
+        // natively translate operators that live in `pg_catalog`, so a
+        // user-defined operator in another schema that happens to share a
+        // symbol (e.g. `=`) with a pg_catalog operator isn't silently
+        // mistranslated. The operator's namespace is the namespace of its
+        // implementing function (`get_opcode` → `get_func_namespace`).
         let opno = (*op_expr).opno;
         let op_name_ptr = pg_sys::get_opname(opno);
-        if op_name_ptr.is_null() {
+        let namespace_oid = pg_sys::get_func_namespace(pg_sys::get_opcode(opno));
+        let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
+        if op_name_ptr.is_null() || namespace_ptr.is_null() {
             pgrx::debug1!(
-                "PredicateTranslator: get_opname returned null [OpExpr] opno={}",
+                "PredicateTranslator: could not resolve operator identity [OpExpr] opno={}",
                 opno.to_u32()
             );
             return None;
         }
+        let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
         let op_str = CStr::from_ptr(op_name_ptr).to_str().ok()?;
+
+        if schema != "pg_catalog" {
+            pgrx::debug1!(
+                "PredicateTranslator: non-pg_catalog operator [OpExpr] op={}.{}, types=({}, {}) | {}",
+                schema,
+                op_str,
+                type_name(left_type),
+                type_name(right_type),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            return None;
+        }
+
         let op = match op_str {
             "=" => Operator::Eq,
             "<>" | "!=" => Operator::NotEq,
@@ -526,7 +545,8 @@ impl<'a> PredicateTranslator<'a> {
             "%" => Operator::Modulo,
             _ => {
                 pgrx::debug1!(
-                    "PredicateTranslator: unsupported operator [OpExpr] op=\"{}\", types=({}, {}) | {}",
+                    "PredicateTranslator: unsupported operator [OpExpr] op=\"{}.{}\", types=({}, {}) | {}",
+                    schema,
                     op_str,
                     type_name(left_type),
                     type_name(right_type),

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -41,11 +41,32 @@ use std::sync::Arc;
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
 use crate::postgres::customscan::expr_eval::InputVarInfo;
-use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
+use crate::postgres::customscan::pg_expr_udf::PgExprUdf;
 
 const PVC_RECURSE_ALL: i32 = (pg_sys::PVC_RECURSE_AGGREGATES
     | pg_sys::PVC_RECURSE_WINDOWFUNCS
     | pg_sys::PVC_RECURSE_PLACEHOLDERS) as i32;
+
+/// Short, `&'static str` label for the subset of PG node tags that reach
+/// `try_wrap_as_udf`. Used only for building human-readable UDF names — a
+/// rename in `pg_sys::NodeTag` won't silently shift the emitted label.
+fn node_tag_label(tag: pg_sys::NodeTag) -> &'static str {
+    match tag {
+        pg_sys::NodeTag::T_OpExpr => "opexpr",
+        pg_sys::NodeTag::T_FuncExpr => "funcexpr",
+        pg_sys::NodeTag::T_BoolExpr => "boolexpr",
+        pg_sys::NodeTag::T_NullTest => "nulltest",
+        pg_sys::NodeTag::T_BooleanTest => "booleantest",
+        pg_sys::NodeTag::T_CaseExpr => "caseexpr",
+        pg_sys::NodeTag::T_CoalesceExpr => "coalesceexpr",
+        pg_sys::NodeTag::T_NullIfExpr => "nullifexpr",
+        pg_sys::NodeTag::T_MinMaxExpr => "minmaxexpr",
+        pg_sys::NodeTag::T_ScalarArrayOpExpr => "scalararrayopexpr",
+        pg_sys::NodeTag::T_CoerceViaIO => "coerceviaio",
+        pg_sys::NodeTag::T_RelabelType => "relabeltype",
+        _ => "expr",
+    }
+}
 
 impl<'a> PredicateTranslator<'a> {
     /// Translate a `FuncExpr` node.
@@ -370,21 +391,7 @@ impl<'a> PredicateTranslator<'a> {
         let pg_expr_string = CStr::from_ptr(node_str).to_string_lossy().into_owned();
         pg_sys::pfree(node_str.cast());
 
-        // Stable UDF names across runs
-        let udf_name = {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
-            let mut hasher = DefaultHasher::new();
-            pg_expr_string.hash(&mut hasher);
-            let short_hash = format!("{:08x}", hasher.finish() as u32);
-
-            let tag = format!("{:?}", (*node).type_)
-                .strip_prefix("T_")
-                .unwrap_or("expr")
-                .to_lowercase();
-
-            format!("{PG_EXPR_UDF_PREFIX}{tag}_{short_hash}")
-        };
+        let udf_name = PgExprUdf::stable_name(node_tag_label((*node).type_), &pg_expr_string);
         let udf = PgExprUdf::new(udf_name, pg_expr_string, input_vars, result_type_oid);
 
         Some(Expr::ScalarFunction(ScalarFunction::new_udf(

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -24,9 +24,6 @@
 //! MinMaxExpr, ScalarArrayOpExpr, and CoerceViaIO — plus a UDF fallback hook
 //! (`try_wrap_as_udf`) for opaque expressions.
 
-use std::ffi::CStr;
-use std::sync::Arc;
-
 use datafusion::functions::core::expr_fn::{coalesce, greatest, least, nullif};
 use datafusion::functions::math::expr_fn::{
     abs, ceil, floor, ln, log10, power, round, signum, sqrt,
@@ -38,6 +35,8 @@ use datafusion::functions::unicode::expr_fn::{character_length, reverse, substr,
 use datafusion::logical_expr::expr::{Case, InList, ScalarFunction};
 use datafusion::logical_expr::{Expr, ScalarUDF};
 use pgrx::{pg_sys, PgList};
+use std::ffi::CStr;
+use std::sync::Arc;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
@@ -371,7 +370,21 @@ impl<'a> PredicateTranslator<'a> {
         let pg_expr_string = CStr::from_ptr(node_str).to_string_lossy().into_owned();
         pg_sys::pfree(node_str.cast());
 
-        let udf_name = format!("{}{:x}", PG_EXPR_UDF_PREFIX, node as usize);
+        // Stable UDF names across runs
+        let udf_name = {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            let mut hasher = DefaultHasher::new();
+            pg_expr_string.hash(&mut hasher);
+            let short_hash = format!("{:08x}", hasher.finish() as u32);
+
+            let tag = format!("{:?}", (*node).type_)
+                .strip_prefix("T_")
+                .unwrap_or("expr")
+                .to_lowercase();
+
+            format!("{PG_EXPR_UDF_PREFIX}{tag}_{short_hash}")
+        };
         let udf = PgExprUdf::new(udf_name, pg_expr_string, input_vars, result_type_oid);
 
         Some(Expr::ScalarFunction(ScalarFunction::new_udf(

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -699,9 +699,7 @@ mod tests {
             Just("lower(e.pattern) = lower(i.name)".to_string()),
             Just("abs(e.threshold) > i.value".to_string()),
             Just("COALESCE(e.pattern, '') = i.name".to_string()),
-            Just(
-                "CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name".to_string(),
-            ),
+            Just("CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name".to_string(),),
             Just("e.pattern = i.name OR length(e.pattern) > 100".to_string()),
             Just("e.pattern = i.name OR e.pattern IS NULL".to_string()),
             Just("upper(e.pattern) = i.name OR e.threshold > i.value".to_string()),

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -400,3 +400,343 @@ impl<'a> PredicateTranslator<'a> {
         )))
     }
 }
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use datafusion::logical_expr::col;
+    use pgrx::prelude::*;
+    use proptest::prelude::*;
+
+    /// All `(name, arity)` pairs that `translate_known_func` must accept
+    /// under `pg_catalog`. Keep in sync with the match arms in
+    /// `PredicateTranslator::translate_known_func`.
+    #[allow(dead_code)]
+    const KNOWN_FUNCS: &[(&str, usize)] = &[
+        // string module (fixed arity)
+        ("upper", 1),
+        ("lower", 1),
+        ("ascii", 1),
+        ("repeat", 2),
+        ("starts_with", 2),
+        ("ends_with", 2),
+        ("replace", 3),
+        // string module (variadic; always match)
+        ("btrim", 0),
+        ("btrim", 1),
+        ("btrim", 2),
+        ("trim", 0),
+        ("trim", 1),
+        ("trim", 2),
+        ("ltrim", 0),
+        ("ltrim", 1),
+        ("ltrim", 2),
+        ("rtrim", 0),
+        ("rtrim", 1),
+        ("rtrim", 2),
+        ("concat", 0),
+        ("concat", 1),
+        ("concat", 2),
+        ("concat", 3),
+        // unicode module
+        ("length", 1),
+        ("char_length", 1),
+        ("character_length", 1),
+        ("substr", 2),
+        ("substr", 3),
+        ("substring", 2),
+        ("substring", 3),
+        ("reverse", 1),
+        // math module
+        ("abs", 1),
+        ("ceil", 1),
+        ("ceiling", 1),
+        ("floor", 1),
+        ("round", 0),
+        ("round", 1),
+        ("round", 2),
+        ("sqrt", 1),
+        ("power", 2),
+        ("pow", 2),
+        ("sign", 1),
+        ("ln", 1),
+        ("log", 1),
+        ("log10", 1),
+        // core module
+        ("coalesce", 0),
+        ("coalesce", 1),
+        ("coalesce", 2),
+        ("coalesce", 3),
+        ("nullif", 2),
+        ("greatest", 0),
+        ("greatest", 1),
+        ("greatest", 2),
+        ("greatest", 3),
+        ("least", 0),
+        ("least", 1),
+        ("least", 2),
+        ("least", 3),
+    ];
+
+    #[allow(dead_code)]
+    fn placeholder_args(arity: usize) -> Vec<Expr> {
+        (0..arity).map(|i| col(format!("c{i}"))).collect()
+    }
+
+    // ---------- Test 1: translate_known_func coverage (pure Rust) ----------
+
+    #[test]
+    fn known_funcs_all_return_some() {
+        for &(name, arity) in KNOWN_FUNCS {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", name, args);
+            assert!(
+                out.is_some(),
+                "expected Some for pg_catalog.{name}/{arity}, got None",
+            );
+        }
+    }
+
+    #[test]
+    fn non_pg_catalog_schema_returns_none() {
+        for &(name, arity) in KNOWN_FUNCS {
+            for schema in ["public", "my_schema", "information_schema", ""] {
+                let args = placeholder_args(arity);
+                let out = PredicateTranslator::translate_known_func(schema, name, args);
+                assert!(
+                    out.is_none(),
+                    "expected None for {schema}.{name}/{arity}, got Some",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wrong_arity_returns_none() {
+        // Fixed-arity functions rejected when called with the wrong count.
+        let cases: &[(&str, usize)] = &[
+            ("upper", 0),
+            ("upper", 2),
+            ("lower", 2),
+            ("replace", 1),
+            ("replace", 2),
+            ("replace", 4),
+            ("ascii", 0),
+            ("ascii", 2),
+            ("repeat", 1),
+            ("repeat", 3),
+            ("starts_with", 1),
+            ("starts_with", 3),
+            ("nullif", 1),
+            ("nullif", 3),
+            ("power", 1),
+            ("power", 3),
+            ("abs", 0),
+            ("abs", 2),
+            ("length", 0),
+            ("length", 2),
+            ("substr", 0),
+            ("substr", 1),
+            ("substr", 4),
+        ];
+        for &(name, arity) in cases {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", name, args);
+            assert!(
+                out.is_none(),
+                "expected None for pg_catalog.{name}/{arity}, got Some",
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        #[test]
+        fn unknown_func_name_returns_none(
+            name in "[a-z_]{3,15}".prop_filter("not a known func", |n| {
+                !KNOWN_FUNCS.iter().any(|(k, _)| *k == n)
+            }),
+            arity in 0usize..5,
+        ) {
+            let args = placeholder_args(arity);
+            let out = PredicateTranslator::translate_known_func("pg_catalog", &name, args);
+            prop_assert!(
+                out.is_none(),
+                "expected None for pg_catalog.{name}/{arity}, got Some",
+            );
+        }
+    }
+
+    // ---------- SQL-level tests (need live Postgres) ----------
+
+    fn setup_test_tables() {
+        pgrx::Spi::run(
+            r#"
+            DROP TABLE IF EXISTS prop_exclusions CASCADE;
+            DROP TABLE IF EXISTS prop_items CASCADE;
+            CREATE TABLE prop_items (
+                id SERIAL PRIMARY KEY,
+                name TEXT NOT NULL,
+                value INT NOT NULL
+            );
+            CREATE TABLE prop_exclusions (
+                id SERIAL PRIMARY KEY,
+                pattern TEXT,
+                threshold INT NOT NULL
+            );
+            INSERT INTO prop_items (name, value) VALUES
+                ('alpha', 10), ('beta', 20), ('gamma', 30),
+                ('', 0), ('UPPER', 100), ('  trimme  ', 50);
+            INSERT INTO prop_exclusions (pattern, threshold) VALUES
+                ('alpha', 5), (NULL, 10), ('', 15),
+                ('BETA', 20), ('gamma', 25), ('  trimme  ', 30);
+            CREATE INDEX prop_items_idx ON prop_items
+                USING bm25 (id, name, value)
+                WITH (
+                    key_field='id',
+                    text_fields='{"name": {"fast": true}}',
+                    numeric_fields='{"value": {"fast": true}}'
+                );
+            CREATE INDEX prop_exclusions_idx ON prop_exclusions
+                USING bm25 (id, pattern, threshold)
+                WITH (
+                    key_field='id',
+                    text_fields='{"pattern": {"fast": true}}',
+                    numeric_fields='{"threshold": {"fast": true}}'
+                );
+            "#,
+        )
+        .expect("setup_test_tables failed");
+    }
+
+    fn run_ids(query: &str) -> Vec<i32> {
+        pgrx::Spi::connect(|client| {
+            let args: [pgrx::datum::DatumWithOid; 0] = [];
+            let result = client.select(query, None, &args)?;
+            let mut ids = Vec::new();
+            for row in result {
+                if let Some(id) = row.get_by_name::<i32, _>("id")? {
+                    ids.push(id);
+                }
+            }
+            Ok::<_, pgrx::spi::Error>(ids)
+        })
+        .expect("run_ids failed")
+    }
+
+    fn explain_plan(query: &str) -> String {
+        pgrx::Spi::connect(|client| {
+            let args: [pgrx::datum::DatumWithOid; 0] = [];
+            let result = client.select(query, None, &args)?;
+            let mut out = String::new();
+            for row in result {
+                if let Some(line) = row.get::<String>(1)? {
+                    out.push_str(&line);
+                    out.push('\n');
+                }
+            }
+            Ok::<_, pgrx::spi::Error>(out)
+        })
+        .expect("explain_plan failed")
+    }
+
+    fn arb_bool_expr() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("e.pattern IS NULL".to_string()),
+            Just("e.pattern IS NOT NULL".to_string()),
+            Just("length(e.pattern) > 3".to_string()),
+            Just("upper(e.pattern) = upper(i.name)".to_string()),
+            Just("COALESCE(e.pattern, '') = i.name".to_string()),
+        ]
+    }
+
+    fn anti_join_query(expr: &str) -> String {
+        // LIMIT is required for JoinScan to absorb a Semi/Anti subquery.
+        format!(
+            "SELECT i.id FROM prop_items i \
+             WHERE NOT EXISTS ( \
+                 SELECT 1 FROM prop_exclusions e \
+                 WHERE e.id @@@ paradedb.all() AND ({expr}) \
+             ) \
+             AND i.id @@@ paradedb.all() \
+             ORDER BY i.id LIMIT 10"
+        )
+    }
+
+    // ---------- Test 2: JoinScan results match native PG ----------
+
+    #[pg_test]
+    fn joinscan_matches_native() {
+        setup_test_tables();
+        let cfg = ProptestConfig::with_cases(5);
+        proptest!(cfg, |(expr in arb_bool_expr())| {
+            let query = anti_join_query(&expr);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+            let joinscan = run_ids(&query);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = off").unwrap();
+            let native = run_ids(&query);
+
+            pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+
+            prop_assert_eq!(joinscan, native, "mismatch for expression: {}", expr);
+        });
+    }
+
+    // ---------- Test 3: EXPLAIN shows JoinScan absorbed the expression ----------
+
+    /// Only cross-table expressions — JoinScan's Semi/Anti absorption
+    /// requires the predicate to reference Vars from both sides of the
+    /// EXISTS/NOT EXISTS subquery. Single-table filters (e.g.
+    /// `length(e.pattern) > 3`) get pushed down as heap filters on the
+    /// inner scan and bypass JoinScan entirely.
+    fn arb_absorbable_expr() -> impl Strategy<Value = String> {
+        prop_oneof![
+            Just("upper(e.pattern) = i.name".to_string()),
+            Just("lower(e.pattern) = lower(i.name)".to_string()),
+            Just("abs(e.threshold) > i.value".to_string()),
+            Just("COALESCE(e.pattern, '') = i.name".to_string()),
+            Just(
+                "CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name".to_string(),
+            ),
+            Just("e.pattern = i.name OR length(e.pattern) > 100".to_string()),
+            Just("e.pattern = i.name OR e.pattern IS NULL".to_string()),
+            Just("upper(e.pattern) = i.name OR e.threshold > i.value".to_string()),
+        ]
+    }
+
+    #[pg_test]
+    fn expression_is_absorbed_by_joinscan() {
+        setup_test_tables();
+        pgrx::Spi::run("SET paradedb.enable_join_custom_scan = on").unwrap();
+        let cfg = ProptestConfig::with_cases(5);
+        proptest!(cfg, |(expr in arb_absorbable_expr())| {
+            let explain_query = format!("EXPLAIN (COSTS OFF) {}", anti_join_query(&expr));
+            let plan = explain_plan(&explain_query);
+
+            prop_assert!(
+                plan.contains("ParadeDB Join Scan"),
+                "expression '{}' was not absorbed by JoinScan. Plan:\n{}",
+                expr,
+                plan
+            );
+            prop_assert!(
+                !plan.contains("JoinScan not used"),
+                "expression '{}' triggered JoinScan decline. Plan:\n{}",
+                expr,
+                plan
+            );
+        });
+    }
+
+    // DISTINCT native-function coverage is already exercised
+    // thoroughly by `tests/pg_regress/sql/join_distinct_expr.sql`, whose
+    // expected output pins `upper(...)`, `character_length(...)`, `IS NULL`,
+    // etc. in the physical plan. Repeating that via a proptest on the
+    // minimal in-test schema triggers an unrelated JoinScan DISTINCT+PK-join
+    // schema bug (column-name="" in apply_distinct_group_by), so the SQL
+    // regression remains the authoritative coverage for that path.
+}

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -24,14 +24,6 @@
 //! MinMaxExpr, ScalarArrayOpExpr, and CoerceViaIO — plus a UDF fallback hook
 //! (`try_wrap_as_udf`) for opaque expressions.
 
-use datafusion::functions::core::expr_fn::{coalesce, greatest, least, nullif};
-use datafusion::functions::math::expr_fn::{
-    abs, ceil, floor, ln, log10, power, round, signum, sqrt,
-};
-use datafusion::functions::string::expr_fn::{
-    ascii, btrim, concat, ends_with, lower, ltrim, repeat, replace, rtrim, starts_with, upper,
-};
-use datafusion::functions::unicode::expr_fn::{character_length, reverse, substr, substring};
 use datafusion::logical_expr::expr::{Case, InList, ScalarFunction};
 use datafusion::logical_expr::{Expr, ScalarUDF};
 use pgrx::{pg_sys, PgList};
@@ -102,6 +94,15 @@ impl<'a> PredicateTranslator<'a> {
     /// Returns `None` for unrecognized functions — the caller can fall back
     /// to UDF wrapping.
     fn translate_known_func(schema: &str, name: &str, args: Vec<Expr>) -> Option<Expr> {
+        // Scoped imports: these expr_fn modules contain very short names
+        // (`abs`, `upper`, `round`, etc.) that could easily shadow or collide
+        // if pulled in at file scope. Keep them local to this function.
+        // Core items aren't glob-re-exported, so list them explicitly.
+        use datafusion::functions::core::expr_fn::{coalesce, greatest, least, nullif};
+        use datafusion::functions::math::expr_fn::*;
+        use datafusion::functions::string::expr_fn::*;
+        use datafusion::functions::unicode::expr_fn::*;
+
         let arity = args.len();
         let mut it = args.into_iter();
         match schema {
@@ -219,6 +220,8 @@ impl<'a> PredicateTranslator<'a> {
 
     /// Translate a `CoalesceExpr` to DataFusion's `coalesce(args)`.
     pub(crate) unsafe fn translate_coalesce_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::coalesce;
+
         let ce = node as *mut pg_sys::CoalesceExpr;
         let pg_args = PgList::<pg_sys::Node>::from_pg((*ce).args);
 
@@ -235,6 +238,8 @@ impl<'a> PredicateTranslator<'a> {
     /// Translate a `NullIfExpr`. Postgres shares the `OpExpr` layout for this
     /// node, so we cast to `OpExpr` and read its two-argument list.
     pub(crate) unsafe fn translate_nullif_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::nullif;
+
         debug_assert_eq!(
             (*node).type_,
             pg_sys::NodeTag::T_NullIfExpr,
@@ -252,6 +257,8 @@ impl<'a> PredicateTranslator<'a> {
 
     /// Translate a `MinMaxExpr` (GREATEST / LEAST).
     pub(crate) unsafe fn translate_min_max_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        use datafusion::functions::core::expr_fn::{greatest, least};
+
         let mmx = node as *mut pg_sys::MinMaxExpr;
         let pg_args = PgList::<pg_sys::Node>::from_pg((*mmx).args);
 

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -24,8 +24,9 @@
 //! MinMaxExpr, ScalarArrayOpExpr, and CoerceViaIO — plus a UDF fallback hook
 //! (`try_wrap_as_udf`) for opaque expressions.
 
+use datafusion::common::ScalarValue;
 use datafusion::logical_expr::expr::{Case, InList, ScalarFunction};
-use datafusion::logical_expr::{Expr, ScalarUDF};
+use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator, ScalarUDF};
 use pgrx::{pg_sys, PgList};
 use std::ffi::CStr;
 use std::sync::Arc;
@@ -406,6 +407,162 @@ impl<'a> PredicateTranslator<'a> {
             Arc::new(ScalarUDF::new_from_impl(udf)),
             input_exprs,
         )))
+    }
+
+    // -----------------------------------------------------------------
+    // Core node-type translators. These are the arms dispatched from
+    // `translate()` in `translator.rs` — `pub(crate)` so the split impl
+    // block in `translator.rs` can call them as methods on `&self`.
+    // -----------------------------------------------------------------
+
+    pub(crate) unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
+        let args = PgList::<pg_sys::Node>::from_pg((*op_expr).args);
+        if args.len() != 2 {
+            return None; // Only support binary operators for now
+        }
+
+        let left = self.translate(args.get_ptr(0)?)?;
+        let right = self.translate(args.get_ptr(1)?)?;
+
+        // Resolve the operator name straight from PG's catalog. The shared
+        // `lookup_operator` table in `opexpr.rs` is scoped to the Tantivy
+        // pushdown set and excludes arithmetic; DataFusion's translator has
+        // its own set of native operators, so we go around it here.
+        let opno = (*op_expr).opno;
+        let op_name_ptr = pg_sys::get_opname(opno);
+        if op_name_ptr.is_null() {
+            return None;
+        }
+        let op_str = CStr::from_ptr(op_name_ptr).to_str().ok()?;
+        let op = match op_str {
+            "=" => Operator::Eq,
+            "<>" | "!=" => Operator::NotEq,
+            "<" => Operator::Lt,
+            "<=" => Operator::LtEq,
+            ">" => Operator::Gt,
+            ">=" => Operator::GtEq,
+            "+" => Operator::Plus,
+            "-" => Operator::Minus,
+            "*" => Operator::Multiply,
+            "/" => Operator::Divide,
+            "%" => Operator::Modulo,
+            _ => return None,
+        };
+
+        Some(Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left),
+            op,
+            Box::new(right),
+        )))
+    }
+
+    pub(crate) unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
+        let varno = (*var).varno as pg_sys::Index;
+        let varattno = (*var).varattno;
+
+        // INDEX_VAR is allowed because it represents a reference to the custom scan's output
+        if varno != pg_sys::INDEX_VAR as pg_sys::Index
+            && !self.sources.iter().any(|s| s.contains_rti(varno))
+        {
+            return None;
+        }
+
+        if let Some(ref mapper) = self.mapper {
+            if let Some(expr) = mapper.map_var(varno, varattno) {
+                return Some(expr);
+            }
+            return None;
+        }
+
+        Some(col("placeholder"))
+    }
+
+    pub(crate) unsafe fn translate_const(&self, c: *mut pg_sys::Const) -> Option<Expr> {
+        if (*c).constisnull {
+            return Some(lit(ScalarValue::Null));
+        }
+
+        let type_oid = (*c).consttype;
+        let datum = (*c).constvalue;
+
+        // Simple mapping for common types
+        let scalar_value = match type_oid {
+            pg_sys::INT2OID => {
+                let val = datum.value() as i16;
+                ScalarValue::Int16(Some(val))
+            }
+            pg_sys::INT4OID => {
+                let val = datum.value() as i32;
+                ScalarValue::Int32(Some(val))
+            }
+            pg_sys::INT8OID => {
+                let val = datum.value() as i64;
+                ScalarValue::Int64(Some(val))
+            }
+            pg_sys::FLOAT4OID => {
+                let val = f32::from_bits(datum.value() as u32);
+                ScalarValue::Float32(Some(val))
+            }
+            pg_sys::FLOAT8OID => {
+                let val = f64::from_bits(datum.value() as u64);
+                ScalarValue::Float64(Some(val))
+            }
+            pg_sys::BOOLOID => {
+                let val = datum.value() != 0;
+                ScalarValue::Boolean(Some(val))
+            }
+            _ => return None,
+        };
+
+        Some(lit(scalar_value))
+    }
+
+    pub(crate) unsafe fn translate_bool_expr(
+        &self,
+        bool_expr: *mut pg_sys::BoolExpr,
+    ) -> Option<Expr> {
+        let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
+
+        match (*bool_expr).boolop {
+            pg_sys::BoolExprType::AND_EXPR => {
+                if args.len() < 2 {
+                    return None;
+                }
+                let mut expr = self.translate(args.get_ptr(0)?)?;
+                for i in 1..args.len() {
+                    let right = self.translate(args.get_ptr(i)?)?;
+                    expr = Expr::BinaryExpr(BinaryExpr::new(
+                        Box::new(expr),
+                        Operator::And,
+                        Box::new(right),
+                    ));
+                }
+                Some(expr)
+            }
+            pg_sys::BoolExprType::OR_EXPR => {
+                if args.len() < 2 {
+                    return None;
+                }
+                let mut expr = self.translate(args.get_ptr(0)?)?;
+                for i in 1..args.len() {
+                    let right = self.translate(args.get_ptr(i)?)?;
+                    expr = Expr::BinaryExpr(BinaryExpr::new(
+                        Box::new(expr),
+                        Operator::Or,
+                        Box::new(right),
+                    ));
+                }
+                Some(expr)
+            }
+            pg_sys::BoolExprType::NOT_EXPR => {
+                if args.len() != 1 {
+                    return None;
+                }
+                let child = self.translate(args.get_ptr(0)?)?;
+                Some(Expr::Not(Box::new(child)))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -1,0 +1,382 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Extended PostgreSQL → DataFusion expression translation.
+//!
+//! This file augments `PredicateTranslator` (defined in `translator.rs`) with
+//! additional node-type handlers via a split `impl` block. The methods here
+//! cover expression shapes beyond the simple binary-operator / Var / Const
+//! core — FuncExpr, NullTest, BooleanTest, CaseExpr, CoalesceExpr, NullIfExpr,
+//! MinMaxExpr, ScalarArrayOpExpr, and CoerceViaIO — plus a UDF fallback hook
+//! (`try_wrap_as_udf`) for opaque expressions.
+
+use std::ffi::CStr;
+use std::sync::Arc;
+
+use datafusion::functions::core::expr_fn::{coalesce, greatest, least, nullif};
+use datafusion::functions::math::expr_fn::{
+    abs, ceil, floor, ln, log10, power, round, signum, sqrt,
+};
+use datafusion::functions::string::expr_fn::{
+    ascii, btrim, concat, ends_with, lower, ltrim, repeat, replace, rtrim, starts_with, upper,
+};
+use datafusion::functions::unicode::expr_fn::{character_length, reverse, substr, substring};
+use datafusion::logical_expr::expr::{Case, InList, ScalarFunction};
+use datafusion::logical_expr::{Expr, ScalarUDF};
+use pgrx::{pg_sys, PgList};
+
+use crate::api::HashSet;
+use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
+use crate::postgres::customscan::expr_eval::InputVarInfo;
+use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
+
+const PVC_RECURSE_ALL: i32 = (pg_sys::PVC_RECURSE_AGGREGATES
+    | pg_sys::PVC_RECURSE_WINDOWFUNCS
+    | pg_sys::PVC_RECURSE_PLACEHOLDERS) as i32;
+
+impl<'a> PredicateTranslator<'a> {
+    /// Translate a `FuncExpr` node.
+    ///
+    /// Looks up the function's `(schema, name)` identity via the Postgres
+    /// catalog, translates each argument recursively, and dispatches to
+    /// [`Self::translate_known_func`]. Returns `None` when any argument
+    /// fails to translate or the function isn't in the known-func map.
+    pub(crate) unsafe fn translate_func_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let func = node as *mut pg_sys::FuncExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*func).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+
+        let funcid = (*func).funcid;
+        let namespace_oid = pg_sys::get_func_namespace(funcid);
+        let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
+        let func_name_ptr = pg_sys::get_func_name(funcid);
+        if namespace_ptr.is_null() || func_name_ptr.is_null() {
+            return None;
+        }
+
+        let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
+        let name = CStr::from_ptr(func_name_ptr).to_str().ok()?;
+
+        Self::translate_known_func(schema, name, df_args)
+    }
+
+    /// Map a `(schema, name, args)` triple to a native DataFusion `Expr`.
+    ///
+    /// Returns `None` for unrecognized functions — the caller can fall back
+    /// to UDF wrapping.
+    fn translate_known_func(schema: &str, name: &str, args: Vec<Expr>) -> Option<Expr> {
+        let arity = args.len();
+        let mut it = args.into_iter();
+        match schema {
+            "pg_catalog" => {
+                match (name, arity) {
+                    // string module
+                    ("upper", 1) => Some(upper(it.next()?)),
+                    ("lower", 1) => Some(lower(it.next()?)),
+                    ("btrim" | "trim", _) => Some(btrim(it.collect())),
+                    ("ltrim", _) => Some(ltrim(it.collect())),
+                    ("rtrim", _) => Some(rtrim(it.collect())),
+                    ("concat", _) => Some(concat(it.collect())),
+                    ("ascii", 1) => Some(ascii(it.next()?)),
+                    ("repeat", 2) => Some(repeat(it.next()?, it.next()?)),
+                    ("starts_with", 2) => Some(starts_with(it.next()?, it.next()?)),
+                    ("ends_with", 2) => Some(ends_with(it.next()?, it.next()?)),
+                    ("replace", 3) => Some(replace(it.next()?, it.next()?, it.next()?)),
+
+                    // unicode module
+                    ("length" | "char_length" | "character_length", 1) => {
+                        Some(character_length(it.next()?))
+                    }
+                    ("substr" | "substring", _) => match arity {
+                        2 => Some(substr(it.next()?, it.next()?)),
+                        3 => Some(substring(it.next()?, it.next()?, it.next()?)),
+                        _ => None,
+                    },
+                    ("reverse", 1) => Some(reverse(it.next()?)),
+
+                    // math module
+                    ("abs", 1) => Some(abs(it.next()?)),
+                    ("ceil" | "ceiling", 1) => Some(ceil(it.next()?)),
+                    ("floor", 1) => Some(floor(it.next()?)),
+                    ("round", _) => Some(round(it.collect())),
+                    ("sqrt", 1) => Some(sqrt(it.next()?)),
+                    ("power" | "pow", 2) => Some(power(it.next()?, it.next()?)),
+                    ("sign", 1) => Some(signum(it.next()?)),
+                    ("ln", 1) => Some(ln(it.next()?)),
+                    ("log" | "log10", 1) => Some(log10(it.next()?)),
+
+                    // core module
+                    ("coalesce", _) => Some(coalesce(it.collect())),
+                    ("nullif", 2) => Some(nullif(it.next()?, it.next()?)),
+                    ("greatest", _) => Some(greatest(it.collect())),
+                    ("least", _) => Some(least(it.collect())),
+
+                    _ => None,
+                }
+            }
+
+            _ => None,
+        }
+    }
+
+    /// Translate a `NullTest` (x IS NULL / IS NOT NULL).
+    pub(crate) unsafe fn translate_null_test(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let nt = node as *mut pg_sys::NullTest;
+        let arg = self.translate((*nt).arg.cast())?;
+        match (*nt).nulltesttype {
+            pg_sys::NullTestType::IS_NULL => Some(Expr::IsNull(Box::new(arg))),
+            pg_sys::NullTestType::IS_NOT_NULL => Some(Expr::IsNotNull(Box::new(arg))),
+            _ => None,
+        }
+    }
+
+    /// Translate a `BooleanTest` (x IS TRUE / IS NOT TRUE / …).
+    pub(crate) unsafe fn translate_boolean_test(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let bt = node as *mut pg_sys::BooleanTest;
+        let arg = self.translate((*bt).arg.cast())?;
+        match (*bt).booltesttype {
+            pg_sys::BoolTestType::IS_TRUE => Some(Expr::IsTrue(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_TRUE => Some(Expr::IsNotTrue(Box::new(arg))),
+            pg_sys::BoolTestType::IS_FALSE => Some(Expr::IsFalse(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_FALSE => Some(Expr::IsNotFalse(Box::new(arg))),
+            pg_sys::BoolTestType::IS_UNKNOWN => Some(Expr::IsUnknown(Box::new(arg))),
+            pg_sys::BoolTestType::IS_NOT_UNKNOWN => Some(Expr::IsNotUnknown(Box::new(arg))),
+            _ => None,
+        }
+    }
+
+    /// Translate a `CaseExpr` (CASE [operand] WHEN … THEN … ELSE … END).
+    pub(crate) unsafe fn translate_case_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let case = node as *mut pg_sys::CaseExpr;
+
+        let operand = if !(*case).arg.is_null() {
+            Some(Box::new(self.translate((*case).arg.cast())?))
+        } else {
+            None
+        };
+
+        let when_list = PgList::<pg_sys::Node>::from_pg((*case).args);
+        let mut when_then_expr: Vec<(Box<Expr>, Box<Expr>)> = Vec::with_capacity(when_list.len());
+        for w in when_list.iter_ptr() {
+            let cw = w as *mut pg_sys::CaseWhen;
+            let when = self.translate((*cw).expr.cast())?;
+            let then = self.translate((*cw).result.cast())?;
+            when_then_expr.push((Box::new(when), Box::new(then)));
+        }
+        if when_then_expr.is_empty() {
+            return None;
+        }
+
+        let else_expr = if !(*case).defresult.is_null() {
+            Some(Box::new(self.translate((*case).defresult.cast())?))
+        } else {
+            None
+        };
+
+        Some(Expr::Case(Case {
+            expr: operand,
+            when_then_expr,
+            else_expr,
+        }))
+    }
+
+    /// Translate a `CoalesceExpr` to DataFusion's `coalesce(args)`.
+    pub(crate) unsafe fn translate_coalesce_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let ce = node as *mut pg_sys::CoalesceExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*ce).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+        if df_args.is_empty() {
+            return None;
+        }
+
+        Some(coalesce(df_args))
+    }
+
+    /// Translate a `NullIfExpr`. Postgres shares the `OpExpr` layout for this
+    /// node, so we cast to `OpExpr` and read its two-argument list.
+    pub(crate) unsafe fn translate_nullif_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        debug_assert_eq!(
+            (*node).type_,
+            pg_sys::NodeTag::T_NullIfExpr,
+            "translate_nullif_expr called with wrong NodeTag"
+        );
+        let op = node as *mut pg_sys::OpExpr;
+        let args = PgList::<pg_sys::Node>::from_pg((*op).args);
+        if args.len() != 2 {
+            return None;
+        }
+        let left = self.translate(args.get_ptr(0)?)?;
+        let right = self.translate(args.get_ptr(1)?)?;
+        Some(nullif(left, right))
+    }
+
+    /// Translate a `MinMaxExpr` (GREATEST / LEAST).
+    pub(crate) unsafe fn translate_min_max_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let mmx = node as *mut pg_sys::MinMaxExpr;
+        let pg_args = PgList::<pg_sys::Node>::from_pg((*mmx).args);
+
+        let df_args: Option<Vec<Expr>> =
+            pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
+        let df_args = df_args?;
+        if df_args.is_empty() {
+            return None;
+        }
+
+        let is_greatest = matches!((*mmx).op, pg_sys::MinMaxOp::IS_GREATEST);
+        Some(if is_greatest {
+            greatest(df_args)
+        } else {
+            least(df_args)
+        })
+    }
+
+    /// Translate a `ScalarArrayOpExpr` (`scalar = ANY(ARRAY[...])` /
+    /// `scalar <> ALL(ARRAY[...])`) to `Expr::InList`.
+    ///
+    /// Only supports the ArrayExpr form of the RHS (literal array); other
+    /// shapes (subqueries, runtime-constructed arrays) return `None`.
+    pub(crate) unsafe fn translate_scalar_array_op_expr(
+        &self,
+        node: *mut pg_sys::Node,
+    ) -> Option<Expr> {
+        let saop = node as *mut pg_sys::ScalarArrayOpExpr;
+        let args = PgList::<pg_sys::Node>::from_pg((*saop).args);
+        if args.len() != 2 {
+            return None;
+        }
+
+        let scalar = self.translate(args.get_ptr(0)?)?;
+
+        let rhs = args.get_ptr(1)?;
+        if (*rhs).type_ != pg_sys::NodeTag::T_ArrayExpr {
+            return None;
+        }
+        let array_expr = rhs as *mut pg_sys::ArrayExpr;
+        let elements = PgList::<pg_sys::Node>::from_pg((*array_expr).elements);
+        let list: Option<Vec<Expr>> = elements.iter_ptr().map(|el| self.translate(el)).collect();
+        let list = list?;
+
+        let negated = !(*saop).useOr;
+
+        Some(Expr::InList(InList {
+            expr: Box::new(scalar),
+            list,
+            negated,
+        }))
+    }
+
+    /// Translate a `CoerceViaIO`. Only transparent text-family coercions are
+    /// accepted (TEXT ↔ VARCHAR ↔ NAME); everything else may change value
+    /// semantics and is rejected.
+    pub(crate) unsafe fn translate_coerce_via_io(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let coerce = node as *mut pg_sys::CoerceViaIO;
+        let arg_node: *mut pg_sys::Node = (*coerce).arg.cast();
+        if arg_node.is_null() {
+            return None;
+        }
+
+        let source = pg_sys::exprType(arg_node);
+        let target = (*coerce).resulttype;
+
+        const TEXT_FAMILY: &[pg_sys::Oid] = &[pg_sys::TEXTOID, pg_sys::VARCHAROID, pg_sys::NAMEOID];
+        let in_text = |oid: pg_sys::Oid| TEXT_FAMILY.contains(&oid);
+
+        if in_text(source) && in_text(target) {
+            self.translate(arg_node)
+        } else {
+            None
+        }
+    }
+
+    /// Wrap an otherwise-untranslatable PostgreSQL expression subtree as a
+    /// [`PgExprUdf`] scalar function. At execution time the UDF rehydrates the
+    /// serialized node, populates a virtual tuple slot from its Arrow input
+    /// columns, and delegates to `ExecEvalExpr`.
+    ///
+    /// Returns `None` when the expression can't be wrapped:
+    ///   - result type is outside the supported set,
+    ///   - some input Var can't be resolved against `self.sources` / mapper,
+    ///   - `nodeToString` returns null.
+    ///
+    /// Callers (see `translate()` in `translator.rs`) gate on
+    /// `self.allow_udf_fallback` before invoking this method.
+    pub(crate) unsafe fn try_wrap_as_udf(&self, node: *mut pg_sys::Node) -> Option<Expr> {
+        let result_type_oid = pg_sys::exprType(node);
+        PgExprUdf::try_result_type_to_arrow(result_type_oid)?;
+
+        let var_list = pg_sys::pull_var_clause(node, PVC_RECURSE_ALL);
+        let vars = PgList::<pg_sys::Var>::from_pg(var_list);
+
+        let mut seen: HashSet<(pg_sys::Index, pg_sys::AttrNumber)> = HashSet::default();
+        let mut input_exprs: Vec<Expr> = Vec::new();
+        let mut input_vars: Vec<InputVarInfo> = Vec::new();
+
+        for var_ptr in vars.iter_ptr() {
+            if var_ptr.is_null() {
+                continue;
+            }
+            let varno = (*var_ptr).varno as pg_sys::Index;
+            let varattno = (*var_ptr).varattno;
+
+            if varno == 0 || varattno <= 0 {
+                continue;
+            }
+            // Skip internal join sentinels (INNER_VAR, OUTER_VAR) but allow
+            // INDEX_VAR — it references the custom scan's own output tlist
+            // and translate_var handles it via the mapper.
+            if varno >= pg_sys::INNER_VAR as pg_sys::Index
+                && varno != pg_sys::INDEX_VAR as pg_sys::Index
+            {
+                continue;
+            }
+            if !seen.insert((varno, varattno)) {
+                continue;
+            }
+
+            let col_expr = self.translate_var(var_ptr)?;
+            input_exprs.push(col_expr);
+            input_vars.push(InputVarInfo {
+                rti: varno,
+                attno: varattno,
+                type_oid: (*var_ptr).vartype,
+                typmod: (*var_ptr).vartypmod,
+                collation: (*var_ptr).varcollid,
+            });
+        }
+
+        let node_str = pg_sys::nodeToString(node.cast());
+        if node_str.is_null() {
+            return None;
+        }
+        let pg_expr_string = CStr::from_ptr(node_str).to_string_lossy().into_owned();
+        pg_sys::pfree(node_str.cast());
+
+        let udf_name = format!("{}{:x}", PG_EXPR_UDF_PREFIX, node as usize);
+        let udf = PgExprUdf::new(udf_name, pg_expr_string, input_vars, result_type_oid);
+
+        Some(Expr::ScalarFunction(ScalarFunction::new_udf(
+            Arc::new(ScalarUDF::new_from_impl(udf)),
+            input_exprs,
+        )))
+    }
+}

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -338,11 +338,12 @@ impl<'a> PredicateTranslator<'a> {
     ///   - some input Var can't be resolved against `self.sources` / mapper,
     ///   - `nodeToString` returns null.
     ///
-    /// Callers (see `translate()` in `translator.rs`) gate on
-    /// `self.allow_udf_fallback` before invoking this method.
+    /// Called unconditionally as the final fallback in
+    /// [`PredicateTranslator::translate`] — any subtree that fails native
+    /// translation is wrapped here.
     pub(crate) unsafe fn try_wrap_as_udf(&self, node: *mut pg_sys::Node) -> Option<Expr> {
         let result_type_oid = pg_sys::exprType(node);
-        PgExprUdf::try_result_type_to_arrow(result_type_oid)?;
+        PgExprUdf::get_result_type_to_arrow(result_type_oid)?;
 
         let var_list = pg_sys::pull_var_clause(node, PVC_RECURSE_ALL);
         let vars = PgList::<pg_sys::Var>::from_pg(var_list);

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -32,7 +32,9 @@ use std::ffi::CStr;
 use std::sync::Arc;
 
 use crate::api::HashSet;
-use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
+use crate::postgres::customscan::datafusion::translator::{
+    deparse_expr_for_debug, node_tag_debug, type_name, PredicateTranslator,
+};
 use crate::postgres::customscan::expr_eval::InputVarInfo;
 use crate::postgres::customscan::pg_expr_udf::PgExprUdf;
 
@@ -81,13 +83,28 @@ impl<'a> PredicateTranslator<'a> {
         let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
         let func_name_ptr = pg_sys::get_func_name(funcid);
         if namespace_ptr.is_null() || func_name_ptr.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: could not resolve function identity [FuncExpr] funcid={}",
+                funcid.to_u32()
+            );
             return None;
         }
 
         let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
         let name = CStr::from_ptr(func_name_ptr).to_str().ok()?;
 
-        Self::translate_known_func(schema, name, df_args)
+        let arity = df_args.len();
+        let result = Self::translate_known_func(schema, name, df_args);
+        if result.is_none() {
+            pgrx::debug1!(
+                "PredicateTranslator: no native mapping [FuncExpr] func={}.{}, arity={} | {}",
+                schema,
+                name,
+                arity,
+                deparse_expr_for_debug(node, self.sources)
+            );
+        }
+        result
     }
 
     /// Map a `(schema, name, args)` triple to a native DataFusion `Expr`.
@@ -203,6 +220,7 @@ impl<'a> PredicateTranslator<'a> {
             when_then_expr.push((Box::new(when), Box::new(then)));
         }
         if when_then_expr.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty WHEN list [CaseExpr]");
             return None;
         }
 
@@ -230,6 +248,7 @@ impl<'a> PredicateTranslator<'a> {
             pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
         let df_args = df_args?;
         if df_args.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty args list [CoalesceExpr]");
             return None;
         }
 
@@ -249,6 +268,10 @@ impl<'a> PredicateTranslator<'a> {
         let op = node as *mut pg_sys::OpExpr;
         let args = PgList::<pg_sys::Node>::from_pg((*op).args);
         if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [NullIfExpr]",
+                args.len()
+            );
             return None;
         }
         let left = self.translate(args.get_ptr(0)?)?;
@@ -267,6 +290,7 @@ impl<'a> PredicateTranslator<'a> {
             pg_args.iter_ptr().map(|arg| self.translate(arg)).collect();
         let df_args = df_args?;
         if df_args.is_empty() {
+            pgrx::debug1!("PredicateTranslator: empty args list [MinMaxExpr]");
             return None;
         }
 
@@ -290,6 +314,10 @@ impl<'a> PredicateTranslator<'a> {
         let saop = node as *mut pg_sys::ScalarArrayOpExpr;
         let args = PgList::<pg_sys::Node>::from_pg((*saop).args);
         if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [ScalarArrayOpExpr]",
+                args.len()
+            );
             return None;
         }
 
@@ -297,6 +325,11 @@ impl<'a> PredicateTranslator<'a> {
 
         let rhs = args.get_ptr(1)?;
         if (*rhs).type_ != pg_sys::NodeTag::T_ArrayExpr {
+            pgrx::debug1!(
+                "PredicateTranslator: RHS is not ArrayExpr [ScalarArrayOpExpr] rhs_tag={} | {}",
+                node_tag_debug(rhs),
+                deparse_expr_for_debug(node, self.sources)
+            );
             return None;
         }
         let array_expr = rhs as *mut pg_sys::ArrayExpr;
@@ -332,6 +365,12 @@ impl<'a> PredicateTranslator<'a> {
         if in_text(source) && in_text(target) {
             self.translate(arg_node)
         } else {
+            pgrx::debug1!(
+                "PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source={}, target={} | {}",
+                type_name(source),
+                type_name(target),
+                deparse_expr_for_debug(node, self.sources)
+            );
             None
         }
     }
@@ -351,7 +390,15 @@ impl<'a> PredicateTranslator<'a> {
     /// translation is wrapped here.
     pub(crate) unsafe fn try_wrap_as_udf(&self, node: *mut pg_sys::Node) -> Option<Expr> {
         let result_type_oid = pg_sys::exprType(node);
-        PgExprUdf::get_result_type_to_arrow(result_type_oid)?;
+        if PgExprUdf::get_result_type_to_arrow(result_type_oid).is_none() {
+            pgrx::debug1!(
+                "PredicateTranslator: unsupported result type for UDF wrap [{}] type={} | {}",
+                node_tag_debug(node),
+                type_name(result_type_oid),
+                deparse_expr_for_debug(node, self.sources)
+            );
+            return None;
+        }
 
         let var_list = pg_sys::pull_var_clause(node, PVC_RECURSE_ALL);
         let vars = PgList::<pg_sys::Var>::from_pg(var_list);
@@ -382,7 +429,19 @@ impl<'a> PredicateTranslator<'a> {
                 continue;
             }
 
-            let col_expr = self.translate_var(var_ptr)?;
+            let col_expr = match self.translate_var(var_ptr) {
+                Some(expr) => expr,
+                None => {
+                    pgrx::debug1!(
+                        "PredicateTranslator: UDF wrap failed — could not resolve Var [{}] varno={}, varattno={} | {}",
+                        node_tag_debug(node),
+                        varno,
+                        varattno,
+                        deparse_expr_for_debug(node, self.sources)
+                    );
+                    return None;
+                }
+            };
             input_exprs.push(col_expr);
             input_vars.push(InputVarInfo {
                 rti: varno,
@@ -395,6 +454,10 @@ impl<'a> PredicateTranslator<'a> {
 
         let node_str = pg_sys::nodeToString(node.cast());
         if node_str.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: nodeToString returned null [{}]",
+                node_tag_debug(node)
+            );
             return None;
         }
         let pg_expr_string = CStr::from_ptr(node_str).to_string_lossy().into_owned();
@@ -416,13 +479,24 @@ impl<'a> PredicateTranslator<'a> {
     // -----------------------------------------------------------------
 
     pub(crate) unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
+        let node = op_expr as *mut pg_sys::Node;
         let args = PgList::<pg_sys::Node>::from_pg((*op_expr).args);
         if args.len() != 2 {
+            pgrx::debug1!(
+                "PredicateTranslator: expected 2 args, got {} [OpExpr]",
+                args.len()
+            );
             return None; // Only support binary operators for now
         }
 
-        let left = self.translate(args.get_ptr(0)?)?;
-        let right = self.translate(args.get_ptr(1)?)?;
+        // Capture raw arg types before translation for diagnostic logging.
+        let left_arg = args.get_ptr(0)?;
+        let right_arg = args.get_ptr(1)?;
+        let left_type = pg_sys::exprType(left_arg);
+        let right_type = pg_sys::exprType(right_arg);
+
+        let left = self.translate(left_arg)?;
+        let right = self.translate(right_arg)?;
 
         // Resolve the operator name straight from PG's catalog. The shared
         // `lookup_operator` table in `opexpr.rs` is scoped to the Tantivy
@@ -431,6 +505,10 @@ impl<'a> PredicateTranslator<'a> {
         let opno = (*op_expr).opno;
         let op_name_ptr = pg_sys::get_opname(opno);
         if op_name_ptr.is_null() {
+            pgrx::debug1!(
+                "PredicateTranslator: get_opname returned null [OpExpr] opno={}",
+                opno.to_u32()
+            );
             return None;
         }
         let op_str = CStr::from_ptr(op_name_ptr).to_str().ok()?;
@@ -446,7 +524,16 @@ impl<'a> PredicateTranslator<'a> {
             "*" => Operator::Multiply,
             "/" => Operator::Divide,
             "%" => Operator::Modulo,
-            _ => return None,
+            _ => {
+                pgrx::debug1!(
+                    "PredicateTranslator: unsupported operator [OpExpr] op=\"{}\", types=({}, {}) | {}",
+                    op_str,
+                    type_name(left_type),
+                    type_name(right_type),
+                    deparse_expr_for_debug(node, self.sources)
+                );
+                return None;
+            }
         };
 
         Some(Expr::BinaryExpr(BinaryExpr::new(
@@ -464,6 +551,11 @@ impl<'a> PredicateTranslator<'a> {
         if varno != pg_sys::INDEX_VAR as pg_sys::Index
             && !self.sources.iter().any(|s| s.contains_rti(varno))
         {
+            pgrx::debug1!(
+                "PredicateTranslator: unknown source [Var] varno={}, varattno={}",
+                varno,
+                varattno
+            );
             return None;
         }
 
@@ -471,6 +563,11 @@ impl<'a> PredicateTranslator<'a> {
             if let Some(expr) = mapper.map_var(varno, varattno) {
                 return Some(expr);
             }
+            pgrx::debug1!(
+                "PredicateTranslator: mapper failed to resolve [Var] varno={}, varattno={}",
+                varno,
+                varattno
+            );
             return None;
         }
 
@@ -511,7 +608,13 @@ impl<'a> PredicateTranslator<'a> {
                 let val = datum.value() != 0;
                 ScalarValue::Boolean(Some(val))
             }
-            _ => return None,
+            _ => {
+                pgrx::debug1!(
+                    "PredicateTranslator: unsupported const type [Const] type={}",
+                    type_name(type_oid)
+                );
+                return None;
+            }
         };
 
         Some(lit(scalar_value))

--- a/pg_search/src/postgres/customscan/datafusion/mod.rs
+++ b/pg_search/src/postgres/customscan/datafusion/mod.rs
@@ -27,5 +27,6 @@
 //! and the `RelNode` family of relation-tree types into this module as well.
 
 pub mod explain;
+mod expr_translators;
 pub mod memory;
 pub mod translator;

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -202,7 +202,11 @@ impl<'a> PredicateTranslator<'a> {
     /// Validates both node-type support and column resolution against
     /// the provided sources, without requiring plan_position or
     /// output_columns.
-    pub unsafe fn can_translate(sources: &'a [&'a JoinSource], node: *mut pg_sys::Node) -> bool {
+    pub unsafe fn can_translate(
+        sources: &'a [&'a JoinSource],
+        node: *mut pg_sys::Node,
+        allow_udf_fallback: bool,
+    ) -> bool {
         struct ValidationMapper<'a> {
             sources: &'a [&'a JoinSource],
         }
@@ -218,7 +222,9 @@ impl<'a> PredicateTranslator<'a> {
         }
 
         let mapper = ValidationMapper { sources };
-        let translator = Self::new(sources).with_mapper(Box::new(mapper));
+        let translator = Self::new(sources)
+            .with_allow_udf_fallback(allow_udf_fallback)
+            .with_mapper(Box::new(mapper));
         translator.translate(node).is_some()
     }
 
@@ -239,7 +245,7 @@ impl<'a> PredicateTranslator<'a> {
             return None;
         }
 
-        match (*node).type_ {
+        let native = match (*node).type_ {
             pg_sys::NodeTag::T_OpExpr => self.translate_op_expr(node as *mut pg_sys::OpExpr),
             pg_sys::NodeTag::T_Var => self.translate_var(node as *mut pg_sys::Var),
             pg_sys::NodeTag::T_Const => self.translate_const(node as *mut pg_sys::Const),
@@ -250,13 +256,7 @@ impl<'a> PredicateTranslator<'a> {
                 let relabel = node as *mut pg_sys::RelabelType;
                 self.translate((*relabel).arg.cast())
             }
-            pg_sys::NodeTag::T_FuncExpr => self.translate_func_expr(node).or_else(|| {
-                if self.allow_udf_fallback {
-                    self.try_wrap_as_udf(node)
-                } else {
-                    None
-                }
-            }),
+            pg_sys::NodeTag::T_FuncExpr => self.translate_func_expr(node),
             pg_sys::NodeTag::T_NullTest => self.translate_null_test(node),
             pg_sys::NodeTag::T_BooleanTest => self.translate_boolean_test(node),
             pg_sys::NodeTag::T_CaseExpr => self.translate_case_expr(node),
@@ -266,7 +266,21 @@ impl<'a> PredicateTranslator<'a> {
             pg_sys::NodeTag::T_ScalarArrayOpExpr => self.translate_scalar_array_op_expr(node),
             pg_sys::NodeTag::T_CoerceViaIO => self.translate_coerce_via_io(node),
             _ => None,
-        }
+        };
+
+        // When `allow_udf_fallback` is on, any subtree that fails native
+        // translation is wrapped in a `PgExprUdf`. This applies uniformly
+        // across node types — e.g. arithmetic OpExprs (`*`, `+`) that
+        // `translate_op_expr` doesn't handle still succeed as UDFs. Wrapping
+        // runs per recursive call, so the innermost failing subtree gets
+        // wrapped and its parent can still evaluate natively.
+        native.or_else(|| {
+            if self.allow_udf_fallback {
+                self.try_wrap_as_udf(node)
+            } else {
+                None
+            }
+        })
     }
 
     unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
@@ -619,7 +633,9 @@ unsafe fn translate_pg_expression_filter(
         sources,
         output_columns,
     };
-    let translator = PredicateTranslator::new(sources).with_mapper(Box::new(mapper));
+    let translator = PredicateTranslator::new(sources)
+        .with_allow_udf_fallback(true)
+        .with_mapper(Box::new(mapper));
     translator.translate(node.cast()).ok_or_else(|| {
         DataFusionError::Internal(
             "PredicateTranslator failed to translate deserialized PgExpression".into(),

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -223,8 +223,8 @@ impl<'a> PredicateTranslator<'a> {
 
         let mapper = ValidationMapper { sources };
         let translator = Self::new(sources)
-            .with_allow_udf_fallback(allow_udf_fallback)
-            .with_mapper(Box::new(mapper));
+            .with_mapper(Box::new(mapper))
+            .with_allow_udf_fallback(allow_udf_fallback);
         translator.translate(node).is_some()
     }
 
@@ -268,12 +268,8 @@ impl<'a> PredicateTranslator<'a> {
             _ => None,
         };
 
-        // When `allow_udf_fallback` is on, any subtree that fails native
-        // translation is wrapped in a `PgExprUdf`. This applies uniformly
-        // across node types — e.g. arithmetic OpExprs (`*`, `+`) that
-        // `translate_op_expr` doesn't handle still succeed as UDFs. Wrapping
-        // runs per recursive call, so the innermost failing subtree gets
-        // wrapped and its parent can still evaluate natively.
+        // Fallback runs per recursive call so the innermost failing subtree
+        // gets wrapped and its parent can still evaluate natively.
         native.or_else(|| {
             if self.allow_udf_fallback {
                 self.try_wrap_as_udf(node)
@@ -611,36 +607,48 @@ pub fn build_join_df_with_filter(
 }
 
 /// Deserialize a PostgreSQL expression from its `nodeToString` representation
-/// and translate it to a DataFusion `Expr` against `sources`. The translator
-/// is seeded with a [`CombinedMapper`] so Var nodes (carrying their original
-/// `(varno, varattno)`) resolve to qualified DataFusion columns.
+/// and translate it to a DataFusion `Expr` against `sources`, using the
+/// caller-supplied `mapper` to resolve Var nodes. `context` is used only in
+/// error messages to disambiguate call sites.
+pub unsafe fn translate_pg_node_string<'a>(
+    pg_node_string: &str,
+    sources: &'a [&'a JoinSource],
+    mapper: Box<dyn ColumnMapper + 'a>,
+    context: &'static str,
+) -> Result<Expr> {
+    let c_str = std::ffi::CString::new(pg_node_string).map_err(|e| {
+        DataFusionError::Internal(format!("CString conversion failed for {context}: {e}"))
+    })?;
+    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
+    if node.is_null() {
+        return Err(DataFusionError::Internal(format!(
+            "stringToNode returned null for {context}"
+        )));
+    }
+
+    let translator = PredicateTranslator::new(sources)
+        .with_mapper(mapper)
+        .with_allow_udf_fallback(true);
+    translator.translate(node.cast()).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "PredicateTranslator failed to translate deserialized {context}"
+        ))
+    })
+}
+
+/// Translate a `PgExpression` join filter using a [`CombinedMapper`] so Var
+/// nodes (carrying their original `(varno, varattno)`) resolve to qualified
+/// DataFusion columns.
 unsafe fn translate_pg_expression_filter(
     pg_node_string: &str,
     sources: &[&JoinSource],
     output_columns: &[OutputColumnInfo],
 ) -> Result<Expr> {
-    let c_str = std::ffi::CString::new(pg_node_string).map_err(|e| {
-        DataFusionError::Internal(format!("CString conversion failed for PgExpression: {e}"))
-    })?;
-    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
-    if node.is_null() {
-        return Err(DataFusionError::Internal(
-            "stringToNode returned null for PgExpression".into(),
-        ));
-    }
-
     let mapper = CombinedMapper {
         sources,
         output_columns,
     };
-    let translator = PredicateTranslator::new(sources)
-        .with_allow_udf_fallback(true)
-        .with_mapper(Box::new(mapper));
-    translator.translate(node.cast()).ok_or_else(|| {
-        DataFusionError::Internal(
-            "PredicateTranslator failed to translate deserialized PgExpression".into(),
-        )
-    })
+    translate_pg_node_string(pg_node_string, sources, Box::new(mapper), "PgExpression")
 }
 
 /// Build equi-join filter expressions from a [`JoinNode`]'s key pairs.

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -75,12 +75,7 @@ pub(crate) unsafe fn deparse_expr_for_debug(
                 pg_sys::deparse_context_for(relname.as_ptr(), source.scan_info.heaprelid);
             context = pg_sys::list_concat(context, rel_context);
         }
-        let deparsed = pg_sys::deparse_expression(
-            node.cast(),
-            context,
-            sources.len() > 1,
-            false,
-        );
+        let deparsed = pg_sys::deparse_expression(node.cast(), context, sources.len() > 1, false);
         if deparsed.is_null() {
             return tag_fallback();
         }

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -38,7 +38,6 @@ pub trait ColumnMapper {
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
     mapper: Option<Box<dyn ColumnMapper + 'a>>,
-    allow_udf_fallback: bool,
 }
 
 impl<'a> PredicateTranslator<'a> {
@@ -46,17 +45,11 @@ impl<'a> PredicateTranslator<'a> {
         Self {
             sources,
             mapper: None,
-            allow_udf_fallback: false,
         }
     }
 
     pub fn with_mapper(mut self, mapper: Box<dyn ColumnMapper + 'a>) -> Self {
         self.mapper = Some(mapper);
-        self
-    }
-
-    pub fn with_allow_udf_fallback(mut self, allow_udf_fallback: bool) -> Self {
-        self.allow_udf_fallback = allow_udf_fallback;
         self
     }
 
@@ -201,11 +194,7 @@ impl<'a> PredicateTranslator<'a> {
     /// Validates both node-type support and column resolution against
     /// the provided sources, without requiring plan_position or
     /// output_columns.
-    pub unsafe fn can_translate(
-        sources: &'a [&'a JoinSource],
-        node: *mut pg_sys::Node,
-        allow_udf_fallback: bool,
-    ) -> bool {
+    pub unsafe fn can_translate(sources: &'a [&'a JoinSource], node: *mut pg_sys::Node) -> bool {
         struct ValidationMapper<'a> {
             sources: &'a [&'a JoinSource],
         }
@@ -221,9 +210,7 @@ impl<'a> PredicateTranslator<'a> {
         }
 
         let mapper = ValidationMapper { sources };
-        let translator = Self::new(sources)
-            .with_mapper(Box::new(mapper))
-            .with_allow_udf_fallback(allow_udf_fallback);
+        let translator = Self::new(sources).with_mapper(Box::new(mapper));
         translator.translate(node).is_some()
     }
 
@@ -269,13 +256,7 @@ impl<'a> PredicateTranslator<'a> {
 
         // Fallback runs per recursive call, so the innermost failing subtree
         // gets wrapped, and its parent can still evaluate natively.
-        native.or_else(|| {
-            if self.allow_udf_fallback {
-                self.try_wrap_as_udf(node)
-            } else {
-                None
-            }
-        })
+        native.or_else(|| self.try_wrap_as_udf(node))
     }
 
     unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
@@ -637,9 +618,7 @@ pub unsafe fn translate_pg_node_string<'a>(
         )));
     }
 
-    let translator = PredicateTranslator::new(sources)
-        .with_mapper(mapper)
-        .with_allow_udf_fallback(true);
+    let translator = PredicateTranslator::new(sources).with_mapper(mapper);
     translator.translate(node.cast()).ok_or_else(|| {
         DataFusionError::Internal(format!(
             "PredicateTranslator failed to translate deserialized {context}"

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -15,11 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use datafusion::common::{Column, JoinType, Result, ScalarValue, TableReference};
+use datafusion::common::{Column, JoinType, Result, TableReference};
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator};
 use datafusion::prelude::DataFrame;
-use pgrx::{pg_sys, PgList};
+use pgrx::pg_sys;
 
 use crate::api::{HashMap, HashSet};
 use crate::postgres::customscan::joinscan::build::{
@@ -37,7 +37,7 @@ pub trait ColumnMapper {
 /// Helper struct for translating PostgreSQL expression trees into DataFusion `Expr`s.
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
-    mapper: Option<Box<dyn ColumnMapper + 'a>>,
+    pub(crate) mapper: Option<Box<dyn ColumnMapper + 'a>>,
 }
 
 impl<'a> PredicateTranslator<'a> {
@@ -259,152 +259,10 @@ impl<'a> PredicateTranslator<'a> {
         native.or_else(|| self.try_wrap_as_udf(node))
     }
 
-    unsafe fn translate_op_expr(&self, op_expr: *mut pg_sys::OpExpr) -> Option<Expr> {
-        let args = PgList::<pg_sys::Node>::from_pg((*op_expr).args);
-        if args.len() != 2 {
-            return None; // Only support binary operators for now
-        }
-
-        let left = self.translate(args.get_ptr(0)?)?;
-        let right = self.translate(args.get_ptr(1)?)?;
-
-        // Resolve the operator name straight from PG's catalog. The shared
-        // `lookup_operator` table in `opexpr.rs` is scoped to the Tantivy
-        // pushdown set and excludes arithmetic; DataFusion's translator has
-        // its own set of native operators, so we go around it here.
-        let opno = (*op_expr).opno;
-        let op_name_ptr = pg_sys::get_opname(opno);
-        if op_name_ptr.is_null() {
-            return None;
-        }
-        let op_str = std::ffi::CStr::from_ptr(op_name_ptr).to_str().ok()?;
-        let op = match op_str {
-            "=" => Operator::Eq,
-            "<>" | "!=" => Operator::NotEq,
-            "<" => Operator::Lt,
-            "<=" => Operator::LtEq,
-            ">" => Operator::Gt,
-            ">=" => Operator::GtEq,
-            "+" => Operator::Plus,
-            "-" => Operator::Minus,
-            "*" => Operator::Multiply,
-            "/" => Operator::Divide,
-            "%" => Operator::Modulo,
-            _ => return None,
-        };
-
-        Some(Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(left),
-            op,
-            Box::new(right),
-        )))
-    }
-
-    pub(crate) unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
-        let varno = (*var).varno as pg_sys::Index;
-        let varattno = (*var).varattno;
-
-        // INDEX_VAR is allowed because it represents a reference to the custom scan's output
-        if varno != pg_sys::INDEX_VAR as pg_sys::Index
-            && !self.sources.iter().any(|s| s.contains_rti(varno))
-        {
-            return None;
-        }
-
-        if let Some(ref mapper) = self.mapper {
-            if let Some(expr) = mapper.map_var(varno, varattno) {
-                return Some(expr);
-            }
-            return None;
-        }
-
-        Some(col("placeholder"))
-    }
-
-    unsafe fn translate_const(&self, c: *mut pg_sys::Const) -> Option<Expr> {
-        if (*c).constisnull {
-            return Some(lit(ScalarValue::Null));
-        }
-
-        let type_oid = (*c).consttype;
-        let datum = (*c).constvalue;
-
-        // Simple mapping for common types
-        let scalar_value = match type_oid {
-            pg_sys::INT2OID => {
-                let val = datum.value() as i16;
-                ScalarValue::Int16(Some(val))
-            }
-            pg_sys::INT4OID => {
-                let val = datum.value() as i32;
-                ScalarValue::Int32(Some(val))
-            }
-            pg_sys::INT8OID => {
-                let val = datum.value() as i64;
-                ScalarValue::Int64(Some(val))
-            }
-            pg_sys::FLOAT4OID => {
-                let val = f32::from_bits(datum.value() as u32);
-                ScalarValue::Float32(Some(val))
-            }
-            pg_sys::FLOAT8OID => {
-                let val = f64::from_bits(datum.value() as u64);
-                ScalarValue::Float64(Some(val))
-            }
-            pg_sys::BOOLOID => {
-                let val = datum.value() != 0;
-                ScalarValue::Boolean(Some(val))
-            }
-            _ => return None,
-        };
-
-        Some(lit(scalar_value))
-    }
-
-    unsafe fn translate_bool_expr(&self, bool_expr: *mut pg_sys::BoolExpr) -> Option<Expr> {
-        let args = PgList::<pg_sys::Node>::from_pg((*bool_expr).args);
-
-        match (*bool_expr).boolop {
-            pg_sys::BoolExprType::AND_EXPR => {
-                if args.len() < 2 {
-                    return None;
-                }
-                let mut expr = self.translate(args.get_ptr(0)?)?;
-                for i in 1..args.len() {
-                    let right = self.translate(args.get_ptr(i)?)?;
-                    expr = Expr::BinaryExpr(BinaryExpr::new(
-                        Box::new(expr),
-                        Operator::And,
-                        Box::new(right),
-                    ));
-                }
-                Some(expr)
-            }
-            pg_sys::BoolExprType::OR_EXPR => {
-                if args.len() < 2 {
-                    return None;
-                }
-                let mut expr = self.translate(args.get_ptr(0)?)?;
-                for i in 1..args.len() {
-                    let right = self.translate(args.get_ptr(i)?)?;
-                    expr = Expr::BinaryExpr(BinaryExpr::new(
-                        Box::new(expr),
-                        Operator::Or,
-                        Box::new(right),
-                    ));
-                }
-                Some(expr)
-            }
-            pg_sys::BoolExprType::NOT_EXPR => {
-                if args.len() != 1 {
-                    return None;
-                }
-                let child = self.translate(args.get_ptr(0)?)?;
-                Some(Expr::Not(Box::new(child)))
-            }
-            _ => None,
-        }
-    }
+    // `translate_op_expr`, `translate_var`, `translate_const`,
+    // `translate_bool_expr` — plus the extended node-type translators and
+    // the UDF fallback — are defined in `expr_translators.rs` on a split
+    // `impl PredicateTranslator` block.
 }
 
 /// Translate a `JoinLevelExpr` predicate into a DataFusion filter expression

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -39,7 +39,7 @@ pub trait ColumnMapper {
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
     mapper: Option<Box<dyn ColumnMapper + 'a>>,
-    pub(crate) allow_udf_fallback: bool,
+    allow_udf_fallback: bool,
 }
 
 impl<'a> PredicateTranslator<'a> {

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -34,6 +34,76 @@ pub trait ColumnMapper {
     fn map_var(&self, varno: pg_sys::Index, varattno: pg_sys::AttrNumber) -> Option<Expr>;
 }
 
+/// Human-readable PG type name (e.g. `"integer"`, `"jsonb"`) for debug
+/// logging. Falls back to `"OID {n}"` if the OID can't be resolved.
+pub(crate) unsafe fn type_name(oid: pg_sys::Oid) -> String {
+    let c_str = pg_sys::format_type_be(oid);
+    if c_str.is_null() {
+        return format!("OID {}", oid);
+    }
+    std::ffi::CStr::from_ptr(c_str)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Deparse a PG expression into readable SQL for debug logs. Builds a
+/// deparse context that covers every join source so Var nodes resolve to
+/// qualified column names (e.g. `e.pattern`). Wrapped in
+/// [`pgrx::PgTryBuilder`] so a PG error inside `deparse_expression` (which
+/// doesn't handle every possible node shape) degrades to a short tag
+/// fallback instead of unwinding the caller.
+pub(crate) unsafe fn deparse_expr_for_debug(
+    node: *mut pg_sys::Node,
+    sources: &[&JoinSource],
+) -> String {
+    use std::panic::AssertUnwindSafe;
+    if node.is_null() {
+        return "<null>".to_string();
+    }
+
+    let tag_fallback = || format!("{:?}", (*node).type_);
+
+    pgrx::PgTryBuilder::new(AssertUnwindSafe(|| {
+        let mut context: *mut pg_sys::List = std::ptr::null_mut();
+        for source in sources {
+            let alias = source.scan_info.alias.as_deref().unwrap_or("?");
+            let relname = match std::ffi::CString::new(alias) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let rel_context =
+                pg_sys::deparse_context_for(relname.as_ptr(), source.scan_info.heaprelid);
+            context = pg_sys::list_concat(context, rel_context);
+        }
+        let deparsed = pg_sys::deparse_expression(
+            node.cast(),
+            context,
+            sources.len() > 1,
+            false,
+        );
+        if deparsed.is_null() {
+            return tag_fallback();
+        }
+        std::ffi::CStr::from_ptr(deparsed)
+            .to_string_lossy()
+            .into_owned()
+    }))
+    .catch_others(|_| tag_fallback())
+    .execute()
+}
+
+/// Short label for a node tag (strips the `T_` prefix). Used in debug
+/// logs so the offending node type is immediately scannable. Separate from
+/// `expr_translators::node_tag_label`, which covers only the subset of
+/// tags that reach the UDF-naming path.
+pub(crate) unsafe fn node_tag_debug(node: *mut pg_sys::Node) -> String {
+    if node.is_null() {
+        return "null".to_string();
+    }
+    let dbg = format!("{:?}", (*node).type_);
+    dbg.strip_prefix("T_").unwrap_or(&dbg).to_string()
+}
+
 /// Helper struct for translating PostgreSQL expression trees into DataFusion `Expr`s.
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
@@ -228,6 +298,7 @@ impl<'a> PredicateTranslator<'a> {
     /// cannot be evaluated purely in DataFusion and must fall back to PostgreSQL evaluation.
     pub unsafe fn translate(&self, node: *mut pg_sys::Node) -> Option<Expr> {
         if node.is_null() {
+            pgrx::debug1!("PredicateTranslator: null node pointer");
             return None;
         }
 
@@ -256,7 +327,17 @@ impl<'a> PredicateTranslator<'a> {
 
         // Fallback runs per recursive call, so the innermost failing subtree
         // gets wrapped, and its parent can still evaluate natively.
-        native.or_else(|| self.try_wrap_as_udf(node))
+        native.or_else(|| {
+            let wrapped = self.try_wrap_as_udf(node);
+            if wrapped.is_none() {
+                pgrx::debug1!(
+                    "PredicateTranslator: UDF fallback failed [{}] | {}",
+                    node_tag_debug(node),
+                    deparse_expr_for_debug(node, self.sources)
+                );
+            }
+            wrapped
+        })
     }
 
     // `translate_op_expr`, `translate_var`, `translate_const`,

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -27,7 +27,6 @@ use crate::postgres::customscan::joinscan::build::{
     RelationAlias,
 };
 use crate::postgres::customscan::joinscan::privdat::{OutputColumnInfo, SCORE_COL_NAME};
-use crate::postgres::customscan::opexpr::lookup_operator;
 use crate::scan::SearchPredicateUDF;
 
 pub trait ColumnMapper {
@@ -268,8 +267,8 @@ impl<'a> PredicateTranslator<'a> {
             _ => None,
         };
 
-        // Fallback runs per recursive call so the innermost failing subtree
-        // gets wrapped and its parent can still evaluate natively.
+        // Fallback runs per recursive call, so the innermost failing subtree
+        // gets wrapped, and its parent can still evaluate natively.
         native.or_else(|| {
             if self.allow_udf_fallback {
                 self.try_wrap_as_udf(node)
@@ -288,16 +287,28 @@ impl<'a> PredicateTranslator<'a> {
         let left = self.translate(args.get_ptr(0)?)?;
         let right = self.translate(args.get_ptr(1)?)?;
 
+        // Resolve the operator name straight from PG's catalog. The shared
+        // `lookup_operator` table in `opexpr.rs` is scoped to the Tantivy
+        // pushdown set and excludes arithmetic; DataFusion's translator has
+        // its own set of native operators, so we go around it here.
         let opno = (*op_expr).opno;
-        let op_str = lookup_operator(opno)?;
-
+        let op_name_ptr = pg_sys::get_opname(opno);
+        if op_name_ptr.is_null() {
+            return None;
+        }
+        let op_str = std::ffi::CStr::from_ptr(op_name_ptr).to_str().ok()?;
         let op = match op_str {
             "=" => Operator::Eq,
-            "<>" => Operator::NotEq,
+            "<>" | "!=" => Operator::NotEq,
             "<" => Operator::Lt,
             "<=" => Operator::LtEq,
             ">" => Operator::Gt,
             ">=" => Operator::GtEq,
+            "+" => Operator::Plus,
+            "-" => Operator::Minus,
+            "*" => Operator::Multiply,
+            "/" => Operator::Divide,
+            "%" => Operator::Modulo,
             _ => return None,
         };
 

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -39,6 +39,7 @@ pub trait ColumnMapper {
 pub struct PredicateTranslator<'a> {
     pub sources: &'a [&'a JoinSource],
     mapper: Option<Box<dyn ColumnMapper + 'a>>,
+    pub(crate) allow_udf_fallback: bool,
 }
 
 impl<'a> PredicateTranslator<'a> {
@@ -46,11 +47,17 @@ impl<'a> PredicateTranslator<'a> {
         Self {
             sources,
             mapper: None,
+            allow_udf_fallback: false,
         }
     }
 
     pub fn with_mapper(mut self, mapper: Box<dyn ColumnMapper + 'a>) -> Self {
         self.mapper = Some(mapper);
+        self
+    }
+
+    pub fn with_allow_udf_fallback(mut self, allow_udf_fallback: bool) -> Self {
+        self.allow_udf_fallback = allow_udf_fallback;
         self
     }
 
@@ -243,10 +250,21 @@ impl<'a> PredicateTranslator<'a> {
                 let relabel = node as *mut pg_sys::RelabelType;
                 self.translate((*relabel).arg.cast())
             }
-            // Type casts (CoerceViaIO, FuncExpr) are not supported because
-            // they may change value semantics. Cross-type comparisons like INT < NUMERIC
-            // require proper type coercion that DataFusion cannot perform correctly when
-            // the underlying fast field storage uses different scales/representations.
+            pg_sys::NodeTag::T_FuncExpr => self.translate_func_expr(node).or_else(|| {
+                if self.allow_udf_fallback {
+                    self.try_wrap_as_udf(node)
+                } else {
+                    None
+                }
+            }),
+            pg_sys::NodeTag::T_NullTest => self.translate_null_test(node),
+            pg_sys::NodeTag::T_BooleanTest => self.translate_boolean_test(node),
+            pg_sys::NodeTag::T_CaseExpr => self.translate_case_expr(node),
+            pg_sys::NodeTag::T_CoalesceExpr => self.translate_coalesce_expr(node),
+            pg_sys::NodeTag::T_NullIfExpr => self.translate_nullif_expr(node),
+            pg_sys::NodeTag::T_MinMaxExpr => self.translate_min_max_expr(node),
+            pg_sys::NodeTag::T_ScalarArrayOpExpr => self.translate_scalar_array_op_expr(node),
+            pg_sys::NodeTag::T_CoerceViaIO => self.translate_coerce_via_io(node),
             _ => None,
         }
     }
@@ -280,7 +298,7 @@ impl<'a> PredicateTranslator<'a> {
         )))
     }
 
-    unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
+    pub(crate) unsafe fn translate_var(&self, var: *mut pg_sys::Var) -> Option<Expr> {
         let varno = (*var).varno as pg_sys::Index;
         let varattno = (*var).varattno;
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1806,7 +1806,7 @@ impl JoinScan {
                 let clause = (*ri).clause;
                 if clause.is_null()
                     || !all_vars_are_fast_fields_recursive(clause.cast(), &current_sources)
-                    || !PredicateTranslator::can_translate(&current_sources, clause.cast())
+                    || !PredicateTranslator::can_translate(&current_sources, clause.cast(), true)
                 {
                     remaining.push(ri);
                     continue;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1806,7 +1806,7 @@ impl JoinScan {
                 let clause = (*ri).clause;
                 if clause.is_null()
                     || !all_vars_are_fast_fields_recursive(clause.cast(), &current_sources)
-                    || !PredicateTranslator::can_translate(&current_sources, clause.cast(), true)
+                    || !PredicateTranslator::can_translate(&current_sources, clause.cast())
                 {
                     remaining.push(ri);
                     continue;

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -113,7 +113,7 @@ pub unsafe fn extract_join_level_conditions(
             }
 
             // Check if the predicate can be translated to DataFusion
-            if !PredicateTranslator::can_translate(sources, clause.cast(), true) {
+            if !PredicateTranslator::can_translate(sources, clause.cast()) {
                 return Err(format!(
                     "Multi-table predicate '{}' cannot be executed by DataFusion (unsupported operator or type)",
                     format_expr_for_explain(clause.cast())

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -113,9 +113,7 @@ pub unsafe fn extract_join_level_conditions(
             }
 
             // Check if the predicate can be translated to DataFusion
-            let translator = PredicateTranslator::new(sources);
-
-            if translator.translate(clause.cast()).is_none() {
+            if !PredicateTranslator::can_translate(sources, clause.cast(), true) {
                 return Err(format!(
                     "Multi-table predicate '{}' cannot be executed by DataFusion (unsupported operator or type)",
                     format_expr_for_explain(clause.cast())

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -85,7 +85,7 @@ use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
     apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
-    make_source_score_col, CombinedMapper, JoinTypeAllowList, PredicateTranslator,
+    make_source_score_col, ColumnMapper, CombinedMapper, JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
@@ -115,6 +115,53 @@ fn resolve_var_to_df_col(
         let mapped = source.map_var(rti, attno)?;
         let field = source.column_name(mapped)?;
         Some(make_source_col(source, &field))
+    })
+}
+
+/// Adapter that lets `PredicateTranslator` resolve Vars against a
+/// `JoinCSClause` by delegating to [`resolve_var_to_df_col`].
+struct JoinClauseMapper<'a> {
+    join_clause: &'a JoinCSClause,
+}
+
+impl<'a> ColumnMapper for JoinClauseMapper<'a> {
+    fn map_var(&self, varno: pg_sys::Index, varattno: pg_sys::AttrNumber) -> Option<Expr> {
+        resolve_var_to_df_col(self.join_clause, varno, varattno)
+    }
+}
+
+/// Translate a `ChildProjection::Expression` via `PredicateTranslator`.
+///
+/// Known `pg_catalog` functions (length, upper, abs, etc.) are mapped to
+/// native DataFusion functions for efficient evaluation; unknown functions
+/// fall back to `PgExprUdf` via `try_wrap_as_udf`.
+unsafe fn translate_child_projection_expr(
+    pg_expr_string: &str,
+    join_clause: &JoinCSClause,
+) -> Result<Expr> {
+    let c_str = std::ffi::CString::new(pg_expr_string).map_err(|e| {
+        DataFusionError::Internal(format!(
+            "CString conversion failed for ChildProjection::Expression: {e}"
+        ))
+    })?;
+    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
+    if node.is_null() {
+        return Err(DataFusionError::Internal(
+            "stringToNode returned null for ChildProjection::Expression".into(),
+        ));
+    }
+
+    let sources = join_clause.plan.sources();
+    let mapper = JoinClauseMapper { join_clause };
+
+    let translator = PredicateTranslator::new(&sources)
+        .with_mapper(Box::new(mapper))
+        .with_allow_udf_fallback(true);
+
+    translator.translate(node.cast()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "PredicateTranslator failed to translate ChildProjection::Expression".into(),
+        )
     })
 }
 
@@ -263,7 +310,8 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
-    let mut builder = SessionStateBuilder::new().with_config(config)
+    let mut builder = SessionStateBuilder::new()
+        .with_config(config)
         .with_default_features();
 
     // Inject visibility before late materialization so ctid lineage is analyzed
@@ -577,7 +625,9 @@ fn build_clause_df<'a>(
             sources: &plan_sources,
             output_columns: &private_data.output_columns,
         };
-        let translator = PredicateTranslator::new(&plan_sources).with_mapper(Box::new(mapper));
+        let translator = PredicateTranslator::new(&plan_sources)
+            .with_mapper(Box::new(mapper))
+            .with_allow_udf_fallback(true);
         let translated_exprs = unsafe { translate_custom_exprs(&translator, custom_exprs)? };
         // Drop the translator (and its borrow on `plan_sources`) before downstream
         // stages re-borrow `plan_sources` for projection / output assembly.
@@ -666,46 +716,8 @@ fn apply_distinct_group_by(
         let col_alias = format!("col_{}", i + 1);
 
         let (expr, map_key) = match proj {
-            build::ChildProjection::Expression {
-                pg_expr_string,
-                input_vars,
-                result_type_oid,
-                ..
-            } => {
-                let udf_name = format!(
-                    "{}{}",
-                    crate::postgres::customscan::pg_expr_udf::PG_EXPR_UDF_PREFIX,
-                    i
-                );
-
-                let input_exprs: Vec<Expr> = input_vars
-                    .iter()
-                    .filter_map(|var_info| {
-                        resolve_var_to_df_col(join_clause, var_info.rti, var_info.attno)
-                    })
-                    .collect();
-
-                if input_exprs.len() != input_vars.len() {
-                    return Err(DataFusionError::Internal(format!(
-                        "PgExprUdf: could not resolve all input columns \
-                         (resolved {} of {})",
-                        input_exprs.len(),
-                        input_vars.len()
-                    )));
-                }
-
-                let udf = crate::postgres::customscan::pg_expr_udf::PgExprUdf::new(
-                    udf_name,
-                    pg_expr_string.clone(),
-                    input_vars.clone(),
-                    *result_type_oid,
-                );
-
-                let e =
-                    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
-                        Arc::new(datafusion::logical_expr::ScalarUDF::new_from_impl(udf)),
-                        input_exprs,
-                    ));
+            build::ChildProjection::Expression { pg_expr_string, .. } => {
+                let e = unsafe { translate_child_projection_expr(pg_expr_string, join_clause)? };
                 // Expressions don't participate in sort-step column mapping
                 (e, None)
             }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -610,9 +610,7 @@ fn build_clause_df<'a>(
             sources: &plan_sources,
             output_columns: &private_data.output_columns,
         };
-        let translator = PredicateTranslator::new(&plan_sources)
-            .with_mapper(Box::new(mapper))
-            .with_allow_udf_fallback(true);
+        let translator = PredicateTranslator::new(&plan_sources).with_mapper(Box::new(mapper));
         let translated_exprs = unsafe { translate_custom_exprs(&translator, custom_exprs)? };
         // Drop the translator (and its borrow on `plan_sources`) before downstream
         // stages re-borrow `plan_sources` for projection / output assembly.

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -263,7 +263,8 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
-    let mut builder = SessionStateBuilder::new().with_config(config);
+    let mut builder = SessionStateBuilder::new().with_config(config)
+        .with_default_features();
 
     // Inject visibility before late materialization so ctid lineage is analyzed
     // while DeferredCtid columns are still present in the logical plan.

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -85,7 +85,8 @@ use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
     apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
-    make_source_score_col, ColumnMapper, CombinedMapper, JoinTypeAllowList, PredicateTranslator,
+    make_source_score_col, translate_pg_node_string, ColumnMapper, CombinedMapper,
+    JoinTypeAllowList, PredicateTranslator,
 };
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
@@ -132,37 +133,21 @@ impl<'a> ColumnMapper for JoinClauseMapper<'a> {
 
 /// Translate a `ChildProjection::Expression` via `PredicateTranslator`.
 ///
-/// Known `pg_catalog` functions (length, upper, abs, etc.) are mapped to
-/// native DataFusion functions for efficient evaluation; unknown functions
-/// fall back to `PgExprUdf` via `try_wrap_as_udf`.
+/// Known `pg_catalog` functions (length, upper, abs, etc.) map to native
+/// DataFusion functions; unknown functions fall back to `PgExprUdf` via
+/// `try_wrap_as_udf`.
 unsafe fn translate_child_projection_expr(
     pg_expr_string: &str,
     join_clause: &JoinCSClause,
 ) -> Result<Expr> {
-    let c_str = std::ffi::CString::new(pg_expr_string).map_err(|e| {
-        DataFusionError::Internal(format!(
-            "CString conversion failed for ChildProjection::Expression: {e}"
-        ))
-    })?;
-    let node = pg_sys::stringToNode(c_str.as_ptr().cast_mut());
-    if node.is_null() {
-        return Err(DataFusionError::Internal(
-            "stringToNode returned null for ChildProjection::Expression".into(),
-        ));
-    }
-
     let sources = join_clause.plan.sources();
     let mapper = JoinClauseMapper { join_clause };
-
-    let translator = PredicateTranslator::new(&sources)
-        .with_mapper(Box::new(mapper))
-        .with_allow_udf_fallback(true);
-
-    translator.translate(node.cast()).ok_or_else(|| {
-        DataFusionError::Internal(
-            "PredicateTranslator failed to translate ChildProjection::Expression".into(),
-        )
-    })
+    translate_pg_node_string(
+        pg_expr_string,
+        &sources,
+        Box::new(mapper),
+        "ChildProjection::Expression",
+    )
 }
 
 /// Query planner that lowers JoinScan's custom logical nodes

--- a/pg_search/src/postgres/customscan/pg_expr_udf.rs
+++ b/pg_search/src/postgres/customscan/pg_expr_udf.rs
@@ -152,6 +152,22 @@ impl PgExprUdf {
         }
     }
 
+    /// Build a deterministic, EXPLAIN-stable UDF name from a short node-tag
+    /// label and the serialized expression. Two subtrees with the same
+    /// serialized form collide on the same name — semantically correct,
+    /// since they're the same expression.
+    ///
+    /// Uses `FxHasher` (from `rustc-hash`) rather than `std`'s
+    /// `DefaultHasher`: the FxHash algorithm is documented and stable across
+    /// Rust releases, whereas `DefaultHasher`'s output is explicitly not.
+    pub fn stable_name(tag: &str, pg_expr_string: &str) -> String {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = rustc_hash::FxHasher::default();
+        pg_expr_string.hash(&mut hasher);
+        let short_hash = hasher.finish() as u32;
+        format!("{PG_EXPR_UDF_PREFIX}{tag}_{short_hash:08x}")
+    }
+
     /// Rebuild derived fields after deserialization.
     pub fn fixup_after_deserialize(&mut self) {
         self.return_type = types_arrow::pg_type_to_arrow(self.result_type_oid);

--- a/pg_search/src/postgres/customscan/pg_expr_udf.rs
+++ b/pg_search/src/postgres/customscan/pg_expr_udf.rs
@@ -139,7 +139,7 @@ impl PgExprUdf {
     /// KEEP IN SYNC with the `eval_expr_to_arrow!` arms in
     /// [`Self::invoke_with_args`] — every OID accepted here must have a
     /// matching match arm there, and vice versa.
-    pub fn try_result_type_to_arrow(oid: pg_sys::Oid) -> Option<DataType> {
+    pub fn get_result_type_to_arrow(oid: pg_sys::Oid) -> Option<DataType> {
         match oid {
             pg_sys::BOOLOID => Some(DataType::Boolean),
             pg_sys::INT2OID => Some(DataType::Int16),
@@ -262,7 +262,7 @@ unsafe fn populate_slot(
 ///
 /// Follows the `fetch_ff_column!` pattern from `fast_fields_helper.rs`.
 ///
-/// KEEP IN SYNC with [`PgExprUdf::try_result_type_to_arrow`] — every PG type
+/// KEEP IN SYNC with [`PgExprUdf::get_result_type_to_arrow`] — every PG type
 /// accepted by that gate must have a matching arm here, and vice versa.
 macro_rules! eval_expr_to_arrow {
     (
@@ -294,13 +294,13 @@ macro_rules! eval_expr_to_arrow {
             )*
             other => {
                 debug_assert!(
-                    Self::try_result_type_to_arrow(other).is_none(),
-                    "PgExprUdf::try_result_type_to_arrow accepts OID {other} but \
+                    Self::get_result_type_to_arrow(other).is_none(),
+                    "PgExprUdf::get_result_type_to_arrow accepts OID {other} but \
                      eval_expr_to_arrow! has no branch for it — keep the two in sync"
                 );
                 return Err(DataFusionError::Internal(format!(
                     "PgExprUdf: unsupported result type OID {other} — \
-                     PgExprUdf::try_result_type_to_arrow must gate wrapping before this point"
+                     PgExprUdf::get_result_type_to_arrow must gate wrapping before this point"
                 )));
             }
         }

--- a/pg_search/src/postgres/customscan/pg_expr_udf.rs
+++ b/pg_search/src/postgres/customscan/pg_expr_udf.rs
@@ -132,6 +132,26 @@ impl PgExprUdf {
         Signature::variadic_any(Volatility::Immutable)
     }
 
+    /// Returns the Arrow `DataType` for a PG result type OID if `PgExprUdf`
+    /// can evaluate it, or `None` if unsupported. This is the single gate for
+    /// whether an expression can be UDF-wrapped.
+    ///
+    /// KEEP IN SYNC with the `eval_expr_to_arrow!` arms in
+    /// [`Self::invoke_with_args`] — every OID accepted here must have a
+    /// matching match arm there, and vice versa.
+    pub fn try_result_type_to_arrow(oid: pg_sys::Oid) -> Option<DataType> {
+        match oid {
+            pg_sys::BOOLOID => Some(DataType::Boolean),
+            pg_sys::INT2OID => Some(DataType::Int16),
+            pg_sys::INT4OID => Some(DataType::Int32),
+            pg_sys::INT8OID => Some(DataType::Int64),
+            pg_sys::FLOAT4OID => Some(DataType::Float32),
+            pg_sys::FLOAT8OID => Some(DataType::Float64),
+            pg_sys::TEXTOID | pg_sys::VARCHAROID | pg_sys::NAMEOID => Some(DataType::Utf8),
+            _ => None,
+        }
+    }
+
     /// Rebuild derived fields after deserialization.
     pub fn fixup_after_deserialize(&mut self) {
         self.return_type = types_arrow::pg_type_to_arrow(self.result_type_oid);
@@ -225,6 +245,9 @@ unsafe fn populate_slot(
 /// and append the result directly to an Arrow builder. No intermediate Vec<Datum>.
 ///
 /// Follows the `fetch_ff_column!` pattern from `fast_fields_helper.rs`.
+///
+/// KEEP IN SYNC with [`PgExprUdf::try_result_type_to_arrow`] — every PG type
+/// accepted by that gate must have a matching arm here, and vice versa.
 macro_rules! eval_expr_to_arrow {
     (
         $self_:expr, $num_rows:expr, $pg_state:expr, $args:expr, $input_vars:expr,
@@ -253,10 +276,17 @@ macro_rules! eval_expr_to_arrow {
                     std::sync::Arc::new(builder.finish()) as std::sync::Arc<dyn Array>
                 }
             )*
-            other => panic!(
-                "PgExprUdf: unsupported result type OID {other} — \
-                 add a branch to eval_expr_to_arrow!"
-            ),
+            other => {
+                debug_assert!(
+                    Self::try_result_type_to_arrow(other).is_none(),
+                    "PgExprUdf::try_result_type_to_arrow accepts OID {other} but \
+                     eval_expr_to_arrow! has no branch for it — keep the two in sync"
+                );
+                return Err(DataFusionError::Internal(format!(
+                    "PgExprUdf: unsupported result type OID {other} — \
+                     PgExprUdf::try_result_type_to_arrow must gate wrapping before this point"
+                )));
+            }
         }
     };
 }
@@ -285,11 +315,8 @@ impl ScalarUDFImpl for PgExprUdf {
         // SAFETY: single-threaded access guaranteed by target_partitions=1.
         let pg_state = unsafe { self.get_or_init_state() };
 
-        debug_assert!(
-            !self.input_vars.is_empty(),
-            "PgExprUdf '{}' has no input_vars — expression must have Var dependencies",
-            self.name
-        );
+        // A UDF over only constants has no input Vars — that's valid.
+        // ExecEvalExpr evaluates it with an empty slot.
 
         let n = args.number_rows;
         let arg_values = &args.args;

--- a/pg_search/tests/pg_regress/expected/expr_translator_debug.out
+++ b/pg_search/tests/pg_regress/expected/expr_translator_debug.out
@@ -57,10 +57,10 @@ WHERE NOT EXISTS (
 AND i.id @@@ paradedb.all()
 LIMIT 5;
 DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
-DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | T_OpExpr
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="pg_catalog.||", types=(text, text) | T_OpExpr
 WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
 DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
-DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | T_OpExpr
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="pg_catalog.||", types=(text, text) | T_OpExpr
                                                                                                      QUERY PLAN                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/expr_translator_debug.out
+++ b/pg_search/tests/pg_regress/expected/expr_translator_debug.out
@@ -1,0 +1,158 @@
+-- Regression test for `PredicateTranslator` debug1 logging.
+--
+-- Every failed translation path emits a structured `pgrx::debug1!` line of
+-- the form:
+--
+--     DEBUG: PredicateTranslator: <reason> [<NodeTag>] <key=value pairs> | <deparsed SQL>
+--
+-- This test raises `client_min_messages` to `debug1` and runs EXPLAIN on
+-- queries crafted to trip specific translator rejection points, verifying
+-- the expected log lines appear in order.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS et_items CASCADE;
+DROP TABLE IF EXISTS et_exclusions CASCADE;
+CREATE TABLE et_items (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    value INT NOT NULL
+);
+CREATE TABLE et_exclusions (
+    id SERIAL PRIMARY KEY,
+    pattern TEXT
+);
+INSERT INTO et_items (name, value) VALUES
+    ('alpha', 10), ('beta', 20);
+INSERT INTO et_exclusions (pattern) VALUES
+    ('alpha'), ('beta');
+CREATE INDEX et_items_idx ON et_items
+    USING bm25 (id, name, value)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"name":{"fast":true}}',
+        numeric_fields = '{"value":{"fast":true}}'
+    );
+CREATE INDEX et_exclusions_idx ON et_exclusions
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"pattern":{"fast":true}}'
+    );
+SET paradedb.enable_join_custom_scan = on;
+SET client_min_messages = 'debug1';
+-- =====================================================================
+-- 1. Unsupported operator (textcat `||`) → [OpExpr] log
+-- =====================================================================
+-- `translate_op_expr` doesn't know the `||` operator. It logs
+--   DEBUG: PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | ...
+-- Also emits
+--   DEBUG: PredicateTranslator: unsupported const type [Const] type=text
+-- for the `'_x'` string literal that `translate_const` doesn't support.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern || '_x' = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | T_OpExpr
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: unsupported const type [Const] type=text
+DEBUG:  PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | T_OpExpr
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CAST(pdb_eval_expr_opexpr_927de030(CAST(e_1.pattern AS Utf8)) AS Utf8View)@1)], projection=[ctid_0@0], fetch=5
+           :     VisibilityFilterExec: tables=[i]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     ProjectionExec: expr=[pattern@0 as pattern, CAST(pdb_eval_expr_opexpr_927de030(CAST(pattern@0 AS Utf8)) AS Utf8View) as CAST(pdb_eval_expr_opexpr_927de030(CAST(e_1.pattern AS Utf8)) AS Utf8View)]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- =====================================================================
+-- 2. Unknown function → [FuncExpr] no native mapping
+-- =====================================================================
+-- `md5` isn't in `translate_known_func`'s pg_catalog map. Expect:
+--   DEBUG: PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | ...
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | T_FuncExpr
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | T_FuncExpr
+                                                                                                       QUERY PLAN                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(e_1.pattern AS Utf8)) AS Utf8View)@1)], projection=[ctid_0@0], fetch=5
+           :     VisibilityFilterExec: tables=[i]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     ProjectionExec: expr=[pattern@0 as pattern, CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) AS Utf8View) as CAST(pdb_eval_expr_funcexpr_685b54ea(CAST(e_1.pattern AS Utf8)) AS Utf8View)]
+           :       CooperativeExec
+           :         PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- =====================================================================
+-- 3. Cross-type cast → [CoerceViaIO] rejected + deparsed SQL in log
+-- =====================================================================
+-- `CAST(i.value AS text)` is a CoerceViaIO from int4 → text. The
+-- translator only allows coercions inside the text family (TEXT ↔
+-- VARCHAR ↔ NAME); int → text is rejected. Because the inner node is
+-- a simple Var reference, `deparse_expression` succeeds here and the
+-- log line includes the actual SQL (e.g. `(i.value)::text`) after the
+-- `|` separator — unlike the first two cases whose cross-RTE shape
+-- forces the helper to fall back to the node-tag label.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CAST(i.value AS text) = e.pattern
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+DEBUG:  PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source=integer, target=text | (i.value)::text
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+DEBUG:  PredicateTranslator: rejected cross-type coercion [CoerceViaIO] source=integer, target=text | (i.value)::text
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(CAST(pdb_eval_expr_coerceviaio_66583d6c(i_0.value) AS Utf8View)@2, pattern@0)], projection=[ctid_0@0, value@1], fetch=5
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, value@1 as value, CAST(pdb_eval_expr_coerceviaio_66583d6c(value@1) AS Utf8View) as CAST(pdb_eval_expr_coerceviaio_66583d6c(i_0.value) AS Utf8View)]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     CooperativeExec
+           :       PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(13 rows)
+
+-- Cleanup
+RESET client_min_messages;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE et_items CASCADE;
+DROP TABLE et_exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -79,7 +79,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -154,7 +154,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -232,7 +232,7 @@ ORDER BY p.name
                              : ProjectionExec: expr=[col_1@0 as col_1, col_3@1 as col_2, col_3@1 as col_3, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
                              :   SortExec: TopK(fetch=10), expr=[col_3@1 ASC NULLS LAST], preserve_partitioning=[false]
                              :     ProjectionExec: expr=[col_1@0 as col_1, col_3@2 as col_3, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1]
-                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
+                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2bf9cc85(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
                              :         VisibilityFilterExec: tables=[s, p]
                              :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4, id@5]
                              :             CooperativeExec
@@ -305,7 +305,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -380,7 +380,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2f11ec81(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -455,7 +455,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -531,7 +531,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) IS NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1
                              :       VisibilityFilterExec: tables=[s, p]
@@ -580,7 +580,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -653,7 +653,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -727,7 +727,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_35992028(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -799,7 +799,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_0(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_7319219f(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -870,7 +870,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[upper(name@1) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -943,7 +943,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_0(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6fc1ff46(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -995,6 +995,83 @@ ORDER BY p.name
 
 SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
+-- TEST 8b: CaseExpr — DISTINCT CASE WHEN col IS NOT NULL THEN col ELSE 'N/A' END
+-- =============================================================================
+-- Exercises the translator's CaseExpr path. EXPLAIN should show
+-- `CASE WHEN ... END` in the DataFusion plan, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: p.name, (CASE WHEN (s.name IS NOT NULL) THEN s.name ELSE 'N/A'::text END)
+               ->  Result
+                     ->  Custom Scan (ParadeDB Join Scan)
+                           Relation Tree: s INNER p
+                           Join Cond: p.supplier_id = s.id
+                           Limit: 10
+                           Distinct: true
+                           Order By: p.name asc
+                           DataFusion Physical Plan: 
+                             : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   TantivyLookupExec: decode=[name]
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
+
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+ supplier_or_default |      name       
+---------------------+-----------------
+ TechCorp            | 
+ TechCorp            | Headphones
+ TechCorp            | Keyboard
+ N/A                 | USB Cable
+ TechCorp            | WIRELESS ROUTER
+ TechCorp            | Wireless Mouse
+ N/A                 | tablet
+ FastParts           | 
+ N/A                 | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+ supplier_or_default |      name       
+---------------------+-----------------
+ TechCorp            | 
+ TechCorp            | Headphones
+ TechCorp            | Keyboard
+ N/A                 | USB Cable
+ TechCorp            | WIRELESS ROUTER
+ TechCorp            | Wireless Mouse
+ N/A                 | tablet
+ FastParts           | 
+ N/A                 | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
 -- TEST 9: Unsupported result type — graceful fallback to native PG
 -- =============================================================================
 -- to_jsonb returns JSONB which is not in is_arrow_convertible.
@@ -1052,6 +1129,85 @@ WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast
 (9 rows)
 
 -- No crash, no error, correct results via native PG.
+-- =============================================================================
+-- TEST 10: Mixed native + PgExprUdf in a single DISTINCT expression
+-- =============================================================================
+-- Outer `upper()` is in the pg_catalog native map; inner `md5()` isn't, so
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show
+-- `upper(pdb_eval_expr_funcexpr_*(...))` in the AggregateExec gby list —
+-- both native and UDF paths exercised in one projection.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+                                                                                                             QUERY PLAN                                                                                                              
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Sort
+               Sort Key: p.name, (upper(md5(s.name)))
+               ->  Result
+                     ->  Custom Scan (ParadeDB Join Scan)
+                           Relation Tree: s INNER p
+                           Join Cond: p.supplier_id = s.id
+                           Limit: 10
+                           Distinct: true
+                           Order By: p.name asc
+                           DataFusion Physical Plan: 
+                             : AggregateExec: mode=Single, gby=[upper(pdb_eval_expr_funcexpr_685b54ea(CAST(name@1 AS Utf8))) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   TantivyLookupExec: decode=[name]
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :       VisibilityFilterExec: tables=[s, p]
+                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :           CooperativeExec
+                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(21 rows)
+
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+            mixed_key             |      name       
+----------------------------------+-----------------
+ D9CE5A9B751D2E18071CC135E51C524B | 
+ D9CE5A9B751D2E18071CC135E51C524B | Headphones
+ D9CE5A9B751D2E18071CC135E51C524B | Keyboard
+                                  | USB Cable
+ D9CE5A9B751D2E18071CC135E51C524B | WIRELESS ROUTER
+ D9CE5A9B751D2E18071CC135E51C524B | Wireless Mouse
+                                  | tablet
+ 9818B8B1AAC79FB78ABE7B48D8ECC003 | 
+                                  | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+            mixed_key             |      name       
+----------------------------------+-----------------
+ D9CE5A9B751D2E18071CC135E51C524B | 
+ D9CE5A9B751D2E18071CC135E51C524B | Headphones
+ D9CE5A9B751D2E18071CC135E51C524B | Keyboard
+                                  | USB Cable
+ D9CE5A9B751D2E18071CC135E51C524B | WIRELESS ROUTER
+ D9CE5A9B751D2E18071CC135E51C524B | Wireless Mouse
+                                  | tablet
+ 9818B8B1AAC79FB78ABE7B48D8ECC003 | 
+                                  | 
+(9 rows)
+
+SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================
 -- CLEANUP
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -232,7 +232,7 @@ ORDER BY p.name
                              : ProjectionExec: expr=[col_1@0 as col_1, col_3@1 as col_2, col_3@1 as col_3, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
                              :   SortExec: TopK(fetch=10), expr=[col_3@1 ASC NULLS LAST], preserve_partitioning=[false]
                              :     ProjectionExec: expr=[col_1@0 as col_1, col_3@2 as col_3, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1]
-                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2bf9cc85(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
+                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2f6d3740(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
                              :         VisibilityFilterExec: tables=[s, p]
                              :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4, id@5]
                              :             CooperativeExec
@@ -380,7 +380,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2f11ec81(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]
@@ -727,7 +727,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_35992028(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_fa6e6477(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -799,7 +799,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_7319219f(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_c51d93e9(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -943,7 +943,7 @@ ORDER BY p.name
                            Distinct: true
                            Order By: p.name asc
                            DataFusion Physical Plan: 
-                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6fc1ff46(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
                              :       VisibilityFilterExec: tables=[s, p]

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -232,7 +232,7 @@ ORDER BY p.name
                              : ProjectionExec: expr=[col_1@0 as col_1, col_3@1 as col_2, col_3@1 as col_3, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
                              :   SortExec: TopK(fetch=10), expr=[col_3@1 ASC NULLS LAST], preserve_partitioning=[false]
                              :     ProjectionExec: expr=[col_1@0 as col_1, col_3@2 as col_3, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1]
-                             :       AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_2f6d3740(supplier_id@2, id@4) as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
+                             :       AggregateExec: mode=Single, gby=[supplier_id@2 * 10 + id@4 as col_1, name@3 as col_2, name@3 as col_3], aggr=[ctid_0, ctid_1]
                              :         VisibilityFilterExec: tables=[s, p]
                              :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4, id@5]
                              :             CooperativeExec
@@ -727,7 +727,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_fa6e6477(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_f1ebe528(supplier_id@2) * 100 as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec
@@ -799,7 +799,7 @@ ORDER BY p.name
                            Order By: p.name asc
                            DataFusion Physical Plan: 
                              : SortExec: TopK(fetch=10), expr=[col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_c51d93e9(supplier_id@2) as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
+                             :   AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_eb551b6f(supplier_id@2) / 3 as col_1, name@3 as col_2], aggr=[ctid_0, ctid_1]
                              :     VisibilityFilterExec: tables=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, supplier_id@3, name@4]
                              :         CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -825,6 +825,142 @@ WARNING:  JoinScan not used: failed to extract join-level conditions (ensure all
 (17 rows)
 
 -- =============================================================================
+-- TEST 12: Functions in cross-table predicates (native DF + UDF fallback)
+-- =============================================================================
+-- Exercise PredicateTranslator's FuncExpr + arithmetic-OpExpr paths inside a
+-- multi-table predicate. Both sides' columns are fast fields, so JoinScan
+-- should absorb these and the EXPLAIN should show `abs(...)` natively while
+-- the arithmetic OpExpr (`-`) gets wrapped as `pdb_eval_expr_opexpr_*` via
+-- `try_wrap_as_udf`.
+-- 12a: abs() wrapping a cross-table arithmetic OpExpr
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.supplier_id, s.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.supplier_id, s.id
+         Relation Tree: s INNER p
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: heap:{OPEXPR :opno 525 :opfuncid 150 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({OPEXPR :opno 555 :opfuncid 181 :opresulttype 23 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1} {VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1}) :location -1}) :location -1} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location -1 :constvalue 4 [ 0 0 0 0 0 0 0 0 ]}) :location -1}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@4 as col_1, supplier_id@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[s, p]
+           :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(pdb_eval_expr_opexpr_1d849f2b(supplier_id@1, id@0)) >= 0
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped arithmetic
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var;
+-- RHS `(s.id * 2)` is an arithmetic OpExpr that `translate_op_expr`
+-- doesn't handle, so it gets wrapped as `pdb_eval_expr_opexpr_*`. The outer
+-- `<=` comparison stays native. EXPLAIN should show BOTH paths side by side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.supplier_id, s.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.supplier_id, s.id
+         Relation Tree: s INNER p
+         Join Cond: p.supplier_id = s.id
+         Join Predicate: heap:{OPEXPR :opno 523 :opfuncid 149 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1}) :location -1} {OPEXPR :opno 514 :opfuncid 141 :opresulttype 23 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location -1 :constvalue 4 [ 2 0 0 0 0 0 0 0 ]}) :location -1}) :location -1}
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@4 as col_1, supplier_id@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[s, p]
+           :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= CAST(pdb_eval_expr_opexpr_75520593(id@0) AS Int64)
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+ id  | supplier_id | supplier_pk 
+-----+-------------+-------------
+ 201 |         151 |         151
+ 206 |         151 |         151
+ 207 |         152 |         152
+(3 rows)
+
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 DROP TABLE IF EXISTS products CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -857,7 +857,7 @@ LIMIT 10;
            :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
            :     VisibilityFilterExec: tables=[s, p]
            :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(pdb_eval_expr_opexpr_1d849f2b(supplier_id@1, id@0)) >= 0
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1 - id@0) >= 0
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
@@ -923,7 +923,7 @@ LIMIT 10;
            :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
            :     VisibilityFilterExec: tables=[s, p]
            :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= CAST(pdb_eval_expr_opexpr_75520593(id@0) AS Int64)
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= id@0 * 2
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -894,28 +894,32 @@ LIMIT 10;
 (3 rows)
 
 SET paradedb.enable_join_custom_scan = on;
--- 12b: native FuncExpr on one side of a comparison, UDF-wrapped arithmetic
--- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var;
--- RHS `(s.id * 2)` is an arithmetic OpExpr that `translate_op_expr`
--- doesn't handle, so it gets wrapped as `pdb_eval_expr_opexpr_*`. The outer
--- `<=` comparison stays native. EXPLAIN should show BOTH paths side by side.
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped FuncExpr
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var.
+-- RHS `length(to_hex(s.id))` nests two FuncExprs: `to_hex` is a pg_catalog
+-- function that is NOT in `translate_known_func`'s native map, so it falls
+-- through to `try_wrap_as_udf` and becomes `pdb_eval_expr_funcexpr_*`. The
+-- outer `length` (→ `character_length`) IS native and wraps the UDF. The
+-- outer `<=` comparison stays native. EXPLAIN should show native
+-- `abs(supplier_id)` and native `character_length(pdb_eval_expr_funcexpr_*(id))`
+-- side by side.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
-                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.supplier_id, s.id
    ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.supplier_id, s.id
          Relation Tree: s INNER p
          Join Cond: p.supplier_id = s.id
-         Join Predicate: heap:{OPEXPR :opno 523 :opfuncid 149 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1}) :location -1} {OPEXPR :opno 514 :opfuncid 141 :opresulttype 23 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location -1 :constvalue 4 [ 2 0 0 0 0 0 0 0 ]}) :location -1}) :location -1}
+         Join Predicate: heap:{OPEXPR :opno 523 :opfuncid 149 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({FUNCEXPR :funcid 1397 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 4 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 1 :varattnosyn 4 :location -1}) :location -1} {FUNCEXPR :funcid 1317 :funcresulttype 23 :funcretset false :funcvariadic false :funcformat 0 :funccollid 0 :inputcollid 100 :args ({FUNCEXPR :funcid 2089 :funcresulttype 25 :funcretset false :funcvariadic false :funcformat 0 :funccollid 100 :inputcollid 0 :args ({VAR :varno 2 :varattno 1 :vartype 23 :vartypmod -1 :varcollid 0 :varnullingrels (b) :varlevelsup 0 :varreturningtype 0 :varnosyn 2 :varattnosyn 1 :location -1}) :location -1}) :location -1}) :location -1}
          Limit: 10
          Order By: p.id asc
          DataFusion Physical Plan: 
@@ -923,7 +927,7 @@ LIMIT 10;
            :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
            :     VisibilityFilterExec: tables=[s, p]
            :       ProjectionExec: expr=[ctid_0@3 as ctid_0, id@4 as id, ctid_1@0 as ctid_1, supplier_id@1 as supplier_id, id@2 as id]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= id@0 * 2
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(supplier_id@1, id@1)], filter=abs(supplier_id@1) <= CAST(character_length(pdb_eval_expr_funcexpr_34e97bf1(id@0)) AS Int64)
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
@@ -934,30 +938,24 @@ SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
- id  | supplier_id | supplier_pk 
------+-------------+-------------
- 201 |         151 |         151
- 206 |         151 |         151
- 207 |         152 |         152
-(3 rows)
+ id | supplier_id | supplier_pk 
+----+-------------+-------------
+(0 rows)
 
 SET paradedb.enable_join_custom_scan = off;
 SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
- id  | supplier_id | supplier_pk 
------+-------------+-------------
- 201 |         151 |         151
- 206 |         151 |         151
- 207 |         152 |         152
-(3 rows)
+ id | supplier_id | supplier_pk 
+----+-------------+-------------
+(0 rows)
 
 SET paradedb.enable_join_custom_scan = on;
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -263,11 +263,12 @@ LIMIT 10;
 
 SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
--- 5. Non-translatable arm: graceful fallback to PG native
+-- 5. Generic function in disjunctive filter: native DataFusion evaluation
 -- =====================================================================
--- A disjunction where one arm uses a function call (length()) that the
--- PredicateTranslator cannot handle. JoinScan should decline and PG's
--- native Nested Loop Anti Join should run — results must still be correct.
+-- A disjunction where one arm uses a pg_catalog function (length()).
+-- PredicateTranslator maps it to DataFusion's native character_length(),
+-- allowing JoinScan to absorb the full expression. The EXPLAIN should
+-- show character_length(...) in the physical plan, not a PgExprUdf.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -279,31 +280,25 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: i.id DESC
-         ->  Nested Loop Anti Join
-               Join Filter: ((e.pattern = i.name) OR (length(e.pattern) > 100))
-               ->  Custom Scan (ParadeDB Base Scan) on items i
-                     Table: items
-                     Index: items_idx
-                     Exec Method: ColumnarExecState
-                     Fast Fields: id, name
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-               ->  Materialize
-                     ->  Custom Scan (ParadeDB Base Scan) on exclusions e
-                           Table: exclusions
-                           Index: exclusions_idx
-                           Exec Method: ColumnarExecState
-                           Fast Fields: pattern
-                           Scores: false
-                           Full Index Scan: true
-                           Tantivy Query: {"with_index":{"query":"all"}}
-(21 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@1 = name@0 OR join_proj_push_down_1@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, character_length(pattern@0) > 100 as join_proj_push_down_1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
 
 SELECT i.id
 FROM items i
@@ -315,7 +310,6 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: e, i)
  id  
 -----
  500

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -922,6 +922,702 @@ LIMIT 10;
 SET paradedb.enable_join_custom_scan TO on;
 DROP TABLE items_vc CASCADE;
 DROP TABLE exclusions_vc CASCADE;
+-- =====================================================================
+-- 13. upper() in EXISTS semi-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `upper(...)` in the physical plan and JoinScan
+-- should absorb the whole semi-join (no "JoinScan not used" warning).
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i SEMI e
+         Limit: 5
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(upper(i_0.name)@3, upper(e_1.pattern)@1)], projection=[ctid_0@0, id@2]
+           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as upper(i_0.name)]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as upper(e_1.pattern)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+ id 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+ id 
+----
+ 10
+ 20
+ 30
+ 40
+ 50
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 14. COALESCE() in NOT EXISTS anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `coalesce(...)` natively, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END@1)], projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, CASE WHEN pattern@0 IS NOT NULL THEN pattern@0 ELSE  END as CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 15. IS NULL arm in disjunctive anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `IS NULL` natively and JoinScan should absorb the
+-- disjunction.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=pattern@1 = name@0 OR join_proj_push_down_1@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, pattern@0 IS NULL as join_proj_push_down_1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 16. CASE WHEN in anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `CASE WHEN ... END` natively, not a PgExprUdf.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(name@1, CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END@1)], projection=[ctid_0@0, id@2]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[pattern@0 as pattern, CASE WHEN pattern@0 IS NOT NULL THEN pattern@0 ELSE  END as CASE WHEN e_1.pattern IS NOT NULL THEN e_1.pattern ELSE Utf8View("") END]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 17. Arithmetic OpExpr (`*`) → UDF fallback
+-- =====================================================================
+-- `translate_op_expr` doesn't handle arithmetic; `allow_udf_fallback`
+-- should wrap the `e.id * 2` subtree in a PgExprUdf so JoinScan still
+-- absorbs the anti-join. EXPLAIN should contain `pdb_eval_expr_opexpr_*`.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_1@1 > id@0, projection=[ctid_0@0, id@1]
+           :       VisibilityFilterExec: tables=[i]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[id@0 as id, pdb_eval_expr_opexpr_bd77129f(id@0) as join_proj_push_down_1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(15 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 18. Mixed native + UDF in one disjunction
+-- =====================================================================
+-- `upper()` is in the pg_catalog map → native; `md5()` is not →
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show `upper`
+-- on one arm and `pdb_eval_expr_funcexpr_*` on the other.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                           QUERY PLAN                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_1@1 = name@0 OR join_proj_push_down_2@2, projection=[ctid_0@0, name@1, id@2]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, CAST(upper(pattern@0) AS Utf8View) as join_proj_push_down_1, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) = never-matches as join_proj_push_down_2]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
+-- =====================================================================
+-- Cross-table disjunction where `upper` and `character_length`
+-- (via the `length` alias) are both in `translate_known_func`'s
+-- pg_catalog map; operators `=`, `>`, `OR` are native structural.
+-- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 > join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, character_length(name@1) as join_proj_push_down_2]
+           :           VisibilityFilterExec: tables=[i]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, character_length(pattern@0) as join_proj_push_down_4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
+-- =====================================================================
+-- Cross-table disjunction: `upper()` maps natively; modulo `%` is an
+-- OpExpr that `translate_op_expr` doesn't handle, so `(e.id % 2)` gets
+-- wrapped as a PgExprUdf. The disjunction spans both tables so the
+-- whole tree is absorbed at the join-level (not pushed down as a
+-- single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_opexpr_*` in the same plan.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_2@2 = join_proj_push_down_1@1 OR join_proj_push_down_3@3 = id@0, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1]
+           :           VisibilityFilterExec: tables=[i]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :         ProjectionExec: expr=[pattern@0 as pattern, id@1 as id, upper(pattern@0) as join_proj_push_down_2, pdb_eval_expr_opexpr_ef78363a(id@1) as join_proj_push_down_3]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(17 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- =====================================================================
+-- 21. Tier 3 — PURE PgExprUdf: every function/arithmetic → UDF
+-- =====================================================================
+-- `md5` isn't in the pg_catalog map; `*` and `+` aren't in
+-- `translate_op_expr`. The top-level `=`, `<>`, `AND` are native
+-- structural combinators, but every function- or arithmetic-producing
+-- subtree is wrapped. EXPLAIN should contain only `pdb_eval_expr_*`
+-- UDFs (both `funcexpr_*` for md5 and `opexpr_*` for the arithmetic),
+-- and NO native pg_catalog scalar function names.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+                                                                                                                                       QUERY PLAN                                                                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: i ANTI e
+         Limit: 5
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(pdb_eval_expr_funcexpr_887b5ea5(i_0.name)@3, pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)@2)], filter=pdb_eval_expr_opexpr_bd77129f(id@1) != pdb_eval_expr_opexpr_1d725e73(id@0), projection=[ctid_0@0, id@1]
+           :       ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, name@2 as name, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@2 AS Utf8)) as pdb_eval_expr_funcexpr_887b5ea5(i_0.name)]
+           :         VisibilityFilterExec: tables=[i]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :       ProjectionExec: expr=[id@0 as id, pattern@1 as pattern, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@1 AS Utf8)) as pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(16 rows)
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+ id  
+-----
+ 500
+ 498
+ 496
+ 494
+ 492
+(5 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -1223,11 +1223,11 @@ LIMIT 5;
 
 SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
--- 17. Arithmetic OpExpr (`*`) → UDF fallback
+-- 17. Arithmetic OpExpr (`*`) maps natively
 -- =====================================================================
--- `translate_op_expr` doesn't handle arithmetic; `allow_udf_fallback`
--- should wrap the `e.id * 2` subtree in a PgExprUdf so JoinScan still
--- absorbs the anti-join. EXPLAIN should contain `pdb_eval_expr_opexpr_*`.
+-- `translate_op_expr` now handles `+`, `-`, `*`, `/`, `%` — the `(e.id * 2)`
+-- subtree maps directly to `Operator::Multiply`. EXPLAIN should contain a
+-- native multiplication (e.g. `id * 2`) and NO `pdb_eval_expr_opexpr_*`.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -1253,7 +1253,7 @@ LIMIT 5;
            :       VisibilityFilterExec: tables=[i]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :       ProjectionExec: expr=[id@0 as id, pdb_eval_expr_opexpr_bd77129f(id@0) as join_proj_push_down_1]
+           :       ProjectionExec: expr=[id@0 as id, id@0 * 2 as join_proj_push_down_1]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (15 rows)
@@ -1457,25 +1457,24 @@ SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
 -- =====================================================================
--- Cross-table disjunction: `upper()` maps natively; modulo `%` is an
--- OpExpr that `translate_op_expr` doesn't handle, so `(e.id % 2)` gets
--- wrapped as a PgExprUdf. The disjunction spans both tables so the
--- whole tree is absorbed at the join-level (not pushed down as a
--- single-table heap filter). EXPLAIN should contain BOTH native
--- `upper(...)` AND `pdb_eval_expr_opexpr_*` in the same plan.
+-- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
+-- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
+-- both tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-                                                                                             QUERY PLAN                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: i ANTI e
@@ -1485,12 +1484,12 @@ LIMIT 5;
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
            :     ProjectionExec: expr=[ctid_0@0 as ctid_0, id@2 as id]
-           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_2@2 = join_proj_push_down_1@1 OR join_proj_push_down_3@3 = id@0, projection=[ctid_0@0, name@1, id@2]
-           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1]
+           :       NestedLoopJoinExec: join_type=LeftAnti, filter=join_proj_push_down_3@2 = join_proj_push_down_1@0 OR join_proj_push_down_4@3 = join_proj_push_down_2@1, projection=[ctid_0@0, name@1, id@2]
+           :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, upper(name@1) as join_proj_push_down_1, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@1 AS Utf8)) as join_proj_push_down_2]
            :           VisibilityFilterExec: tables=[i]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
-           :         ProjectionExec: expr=[pattern@0 as pattern, id@1 as id, upper(pattern@0) as join_proj_push_down_2, pdb_eval_expr_opexpr_ef78363a(id@1) as join_proj_push_down_3]
+           :         ProjectionExec: expr=[pattern@0 as pattern, upper(pattern@0) as join_proj_push_down_3, pdb_eval_expr_funcexpr_685b54ea(CAST(pattern@0 AS Utf8)) as join_proj_push_down_4]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
 (17 rows)
@@ -1500,7 +1499,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -1520,7 +1519,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -1536,14 +1535,13 @@ LIMIT 5;
 
 SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
--- 21. Tier 3 — PURE PgExprUdf: every function/arithmetic → UDF
+-- 21. Tier 3 — PURE PgExprUdf: every function → UDF
 -- =====================================================================
--- `md5` isn't in the pg_catalog map; `*` and `+` aren't in
--- `translate_op_expr`. The top-level `=`, `<>`, `AND` are native
--- structural combinators, but every function- or arithmetic-producing
--- subtree is wrapped. EXPLAIN should contain only `pdb_eval_expr_*`
--- UDFs (both `funcexpr_*` for md5 and `opexpr_*` for the arithmetic),
--- and NO native pg_catalog scalar function names.
+-- Neither `md5` nor `to_hex` is in the pg_catalog map, so both FuncExprs
+-- are wrapped by `try_wrap_as_udf`. The top-level `=`, `<>`, `AND` are
+-- native structural combinators, but every function-producing subtree
+-- is UDF-wrapped. EXPLAIN should contain only `pdb_eval_expr_funcexpr_*`
+-- wrappers and NO native pg_catalog scalar function names.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -1551,13 +1549,13 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5;
-                                                                                                                                       QUERY PLAN                                                                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                         QUERY PLAN                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: i ANTI e
@@ -1566,7 +1564,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            :   SortExec: TopK(fetch=5), expr=[id@1 DESC], preserve_partitioning=[false]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(pdb_eval_expr_funcexpr_887b5ea5(i_0.name)@3, pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)@2)], filter=pdb_eval_expr_opexpr_bd77129f(id@1) != pdb_eval_expr_opexpr_1d725e73(id@0), projection=[ctid_0@0, id@1]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(pdb_eval_expr_funcexpr_887b5ea5(i_0.name)@3, pdb_eval_expr_funcexpr_685b54ea(e_1.pattern)@2)], filter=pdb_eval_expr_funcexpr_7e60c530(id@1) != pdb_eval_expr_funcexpr_64208395(id@0), projection=[ctid_0@0, id@1]
            :       ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, name@2 as name, pdb_eval_expr_funcexpr_887b5ea5(CAST(name@2 AS Utf8)) as pdb_eval_expr_funcexpr_887b5ea5(i_0.name)]
            :         VisibilityFilterExec: tables=[i]
            :           CooperativeExec
@@ -1582,7 +1580,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -1603,7 +1601,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC

--- a/pg_search/tests/pg_regress/sql/expr_translator_debug.sql
+++ b/pg_search/tests/pg_regress/sql/expr_translator_debug.sql
@@ -1,0 +1,105 @@
+-- Regression test for `PredicateTranslator` debug1 logging.
+--
+-- Every failed translation path emits a structured `pgrx::debug1!` line of
+-- the form:
+--
+--     DEBUG: PredicateTranslator: <reason> [<NodeTag>] <key=value pairs> | <deparsed SQL>
+--
+-- This test raises `client_min_messages` to `debug1` and runs EXPLAIN on
+-- queries crafted to trip specific translator rejection points, verifying
+-- the expected log lines appear in order.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS et_items CASCADE;
+DROP TABLE IF EXISTS et_exclusions CASCADE;
+
+CREATE TABLE et_items (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    value INT NOT NULL
+);
+CREATE TABLE et_exclusions (
+    id SERIAL PRIMARY KEY,
+    pattern TEXT
+);
+INSERT INTO et_items (name, value) VALUES
+    ('alpha', 10), ('beta', 20);
+INSERT INTO et_exclusions (pattern) VALUES
+    ('alpha'), ('beta');
+
+CREATE INDEX et_items_idx ON et_items
+    USING bm25 (id, name, value)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"name":{"fast":true}}',
+        numeric_fields = '{"value":{"fast":true}}'
+    );
+CREATE INDEX et_exclusions_idx ON et_exclusions
+    USING bm25 (id, pattern)
+    WITH (
+        key_field = 'id',
+        text_fields = '{"pattern":{"fast":true}}'
+    );
+
+SET paradedb.enable_join_custom_scan = on;
+SET client_min_messages = 'debug1';
+
+-- =====================================================================
+-- 1. Unsupported operator (textcat `||`) → [OpExpr] log
+-- =====================================================================
+-- `translate_op_expr` doesn't know the `||` operator. It logs
+--   DEBUG: PredicateTranslator: unsupported operator [OpExpr] op="||", types=(text, text) | ...
+-- Also emits
+--   DEBUG: PredicateTranslator: unsupported const type [Const] type=text
+-- for the `'_x'` string literal that `translate_const` doesn't support.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND e.pattern || '_x' = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- =====================================================================
+-- 2. Unknown function → [FuncExpr] no native mapping
+-- =====================================================================
+-- `md5` isn't in `translate_known_func`'s pg_catalog map. Expect:
+--   DEBUG: PredicateTranslator: no native mapping [FuncExpr] func=pg_catalog.md5, arity=1 | ...
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = i.name
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- =====================================================================
+-- 3. Cross-type cast → [CoerceViaIO] rejected + deparsed SQL in log
+-- =====================================================================
+-- `CAST(i.value AS text)` is a CoerceViaIO from int4 → text. The
+-- translator only allows coercions inside the text family (TEXT ↔
+-- VARCHAR ↔ NAME); int → text is rejected. Because the inner node is
+-- a simple Var reference, `deparse_expression` succeeds here and the
+-- log line includes the actual SQL (e.g. `(i.value)::text`) after the
+-- `|` separator — unlike the first two cases whose cross-RTE shape
+-- forces the helper to fall back to the node-tag label.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id FROM et_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM et_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CAST(i.value AS text) = e.pattern
+)
+AND i.id @@@ paradedb.all()
+LIMIT 5;
+
+-- Cleanup
+RESET client_min_messages;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE et_items CASCADE;
+DROP TABLE et_exclusions CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_distinct_expr.sql
+++ b/pg_search/tests/pg_regress/sql/join_distinct_expr.sql
@@ -412,6 +412,36 @@ ORDER BY p.name
 SET paradedb.enable_join_custom_scan = on;
 
 -- =============================================================================
+-- TEST 8b: CaseExpr — DISTINCT CASE WHEN col IS NOT NULL THEN col ELSE 'N/A' END
+-- =============================================================================
+-- Exercises the translator's CaseExpr path. EXPLAIN should show
+-- `CASE WHEN ... END` in the DataFusion plan, not a PgExprUdf wrapper.
+
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
 -- TEST 9: Unsupported result type — graceful fallback to native PG
 -- =============================================================================
 -- to_jsonb returns JSONB which is not in is_arrow_convertible.
@@ -435,6 +465,37 @@ ORDER BY p.name
     LIMIT 10;
 
 -- No crash, no error, correct results via native PG.
+
+-- =============================================================================
+-- TEST 10: Mixed native + PgExprUdf in a single DISTINCT expression
+-- =============================================================================
+-- Outer `upper()` is in the pg_catalog native map; inner `md5()` isn't, so
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show
+-- `upper(pdb_eval_expr_funcexpr_*(...))` in the AggregateExec gby list —
+-- both native and UDF paths exercised in one projection.
+EXPLAIN (COSTS OFF)
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
+FROM dex_products p
+         JOIN dex_suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
+ORDER BY p.name
+    LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
 
 -- =============================================================================
 -- CLEANUP

--- a/pg_search/tests/pg_regress/sql/join_predicates.sql
+++ b/pg_search/tests/pg_regress/sql/join_predicates.sql
@@ -472,6 +472,75 @@ WHERE p.description @@@ 'wireless'
 LIMIT 10;
 
 -- =============================================================================
+-- TEST 12: Functions in cross-table predicates (native DF + UDF fallback)
+-- =============================================================================
+-- Exercise PredicateTranslator's FuncExpr + arithmetic-OpExpr paths inside a
+-- multi-table predicate. Both sides' columns are fast fields, so JoinScan
+-- should absorb these and the EXPLAIN should show `abs(...)` natively while
+-- the arithmetic OpExpr (`-`) gets wrapped as `pdb_eval_expr_opexpr_*` via
+-- `try_wrap_as_udf`.
+
+-- 12a: abs() wrapping a cross-table arithmetic OpExpr
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id - s.id) >= 0
+ORDER BY p.id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped arithmetic
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var;
+-- RHS `(s.id * 2)` is an arithmetic OpExpr that `translate_op_expr`
+-- doesn't handle, so it gets wrapped as `pdb_eval_expr_opexpr_*`. The outer
+-- `<=` comparison stays native. EXPLAIN should show BOTH paths side by side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+
+SET paradedb.enable_join_custom_scan = off;
+SELECT p.id, p.supplier_id, s.id AS supplier_pk
+FROM products p
+JOIN suppliers s ON p.supplier_id = s.id
+WHERE p.description @@@ 'wireless'
+  AND abs(p.supplier_id) <= (s.id * 2)
+ORDER BY p.id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 

--- a/pg_search/tests/pg_regress/sql/join_predicates.sql
+++ b/pg_search/tests/pg_regress/sql/join_predicates.sql
@@ -508,17 +508,21 @@ ORDER BY p.id
 LIMIT 10;
 SET paradedb.enable_join_custom_scan = on;
 
--- 12b: native FuncExpr on one side of a comparison, UDF-wrapped arithmetic
--- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var;
--- RHS `(s.id * 2)` is an arithmetic OpExpr that `translate_op_expr`
--- doesn't handle, so it gets wrapped as `pdb_eval_expr_opexpr_*`. The outer
--- `<=` comparison stays native. EXPLAIN should show BOTH paths side by side.
+-- 12b: native FuncExpr on one side of a comparison, UDF-wrapped FuncExpr
+-- on the other. LHS `abs(p.supplier_id)` is a native FuncExpr over a Var.
+-- RHS `length(to_hex(s.id))` nests two FuncExprs: `to_hex` is a pg_catalog
+-- function that is NOT in `translate_known_func`'s native map, so it falls
+-- through to `try_wrap_as_udf` and becomes `pdb_eval_expr_funcexpr_*`. The
+-- outer `length` (→ `character_length`) IS native and wraps the UDF. The
+-- outer `<=` comparison stays native. EXPLAIN should show native
+-- `abs(supplier_id)` and native `character_length(pdb_eval_expr_funcexpr_*(id))`
+-- side by side.
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
 
@@ -526,7 +530,7 @@ SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
 
@@ -535,7 +539,7 @@ SELECT p.id, p.supplier_id, s.id AS supplier_pk
 FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
-  AND abs(p.supplier_id) <= (s.id * 2)
+  AND abs(p.supplier_id) <= length(to_hex(s.id))
 ORDER BY p.id
 LIMIT 10;
 SET paradedb.enable_join_custom_scan = on;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -706,11 +706,11 @@ LIMIT 5;
 SET paradedb.enable_join_custom_scan TO on;
 
 -- =====================================================================
--- 17. Arithmetic OpExpr (`*`) → UDF fallback
+-- 17. Arithmetic OpExpr (`*`) maps natively
 -- =====================================================================
--- `translate_op_expr` doesn't handle arithmetic; `allow_udf_fallback`
--- should wrap the `e.id * 2` subtree in a PgExprUdf so JoinScan still
--- absorbs the anti-join. EXPLAIN should contain `pdb_eval_expr_opexpr_*`.
+-- `translate_op_expr` now handles `+`, `-`, `*`, `/`, `%` — the `(e.id * 2)`
+-- subtree maps directly to `Operator::Multiply`. EXPLAIN should contain a
+-- native multiplication (e.g. `id * 2`) and NO `pdb_eval_expr_opexpr_*`.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -835,19 +835,18 @@ SET paradedb.enable_join_custom_scan TO on;
 -- =====================================================================
 -- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
 -- =====================================================================
--- Cross-table disjunction: `upper()` maps natively; modulo `%` is an
--- OpExpr that `translate_op_expr` doesn't handle, so `(e.id % 2)` gets
--- wrapped as a PgExprUdf. The disjunction spans both tables so the
--- whole tree is absorbed at the join-level (not pushed down as a
--- single-table heap filter). EXPLAIN should contain BOTH native
--- `upper(...)` AND `pdb_eval_expr_opexpr_*` in the same plan.
+-- Cross-table disjunction: `upper()` maps natively; `md5()` isn't in the
+-- pg_catalog map so it gets wrapped as a PgExprUdf. The disjunction spans
+-- both tables so the whole tree is absorbed at the join level (not pushed
+-- down as a single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_funcexpr_*` in the same plan.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -858,7 +857,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -870,7 +869,7 @@ FROM items i
 WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
-      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+      AND (upper(e.pattern) = upper(i.name) OR md5(e.pattern) = md5(i.name))
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -878,14 +877,13 @@ LIMIT 5;
 SET paradedb.enable_join_custom_scan TO on;
 
 -- =====================================================================
--- 21. Tier 3 — PURE PgExprUdf: every function/arithmetic → UDF
+-- 21. Tier 3 — PURE PgExprUdf: every function → UDF
 -- =====================================================================
--- `md5` isn't in the pg_catalog map; `*` and `+` aren't in
--- `translate_op_expr`. The top-level `=`, `<>`, `AND` are native
--- structural combinators, but every function- or arithmetic-producing
--- subtree is wrapped. EXPLAIN should contain only `pdb_eval_expr_*`
--- UDFs (both `funcexpr_*` for md5 and `opexpr_*` for the arithmetic),
--- and NO native pg_catalog scalar function names.
+-- Neither `md5` nor `to_hex` is in the pg_catalog map, so both FuncExprs
+-- are wrapped by `try_wrap_as_udf`. The top-level `=`, `<>`, `AND` are
+-- native structural combinators, but every function-producing subtree
+-- is UDF-wrapped. EXPLAIN should contain only `pdb_eval_expr_funcexpr_*`
+-- wrappers and NO native pg_catalog scalar function names.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i
@@ -893,7 +891,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -905,7 +903,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
@@ -918,7 +916,7 @@ WHERE NOT EXISTS (
     SELECT 1 FROM exclusions e
     WHERE e.id @@@ paradedb.all()
       AND md5(e.pattern) = md5(i.name)
-      AND (e.id * 2) <> (i.id + 1)
+      AND to_hex(e.id) <> to_hex(i.id)
 )
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -543,6 +543,388 @@ SET paradedb.enable_join_custom_scan TO on;
 DROP TABLE items_vc CASCADE;
 DROP TABLE exclusions_vc CASCADE;
 
+-- =====================================================================
+-- 13. upper() in EXISTS semi-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `upper(...)` in the physical plan and JoinScan
+-- should absorb the whole semi-join (no "JoinScan not used" warning).
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND upper(e.pattern) = upper(i.name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 14. COALESCE() in NOT EXISTS anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `coalesce(...)` natively, not a PgExprUdf wrapper.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND COALESCE(e.pattern, '') = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 15. IS NULL arm in disjunctive anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `IS NULL` natively and JoinScan should absorb the
+-- disjunction.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern IS NULL)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 16. CASE WHEN in anti-join filter (native DataFusion)
+-- =====================================================================
+-- EXPLAIN should show `CASE WHEN ... END` natively, not a PgExprUdf.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 17. Arithmetic OpExpr (`*`) → UDF fallback
+-- =====================================================================
+-- `translate_op_expr` doesn't handle arithmetic; `allow_udf_fallback`
+-- should wrap the `e.id * 2` subtree in a PgExprUdf so JoinScan still
+-- absorbs the anti-join. EXPLAIN should contain `pdb_eval_expr_opexpr_*`.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.id * 2) > i.id
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 18. Mixed native + UDF in one disjunction
+-- =====================================================================
+-- `upper()` is in the pg_catalog map → native; `md5()` is not →
+-- `try_wrap_as_udf` wraps the md5 FuncExpr. EXPLAIN should show `upper`
+-- on one arm and `pdb_eval_expr_funcexpr_*` on the other.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = i.name OR md5(e.pattern) = 'never-matches')
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 19. Tier 1 — ALL NATIVE: every function maps to DataFusion
+-- =====================================================================
+-- Cross-table disjunction where `upper` and `character_length`
+-- (via the `length` alias) are both in `translate_known_func`'s
+-- pg_catalog map; operators `=`, `>`, `OR` are native structural.
+-- The EXPLAIN should contain NO `pdb_eval_expr_*` UDFs anywhere.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR length(e.pattern) > length(i.name))
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 20. Tier 2 — MIXED native + PgExprUdf in a single predicate
+-- =====================================================================
+-- Cross-table disjunction: `upper()` maps natively; modulo `%` is an
+-- OpExpr that `translate_op_expr` doesn't handle, so `(e.id % 2)` gets
+-- wrapped as a PgExprUdf. The disjunction spans both tables so the
+-- whole tree is absorbed at the join-level (not pushed down as a
+-- single-table heap filter). EXPLAIN should contain BOTH native
+-- `upper(...)` AND `pdb_eval_expr_opexpr_*` in the same plan.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (upper(e.pattern) = upper(i.name) OR (e.id % 2) = i.id)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- =====================================================================
+-- 21. Tier 3 — PURE PgExprUdf: every function/arithmetic → UDF
+-- =====================================================================
+-- `md5` isn't in the pg_catalog map; `*` and `+` aren't in
+-- `translate_op_expr`. The top-level `=`, `<>`, `AND` are native
+-- structural combinators, but every function- or arithmetic-producing
+-- subtree is wrapped. EXPLAIN should contain only `pdb_eval_expr_*`
+-- UDFs (both `funcexpr_*` for md5 and `opexpr_*` for the arithmetic),
+-- and NO native pg_catalog scalar function names.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+
+SET paradedb.enable_join_custom_scan TO off;
+SELECT i.id
+FROM items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND md5(e.pattern) = md5(i.name)
+      AND (e.id * 2) <> (i.id + 1)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5;
+SET paradedb.enable_join_custom_scan TO on;
+
 -- Cleanup
 DROP TABLE items CASCADE;
 DROP TABLE exclusions CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive.sql
@@ -172,11 +172,12 @@ LIMIT 10;
 SET paradedb.enable_join_custom_scan TO on;
 
 -- =====================================================================
--- 5. Non-translatable arm: graceful fallback to PG native
+-- 5. Generic function in disjunctive filter: native DataFusion evaluation
 -- =====================================================================
--- A disjunction where one arm uses a function call (length()) that the
--- PredicateTranslator cannot handle. JoinScan should decline and PG's
--- native Nested Loop Anti Join should run — results must still be correct.
+-- A disjunction where one arm uses a pg_catalog function (length()).
+-- PredicateTranslator maps it to DataFusion's native character_length(),
+-- allowing JoinScan to absorb the full expression. The EXPLAIN should
+-- show character_length(...) in the physical plan, not a PgExprUdf.
 EXPLAIN (COSTS OFF, TIMING OFF)
 SELECT i.id
 FROM items i


### PR DESCRIPTION
## What

JoinScan now evaluates known `pg_catalog` functions (`upper`, `lower`, `length`, `abs`, `coalesce`, `CASE WHEN`, `IS NULL`, etc.) and arithmetic operators (`+`, `-`, `*`, `/`, `%`) natively inside DataFusion's columnar engine. Expressions with unknown or user-defined functions are automatically wrapped in `PgExprUdf` as a fallback, allowing JoinScan to absorb queries it previously declined entirely.

## Why

Before this change, any expression containing a function call, `IS NULL`, `CASE WHEN`, `COALESCE`, `IN (...)`, or arithmetic caused JoinScan to reject the query. This had two consequences:

**Queries were rejected entirely.** Semi/Anti joins with these expressions in filters fell back to Postgres's native nested loop — losing Tantivy search acceleration for the `@@@` predicates in the same query:

```sql
-- Previously: WARNING: JoinScan not used → Postgres nested loop, no Tantivy
-- Now: JoinScan absorbs it, length() evaluates natively as character_length()
SELECT i.id FROM items i
WHERE NOT EXISTS (
    SELECT 1 FROM exclusions e
    WHERE e.id @@@ 'all'
    AND (e.pattern = i.name OR length(e.pattern) > 100)
)
AND i.id @@@ 'category:"target"'
ORDER BY i.id DESC LIMIT 5;
```

**Unnecessary per-row overhead.** DISTINCT/ORDER BY expressions like `upper(name)` were unconditionally wrapped in `PgExprUdf`, crossing the PG↔Rust boundary via `ExecEvalExpr` for every row instead of using DataFusion's batch evaluation:

```sql
-- Previously: pdb_eval_expr_0(CAST(name AS Utf8)) → ExecEvalExpr per row
-- Now: upper(name) → native DataFusion columnar evaluation
SELECT DISTINCT upper(s.name), p.name
FROM suppliers s JOIN products p ON s.id = p.supplier_id
WHERE s.id @@@ 'all' AND p.id @@@ 'all'
ORDER BY p.name LIMIT 10;
```

## How

**Two-tier expression translation.** `PredicateTranslator` first attempts to map expressions to native DataFusion equivalents. When native translation fails, the expression is wrapped in `PgExprUdf` as a fallback — JoinScan absorbs the query regardless, using Tantivy for search predicates and PgExprUdf only for the opaque parts.

### Natively mapped `pg_catalog` functions

- **String:** `upper`, `lower`, `length`/`char_length`/`character_length`, `btrim`/`trim`, `ltrim`, `rtrim`, `substr`/`substring`, `replace`, `concat`, `starts_with`, `ends_with`, `repeat`, `reverse`, `ascii`
- **Math:** `abs`, `ceil`/`ceiling`, `floor`, `round`, `sqrt`, `power`/`pow`, `sign`, `ln`, `log`/`log10`
- **Core:** `coalesce`, `nullif`, `greatest`, `least`

### Natively mapped operators

- **Comparison:** `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`
- **Arithmetic:** `+`, `-`, `*`, `/`, `%`

### Natively mapped expression types

- `IS NULL` / `IS NOT NULL`
- `IS TRUE` / `IS FALSE` / `IS UNKNOWN` (and their negations)
- `CASE WHEN ... THEN ... ELSE ... END`
- `IN (...)` / `NOT IN (...)`
- `GREATEST(...)` / `LEAST(...)`
- Text-family `CoerceViaIO` (TEXT ↔ VARCHAR ↔ NAME)

**Unified evaluation path.** Previously, Semi/Anti join filters and DISTINCT/ORDER BY expressions used completely separate evaluation paths. Both now go through the same translator with the same two-tier logic.

**Operator name resolution.** `translate_op_expr` now resolves operator names directly via `pg_sys::get_opname` instead of the existing `lookup_operator` table (which only covered comparison operators and is still used by other code paths). This cleanly supports arithmetic without modifying the shared operator lookup infrastructure.

**Session registers DataFusion built-ins.** Native function expressions survive the protobuf plan serialization round-trip because `build_base_session` now includes `.with_default_features()`.

### New query shapes that now work

```sql
-- IS NULL in disjunctive filter (previously rejected)
WHERE NOT EXISTS (... AND (e.pattern = i.name OR e.pattern IS NULL))

-- COALESCE in join filter (previously rejected)
WHERE NOT EXISTS (... AND COALESCE(e.pattern, '') = i.name)

-- CASE WHEN in join filter (previously rejected)
WHERE NOT EXISTS (... AND CASE WHEN e.pattern IS NOT NULL THEN e.pattern ELSE '' END = i.name)

-- Arithmetic in join filter (previously rejected or UDF-wrapped)
WHERE NOT EXISTS (... AND e.threshold * 2 > i.value + 10)

-- Cross-table function predicates on inner joins (previously rejected)
WHERE upper(i.name) = upper(c.label)

-- Unknown functions absorbed via UDF fallback (previously rejected)
WHERE my_schema.custom_func(e.pattern) = i.name
```

## Tests

- **`join_semi_anti_disjunctive`** — test 5 (`length()` in disjunctive anti-join) updated: previously showed `WARNING: JoinScan not used` with a 21-row Nested Loop plan, now shows a 16-row JoinScan plan with native `character_length(...)`. New tests for `upper`, `COALESCE`, `IS NULL`, `CASE WHEN`, arithmetic, and mixed native+UDF expressions. Result correctness cross-checked against JoinScan-off.
- **`join_distinct_expr`** — EXPLAIN output updated across all expression cases: `pdb_eval_expr_0(...)` replaced by native function names (`upper(...)`, `character_length(...)`, `IS NULL`, `CASE WHEN ... END`). Expressions that can't be natively translated retain `pdb_eval_expr_*` with hash-based names.
- **Property tests** — pure-Rust tests for `translate_known_func` (known functions, wrong schema, wrong arity), proptest for random unknown function names, SQL-level `#[pg_test]` for JoinScan-on vs JoinScan-off result equivalence and absorption verification.
- All existing regression tests pass.