### PR TITLE
docs: Remove global robots metatag overriding per-page noindex

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -544,12 +544,10 @@
   },
   "seo": {
     "metatags": {
-      "robots": "index, follow",
       "charset": "UTF-8",
       "viewport": "width=device-width, initial-scale=1.0",
       "keywords": "paradedb, postgres, search, analytics, bm25, full-text search, hybrid search, faceted search, columnar, olap",
       "author": "ParadeDB",
-      "googlebot": "index, follow",
       "google": "notranslate",
       "generator": "Mintlify",
       "theme-color": "#000000",


### PR DESCRIPTION
## Summary
- `docs/docs.json` was setting global `robots: index, follow` and `googlebot: index, follow` metatags, which Mintlify injects into every page and which overrode the per-page `noindex: true` frontmatter on all 112 `docs/changelog/*.mdx` files.
- As a result, the rendered HTML for changelog pages contained `<meta name="robots" content="index, follow"/>` and they remained indexable in Google (surfacing as low-value version-string queries in GSC/Gauge).
- Dropping both global defaults lets the per-page `noindex: true` frontmatter take effect. Default indexing behavior for other pages is unchanged (`index, follow` is Google's implicit default).

## Test plan
- [x] After Mintlify deploy, verify `curl -s https://docs.paradedb.com/changelog/0.15.23 | grep -i robots` returns `<meta name="robots" content="noindex"/>` (or equivalent)
- [x] Verify a non-changelog page (e.g. `/welcome` or `/documentation/getting-started/install`) still has no `noindex` directive
- [x] Confirm changelog pages begin dropping out of GSC over subsequent crawls